### PR TITLE
fix tests with references to old stop ids

### DIFF
--- a/apps/schedules/test/repo_test.exs
+++ b/apps/schedules/test/repo_test.exs
@@ -91,18 +91,18 @@ defmodule Schedules.RepoTest do
   end
 
   describe "schedule_for_trip/2" do
-    @trip_id "Lowell"
+    @trip_id "place-NHRML-0254"
              |> schedule_for_stop(direction_id: 1)
              |> List.first()
              |> Map.get(:trip)
              |> Map.get(:id)
 
     test "returns stops in order of their stop_sequence for a given trip" do
-      # find a Lowell trip ID
+      # find a place-NHRML-0254 trip ID
       response = schedule_for_trip(@trip_id)
       assert response |> Enum.all?(fn schedule -> schedule.trip.id == @trip_id end)
       refute response == []
-      assert List.first(response).stop.id == "Lowell"
+      assert List.first(response).stop.id == "place-NHRML-0254"
       assert List.last(response).stop.id == "place-north"
     end
 
@@ -157,11 +157,11 @@ defmodule Schedules.RepoTest do
       today = Util.service_date() |> Timex.format!("{ISOdate}")
 
       response =
-        origin_destination("Anderson/ Woburn", "North Station", date: today, direction_id: 1)
+        origin_destination("place-NHRML-0127", "North Station", date: today, direction_id: 1)
 
       [{origin, dest} | _] = response
 
-      assert origin.stop.id == "Anderson/ Woburn"
+      assert origin.stop.id == "place-NHRML-0127"
       assert dest.stop.id == "place-north"
       assert origin.trip.id == dest.trip.id
       assert origin.time < dest.time
@@ -169,10 +169,10 @@ defmodule Schedules.RepoTest do
 
     test "does not require a direction id" do
       today = Util.service_date() |> Timex.format!("{ISOdate}")
-      no_direction_id = origin_destination("Anderson/ Woburn", "North Station", date: today)
+      no_direction_id = origin_destination("place-NHRML-0127", "North Station", date: today)
 
       direction_id =
-        origin_destination("Anderson/ Woburn", "North Station", date: today, direction_id: 1)
+        origin_destination("place-NHRML-0127", "North Station", date: today, direction_id: 1)
 
       assert no_direction_id == direction_id
     end
@@ -196,7 +196,7 @@ defmodule Schedules.RepoTest do
       with_mock V3Api.Schedules, all: fn _ -> {:error, :tuple} end do
         response =
           origin_destination(
-            "Anderson/ Woburn",
+            "place-NHRML-0127",
             "North Station"
           )
 
