### PR TITLE
add empty message to route cards

### DIFF
--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/RouteCardTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/RouteCardTest.tsx.snap
@@ -216,6 +216,18 @@ exports[`renders blue line routes 1`] = `
       Blue Line
     </span>
   </a>
+  <div>
+    No departures within 24 hours
+  </div>
+  <div>
+    <a
+      href="/schedules/Blue"
+    >
+      View 
+      Blue Line
+       schedules
+    </a>
+  </div>
 </div>
 `;
 
@@ -233,6 +245,18 @@ exports[`renders bus routes 1`] = `
       Bus
     </span>
   </a>
+  <div>
+    No departures within 24 hours
+  </div>
+  <div>
+    <a
+      href="/schedules/Bus"
+    >
+      View 
+      Bus
+       schedules
+    </a>
+  </div>
 </div>
 `;
 
@@ -250,6 +274,18 @@ exports[`renders ferry routes 1`] = `
       Charlestown Ferry
     </span>
   </a>
+  <div>
+    No departures within 24 hours
+  </div>
+  <div>
+    <a
+      href="/schedules/Boat-F4"
+    >
+      View 
+      Charlestown Ferry
+       schedules
+    </a>
+  </div>
 </div>
 `;
 
@@ -267,6 +303,18 @@ exports[`renders green line routes 1`] = `
       B Line
     </span>
   </a>
+  <div>
+    No departures within 24 hours
+  </div>
+  <div>
+    <a
+      href="/schedules/Green-B"
+    >
+      View 
+      B Line
+       schedules
+    </a>
+  </div>
 </div>
 `;
 
@@ -284,6 +332,18 @@ exports[`renders orange line routes 1`] = `
       Orange Line
     </span>
   </a>
+  <div>
+    No departures within 24 hours
+  </div>
+  <div>
+    <a
+      href="/schedules/Orange"
+    >
+      View 
+      Orange Line
+       schedules
+    </a>
+  </div>
 </div>
 `;
 
@@ -301,5 +361,17 @@ exports[`renders red line routes 1`] = `
       Red Line
     </span>
   </a>
+  <div>
+    No departures within 24 hours
+  </div>
+  <div>
+    <a
+      href="/schedules/Red"
+    >
+      View 
+      Red Line
+       schedules
+    </a>
+  </div>
 </div>
 `;

--- a/apps/site/assets/ts/stop/components/RouteCard.tsx
+++ b/apps/site/assets/ts/stop/components/RouteCard.tsx
@@ -45,6 +45,16 @@ const RouteCard = ({
 }: Props): ReactElement<HTMLElement> => (
   <div className="m-stop-page__departures-route">
     <Header route={route} />
+    {directions.length === 0 && (
+      <>
+        <div>No departures within 24 hours</div>
+        <div>
+          <a href={`/schedules/${route.id}`}>
+            View {route.long_name} schedules
+          </a>
+        </div>
+      </>
+    )}
 
     {directions.map(direction => (
       <Direction


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🚉 Stations/Stops | Departure empty state](https://app.asana.com/0/555089885850811/1120980093749753)

This simply adds a message when there are no predictions; I'm planning to update the logic behind when we show predictions as a separate ticket.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass on localhost:
  - [x] `npm test` (includes mix test, JS tests, and Backstop)
  - [x] `npm run dialyzer`
  - [x] `pronto run -c origin/master`

<br>
Assigned to: @meagonqz // @ingridpierre 
