### PR TITLE
add keyboard:false to map markers

### DIFF
--- a/apps/site/assets/ts/leaflet/components/Map.tsx
+++ b/apps/site/assets/ts/leaflet/components/Map.tsx
@@ -107,6 +107,7 @@ const Component = ({
             position={[marker.latitude, marker.longitude]}
             ref={ref => ref && rotateMarker(ref.leafletElement, marker)}
             zIndexOffset={marker.z_index}
+            keyboard={false}
           >
             {marker.tooltip && (
               <Popup minWidth={320} maxHeight={175}>

--- a/apps/site/assets/ts/tnm/components/leaflet/MarkerWrapper.tsx
+++ b/apps/site/assets/ts/tnm/components/leaflet/MarkerWrapper.tsx
@@ -108,6 +108,7 @@ const MarkerWrapper = ({
         onFocus={toggleHovered}
         onMouseOut={toggleHovered}
         onBlur={toggleHovered}
+        keyboard={false}
       >
         {tooltipComponent ? (
           <Popup


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [♿  Map captures tab on schedule line page](https://app.asana.com/0/555089885850811/1126862660664679)

Prevents markers from being selectable by tabbing.

<br>
Assigned to: @meagonqz 
