### PR TITLE
add predictions to CR timetable

### DIFF
--- a/apps/site/assets/ts/leaflet/icon.ts
+++ b/apps/site/assets/ts/leaflet/icon.ts
@@ -25,10 +25,9 @@ export default (
   const iconOpts =
     opts !== null && opts
       ? {
-          iconAnchor: opts.icon_anchor,
-          iconSize: opts.icon_size,
-          popupAnchor: opts.popup_anchor,
-          ...opts
+          iconAnchor: opts.icon_anchor || defaultIconOpts.iconAnchor,
+          iconSize: opts.icon_size || defaultIconOpts.iconSize,
+          popupAnchor: opts.popup_anchor || defaultIconOpts.popupAnchor
         }
       : defaultIconOpts;
   return icon === null

--- a/apps/site/assets/ts/schedule/components/Map.tsx
+++ b/apps/site/assets/ts/schedule/components/Map.tsx
@@ -57,7 +57,7 @@ const zIndex = (icon: string | null): number | undefined =>
 
 const updateMarker = (marker: Marker): Marker => ({
   ...marker,
-  tooltip: <div>{marker.tooltip_text}</div>,
+  tooltip: marker.tooltip_text ? <div dangerouslySetInnerHTML={{__html: marker.tooltip_text}}/> : <div/>,
   icon_opts: iconOpts(marker.icon), // eslint-disable-line @typescript-eslint/camelcase
   z_index: zIndex(marker.icon) // eslint-disable-line @typescript-eslint/camelcase
 });

--- a/apps/site/lib/site_web/channels/vehicle_channel.ex
+++ b/apps/site/lib/site_web/channels/vehicle_channel.ex
@@ -41,7 +41,7 @@ defmodule SiteWeb.VehicleChannel do
     route = Routes.Repo.get(vehicle.route_id)
     stop_name = get_stop_name(vehicle.stop_id)
     trip = Schedules.Repo.trip(vehicle.trip_id)
-    prediction = List.first(Predictions.Repo.all(trip: vehicle.trip_id))
+    prediction = List.first(Predictions.Repo.all(trip: vehicle.trip_id, stop: vehicle.stop_id))
 
     %{
       data: %{vehicle: vehicle, stop_name: stop_name},

--- a/apps/site/lib/site_web/channels/vehicle_channel.ex
+++ b/apps/site/lib/site_web/channels/vehicle_channel.ex
@@ -41,6 +41,7 @@ defmodule SiteWeb.VehicleChannel do
     route = Routes.Repo.get(vehicle.route_id)
     stop_name = get_stop_name(vehicle.stop_id)
     trip = Schedules.Repo.trip(vehicle.trip_id)
+    prediction = List.first(Predictions.Repo.all(trip: vehicle.trip_id))
 
     %{
       data: %{vehicle: vehicle, stop_name: stop_name},
@@ -53,14 +54,14 @@ defmodule SiteWeb.VehicleChannel do
           rotation_angle: vehicle.bearing,
           tooltip_text:
             %VehicleTooltip{
-              prediction: nil,
+              prediction: prediction,
               vehicle: vehicle,
               route: route,
               stop_name: stop_name,
               trip: trip
             }
             |> VehicleHelpers.tooltip()
-            |> Floki.text()
+            |> Floki.text(sep: "<br>")
         )
     }
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Provide better messages in Commuter Rail timetable tooltips](https://app.asana.com/0/477545582537986/1108435465356012)

This wasn't done before for a couple reasons but also because I don't know if there will be performance issues with pulling these predictions on vehicle updates. The existing ticket is a 3 because we might prefer to do prediction streaming from the API. We could see if this suffices for now?

<br>
Assigned to: @katehedgpeth 
