### PR TITLE
don't render empty description lists

### DIFF
--- a/apps/site/lib/site_web/views/content_view.ex
+++ b/apps/site/lib/site_web/views/content_view.ex
@@ -8,7 +8,7 @@ defmodule SiteWeb.ContentView do
 
   alias Content.Field.{File, Image, Link}
   alias Content.Paragraph
-  alias Content.Paragraph.{Callout, ColumnMulti, FareCard}
+  alias Content.Paragraph.{Callout, ColumnMulti, DescriptionList, FareCard}
   alias Site.ContentRewriter
 
   defdelegate fa_icon_for_file_type(mime), to: Site.FontAwesomeHelpers
@@ -66,6 +66,11 @@ defmodule SiteWeb.ContentView do
       element: fare_card_element(paragraph.link),
       conn: conn
     )
+  end
+
+  def render_content(%DescriptionList{descriptions: []}, _conn) do
+    # don't render header if list has no items
+    ""
   end
 
   def render_content(paragraph, conn) do

--- a/apps/site/test/site_web/views/content_view_test.exs
+++ b/apps/site/test/site_web/views/content_view_test.exs
@@ -378,6 +378,22 @@ defmodule SiteWeb.ContentViewTest do
       assert rendered =~ "Week pass"
     end
 
+    test "does not render empty description lists", %{conn: conn} do
+      paragraph = %DescriptionList{
+        header: %ColumnMultiHeader{
+          text: HTML.raw("<p>Header copy</p>\n")
+        }
+      }
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "c-paragraph--description-list"
+      refute rendered =~ "Header copy"
+    end
+
     test "renders a ContentList", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞  Hide entire Content List ¶ if list of content is empty](https://app.asana.com/0/555089885850811/1122465604344968)

Prevents header of description lists from being rendered if the list has no contents.

<br>
Assigned to: @ryan-mahoney 
