### PR TITLE
fix Google Places place parser

### DIFF
--- a/apps/google_maps/lib/google_maps/place/prediction.ex
+++ b/apps/google_maps/lib/google_maps/place/prediction.ex
@@ -5,7 +5,6 @@ defmodule GoogleMaps.Place.Prediction do
 
   @type t :: %__MODULE__{
           description: String.t(),
-          id: String.t(),
           matched_substrings: [map()],
           place_id: String.t(),
           reference: String.t(),
@@ -16,7 +15,6 @@ defmodule GoogleMaps.Place.Prediction do
 
   defstruct [
     :description,
-    :id,
     :matched_substrings,
     :place_id,
     :reference,
@@ -29,7 +27,6 @@ defmodule GoogleMaps.Place.Prediction do
   def new(
         %{
           "description" => description,
-          "id" => id,
           "matched_substrings" => matched_substrings,
           "place_id" => place_id,
           "reference" => reference,
@@ -39,7 +36,6 @@ defmodule GoogleMaps.Place.Prediction do
       ) do
     %__MODULE__{
       description: description,
-      id: id,
       matched_substrings: matched_substrings,
       place_id: place_id,
       reference: reference,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fix error w/ Google Places API](https://app.asana.com/0/555089885850811/1128769227442731)

This issue was clogging up our Sentry error log.

It seems that Google Places API is not always providing the `id` attribute. We weren't using this attribute, so I removed it from the struct altogether so it no longer matters if they provide it or not.

<br>
Assigned to: @meagonqz 
