### PR TITLE
make :route_patterns a dependency of :site app

### DIFF
--- a/apps/site/mix.exs
+++ b/apps/site/mix.exs
@@ -56,7 +56,8 @@ defmodule Site.Mixfile do
       :polyline,
       :util,
       :trip_plan,
-      :services
+      :services,
+      :route_patterns
     ]
 
     apps =
@@ -124,7 +125,8 @@ defmodule Site.Mixfile do
       {:util, in_umbrella: true},
       {:predictions, in_umbrella: true},
       {:trip_plan, in_umbrella: true},
-      {:services, in_umbrella: true}
+      {:services, in_umbrella: true},
+      {:route_patterns, in_umbrella: true}
     ]
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Look into schedule 500 error on dev](https://app.asana.com/0/555089885850811/1130522906709257)

The application build is crashing because `:route_patterns` was never added as a dependency to the `:site` application after the modules were referenced.

A similar issue happened recently with the `:services` application.

<br>
Assigned to: @meagonqz 
