### PR TITLE
CR Timetable | add stop name to aria lable for each time

### DIFF
--- a/apps/site/lib/site_web/templates/schedule/_timetable_schedule.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_timetable_schedule.html.eex
@@ -17,7 +17,7 @@
       <% end %>
     </span>
     <span class="m-timetable__time">
-      <span class="sr-only"><%= format_schedule_time_for_screenreader(@trip_schedule.time) %></span>
+      <span class="sr-only"><%= [@stop.name, " ", format_schedule_time_for_screenreader(@trip_schedule.time)] %></span>
       <span aria-hidden="true"><%= format_schedule_time(@trip_schedule.time) %></span>
     </span>
     <span class="m-timetable__vehicle-icon" id="<%="#{@stop.name}-#{trip_id}"%>">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [♿  CR Timetable | Add stop name to aria labels](https://app.asana.com/0/555089885850811/1130340429843891)

Added the stop name into the screen-reader only time wording of the CR timetable. The ticked mentions the train number, but that is already being read as it is the row header.

<br>
Assigned to: @meagonqz 
