### PR TITLE
Improve Predictions.Repo.all performance

### DIFF
--- a/apps/json_api/lib/json_api.ex
+++ b/apps/json_api/lib/json_api.ex
@@ -42,7 +42,7 @@ defmodule JsonApi do
 
   @spec parse(String.t()) :: JsonApi.t() | {:error, any}
   def parse(body) do
-    with {:ok, parsed} <- Poison.Parser.parse(body),
+    with {:ok, parsed} <- Jason.decode(body),
          {:ok, data} <- parse_data(parsed) do
       %JsonApi{
         links: parse_links(parsed),
@@ -57,7 +57,7 @@ defmodule JsonApi do
     end
   end
 
-  @spec parse_links(Poison.Parser.t()) :: %{String.t() => String.t()}
+  @spec parse_links(term()) :: %{String.t() => String.t()}
   defp parse_links(%{"links" => links}) do
     links
     |> Enum.filter(fn {key, value} -> is_binary(key) && is_binary(value) end)
@@ -68,7 +68,7 @@ defmodule JsonApi do
     %{}
   end
 
-  @spec parse_data(Poison.Parser.t()) :: {:ok, [JsonApi.Item.t()]} | {:error, any}
+  @spec parse_data(term()) :: {:ok, [JsonApi.Item.t()]} | {:error, any}
   defp parse_data(%{"data" => data} = parsed) when is_list(data) do
     included = parse_included(parsed)
     {:ok, Enum.map(data, &parse_data_item(&1, included))}

--- a/apps/json_api/mix.exs
+++ b/apps/json_api/mix.exs
@@ -40,6 +40,7 @@ defmodule JsonApi.Mixfile do
   defp deps do
     [
       {:poison, ">= 0.0.0"},
+      {:jason, "~> 1.1"},
       {:excoveralls, "~> 0.5", only: :test},
       {:benchfella, "~> 0.3", only: :dev}
     ]

--- a/apps/json_api/mix.exs
+++ b/apps/json_api/mix.exs
@@ -21,7 +21,7 @@ defmodule JsonApi.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :poison]]
+    [applications: [:logger, :poison, :jason]]
   end
 
   # Dependencies can be Hex packages:

--- a/apps/predictions/lib/repo.ex
+++ b/apps/predictions/lib/repo.ex
@@ -130,9 +130,7 @@ defmodule Predictions.Repo do
   end
 
   def load_from_other_repos(predictions) do
-    predictions
-    |> Task.async_stream(&record_to_structs/1)
-    |> Enum.flat_map(fn {:ok, prediction} -> prediction end)
+    Enum.flat_map(predictions, &record_to_structs/1)
   end
 
   defp record_to_structs({_, _, nil, _, _, _, _, _, _, _, _}) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔧 Latency | Improve performance of TransitNearMe module](https://app.asana.com/0/555089885850811/1128108664139983)

This is a difficult problem because what we really want to do is retrieve fewer predictions, but there is really no current way to get a maximum of 2 predictions for each headway that passes through a stop.

Still, there were some optimizations that should make things faster.

1. remove a call to `Task.async_stream`.  Rather than speeding things up, this call seems to have resulted in a lot of inter-process communication overhead.

2. parse JSON with the newer `jason` elixir library which is faster and uses less memory.

---

The following flame graphs were generated with this command: `:eflame.apply(:normal, "stacks.out", Predictions.Repo, :all, [[stop: "place-welln"]])`

### Before

![Screen Shot 2019-06-25 at 2 37 45 PM](https://user-images.githubusercontent.com/988609/60124119-eff05f00-9756-11e9-81b8-6d745a16793b.png)

### Remove Async

![Screen Shot 2019-06-25 at 2 37 57 PM](https://user-images.githubusercontent.com/988609/60124122-f252b900-9756-11e9-960e-1378351e1d23.png)


### Add jason

![Screen Shot 2019-06-25 at 2 38 07 PM](https://user-images.githubusercontent.com/988609/60124127-f4b51300-9756-11e9-9ba7-943630bbd911.png)


<br>
Assigned to: @meagonqz 
