### PR TITLE
Update URLs in map helper, remove temporary test changes

### DIFF
--- a/apps/predictions/test/repo_test.exs
+++ b/apps/predictions/test/repo_test.exs
@@ -38,7 +38,7 @@ defmodule Predictions.RepoTest do
     test "filters by min_time" do
       min_time = Util.now() |> Timex.shift(minutes: 15)
       predictions = Repo.all(route: "Orange", min_time: min_time)
-      # refute Enum.empty?(predictions)
+      refute Enum.empty?(predictions)
 
       for prediction <- predictions do
         assert DateTime.compare(prediction.time, min_time) in [:gt, :eq]

--- a/apps/site/lib/site/map_helpers.ex
+++ b/apps/site/lib/site/map_helpers.ex
@@ -8,29 +8,29 @@ defmodule Site.MapHelpers do
   def map_pdf_url(:subway) do
     static_url(
       SiteWeb.Endpoint,
-      "/sites/default/files/maps/2019-04-08-rapid-transit-key-bus-routes-map-v33.pdf"
+      "/subway-map"
     )
   end
 
   def map_pdf_url(:bus) do
     static_url(
       SiteWeb.Endpoint,
-      "/sites/default/files/maps/2019-04-08-mbta-system-map-full-revised.pdf"
+      "/bus-map"
     )
   end
 
   def map_pdf_url(:commuter_rail) do
-    static_url(SiteWeb.Endpoint, "/sites/default/files/maps/2019-04-08-commuter-rail-map-v33.pdf")
+    static_url(SiteWeb.Endpoint, "/cr-map")
   end
 
   def map_pdf_url(:ferry) do
-    static_url(SiteWeb.Endpoint, "/sites/default/files/maps/2018-08-ferry-map.pdf")
+    static_url(SiteWeb.Endpoint, "/ferry-map")
   end
 
   def map_pdf_url(:commuter_rail_zones) do
     static_url(
       SiteWeb.Endpoint,
-      "/sites/default/files/maps/2019-04-08-commuter-rail-map-zones.pdf"
+      "/cr-map-zones"
     )
   end
 

--- a/apps/site/test/site/lib/react_test.exs
+++ b/apps/site/test/site/lib/react_test.exs
@@ -76,27 +76,27 @@ defmodule Site.ReactTest do
       assert log =~ ~r/react_renderer component=TransitNearMe.* is not a function/
     end
 
-    # test "it translates zero-width space HTML entities into UTF-8 characters", %{
-    #   route_sidebar_data: route_sidebar_data,
-    #   stop_sidebar_data: stop_sidebar_data
-    # } do
-    #   # There's something between the quotes, really.
-    #   zero_width_space = "​"
+    test "it translates zero-width space HTML entities into UTF-8 characters", %{
+      route_sidebar_data: route_sidebar_data,
+      stop_sidebar_data: stop_sidebar_data
+    } do
+      # There's something between the quotes, really.
+      zero_width_space = "​"
 
-    #   # Demonstrate that the data going in includes a zero-width space
-    #   assert Poison.encode!(route_sidebar_data) =~ zero_width_space
+      # Demonstrate that the data going in includes a zero-width space
+      assert Poison.encode!(route_sidebar_data) =~ zero_width_space
 
-    #   assert {:safe, body} =
-    #            React.render("TransitNearMe", %{
-    #              query: %{},
-    #              mapId: "map-id",
-    #              mapData: %{markers: []},
-    #              routeSidebarData: route_sidebar_data,
-    #              stopSidebarData: stop_sidebar_data
-    #            })
+      assert {:safe, body} =
+               React.render("TransitNearMe", %{
+                 query: %{},
+                 mapId: "map-id",
+                 mapData: %{markers: []},
+                 routeSidebarData: route_sidebar_data,
+                 stopSidebarData: stop_sidebar_data
+               })
 
-    #   assert body =~ zero_width_space
-    # end
+      assert body =~ zero_width_space
+    end
   end
 
   describe "init/1" do

--- a/apps/site/test/site/map_helpers_test.exs
+++ b/apps/site/test/site/map_helpers_test.exs
@@ -8,20 +8,20 @@ defmodule MapHelpersTest do
       assert map_pdf_url(:subway) ==
                static_url(
                  SiteWeb.Endpoint,
-                 "/sites/default/files/maps/2019-04-08-rapid-transit-key-bus-routes-map-v33.pdf"
+                 "/subway-map"
                )
     end
 
     test "returns the map link for ferry" do
       assert map_pdf_url(:ferry) ==
-               static_url(SiteWeb.Endpoint, "/sites/default/files/maps/2018-08-ferry-map.pdf")
+               static_url(SiteWeb.Endpoint, "/ferry-map")
     end
 
     test "returns the bus map for bus" do
       assert map_pdf_url(:bus) ==
                static_url(
                  SiteWeb.Endpoint,
-                 "/sites/default/files/maps/2019-04-08-mbta-system-map-full-revised.pdf"
+                 "/bus-map"
                )
     end
 
@@ -29,7 +29,7 @@ defmodule MapHelpersTest do
       assert map_pdf_url(:commuter_rail) ==
                static_url(
                  SiteWeb.Endpoint,
-                 "/sites/default/files/maps/2019-04-08-commuter-rail-map-v33.pdf"
+                 "/cr-map"
                )
     end
   end

--- a/apps/site/test/site/transit_near_me_test.exs
+++ b/apps/site/test/site/transit_near_me_test.exs
@@ -208,7 +208,13 @@ defmodule Site.TransitNearMeTest do
       data = TransitNearMe.build(@address, date: @date, now: Util.now())
       routes = TransitNearMe.routes_for_stop(data, "place-pktrm")
 
