### PR TITLE
add route_patterns app

### DIFF
--- a/apps/route_patterns/.formatter.exs
+++ b/apps/route_patterns/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/apps/route_patterns/.gitignore
+++ b/apps/route_patterns/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+route_patterns-*.tar
+

--- a/apps/route_patterns/README.md
+++ b/apps/route_patterns/README.md
@@ -1,0 +1,21 @@
+# RoutePatterns
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `route_patterns` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:route_patterns, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/route_patterns](https://hexdocs.pm/route_patterns).
+

--- a/apps/route_patterns/config/config.exs
+++ b/apps/route_patterns/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# third-party users, it should be done in your "mix.exs" file.
+
+# You can configure your application as:
+#
+#     config :route_patterns, key: :value
+#
+# and access this configuration in your application as:
+#
+#     Application.get_env(:route_patterns, :key)
+#
+# You can also configure a third-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env()}.exs"

--- a/apps/route_patterns/lib/application.ex
+++ b/apps/route_patterns/lib/application.ex
@@ -1,0 +1,20 @@
+defmodule RoutePatterns.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    # List all child processes to be supervised
+    children = [
+      # Starts a worker by calling: RoutePatterns.Worker.start_link(arg)
+      # {RoutePatterns.Worker, arg}
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: RoutePatterns.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/apps/route_patterns/lib/repo.ex
+++ b/apps/route_patterns/lib/repo.ex
@@ -1,0 +1,24 @@
+defmodule RoutePatterns.Repo do
+  @moduledoc false
+  alias RoutePatterns.RoutePattern
+  alias V3Api.RoutePatterns, as: RoutePatternsApi
+
+  def by_route_id(route_id, opts \\ []) do
+    opts
+    |> Keyword.get(:direction_id)
+    |> case do
+      nil -> [route: route_id]
+      direction_id -> [route: route_id, direction_id: direction_id]
+    end
+    |> RoutePatternsApi.all()
+    |> parse_api_response()
+  end
+
+  defp parse_api_response({:error, error}) do
+    {:error, error}
+  end
+
+  defp parse_api_response(%JsonApi{data: data}) do
+    Enum.map(data, &RoutePattern.new/1)
+  end
+end

--- a/apps/route_patterns/lib/route_pattern.ex
+++ b/apps/route_patterns/lib/route_pattern.ex
@@ -1,0 +1,60 @@
+defmodule RoutePatterns.RoutePattern do
+  @moduledoc """
+  Route patterns are used to describe the subsets of a route, representing different
+  possible patterns of where trips may serve. For example, a bus route may have multiple
+  branches, and each branch may be modeled as a separate route pattern per direction.
+  Hierarchically, the route pattern level may be considered to be larger than the trip
+  level and smaller than the route level.
+
+  For most MBTA modes, a route pattern will typically represent a unique set of stops
+  that may be served on a route-trip combination. Seasonal schedule changes may result
+  in trips within a route pattern having different routings. In simple changes, such a
+  single bus stop removed or added between one schedule rating and the next (for example,
+  between the Summer and Fall schedules), trips will be maintained on the same
+  route_pattern_id. If the changes are significant, a new route_pattern_id may be introduced.
+
+  For Commuter Rail, express or skip-stop trips use the same route pattern as local trips.
+  Some branches do have multiple route patterns when the train takes a different path.
+  For example, CR-Providence has two route patterns per direction, one for the Wickford
+  Junction branch and the other for the Stoughton branch.
+  """
+
+  alias JsonApi.Item
+
+  defstruct [
+    :direction_id,
+    :id,
+    :name,
+    :representative_trip_id,
+    :route_id,
+    :sort_order,
+    :time_desc,
+    :typicality
+  ]
+
+  def new(%Item{
+        id: id,
+        attributes: %{
+          "direction_id" => direction_id,
+          "name" => name,
+          "sort_order" => sort_order,
+          "time_desc" => time_desc,
+          "typicality" => typicality
+        },
+        relationships: %{
+          "representative_trip" => [%Item{id: representative_trip_id}],
+          "route" => [%Item{id: route_id}]
+        }
+      }) do
+    %__MODULE__{
+      direction_id: direction_id,
+      id: id,
+      name: name,
+      representative_trip_id: representative_trip_id,
+      route_id: route_id,
+      sort_order: sort_order,
+      time_desc: time_desc,
+      typicality: typicality
+    }
+  end
+end

--- a/apps/route_patterns/lib/route_patterns.ex
+++ b/apps/route_patterns/lib/route_patterns.ex
@@ -1,0 +1,18 @@
+defmodule RoutePatterns do
+  @moduledoc """
+  Documentation for RoutePatterns.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> RoutePatterns.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/apps/route_patterns/mix.exs
+++ b/apps/route_patterns/mix.exs
@@ -1,0 +1,34 @@
+defmodule RoutePatterns.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :route_patterns,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.8",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {RoutePatterns.Application, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      {:v3_api, in_umbrella: true}
+    ]
+  end
+end

--- a/apps/route_patterns/test/repo_test.exs
+++ b/apps/route_patterns/test/repo_test.exs
@@ -1,0 +1,17 @@
+defmodule RoutePatterns.RepoTest do
+  use ExUnit.Case, async: true
+  alias RoutePatterns.{Repo, RoutePattern}
+
+  describe "by_route_id" do
+    test "returns route patterns for a route" do
+      assert [%RoutePattern{} | _] = Repo.by_route_id("Red")
+    end
+
+    test "takes a direction_id param" do
+      all_patterns = Repo.by_route_id("Red")
+      assert all_patterns |> Enum.map(& &1.direction_id) |> Enum.uniq() == [0, 1]
+      alewife_patterns = Repo.by_route_id("Red", direction_id: 1)
+      assert alewife_patterns |> Enum.map(& &1.direction_id) |> Enum.uniq() == [1]
+    end
+  end
+end

--- a/apps/route_patterns/test/route_patterns_test.exs
+++ b/apps/route_patterns/test/route_patterns_test.exs
@@ -1,0 +1,8 @@
+defmodule RoutePatternsTest do
+  use ExUnit.Case
+  doctest RoutePatterns
+
+  test "greets the world" do
+    assert RoutePatterns.hello() == :world
+  end
+end

--- a/apps/route_patterns/test/test_helper.exs
+++ b/apps/route_patterns/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/apps/v3_api/lib/route_patterns.ex
+++ b/apps/v3_api/lib/route_patterns.ex
@@ -1,0 +1,8 @@
+defmodule V3Api.RoutePatterns do
+  @moduledoc false
+
+  @spec all(Keyword.t()) :: JsonApi.t() | {:error, any}
+  def all(params \\ []) do
+    V3Api.get_json("/route_patterns", params)
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** support for [TICKET_NAME](https://app.asana.com/0/555089885850811/1127979261717805)

Adds a RoutePatterns app for fetching route patterns. Will be used by the route variation dropdown on the schedule page.

<br>
Assigned to: @ryan-mahoney 
