### PR TITLE
don't do extra calculation for parking note

### DIFF
--- a/apps/site/assets/ts/stop/__tests__/sidebar/ParkingTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/sidebar/ParkingTest.tsx
@@ -166,8 +166,7 @@ describe("Parking", () => {
       parking_lots: [
         {
           ...parkingLot,
-          utilization: { ...utilization, typical: 100 },
-          capacity: { total: 200 }
+          utilization: { ...utilization, arrive_before: undefined }
         }
       ]
     };

--- a/apps/site/assets/ts/stop/components/sidebar/Parking.tsx
+++ b/apps/site/assets/ts/stop/components/sidebar/Parking.tsx
@@ -15,15 +15,11 @@ const renderUtilization = (
       utilization: { typical, arrive_before }
     } = lot;
     if (typical && total) {
-      let message = `Parking spots at ${name} fill up quickly.`;
-
-      const demandForSpaces = typical / total;
-      if (demandForSpaces > 0.9) {
+      let message;
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      if (arrive_before) {
         // eslint-disable-next-line @typescript-eslint/camelcase
-        if (arrive_before) {
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          message = `${message} We recommend arriving before ${arrive_before}.`;
-        }
+        message = `Parking spots at ${name} fill up quickly. We recommend arriving before ${arrive_before}.`;
       } else {
         message = `Parking at ${name} is generally available throughout the weekday.`;
       }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞🚗 Station pages *sometimes* pull wrong parking data](https://app.asana.com/0/555089885850811/1122296944502350)

We were doing an unnecessary extra calculation to determine whether to show a note about arriving early for station parking. This changes to logic to simply show what the API gives us.

<br>
Assigned to: @meagonqz 
