### PR TITLE
Schedule Finder | Trip details from the selected origin

### DIFF
--- a/apps/site/assets/ts/schedule/__tests__/ScheduleTableTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleTableTest.tsx
@@ -123,6 +123,14 @@ describe("ScheduleTable", () => {
     expect(enzymeToJsonWithoutProps(wrapper)).toMatchSnapshot();
   });
 
+  it("it renders an empty message", () => {
+    createReactRoot();
+    const wrapper = mount(
+      <ScheduleTable schedule={{ by_trip: {}, trip_order: [] }} />
+    );
+    expect(enzymeToJsonWithoutProps(wrapper)).toMatchSnapshot();
+  });
+
   it("it renders CR schedules", () => {
     createReactRoot();
     const wrapper = mount(

--- a/apps/site/assets/ts/schedule/__tests__/ServiceSelectorTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ServiceSelectorTest.tsx
@@ -72,7 +72,12 @@ describe("ServiceSelector", () => {
   it("it renders", () => {
     createReactRoot();
     const tree = renderer.create(
-      <ServiceSelector services={services} directionId={0} routeId={"111"} />
+      <ServiceSelector
+        stopId="stopId"
+        services={services}
+        directionId={0}
+        routeId={"111"}
+      />
     );
     expect(tree).toMatchSnapshot();
   });
@@ -103,13 +108,14 @@ describe("ServiceSelector", () => {
         services,
         "BUS319-P-Sa-02",
         "83",
+        "stopId",
         1,
         loadingSpy,
         serviceScheduleSpy
       );
 
       expect(window.fetch).toHaveBeenCalledWith(
-        "/schedules/schedule_api?id=83&date=2019-08-31&direction_id=1"
+        "/schedules/schedule_api?id=83&date=2019-08-31&direction_id=1&stop_id=stopId"
       );
 
       expect(loadingSpy).toHaveBeenCalledTimes(2);
@@ -131,6 +137,7 @@ describe("ServiceSelector", () => {
           services,
           "BAD-SERVICE-ID",
           "83",
+          "stopId",
           1,
           loadingSpy,
           serviceScheduleSpy
@@ -156,6 +163,7 @@ describe("ServiceSelector", () => {
           services,
           "BUS319-P-Sa-02",
           "83",
+          "stopId",
           1,
           loadingSpy,
           serviceScheduleSpy

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
@@ -11696,3 +11696,13 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
   </table>
 </ScheduleTable>
 `;
+
+exports[`ScheduleTable it renders an empty message 1`] = `
+<ScheduleTable>
+  <div
+    className="callout schedule-table--empty"
+  >
+    There is no scheduled service for this time period.
+  </div>
+</ScheduleTable>
+`;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -136,6 +136,7 @@ const ScheduleModalContent = ({
       <div>from {stopNameLink(selectedOrigin, stops)}</div>
       <UpcomingDepartures state={state} />
       <ServiceSelector
+        stopId={selectedOrigin}
         services={services}
         routeId={routeId}
         directionId={selectedDirection}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef
 } from "react";
 import SelectContainer from "./SelectContainer";
-import { ServiceWithServiceDate, DirectionId } from "../../../__v3api";
+import { ServiceWithServiceDate, DirectionId, Stop } from "../../../__v3api";
 import {
   ServicesKeyedByGroup,
   groupServiceByDate,
@@ -29,6 +29,7 @@ const optGroupTitles: { [key in ServiceOptGroup]: string } = {
 };
 
 interface Props {
+  stopId: string;
   services: ServiceWithServiceDate[];
   routeId: string;
   directionId: DirectionId;
@@ -66,6 +67,7 @@ export const fetchSchedule = (
   services: ServiceWithServiceDate[],
   selectedServiceId: string,
   routeId: string,
+  stopId: string,
   directionId: DirectionId,
   setIsLoading: Dispatch<SetStateAction<boolean>>,
   setSelectedServiceSchedule: Dispatch<SetStateAction<null>>
@@ -85,7 +87,7 @@ export const fetchSchedule = (
       .fetch(
         `/schedules/schedule_api?id=${routeId}&date=${
           selectedService.end_date
-        }&direction_id=${directionId}`
+        }&direction_id=${directionId}&stop_id=${stopId}`
       )
       .then(response => {
         setIsLoading(false);
@@ -97,6 +99,7 @@ export const fetchSchedule = (
 };
 
 export const ServiceSelector = ({
+  stopId,
   services,
   routeId,
   directionId
@@ -113,6 +116,7 @@ export const ServiceSelector = ({
         services,
         selectedServiceId,
         routeId,
+        stopId,
         directionId,
         setIsLoading,
         setSelectedServiceSchedule

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef
 } from "react";
 import SelectContainer from "./SelectContainer";
-import { ServiceWithServiceDate, DirectionId, Stop } from "../../../__v3api";
+import { ServiceWithServiceDate, DirectionId } from "../../../__v3api";
 import {
   ServicesKeyedByGroup,
   groupServiceByDate,

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -121,7 +121,7 @@ export const ServiceSelector = ({
         setIsLoading,
         setSelectedServiceSchedule
       ),
-    [services, directionId, routeId, selectedServiceId]
+    [services, directionId, routeId, selectedServiceId, stopId]
   );
 
   if (services.length <= 0) return null;

--- a/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
@@ -40,7 +40,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
       |> Enum.map(fn {trip_id, schedules} ->
         {trip_id, prune_schedules_by_stop(schedules, stop_id)}
       end)
-      |> Enum.split_with(fn {trip_id, schedules} ->
+      |> Enum.split_with(fn {_trip_id, schedules} ->
         Enum.empty?(schedules) || length(schedules) == 1
       end)
 

--- a/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
@@ -61,6 +61,8 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
     |> Enum.into(%{})
   end
 
+  def fares_for_service([]), do: []
+
   def fares_for_service(schedules) do
     origin = List.first(schedules)
 
@@ -73,11 +75,15 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
     )
   end
 
+  def duration_for_service([]), do: []
+
   def duration_for_service(schedules) do
     first = List.first(schedules).time
     last = List.last(schedules).time
     %{schedules: schedules, duration: Timex.diff(last, first, :minutes)}
   end
+
+  def formatted_time([]), do: []
 
   def formatted_time(%{schedules: schedules, duration: duration}) do
     time_formatted_schedules =

--- a/apps/site/test/site_web/controllers/schedule/schedule_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/schedule_api_test.exs
@@ -6,7 +6,9 @@ defmodule SiteWeb.ScheduleController.ScheduleApiTest do
   describe "ScheduleApi" do
     test "schedules are returned for a date for bus", %{conn: conn} do
       date = Util.now() |> Date.to_iso8601()
-      path = schedule_api_path(conn, :show, %{id: 111, direction_id: 0, date: date})
+
+      path =
+        schedule_api_path(conn, :show, %{id: 111, direction_id: 0, date: date, stop_id: "5615"})
 
       response =
         conn
@@ -19,7 +21,14 @@ defmodule SiteWeb.ScheduleController.ScheduleApiTest do
 
     test "schedules are returned for a date for subway", %{conn: conn} do
       date = Util.now() |> Date.to_iso8601()
-      path = schedule_api_path(conn, :show, %{id: "Red", direction_id: 0, date: date})
+
+      path =
+        schedule_api_path(conn, :show, %{
+          id: "Red",
+          direction_id: 0,
+          date: date,
+          stop_id: "place-cntsq"
+        })
 
       response =
         conn
@@ -32,7 +41,14 @@ defmodule SiteWeb.ScheduleController.ScheduleApiTest do
 
     test "schedules are returned for a date for CR", %{conn: conn} do
       date = Util.now() |> Date.to_iso8601()
-      path = schedule_api_path(conn, :show, %{id: "CR-Kingston", direction_id: 0, date: date})
+
+      path =
+        schedule_api_path(conn, :show, %{
+          id: "CR-Kingston",
+          direction_id: 0,
+          date: date,
+          stop_id: "place-PB-0194"
+        })
 
       response =
         conn
@@ -45,7 +61,14 @@ defmodule SiteWeb.ScheduleController.ScheduleApiTest do
 
     test "schedules are returned for a date for ferry", %{conn: conn} do
       date = Util.now() |> Date.to_iso8601()
-      path = schedule_api_path(conn, :show, %{id: "Boat-F1", direction_id: 0, date: date})
+
+      path =
+        schedule_api_path(conn, :show, %{
+          id: "Boat-F1",
+          direction_id: 0,
+          date: date,
+          stop_id: "Boat-Logan"
+        })
 
       response =
         conn


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱Schedules | 🐞 Finder Tool - Trip details are incorrect](https://app.asana.com/0/555089885850811/1132361826199925)

Prune the schedules so that they are not the full trip but only the section of the trip from the selected origin.

It doesn't seem like there's an efficient way to query this from the api so I pruned the schedules after we request them.

<br>
Assigned to: @ryan-mahoney 
