### PR TITLE
Change 424 bus from inner express to local

### DIFF
--- a/apps/fares/lib/fares.ex
+++ b/apps/fares/lib/fares.ex
@@ -5,7 +5,7 @@ defmodule Fares do
   @silver_line_rapid_transit ~w(741 742 743 746)
   @silver_line_rapid_transit_set MapSet.new(@silver_line_rapid_transit)
 
-  @inner_express_routes ~w(170 325 326 351 424 426 428 434 448 449 450 459 501 502 503 504 553 554 556 558)
+  @inner_express_routes ~w(170 325 326 351 426 428 434 448 449 450 459 501 502 503 504 553 554 556 558)
   @inner_express_route_set MapSet.new(@inner_express_routes)
 
   @outer_express_routes ~w(352 354 505)

--- a/apps/fares/lib/fares.ex
+++ b/apps/fares/lib/fares.ex
@@ -5,7 +5,7 @@ defmodule Fares do
   @silver_line_rapid_transit ~w(741 742 743 746)
   @silver_line_rapid_transit_set MapSet.new(@silver_line_rapid_transit)
 
-  @inner_express_routes ~w(170 325 326 351 426 428 434 448 449 450 459 501 502 503 504 553 554 556 558)
+  @inner_express_routes ~w(170 325 326 351 426 428 434 450 459 501 502 503 504 553 554 556 558)
   @inner_express_route_set MapSet.new(@inner_express_routes)
 
   @outer_express_routes ~w(352 354 505)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [❗🚍 Better Bus | Remove 424 from hard-coded list of express routes for Sept 1](https://app.asana.com/0/555089885850811/1133711653869789)

This changes the 424 from an inner express bus to a local. I considered making the code changes detailed in the ticket, but on investigation decided that it was more complex than I wanted to do for something with a hard deadline like this.

<br>
Assigned to: @meagonqz 
