### PR TITLE
Add alert count per route to realtime API

### DIFF
--- a/apps/site/lib/site/realtime_schedule.ex
+++ b/apps/site/lib/site/realtime_schedule.ex
@@ -143,6 +143,7 @@ defmodule Site.RealtimeSchedule do
             "page[limit]": @predicted_schedules_per_stop
           ]
           |> predictions_fn.()
+          |> Enum.filter(& &1.time)
 
         {key, next_two_predictions}
       end)

--- a/apps/site/lib/site/realtime_schedule.ex
+++ b/apps/site/lib/site/realtime_schedule.ex
@@ -108,7 +108,8 @@ defmodule Site.RealtimeSchedule do
   end
 
   defp get_high_priority_alert_count_for_route(route_id, now, alerts_fn) do
-    alerts_fn.([route_id], now)
+    [route_id]
+    |> alerts_fn.(now)
     |> Enum.filter(&(&1.priority == :high))
     |> length
   end

--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -1,6 +1,9 @@
 defmodule Site.RealtimeScheduleTest do
   use ExUnit.Case
 
+  alias Alerts.Alert
+  alias Alerts.InformedEntity, as: IE
+  alias Alerts.InformedEntitySet, as: IESet
   alias Predictions.Prediction
   alias RoutePatterns.RoutePattern
   alias Routes.Route
@@ -126,12 +129,38 @@ defmodule Site.RealtimeScheduleTest do
     }
   ]
 
+  @alerts [
+    %Alert{
+      id: "1234",
+      active_period: [{@now, @now}],
+      priority: :high,
+      informed_entity: %IESet{
+        entities: [
+          %IE{route: "Orange"},
+          %IE{route: "70"}
+        ]
+      }
+    },
+    %Alert{
+      id: "2345",
+      active_period: [{@now, @now}],
+      priority: :high,
+      informed_entity: %IESet{
+        entities: [
+          %IE{route: "Orange"},
+          %IE{route: "Red"}
+        ]
+      }
+    }
+  ]
+
   test "stop_data/3" do
     opts = [
       stops_fn: fn _ -> @stop end,
       routes_fn: fn _ -> @route_with_patterns end,
       predictions_fn: fn _ -> @predictions end,
-      schedules_fn: fn _, _ -> @schedules end
+      schedules_fn: fn _, _ -> @schedules end,
+      alerts_fn: fn _, _ -> @alerts end
     ]
 
     stops = [@stop.id]
@@ -209,6 +238,7 @@ defmodule Site.RealtimeScheduleTest do
         },
         route: %{
           __struct__: Routes.Route,
+          alert_count: 2,
           custom_route?: false,
           description: :rapid_transit,
           direction_destinations: %{"0" => "Forest Hills", "1" => "Oak Grove"},


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Realtime API | alert count per route](https://app.asana.com/0/555089885850811/1135263069483354)

The realtime API now includes, on a per-route basis, the `alert_count` attribute needed to make alert icons appear where appropriate in TNM.

Also fixed a pre-existing bug in the realtime API where it crashed on skipped predictions.

<br>
Assigned to: @meagonqz 
