### PR TITLE
use Jason

### DIFF
--- a/apps/json_api/lib/json_api.ex
+++ b/apps/json_api/lib/json_api.ex
@@ -42,7 +42,7 @@ defmodule JsonApi do
 
   @spec parse(String.t()) :: JsonApi.t() | {:error, any}
   def parse(body) do
-    with {:ok, parsed} <- Poison.Parser.parse(body),
+    with {:ok, parsed} <- Jason.decode(body),
          {:ok, data} <- parse_data(parsed) do
       %JsonApi{
         links: parse_links(parsed),
@@ -57,7 +57,7 @@ defmodule JsonApi do
     end
   end
 
-  @spec parse_links(Poison.Parser.t()) :: %{String.t() => String.t()}
+  @spec parse_links(term()) :: %{String.t() => String.t()}
   defp parse_links(%{"links" => links}) do
     links
     |> Enum.filter(fn {key, value} -> is_binary(key) && is_binary(value) end)
@@ -68,7 +68,7 @@ defmodule JsonApi do
     %{}
   end
 
-  @spec parse_data(Poison.Parser.t()) :: {:ok, [JsonApi.Item.t()]} | {:error, any}
+  @spec parse_data(term()) :: {:ok, [JsonApi.Item.t()]} | {:error, any}
   defp parse_data(%{"data" => data} = parsed) when is_list(data) do
     included = parse_included(parsed)
     {:ok, Enum.map(data, &parse_data_item(&1, included))}

--- a/apps/json_api/mix.exs
+++ b/apps/json_api/mix.exs
@@ -21,7 +21,7 @@ defmodule JsonApi.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :poison]]
+    [applications: [:logger, :poison, :jason]]
   end
 
   # Dependencies can be Hex packages:
@@ -40,6 +40,7 @@ defmodule JsonApi.Mixfile do
   defp deps do
     [
       {:poison, ">= 0.0.0"},
+      {:jason, "~> 1.1"},
       {:excoveralls, "~> 0.5", only: :test},
       {:benchfella, "~> 0.3", only: :dev}
     ]


### PR DESCRIPTION
#### Summary of changes
NO TICKET

Use `jason` for API JSON parsing. This is somewhat of a no brainer because it is easy to drop in an is has been proven to increase performance and memory usage when parsing JSON over `Poison`.

https://medium.com/@_pat_nowak_/long-live-the-jason-new-json-library-de30fcde521d

<br>
Assigned to: @meagonqz 
