### PR TITLE
Remove call to Services.Repo.by_route_id

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -64,11 +64,11 @@ defmodule SiteWeb.ScheduleController.LineController do
         fare_link: ScheduleView.route_fare_link(conn.assigns.route),
         holidays: conn.assigns.holidays,
         route: Route.to_json_safe(conn.assigns.route),
-        services:
-          conn.assigns.route.id
-          |> Services.Repo.by_route_id()
-          |> Enum.sort_by(&sort_services_by_date/1)
-          |> Enum.map(&Map.put(&1, :service_date, service_date)),
+        services: [],
+        # conn.assigns.route.id
+        # |> Services.Repo.by_route_id()
+        # |> Enum.sort_by(&sort_services_by_date/1)
+        # |> Enum.map(&Map.put(&1, :service_date, service_date)),
         schedule_note: ScheduleNote.new(conn.assigns.route),
         stops: simple_stop_list(conn.assigns.all_stops),
         direction_id: conn.assigns.direction_id

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -37,7 +37,7 @@ defmodule SiteWeb.ScheduleController.LineController do
   end
 
   def assign_schedule_page_data(conn) do
-    service_date = Util.service_date()
+    # service_date = Util.service_date()
 
     assign(
       conn,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket, hotfix

```
** (exit) an exception was raised:
    ** (UndefinedFunctionError) function Services.Repo.by_route_id/1 is undefined (module Services.Repo is not available)
        Services.Repo.by_route_id("Red")
        (site) lib/site_web/controllers/schedule/line_controller.ex:69: SiteWeb.ScheduleController.LineController.assign_schedule_page_data/1
        (site) lib/site_web/controllers/schedule/line_controller.ex:35: SiteWeb.ScheduleController.LineController.show/2
        (site) lib/site_web/controllers/schedule/line_controller.ex:1: SiteWeb.ScheduleController.LineController.action/2
        (site) lib/site_web/controllers/schedule/line_controller.ex:1: SiteWeb.ScheduleController.LineController.phoenix_controller_pipeline/2
        (site) lib/site_web/endpoint.ex:1: SiteWeb.Endpoint.instrument/4
        (phoenix) lib/phoenix/router.ex:275: Phoenix.Router.__call__/1
        (site) lib/plug/error_handler.ex:64: SiteWeb.Router.call/2
```

I'm not sure what's causing this, but if we don't call this function it'll resolve the 500s that are preventing a deploy.

<br>
Assigned to: @NAME
