### PR TITLE
encode : in trip id test

### DIFF
--- a/apps/site/test/site/trip_plan/related_link_test.exs
+++ b/apps/site/test/site/trip_plan/related_link_test.exs
@@ -25,7 +25,7 @@ defmodule Site.TripPlan.RelatedLinkTest do
       assert [route_link, fare_link] = links_for_itinerary(itinerary)
       assert text(route_link) == expected_route
       assert url(route_link) =~ Timex.format!(itinerary.start, "date={ISOdate}")
-      assert url(route_link) =~ URI.encode("trip=#{trip_id}")
+      assert url(route_link) =~ ~s(trip=#{String.replace(trip_id, ":", "%3A")})
       assert route_link.icon_name == expected_icon
       assert fare_link.text == "View fare information"
       # fare URL is tested later


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** no ticket

`URI.encode` doesn't encode colons, so we have to replace it manually for this test to pass.

<br>
Assigned to: @ryan-mahoney 
