### PR TITLE
Intelligent / overridable Content List CTAs

### DIFF
--- a/apps/content/lib/cms/static.ex
+++ b/apps/content/lib/cms/static.ex
@@ -70,6 +70,10 @@ defmodule Content.CMS.Static do
     parse_json("cms/teasers_diversion.json")
   end
 
+  def teaser_empty_response do
+    []
+  end
+
   # Repositories of multiple, full-object responses (maximum data)
 
   def news_repo do
@@ -373,6 +377,10 @@ defmodule Content.CMS.Static do
 
   def view("/cms/teasers", %{type: :project_update}) do
     {:ok, teaser_project_update_response()}
+  end
+
+  def view("/cms/teasers", %{promoted: 0}) do
+    {:ok, teaser_empty_response()}
   end
 
   def view("/cms/teasers", %{type: :diversion}) do

--- a/apps/content/lib/paragraph/content_list.ex
+++ b/apps/content/lib/paragraph/content_list.ex
@@ -7,22 +7,26 @@ defmodule Content.Paragraph.ContentList do
   import Content.Helpers, only: [field_value: 2, int_or_string_to_int: 1, content_type: 1]
   import Content.Paragraph, only: [parse_header: 1]
 
-  alias Content.{Paragraph.ColumnMultiHeader, Repo, Teaser}
+  alias Content.{Field.Link, Paragraph.ColumnMultiHeader, Repo, Teaser}
 
   defstruct header: nil,
             right_rail: false,
             ingredients: %{},
             recipe: [],
-            teasers: []
+            teasers: [],
+            more_link: nil
 
   @type order :: :DESC | :ASC
+
+  @type text_or_nil :: String.t() | nil
 
   @type t :: %__MODULE__{
           header: ColumnMultiHeader.t() | nil,
           right_rail: boolean(),
           ingredients: map(),
           recipe: Keyword.t(),
-          teasers: [Teaser.t()]
+          teasers: [Teaser.t()],
+          more_link: Link.t() | nil
         }
 
   @spec from_api(map) :: t
@@ -53,11 +57,20 @@ defmodule Content.Paragraph.ContentList do
 
     recipe = combine(ingredients)
 
+    more_link =
+      setup_link(
+        ingredients,
+        field_value(data, "field_more_link_behavior"),
+        field_value(data, "field_more_link"),
+        field_value(data, "field_more_text")
+      )
+
     %__MODULE__{
       header: parse_header(data),
       right_rail: field_value(data, "field_right_rail"),
       ingredients: ingredients,
-      recipe: recipe
+      recipe: recipe,
+      more_link: more_link
     }
   end
 
@@ -207,8 +220,75 @@ defmodule Content.Paragraph.ContentList do
   end
 
   # Convert order value strings to atoms
-  @spec order(String.t() | nil) :: order()
+  @spec order(text_or_nil) :: order()
   defp order("ASC"), do: :ASC
   defp order("DESC"), do: :DESC
   defp order(_), do: nil
+
+  @spec setup_link(map(), text_or_nil, text_or_nil, text_or_nil) :: Link.t() | nil
+  defp setup_link(ingredients, "show", nil, nil) do
+    default_link(ingredients)
+  end
+
+  defp setup_link(ingredients, "show", url, title) do
+    custom_link(ingredients, url, title)
+  end
+
+  defp setup_link(_, "hide", _, _) do
+    nil
+  end
+
+  defp setup_link(ingredients, _auto, _, _) do
+    default_link(ingredients)
+  end
+
+  @spec custom_link(map, text_or_nil, text_or_nil) :: Link.t() | nil
+  defp custom_link(ingredients, url, nil) do
+    ingredients
+    |> default_link()
+    |> Map.put(:url, url)
+  end
+
+  defp custom_link(ingredients, nil, title) do
+    ingredients
+    |> default_link()
+    |> Map.put(:title, title)
+  end
+
+  defp custom_link(_, _, _) do
+    nil
+  end
+
+  @spec default_link(map) :: Link.t()
+  defp default_link(%{host_id: id, type: :project_update}) do
+    %Link{
+      title: "View all project updates",
+      url: "/projects/#{id}/updates"
+    }
+  end
+
+  defp default_link(%{type: :event}) do
+    %Link{
+      title: "View all events",
+      url: "/events"
+    }
+  end
+
+  defp default_link(%{type: :news_entry}) do
+    %Link{
+      title: "View all news",
+      url: "/news"
+    }
+  end
+
+  defp default_link(%{type: :project}) do
+    %Link{
+      title: "View all projects",
+      url: "/projects"
+    }
+  end
+
+  defp default_link(_) do
+    nil
+  end
 end

