### PR TITLE
Keep redirect [sub] params [if whitelisted]

### DIFF
--- a/apps/content/lib/cms/http_client.ex
+++ b/apps/content/lib/cms/http_client.ex
@@ -80,14 +80,6 @@ defmodule Content.CMS.HTTPClient do
     stringify_params({key <> "[#{sub_key}]", sub_val}, acc)
   end
 
-  # Nested params from 302 redirects come in as a single-pair Map.t() element
-  defp list_to_params(key, acc, val) when is_map(val) do
-    val
-    |> Map.to_list()
-    |> Enum.at(0)
-    |> (&list_to_params(key, acc, &1)).()
-  end
-
   # Drop entire param (key[subkey]=val) completely
   defp list_to_params(_, acc, _) do
     acc

--- a/apps/content/test/cms/http_client_test.exs
+++ b/apps/content/test/cms/http_client_test.exs
@@ -141,15 +141,15 @@ defmodule Content.CMS.HTTPClientTest do
       end
     end
 
-    test "nested key values in request work when being redirected by CMS" do
-      with_mock ExternalRequest, process: fn _method, _path, _body, _params -> {:ok, []} end do
+    test "nested and non-nested key values in request work when being redirected by CMS" do
+      with_mock ExternalRequest,
+        process: fn _method, _path, _body, _params -> {:ok, []} end do
         view(
           "/redirect",
           %{
-            "location" => [
-              %{"lattitude" => "1234"},
-              %{"longitude" => "5678"}
-            ]
+            "location" => %{"lattitude" => "1234", "longitude" => "5678"},
+            "foo" => %{"bad_sub_key" => "bar"},
+            "fiz" => "baz"
           }
         )
 
@@ -160,6 +160,7 @@ defmodule Content.CMS.HTTPClientTest do
                    "",
                    params: [
                      {"_format", "json"},
+                     {"fiz", "baz"},
                      {"location[lattitude]", "1234"},
                      {"location[longitude]", "5678"}
                    ]

--- a/apps/content/test/cms/http_client_test.exs
+++ b/apps/content/test/cms/http_client_test.exs
@@ -115,7 +115,16 @@ defmodule Content.CMS.HTTPClientTest do
 
     test "certain nested params are allowed, ordered, and keys are replaced by key[nested_key]" do
       with_mock ExternalRequest, process: fn _method, _path, _body, _params -> {:ok, []} end do
-        view("/path", %{"foo" => [bar: "baz", min: :should_be_string, max: "string"]})
+        view(
+          "/path",
+          %{
+            "foo" => [
+              bad_sub_key: "foobar",
+              min: :should_be_string,
+              max: "string"
+            ]
+          }
+        )
 
         assert called(
                  ExternalRequest.process(
@@ -126,6 +135,33 @@ defmodule Content.CMS.HTTPClientTest do
                      {"_format", "json"},
                      {"foo[min]", "should_be_string"},
                      {"foo[max]", "string"}
+                   ]
+                 )
+               )
+      end
+    end
+
+    test "nested key values in request work when being redirected by CMS" do
+      with_mock ExternalRequest, process: fn _method, _path, _body, _params -> {:ok, []} end do
+        view(
+          "/redirect",
+          %{
+            "location" => [
+              %{"lattitude" => "1234"},
+              %{"longitude" => "5678"}
+            ]
+          }
+        )
+
+        assert called(
+                 ExternalRequest.process(
+                   :get,
+                   "/redirect",
+                   "",
+                   params: [
+                     {"_format", "json"},
+                     {"location[lattitude]", "1234"},
+                     {"location[longitude]", "5678"}
                    ]
                  )
                )


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [AFC 2.0 Charlie | TNM vanity and UTM params](https://app.asana.com/0/555089885850811/1122614077520942)

[Please include a brief description of what was changed]

When the CMS API calls `view/2` on a Drupal path that is actually a redirect, we lost some of the params (both top-level and nested) due to the redirect using a Map and Strings vs. a List and Atoms to define the params.

This PR adds clauses and guards for redirects where the params are in this alternate format, and continues to sanitize nested and non-nested params.

I've also confirmed the CMS merges normal params from the request with those of the redirect location (it just had trouble with nested param format).

**Test Link** (note: connect to the live CMS when testing):

http://localhost:4001/transit-near-me-charlie?location[lattitude]=12345&location[longitude]=12345&badkey[badsubkey]=badbadbad

**Should redirect to:**

http://localhost:4001/transit-near-me?location%5Blattitude%5D=12345&location%5Blongitude%5D=12345&utm_campaign=charlie&utm_medium=transit-near-me&utm_source=cubic