### PR TITLE
speed up Transit Near Me

### DIFF
--- a/apps/site/test/site/transit_near_me_test.exs
+++ b/apps/site/test/site/transit_near_me_test.exs
@@ -208,12 +208,12 @@ defmodule Site.TransitNearMeTest do
       data = TransitNearMe.build(@address, date: @date, now: Util.now())
       routes = TransitNearMe.routes_for_stop(data, "place-pktrm")
 
-      assert Enum.map(routes, & &1.name) == [
-               "Red Line",
+      assert Enum.sort(Enum.map(routes, & &1.name)) == [
                "Green Line B",
                "Green Line C",
+               "Green Line D",
                "Green Line E",
-               "Green Line D"
+               "Red Line"
              ]
     end
   end

--- a/apps/site/test/site_web/controllers/transit_near_me/stops_with_routes_test.exs
+++ b/apps/site/test/site_web/controllers/transit_near_me/stops_with_routes_test.exs
@@ -61,15 +61,15 @@ defmodule SiteWeb.TransitNearMeController.StopsWithRoutesTest do
       assert distance == 0.04083664794103045
 
       expected_routes = [
-        red_line: [@subway],
-        mattapan_trolley: [@mattapan],
-        green_line: [Route.to_naive(@green_branch)],
         bus: [@bus],
         commuter_rail: [@cr],
-        ferry: [@ferry]
+        ferry: [@ferry],
+        green_line: [Route.to_naive(@green_branch)],
+        mattapan_trolley: [@mattapan],
+        red_line: [@subway]
       ]
 
-      assert routes == expected_routes
+      assert Enum.sort(routes) == expected_routes
     end
   end
 


### PR DESCRIPTION
#### Summary of changes

Some quick code improvements to speed up Transit Near Me.

Some future work would also be filtering the fetched predictions based on the `route_type` Predictions filter, but I don't understand the TNM code well enough to do that yet.

Testing script:
`ab -c 5 -n 10 'http://localhost:4001/transit-near-me/api?from=search-route--bus&query=Bank%20of%20America%20Financial%20Center%2C%20Washington%20Street%2C%20Boston%2C%20MA%2C%20USA&location[latitude]=42.352191&location[longitude]=-71.06252239999999&location[address]=Bank%20of%20America%20Financial%20Center%2C%20Washington%20Street%2C%20Boston%2C%20MA%2C%20USA&filter=bus'`


before:
```
Percentage of the requests served within a certain time (ms)
  50%   3400
  66%   3465
  75%   3481
  80%   3506
  90%   3534
  95%   3534
  98%   3534
  99%   3534
 100%   3534 (longest request)
```

after:
```
Percentage of the requests served within a certain time (ms)
  50%   1970
  66%   1981
  75%   2008
  80%   2012
  90%   2019
  95%   2019
  98%   2019
  99%   2019
 100%   2019 (longest request)
```
