### PR TITLE
use style guide time format for events

### DIFF
--- a/apps/site/lib/site_web/views/content_view.ex
+++ b/apps/site/lib/site_web/views/content_view.ex
@@ -154,8 +154,12 @@ defmodule SiteWeb.ContentView do
     }"
   end
 
+  defp format_time(%{minute: 0} = time) do
+    Timex.format!(time, "{h12} {AM}")
+  end
+
   defp format_time(time) do
-    Timex.format!(time, "{h12}:{m}{am}")
+    Timex.format!(time, "{h12}:{m} {AM}")
   end
 
   defp nested_paragraphs(columns), do: columns |> Enum.flat_map(& &1.paragraphs)

--- a/apps/site/test/site_web/views/content_view_test.exs
+++ b/apps/site/test/site_web/views/content_view_test.exs
@@ -768,19 +768,19 @@ defmodule SiteWeb.ContentViewTest do
   describe "render_duration/2" do
     test "with no end time, only renders start time" do
       actual = render_duration(~N[2016-11-15T10:00:00], nil)
-      expected = "November 15, 2016 at 10:00am"
+      expected = "November 15, 2016 at 10 AM"
       assert expected == actual
     end
 
     test "with start/end on same day, only renders date once" do
       actual = render_duration(~N[2016-11-14T12:00:00], ~N[2016-11-14T14:30:00])
-      expected = "November 14, 2016 at 12:00pm - 2:30pm"
+      expected = "November 14, 2016 at 12 PM - 2:30 PM"
       assert expected == actual
     end
 
     test "with start/end on different days, renders both dates" do
       actual = render_duration(~N[2016-11-14T12:00:00], ~N[2016-12-01T14:30:00])
-      expected = "November 14, 2016 12:00pm - December 1, 2016 2:30pm"
+      expected = "November 14, 2016 12 PM - December 1, 2016 2:30 PM"
       assert expected == actual
     end
 
@@ -792,7 +792,7 @@ defmodule SiteWeb.ContentViewTest do
         )
 
       # could also be November 6th, 1:00 AM (test daylight savings)
-      expected = "November 5, 2016 1:00am - November 6, 2016 2:00am"
+      expected = "November 5, 2016 1 AM - November 6, 2016 2 AM"
       assert expected == actual
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⭐ Event time format should match content style guide](https://app.asana.com/0/555089885850811/1116681773922428)

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass on localhost:
  - [x] `npm test` (includes mix test, JS tests, and Backstop)
  - [x] `npm run dialyzer`
  - [x] `pronto run -c origin/master`

<br>
Assigned to: @meagonqz  
