### PR TITLE
show links in alert banner

### DIFF
--- a/apps/site/assets/css/core.scss
+++ b/apps/site/assets/css/core.scss
@@ -46,7 +46,7 @@ body {
   &.no-js {
     .collapse:target {
       display: block;
-    };
+    }
 
     .hidden-no-js {
       display: none;
@@ -234,12 +234,12 @@ small {
   padding: 0;
 
   a {
-    color: $gray-dark;
-
-    @include hover-focus-active {
-      text-decoration: none;
-    }
+    text-decoration: underline;
   }
+}
+
+.alert-announcement__header {
+  cursor: pointer;
 }
 
 // To be removed once the smart banner is disabled

--- a/apps/site/lib/site_web/templates/layout/_alert_announcement.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_alert_announcement.html.eex
@@ -1,3 +1,3 @@
-<%= link to: (@alert_banner.url || alert_path(@conn, :index)), class: "alert-announcement__header" do %>
+<div class="alert-announcement__header" onclick="location.href='<%= @alert_banner.url || alert_path(@conn, :index) %>';">
   <%= SiteWeb.AlertView.render "_banner.html", alert: %{Alerts.Repo.by_id(@alert_banner.id) | header: @alert_banner.title, priority: :system} %>
-<% end %>
+</div>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⭐ Alert Banner | Links look like plain text](https://app.asana.com/0/555089885850811/1126696422778125)

![alert-banner](https://user-images.githubusercontent.com/988609/59633570-c3b35d80-911a-11e9-9ed2-bab822e2613f.png)


There were two problems causing this issue:
- it is not valid to nest and `a` tag inside another `a` tag
- there were styles intended for the outer tag that were being applied to the inner tag

<br>
Assigned to: @meagonqz 
