### PR TITLE
IE11: add fetch polyfilll to app.js and fix up response.body

### DIFF
--- a/apps/site/assets/js/app-entry.js
+++ b/apps/site/assets/js/app-entry.js
@@ -1,3 +1,4 @@
 import "@babel/polyfill";
+import "whatwg-fetch";
 import "../css/app.scss";
 import "./app";

--- a/apps/site/assets/ts/projects/components/MoreProjectsTable.tsx
+++ b/apps/site/assets/ts/projects/components/MoreProjectsTable.tsx
@@ -24,8 +24,7 @@ export const fetchMoreProjects = async (
 
   const offset = state.projects.length;
   const response = await window.fetch(`/project_api?offset=${offset}`);
-  const projects: Project[] =
-    response.ok && response.body ? Array.from(await response.json()) : [];
+  const projects: Project[] = response.ok ? await response.json() : [];
   setState({
     projects: state.projects.concat(projects),
     fetchInProgress: false

--- a/apps/site/assets/ts/stop/stop-loader.tsx
+++ b/apps/site/assets/ts/stop/stop-loader.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import "whatwg-fetch";
 import StopPage from "./components/StopPage";
 import { StopPageData, StopMapData } from "./components/__stop";
 

--- a/apps/site/assets/ts/tnm/transit-near-me-loader.tsx
+++ b/apps/site/assets/ts/tnm/transit-near-me-loader.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import "whatwg-fetch";
 import { MapData } from "../leaflet/components/__mapdata";
 import { doWhenGoogleMapsIsReady } from "../../js/google-maps-loaded";
 import TransitNearMeSearch from "./search";


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [IE11: async/await and fetch should work via polyfill](https://app.asana.com/0/555089885850811/1135644534502577)

A problem that wasn't related to async/await is that response.body was always undefined with the whatwg-fetch polyfill. I think that does not exist in this polyfill: https://github.github.io/fetch/
The polyfill doesn't support the readable stream type of body but we don't use that, see more here: https://github.com/github/fetch/pull/32

We separate out vendor packages into vendor.js in production builds so moving this import doesn't make a difference in bundle size/composition.

This is deployed to green.dev.mbtace.com

<br>
Assigned to: @ryan-mahoney 