### PR TITLE
Fix View Fares link on current schedule page

### DIFF
--- a/apps/site/lib/site_web/templates/schedule/_trip_info.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_trip_info.html.eex
@@ -51,7 +51,7 @@
             end
           end %>
       <%= Fares.Format.price(base_fare) %>
-      (<%= link("View fares", to: fare_path(@conn, :show, fare_group(@route.type), fare_params(@origin, @destination))) %>)
+      (<%= link("View fares", to: cms_static_page_path(@conn, ["/fares/", @route |> Route.type_atom() |> Atom.to_string() |> String.replace("_", "-"), "-fares"])) %>)
     </div>
     <%= if @route.type === 2 do %>
       <div class="trip-fare">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fares | 404 on "View fares" link from Schedule pages](https://app.asana.com/0/555089885850811/1131253174031033)

"View fares" link on the current page goes to the cms static pages as requested in the ticket. We'll be replacing this page soon enough so I didn't get too fancy.

<br>
Assigned to: @NAME