-      assert length(Enum.map(routes, & &1.name)) > 0
+      assert Enum.map(routes, & &1.name) == [
+               "Red Line",
+               "Green Line B",
+               "Green Line C",
+               "Green Line E",
+               "Green Line D"
+             ]
     end
   end
 
@@ -226,7 +232,7 @@ defmodule Site.TransitNearMeTest do
 
       routes = TransitNearMe.schedules_for_routes(data, alerts, now: now)
 
-      # [%{id: closest_stop} | _] = data.stops
+      [%{id: closest_stop} | _] = data.stops
 
       assert [route_with_stops_with_directions | _] = routes
 
@@ -241,39 +247,44 @@ defmodule Site.TransitNearMeTest do
       assert %{stops_with_directions: [stop_with_directions | _]} =
                route_with_stops_with_directions
 
-      # assert %{alert_count: 1} = nil
+      assert %{alert_count: 1} = Enum.find(routes, &(&1.route.id == "Orange"))
 
       stop = stop_with_directions.stop
       assert %Stop{} = stop
-      # assert stop.id == closest_stop
+      assert stop.id == closest_stop
 
-      # assert stop_with_directions |> Map.keys() |> Enum.sort() == nil
+      assert stop_with_directions |> Map.keys() |> Enum.sort() == [
+               :directions,
+               :distance,
+               :href,
+               :stop
+             ]
 
-      # assert stop_with_directions.distance == "238 ft"
+      assert stop_with_directions.distance == "238 ft"
 
-      # assert %{directions: [direction | _]} = stop_with_directions
+      assert %{directions: [direction | _]} = stop_with_directions
 
-      # assert direction.direction_id in [0, 1]
+      assert direction.direction_id in [0, 1]
 
-      # assert Map.keys(direction) == [:direction_id, :headsigns]
+      assert Map.keys(direction) == [:direction_id, :headsigns]
 
-      # assert %{headsigns: [headsign | _]} = direction
+      assert %{headsigns: [headsign | _]} = direction
 
-      # assert Map.keys(headsign) == [:name, :times, :train_number]
+      assert Map.keys(headsign) == [:name, :times, :train_number]
 
-      # assert length(headsign.times) <= 2
+      assert length(headsign.times) <= 2
 
-      # assert %{times: [time | _]} = headsign
+      assert %{times: [time | _]} = headsign
 
-      # assert Map.keys(time) == [:delay, :prediction, :scheduled_time]
+      assert Map.keys(time) == [:delay, :prediction, :scheduled_time]
 
-      # assert %{scheduled_time: scheduled_time, prediction: prediction} = time
+      assert %{scheduled_time: scheduled_time, prediction: prediction} = time
 
-      # assert {:ok, _} = Timex.parse(Enum.join(scheduled_time), "{h12}:{m} {AM}")
+      assert {:ok, _} = Timex.parse(Enum.join(scheduled_time), "{h12}:{m} {AM}")
 
-      # if prediction do
-      #   assert Map.keys(prediction) == [:seconds, :status, :time, :track]
-      # end
+      if prediction do
+        assert Map.keys(prediction) == [:seconds, :status, :time, :track]
+      end
     end
 
     test "sorts directions and headsigns within stops" do

--- a/apps/site/test/site_web/controllers/schedule/green_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/green_test.exs
@@ -95,7 +95,7 @@ defmodule SiteWeb.ScheduleController.GreenTest do
 
     all_stops = Enum.map(all_stops, & &1.id)
     assert "place-lake" in all_stops
-    # assert "place-clmnl" in all_stops
+    assert "place-clmnl" in all_stops
     assert "place-river" in all_stops
     assert "place-hsmnl" in all_stops
   end

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -26,7 +26,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       conn = get(conn, trip_view_path(conn, :show, "1", origin: "2167", direction_id: "1"))
       html_response(conn, 200)
       assert conn.assigns.origin.id == "2167"
-      assert conn.assigns.trip_info == nil
+      assert conn.assigns.trip_info
     end
 
     test "finds a trip list with origin and destination", %{conn: conn} do
@@ -39,7 +39,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       html_response(conn, 200)
       assert conn.assigns.origin.id == "2167"
       assert conn.assigns.destination.id == "82"
-      assert conn.assigns.trip_info == nil
+      assert conn.assigns.trip_info
       assert conn.assigns.schedules != nil
       assert conn.assigns.predictions != nil
     end
@@ -79,7 +79,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert conn.assigns.tab == "trip-view"
       refute conn.assigns.schedules == nil
       refute conn.assigns.predictions == nil
-      assert conn.assigns.trip_info == nil
+      assert conn.assigns.trip_info
     end
 
     test "assigns information for the timetable", %{conn: conn} do
@@ -213,7 +213,7 @@ defmodule SiteWeb.ScheduleControllerTest do
           trip_view_path(conn, :show, "Mattapan", origin: "place-butlr", direction_id: "1")
         )
 
-      assert conn.assigns.trip_info == nil
+      assert conn.assigns.trip_info
       refute Enum.empty?(conn.assigns.journeys)
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💲New fares | Update map targets](https://app.asana.com/0/555089885850811/1129270878312734)

- some tests were changed late last night to get a build to pass in CI, those changes are reverted here
- use vanity URLs for map PDFs so content can manage this fully without requiring code changes when maps are updated

<br>
Assigned to: @meagonqz 
