### PR TITLE
Schedule Finder | Duplicate stops

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -124,7 +124,7 @@ defmodule SiteWeb.ScheduleController.LineController do
   def reverse_direction("1"), do: "0"
 
   def simple_stop_list(all_stops) do
-    Enum.map(all_stops, &simple_stop/1)
+    all_stops |> Enum.map(&simple_stop/1) |> Enum.uniq_by(& &1.id)
   end
 
   def simple_stop(%{


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedule Finder | Duplicate stops](https://app.asana.com/0/555089885850811/1134882691751327)

The struct that we are using for this stops list is derived from the struct that creates the "stop bubbles" for the schedule page. I looked into deconstructing that data so we could be more deliberate about the order of stops, but I think that'd be more work than a 1. This solves for the problem for http://localhost:4001/schedules/39/line example in the ticket if you
`export V3_URL="https://green.dev.api.mbtace.com"` before running `mix phx.server`

<br>
Assigned to: @NAME
