### PR TITLE
don't redirect commuter_rail on homepage

### DIFF
--- a/apps/site/lib/site_web/views/page_view.ex
+++ b/apps/site/lib/site_web/views/page_view.ex
@@ -37,6 +37,8 @@ defmodule SiteWeb.PageView do
   defp shortcut_link(:the_ride),
     do: cms_static_page_path(SiteWeb.Endpoint, "/accessibility/the-ride")
 
+  defp shortcut_link(:commuter_rail), do: schedule_path(SiteWeb.Endpoint, :show, :"commuter-rail")
+
   defp shortcut_link(mode), do: schedule_path(SiteWeb.Endpoint, :show, mode)
 
   @spec shortcut_text(atom) :: [Phoenix.HTML.Safe.t()]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⭐ Homepage Commuter Rail Lines icon link wrong URL](https://app.asana.com/0/555089885850811/1112126309976758)

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass on localhost:
  - [x] `npm test` (includes mix test, JS tests, and Backstop)
  - [x] `npm run dialyzer`
  - [x] `pronto run -c origin/master`

<br>
Assigned to: @amaisano 
