### PR TITLE
OpenStreetMaps | Map zoom reset

### DIFF
--- a/apps/site/assets/ts/schedule/components/Map.tsx
+++ b/apps/site/assets/ts/schedule/components/Map.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useReducer, useEffect, Dispatch } from "react";
+import React, {
+  ReactElement,
+  useReducer,
+  useEffect,
+  Dispatch,
+  useRef
+} from "react";
 import initChannel, { SocketEvent } from "./Channel";
 import Map from "../../leaflet/components/Map";
 import getBounds from "../../leaflet/bounds";
@@ -112,11 +118,12 @@ export const reducer = (state: Marker[], action: Action): Marker[] => {
 };
 
 export default ({ data, channel }: Props): ReactElement<HTMLElement> => {
+  const bounds = useRef(getBounds(data.markers));
   const [state, dispatch] = useReducer(reducer, data.markers.map(updateMarker));
   useEffect(() => setupChannels(channel, dispatch), [channel]);
   return (
     <div className="m-schedule__map">
-      <Map bounds={getBounds(state)} mapData={{ ...data, markers: state }} />
+      <Map bounds={bounds.current} mapData={{ ...data, markers: state }} />
     </div>
   );
 };


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔍 OpenStreetMaps | Map zoom reset](https://app.asana.com/0/555089885850811/1125936468243528)

We were calculating the bounds based on the markers and since the markers are live updated, it would sometimes change the bounds if the markers changed enough in position on the map.

This sets the bound to whatever the initial bounds are from the initial markers. It doesn't update the bounds when vehicles move or are added/removed from the map.

<br>
Assigned to: @NAME