--- a/apps/site/lib/site_web/templates/content/_content_list.html.eex
+++ b/apps/site/lib/site_web/templates/content/_content_list.html.eex
@@ -7,7 +7,7 @@
       type: Keyword.get(@content.recipe, :type, :generic),
       conn: @conn) %>
 
-<%= if list_cta?({@content.ingredients.type, @content.cta}, @content.teasers, @conn.path_info) do %>
+<%= if list_cta?(@content.ingredients.type, @content.cta, @content.teasers, @conn.path_info) do %>
   <% cta = setup_list_cta(@content, @conn.path_info) %>
 
   <p>

--- a/apps/site/lib/site_web/templates/content/_content_list.html.eex
+++ b/apps/site/lib/site_web/templates/content/_content_list.html.eex
@@ -3,7 +3,14 @@
 <% end %>
 
 <%= render("_teaser_list.html",
-      list: @content,
       teasers: @content.teasers,
       type: Keyword.get(@content.recipe, :type, :generic),
       conn: @conn) %>
+
+<%= if list_cta?({@content.ingredients.type, @content.cta}, @content.teasers, @conn.path_info) do %>
+  <% cta = setup_list_cta(@content, @conn.path_info) %>
+
+  <p>
+    <%= link cta.title, to: cms_static_page_path(@conn, cta.url), class: "c-call-to-action" %>
+  </p>
+<% end %>

--- a/apps/site/lib/site_web/templates/content/_content_list.html.eex
+++ b/apps/site/lib/site_web/templates/content/_content_list.html.eex
@@ -3,6 +3,7 @@
 <% end %>
 
 <%= render("_teaser_list.html",
+      list: @content,
       teasers: @content.teasers,
       type: Keyword.get(@content.recipe, :type, :generic),
       conn: @conn) %>

--- a/apps/site/lib/site_web/templates/content/_teaser_list.html.eex
+++ b/apps/site/lib/site_web/templates/content/_teaser_list.html.eex
@@ -7,9 +7,13 @@
     %>
 
     <%= link to: cms_static_page_path(@conn, teaser.path), id: teaser.id,
-             class: "c-content-teaser c-content-teaser--#{css_type} c-content-teaser--#{color}" do %>
+            class: "c-content-teaser c-content-teaser--#{css_type} c-content-teaser--#{color}" do %>
       <%= SiteWeb.Content.TeaserView.render("_#{@type}.html", teaser: teaser, conn: @conn) %>
     <% end %>
 
+  <% end %>
+
+  <%= if SiteWeb.Content.TeaserView.list_more_link?(@list, @teasers) do %>
+    <%= link(@list.more_link.title, class: "c-call-to-action", to: @list.more_link.url) %>
   <% end %>
 </div>

--- a/apps/site/lib/site_web/templates/content/_teaser_list.html.eex
+++ b/apps/site/lib/site_web/templates/content/_teaser_list.html.eex
@@ -12,8 +12,4 @@
     <% end %>
 
   <% end %>
-
-  <%= if SiteWeb.Content.TeaserView.list_more_link?(@list, @teasers) do %>
-    <%= link(@list.more_link.title, class: "c-call-to-action", to: @list.more_link.url) %>
-  <% end %>
 </div>

--- a/apps/site/lib/site_web/views/content_view.ex
+++ b/apps/site/lib/site_web/views/content_view.ex
@@ -6,9 +6,12 @@ defmodule SiteWeb.ContentView do
 
   import SiteWeb.TimeHelpers
 
+  alias Content.CMS
   alias Content.Field.{File, Image, Link}
   alias Content.Paragraph
   alias Content.Paragraph.{Callout, ColumnMulti, ContentList, FareCard}
+  alias Content.Teaser
+  alias Plug.Conn
   alias Site.ContentRewriter
 
   defdelegate fa_icon_for_file_type(mime), to: Site.FontAwesomeHelpers
@@ -25,7 +28,7 @@ defmodule SiteWeb.ContentView do
   end
 
   @doc "Universal wrapper around all paragraph types"
-  @spec render_paragraph(Paragraph.t(), Plug.Conn.t()) :: Phoenix.HTML.safe()
+  @spec render_paragraph(Paragraph.t(), Conn.t()) :: Phoenix.HTML.safe()
   # Don't render Content List if list has no items
   def render_paragraph(%ContentList{teasers: []}, _), do: []
 
