### PR TITLE
Add ellipsis to long headsign names

### DIFF
--- a/apps/site/assets/css/_stop-bubbles.scss
+++ b/apps/site/assets/css/_stop-bubbles.scss
@@ -63,18 +63,22 @@ $location-line-width: $space-6;
 
 .route-branch-headsign-wrapper {
   display: inline-flex;
-  max-width: 16rem;
+  max-width: 14rem;
 
   @include media-breakpoint-only(sm) {
-    max-width: 20rem;
+    max-width: 23rem;
   }
 
   @include media-breakpoint-only(md) {
-    max-width: 11rem;
+    max-width: 21rem;
+  }
+
+  @include media-breakpoint-only(lg) {
+    max-width: 28rem;
   }
 
   @include media-breakpoint-only(xxl) {
-    max-width: 20rem;
+    max-width: 32rem;
   }
 }
 

--- a/apps/site/assets/css/_stop-bubbles.scss
+++ b/apps/site/assets/css/_stop-bubbles.scss
@@ -42,7 +42,7 @@ $location-line-width: $space-6;
   align-items: stretch;
   display: flex;
   flex: 1 1 0%;
-  overflow: visible; // if set to hidden, site works better in IE10, but then cirlces are slightly cropped everywhere
+  overflow: visible; // if set to hidden, site works better in IE10, but then circles are slightly cropped everywhere
   width: 100%;
 
   &.expanded {
@@ -59,6 +59,29 @@ $location-line-width: $space-6;
 
 .route-branch-stop-prediction {
   text-align: right;
+}
+
+.route-branch-headsign-wrapper {
+  display: inline-flex;
+  max-width: 16rem;
+
+  @include media-breakpoint-only(sm) {
+    max-width: 20rem;
+  }
+
+  @include media-breakpoint-only(md) {
+    max-width: 11rem;
+  }
+
+  @include media-breakpoint-only(xxl) {
+    max-width: 20rem;
+  }
+}
+
+.route-branch-headsign {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .route-branch-stop-bubbles {

--- a/apps/site/lib/site_web/templates/schedule/_line_page_stop_info.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line_page_stop_info.html.eex
@@ -5,10 +5,9 @@
   <%= render "_line_page_stop_text_icons.html", stop: @stop, conn: @conn %>
   <div class="route-branch-stop-info-container">
     <div>
-      <%= if @stop.zone do %>
+      <%= if @stop.zone && @route.type == 2 do %>
         <div>
           <div class="commuter-rail-zone route-branch-stop-zone">
-            <%= unless @route.type == 2 do %>Commuter Rail<% end %>
             <span class="u-nowrap">Zone <%= @stop.zone %></span>
           </div>
         </div>

--- a/apps/site/lib/site_web/templates/schedule/_line_page_stop_prediction.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line_page_stop_prediction.html.eex
@@ -1,7 +1,9 @@
 <%= for headsign <- @time_data do %>
   <%= for %{prediction: %{time: time}} <- headsign.times do %>
     <div class="route-branch-stop-prediction">
-      <%= headsign.name %>
+      <span class="route-branch-headsign-wrapper">
+        <span class="route-branch-headsign"><%= headsign.name %></span>
+      </span>
       <strong><%= time %></strong>
     </div>
   <% end %>  

--- a/apps/site/lib/site_web/templates/schedule/_line_page_stop_prediction_cr.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line_page_stop_prediction_cr.html.eex
@@ -12,7 +12,11 @@
           <span class="u-linethrough"><%= time_data.scheduled_time %></span> <strong><%= time_data.prediction.time %></strong>
         <% end %>
       </div>
-      <%= headsign.name %><%= train_info %> · <span class="u-nowrap"><%= status %></span>
+      <span class="route-branch-headsign-wrapper">
+        <span class="route-branch-headsign">
+          <%= headsign.name %>
+        </span>
+      </span><%= train_info %> · <span class="u-nowrap"><%= status %></span>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱ Schedules | Add ellipsis to long headsign names](https://app.asana.com/0/477545582537986/1124353435273956/f)

- This change has no effect to most headsigns, but now longer ones will not wrap.
- removed zone tag for all modes except CR

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass on localhost:
  - [x] `npm test` (includes mix test, JS tests, and Backstop)
  - [x] `npm run dialyzer`
  - [x] `pronto run -c origin/master`

<br>
Assigned to: @amaisano 