### PR TITLE
Add cdn.knightlab.com to EmbeddedMedia

### DIFF
--- a/apps/site/lib/site/content_rewriters/embedded_media.ex
+++ b/apps/site/lib/site/content_rewriters/embedded_media.ex
@@ -12,7 +12,8 @@ defmodule Site.ContentRewriters.EmbeddedMedia do
     "livestream.com",
     "mbtace.com/shuttle-tracker",
     "youtube.com",
-    "youtu.be"
+    "youtu.be",
+    "cdn.knightlab.com"
   ]
 
   defstruct alignment: :none,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [❗ 🚧 🔶 OL Cars | Embedded iframe has funky sizing](https://app.asana.com/0/555089885850811/1134554424225557)

This allows these iframes to be full width (break out of our columns). 

The scrollbars are due to the Knightlab/Juxtapose javascript in the iframe setting an explicit width/height on an element within it. I don't see any easy way around this. After this change, content authors could use option #2 on https://mbta.com/projects/orange-line-improvement-program/update/new-orange-line-cars?preview=&vid=28918&nid=4453. It seems to resize itself best in our flexbox layout.

The image may not break out of the column at certain viewpoints. If you inspect the element, you will see it has added padding (top or left) because Juxtapose is trying to retain the original aspect ratio of the images. The padding keeps the image from getting stretched.

Deployed to dev-green at https://green.dev.mbtace.com/projects/orange-line-improvement-program/update/new-orange-line-cars?preview=&vid=28918&nid=4453

<br>
Assigned to: @NAME