@@ -43,7 +46,7 @@ defmodule SiteWeb.ContentView do
   Intelligently choose and render paragraph template based on type, except
   for certain types which either have no template or require special values.
   """
-  @spec render_content(Paragraph.t(), Plug.Conn.t()) :: Phoenix.HTML.safe()
+  @spec render_content(Paragraph.t(), Conn.t()) :: Phoenix.HTML.safe()
   def render_content(paragraph, conn)
 
   def render_content(%ColumnMulti{display_options: "grouped"} = paragraph, conn) do
@@ -132,6 +135,49 @@ defmodule SiteWeb.ContentView do
     end
   end
 
+  @spec list_cta?({CMS.type(), map()}, [Teaser.t()], [String.t()]) :: boolean()
+  # No results
+  def list_cta?(_, [], _) do
+    false
+  end
+
+  # Is not requested (hide)
+  def list_cta?({_, %{behavior: "hide"}}, _, _) do
+    false
+  end
+
+  # Is a list of project updates, AND is sitting on a valid project page
+  def list_cta?({:project_update, _}, _, ["projects", _]) do
+    true
+  end
+
+  # Is requested (auto/overridden) BUT has no default (generic destination) AND user has not provided a link
+  def list_cta?({type, %{url: url, text: text}}, _, _)
+      when type in [:project_update, :diversion, :page] and (is_nil(url) or is_nil(text)) do
+    false
+  end
+
+  # Either has required link values or has a readily available default link path
+  def list_cta?(_, _, _) do
+    true
+  end
+
+  @spec setup_list_cta(ContentList.t(), [String.t()]) :: Link.t()
+  def setup_list_cta(list, conn_path) do
+    current_path =
+      [""]
+      |> Enum.concat(conn_path)
+      |> Enum.join("/")
+
+    case list.cta do
+      %{text: nil, url: nil} ->
+        default_list_cta(list.ingredients.type, current_path)
+
+      link_parts ->
+        custom_list_cta(list.ingredients.type, link_parts, current_path)
+    end
+  end
+
   defp maybe_shift_timezone(%NaiveDateTime{} = time) do
     time
   end
@@ -191,4 +237,55 @@ defmodule SiteWeb.ContentView do
   @spec paragraph_classes(Paragraph.t()) :: iodata()
   defp paragraph_classes(%Callout{image: %Image{}}), do: ["c-callout--with-image"]
   defp paragraph_classes(_), do: []
+
+  # Automatically map each list to a destination page based on content type
+  @spec default_list_cta(CMS.type(), String.t()) :: Link.t()
+  defp default_list_cta(:project_update, current_path) do
+    %Link{
+      title: "View all project updates",
+      url: "#{current_path}/updates"
+    }
+  end
+
+  defp default_list_cta(:event, _current_path) do
+    %Link{
+      title: "View all events",
+      url: "/events"
+    }
+  end
+
+  defp default_list_cta(:news_entry, _current_path) do
+    %Link{
+      title: "View all news",
+      url: "/news"
+    }
+  end
+
+  defp default_list_cta(:project, _current_path) do
+    %Link{
+      title: "View all projects",
+      url: "/projects"
+    }
+  end
+
+  # Override one or both of the url/text values for the list CTA
+  @spec custom_list_cta(CMS.type(), map, String.t()) :: Link.t()
+  defp custom_list_cta(type, %{text: nil, url: url}, current_path) do
+    type
+    |> default_list_cta(current_path)
+    |> Map.put(:url, url)
+  end
+
+  defp custom_list_cta(type, %{text: text, url: nil}, current_path) do
+    type
+    |> default_list_cta(current_path)
+    |> Map.put(:title, text)
+  end
+
+  defp custom_list_cta(_type, %{text: text, url: url}, _current_path) do
+    %Link{
+      title: text,
+      url: url
+    }
+  end
 end

--- a/apps/site/lib/site_web/views/content_view.ex
+++ b/apps/site/lib/site_web/views/content_view.ex
@@ -135,38 +135,37 @@ defmodule SiteWeb.ContentView do
     end
   end
 
-  @spec list_cta?({CMS.type(), map()}, [Teaser.t()], [String.t()]) :: boolean()
+  @spec list_cta?(CMS.type(), map(), [Teaser.t()], [String.t()]) :: boolean()
   # No results
-  def list_cta?(_, [], _) do
+  def list_cta?(_type, _cta, [], _path) do
     false
   end
 
   # Is not requested (hide)
-  def list_cta?({_, %{behavior: "hide"}}, _, _) do
+  def list_cta?(_type, %{behavior: "hide"}, _teasers, _path) do
     false
   end
 
   # Is a list of project updates, AND is sitting on a valid project page
-  def list_cta?({:project_update, _}, _, ["projects", _]) do
+  def list_cta?(:project_update, _cta, _teasers, ["projects", _]) do
     true
   end
 
   # Is requested (auto/overridden) BUT has no default (generic destination) AND user has not provided a link
-  def list_cta?({type, %{url: url, text: text}}, _, _)
+  def list_cta?(type, %{url: url, text: text}, _teasers, _path)
       when type in [:project_update, :diversion, :page] and (is_nil(url) or is_nil(text)) do
     false
   end
 
   # Either has required link values or has a readily available default link path
-  def list_cta?(_, _, _) do
+  def list_cta?(_type, _cta, _teasers, _path) do
     true
   end
 
   @spec setup_list_cta(ContentList.t(), [String.t()]) :: Link.t()
   def setup_list_cta(list, conn_path) do
     current_path =
-      [""]
-      |> Enum.concat(conn_path)
+      ["" | conn_path]
       |> Enum.join("/")
 
     case list.cta do

--- a/apps/site/lib/site_web/views/teaser_view.ex
+++ b/apps/site/lib/site_web/views/teaser_view.ex
@@ -6,7 +6,6 @@ defmodule SiteWeb.Content.TeaserView do
 
   import SiteWeb.ContentHelpers, only: [cms_route_to_class: 1]
 
-  alias Content.Paragraph.ContentList
   alias Content.Teaser
 
   @spec teaser_color(Teaser.t()) :: String.t()
@@ -30,9 +29,4 @@ defmodule SiteWeb.Content.TeaserView do
     |> Enum.reject(&is_nil/1)
     |> Enum.join(", ")
   end
-
-  @spec list_more_link?(ContentList.t(), [Teaser.t()]) :: boolean()
-  def list_more_link?(_, []), do: false
-  def list_more_link?(%ContentList{more_link: nil}, _), do: false
-  def list_more_link?(_, _), do: true
 end

--- a/apps/site/lib/site_web/views/teaser_view.ex
+++ b/apps/site/lib/site_web/views/teaser_view.ex
@@ -6,6 +6,7 @@ defmodule SiteWeb.Content.TeaserView do
 
   import SiteWeb.ContentHelpers, only: [cms_route_to_class: 1]
 
+  alias Content.Paragraph.ContentList
   alias Content.Teaser
 
   @spec teaser_color(Teaser.t()) :: String.t()
@@ -29,4 +30,9 @@ defmodule SiteWeb.Content.TeaserView do
     |> Enum.reject(&is_nil/1)
     |> Enum.join(", ")
   end
+
+  @spec list_more_link?(ContentList.t(), [Teaser.t()]) :: boolean()
+  def list_more_link?(_, []), do: false
+  def list_more_link?(%ContentList{more_link: nil}, _), do: false
+  def list_more_link?(_, _), do: true
 end

--- a/apps/site/test/site_web/views/content_view_test.exs
+++ b/apps/site/test/site_web/views/content_view_test.exs
@@ -100,7 +100,7 @@ defmodule SiteWeb.ContentViewTest do
     end
 
     test "renders a diversion as a generic page", %{diversion: diversion} do
-      fake_conn = %{request_path: "/"}
+      fake_conn = %{request_path: "/", path_info: ["diversions", "diversion-2"]}
 
       rendered =
         "page.html"
@@ -389,8 +389,11 @@ defmodule SiteWeb.ContentViewTest do
             type: :project_update,
             date: "now",
             date_op: ">="
-          ]
+          ],
+          cta: %{behavior: "default", text: nil, url: nil}
         })
+
+      conn = Map.put(conn, :path_info, ["projects", "a-project"])
 
       rendered =
         paragraph
@@ -401,6 +404,8 @@ defmodule SiteWeb.ContentViewTest do
       assert rendered =~ "c-teaser-list--project-update"
       assert rendered =~ "c-content-teaser--project-update"
       assert rendered =~ "Header copy"
+      assert rendered =~ "c-call-to-action"
+      assert rendered =~ "View all project updates"
     end
 
     test "does not render empty content lists", %{conn: conn} do
@@ -879,6 +884,206 @@ defmodule SiteWeb.ContentViewTest do
 
     test "wraps content with nothing if the condition is false" do
       assert extend_width_if(false, :table, do: "foo") == "foo"
+    end
+  end
+
+  describe "list_cta?/3" do
+    test "does not render CTA if there are no teaser results", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :event},
+          recipe: [promoted: 0],
+          cta: %{behavior: "default", text: nil, url: nil}
+        })
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      refute rendered =~ "c-call-to-action"
+    end
+
+    test "does not render CTA if author has selected to hide the CTA", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :project_update},
+          recipe: [type: :project_update],
+          cta: %{behavior: "hide", text: nil, url: nil}
+        })
+
+      conn = Map.put(conn, :path_info, ["projects", "a-project"])
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      refute rendered =~ "c-call-to-action"
+    end
+
+    test "does not render CTA for project updates list if not on a project", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :project_update},
+          recipe: [type: :project_update],
+          cta: %{behavior: "default", text: nil, url: nil}
+        })
+
+      conn = Map.put(conn, :path_info, ["not-projects", "not-a-project"])
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      refute rendered =~ "c-call-to-action"
+    end
+
+    test "renders CTA for project updates list on non-project if overridden", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :project_update},
+          recipe: [type: :project_update],
+          cta: %{behavior: "default", text: "Custom CTA", url: "/project/manually-linked/updates"}
+        })
+
+      conn = Map.put(conn, :path_info, ["not-projects", "not-a-project"])
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "c-call-to-action"
+      assert rendered =~ "Custom CTA"
+      assert rendered =~ "/project/manually-linked/updates"
+    end
+
+    test "does not render CTA for types that have no generic destination", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :diversion},
+          recipe: [type: :diversion],
+          cta: %{behavior: "default", text: nil, url: nil}
+        })
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      refute rendered =~ "c-call-to-action"
+    end
+
+    test "renders CTA for types without generic destination if overridden", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :diversion},
+          recipe: [type: :diversion],
+          cta: %{behavior: "default", text: "Go here!", url: "/news"}
+        })
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "c-call-to-action"
+      assert rendered =~ "Go here!"
+      assert rendered =~ "/news"
+    end
+  end
+
+  describe "setup_list_cta/2" do
+    test "renders automatic CTA for news content lists", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :news_entry},
+          recipe: [type: :news_entry],
+          cta: %{behavior: "default", text: nil, url: nil}
+        })
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "c-call-to-action"
+      assert rendered =~ "View all news"
+      assert rendered =~ "/news"
+    end
+
+    test "renders automatic CTA for event content lists", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :event},
+          recipe: [type: :event],
+          cta: %{behavior: "default", text: nil, url: nil}
+        })
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "c-call-to-action"
+      assert rendered =~ "View all events"
+      assert rendered =~ "/events"
+    end
+
+    test "renders automatic CTA for project content lists", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :project},
+          recipe: [type: :project],
+          cta: %{behavior: "default", text: nil, url: nil}
+        })
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "c-call-to-action"
+      assert rendered =~ "View all projects"
+      assert rendered =~ "/projects"
+    end
+
+    test "renders default CTA url but with overridden CTA text from author", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :event},
+          recipe: [type: :event],
+          cta: %{behavior: "default", text: "More where that came from...", url: nil}
+        })
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "c-call-to-action"
+      assert rendered =~ "More where that came from..."
+      assert rendered =~ "/events"
+    end
+
+    test "renders default CTA text but with overridden CTA url from author", %{conn: conn} do
+      paragraph =
+        ContentList.fetch_teasers(%ContentList{
+          ingredients: %{type: :event},
+          recipe: [type: :event],
+          cta: %{behavior: "default", text: nil, url: "/special-events"}
+        })
+
+      rendered =
+        paragraph
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "c-call-to-action"
+      assert rendered =~ "View all events"
+      assert rendered =~ "/special-events"
     end
   end
 end

--- a/apps/site/test/site_web/views/content_view_test.exs
+++ b/apps/site/test/site_web/views/content_view_test.exs
@@ -896,12 +896,7 @@ defmodule SiteWeb.ContentViewTest do
           cta: %{behavior: "default", text: nil, url: nil}
         })
 
-      rendered =
-        paragraph
-        |> render_paragraph(conn)
-        |> HTML.safe_to_string()
-
-      refute rendered =~ "c-call-to-action"
+      assert [] = render_paragraph(paragraph, conn)
     end
 
     test "does not render CTA if author has selected to hide the CTA", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Automatically add "View More" link to content lists](https://app.asana.com/0/555089885850811/1117410708814919)

**NOTE:** Depends on mbta/cms#283

Since we are no longer hard-coding sidebar lists like Project Updates and they now come direct from the CMS, we can parse new CTA-related fields from this paragraph type to generate a relevant "View all..." link below the list of teasers.

Authors are also able to override this behavior by either hiding the CTA all together, or overriding either or both the CTA text or CTA url.

This makes content lists much more powerful for teasing a subset of content that lives elsewhere on the website (or even on an external website).

