### PR TITLE
Repo.teasers should support multiple `type` values

### DIFF
--- a/apps/content/lib/cms/static.ex
+++ b/apps/content/lib/cms/static.ex
@@ -367,15 +367,15 @@ defmodule Content.CMS.Static do
     {:ok, []}
   end
 
-  def view("/cms/teasers", %{type: :project, sticky: 1}) do
+  def view("/cms/teasers", %{type: [:project], sticky: 1}) do
     {:ok, teaser_featured_projects_response()}
   end
 
-  def view("/cms/teasers", %{type: :project}) do
+  def view("/cms/teasers", %{type: [:project]}) do
     {:ok, teaser_project_response()}
   end
 
-  def view("/cms/teasers", %{type: :project_update}) do
+  def view("/cms/teasers", %{type: [:project_update]}) do
     {:ok, teaser_project_update_response()}
   end
 
@@ -383,19 +383,19 @@ defmodule Content.CMS.Static do
     {:ok, teaser_empty_response()}
   end
 
-  def view("/cms/teasers", %{type: :diversion}) do
+  def view("/cms/teasers", %{type: [:diversion]}) do
     {:ok, teaser_diversion_response()}
   end
 
-  def view("/cms/teasers", %{type: :news_entry, except: 3518, items_per_page: 4}) do
+  def view("/cms/teasers", %{type: [:news_entry], except: 3518, items_per_page: 4}) do
     {:ok, teaser_news_entry_response() |> Enum.take(4)}
   end
 
-  def view("/cms/teasers", %{type: :news_entry}) do
+  def view("/cms/teasers", %{type: [:news_entry]}) do
     {:ok, teaser_news_entry_response()}
   end
 
-  def view("/cms/teasers", %{type: :event}) do
+  def view("/cms/teasers", %{type: [:event]}) do
     {:ok, teaser_event_response()}
   end
 
@@ -486,11 +486,11 @@ defmodule Content.CMS.Static do
   def redirect(path, params, code),
     do: redirect(path <> "?" <> URI.encode_query(params), %{}, code)
 
-  defp filter_teasers(teasers, %{type: type, type_op: "not in"}) do
+  defp filter_teasers(teasers, %{type: [type], type_op: "not in"}) do
     Enum.reject(teasers, &filter_teaser?(&1, type))
   end
 
-  defp filter_teasers(teasers, %{type: type}) do
+  defp filter_teasers(teasers, %{type: [type]}) do
     Enum.filter(teasers, &filter_teaser?(&1, type))
   end
 

--- a/apps/content/lib/cms/static.ex
+++ b/apps/content/lib/cms/static.ex
@@ -379,6 +379,10 @@ defmodule Content.CMS.Static do
     {:ok, teaser_project_update_response()}
   end
 
+  def view("/cms/teasers", %{type: [:project, :project_update]}) do
+    {:ok, teaser_project_response() ++ teaser_project_update_response()}
+  end
+
   def view("/cms/teasers", %{promoted: 0}) do
     {:ok, teaser_empty_response()}
   end

--- a/apps/content/lib/helpers.ex
+++ b/apps/content/lib/helpers.ex
@@ -178,7 +178,7 @@ defmodule Content.Helpers do
     |> Map.get("name", "")
   end
 
