### PR TITLE
If ¶s are present, use dynamic sidebar content

### DIFF
--- a/apps/site/lib/site_web/controllers/project_controller.ex
+++ b/apps/site/lib/site_web/controllers/project_controller.ex
@@ -74,6 +74,15 @@ defmodule SiteWeb.ProjectController do
       Breadcrumb.build(project.title)
     ]
 
+    {past_events, upcoming_events} =
+      Enum.split_with(events, &Event.past?(&1, conn.assigns.date_time))
+
+    {sidebar_class, sidebar_right} =
+      case {updates, diversions} do
+        {[], []} -> {"c-cms--no-sidebar", false}
+        {_, _} -> {"c-cms--with-sidebar c-cms--sidebar-right", true}
+      end
+
     conn
     |> put_view(ProjectView)
     |> render("show.html", %{
@@ -82,7 +91,9 @@ defmodule SiteWeb.ProjectController do
       updates: updates,
       past_events: past_events,
       upcoming_events: upcoming_events,
-      diversions: diversions
+      diversions: diversions,
+      sidebar_class: sidebar_class,
+      sidebar_right: sidebar_right
     })
   end
 

--- a/apps/site/lib/site_web/controllers/project_controller.ex
+++ b/apps/site/lib/site_web/controllers/project_controller.ex
@@ -74,9 +74,6 @@ defmodule SiteWeb.ProjectController do
       Breadcrumb.build(project.title)
     ]
 
-    {past_events, upcoming_events} =
-      Enum.split_with(events, &Event.past?(&1, conn.assigns.date_time))
-
     {sidebar_class, sidebar_right} =
       case {updates, diversions} do
         {[], []} -> {"c-cms--no-sidebar", false}

--- a/apps/site/lib/site_web/templates/project/show.html.eex
+++ b/apps/site/lib/site_web/templates/project/show.html.eex
@@ -1,12 +1,5 @@
-<%
-  {sidebar_class, sidebar_right} = case {@updates, @diversions} do
-    {[], []} -> {"c-cms--no-sidebar", false}
-    {_, _} -> {"c-cms--with-sidebar c-cms--sidebar-right", true}
-  end
-%>
-
 <div class="container">
-  <div class="c-cms <%= sidebar_class %>">
+  <div class="c-cms <%= @sidebar_class %>">
 
     <div class="c-cms__header">
       <div class="c-cms__title">
@@ -82,7 +75,7 @@
 
       <%# End main body column %>
 
-      <%= if sidebar_right do %>
+      <%= if @sidebar_right do %>
         <%= if Enum.empty?(@project.paragraphs) do %>
 
           <%# No paragraphs means use hard-coded sidebar components %>

--- a/apps/site/lib/site_web/templates/project/show.html.eex
+++ b/apps/site/lib/site_web/templates/project/show.html.eex
@@ -1,14 +1,18 @@
+<%
+  {sidebar_class, sidebar_right} = case {@updates, @diversions} do
+    {[], []} -> {"c-cms--no-sidebar", false}
+    {_, _} -> {"c-cms--with-sidebar c-cms--sidebar-right", true}
+  end
+%>
+
 <div class="container">
-  <% sidebar_class = case {@updates, @diversions} do
-    {[], []} -> "c-cms--no-sidebar"
-    {_, _} -> "c-cms--with-sidebar c-cms--sidebar-right"
-    end
-  %>
   <div class="c-cms <%= sidebar_class %>">
 
     <div class="c-cms__header">
       <div class="c-cms__title">
         <h1 class="c-cms__title-text"><%= @project.title %></h1>
+
+        <%# Always render the Updated on date as the first field %>
         <h2 class="c-cms__meta">Updated on <%= format_full_date(@project.updated_on) %></h2>
       </div>
     </div>
@@ -16,6 +20,8 @@
     <div class="c-cms__content">
       <div class="c-cms__body">
         <div class="page-section project-hero-image">
+
+          <%# Always render the featured image (if present) %>
           <%= if @project.featured_image do %>
             <figure class="c-media c-media--image c-media--wide">
               <div class="c-media__content">
@@ -27,6 +33,8 @@
 
         <%# If there are no paragraphs, use static fields: %>
         <%= if Enum.empty?(@project.paragraphs) do %>
+
+          <%# If there are no paragraphs, use static fields (old layout) %>
           <%= if @project.start_year || @project.status do %>
             <div class="page-section project-summary">
               <%= if @project.start_year do %>
@@ -50,25 +58,48 @@
 
           <%= unless Enum.empty?(@past_events), do: SiteWeb.EventView.render "_event_list.html",
             events: @past_events, title: "Past Meetings", conn: @conn %>
+
         <% else %>
