### PR TITLE
Schedules | Fix sorting for Saturday service

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
@@ -24,7 +24,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
       |> Repo.by_route_ids(date: date, direction_id: direction_id)
       |> Enum.map(&Map.update!(&1, :route, fn route -> Route.to_json_safe(route) end))
 
-    ordered_trips = services |> Enum.sort_by(& &1.time) |> Enum.map(& &1.trip.id) |> Enum.uniq()
+    ordered_trips = services |> Enum.map(& &1.trip.id) |> Enum.uniq()
 
     services_by_trip =
       services


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Schedules | Saturday schedules appear to have incorrect time ranges for service](https://app.asana.com/0/555089885850811/1131960756153348)

`Enum.sort_by` with a DateTime was putting 09/01 before 08/31. I looked into the list of schedules and they are already in order by time, so I removed the sort.

```
pry(1)> a = [List.first(services), List.last(services)] |> Enum.sort_by(& &1.time)
[
  %Schedules.Schedule{
    early_departure?: false,
    flag?: false,
    last_stop?: true,
    pickup_type: 1,
    route: ...,
    stop: ...,
    stop_sequence: 4,
    time: #DateTime<2019-09-01 01:01:00-04:00 -04 Etc/GMT+4>,
    trip: %Schedules.Trip{
      bikes_allowed?: true,
      direction_id: 0,
      headsign: "Silver Line Way",
      id: "40673166",
      name: "",
      shape_id: "7460007"
    }
  },
  %Schedules.Schedule{
    early_departure?: false,
    flag?: false,
    last_stop?: false,
    pickup_type: 0,
    route: ...,
    stop: ...,
    stop_sequence: 1,
    time: #DateTime<2019-08-31 05:50:00-04:00 -04 Etc/GMT+4>,
    trip: %Schedules.Trip{
      bikes_allowed?: true,
      direction_id: 0,
      headsign: "Drydock",
      id: "40672179",
      name: "",
      shape_id: "7420039"
    }
  }
]
```

Should have used https://hexdocs.pm/elixir/DateTime.html#compare/2 here but we can remove the unnecessary work instead.

<br>
Assigned to: @NAME
