### PR TITLE
Legacy Support | old site requests should use https

### DIFF
--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -50,7 +50,7 @@ config :sentry,
   included_environments: [:prod],
   json_library: Poison
 
-config :site, :former_mbta_site, host: "http://old.mbta.com"
+config :site, :former_mbta_site, host: "https://old.mbta.com"
 config :site, tile_server_url: "https://mbta-map-tiles-dev.s3.amazonaws.com"
 
 config :site, OldSiteFileController,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** NO TICKET

Tests were failing because `old.mbta.com` now expects to be called over `https`.

<br>
Assigned to: @phildarnowsky 
