### PR TITLE
standardize alert banner parsing

### DIFF
--- a/apps/site/lib/site_web/templates/layout/_alert_announcement.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_alert_announcement.html.eex
@@ -1,3 +1,3 @@
 <%= link to: (@alert_banner.url || alert_path(@conn, :index)), class: "alert-announcement__header" do %>
-  <%= SiteWeb.AlertView.render "_banner.html", alert: %{Alerts.Repo.by_id(@alert_banner.id) | priority: :system} %>
+  <%= SiteWeb.AlertView.render "_banner.html", alert: %{Alerts.Repo.by_id(@alert_banner.id) | header: @alert_banner.title, priority: :system} %>
 <% end %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🚒 Website Alert Banner - Use banner text field](https://app.asana.com/0/555089885850811/1126432560732675)

Previously, we had a separate struct for banners, which had different keys from the normal `%Alert{}` struct. When we redesigned the alerts page, we stopped using that banner struct directly -- we still kept it but we were only using it to store the ID of the alert it represented. The alert was parsed as a normal alert, and so it kept the text from the `header` attribute -- but banners are supposed to use the text from the `banner` attribute.

This refactor removes the `Banner` struct entirely, and updates how we select text for the `header` field for alerts. We store only the ID of the banner alert in the repo instead of storing the full alert separately.

<br>
Assigned to: @ryan-mahoney 
