### PR TITLE
Schedule Finder | Polish

### DIFF
--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -239,7 +239,7 @@
     @include media-breakpoint-up(md) {
       left: 50%;
       transform: translate(-50%, -50%);
-      width: 400px;
+      width: 500px;
     }
   }
 }

--- a/apps/site/assets/ts/helpers/__tests__/fetchTest.ts
+++ b/apps/site/assets/ts/helpers/__tests__/fetchTest.ts
@@ -1,0 +1,28 @@
+import { reducer } from "../fetch";
+
+describe("reducer", () => {
+  it("handles a fetch complete action", () => {
+    const newState = reducer(
+      { error: false, isLoading: true, data: null },
+      { type: "FETCH_COMPLETE", payload: [] }
+    );
+    expect(newState).toEqual({ data: [], isLoading: false, error: false });
+  });
+
+  it("handles a fetch error action", () => {
+    const newState = reducer(
+      { error: false, isLoading: true, data: null },
+      { type: "FETCH_ERROR" }
+    );
+    expect(newState).toEqual({ data: null, isLoading: false, error: true });
+  });
+
+  it("handles an unknown action", () => {
+    const newState = reducer(
+      { error: false, isLoading: true, data: null },
+      // @ts-ignore
+      { type: "UNKNOWN" }
+    );
+    expect(newState).toEqual({ data: null, isLoading: true, error: false });
+  });
+});

--- a/apps/site/assets/ts/helpers/__tests__/service-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/service-test.ts
@@ -122,10 +122,10 @@ describe("groupServiceByDate", () => {
     });
   });
 
