### PR TITLE
Fix schedule page tooltip having undefined anchor

### DIFF
--- a/apps/site/assets/ts/leaflet/__tests__/icon-test.ts
+++ b/apps/site/assets/ts/leaflet/__tests__/icon-test.ts
@@ -15,7 +15,7 @@ it("returns default icon opts if options are missing", () => {
   expect(iconClass!.options).toEqual({
     ...defaultIconOpts,
     iconRetinaUrl: "/images/icon-string.svg",
-    iconUrl: "/images/icon-string.svg",
+    iconUrl: "/images/icon-string.svg"
   });
 });
 
@@ -25,6 +25,6 @@ it("returns default icon opts if some options are missing", () => {
     ...defaultIconOpts,
     iconRetinaUrl: "/images/icon-string.svg",
     iconSize: [50, 50],
-    iconUrl: "/images/icon-string.svg",
+    iconUrl: "/images/icon-string.svg"
   });
 });

--- a/apps/site/assets/ts/leaflet/__tests__/icon-test.ts
+++ b/apps/site/assets/ts/leaflet/__tests__/icon-test.ts
@@ -22,10 +22,9 @@ it("returns default icon opts if options are missing", () => {
 it("returns default icon opts if some options are missing", () => {
   const iconClass = icon("string", { icon_size: [50, 50] });
   expect(iconClass!.options).toEqual({
-    iconAnchor: [22, 55],
+    ...defaultIconOpts,
     iconRetinaUrl: "/images/icon-string.svg",
     iconSize: [50, 50],
     iconUrl: "/images/icon-string.svg",
-    popupAnchor: [0, -37]
   });
 });

--- a/apps/site/assets/ts/leaflet/__tests__/icon-test.ts
+++ b/apps/site/assets/ts/leaflet/__tests__/icon-test.ts
@@ -1,4 +1,4 @@
-import icon from "../icon";
+import icon, { defaultIconOpts } from "../icon";
 
 it("generates a leaflet icon", () => {
   const iconClass = icon("abc");
@@ -8,4 +8,24 @@ it("generates a leaflet icon", () => {
 it("returns undefined if no icon", () => {
   const iconClass = icon(null);
   expect(iconClass).toBeUndefined();
+});
+
+it("returns default icon opts if options are missing", () => {
+  const iconClass = icon("string", {});
+  expect(iconClass!.options).toEqual({
+    ...defaultIconOpts,
+    iconRetinaUrl: "/images/icon-string.svg",
+    iconUrl: "/images/icon-string.svg",
+  });
+});
+
+it("returns default icon opts if some options are missing", () => {
+  const iconClass = icon("string", { icon_size: [50, 50] });
+  expect(iconClass!.options).toEqual({
+    iconAnchor: [22, 55],
+    iconRetinaUrl: "/images/icon-string.svg",
+    iconSize: [50, 50],
+    iconUrl: "/images/icon-string.svg",
+    popupAnchor: [0, -37]
+  });
 });

--- a/apps/site/assets/ts/leaflet/icon.ts
+++ b/apps/site/assets/ts/leaflet/icon.ts
@@ -12,7 +12,7 @@ interface LeafletOpts {
   popupAnchor: [number, number];
 }
 
-const defaultIconOpts: LeafletOpts = {
+export const defaultIconOpts: LeafletOpts = {
   iconAnchor: [22, 55],
   iconSize: [45, 75],
   popupAnchor: [0, -37]

--- a/apps/site/assets/ts/leaflet/icon.ts
+++ b/apps/site/assets/ts/leaflet/icon.ts
@@ -25,10 +25,9 @@ export default (
   const iconOpts =
     opts !== null && opts
       ? {
-          iconAnchor: opts.icon_anchor,
-          iconSize: opts.icon_size,
-          popupAnchor: opts.popup_anchor,
-          ...opts
+          iconAnchor: opts.icon_anchor || defaultIconOpts.iconAnchor,
+          iconSize: opts.icon_size || defaultIconOpts.iconSize,
+          popupAnchor: opts.popup_anchor || defaultIconOpts.popupAnchor
         }
       : defaultIconOpts;
   return icon === null


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

Allow any one of the options to be provided, use default values when others are not.

Discovered this when looking at the commuter rail tooltips. The updates on the schedule page don't provide an icon anchor, so it was set as undefined and leaflet was throwing a console error when you tried to open a tooltip.

<br>
Assigned to: @ryan-mahoney 