+
+          <%# Only render paragraphs if at least one is present %>
           <%= for paragraph <- @project.paragraphs do %>
             <%= SiteWeb.ContentView.render_paragraph(paragraph, @conn) %>
           <% end %>
+
         <% end %>
 
+        <%# Always render the Contact information component %>
         <%= if Content.Project.contact?(@project), do: render "_contact.html", project: @project %>
 
-          <%# Project Updates section placement for one-column width: %>
+        <%= if Enum.empty?(@project.paragraphs) do %>
+
+          <%# Project Updates section placement for one-column width (project w/o paragraphs) %>
           <%= unless Enum.empty?(@diversions), do: render("_diversions.html", conn: @conn, teasers: @diversions, class: "c-paragraph--right-rail u-full-bleed") %>
           <%= unless Enum.empty?(@updates), do: render "_updates.html", conn: @conn, updates: @updates, project: @project, class: "c-paragraph--right-rail u-full-bleed" %>
+
+        <% end %>
       </div>
 
-      <%= unless Enum.empty?(@updates) && Enum.empty?(@diversions) do %>
-        <div class="c-cms__sidebar">
-          <%= unless Enum.empty?(@diversions), do: render("_diversions.html", conn: @conn, teasers: @diversions, class: "") %>
-          <%= unless Enum.empty?(@updates), do: render("_updates.html", conn: @conn, updates: @updates, project: @project, class: "") %>
-        </div>
+      <%# End main body column %>
+
+      <%= if sidebar_right do %>
+        <%= if Enum.empty?(@project.paragraphs) do %>
+
+          <%# No paragraphs means use hard-coded sidebar components %>
+          <div class="c-cms__sidebar">
+            <%= unless Enum.empty?(@diversions), do: render("_diversions.html", conn: @conn, teasers: @diversions, class: "") %>
+            <%= unless Enum.empty?(@updates), do: render("_updates.html", conn: @conn, updates: @updates, project: @project, class: "") %>
+          </div>
+
+        <% else %>
+
+          <%# If paragraphs are present, rely 100% on them for sidebar components %>
+          <%= render(SiteWeb.ContentView, "_sidebar_right.html", page: @project, conn: @conn) %>
+
+        <% end %>
       <% end %>
+
+      <%# End sidebar column %>
     </div>
   </div>
 </div>

--- a/apps/site/test/site_web/views/project_view_test.exs
+++ b/apps/site/test/site_web/views/project_view_test.exs
@@ -65,6 +65,7 @@ defmodule SiteWeb.ProjectViewTest do
       id: 3
     }
   ]
+  @sidebar_class "c-cms--with-sidebar c-cms--sidebar-right"
 
   describe "show_all_updates_link?" do
     test "returns false if there are 3 items or less" do
@@ -104,7 +105,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -116,6 +119,33 @@ defmodule SiteWeb.ProjectViewTest do
       refute output =~ "Status:"
     end
 
+    test "if right rail paragraphs are present, right sidebar should be comprised of dynamic content" do
+      project =
+        @project
+        |> Map.put(:paragraphs, [
+          %CustomHTML{body: "Paragraph content"},
+          %CustomHTML{body: "Sidebar content", right_rail: true}
+        ])
+
+      output =
+        "show.html"
+        |> ProjectView.render(
+          project: project,
+          updates: @updates,
+          diversions: @diversions,
+          conn: @conn,
+          upcoming_events: @events,
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
+        )
+        |> HTML.safe_to_string()
+
+      assert output =~ "Paragraph content"
+      assert output =~ "Sidebar content"
+      refute output =~ "teaser2"
+    end
+
     test "if paragraphs are not present, show timeline, status" do
       output =
         "show.html"
@@ -125,7 +155,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -147,7 +179,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -166,7 +200,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -184,7 +220,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -202,7 +240,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -220,7 +260,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -238,7 +280,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -256,7 +300,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -274,7 +320,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -292,7 +340,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -310,7 +360,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -328,7 +380,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -346,7 +400,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -366,7 +422,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -383,7 +441,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 
@@ -406,7 +466,9 @@ defmodule SiteWeb.ProjectViewTest do
           diversions: @diversions,
           conn: @conn,
           upcoming_events: @events,
-          past_events: @events
+          past_events: @events,
+          sidebar_class: @sidebar_class,
+          sidebar_right: true
         )
         |> HTML.safe_to_string()
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Remove hard-coded project sidebar](https://app.asana.com/0/555089885850811/1117410708814904)

When paragraphs are present, don't use the hard-coded sidebar; use the dynamic sidebar that generic pages use (includes ordered paragraphs of content lists).
- added comments
- simplified if/then logic/conditions