### PR TITLE
handle nil prediction time in TNM

### DIFF
--- a/apps/site/lib/site/transit_near_me.ex
+++ b/apps/site/lib/site/transit_near_me.ex
@@ -603,11 +603,15 @@ defmodule Site.TransitNearMe do
   end
 
   @spec simple_prediction(Prediction.t() | nil, atom, DateTime.t()) :: simple_prediction | nil
-  def simple_prediction(nil, _, _) do
+  def simple_prediction(nil, _route_type, _now) do
     nil
   end
 
-  def simple_prediction(%Prediction{} = prediction, route_type, now) do
+  def simple_prediction(%Prediction{time: nil}, _route_type, _now) do
+    nil
+  end
+
+  def simple_prediction(%Prediction{time: %DateTime{}} = prediction, route_type, now) do
     seconds = Timex.diff(prediction.time, now, :seconds)
 
     prediction


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** no ticket

Predictions sometimes don't have times, which causes the `Timex.diff` function to raise.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass on localhost:
  - [x] `npm test` (includes mix test, JS tests, and Backstop)
  - [x] `npm run dialyzer`
  - [x] `pronto run -c origin/master`

<br>
Assigned to: @ryan-mahoney 
