### PR TITLE
Include current date/time in HEAT messages

### DIFF
--- a/apps/feedback/config/config.exs
+++ b/apps/feedback/config/config.exs
@@ -27,6 +27,7 @@ config :feedback,
   support_ticket_reply_email: System.get_env("SUPPORT_TICKET_REPLY_EMAIL") || "reply@test.com",
   mailgun_domain: System.get_env("MAILGUN_DOMAIN") || "",
   mailgun_key: System.get_env("MAILGUN_API_KEY") || "",
-  test_mail_file: "/tmp/mailgun.json"
+  test_mail_file: "/tmp/mailgun.json",
+  time_fetcher: DateTime
 
 import_config "#{Mix.env()}.exs"

--- a/apps/feedback/config/test.exs
+++ b/apps/feedback/config/test.exs
@@ -1,1 +1,4 @@
 use Mix.Config
+
+config :feedback,
+  time_fetcher: Feedback.FakeDateTime

--- a/apps/feedback/lib/fake_date_time.ex
+++ b/apps/feedback/lib/fake_date_time.ex
@@ -1,0 +1,7 @@
+defmodule Feedback.FakeDateTime do
+  def utc_now() do
+    # This timestamp is July 8 2019, 08:04:03 UTC
+    {:ok, test_time} = DateTime.from_unix(1_562_573_043)
+    test_time
+  end
+end

--- a/apps/feedback/lib/fake_date_time.ex
+++ b/apps/feedback/lib/fake_date_time.ex
@@ -1,5 +1,7 @@
 defmodule Feedback.FakeDateTime do
-  def utc_now() do
+  @moduledoc "Mock DateTime module for testing"
+
+  def utc_now do
     # This timestamp is July 8 2019, 08:04:03 UTC
     {:ok, test_time} = DateTime.from_unix(1_562_573_043)
     test_time

--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -32,7 +32,7 @@ defmodule Feedback.Mailer do
       <MODE></MODE>
       <LINE></LINE>
       <STATION></STATION>
-      <INCIDENTDATE></INCIDENTDATE>
+      <INCIDENTDATE>#{formatted_utc_timestamp()}</INCIDENTDATE>
       <VEHICLE></VEHICLE>
       <FIRSTNAME>#{format_first_name(message.name)}</FIRSTNAME>
       <LASTNAME>#{format_last_name(message.name)}</LASTNAME>
@@ -107,5 +107,12 @@ defmodule Feedback.Mailer do
       "" -> Application.get_env(:feedback, :support_ticket_reply_email)
       email -> email
     end
+  end
+
+  defp formatted_utc_timestamp() do
+    time_fetcher = Application.get_env(:feedback, :time_fetcher)
+
+    time_fetcher.utc_now
+    |> Timex.format!("{0M}/{0D}/{YYYY} {h24}:{m}")
   end
 end

--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -109,7 +109,7 @@ defmodule Feedback.Mailer do
     end
   end
 
-  defp formatted_utc_timestamp() do
+  defp formatted_utc_timestamp do
     time_fetcher = Application.get_env(:feedback, :time_fetcher)
 
     time_fetcher.utc_now

--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -110,7 +110,7 @@ defmodule Feedback.Mailer do
   end
 
   defp formatted_utc_timestamp do
-    time_fetcher = Application.get_env(:feedback, :time_fetcher)
+    time_fetcher = Application.get_env(:feedback, :time_fetcher) || DateTime
 
     time_fetcher.utc_now
     |> Timex.format!("{0M}/{0D}/{YYYY} {h24}:{m}")

--- a/apps/feedback/test/mailer_test.exs
+++ b/apps/feedback/test/mailer_test.exs
@@ -36,7 +36,7 @@ defmodule Feedback.MailerTest do
                  <MODE></MODE>
                  <LINE></LINE>
                  <STATION></STATION>
-                 <INCIDENTDATE></INCIDENTDATE>
+                 <INCIDENTDATE>07/08/2019 08:04</INCIDENTDATE>
                  <VEHICLE></VEHICLE>
                  <FIRSTNAME>Riding</FIRSTNAME>
                  <LASTNAME>Public</LASTNAME>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [ℹ️ Contact Us | Current Date and Time](https://app.asana.com/0/555089885850811/1129241877448150)

Messages to HEAT should make use of the `INCIDENTDATE` field, filling it in with a UTC timestamp in 24-hour format.

<br>
Assigned to: @meagonqz 
