### PR TITLE
remove call to services.repo

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -61,10 +61,6 @@ defmodule SiteWeb.ScheduleController.LineController do
         fare_link: ScheduleView.route_fare_link(conn.assigns.route),
         holidays: conn.assigns.holidays,
         route: Route.to_json_safe(conn.assigns.route),
-        services:
-          conn.assigns.route.id
-          |> Services.Repo.by_route_id()
-          |> Enum.sort_by(&Date.to_string(&1.start_date)),
         schedule_note: ScheduleNote.new(conn.assigns.route),
         stops: simple_stop_list(conn.assigns.all_stops),
         direction_id: conn.assigns.direction_id


### PR DESCRIPTION
#### Summary of changes
NO TICKET

This call was resulting in some crashes on dev/dev-green so I just want to remove this so it doesn't sneak into a deploy next week.  Also, we are not using this yet, so it is harmless to remove it for now.

@meagonqz 