### PR TITLE
Log messages to calculate predictions cache miss ratio

### DIFF
--- a/apps/predictions/lib/repo.ex
+++ b/apps/predictions/lib/repo.ex
@@ -13,6 +13,8 @@ defmodule Predictions.Repo do
   ]
 
   def all(opts) when is_list(opts) and opts != [] do
+    Logger.info("predictions_repo_all")
+
     @default_params
     |> add_optional_param(opts, :route)
     |> add_optional_param(opts, :stop)
@@ -31,6 +33,8 @@ defmodule Predictions.Repo do
   end
 
   defp fetch(params) do
+    Logger.info("predictions_repo_all_cache_miss")
+
     case V3Api.Predictions.all(params) do
       {:error, error} ->
         warn_error(params, error)

--- a/apps/predictions/lib/repo.ex
+++ b/apps/predictions/lib/repo.ex
@@ -13,7 +13,7 @@ defmodule Predictions.Repo do
   ]
 
   def all(opts) when is_list(opts) and opts != [] do
-    Logger.info("predictions_repo_all_cache=call")
+    _ = Logger.info("predictions_repo_all_cache=call")
 
     @default_params
     |> add_optional_param(opts, :route)
@@ -33,7 +33,7 @@ defmodule Predictions.Repo do
   end
 
   defp fetch(params) do
-    Logger.info("predictions_repo_all_cache=cache_miss")
+    _ = Logger.info("predictions_repo_all_cache=cache_miss")
 
     case V3Api.Predictions.all(params) do
       {:error, error} ->

--- a/apps/predictions/lib/repo.ex
+++ b/apps/predictions/lib/repo.ex
@@ -13,7 +13,7 @@ defmodule Predictions.Repo do
   ]
 
   def all(opts) when is_list(opts) and opts != [] do
-    Logger.info("predictions_repo_all")
+    Logger.info("predictions_repo_all_cache=call")
 
     @default_params
     |> add_optional_param(opts, :route)
@@ -33,7 +33,7 @@ defmodule Predictions.Repo do
   end
 
   defp fetch(params) do
-    Logger.info("predictions_repo_all_cache_miss")
+    Logger.info("predictions_repo_all_cache=cache_miss")
 
     case V3Api.Predictions.all(params) do
       {:error, error} ->


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔧 Performance: Log cache/hit ratio for predictions repo](https://app.asana.com/0/555089885850811/1129115952715485)

Added two log messages. One gets logged every time `Predictions.Repo.all` gets called, the other gets logged only when that function has a cache miss. From this, we can calculate our cache miss (or hit) ratio via Splunk.

<br>
Assigned to: @ryan-mahoney 
