### PR TITLE
Timetable | Use headsign for nil stops

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -1,7 +1,7 @@
 defmodule SiteWeb.ScheduleController.TimetableController do
   use SiteWeb, :controller
-  alias SiteWeb.ScheduleView
   alias Routes.Route
+  alias SiteWeb.ScheduleView
 
   plug(SiteWeb.Plugs.Route)
   plug(SiteWeb.Plugs.DateInRating)
@@ -157,19 +157,19 @@ defmodule SiteWeb.ScheduleController.TimetableController do
   end
 
   defp construct_vehicle_data(%Schedules.Schedule{
-         route: %Route{description: :rail_replacement_bus},
-         stop_sequence: s,
-         trip: %Schedules.Trip{id: ti, headsign: headsign}
-       }) do
-    %{stop_sequence: s, stop_name: headsign, trip_id: ti}
-  end
-
-  defp construct_vehicle_data(%Schedules.Schedule{
          stop: %Stops.Stop{name: sn},
          stop_sequence: s,
          trip: %Schedules.Trip{id: ti}
        }) do
     %{stop_sequence: s, stop_name: sn, trip_id: ti}
+  end
+
+  defp construct_vehicle_data(%Schedules.Schedule{
+         route: %Route{description: :rail_replacement_bus},
+         stop_sequence: s,
+         trip: %Schedules.Trip{id: ti, headsign: headsign}
+       }) do
+    %{stop_sequence: s, stop_name: headsign, trip_id: ti}
   end
 
   @spec prior_stops(map) :: map

--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -148,6 +148,14 @@ defmodule SiteWeb.ScheduleController.TimetableController do
   end
 
   defp construct_vehicle_data(%Schedules.Schedule{
+         stop: nil,
+         stop_sequence: s,
+         trip: %Schedules.Trip{id: ti, headsign: headsign}
+       }) do
+    %{stop_sequence: s, stop_name: headsign, trip_id: ti}
+  end
+
+  defp construct_vehicle_data(%Schedules.Schedule{
          stop: %Stops.Stop{name: sn},
          stop_sequence: s,
          trip: %Schedules.Trip{id: ti}

--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -1,6 +1,7 @@
 defmodule SiteWeb.ScheduleController.TimetableController do
   use SiteWeb, :controller
   alias SiteWeb.ScheduleView
+  alias Routes.Route
 
   plug(SiteWeb.Plugs.Route)
   plug(SiteWeb.Plugs.DateInRating)
@@ -149,6 +150,14 @@ defmodule SiteWeb.ScheduleController.TimetableController do
 
   defp construct_vehicle_data(%Schedules.Schedule{
          stop: nil,
+         stop_sequence: s,
+         trip: %Schedules.Trip{id: ti, headsign: headsign}
+       }) do
+    %{stop_sequence: s, stop_name: headsign, trip_id: ti}
+  end
+
+  defp construct_vehicle_data(%Schedules.Schedule{
+         route: %Route{description: :rail_replacement_bus},
          stop_sequence: s,
          trip: %Schedules.Trip{id: ti, headsign: headsign}
        }) do

--- a/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
@@ -2,9 +2,9 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
   @moduledoc false
   use ExUnit.Case, async: true
   import SiteWeb.ScheduleController.TimetableController
+  alias Routes.Route
   alias Stops.Stop
   alias Schedules.{Schedule, Trip}
-  alias Routes.Route
 
   @stops [
     %Stop{id: "1"},

--- a/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
@@ -4,6 +4,7 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
   import SiteWeb.ScheduleController.TimetableController
   alias Stops.Stop
   alias Schedules.{Schedule, Trip}
+  alias Routes.Route
 
   @stops [
     %Stop{id: "1"},
@@ -31,6 +32,21 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
     }
   ]
 
+  @odd_schedules [
+    %Schedule{
+      stop_sequence: 4,
+      time: DateTime.from_unix!(50_000),
+      stop: nil,
+      trip: %Trip{id: "trip-4", headsign: "shuttle", name: "789"}
+    },
+    %Schedule{
+      stop_sequence: 5,
+      time: DateTime.from_unix!(50_000),
+      route: %Route{description: :rail_replacement_bus},
+      stop: %Stop{id: "5", name: "name3"},
+      trip: %Trip{id: "trip-5", headsign: "shuttle", name: "789"}
+    }
+  ]
   @vehicle_schedules %{
     "name1-trip-1" => %{
       stop_name: "name1",
@@ -46,7 +62,9 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
       stop_name: "name3",
       stop_sequence: 3,
       trip_id: "trip-3"
-    }
+    },
+    "name3-trip-5" => %{stop_name: "name3", stop_sequence: 5, trip_id: "trip-5"},
+    "shuttle-trip-4" => %{stop_name: "shuttle", stop_sequence: 4, trip_id: "trip-4"}
   }
 
   describe "build_timetable/2" do
@@ -77,7 +95,7 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
 
   describe "vehicle_schedules/1" do
     test "constructs vehicle data for channel consumption" do
-      vehicles = vehicle_schedules(@schedules)
+      vehicles = vehicle_schedules(Enum.concat(@schedules, @odd_schedules))
       assert @vehicle_schedules == vehicles
     end
   end
@@ -89,8 +107,11 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
       assert %{
                "trip-1-1" => "name1-trip-1",
                "trip-2-2" => "name2-trip-2",
-               "trip-3-3" => "name3-trip-3"
-             } == stops
+               "trip-3-3" => "name3-trip-3",
+               "trip-4-4" => "shuttle-trip-4",
+               "trip-5-5" => "name3-trip-5"
+             } ==
+               stops
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

We are experiencing 500s on pages in the future where schedules did not have a stop. This occurred for Malden shuttles. Updating this processing to use the headsign if the stop is not available. This data does get processed for the tooltips to keep track of what the prior stop is, which might not apply to this data but is processed anyway. 

The ticket in the backlog to address this is to not build data for the vehicle tooltips if the date is not today.

<br>
Assigned to: @NAME
