### PR TITLE
Remove hard-coded H2 from project template

### DIFF
--- a/apps/site/lib/site_web/templates/project/show.html.eex
+++ b/apps/site/lib/site_web/templates/project/show.html.eex
@@ -25,8 +25,6 @@
           <% end %>
         </div>
 
-        <h2>About the Project</h2>
-
         <%# If there are no paragraphs, use static fields: %>
         <%= if Enum.empty?(@project.paragraphs) do %>
           <%= if @project.start_year || @project.status do %>

--- a/apps/site/test/site_web/views/project_view_test.exs
+++ b/apps/site/test/site_web/views/project_view_test.exs
@@ -136,7 +136,7 @@ defmodule SiteWeb.ProjectViewTest do
         )
         |> HTML.safe_to_string()
 
-      assert output =~ "About the Project"
+      refute output =~ "About the Project"
       assert output =~ "Project Updates"
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Project pages | Remove "About the project" H1 from template](https://app.asana.com/0/555089885850811/1128553720328271)

Self-explanatory.