### PR TITLE
Prevent empty sidebar right from rendering

### DIFF
--- a/apps/site/lib/site_web/views/page_content_view.ex
+++ b/apps/site/lib/site_web/views/page_content_view.ex
@@ -48,6 +48,20 @@ defmodule SiteWeb.CMS.PageView do
 
   @spec has_right_rail?(Page.t()) :: boolean
   def has_right_rail?(%{paragraphs: paragraphs}) do
-    Enum.any?(paragraphs, &Paragraph.right_rail?(&1))
+    Enum.any?(paragraphs, &right_rail_check(&1))
+  end
+
+  # Checks if any paragraphs have been assigned to the right rail.
+  # If the paragraph is a ContentList.t(), ensure it has teasers.
+  defp right_rail_check(paragraph) do
+    if Paragraph.right_rail?(paragraph) do
+      if Map.has_key?(paragraph, :teasers) do
+        if Enum.empty?(paragraph.teasers), do: false, else: true
+      else
+        true
+      end
+    else
+      false
+    end
   end
 end

--- a/apps/site/test/site_web/views/page_content_view_test.exs
+++ b/apps/site/test/site_web/views/page_content_view_test.exs
@@ -4,7 +4,7 @@ defmodule SiteWeb.CMS.PageViewTest do
   import SiteWeb.CMS.PageView
 
   alias CMS.Page.Basic
-  alias CMS.Partial.Paragraph.CustomHTML
+  alias CMS.Partial.Paragraph.{ContentList, CustomHTML}
   alias Phoenix.HTML
 
   describe "render_page/2" do
@@ -55,6 +55,20 @@ defmodule SiteWeb.CMS.PageViewTest do
         paragraphs: [
           %CustomHTML{body: HTML.raw("<p>Hello</p>"), right_rail: false},
           %CustomHTML{body: HTML.raw("<p>world</p>"), right_rail: false}
+        ]
+      }
+
+      refute has_right_rail?(page)
+    end
+
+    test "returns false if ContentList paragraph is right rail, but has no results" do
+      page = %Basic{
+        paragraphs: [
+          %ContentList{
+            header: %CustomHTML{body: HTML.raw("<p>Hello</p>")},
+            right_rail: true,
+            teasers: []
+          }
         ]
       }
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket.

When there are only empty content list(s), don't render right sidebar. I noticed this on some projects where the layout was shifted over for a sidebar, yet there was no sidebar content.