### PR TITLE
feat: don't crash when there are no cookies

### DIFF
--- a/apps/site/assets/js/cookies.js
+++ b/apps/site/assets/js/cookies.js
@@ -5,13 +5,14 @@ export function getCookie(name) {
 export function getCookieFromString(cookies, name) {
   const cookieArray = cookies.split(";");
 
-  let cookieHash = {};
   for (let cookie in cookieArray) {
     let key;
     let value;
     [key, value] = cookieArray[cookie].split("=");
-    cookieHash[key.trim()] = value.trim();
+    if (key && key.trim() === name) {
+      return value.trim();
+    }
   }
 
-  return cookieHash[name];
+  return null;
 }

--- a/apps/site/assets/js/test/cookies_test.js
+++ b/apps/site/assets/js/test/cookies_test.js
@@ -3,6 +3,12 @@ import * as Cookies from "../cookies";
 
 describe("Cookies", () => {
   describe("getCookieFromString", () => {
+    it("gets correct result for no cookies", () => {
+      const cookies = "";
+      const result = Cookies.getCookieFromString(cookies, "cookie");
+      assert.equal(result, null);
+    });
+
     it("gets correct result for single cookie", () => {
       const cookies = "cookie1=value1";
       const result = Cookies.getCookieFromString(cookies, "cookie1");


### PR DESCRIPTION
I ran into this issue running the Wallaby tests. I didn't have any cookies,
so this lookup crashed each test.

We also don't need to build the hash: once we've found the key we're looking
for we can stop.

<br>
Assigned to: @ryan-mahoney 
