### PR TITLE
Algolia Index update: Handle route id of Green

### DIFF
--- a/apps/algolia/lib/algolia/routes.ex
+++ b/apps/algolia/lib/algolia/routes.ex
@@ -26,7 +26,11 @@ defmodule Algolia.Routes do
   def filter_stations(stops, 3), do: Enum.filter(stops, & &1.station?)
   def filter_stations(stops, _), do: stops
 
-  @spec headsigns(String.t()) :: [String.t()]
+  @spec headsigns(String.t()) :: [String.t()] | nil
+  def headsigns("Green") do
+    nil
+  end
+
   def headsigns(id) do
     id
     |> @repo.get()


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🚧 🔴 🔧 Wollaston | Add Wollaston back to stops index](https://app.asana.com/0/555089885850811/1135967865570354)

Wollaston is already showing in production as a stop in Algolia.

The algolia update wasn't completing due to a route being set to "Green" which isn't a valid route id.

<br>
Assigned to: @NAME
