### PR TITLE
ensure desktop menu z-index above map

### DIFF
--- a/apps/site/assets/css/_variables.scss
+++ b/apps/site/assets/css/_variables.scss
@@ -112,6 +112,7 @@ $btn-padding-x: $base-spacing * 1.6;
 $btn-padding-y: $base-spacing * .6;
 
 $z-index-modal: 101;
+$z-index-desktop-menu: 100;
 $z-index-above-leaflet: 23;
 $z-index-leaflet-level-8: 21;
 $z-index-leaflet-level-7: 21;
@@ -121,7 +122,6 @@ $z-index-leaflet-level-4: 18;
 $z-index-leaflet-level-3: 17;
 $z-index-leaflet-level-2: 16;
 $z-index-leaflet-level-1: 15;
-$z-index-desktop-menu: 14;
 $zindex-sticky: 13;
 $z-index-datepicker-content: 12;
 $z-index-search-bar-results: 11;


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Trip Planner | map renders on top of nav dropdown](https://app.asana.com/0/555089885850811/1130270846783244)

Change `z-index` of desktop menu to ensure it is higher than leaflet `z-index`.

---
<img width="941" alt="Screen Shot 2019-07-18 at 4 02 15 PM" src="https://user-images.githubusercontent.com/988609/61488185-981fcf00-a975-11e9-9650-68514e2dfc25.png">

<br>
Assigned to: @phildarnowsky  
