### PR TITLE
shorten min_time shift in prediction test

### DIFF
--- a/apps/predictions/test/repo_test.exs
+++ b/apps/predictions/test/repo_test.exs
@@ -36,7 +36,7 @@ defmodule Predictions.RepoTest do
     end
 
     test "filters by min_time" do
-      min_time = Util.now() |> Timex.shift(hours: 1)
+      min_time = Util.now() |> Timex.shift(minutes: 15)
       predictions = Repo.all(route: "Red", min_time: min_time)
       refute Enum.empty?(predictions)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** no ticket

Red line is struggling today, and this test is failing because there are no predictions more than an hour away. This shift doesn't need to be so large for this test to be valid.

<br>
Assigned to: @name
