### PR TITLE
realtime API bug fixes

### DIFF
--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -134,7 +134,7 @@ defmodule Site.RealtimeScheduleTest do
       schedules_fn: fn _, _ -> @schedules end
     ]
 
-    stops = [@stop]
+    stops = [@stop.id]
 
     expected = [
       %{


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** NO TICKET

Address some realtime API bugs observed when testing Transit Near Me

- don't need to filter predictions by `min_time` when fetching from Repo
- don't fetch schedules for subway
- use a more detailed key for grouping schedules/predictions by route_pattern
- sort predictions by date when they are combined for similar route_patterns

<br>
Assigned to: @phildarnowsky 
