### PR TITLE
Only use new schedule loader if root element present

### DIFF
--- a/apps/site/assets/ts/schedule/schedule-loader.tsx
+++ b/apps/site/assets/ts/schedule/schedule-loader.tsx
@@ -61,6 +61,12 @@ const renderDirection = (schedulePageData: SchedulePageData): void => {
     shape_map: shapesById,
     route
   } = schedulePageData;
+
+  const root = document.getElementById("react-schedule-direction-root");
+  if (!root) {
+    return;
+  }
+
   ReactDOM.render(
     <ScheduleDirection
       directionId={directionId}
@@ -68,7 +74,7 @@ const renderDirection = (schedulePageData: SchedulePageData): void => {
       routePatternsByDirection={routePatternsByDirection}
       shapesById={shapesById}
     />,
-    document.getElementById("react-schedule-direction-root")
+    root
   );
 };
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔧 Invariant Violation: Target container is not a DOM element.](https://app.asana.com/0/555089885850811/1131943808986522)

The root element for the new schedule loader stuff was only rendered if the direction-redesign flag was set, but the React code itself runs whether or not the flag is set, so that caused an error when the flag was unset. Fixed.

<br>
Assigned to: @ryan-mahoney 
