### PR TITLE
Use Repo.teasers for event index

### DIFF
--- a/apps/site/lib/site_web/controllers/event_controller.ex
+++ b/apps/site/lib/site_web/controllers/event_controller.ex
@@ -15,15 +15,19 @@ defmodule SiteWeb.EventController do
     {:ok, current_month} = Date.new(Util.today().year, Util.today().month, 1)
     date_range = EventDateRange.build(params, current_month)
 
-    events_fn = fn ->
-      date_range
-      |> Enum.into([])
-      |> Repo.events()
+    event_teasers_fn = fn ->
+      Repo.teasers(
+        type: :event,
+        items_per_page: 50,
+        date_op: "between",
+        date: [min: date_range.start_time_gt, max: date_range.start_time_lt],
+        sort_order: "ASC"
+      )
     end
 
     conn
     |> assign(:month, date_range.start_time_gt)
-    |> async_assign_default(:events, events_fn, [])
+    |> async_assign_default(:events, event_teasers_fn, [])
     |> assign(:breadcrumbs, [Breadcrumb.build("Events")])
     |> await_assign_all_default(__MODULE__)
     |> render("index.html", conn: conn)

--- a/apps/site/lib/site_web/controllers/project_controller.ex
+++ b/apps/site/lib/site_web/controllers/project_controller.ex
@@ -181,28 +181,15 @@ defmodule SiteWeb.ProjectController do
   end
 
   @spec get_events_async(integer, :past | :upcoming) :: (() -> [Teaser.t()])
-  def get_events_async(id, :past) do
+  def get_events_async(id, timeframe) do
     fn ->
       Repo.teasers(
         type: :event,
         related_to: id,
         items_per_page: 10,
-        date_op: "<",
+        date_op: (timeframe == :past && "<") || ">=",
         date: [value: "now"],
-        sort_order: "DESC"
-      )
-    end
-  end
-
-  def get_events_async(id, :upcoming) do
-    fn ->
-      Repo.teasers(
-        type: :event,
-        related_to: id,
-        items_per_page: 10,
-        date_op: ">=",
-        date: [value: "now"],
-        sort_order: "ASC"
+        sort_order: (timeframe == :past && "DESC") || "ASC"
       )
     end
   end

--- a/apps/site/lib/site_web/controllers/project_controller.ex
+++ b/apps/site/lib/site_web/controllers/project_controller.ex
@@ -1,7 +1,7 @@
 defmodule SiteWeb.ProjectController do
   use SiteWeb, :controller
 
-  alias Content.{Event, Project, ProjectUpdate, Repo, Teaser}
+  alias Content.{Project, ProjectUpdate, Repo, Teaser}
   alias Plug.Conn
   alias SiteWeb.ProjectView
 
@@ -57,10 +57,11 @@ defmodule SiteWeb.ProjectController do
 
   @spec show_project(Conn.t(), Project.t()) :: Conn.t()
   def show_project(conn, project) do
-    [events, updates, diversions] =
+    [past_events, upcoming_events, updates, diversions] =
       Util.async_with_timeout(
         [
-          get_events_async(project.id),
+          get_events_async(project.id, :past),
+          get_events_async(project.id, :upcoming),
           get_updates_async(project.id),
           get_diversions_async(project.id)
         ],
@@ -72,9 +73,6 @@ defmodule SiteWeb.ProjectController do
       Breadcrumb.build(@breadcrumb_base, project_path(conn, :index)),
       Breadcrumb.build(project.title)
     ]
-
-    {past_events, upcoming_events} =
-      Enum.split_with(events, &Event.past?(&1, conn.assigns.date_time))
 
     conn
     |> put_view(ProjectView)
@@ -182,8 +180,32 @@ defmodule SiteWeb.ProjectController do
     end
   end
 
-  @spec get_events_async(integer) :: (() -> [Event.t()])
-  def get_events_async(id), do: fn -> Repo.events(project_id: id) end
+  @spec get_events_async(integer, :past | :upcoming) :: (() -> [Teaser.t()])
+  def get_events_async(id, :past) do
+    fn ->
+      Repo.teasers(
+        type: :event,
+        related_to: id,
+        items_per_page: 10,
+        date_op: "<",
+        date: [value: "now"],
+        sort_order: "DESC"
+      )
+    end
+  end
+
+  def get_events_async(id, :upcoming) do
+    fn ->
+      Repo.teasers(
+        type: :event,
+        related_to: id,
+        items_per_page: 10,
+        date_op: ">=",
+        date: [value: "now"],
+        sort_order: "ASC"
+      )
+    end
+  end
 
   @spec get_updates_async(integer) :: (() -> [Teaser.t()])
   def get_updates_async(id) do

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -5,7 +5,7 @@
     <%= for event <- @events do %>
       <li class="list-group-item">
         <div>
-          <%= render_duration(event.date, nil) %>
+          <%= render_duration(event.date, event.date_end) %>
         </div>
         <div>
           <%= link to: cms_static_page_path(@conn, event.path) do %>

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -3,14 +3,23 @@
   <%= content_tag(:h2, @title, extra_classes) %>
   <ul class="list-group list-group-flush">
     <%= for event <- @events do %>
+      <%
+        range = case event do
+          %Content.Teaser{} = item -> %{start: item.date, stop: item.date_end}
+          %Content.Event{} = item -> %{start: item.start_time, stop: item.end_time}
+        end
+
+        path_fn = case event do
+          %Content.Teaser{path: path} -> fn -> cms_static_page_path(@conn, path) end
+          %Content.Event{} -> fn -> event_path(@conn, :show, event) end
+        end
+      %>
       <li class="list-group-item">
         <div>
