### PR TITLE
Fix alert icons in Transit Near Me

### DIFF
--- a/apps/site/lib/site/transit_near_me.ex
+++ b/apps/site/lib/site/transit_near_me.ex
@@ -290,10 +290,12 @@ defmodule Site.TransitNearMe do
       ) do
     route = PredictedSchedule.route(ps)
 
+    alert_count = get_alert_count_for_route(route, alerts)
+    route = JsonHelpers.stringified_route(route) |> Map.put(:alert_count, alert_count)
+
     %{
-      route: JsonHelpers.stringified_route(route),
-      stops_with_directions: get_stops_for_route(schedules, distances, opts),
-      alert_count: get_alert_count_for_route(route, alerts)
+      route: route,
+      stops_with_directions: get_stops_for_route(schedules, distances, opts)
     }
   end
 

--- a/apps/site/test/site/transit_near_me_test.exs
+++ b/apps/site/test/site/transit_near_me_test.exs
@@ -237,7 +237,6 @@ defmodule Site.TransitNearMeTest do
       assert [route_with_stops_with_directions | _] = routes
 
       assert route_with_stops_with_directions |> Map.keys() |> Enum.sort() == [
-               :alert_count,
                :route,
                :stops_with_directions
              ]
@@ -247,7 +246,8 @@ defmodule Site.TransitNearMeTest do
       assert %{stops_with_directions: [stop_with_directions | _]} =
                route_with_stops_with_directions
 
-      assert %{alert_count: 1} = Enum.find(routes, &(&1.route.id == "Orange"))
+      assert %{alert_count: 1} =
+               Enum.find(routes, &(&1.route.id == "Orange")) |> Map.fetch!(:route)
 
       stop = stop_with_directions.stop
       assert %Stop{} = stop


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Routes with high priority alerts aren't showing alert icon in TNM](https://app.asana.com/0/555089885850811/1135457050018732)

A bug in Transit Near Me was preventing routes with alerts from showing alert icons. Fixed.

<br>
Assigned to: @ryan-mahoney 
