### PR TITLE
don't render old connections template on new line page

### DIFF
--- a/apps/site/lib/site_web/templates/schedule/_line.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line.html.eex
@@ -58,8 +58,8 @@
         <%= render "_cms_teasers.html", featured_content: @featured_content, news: @news, conn: @conn %>
         <%= render "_pdf_schedules.html", assigns %>
       <% end %>
-      <%= render "_line_connections.html", assigns %>
       <%= if !redesign? do %>
+        <%= render "_line_connections.html", assigns %>
         <%= render "_fares.html", assigns %>
         <div class="hours">
           <%= if assigns[:hours_of_operation] do %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱Schedules | Accordions - Connections](https://app.asana.com/0/555089885850811/1118913618186294)

Moves old connection list so that it's not shown with react content

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass on localhost:
  - [x] `npm test` (includes mix test, JS tests, and Backstop)
  - [x] `npm run dialyzer`
  - [x] `pronto run -c origin/master`

<br>
Assigned to: @ryan-mahoney 
