### PR TITLE
add header to schedule finder modal

### DIFF
--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -139,3 +139,16 @@
   right: $base-spacing / 2;
   top: $base-spacing / 2;
 }
+
+.schedule-finder__modal-header {
+  display: flex;
+  margin-bottom: $base-spacing / 4;
+}
+
+.schedule-finder__modal-route-pill {
+  margin-bottom: 0;
+  margin-right: $base-spacing;
+  margin-top: 0;
+  padding-left: $base-spacing;
+  padding-right: $base-spacing;
+}

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleFinderTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleFinderTest.tsx
@@ -3,6 +3,7 @@ import renderer from "react-test-renderer";
 import { mount } from "enzyme";
 import { createReactRoot } from "../../app/helpers/testUtils";
 import ScheduleFinder from "../components/ScheduleFinder";
+import { DirectionInfo, Route } from "../../__v3api";
 
 // the enzyme test was done as one test because there was
 // an issue mounting it more than once due to the focus-trap
@@ -10,8 +11,17 @@ import ScheduleFinder from "../components/ScheduleFinder";
 
 /* eslint-disable @typescript-eslint/camelcase */
 const body = '<div id="react-root"></div>';
-const directionDestinations = { 0: "Oak Grove", 1: "Forest Hills" };
-const directionNames = { 0: "Inbound", 1: "Outbound" };
+const route: Route = {
+  alert_count: 0,
+  description: "",
+  direction_destinations: { 0: "Oak Grove", 1: "Forest Hills" },
+  direction_names: { 0: "Inbound", 1: "Outbound" },
+  header: "",
+  id: "Orange",
+  long_name: "Orange Line",
+  name: "Orange",
+  type: 1
+};
 const stops = [
   { name: "Malden Center", id: "place-mlmnl" },
   { name: "Wellington", id: "place-welln" }
@@ -20,13 +30,7 @@ const stops = [
 it("renders", () => {
   createReactRoot();
   const tree = renderer
-    .create(
-      <ScheduleFinder
-        directionDestinations={directionDestinations}
-        directionNames={directionNames}
-        stops={stops}
-      />
-    )
+    .create(<ScheduleFinder route={route} stops={stops} />)
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
@@ -34,13 +38,7 @@ it("renders", () => {
 it("opens modal after displaying error", () => {
   document.body.innerHTML = body;
 
-  const wrapper = mount(
-    <ScheduleFinder
-      directionDestinations={directionDestinations}
-      directionNames={directionNames}
-      stops={stops}
-    />
-  );
+  const wrapper = mount(<ScheduleFinder route={route} stops={stops} />);
 
   // there should be no errors
   expect(wrapper.exists(".error-container")).toBeFalsy();
@@ -55,7 +53,7 @@ it("opens modal after displaying error", () => {
 
   wrapper
     .find("#sf_direction_select")
-    .simulate("change", { target: { value: 1 } });
+    .simulate("change", { target: { value: "1" } });
 
   wrapper.find("input").simulate("click");
 
@@ -77,7 +75,7 @@ it("opens modal after displaying error", () => {
 
   wrapper
     .find("#sf_direction_select")
-    .simulate("change", { target: { value: 1 } });
+    .simulate("change", { target: { value: "1" } });
 
   wrapper.find("input").simulate("click");
 
@@ -90,4 +88,34 @@ it("opens modal after displaying error", () => {
   // for code cov
   wrapper.find("#sf_origin_select").simulate("keyUp", { key: "Enter" });
   wrapper.find("#sf_direction_select").simulate("keyUp", { key: "Enter" });
+});
+
+it("modal renders route pill for bus lines", () => {
+  const subwayWrapper = mount(<ScheduleFinder stops={stops} route={route} />);
+  subwayWrapper
+    .find("#sf_direction_select")
+    .simulate("change", { target: { value: "1" } });
+
+  subwayWrapper
+    .find("#sf_origin_select")
+    .simulate("change", { target: { value: "place-welln" } });
+
+  subwayWrapper.find("input").simulate("click");
+
+  expect(subwayWrapper.exists(".m-route-pills")).toBeFalsy();
+
+  const busRoute: Route = { ...route, id: "66", name: "66", type: 3 };
+  const busWrapper = mount(<ScheduleFinder stops={stops} route={busRoute} />);
+  busWrapper
+    .find("#sf_direction_select")
+    .simulate("change", { target: { value: "0" } });
+
+  busWrapper
+    .find("#sf_origin_select")
+    .simulate("change", { target: { value: "place-welln" } });
+
+  busWrapper.find("input").simulate("click");
+
+  expect(busWrapper.exists(".m-route-pills")).toBeTruthy();
+  expect(busWrapper.exists(".u-bg--bus")).toBeTruthy();
 });

--- a/apps/site/assets/ts/schedule/__tests__/SchedulePageTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/SchedulePageTest.tsx
@@ -4,6 +4,7 @@ import { createReactRoot } from "../../app/helpers/testUtils";
 import SchedulePage from "../components/SchedulePage";
 import { TypedRoutes } from "../../stop/components/__stop";
 import ScheduleNote from "../components/ScheduleNote";
+import { Route } from "../../__v3api";
 
 const pdfs = [
   {
@@ -46,8 +47,17 @@ const holidays = [
   }
 ];
 
-const directionDestinations = { 0: "Oak Grove", 1: "Forest Hills" };
-const directionNames = { 0: "Inbound", 1: "Outbound" };
+const route: Route = {
+  alert_count: 0,
+  description: "",
+  direction_destinations: { 0: "Oak Grove", 1: "Forest Hills" },
+  direction_names: { 0: "Inbound", 1: "Outbound" },
+  header: "",
+  id: "Orange",
+  name: "Orange",
+  long_name: "Orange Line",
+  type: 1
+};
 const stops = [
   { name: "Malden Center", id: "place-mlmnl" },
   { name: "Wellington", id: "place-welln" }
@@ -67,9 +77,7 @@ it("it renders", () => {
           holidays,
           pdfs,
           teasers,
-          route_type: 1,
-          direction_names: directionNames,
-          direction_destinations: directionDestinations,
+          route,
           stops
         }}
       />
@@ -99,9 +107,7 @@ it("it renders with conditional components", () => {
         holidays,
         pdfs,
         teasers,
-        route_type: 1,
-        direction_names: directionNames,
-        direction_destinations: directionDestinations,
+        route,
         stops
       }}
     />

--- a/apps/site/assets/ts/schedule/components/SchedulePage.tsx
+++ b/apps/site/assets/ts/schedule/components/SchedulePage.tsx
@@ -22,10 +22,8 @@ const SchedulePage = ({
     fares,
     holidays,
     fare_link: fareLink,
-    route_type: routeType,
+    route,
     schedule_note: scheduleNote,
-    direction_names: directionNames,
-    direction_destinations: directionDestinations,
     stops
   }
 }: Props): ReactElement<HTMLElement> => (
@@ -36,18 +34,16 @@ const SchedulePage = ({
         scheduleNote={scheduleNote}
       />
     )}
-    {routeType !== 0 &&
-    routeType !== 1 && ( // don't show for subway
-        <ScheduleFinder
-          directionDestinations={directionDestinations}
-          directionNames={directionNames}
-          stops={stops}
-        />
-      )}
+    {route.type !== 0 && route.type !== 1 && (
+      <ScheduleFinder
+        route={route} // don't show for subway
+        stops={stops}
+      />
+    )}
     <ContentTeasers teasers={teasers} />
     <PDFSchedules pdfs={pdfs} />
     <Connections connections={connections} />
-    <Fares fares={fares} fareLink={fareLink} routeType={routeType} />
+    <Fares fares={fares} fareLink={fareLink} routeType={route.type} />
     <HoursOfOperation hours={hours} />
     <UpcomingHolidays holidays={holidays} />
   </>

--- a/apps/site/assets/ts/schedule/components/__schedule.d.ts
+++ b/apps/site/assets/ts/schedule/components/__schedule.d.ts
@@ -1,5 +1,5 @@
 import { TypedRoutes } from "../../stop/components/__stop";
-import { DirectionInfo, RouteType } from "../../__v3api";
+import { Route } from "../../__v3api";
 
 export interface SchedulePageData {
   connections: TypedRoutes[];
@@ -9,10 +9,8 @@ export interface SchedulePageData {
   fares: Fare[];
   fare_link: string;
   holidays: Holiday[];
-  route_type: RouteType;
+  route: Route;
   schedule_note: ScheduleNote | null;
-  direction_destinations: DirectionInfo;
-  direction_names: DirectionInfo;
   stops: SimpleStop[];
 }
 

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -2,7 +2,7 @@ defmodule SiteWeb.ScheduleController.LineController do
   use SiteWeb, :controller
   alias Phoenix.HTML
   alias Routes.{Group, Route}
-  alias Site.{JsonHelpers, ScheduleNote}
+  alias Site.ScheduleNote
   alias SiteWeb.{ScheduleView, ViewHelpers}
 
   plug(SiteWeb.Plugs.Route)
@@ -60,11 +60,8 @@ defmodule SiteWeb.ScheduleController.LineController do
           end),
         fare_link: ScheduleView.route_fare_link(conn.assigns.route),
         holidays: conn.assigns.holidays,
-        route_type: conn.assigns.route.type,
+        route: Route.to_json_safe(conn.assigns.route),
         schedule_note: ScheduleNote.new(conn.assigns.route),
-        direction_destinations:
-          JsonHelpers.update_map_for_encoding(conn.assigns.route.direction_destinations),
-        direction_names: JsonHelpers.update_map_for_encoding(conn.assigns.route.direction_names),
         stops: simple_stop_list(conn.assigns.all_stops)
       }
     )


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱Schedules | Input box - Submit button opens schedule modal](https://app.asana.com/0/555089885850811/1122431599573151)

Adds a formatted header to the schedule finder modal.

![Screen Shot 2019-06-11 at 2 37 19 PM](https://user-images.githubusercontent.com/125874/59297555-7cc6f300-8c56-11e9-9703-4ea2056f9eec.png)

![Screen Shot 2019-06-11 at 2 38 33 PM](https://user-images.githubusercontent.com/125874/59297662-be579e00-8c56-11e9-8194-98e5e53ff754.png)

![Screen Shot 2019-06-11 at 2 39 20 PM](https://user-images.githubusercontent.com/125874/59297666-c283bb80-8c56-11e9-9970-d53a0dee11c8.png)


<br>
Assigned to: @ryan-mahoney 
