### PR TITLE
Redirect routes eliminated by Better Bus Project

### DIFF
--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -74,12 +74,26 @@ defmodule SiteWeb.Router do
     get("/schedules/SL5", Redirector, to: "/schedules/749")
     get("/schedules/sl5", Redirector, to: "/schedules/749")
 
-    get("/schedules/CT1", Redirector, to: "/schedules/701")
-    get("/schedules/ct1", Redirector, to: "/schedules/701")
     get("/schedules/CT2", Redirector, to: "/schedules/747")
     get("/schedules/ct2", Redirector, to: "/schedules/747")
     get("/schedules/CT3", Redirector, to: "/schedules/708")
     get("/schedules/ct3", Redirector, to: "/schedules/708")
+
+    # bus routes eliminated by Better Bus Project
+    get("/schedules/CT1", Redirector, to: "/betterbus-CT1")
+    get("/schedules/CT1/*path_params", Redirector, to: "/betterbus-CT1")
+    get("/schedules/ct1", Redirector, to: "/betterbus-CT1")
+    get("/schedules/ct1/*path_params", Redirector, to: "/betterbus-CT1")
+    get("/schedules/701", Redirector, to: "/betterbus-CT1")
+    get("/schedules/701/*path_params", Redirector, to: "/betterbus-CT1")
+    get("/schedules/5", Redirector, to: "/betterbus-5")
+    get("/schedules/5/*path_params", Redirector, to: "/betterbus-5")
+    get("/schedules/459", Redirector, to: "/betterbus-455-459")
+    get("/schedules/459/*path_params", Redirector, to: "/betterbus-455-459")
+    get("/schedules/448", Redirector, to: "/betterbus-440s")
+    get("/schedules/448/*path_params", Redirector, to: "/betterbus-440s")
+    get("/schedules/449", Redirector, to: "/betterbus-440s")
+    get("/schedules/449/*path_params", Redirector, to: "/betterbus-440s")
 
     get("/", PageController, :index)
 

--- a/apps/site/test/site_web/router_test.exs
+++ b/apps/site/test/site_web/router_test.exs
@@ -7,7 +7,7 @@ defmodule Phoenix.Router.RoutingTest do
       assert redirected_to(conn, 301) == "/stops/Yawkey"
     end
 
-    test "SL", %{conn: conn} do
+    test "SL buses", %{conn: conn} do
       conn = get(conn, "/schedules/SL1")
       assert redirected_to(conn, 301) == "/schedules/741"
 
@@ -37,13 +37,9 @@ defmodule Phoenix.Router.RoutingTest do
 
       conn = get(conn, "/schedules/sl5")
       assert redirected_to(conn, 301) == "/schedules/749"
+    end
 
-      conn = get(conn, "/schedules/CT1")
-      assert redirected_to(conn, 301) == "/schedules/701"
-
-      conn = get(conn, "/schedules/ct1")
-      assert redirected_to(conn, 301) == "/schedules/701"
-
+    test "CT buses", %{conn: conn} do
       conn = get(conn, "/schedules/CT2")
       assert redirected_to(conn, 301) == "/schedules/747"
 
@@ -55,6 +51,50 @@ defmodule Phoenix.Router.RoutingTest do
 
       conn = get(conn, "/schedules/ct3")
       assert redirected_to(conn, 301) == "/schedules/708"
+    end
+
+    test "routes eliminated by Better Bus Project", %{conn: conn} do
+      conn = get(conn, "/schedules/CT1")
+      assert redirected_to(conn, 301) == "/betterbus-CT1"
+
+      conn = get(conn, "/schedules/CT1/tab")
+      assert redirected_to(conn, 301) == "/betterbus-CT1"
+
+      conn = get(conn, "/schedules/ct1")
+      assert redirected_to(conn, 301) == "/betterbus-CT1"
+
+      conn = get(conn, "/schedules/ct1/tab")
+      assert redirected_to(conn, 301) == "/betterbus-CT1"
+
+      conn = get(conn, "/schedules/701")
+      assert redirected_to(conn, 301) == "/betterbus-CT1"
+
+      conn = get(conn, "/schedules/701/tab")
+      assert redirected_to(conn, 301) == "/betterbus-CT1"
+
+      conn = get(conn, "/schedules/5")
+      assert redirected_to(conn, 301) == "/betterbus-5"
+
+      conn = get(conn, "/schedules/5/tab")
+      assert redirected_to(conn, 301) == "/betterbus-5"
+
+      conn = get(conn, "/schedules/459")
+      assert redirected_to(conn, 301) == "/betterbus-455-459"
+
+      conn = get(conn, "/schedules/459/tab")
+      assert redirected_to(conn, 301) == "/betterbus-455-459"
+
+      conn = get(conn, "/schedules/448")
+      assert redirected_to(conn, 301) == "/betterbus-440s"
+
+      conn = get(conn, "/schedules/448/tab")
+      assert redirected_to(conn, 301) == "/betterbus-440s"
+
+      conn = get(conn, "/schedules/449")
+      assert redirected_to(conn, 301) == "/betterbus-440s"
+
+      conn = get(conn, "/schedules/449/tab")
+      assert redirected_to(conn, 301) == "/betterbus-440s"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [❗🚍 Better Bus | Redirect eliminated routes Sept 1 onward](https://app.asana.com/0/555089885850811/1134934127605007)

Some bus routes are getting eliminated by the Better Bus Project. This PR redirects their schedule, etc. pages to the appropriate Better Bus Project page.

<br>
Assigned to: @meagonqz 
