### PR TITLE
test fixes related to inclusion of SSR CR route

### DIFF
--- a/apps/site/test/detailed_stop_group_test.exs
+++ b/apps/site/test/detailed_stop_group_test.exs
@@ -20,7 +20,8 @@ defmodule DetailedStopGroupTest do
           "Middleborough/Lakeville Line",
           "Needham Line",
           "Newburyport/Rockport Line",
-          "Providence/Stoughton Line"
+          "Providence/Stoughton Line",
+          "South Shore Limited"
         ])
 
       route_names =

--- a/apps/site/test/site_web/controllers/stop_controller_test.exs
+++ b/apps/site/test/site_web/controllers/stop_controller_test.exs
@@ -95,7 +95,7 @@ defmodule SiteWeb.StopControllerTest do
     conn =
       conn
       |> put_req_cookie("stop_page_redesign", "true")
-      |> get(stop_path(conn, :show, 9_070_130))
+      |> get(stop_path(conn, :show, 70_130))
 
     assert redirected_to(conn) == stop_path(conn, :show, "place-harvd")
   end


### PR DESCRIPTION
#### Summary of changes
NO TICKET

fix some test fails that occurred after recent GTFS changes.

- inclusion of new CR-SouthShoreLtd route
- remove a reference to a decommissioned child stop

<br>
Assigned to: @katehedgpeth 
