### PR TITLE
assign schedule_page_data in green line controller

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/green.ex
+++ b/apps/site/lib/site_web/controllers/schedule/green.ex
@@ -70,7 +70,7 @@ defmodule SiteWeb.ScheduleController.Green do
     |> call_plug(SiteWeb.ScheduleController.CMS)
     |> await_assign_all_default(__MODULE__)
     |> put_view(ScheduleView)
-    |> LineController.assign_shedule_page_data()
+    |> LineController.assign_schedule_page_data()
     |> render("show.html", [])
   end
 

--- a/apps/site/lib/site_web/controllers/schedule/green.ex
+++ b/apps/site/lib/site_web/controllers/schedule/green.ex
@@ -3,6 +3,7 @@ defmodule SiteWeb.ScheduleController.Green do
 
   import UrlHelpers, only: [update_url: 2]
   alias Schedules.Schedule
+  alias SiteWeb.ScheduleController.LineController
   alias SiteWeb.ScheduleView
 
   plug(:route)
@@ -44,14 +45,14 @@ defmodule SiteWeb.ScheduleController.Green do
   def trip_view(conn, _params) do
     conn
     |> assign(:tab, "trip-view")
-    |> put_view(SiteWeb.ScheduleView)
+    |> put_view(ScheduleView)
     |> render("show.html", [])
   end
 
   def alerts(conn, _params) do
     conn
     |> assign(:tab, "alerts")
-    |> put_view(SiteWeb.ScheduleView)
+    |> put_view(ScheduleView)
     |> render("show.html", [])
   end
 
@@ -68,14 +69,8 @@ defmodule SiteWeb.ScheduleController.Green do
     |> call_plug(SiteWeb.ScheduleController.Line)
     |> call_plug(SiteWeb.ScheduleController.CMS)
     |> await_assign_all_default(__MODULE__)
-    |> put_view(SiteWeb.ScheduleView)
-    |> assign(
-      :schedule_page_data,
-      %{
-        pdfs:
-          ScheduleView.route_pdfs(conn.assigns.route_pdfs, conn.assigns.route, conn.assigns.date)
-      }
-    )
+    |> put_view(ScheduleView)
+    |> LineController.assign_shedule_page_data()
     |> render("show.html", [])
   end
 

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -30,11 +30,11 @@ defmodule SiteWeb.ScheduleController.LineController do
       |> await_assign_all_default(__MODULE__)
 
     conn
-    |> assign_shedule_page_data()
+    |> assign_schedule_page_data()
     |> render("show.html", [])
   end
 
-  def assign_shedule_page_data(conn) do
+  def assign_schedule_page_data(conn) do
     assign(
       conn,
       :schedule_page_data,

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -30,7 +30,13 @@ defmodule SiteWeb.ScheduleController.LineController do
       |> await_assign_all_default(__MODULE__)
 
     conn
-    |> assign(
+    |> assign_shedule_page_data()
+    |> render("show.html", [])
+  end
+
+  def assign_shedule_page_data(conn) do
+    assign(
+      conn,
       :schedule_page_data,
       %{
         connections: group_connections(conn.assigns.connections),
@@ -53,7 +59,6 @@ defmodule SiteWeb.ScheduleController.LineController do
         route_type: conn.assigns.route.type
       }
     )
-    |> render("show.html", [])
   end
 
   defp tab_name(conn, _), do: assign(conn, :tab, "line")


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱ Schedules | /schedules/Green is not rendering React components](https://app.asana.com/0/477545582537986/1123858331590598/f)

Green line has it's own schedule-line controller because the data processing is significantly different than other routes. The React components were not showing on the Green page because `schedule_page_data` was not being assigned with all data values.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass on localhost:
  - [x] `npm test` (includes mix test, JS tests, and Backstop)
  - [x] `npm run dialyzer`
  - [x] `pronto run -c origin/master`

<br>
Assigned to: @katehedgpeth 
