### PR TITLE
Timetable | Don't calculate tooltip data when it's not today

### DIFF
--- a/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
@@ -95,8 +95,20 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
 
   describe "vehicle_schedules/1" do
     test "constructs vehicle data for channel consumption" do
-      vehicles = vehicle_schedules(Enum.concat(@schedules, @odd_schedules))
+      vehicles =
+        vehicle_schedules(
+          %{assigns: %{date: Util.service_date()}},
+          Enum.concat(@schedules, @odd_schedules)
+        )
+
       assert @vehicle_schedules == vehicles
+    end
+
+    test "doesn't constructs vehicle data for channel consumption if the date is not today" do
+      vehicles =
+        vehicle_schedules(%{assigns: %{date: Date.add(Util.service_date(), 1)}}, @schedules)
+
+      assert vehicles == %{}
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

There's a ticket in the backlog to make the Vehicle stream Phoenix channel to not start on days that are not today, which is a modular level change.

In this case, on a controller level, we are computing extra data specific to CR that is not provided in the Vehicle stream. We don't need this data if it's not the current service day.
 
<br>
Assigned to: @NAME