-  @spec content_type(String.t()) :: Content.CMS.type()
+  @spec content_type(String.t()) :: Content.CMS.type() | nil
   for atom <- ~w(
     diversion
     event

--- a/apps/content/lib/paragraph/content_list.ex
+++ b/apps/content/lib/paragraph/content_list.ex
@@ -43,7 +43,7 @@ defmodule Content.Paragraph.ContentList do
       terms: terms,
       term_depth: field_value(data, "field_term_depth"),
       items_per_page: field_value(data, "field_number_of_items"),
-      type: data |> field_value("field_content_type") |> content_type(),
+      type: [data |> field_value("field_content_type") |> content_type()],
       type_op: field_value(data, "field_type_logic"),
       promoted: field_value(data, "field_promoted"),
       sticky: field_value(data, "field_sticky"),
@@ -212,7 +212,7 @@ defmodule Content.Paragraph.ContentList do
 
   # Limit amount of teasers when certain types are requested
   @spec limit_count_by_type(map) :: map
-  defp limit_count_by_type(%{type: type} = ingredients)
+  defp limit_count_by_type(%{type: [type]} = ingredients)
        when type in [:project_update, :project, :diversion] do
     Map.put(ingredients, :items_per_page, 2)
   end

--- a/apps/content/lib/paragraph/content_list.ex
+++ b/apps/content/lib/paragraph/content_list.ex
@@ -202,6 +202,13 @@ defmodule Content.Paragraph.ContentList do
     |> combine()
   end
 
+  # If no types are specified, discard the :type key.
+  defp combine(%{type: [nil]} = ingredients) do
+    ingredients
+    |> Map.drop([:type])
+    |> combine()
+  end
+
   # Ingredients are ready to bake into opts for endpoint call. Discard
   # all nil values and converts remaining ingredients to a list
   defp combine(ingredients) do

--- a/apps/content/lib/paragraph/content_list.ex
+++ b/apps/content/lib/paragraph/content_list.ex
@@ -39,11 +39,20 @@ defmodule Content.Paragraph.ContentList do
       |> Enum.map(& &1["target_id"])
       |> Enum.reject(&is_nil(&1))
 
+    type =
+      data
+      |> field_value("field_content_type")
+      |> content_type()
+      |> case do
+        nil -> nil
+        type -> [type]
+      end
+
     ingredients = %{
+      type: type,
       terms: terms,
       term_depth: field_value(data, "field_term_depth"),
       items_per_page: field_value(data, "field_number_of_items"),
-      type: [data |> field_value("field_content_type") |> content_type()],
       type_op: field_value(data, "field_type_logic"),
       promoted: field_value(data, "field_promoted"),
       sticky: field_value(data, "field_sticky"),
@@ -199,13 +208,6 @@ defmodule Content.Paragraph.ContentList do
     ingredients
     |> Map.drop([:date_min, :date_max])
     |> Map.put(:date, value: date)
-    |> combine()
-  end
-
-  # If no types are specified, discard the :type key.
-  defp combine(%{type: [nil]} = ingredients) do
-    ingredients
-    |> Map.drop([:type])
     |> combine()
   end
 

--- a/apps/content/lib/repo.ex
+++ b/apps/content/lib/repo.ex
@@ -230,7 +230,7 @@ defmodule Content.Repo do
 
   @type teaser_filters :: %{
           optional(:sidebar) => integer,
-          optional(:type) => CMS.type(),
+          optional(:type) => [CMS.type()],
           optional(:type_op) => String.t(),
           optional(:related_to) => integer,
           optional(:except) => integer,
@@ -275,7 +275,7 @@ defmodule Content.Repo do
   end
 
   @spec teaser_sort(teaser_filters) :: teaser_filters
-  defp teaser_sort(%{type: type} = params)
+  defp teaser_sort(%{type: [type]} = params)
        when type in [:news_entry, :event, :project_update, :project] do
     order = Map.get(params, :sort_order, :DESC)
 

--- a/apps/content/lib/repo.ex
+++ b/apps/content/lib/repo.ex
@@ -187,23 +187,26 @@ defmodule Content.Repo do
   @doc """
   Returns a list of teaser items.
 
-  Opts can include :type, which can be one of:
-    :news_entry
-    :event
-    :project
-    :page
-    :project_update
+  TYPE
 
-  If no type is specified, results can be of mixed types.
+  Opts can include :type, which is a list that can contain one
+  or more of the CMS.type() atoms (ex: [:news_entry, :event]).
+
+  If no types are specified, results can be of mixed types.
 
   To filter by a route include :route_id, for example:
     "/guides/subway" or just "subway"
 
   To fetch all items that are NOT of a specific type,
-  use [type: _type, type_op: "not in"]
+  use [type: [_type], type_op: "not in"]. type_op: "in"
+  is the default value for this filter if not supplied.
+
+  RELATIONSHIPS
 
   To fetch items related to a given ID, use the "related_to"
   parameter with an integer value (usually a content ID).
+
+  ITEMS PER PAGE
 
   Opts can also include :items_per_page, which sets
   the number of items to return. Default is 5 items.

--- a/apps/content/test/cms/http_client_test.exs
+++ b/apps/content/test/cms/http_client_test.exs
@@ -141,6 +141,35 @@ defmodule Content.CMS.HTTPClientTest do
       end
     end
 
+    test "CMS-style multiple argument params are converted to key[] for each argument" do
+      with_mock ExternalRequest, process: fn _method, _path, _body, _params -> {:ok, []} end do
+        view(
+          "/path",
+          %{
+            "type" => [
+              :project,
+              :project_update,
+              :event
+            ]
+          }
+        )
+
+        assert called(
+                 ExternalRequest.process(
+                   :get,
+                   "/path",
+                   "",
+                   params: [
+                     {"_format", "json"},
+                     {"type[]", "project"},
+                     {"type[]", "project_update"},
+                     {"type[]", "event"}
+                   ]
+                 )
+               )
+      end
+    end
+
     test "nested and non-nested key values in request work when being redirected by CMS" do
       with_mock ExternalRequest,
         process: fn _method, _path, _body, _params -> {:ok, []} end do

--- a/apps/content/test/cms/static_test.exs
+++ b/apps/content/test/cms/static_test.exs
@@ -49,8 +49,8 @@ defmodule Content.CMS.StaticTest do
       end
     end
 
-    test "/cms/teasers?type=news_entry" do
-      assert {:ok, news_entries} = view("/cms/teasers", %{type: :news_entry})
+    test "/cms/teasers?type[]=news_entry" do
+      assert {:ok, news_entries} = view("/cms/teasers", %{type: [:news_entry]})
       refute Enum.empty?(news_entries)
 
       for news_entry <- news_entries do
@@ -58,8 +58,8 @@ defmodule Content.CMS.StaticTest do
       end
     end
 
-    test "/cms/teasers?type=project_update" do
-      assert {:ok, updates} = view("/cms/teasers", %{type: :project_update})
+    test "/cms/teasers?type[]=project_update" do
+      assert {:ok, updates} = view("/cms/teasers", %{type: [:project_update]})
       refute Enum.empty?(updates)
 
       for update <- updates do
@@ -67,8 +67,8 @@ defmodule Content.CMS.StaticTest do
       end
     end
 
-    test "/cms/teasers?type=project" do
-      assert {:ok, projects} = view("/cms/teasers", %{type: :project})
+    test "/cms/teasers?type[]=project" do
+      assert {:ok, projects} = view("/cms/teasers", %{type: [:project]})
       refute Enum.empty?(projects)
 
       for project <- projects do
@@ -76,8 +76,8 @@ defmodule Content.CMS.StaticTest do
       end
     end
 
-    test "/cms/teasers?type=event" do
-      assert {:ok, events} = view("/cms/teasers", %{type: :event})
+    test "/cms/teasers?type[]=event" do
+      assert {:ok, events} = view("/cms/teasers", %{type: [:event]})
       refute Enum.empty?(events)
 
       for event <- events do
@@ -85,8 +85,8 @@ defmodule Content.CMS.StaticTest do
       end
     end
 
-    test "/cms/teasers?type=diversion" do
-      assert {:ok, diversions} = view("/cms/teasers", %{type: :diversion})
+    test "/cms/teasers?type[]=diversion" do
+      assert {:ok, diversions} = view("/cms/teasers", %{type: [:diversion]})
       refute Enum.empty?(diversions)
 
       for diversion <- diversions do

--- a/apps/content/test/paragraph/content_list_test.exs
+++ b/apps/content/test/paragraph/content_list_test.exs
@@ -7,18 +7,17 @@ defmodule Content.Paragraph.ContentListTest do
 
   use ExUnit.Case, async: true
 
-  alias Content.Helpers
   alias Content.Paragraph.ContentList
 
   describe "from_api/1" do
     test "If type is specified, it should result in a single-item list" do
-      opts = cms_map(type: Helpers.content_type("project_update"))
+      opts = cms_map(content_type: "news_entry")
 
-      assert opts == [type: [:project_update]]
+      assert opts == [type: [:news_entry]]
     end
 
     test "If no type is specified, it should not be present in opts[]" do
-      opts = cms_map(type: Helpers.content_type(""))
+      opts = cms_map(content_type: "")
 
       assert opts == []
     end

--- a/apps/content/test/paragraph/content_list_test.exs
+++ b/apps/content/test/paragraph/content_list_test.exs
@@ -7,9 +7,22 @@ defmodule Content.Paragraph.ContentListTest do
 
   use ExUnit.Case, async: true
 
+  alias Content.Helpers
   alias Content.Paragraph.ContentList
 
   describe "from_api/1" do
+    test "If type is specified, it should result in a single-item list" do
+      opts = cms_map(type: Helpers.content_type("project_update"))
+
+      assert opts == [type: [:project_update]]
+    end
+
+    test "If no type is specified, it should not be present in opts[]" do
+      opts = cms_map(type: Helpers.content_type(""))
+
+      assert opts == []
+    end
+
     test "If no relationship data is found, discard all related data" do
       opts =
         cms_map(

--- a/apps/content/test/paragraph/content_list_test.exs
+++ b/apps/content/test/paragraph/content_list_test.exs
@@ -172,7 +172,7 @@ defmodule Content.Paragraph.ContentListTest do
         sorting_logic: nil
       )
 
-    assert opts == [items_per_page: 5, type: :event]
+    assert opts == [items_per_page: 5, type: [:event]]
   end
 
   defp cms_map(fields) do

--- a/apps/content/test/paragraph_test.exs
+++ b/apps/content/test/paragraph_test.exs
@@ -303,7 +303,7 @@ defmodule Content.ParagraphTest do
              terms: [],
              term_depth: 4,
              items_per_page: 5,
-             type: :project_update,
+             type: [:project_update],
              type_op: nil,
              promoted: nil,
              sticky: "0",
@@ -324,7 +324,7 @@ defmodule Content.ParagraphTest do
              related_to: 3004,
              sort_order: :DESC,
              sticky: "0",
-             type: :project_update
+             type: [:project_update]
            ] == recipe
   end
 

--- a/apps/content/test/repo_test.exs
+++ b/apps/content/test/repo_test.exs
@@ -228,7 +228,7 @@ defmodule Content.RepoTest do
   describe "teasers/1" do
     test "returns only teasers for a project type" do
       types =
-        [type: :project]
+        [type: [:project]]
         |> Repo.teasers()
         |> MapSet.new(& &1.type)
         |> MapSet.to_list()
@@ -238,7 +238,7 @@ defmodule Content.RepoTest do
 
     test "returns all teasers for a type that are sticky" do
       teasers =
-        [type: :project, sticky: 1]
+        [type: [:project], sticky: 1]
         |> Repo.teasers()
 
       assert [%Teaser{}, %Teaser{}, %Teaser{}] = teasers
@@ -309,7 +309,7 @@ defmodule Content.RepoTest do
     end
 
     test "takes a :type option" do
-      teasers = Repo.teasers(route_id: "Red", type: :project, sidebar: 1)
+      teasers = Repo.teasers(route_id: "Red", type: [:project], sidebar: 1)
       assert Enum.all?(teasers, &(&1.type == :project))
     end
 
@@ -317,7 +317,7 @@ defmodule Content.RepoTest do
       all_teasers = Repo.teasers(route_id: "Red", sidebar: 1)
       assert Enum.any?(all_teasers, &(&1.type == :project))
 
-      filtered = Repo.teasers(route_id: "Red", type: :project, type_op: "not in", sidebar: 1)
+      filtered = Repo.teasers(route_id: "Red", type: [:project], type_op: "not in", sidebar: 1)
       refute Enum.empty?(filtered)
       refute Enum.any?(filtered, &(&1.type == :project))
     end
@@ -387,21 +387,21 @@ defmodule Content.RepoTest do
     test "sets correct :sort_by and :sort_order options for project_update and news_entry requests" do
       mock_view = fn
         "/cms/teasers",
-        %{type: :project_update, sort_by: "field_posted_on_value", sort_order: :DESC} ->
+        %{type: [:project_update], sort_by: "field_posted_on_value", sort_order: :DESC} ->
           {:ok, []}
 
         "/cms/teasers",
-        %{type: :news_entry, sort_by: "field_posted_on_value", sort_order: :ASC} ->
+        %{type: [:news_entry], sort_by: "field_posted_on_value", sort_order: :ASC} ->
           {:ok, []}
       end
 
       with_mock Static, view: mock_view do
-        Repo.teasers(type: :project_update)
-        Repo.teasers(type: :news_entry, sort_order: :ASC)
+        Repo.teasers(type: [:project_update])
+        Repo.teasers(type: [:news_entry], sort_order: :ASC)
 
         "/cms/teasers"
         |> Static.view(%{
-          type: :project_update,
+          type: [:project_update],
           sort_by: "field_posted_on_value",
           sort_order: :DESC
         })
@@ -409,7 +409,7 @@ defmodule Content.RepoTest do
 
         "/cms/teasers"
         |> Static.view(%{
-          type: :news_entry,
+          type: [:news_entry],
           sort_by: "field_posted_on_value",
           sort_order: :ASC
         })
@@ -419,45 +419,46 @@ defmodule Content.RepoTest do
 
     test "sets correct :sort_by and :sort_order options for project requests" do
       mock_view = fn
-        "/cms/teasers", %{type: :project, sort_by: "field_updated_on_value", sort_order: :DESC} ->
+        "/cms/teasers",
+        %{type: [:project], sort_by: "field_updated_on_value", sort_order: :DESC} ->
           {:ok, []}
       end
 
       with_mock Static, view: mock_view do
-        Repo.teasers(type: :project)
+        Repo.teasers(type: [:project])
 
         "/cms/teasers"
-        |> Static.view(%{type: :project, sort_by: "field_updated_on_value", sort_order: :DESC})
+        |> Static.view(%{type: [:project], sort_by: "field_updated_on_value", sort_order: :DESC})
         |> assert_called()
       end
     end
 
     test "sets correct :sort_by and :sort_order options for event requests" do
       mock_view = fn
-        "/cms/teasers", %{type: :event, sort_by: "field_start_time_value", sort_order: :DESC} ->
+        "/cms/teasers", %{type: [:event], sort_by: "field_start_time_value", sort_order: :DESC} ->
           {:ok, []}
       end
 
       with_mock Static, view: mock_view do
-        Repo.teasers(type: :event)
+        Repo.teasers(type: [:event])
 
         "/cms/teasers"
-        |> Static.view(%{type: :event, sort_by: "field_start_time_value", sort_order: :DESC})
+        |> Static.view(%{type: [:event], sort_by: "field_start_time_value", sort_order: :DESC})
         |> assert_called()
       end
     end
 
     test "drops :sort_by and :sort_order options for invalid sortable types" do
       mock_view = fn
-        "/cms/teasers", %{type: :page} ->
+        "/cms/teasers", %{type: [:page]} ->
           {:ok, []}
       end
 
       with_mock Static, view: mock_view do
-        Repo.teasers(type: :page, sort_by: :ASC)
+        Repo.teasers(type: [:page], sort_by: :ASC)
 
         "/cms/teasers"
-        |> Static.view(%{type: :page})
+        |> Static.view(%{type: [:page]})
         |> assert_called()
       end
     end

--- a/apps/content/test/repo_test.exs
+++ b/apps/content/test/repo_test.exs
@@ -236,6 +236,16 @@ defmodule Content.RepoTest do
       assert types == [:project]
     end
 
+    test "returns teasers for a project and project update type" do
+      types =
+        [type: [:project, :project_update]]
+        |> Repo.teasers()
+        |> MapSet.new(& &1.type)
+        |> MapSet.to_list()
+
+      assert types == [:project, :project_update]
+    end
+
     test "returns all teasers for a type that are sticky" do
       teasers =
         [type: [:project], sticky: 1]

--- a/apps/site/lib/css_helpers.ex
+++ b/apps/site/lib/css_helpers.ex
@@ -16,8 +16,14 @@ defmodule CSSHelpers do
   end
 
   @doc "Returns a css class: a string with hyphens."
-  @spec atom_to_class(atom) :: String.t()
-  def atom_to_class(atom) do
+  @spec atom_to_class([atom()] | atom()) :: String.t()
+  def atom_to_class(atom) when is_atom(atom) do
+    atom
+    |> Atom.to_string()
+    |> String.replace("_", "-")
+  end
+
+  def atom_to_class([atom]) do
     atom
     |> Atom.to_string()
     |> String.replace("_", "-")

--- a/apps/site/lib/site_web/controllers/event_controller.ex
+++ b/apps/site/lib/site_web/controllers/event_controller.ex
@@ -17,7 +17,7 @@ defmodule SiteWeb.EventController do
 
     event_teasers_fn = fn ->
       Repo.teasers(
-        type: :event,
+        type: [:event],
         items_per_page: 50,
         date_op: "between",
         date: [min: date_range.start_time_gt, max: date_range.start_time_lt],

--- a/apps/site/lib/site_web/controllers/mode/hub_behavior.ex
+++ b/apps/site/lib/site_web/controllers/mode/hub_behavior.ex
@@ -39,8 +39,8 @@ defmodule SiteWeb.Mode.HubBehavior do
   defp render_index(conn, mode_strategy, mode_routes, params) do
     alerts_fn = fn -> alerts(mode_routes, conn.assigns.date_time) end
     guides_fn = fn -> mode_strategy.mode_name() |> guides() end
-    news_fn = fn -> mode_strategy.mode_name() |> teasers(:news_entry) end
-    projects_fn = fn -> mode_strategy.mode_name() |> teasers(:project, 2) end
+    news_fn = fn -> mode_strategy.mode_name() |> teasers([:news_entry]) end
+    projects_fn = fn -> mode_strategy.mode_name() |> teasers([:project], 2) end
 
     conn
     |> filter_recently_visited(mode_strategy.route_type)
@@ -96,7 +96,7 @@ defmodule SiteWeb.Mode.HubBehavior do
 
   @spec guides(String.t()) :: [Teaser.t()]
   defp guides(mode) do
-    Content.Repo.teasers(type: :page, topic: "guides", sidebar: 1, mode: mode_to_param(mode))
+    Content.Repo.teasers(type: [:page], topic: "guides", sidebar: 1, mode: mode_to_param(mode))
   end
 
   @spec mode_to_param(String.t()) :: String.t()

--- a/apps/site/lib/site_web/controllers/mode/hub_behavior.ex
+++ b/apps/site/lib/site_web/controllers/mode/hub_behavior.ex
@@ -1,6 +1,7 @@
 defmodule SiteWeb.Mode.HubBehavior do
-  alias Content.Teaser
+  alias Content.{CMS, Teaser}
   alias Fares.Summary
+  alias Routes.Route
 
   @moduledoc "Behavior for mode hub pages."
 
@@ -48,7 +49,7 @@ defmodule SiteWeb.Mode.HubBehavior do
     |> async_assign_default(:alerts, alerts_fn, [])
     |> assign(:green_routes, green_routes())
     |> assign(:routes, mode_routes)
-    |> assign(:route_type, mode_strategy.route_type |> Routes.Route.type_atom())
+    |> assign(:route_type, mode_strategy.route_type |> Route.type_atom())
     |> assign(:mode_name, mode_strategy.mode_name())
     |> assign(:mode_icon, mode_strategy.mode_icon())
     |> assign(:fare_description, mode_strategy.fare_description())
@@ -106,14 +107,14 @@ defmodule SiteWeb.Mode.HubBehavior do
     |> String.replace(" ", "-")
   end
 
-  @spec teasers(String.t(), atom, integer) :: [Teaser.t()]
+  @spec teasers(String.t(), [CMS.type()], integer) :: [Teaser.t()]
   defp teasers(mode, content_type, limit \\ 10) do
     mode
     |> mode_to_param()
     |> do_teasers(content_type, limit)
   end
 
-  @spec do_teasers(String.t(), atom, integer) :: [Teaser.t()]
+  @spec do_teasers(String.t(), [CMS.type()], integer) :: [Teaser.t()]
   defp do_teasers(mode, content_type, limit) do
     [mode: mode, type: content_type, sidebar: 1, items_per_page: limit]
     |> Content.Repo.teasers()

--- a/apps/site/lib/site_web/controllers/news_entry_controller.ex
+++ b/apps/site/lib/site_web/controllers/news_entry_controller.ex
@@ -15,7 +15,7 @@ defmodule SiteWeb.NewsEntryController do
 
     news_entry_teasers_fn = fn ->
       Repo.teasers(
-        type: :news_entry,
+        type: [:news_entry],
         items_per_page: items_per_page,
         offset: items_per_page * zero_based_current_page
       )
@@ -23,7 +23,7 @@ defmodule SiteWeb.NewsEntryController do
 
     upcoming_news_entry_teasers_fn = fn ->
       Repo.teasers(
-        type: :news_entry,
+        type: [:news_entry],
         items_per_page: items_per_page,
         offset: items_per_page * zero_based_next_page
       )
@@ -56,7 +56,7 @@ defmodule SiteWeb.NewsEntryController do
 
   @spec show_news_entry(Conn.t(), NewsEntry.t()) :: Conn.t()
   def show_news_entry(conn, %NewsEntry{posted_on: posted_on} = news_entry) do
-    recent_news = Repo.teasers(type: :news_entry, except: news_entry.id, items_per_page: 4)
+    recent_news = Repo.teasers(type: [:news_entry], except: news_entry.id, items_per_page: 4)
 
     conn
     |> ControllerHelpers.unavailable_after_one_year(posted_on)

--- a/apps/site/lib/site_web/controllers/page_controller.ex
+++ b/apps/site/lib/site_web/controllers/page_controller.ex
@@ -40,7 +40,7 @@ defmodule SiteWeb.PageController do
 
   @spec news :: [Teaser.t()]
   defp news do
-    [items_per_page: 5, type: :news_entry]
+    [items_per_page: 5, type: [:news_entry]]
     |> Content.Repo.teasers()
     |> Enum.map(&add_utm_url/1)
   end

--- a/apps/site/lib/site_web/controllers/project_controller.ex
+++ b/apps/site/lib/site_web/controllers/project_controller.ex
@@ -9,13 +9,13 @@ defmodule SiteWeb.ProjectController do
 
   def index(conn, _) do
     project_teasers_fn = fn ->
-      [type: :project, items_per_page: 50]
+      [type: [:project], items_per_page: 50]
       |> Repo.teasers()
       |> sort_by_date()
     end
 
     featured_project_teasers_fn = fn ->
-      [type: :project, sticky: 1]
+      [type: [:project], sticky: 1]
       |> Repo.teasers()
       |> sort_by_date()
     end
@@ -117,7 +117,7 @@ defmodule SiteWeb.ProjectController do
           updates:
             teasers_fn.(
               related_to: project.id,
-              type: :project_update,
+              type: [:project_update],
               items_per_page: 50
             )
         })
@@ -204,11 +204,11 @@ defmodule SiteWeb.ProjectController do
 
   @spec get_updates_async(integer) :: (() -> [Teaser.t()])
   def get_updates_async(id) do
-    fn -> Repo.teasers(related_to: id, type: :project_update) end
+    fn -> Repo.teasers(related_to: id, type: [:project_update]) end
   end
 
   @spec get_diversions_async(integer) :: (() -> [Teaser.t()])
   def get_diversions_async(id) do
-    fn -> Repo.teasers(related_to: id, type: :diversion) end
+    fn -> Repo.teasers(related_to: id, type: [:diversion]) end
   end
 end

--- a/apps/site/lib/site_web/controllers/project_controller.ex
+++ b/apps/site/lib/site_web/controllers/project_controller.ex
@@ -192,7 +192,7 @@ defmodule SiteWeb.ProjectController do
   def get_events_async(id, timeframe) do
     fn ->
       Repo.teasers(
-        type: :event,
+        type: [:event],
         related_to: id,
         items_per_page: 10,
         date_op: (timeframe == :past && "<") || ">=",

--- a/apps/site/lib/site_web/controllers/schedule/cms.ex
+++ b/apps/site/lib/site_web/controllers/schedule/cms.ex
@@ -60,6 +60,6 @@ defmodule SiteWeb.ScheduleController.CMS do
     %{teaser | path: url}
   end
 
-  defp utm_type([:news_entry]), do: :news
+  defp utm_type(:news_entry), do: :news
   defp utm_type(type), do: type
 end

--- a/apps/site/lib/site_web/controllers/schedule/cms.ex
+++ b/apps/site/lib/site_web/controllers/schedule/cms.ex
@@ -11,8 +11,7 @@ defmodule SiteWeb.ScheduleController.CMS do
   alias Content.{Repo, Teaser}
 
   @featured_opts [
-    type: :news_entry,
-    type_op: "not in",
+    type: [:project, :project_update],
     items_per_page: 1,
     sidebar: 1
   ]
@@ -35,7 +34,7 @@ defmodule SiteWeb.ScheduleController.CMS do
     end
 
     news_fn = fn ->
-      [route_id: route.id, type: :news_entry, sidebar: 1]
+      [route_id: route.id, type: [:news_entry], sidebar: 1]
       |> Repo.teasers()
       |> Enum.map(&set_utm_params(&1, route))
     end
@@ -61,6 +60,6 @@ defmodule SiteWeb.ScheduleController.CMS do
     %{teaser | path: url}
   end
 
-  defp utm_type(:news_entry), do: :news
+  defp utm_type([:news_entry]), do: :news
   defp utm_type(type), do: type
 end

--- a/apps/site/lib/site_web/templates/content/_content_list.html.eex
+++ b/apps/site/lib/site_web/templates/content/_content_list.html.eex
@@ -2,12 +2,13 @@
   <%= ContentRewriter.rewrite(@content.header.text, @conn) %>
 <% end %>
 
-<%= render("_teaser_list.html",
-      teasers: @content.teasers,
-      type: Keyword.get(@content.recipe, :type, :generic),
-      conn: @conn) %>
+<%
+  [type] = Keyword.get(@content.recipe, :type, [:generic])
+%>
 
-<%= if list_cta?(@content.ingredients.type, @content.cta, @content.teasers, @conn.path_info) do %>
+<%= render("_teaser_list.html", teasers: @content.teasers, type: type, conn: @conn) %>
+
+<%= if list_cta?(type, @content.cta, @content.teasers, @conn.path_info) do %>
   <% cta = setup_list_cta(@content, @conn.path_info) %>
 
   <p>

--- a/apps/site/lib/site_web/views/content_view.ex
+++ b/apps/site/lib/site_web/views/content_view.ex
@@ -238,29 +238,29 @@ defmodule SiteWeb.ContentView do
   defp paragraph_classes(_), do: []
 
   # Automatically map each list to a destination page based on content type
-  @spec default_list_cta(CMS.type(), String.t()) :: Link.t()
-  defp default_list_cta(:project_update, current_path) do
+  @spec default_list_cta([CMS.type()], String.t()) :: Link.t()
+  defp default_list_cta([:project_update], current_path) do
     %Link{
       title: "View all project updates",
       url: "#{current_path}/updates"
     }
   end
 
-  defp default_list_cta(:event, _current_path) do
+  defp default_list_cta([:event], _current_path) do
     %Link{
       title: "View all events",
       url: "/events"
     }
   end
 
-  defp default_list_cta(:news_entry, _current_path) do
+  defp default_list_cta([:news_entry], _current_path) do
     %Link{
       title: "View all news",
       url: "/news"
     }
   end
 
-  defp default_list_cta(:project, _current_path) do
+  defp default_list_cta([:project], _current_path) do
     %Link{
       title: "View all projects",
       url: "/projects"
@@ -268,7 +268,7 @@ defmodule SiteWeb.ContentView do
   end
 
   # Override one or both of the url/text values for the list CTA
-  @spec custom_list_cta(CMS.type(), map, String.t()) :: Link.t()
+  @spec custom_list_cta([CMS.type()], map, String.t()) :: Link.t()
   defp custom_list_cta(type, %{text: nil, url: url}, current_path) do
     type
     |> default_list_cta(current_path)

--- a/apps/site/test/site_web/controllers/project_controller_test.exs
+++ b/apps/site/test/site_web/controllers/project_controller_test.exs
@@ -26,21 +26,21 @@ defmodule SiteWeb.ProjectControllerTest do
           related_to: 3004,
           sort_by: "field_posted_on_value",
           sort_order: :DESC,
-          type: :project_update
+          type: [:project_update]
         } ->
           {:ok, []}
 
         "/cms/teasers",
         %{
           related_to: 3004,
-          type: :diversion
+          type: [:diversion]
         } ->
           {:ok, []}
 
         "/cms/teasers",
         %{
           related_to: 3004,
-          type: :event,
+          type: [:event],
           date_op: "<"
         } ->
           {:ok, []}
@@ -48,7 +48,7 @@ defmodule SiteWeb.ProjectControllerTest do
         "/cms/teasers",
         %{
           related_to: 3004,
-          type: :event,
+          type: [:event],
           date_op: ">="
         } ->
           {:ok, []}
@@ -63,21 +63,21 @@ defmodule SiteWeb.ProjectControllerTest do
           related_to: 3004,
           sort_by: "field_posted_on_value",
           sort_order: :DESC,
-          type: :project_update
+          type: [:project_update]
         })
         |> assert_called()
 
         "/cms/teasers"
         |> Static.view(%{
           related_to: 3004,
-          type: :diversion
+          type: [:diversion]
         })
         |> assert_called()
 
         "/cms/teasers"
         |> Static.view(%{
           related_to: 3004,
-          type: :event,
+          type: [:event],
           date_op: "<"
         })
         |> assert_called()
@@ -85,7 +85,7 @@ defmodule SiteWeb.ProjectControllerTest do
         "/cms/teasers"
         |> Static.view(%{
           related_to: 3004,
-          type: :event,
+          type: [:event],
           date_op: ">="
         })
         |> assert_called()
@@ -147,7 +147,7 @@ defmodule SiteWeb.ProjectControllerTest do
 
       teaser = teaser_factory(:project_updates, 0)
 
-      teasers_fn = fn [related_to: ^project_id, type: :project_update, items_per_page: 50] ->
+      teasers_fn = fn [related_to: ^project_id, type: [:project_update], items_per_page: 50] ->
         [teaser]
       end
 
@@ -173,7 +173,7 @@ defmodule SiteWeb.ProjectControllerTest do
       project = project_factory(0)
       project_id = project.id
 
-      teasers_fn = fn [related_to: ^project_id, type: :project_update, items_per_page: 50] ->
+      teasers_fn = fn [related_to: ^project_id, type: [:project_update], items_per_page: 50] ->
         []
       end
 

--- a/apps/site/test/site_web/views/content_view_test.exs
+++ b/apps/site/test/site_web/views/content_view_test.exs
@@ -384,9 +384,9 @@ defmodule SiteWeb.ContentViewTest do
           header: %ColumnMultiHeader{
             text: HTML.raw("<p>Header copy.</p>\n")
           },
-          ingredients: %{type: :project_update},
+          ingredients: %{type: [:project_update]},
           recipe: [
-            type: :project_update,
+            type: [:project_update],
             date: "now",
             date_op: ">="
           ],
@@ -891,7 +891,7 @@ defmodule SiteWeb.ContentViewTest do
     test "does not render CTA if there are no teaser results", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :event},
+          ingredients: %{type: [:event]},
           recipe: [promoted: 0],
           cta: %{behavior: "default", text: nil, url: nil}
         })
@@ -902,8 +902,8 @@ defmodule SiteWeb.ContentViewTest do
     test "does not render CTA if author has selected to hide the CTA", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :project_update},
-          recipe: [type: :project_update],
+          ingredients: %{type: [:project_update]},
+          recipe: [type: [:project_update]],
           cta: %{behavior: "hide", text: nil, url: nil}
         })
 
@@ -920,8 +920,8 @@ defmodule SiteWeb.ContentViewTest do
     test "does not render CTA for project updates list if not on a project", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :project_update},
-          recipe: [type: :project_update],
+          ingredients: %{type: [:project_update]},
+          recipe: [type: [:project_update]],
           cta: %{behavior: "default", text: nil, url: nil}
         })
 
@@ -938,8 +938,8 @@ defmodule SiteWeb.ContentViewTest do
     test "renders CTA for project updates list on non-project if overridden", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :project_update},
-          recipe: [type: :project_update],
+          ingredients: %{type: [:project_update]},
+          recipe: [type: [:project_update]],
           cta: %{behavior: "default", text: "Custom CTA", url: "/project/manually-linked/updates"}
         })
 
@@ -958,8 +958,8 @@ defmodule SiteWeb.ContentViewTest do
     test "does not render CTA for types that have no generic destination", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :diversion},
-          recipe: [type: :diversion],
+          ingredients: %{type: [:diversion]},
+          recipe: [type: [:diversion]],
           cta: %{behavior: "default", text: nil, url: nil}
         })
 
@@ -974,8 +974,8 @@ defmodule SiteWeb.ContentViewTest do
     test "renders CTA for types without generic destination if overridden", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :diversion},
-          recipe: [type: :diversion],
+          ingredients: %{type: [:diversion]},
+          recipe: [type: [:diversion]],
           cta: %{behavior: "default", text: "Go here!", url: "/news"}
         })
 
@@ -994,8 +994,8 @@ defmodule SiteWeb.ContentViewTest do
     test "renders automatic CTA for news content lists", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :news_entry},
-          recipe: [type: :news_entry],
+          ingredients: %{type: [:news_entry]},
+          recipe: [type: [:news_entry]],
           cta: %{behavior: "default", text: nil, url: nil}
         })
 
@@ -1012,8 +1012,8 @@ defmodule SiteWeb.ContentViewTest do
     test "renders automatic CTA for event content lists", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :event},
-          recipe: [type: :event],
+          ingredients: %{type: [:event]},
+          recipe: [type: [:event]],
           cta: %{behavior: "default", text: nil, url: nil}
         })
 
@@ -1030,8 +1030,8 @@ defmodule SiteWeb.ContentViewTest do
     test "renders automatic CTA for project content lists", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :project},
-          recipe: [type: :project],
+          ingredients: %{type: [:project]},
+          recipe: [type: [:project]],
           cta: %{behavior: "default", text: nil, url: nil}
         })
 
@@ -1048,8 +1048,8 @@ defmodule SiteWeb.ContentViewTest do
     test "renders default CTA url but with overridden CTA text from author", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :event},
-          recipe: [type: :event],
+          ingredients: %{type: [:event]},
+          recipe: [type: [:event]],
           cta: %{behavior: "default", text: "More where that came from...", url: nil}
         })
 
@@ -1066,8 +1066,8 @@ defmodule SiteWeb.ContentViewTest do
     test "renders default CTA text but with overridden CTA url from author", %{conn: conn} do
       paragraph =
         ContentList.fetch_teasers(%ContentList{
-          ingredients: %{type: :event},
-          recipe: [type: :event],
+          ingredients: %{type: [:event]},
+          recipe: [type: [:event]],
           cta: %{behavior: "default", text: nil, url: "/special-events"}
         })
 

--- a/apps/site/test/site_web/views/partial_view_test.exs
+++ b/apps/site/test/site_web/views/partial_view_test.exs
@@ -125,7 +125,7 @@ defmodule SiteWeb.PartialViewTest do
 
   describe "teaser/1" do
     test "renders the title, topic and description for teasers with topic" do
-      assert [teaser | _] = Repo.teasers(type: :project)
+      assert [teaser | _] = Repo.teasers(type: [:project])
       assert %Teaser{topic: "Projects"} = teaser
       rendered = teaser |> PartialView.teaser() |> safe_to_string()
       assert rendered =~ teaser.image.url


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Events are taking the place of projects](https://app.asana.com/0/555089885850811/1130887606820083)

Changes `Repo.teasers` `type` option from single atom to list of atoms.
- `type: [:project, :news_entry]` will be converted to `{"type[]", "project"}, {"type[]", "news_entry}`

NOTE: Must be deployed _first_, then mbta/cms#286 can be deployed.