### PR TITLE
Fix Foxboro fares

### DIFF
--- a/apps/fares/lib/fares.ex
+++ b/apps/fares/lib/fares.ex
@@ -11,6 +11,8 @@ defmodule Fares do
   @outer_express_routes ~w(352 354 505)
   @outer_express_route_set MapSet.new(@outer_express_routes)
 
+  @foxboro_place_id "place-FS-0049"
+
   @type ferry_name ::
           :ferry_cross_harbor
           | :ferry_inner_harbor
@@ -24,7 +26,7 @@ defmodule Fares do
   def fare_for_stops(route_type_atom, origin_id, destination_id)
 
   def fare_for_stops(:commuter_rail, origin, destination)
-      when origin == "Foxboro" or destination == "Foxboro" do
+      when origin == @foxboro_place_id or destination == @foxboro_place_id do
     {:ok, :foxboro}
   end
 

--- a/apps/site/lib/site/base_fare.ex
+++ b/apps/site/lib/site/base_fare.ex
@@ -12,6 +12,7 @@ defmodule Site.BaseFare do
   alias Routes.Route
 
   @default_filters [reduced: nil, duration: :single_trip]
+  @default_foxboro_filters [reduced: nil, duration: :round_trip]
 
   @spec base_fare(
           Route.t() | map,
@@ -29,7 +30,14 @@ defmodule Site.BaseFare do
       |> Route.type_atom()
       |> name_or_mode_filter(route, origin_id, destination_id)
 
-    @default_filters
+    default_filters =
+      if {:name, :foxboro} in route_filters do
+        @default_foxboro_filters
+      else
+        @default_filters
+      end
+
+    default_filters
     |> Keyword.merge(route_filters)
     |> fare_fn.()
     |> Enum.min_by(& &1.cents, fn -> nil end)

--- a/apps/site/lib/site_web/templates/schedule/_trip_info.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_trip_info.html.eex
@@ -53,7 +53,7 @@
       <%= Fares.Format.price(base_fare) %>
       (<%= link("View fares", to: cms_static_page_path(@conn, ["/fares/", @route |> Route.type_atom() |> Atom.to_string() |> String.replace("_", "-"), "-fares"])) %>)
     </div>
-    <%= if @route.type === 2 do %>
+    <%= if @route.type === 2 && @route.id != "CR-Foxboro" do %>
       <div class="trip-fare">
         <strong>Unlimited Weekends:</strong>
         $10

--- a/apps/site/test/site/lib/base_fare_test.exs
+++ b/apps/site/test/site/lib/base_fare_test.exs
@@ -238,6 +238,18 @@ defmodule BaseFareTest do
       assert %Fares.Fare{cents: 401} = base_fare(route, origin_id, destination_id, fare_fn)
     end
 
+    test "returns the appropriate fare for Foxboro" do
+      route = %Route{type: 2}
+      south_station_id = "place-sstat"
+      foxboro_id = "place-FS-0049"
+
+      assert %Fares.Fare{cents: 2000, duration: :round_trip} =
+               base_fare(route, south_station_id, foxboro_id)
+
+      assert %Fares.Fare{cents: 2000, duration: :round_trip} =
+               base_fare(route, foxboro_id, south_station_id)
+    end
+
     test "returns nil if no matching fares found" do
       route = %Route{type: 2, id: "CapeFlyer"}
       origin_id = "place-sstat"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Incorrect pricing on CR for special events](https://app.asana.com/0/555089885850811/1135048817493698)

Looking at a schedule page for Foxboro with a special event, e.g. https://www.mbta.com/schedules/CR-Foxboro/schedule?date=2019-08-22&direction_id=0, you'll see prices appropriate for a Zone 1A trip, rather than the $20 flat round-trip fare. Also, it mentions the "Unlimited Weekends" deal that isn't valid for travel to Foxboro. Fixed.

<br>
Assigned to: @meagonqz 
