### PR TITLE
use PredictedSchedule in TNM

### DIFF
--- a/apps/site/lib/predicted_schedule.ex
+++ b/apps/site/lib/predicted_schedule.ex
@@ -114,6 +114,15 @@ defmodule PredictedSchedule do
     nil
   end
 
+  @spec last_stop?(t) :: boolean
+  def last_stop?(%PredictedSchedule{schedule: %Schedule{last_stop?: last_stop?}}) do
+    last_stop?
+  end
+
+  def last_stop?(%PredictedSchedule{}) do
+    false
+  end
+
   @doc """
   Retrieves status from predicted schedule if one is available
   """

--- a/apps/site/test/site_web/controllers/transit_near_me/stops_with_routes_test.exs
+++ b/apps/site/test/site_web/controllers/transit_near_me/stops_with_routes_test.exs
@@ -21,28 +21,28 @@ defmodule SiteWeb.TransitNearMeController.StopsWithRoutesTest do
     longitude: -71.067
   }
 
+  setup do
+    data = %TransitNearMe{
+      schedules: %{
+        "stop-id" => [
+          %PredictedSchedule{schedule: %Schedule{route: @mattapan, stop: @stop}},
+          %PredictedSchedule{schedule: %Schedule{route: @green_branch, stop: @stop}},
+          %PredictedSchedule{schedule: %Schedule{route: @subway, stop: @stop}},
+          %PredictedSchedule{schedule: %Schedule{route: @cr, stop: @stop}},
+          %PredictedSchedule{schedule: %Schedule{route: @bus, stop: @stop}},
+          %PredictedSchedule{schedule: %Schedule{route: @ferry, stop: @stop}}
+        ]
+      },
+      distances: %{
+        "stop-id" => 0.04083664794103045
+      },
+      stops: [@stop]
+    }
+
+    %{data: data}
+  end
+
   describe "from_routes_and_stops/1" do
-    setup do
-      data = %TransitNearMe{
-        schedules: %{
-          "stop-id" => [
-            %Schedule{route: @mattapan, stop: @stop},
-            %Schedule{route: @green_branch, stop: @stop},
-            %Schedule{route: @subway, stop: @stop},
-            %Schedule{route: @cr, stop: @stop},
-            %Schedule{route: @bus, stop: @stop},
-            %Schedule{route: @ferry, stop: @stop}
-          ]
-        },
-        distances: %{
-          "stop-id" => 0.04083664794103045
-        },
-        stops: [@stop]
-      }
-
-      %{data: data}
-    end
-
     test "builds a list of stops and the routes that stop at each one", %{
       data: data
     } do
@@ -74,24 +74,7 @@ defmodule SiteWeb.TransitNearMeController.StopsWithRoutesTest do
   end
 
   describe "stops_with_routes/2" do
-    test "returns an encodable map with formatted data" do
-      stops = %TransitNearMe{
-        schedules: %{
-          "stop-id" => [
-            %Schedule{route: @mattapan, stop: @stop},
-            %Schedule{route: @green_branch, stop: @stop},
-            %Schedule{route: @subway, stop: @stop},
-            %Schedule{route: @cr, stop: @stop},
-            %Schedule{route: @bus, stop: @stop},
-            %Schedule{route: @ferry, stop: @stop}
-          ]
-        },
-        distances: %{
-          "stop-id" => 0.05
-        },
-        stops: [@stop]
-      }
-
+    test "returns an encodable map with formatted data", %{data: stops} do
       stops_map = StopsWithRoutes.stops_with_routes(stops)
       %{stop: stop_with_data, routes: routes} = List.first(stops_map)
       route = routes |> List.first() |> Map.get(:routes) |> List.first()
@@ -103,7 +86,7 @@ defmodule SiteWeb.TransitNearMeController.StopsWithRoutesTest do
 
       assert %Stop{} = stop_with_data.stop
 
-      assert stop_with_data.distance == "291 ft"
+      assert stop_with_data.distance == "238 ft"
       assert {:ok, _} = Poison.encode(stops_map)
     end
   end

--- a/apps/site/test/site_web/controllers/transit_near_me_controller_test.exs
+++ b/apps/site/test/site_web/controllers/transit_near_me_controller_test.exs
@@ -63,14 +63,30 @@ defmodule SiteWeb.TransitNearMeControllerTest do
     stops: [@back_bay],
     schedules: %{
       "place-bbsta" => [
-        %Schedule{stop: @back_bay, route: struct(Route, @orange_line)},
-        %Schedule{stop: @back_bay, route: struct(Route, @cr_worcester)},
-        %Schedule{stop: @back_bay, route: struct(Route, @cr_franklin)},
-        %Schedule{stop: @back_bay, route: struct(Route, @cr_needham)},
-        %Schedule{stop: @back_bay, route: struct(Route, @cr_providence)},
-        %Schedule{stop: @back_bay, route: struct(Route, @bus_10)},
-        %Schedule{stop: @back_bay, route: struct(Route, @bus_39)},
-        %Schedule{stop: @back_bay, route: struct(Route, @bus_170)}
+        %PredictedSchedule{
+          schedule: %Schedule{stop: @back_bay, route: struct(Route, @orange_line)}
+        },
+        %PredictedSchedule{
+          schedule: %Schedule{stop: @back_bay, route: struct(Route, @cr_worcester)}
+        },
+        %PredictedSchedule{
+          schedule: %Schedule{stop: @back_bay, route: struct(Route, @cr_franklin)}
+        },
+        %PredictedSchedule{
+          schedule: %Schedule{stop: @back_bay, route: struct(Route, @cr_needham)}
+        },
+        %PredictedSchedule{
+          schedule: %Schedule{stop: @back_bay, route: struct(Route, @cr_providence)}
+        },
+        %PredictedSchedule{
+          schedule: %Schedule{stop: @back_bay, route: struct(Route, @bus_10)}
+        },
+        %PredictedSchedule{
+          schedule: %Schedule{stop: @back_bay, route: struct(Route, @bus_39)}
+        },
+        %PredictedSchedule{
+          schedule: %Schedule{stop: @back_bay, route: struct(Route, @bus_170)}
+        }
       ]
     }
   }
@@ -160,10 +176,7 @@ defmodule SiteWeb.TransitNearMeControllerTest do
 
   describe "with no location params" do
     test "does not attempt to calculate stops with routes", %{conn: conn} do
-      conn =
-        conn
-        |> put_req_cookie("transit_near_me_redesign", "true")
-        |> get(transit_near_me_path(conn, :index))
+      conn = get(conn, transit_near_me_path(conn, :index))
 
       assert conn.status == 200
 
@@ -181,10 +194,7 @@ defmodule SiteWeb.TransitNearMeControllerTest do
     test "assigns stops with routes", %{conn: conn} do
       params = %{"address" => %{"latitude" => "valid", "longitude" => "valid"}}
 
-      conn =
-        conn
-        |> put_req_cookie("transit_near_me_redesign", "true")
-        |> get(transit_near_me_path(conn, :index, params))
+      conn = get(conn, transit_near_me_path(conn, :index, params))
 
       assert conn.status == 200
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** no ticket

Updates the TransitNearMe methods to use PredictedSchedule to match schedules with predictions, which is generally more reliable.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass on localhost:
  - [x] `npm test` (includes mix test, JS tests, and Backstop)
  - [x] `npm run dialyzer`
  - [x] `pronto run -c origin/master`

<br>
Assigned to: @meagonqz 