@@ -315,15 +315,15 @@ defmodule Schedules.RepoTest do
   describe "has_trip?/1" do
     test "keeps parsed schedules with trips" do
       assert has_trip?(
-               {"CR-Lowell", "CR-Weekday-Fall-18-348", "Lowell",
+               {"CR-Lowell", "CR-Weekday-Fall-18-348", "place-NHRML-0254",
                 "2018-11-05 23:05:00-05:00 -05 Etc/GMT+5", false, false, false, 1, 0}
              )
     end
 
     test "filters out parsed schedules that returned without trips" do
       refute has_trip?(
-               {"CR-Lowell", nil, "Lowell", "2018-11-05 23:05:00-05:00 -05 Etc/GMT+5", false,
-                false, false, 1, 0}
+               {"CR-Lowell", nil, "place-NHRML-0254", "2018-11-05 23:05:00-05:00 -05 Etc/GMT+5",
+                false, false, false, 1, 0}
              )
     end
   end

--- a/apps/site/test/site/lib/vehicle_helpers_test.exs
+++ b/apps/site/test/site/lib/vehicle_helpers_test.exs
@@ -51,11 +51,11 @@ defmodule Site.VehicleHelpersTest do
 
     test "translate parent stop to itself" do
       locations = %{
-        {"CR-Weekday-Spring-19-330", "Lowell"} => %Vehicles.Vehicle{
+        {"CR-Weekday-Spring-19-330", "place-NHRML-0254"} => %Vehicles.Vehicle{
           latitude: 1.1,
           longitude: 2.2,
           status: :stopped,
-          stop_id: "Lowell",
+          stop_id: "place-NHRML-0254",
           trip_id: "CR-Weekday-Spring-19-330",
           shape_id: "903_0018"
         }
@@ -63,7 +63,7 @@ defmodule Site.VehicleHelpersTest do
 
       assert @route
              |> build_tooltip_index(locations, @predictions)
-             |> Map.has_key?("Lowell")
+             |> Map.has_key?("place-NHRML-0254")
     end
 
     test "verify the Vehicle tooltip data" do

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -250,9 +250,9 @@ defmodule SiteWeb.ScheduleController.LineTest do
 
       for {id, idx} <- [
             {"place-sstat", 0},
-            {"Canton Junction", 5},
-            {"Stoughton", 7},
-            {"Wickford Junction", 14}
+            {"place-NEC-2139", 5},
+            {"place-SB-0189", 7},
+            {"place-NEC-1659", 14}
           ] do
         assert stops |> Enum.at(idx) |> elem(1) == id
       end

--- a/apps/site/test/site_web/controllers/schedule/origin_destination_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/origin_destination_test.exs
@@ -127,7 +127,7 @@ defmodule SiteWeb.ScheduleController.OriginDestinationTest do
       refute conn.assigns.origin == nil
       assert conn.assigns.origin.id == "place-hymnl"
       refute conn.assigns.destination == nil
-      assert conn.assigns.destination.id == "64"
+      assert conn.assigns.destination.id == "place-dudly"
       assert conn.assigns.direction_id == 1
     end
 

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -75,7 +75,7 @@ defmodule SiteWeb.ScheduleControllerTest do
     end
 
     test "assigns information for the trip view", %{conn: conn} do
-      conn = get(conn, trip_view_path(conn, :show, "CR-Worcester", origin: "Westborough"))
+      conn = get(conn, trip_view_path(conn, :show, "CR-Worcester", origin: "place-WML-0340"))
       assert conn.assigns.tab == "trip-view"
       refute conn.assigns.schedules == nil
       refute conn.assigns.predictions == nil
@@ -118,8 +118,8 @@ defmodule SiteWeb.ScheduleControllerTest do
       conn = get(conn, trip_view_path(conn, :show, "CR-Lowell"))
       zone_map = conn.assigns.zone_map
 
-      assert "North Billerica" in Map.keys(zone_map)
-      assert zone_map["North Billerica"] == "5"
+      assert "place-NHRML-0218" in Map.keys(zone_map)
+      assert zone_map["place-NHRML-0218"] == "5"
     end
   end
 
@@ -260,7 +260,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       end
 
       # stops are in inbound order
-      assert List.first(stops).id == "Needham Heights"
+      assert List.first(stops).id == "place-NB-0137"
       assert List.last(stops).id == "place-sstat"
 
       # includes the stop features

--- a/apps/site/test/site_web/controllers/stop_controller_test.exs
+++ b/apps/site/test/site_web/controllers/stop_controller_test.exs
@@ -77,7 +77,7 @@ defmodule SiteWeb.StopControllerTest do
     conn =
       conn
       |> put_req_cookie("stop_page_redesign", "true")
-      |> get(stop_path(conn, :show, "Worcester"))
+      |> get(stop_path(conn, :show, "place-WML-0442"))
 
     assert conn.assigns.zone_number == "8"
   end

--- a/apps/stops/test/api_test.exs
+++ b/apps/stops/test/api_test.exs
@@ -5,9 +5,9 @@ defmodule Stops.ApiTest do
 
   describe "by_gtfs_id/1" do
     test "uses the gtfs ID to find a stop" do
-      {:ok, stop} = by_gtfs_id("Anderson/ Woburn")
+      {:ok, stop} = by_gtfs_id("place-NHRML-0127")
 
-      assert stop.id == "Anderson/ Woburn"
+      assert stop.id == "place-NHRML-0127"
       assert stop.name == "Anderson/Woburn"
       assert stop.station?
       assert stop.accessibility != []

--- a/apps/stops/test/nearby_test.exs
+++ b/apps/stops/test/nearby_test.exs
@@ -154,8 +154,8 @@ defmodule Stops.NearbyTest do
       actual = @position |> api_around(radius: 0.06) |> distance_sort
 
       expected = [
-        %{id: "North Billerica", latitude: 42.593248, longitude: -71.280995},
-        %{id: "Wilmington", latitude: 42.546624, longitude: -71.174334},
+        %{id: "place-NHRML-0218", latitude: 42.593248, longitude: -71.280995},
+        %{id: "place-NHRML-0152", latitude: 42.546624, longitude: -71.174334},
         %{id: "6902", latitude: 42.519675, longitude: -71.21163}
       ]
 

--- a/apps/stops/test/repo_test.exs
+++ b/apps/stops/test/repo_test.exs
@@ -50,7 +50,7 @@ defmodule Stops.RepoTest do
       response = by_route("CR-Lowell", 1)
 
       assert response != []
-      assert match?(%Stop{id: "Lowell", name: "Lowell"}, List.first(response))
+      assert match?(%Stop{id: "place-NHRML-0254", name: "Lowell"}, List.first(response))
       assert match?(%Stop{id: "place-north", name: "North Station"}, List.last(response))
       assert response == Enum.uniq(response)
     end
@@ -59,23 +59,23 @@ defmodule Stops.RepoTest do
       response = by_route("CR-Fitchburg", 1)
 
       assert Enum.map(response, &{&1.id, &1.name}) == [
-               {"Wachusett", "Wachusett"},
-               {"Fitchburg", "Fitchburg"},
-               {"North Leominster", "North Leominster"},
-               {"Shirley", "Shirley"},
-               {"Ayer", "Ayer"},
-               {"Littleton / Rte 495", "Littleton/Rte 495"},
-               {"South Acton", "South Acton"},
-               {"West Concord", "West Concord"},
-               {"Concord", "Concord"},
-               {"Lincoln", "Lincoln"},
-               {"Silver Hill", "Silver Hill"},
-               {"Hastings", "Hastings"},
-               {"Kendal Green", "Kendal Green"},
-               {"Brandeis/ Roberts", "Brandeis/Roberts"},
-               {"Waltham", "Waltham"},
-               {"Waverley", "Waverley"},
-               {"Belmont", "Belmont"},
+               {"place-FR-3338", "Wachusett"},
+               {"place-FR-0494", "Fitchburg"},
+               {"place-FR-0451", "North Leominster"},
+               {"place-FR-0394", "Shirley"},
+               {"place-FR-0361", "Ayer"},
+               {"place-FR-0301", "Littleton/Rte 495"},
+               {"place-FR-0253", "South Acton"},
+               {"place-FR-0219", "West Concord"},
+               {"place-FR-0201", "Concord"},
+               {"place-FR-0167", "Lincoln"},
+               {"place-FR-0147", "Silver Hill"},
+               {"place-FR-0137", "Hastings"},
+               {"place-FR-0132", "Kendal Green"},
+               {"place-FR-0115", "Brandeis/Roberts"},
+               {"place-FR-0098", "Waltham"},
+               {"place-FR-0074", "Waverley"},
+               {"place-FR-0064", "Belmont"},
                {"place-portr", "Porter"},
                {"place-north", "North Station"}
              ]
@@ -111,8 +111,8 @@ defmodule Stops.RepoTest do
   describe "by_routes/3" do
     test "can return stops from multiple route IDs" do
       response = by_routes(["CR-Lowell", "CR-Haverhill"], 1)
-      assert Enum.find(response, &(&1.id == "Lowell"))
-      assert Enum.find(response, &(&1.id == "Haverhill"))
+      assert Enum.find(response, &(&1.id == "place-NHRML-0254"))
+      assert Enum.find(response, &(&1.id == "place-WR-0329"))
       # North Station only appears once
       assert response |> Enum.filter(&(&1.id == "place-north")) |> length == 1
     end
@@ -123,7 +123,7 @@ defmodule Stops.RepoTest do
       # commuter rail
       response = by_route_type(2)
 
-      assert Enum.find(response, &(&1.id == "Lowell"))
+      assert Enum.find(response, &(&1.id == "place-NHRML-0254"))
 
       # uses parent stop
       assert Enum.find(response, &(&1.id == "North Station")) == nil


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** NO TICKET

Fix tests that failed due to some `Stop.id` changes in upstream GTFS / API.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass on localhost:
  - [x] `npm test` (includes mix test, JS tests, and Backstop)
  - [x] `npm run dialyzer`
  - [x] `pronto run -c origin/master`

<br>
Assigned to: @katehedgpeth 