-  it("groups upcoming schedules as other with proper service period", () => {
+  it("groups upcoming schedules as future with proper service period", () => {
     const groupedService = groupServiceByDate(upcomingService);
     expect(groupedService).toEqual({
-      type: "other",
+      type: "future",
       servicePeriod: "starts July 1",
       service: upcomingService
     });
@@ -142,14 +142,14 @@ describe("groupServiceByDate", () => {
       service: { ...service, service_date: "06-25-19" }
     });
   });
-  it("marks other schedules as others", () => {
+  it("marks future schedules as future", () => {
     const groupedService = groupServiceByDate({
       ...currentService,
       start_date: "2019-01-01",
       end_date: "2019-01-02"
     });
     expect(groupedService).toEqual({
-      type: "other",
+      type: "future",
       servicePeriod: "January 1 to January 2",
       service: {
         ...currentService,
@@ -166,7 +166,7 @@ const groupServices = (services: ServiceWithServiceDate[]) =>
     .reduce(
       (acc: ServicesKeyedByGroup, currService: ServiceByOptGroup) =>
         groupByType(acc, currService),
-      { other: [], current: [], holiday: [] }
+      { future: [], current: [], holiday: [] }
     );
 
 const holidayService = { ...service, service_date: "2019-06-25" };

--- a/apps/site/assets/ts/helpers/fetch.ts
+++ b/apps/site/assets/ts/helpers/fetch.ts
@@ -1,12 +1,12 @@
 export type fetchAction =
   // @ts-ignore should add a generic here
-  | { type: "FETCH_COMPLETE"; payload: any }
+  | { type: "FETCH_COMPLETE"; payload: any } // eslint-disable-line
   | { type: "FETCH_ERROR" }
   | { type: "FETCH_STARTED" };
 
 export interface State {
   // @ts-ignore should add a generic
-  data: any | null;
+  data: any | null; // eslint-disable-line
   isLoading: boolean;
   error: boolean;
 }

--- a/apps/site/assets/ts/helpers/fetch.ts
+++ b/apps/site/assets/ts/helpers/fetch.ts
@@ -1,0 +1,25 @@
+export type fetchAction =
+  // @ts-ignore should add a generic here
+  | { type: "FETCH_COMPLETE"; payload: any }
+  | { type: "FETCH_ERROR" }
+  | { type: "FETCH_STARTED" };
+
+export interface State {
+  // @ts-ignore should add a generic
+  data: any | null;
+  isLoading: boolean;
+  error: boolean;
+}
+
+export const reducer = (state: State, action: fetchAction): State => {
+  switch (action.type) {
+    case "FETCH_STARTED":
+      return { isLoading: true, error: false, data: null };
+    case "FETCH_COMPLETE":
+      return { data: action.payload, isLoading: false, error: false };
+    case "FETCH_ERROR":
+      return { ...state, error: true, isLoading: false };
+    default:
+      return state;
+  }
+};

--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -24,7 +24,7 @@ const holidayDate = (service: Service): string => {
   return note || `on ${formattedDate(new Date(service.start_date))}`;
 };
 
-export type ServiceOptGroup = "current" | "holiday" | "other";
+export type ServiceOptGroup = "current" | "holiday" | "future";
 
 export interface ServiceByOptGroup {
   type: ServiceOptGroup;
@@ -120,14 +120,14 @@ export const groupServiceByDate = (
 
   if (serviceDateTime < startDateTime) {
     return {
-      type: "other",
+      type: "future",
       servicePeriod: `starts ${formattedDate(startDateObject)}`,
       service
     };
   }
 
   return {
-    type: "other",
+    type: "future",
     servicePeriod: `${formattedDate(startDateObject)} to ${formattedDate(
       endDateObject
     )}`,

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleModalTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleModalTest.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import renderer, { act } from "react-test-renderer";
 import { EnhancedRoute, RouteType } from "../../__v3api";
 import ScheduleModalContent, {
-  reducer,
   fetchData
 } from "../components/schedule-finder/ScheduleModalContent";
 import { SimpleStop } from "../components/__schedule";
@@ -183,33 +182,6 @@ describe("ScheduleModal", () => {
           type: "FETCH_ERROR"
         });
       });
-    });
-  });
-
-  describe("reducer", () => {
-    it("handles a fetch complete action", () => {
-      const newState = reducer(
-        { error: false, isLoading: true, data: null },
-        { type: "FETCH_COMPLETE", payload: [] }
-      );
-      expect(newState).toEqual({ data: [], isLoading: false, error: false });
-    });
-
-    it("handles a fetch error action", () => {
-      const newState = reducer(
-        { error: false, isLoading: true, data: null },
-        { type: "FETCH_ERROR" }
-      );
-      expect(newState).toEqual({ data: null, isLoading: false, error: true });
-    });
-
-    it("handles an unknown action", () => {
-      const newState = reducer(
-        { error: false, isLoading: true, data: null },
-        // @ts-ignore
-        { type: "UNKNOWN" }
-      );
-      expect(newState).toEqual({ data: null, isLoading: true, error: false });
     });
   });
 });

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
@@ -58,7 +58,7 @@ Array [
           label="Holiday Schedules"
         />
         <optgroup
-          label="Other Schedules"
+          label="Future Schedules"
         />
       </select>
       <span

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -8,6 +8,7 @@ import {
   RoutePatternsByDirection
 } from "../__schedule";
 import isSilverLine from "../../../helpers/silver-line";
+import { reducer } from "../../../helpers/fetch";
 import ServiceSelector from "./ServiceSelector";
 
 const stopInfo = (
@@ -44,19 +45,6 @@ type fetchAction =
   | { type: "FETCH_COMPLETE"; payload: StopPrediction[] }
   | { type: "FETCH_ERROR" }
   | { type: "FETCH_STARTED" };
-
-export const reducer = (state: State, action: fetchAction): State => {
-  switch (action.type) {
-    case "FETCH_STARTED":
-      return { isLoading: true, error: false, data: null };
-    case "FETCH_COMPLETE":
-      return { data: action.payload, isLoading: false, error: false };
-    case "FETCH_ERROR":
-      return { ...state, error: true, isLoading: false };
-    default:
-      return state;
-  }
-};
 
 export const fetchData = (
   routeId: string,

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -1,11 +1,4 @@
-import React, {
-  Dispatch,
-  ReactElement,
-  SetStateAction,
-  useEffect,
-  useState,
-  useReducer
-} from "react";
+import React, { ReactElement, useEffect, useState, useReducer } from "react";
 import SelectContainer from "./SelectContainer";
 import { ServiceWithServiceDate } from "../../../__v3api";
 import {

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -18,6 +18,7 @@ import {
   serviceDays,
   hasMultipleWeekdaySchedules
 } from "../../../helpers/service";
+import { reducer } from "../../../helpers/fetch";
 import ScheduleTable from "./ScheduleTable";
 import { SelectedDirection } from "../ScheduleFinder";
 import { RoutePatternWithShape, ServiceScheduleInfo } from "../__schedule";
@@ -74,19 +75,6 @@ type fetchAction =
   | { type: "FETCH_ERROR" }
   | { type: "FETCH_STARTED" };
 
-export const reducer = (state: State, action: fetchAction): State => {
-  switch (action.type) {
-    case "FETCH_STARTED":
-      return { isLoading: true, error: false, data: null };
-    case "FETCH_COMPLETE":
-      return { data: action.payload, isLoading: false, error: false };
-    case "FETCH_ERROR":
-      return { ...state, error: true, isLoading: false };
-    default:
-      return state;
-  }
-};
-
 export const fetchData = (
   routeId: string,
   stopId: string,
@@ -119,41 +107,6 @@ interface State {
   error: boolean;
 }
 
-export const fetchSchedule = (
-  services: ServiceWithServiceDate[],
-  selectedServiceId: string,
-  routeId: string,
-  stopId: string,
-  directionId: SelectedDirection,
-  setIsLoading: Dispatch<SetStateAction<boolean>>,
-  setSelectedServiceSchedule: Dispatch<SetStateAction<null>>
-): void => {
-  setIsLoading(true);
-
-  const selectedService = services.find(
-    service => service.id === selectedServiceId
-  );
-
-  if (!selectedService) {
-    return;
-  }
-
-  if (window.fetch) {
-    window
-      .fetch(
-        `/schedules/schedule_api?id=${routeId}&date=${
-          selectedService.end_date
-        }&direction_id=${directionId}&stop_id=${stopId}`
-      )
-      .then(response => {
-        setIsLoading(false);
-        if (response.ok) return response.json();
-        throw new Error(response.statusText);
-      })
-      .then(json => setSelectedServiceSchedule(json));
-  }
-};
-
 export const ServiceSelector = ({
   stopId,
   services,
@@ -181,23 +134,6 @@ export const ServiceSelector = ({
     },
     [services, routeId, directionId, stopId, selectedServiceId]
   );
-
-  //   const [isLoading, setIsLoading] = useState(true);
-  //   const [selectedServiceSchedule, setSelectedServiceSchedule] = useState(null);
-
-  //   useEffect(
-  //     () =>
-  //       fetchSchedule(
-  //         services,
-  //         selectedServiceId,
-  //         routeId,
-  //         stopId,
-  //         directionId,
-  //         setIsLoading,
-  //         setSelectedServiceSchedule
-  //       ),
-  //     [services, directionId, routeId, selectedServiceId, stopId]
-  //   );
 
   if (services.length <= 0) return null;
 
@@ -254,8 +190,10 @@ export const ServiceSelector = ({
 
       {/* istanbul ignore next */ !state.isLoading &&
         /* istanbul ignore next */ state.data && (
-          /* istanbul ignore next */
-          <ScheduleTable schedule={state.data!} routePatterns={routePatterns} />
+          /* istanbul ignore next */ <ScheduleTable
+            schedule={state.data!}
+            routePatterns={routePatterns}
+          />
         )}
     </>
   );

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -24,12 +24,12 @@ import { RoutePatternWithShape } from "../__schedule";
 // until we come up with a good integration test for async with loading
 // some lines in this file have been ignored from codecov
 
-const optGroupNames: ServiceOptGroup[] = ["current", "holiday", "other"];
+const optGroupNames: ServiceOptGroup[] = ["current", "holiday", "future"];
 
 const optGroupTitles: { [key in ServiceOptGroup]: string } = {
   current: "Current Schedules",
   holiday: "Holiday Schedules",
-  other: "Other Schedules"
+  future: "Future Schedules"
 };
 
 interface Props {
@@ -132,7 +132,7 @@ export const ServiceSelector = ({
 
   const servicesByOptGroup: ServicesKeyedByGroup = services
     .map((service: ServiceWithServiceDate) => groupServiceByDate(service))
-    .reduce(groupByType, { current: [], holiday: [], other: [] });
+    .reduce(groupByType, { current: [], holiday: [], future: [] });
 
   const defaultServiceId = getTodaysScheduleId(servicesByOptGroup);
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱Schedules | Finder Tool - Polish](https://app.asana.com/0/555089885850811/1131943808986526)

I ran the Modal flickering that can be see on LG devices (see ticket for an example) through the Chrome Performance tool that can take snapshots. It showed that the modal was going from old data -> spinner -> old data -> new data.

Since the modal went from big to small, the transition was more noticeable. This would be more noticeable on a 3G network on an older mobile device. I was able to emulate that scenario by using the Chrome Performance tool to add network and CPU throttling.

Looking at the code, 
the state was set to loading
-> a render to show the spinner happened,
the state was set to not loading
-> a render to hide the spinner happened and show the (still old) data,
then the state was set with the new data
-> a render to show the new data happened

`useReducer` is common when making external API calls as it can be helpful with debugging and when combining or caching API data across different calls. This also could have used a single `useState({ isLoading: boolean, data: Payload | null })` to set isLoading to false and data to the new data at the same time.

<br>
Assigned to: @phildarnowsky 