### PR TITLE
Corrected fix for empty content lists

### DIFF
--- a/apps/site/lib/site_web/views/content_view.ex
+++ b/apps/site/lib/site_web/views/content_view.ex
@@ -8,7 +8,7 @@ defmodule SiteWeb.ContentView do
 
   alias Content.Field.{File, Image, Link}
   alias Content.Paragraph
-  alias Content.Paragraph.{Callout, ColumnMulti, DescriptionList, FareCard}
+  alias Content.Paragraph.{Callout, ColumnMulti, ContentList, FareCard}
   alias Site.ContentRewriter
 
   defdelegate fa_icon_for_file_type(mime), to: Site.FontAwesomeHelpers
@@ -26,6 +26,9 @@ defmodule SiteWeb.ContentView do
 
   @doc "Universal wrapper around all paragraph types"
   @spec render_paragraph(Paragraph.t(), Plug.Conn.t()) :: Phoenix.HTML.safe()
+  # Don't render Content List if list has no items
+  def render_paragraph(%ContentList{teasers: []}, _), do: []
+
   def render_paragraph(paragraph, conn) do
     render(
       "_paragraph.html",
@@ -66,11 +69,6 @@ defmodule SiteWeb.ContentView do
       element: fare_card_element(paragraph.link),
       conn: conn
     )
-  end
-
-  def render_content(%DescriptionList{descriptions: []}, _conn) do
-    # don't render header if list has no items
-    ""
   end
 
   def render_content(paragraph, conn) do

--- a/apps/site/test/site_web/views/content_view_test.exs
+++ b/apps/site/test/site_web/views/content_view_test.exs
@@ -378,22 +378,6 @@ defmodule SiteWeb.ContentViewTest do
       assert rendered =~ "Week pass"
     end
 
-    test "does not render empty description lists", %{conn: conn} do
-      paragraph = %DescriptionList{
-        header: %ColumnMultiHeader{
-          text: HTML.raw("<p>Header copy</p>\n")
-        }
-      }
-
-      rendered =
-        paragraph
-        |> render_paragraph(conn)
-        |> HTML.safe_to_string()
-
-      assert rendered =~ "c-paragraph--description-list"
-      refute rendered =~ "Header copy"
-    end
-
     test "renders a ContentList", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
@@ -417,6 +401,17 @@ defmodule SiteWeb.ContentViewTest do
       assert rendered =~ "c-teaser-list--project-update"
       assert rendered =~ "c-content-teaser--project-update"
       assert rendered =~ "Header copy"
+    end
+
+    test "does not render empty content lists", %{conn: conn} do
+      paragraph = %ContentList{
+        header: %ColumnMultiHeader{
+          text: HTML.raw("<p>Header copy</p>\n")
+        },
+        teasers: []
+      }
+
+      assert [] = render_paragraph(paragraph, conn)
     end
 
     test "renders a FareCard", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Hide entire Content List ¶ if list of content is empty](https://app.asana.com/0/477545582537986/1122465604344968/f)

Render NOTHING if **content list** has **no teaser results**
- Fixes #54 (wrong paragraph type / logic)