### PR TITLE
Allow basic pages tagged with route to appear in promo slot

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/cms.ex
+++ b/apps/site/lib/site_web/controllers/schedule/cms.ex
@@ -11,7 +11,7 @@ defmodule SiteWeb.ScheduleController.CMS do
   alias CMS.{Partial.Teaser, Repo}
 
   @featured_opts [
-    type: [:project, :project_update],
+    type: [:project, :project_update, :page],
     items_per_page: 1,
     sidebar: 1
   ]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Allow /schedules/*/line to promo basic pages with page type=Projects](https://app.asana.com/0/555089885850811/1133912070337208)

- on route pages, authors can now feature basic pages tagged with that route
- requires the content to be published (created date) more recent than any other competing, similarly-tagged content
- basic page content must be "Promoted to sidebar" as well

![image](https://user-images.githubusercontent.com/688435/62658923-f4a05980-b937-11e9-8cc1-b2482830215b.png)