-          <%= render_duration(event.date, event.date_end) %>
+          <%= render_duration(range.start, range.stop) %>
         </div>
         <div>
-          <%= link to: cms_static_page_path(@conn, event.path) do %>
-            <%= event.title %>
-          <% end %>
+          <%= link event.title, to: path_fn.() %>
         </div>
       </li>
     <% end %>

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -5,10 +5,10 @@
     <%= for event <- @events do %>
       <li class="list-group-item">
         <div>
-          <%= render_duration(event.start_time, event.end_time) %>
+          <%= render_duration(event.date, nil) %>
         </div>
         <div>
-          <%= link to: event_path(@conn, :show, event) do %>
+          <%= link to: cms_static_page_path(@conn, event.path) do %>
             <%= event.title %>
           <% end %>
         </div>

--- a/apps/site/lib/site_web/views/teaser_view.ex
+++ b/apps/site/lib/site_web/views/teaser_view.ex
@@ -13,16 +13,8 @@ defmodule SiteWeb.Content.TeaserView do
   def teaser_color(%Teaser{routes: []}), do: "unknown"
 
   @spec display_date(Teaser.t()) :: String.t()
-  def display_date(%Teaser{type: :event, date: date, date_end: nil}) do
+  def display_date(%Teaser{type: :event, date: date}) do
     Timex.format!(date, "{Mfull} {D}, {YYYY}, {h12}:{m} {AM}")
-  end
-
-  def display_date(%Teaser{type: :event, date: date_start, date_end: date_end}) do
-    [
-      Timex.format!(date_start, "{Mfull} {D}, {YYYY}, {h12}:{m} {AM}"),
-      " - ",
-      Timex.format!(date_end, "{h12}:{m} {AM}")
-    ]
   end
 
   def display_date(%Teaser{date: date}) do

--- a/apps/site/lib/site_web/views/teaser_view.ex
+++ b/apps/site/lib/site_web/views/teaser_view.ex
@@ -13,8 +13,16 @@ defmodule SiteWeb.Content.TeaserView do
   def teaser_color(%Teaser{routes: []}), do: "unknown"
 
   @spec display_date(Teaser.t()) :: String.t()
-  def display_date(%Teaser{type: :event, date: date}) do
+  def display_date(%Teaser{type: :event, date: date, date_end: nil}) do
     Timex.format!(date, "{Mfull} {D}, {YYYY}, {h12}:{m} {AM}")
+  end
+
+  def display_date(%Teaser{type: :event, date: date_start, date_end: date_end}) do
+    [
+      Timex.format!(date_start, "{Mfull} {D}, {YYYY}, {h12}:{m} {AM}"),
+      " - ",
+      Timex.format!(date_end, "{h12}:{m} {AM}")
+    ]
   end
 
   def display_date(%Teaser{date: date}) do

--- a/apps/site/test/site_web/controllers/project_controller_test.exs
+++ b/apps/site/test/site_web/controllers/project_controller_test.exs
@@ -37,7 +37,20 @@ defmodule SiteWeb.ProjectControllerTest do
         } ->
           {:ok, []}
 
-        "/cms/events", [project_id: 3004] ->
+        "/cms/teasers",
+        %{
+          related_to: 3004,
+          type: :event,
+          date_op: "<"
+        } ->
+          {:ok, []}
+
+        "/cms/teasers",
+        %{
+          related_to: 3004,
+          type: :event,
+          date_op: ">="
+        } ->
           {:ok, []}
       end
 
@@ -61,8 +74,20 @@ defmodule SiteWeb.ProjectControllerTest do
         })
         |> assert_called()
 
-        "/cms/events"
-        |> Static.view(project_id: 3004)
+        "/cms/teasers"
+        |> Static.view(%{
+          related_to: 3004,
+          type: :event,
+          date_op: "<"
+        })
+        |> assert_called()
+
+        "/cms/teasers"
+        |> Static.view(%{
+          related_to: 3004,
+          type: :event,
+          date_op: ">="
+        })
         |> assert_called()
       end
     end

--- a/apps/site/test/site_web/views/project_view_test.exs
+++ b/apps/site/test/site_web/views/project_view_test.exs
@@ -1,13 +1,14 @@
 defmodule SiteWeb.ProjectViewTest do
   use SiteWeb.ConnCase, async: true
 
-  alias Content.{Event, Field.Image, Paragraph.CustomHTML, Project, Teaser}
+  alias Content.{Field.Image, Paragraph.CustomHTML, Project, Teaser}
   alias Phoenix.HTML
   alias Plug.Conn
   alias SiteWeb.ProjectView
 
   @now Timex.now()
   @conn %Conn{}
+
   @project %Project{
     id: 1,
     updated_on: @now,
@@ -16,7 +17,20 @@ defmodule SiteWeb.ProjectViewTest do
     start_year: @now.year,
     status: "In Progress"
   }
-  @events [%Event{id: 1, start_time: @now, end_time: @now, path_alias: nil}]
+
+  @events [
+    %Teaser{
+      type: :event,
+      path: "/events/2019-12-16/joint-meeting-the-fiscal-management",
+      image: nil,
+      text: "event teaser",
+      title: "Event title",
+      date: @now,
+      date_end: @now,
+      id: 1
+    }
+  ]
+
   @updates [
     %Teaser{
       type: :project_update,
@@ -39,6 +53,7 @@ defmodule SiteWeb.ProjectViewTest do
       id: 2
     }
   ]
+
   @diversions [
     %Teaser{
       type: :diversion,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Use teaser request for Events](https://app.asana.com/0/555089885850811/958950737688914)

- dependent on #84 
- make event times naive once parsed to avoid double TZ shift
- we only have the start time at the moment, not the whole range
