### PR TITLE
Make Projects category headers link to /projects

### DIFF
--- a/apps/cms/lib/helpers.ex
+++ b/apps/cms/lib/helpers.ex
@@ -20,7 +20,7 @@ defmodule CMS.Helpers do
     end
   end
 
-  @spec handle_html(String.t() | nil) :: Phoenix.HTML.safe()
+  @spec handle_html(String.t() | nil) :: HTML.safe()
   def handle_html(html) do
     (html || "")
     |> CustomHTML5Scrubber.html5()

--- a/apps/site/assets/css/_banner.scss
+++ b/apps/site/assets/css/_banner.scss
@@ -2,6 +2,7 @@
   color: inherit;
   display: block;
   margin-top: $base-spacing * 3;
+  position: relative;
 
   &:hover {
     color: inherit;
@@ -97,10 +98,10 @@
   padding: $base-spacing;
 
   @include media-breakpoint-down(xs) {
+    margin-bottom: $base-spacing * 5;
     margin-left: $base-spacing * 2;
     margin-right: $base-spacing * 2;
-    position: relative;
-    top: -$base-spacing * 4;
+    margin-top: -$base-spacing * 4;
   }
 
   @include media-breakpoint-up(sm) {
@@ -158,6 +159,38 @@
 
 .m-banner__category {
   font-weight: bold;
+
+  a {
+    left: -$base-spacing / 2;
+    padding: $base-spacing / 2;
+    position: relative;
+    z-index: 1;
+
+    @include hover-focus-active {
+      text-decoration: none;
+    }
+
+    &:hover::after {
+      content: ' ' attr(title);
+      opacity: .5;
+      white-space: pre;
+    }
+  }
+}
+
+.m-banner__title {
+  a {
+    display: inline-block;
+
+    &::after {
+      bottom: 0;
+      content: '';
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+  }
 }
 
 .m-banner__cta {

--- a/apps/site/assets/css/_banner.scss
+++ b/apps/site/assets/css/_banner.scss
@@ -2,7 +2,6 @@
   color: inherit;
   display: block;
   margin-top: $base-spacing * 3;
-  position: relative;
 
   &:hover {
     color: inherit;
@@ -161,19 +160,8 @@
   font-weight: bold;
 
   a {
-    left: -$base-spacing / 2;
-    padding: $base-spacing / 2;
-    position: relative;
-    z-index: 1;
-
     @include hover-focus-active {
       text-decoration: none;
-    }
-
-    &:hover::after {
-      content: ' ' attr(title);
-      opacity: .5;
-      white-space: pre;
     }
   }
 }
@@ -181,15 +169,6 @@
 .m-banner__title {
   a {
     display: inline-block;
-
-    &::after {
-      bottom: 0;
-      content: '';
-      left: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
   }
 }
 

--- a/apps/site/assets/css/_banner.scss
+++ b/apps/site/assets/css/_banner.scss
@@ -158,18 +158,6 @@
 
 .m-banner__category {
   font-weight: bold;
-
-  a {
-    @include hover-focus-active {
-      text-decoration: none;
-    }
-  }
-}
-
-.m-banner__title {
-  a {
-    display: inline-block;
-  }
 }
 
 .m-banner__cta {
@@ -182,7 +170,6 @@
     background: $brand-primary-lightest;
     text-decoration: none;
   }
-
 }
 
 .m-banner__date {

--- a/apps/site/assets/css/_content-teasers.scss
+++ b/apps/site/assets/css/_content-teasers.scss
@@ -45,17 +45,6 @@
     }
   }
 
-  .c-content-teaser__title {
-    a::after {
-      bottom: 0;
-      content: '';
-      left: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
-  }
-
   &:nth-child(odd) {
     clear: both;
   }
@@ -122,21 +111,6 @@
 .c-content-teaser__date,
 .c-content-teaser__topic {
   font-weight: 700;
-}
-
-.c-content-teaser__topic {
-  a {
-    left: -$base-spacing / 2;
-    padding: $base-spacing / 2;
-    position: relative;
-    z-index: 1;
-
-    &:hover::after {
-      color: $gray-lighter;
-      content: ' ' attr(title);
-      white-space: pre;
-    }
-  }
 }
 
 .c-content-teaser__title {

--- a/apps/site/assets/css/_content-teasers.scss
+++ b/apps/site/assets/css/_content-teasers.scss
@@ -25,6 +25,7 @@
   border: 0;
   color: inherit;
   display: block;
+  position: relative;
   text-decoration: none;
 
   &--event,
@@ -35,12 +36,23 @@
     }
   }
 
-  &:hover {
+  a {
     color: inherit;
-    text-decoration: none;
 
-    .c-content-teaser__title {
+    &:hover {
       color: $brand-primary;
+      text-decoration: none;
+    }
+  }
+
+  .c-content-teaser__title {
+    a::after {
+      bottom: 0;
+      content: '';
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
     }
   }
 
@@ -110,6 +122,21 @@
 .c-content-teaser__date,
 .c-content-teaser__topic {
   font-weight: 700;
+}
+
+.c-content-teaser__topic {
+  a {
+    left: -$base-spacing / 2;
+    padding: $base-spacing / 2;
+    position: relative;
+    z-index: 1;
+
+    &:hover::after {
+      color: $gray-lighter;
+      content: ' ' attr(title);
+      white-space: pre;
+    }
+  }
 }
 
 .c-content-teaser__title {

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -172,7 +172,7 @@
     &:hover::after {
       // scss-lint:disable DuplicateProperty PropertySortOrder
       content: ' ' attr(title);
-      opacity: .5;
+      opacity: .65;
       white-space: pre;
 
       // Grayscale/desaturated

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -168,16 +168,5 @@
     padding: $base-spacing / 2;
     position: relative;
     z-index: 1;
-
-    &:hover::after {
-      // scss-lint:disable DuplicateProperty PropertySortOrder
-      content: ' ' attr(title);
-      opacity: .65;
-      white-space: pre;
-
-      // Grayscale/desaturated
-      filter: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' ><filter id='gray'><feColorMatrix in='SourceGraphic' type='saturate' values='0' /></filter></svg>#gray");
-      filter: grayscale(100%);
-    }
   }
 }

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -146,3 +146,38 @@
                  10vw 0 $brand-primary-lightest-contrast;
   }
 }
+
+.u-linked-card {
+  position: relative;
+
+  &__primary-link {
+    display: inline-block;
+
+    &::after {
+      bottom: 0;
+      content: '';
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+  }
+
+  &__secondary-link {
+    left: -$base-spacing / 2;
+    padding: $base-spacing / 2;
+    position: relative;
+    z-index: 1;
+
+    &:hover::after {
+      // scss-lint:disable DuplicateProperty PropertySortOrder
+      content: ' ' attr(title);
+      opacity: .5;
+      white-space: pre;
+
+      // Grayscale/desaturated
+      filter: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' ><filter id='gray'><feColorMatrix in='SourceGraphic' type='saturate' values='0' /></filter></svg>#gray");
+      filter: grayscale(100%);
+    }
+  }
+}

--- a/apps/site/assets/css/_whats-happening.scss
+++ b/apps/site/assets/css/_whats-happening.scss
@@ -42,6 +42,12 @@
     padding: $base-spacing / 2;
     position: relative;
     z-index: 1;
+
+    &:hover::after {
+      color: $gray-lighter;
+      content: ' ' attr(title);
+      white-space: pre;
+    }
   }
 }
 

--- a/apps/site/assets/css/_whats-happening.scss
+++ b/apps/site/assets/css/_whats-happening.scss
@@ -36,21 +36,27 @@
 .m-whats-happening__category {
   font-weight: bold;
   margin-top: $base-spacing / 2;
+
+  a {
+    left: -$base-spacing / 2;
+    padding: $base-spacing / 2;
+    position: relative;
+    z-index: 1;
+  }
 }
 
 .m-whats-happening__item {
   flex-basis: 0;
   flex-grow: 1;
   margin: 0 $base-spacing / 2 $base-spacing / 2;
+  position: relative;
 
   a {
     color: $black;
     text-decoration: none;
 
     @include hover-focus-active {
-      .about-link {
-        text-decoration: inherit;
-      }
+      color: $brand-primary;
     }
   }
 
@@ -58,11 +64,14 @@
     font-family: $font-family-base;
     font-size: $font-size-h3;
     margin: 0;
-  }
 
-  &:hover {
-    .m-whats-happening__title {
-      color: $brand-primary;
+    a::after {
+      bottom: 0;
+      content: '';
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
     }
   }
 }

--- a/apps/site/assets/css/_whats-happening.scss
+++ b/apps/site/assets/css/_whats-happening.scss
@@ -36,26 +36,12 @@
 .m-whats-happening__category {
   font-weight: bold;
   margin-top: $base-spacing / 2;
-
-  a {
-    left: -$base-spacing / 2;
-    padding: $base-spacing / 2;
-    position: relative;
-    z-index: 1;
-
-    &:hover::after {
-      color: $gray-lighter;
-      content: ' ' attr(title);
-      white-space: pre;
-    }
-  }
 }
 
 .m-whats-happening__item {
   flex-basis: 0;
   flex-grow: 1;
   margin: 0 $base-spacing / 2 $base-spacing / 2;
-  position: relative;
 
   a {
     color: $black;
@@ -70,15 +56,6 @@
     font-family: $font-family-base;
     font-size: $font-size-h3;
     margin: 0;
-
-    a::after {
-      bottom: 0;
-      content: '';
-      left: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
   }
 }
 

--- a/apps/site/lib/site_web/templates/page/_banner.html.eex
+++ b/apps/site/lib/site_web/templates/page/_banner.html.eex
@@ -1,14 +1,14 @@
-<a href="<%= cms_static_page_path(@conn, @banner.utm_url) %>" class="m-banner m-banner--responsive m-banner--<%= @banner.banner_type %>">
+<div class="m-banner m-banner--responsive m-banner--<%= @banner.banner_type %>">
   <div class="m-banner__image m-banner__image--responsive m-banner__image--<%= @banner.banner_type %>" style="background-image: url(<%= @banner.thumb.url %>)">
     <div class="sr-only">
       <%= @banner.thumb.alt %>
     </div>
     <div class="container hidden-xs-down">
-      <%= render "_banner_content.html", banner: @banner %>
+      <%= render "_banner_content.html", banner: @banner, conn: @conn %>
     </div>
   </div>
   <div class="hidden-sm-up">
     <%# mobile banner design requires a different div structure %>
-    <%= render "_banner_content.html", banner: @banner %>
+    <%= render "_banner_content.html", banner: @banner, conn: @conn %>
   </div>
-</a>
+</div>

--- a/apps/site/lib/site_web/templates/page/_banner.html.eex
+++ b/apps/site/lib/site_web/templates/page/_banner.html.eex
@@ -1,4 +1,4 @@
-<div class="m-banner m-banner--responsive m-banner--<%= @banner.banner_type %>">
+<div class="m-banner m-banner--responsive m-banner--<%= @banner.banner_type %> u-linked-card">
   <div class="m-banner__image m-banner__image--responsive m-banner__image--<%= @banner.banner_type %>" style="background-image: url(<%= @banner.thumb.url %>)">
     <div class="sr-only">
       <%= @banner.thumb.alt %>

--- a/apps/site/lib/site_web/templates/page/_banner_content.html.eex
+++ b/apps/site/lib/site_web/templates/page/_banner_content.html.eex
@@ -4,7 +4,7 @@
       <%= link_category(@banner.category)%>
     </div>
     <h2 class="h2 m-banner__title m-banner__title--<%= @banner.banner_type %>">
-      <%= link @banner.title, to: cms_static_page_path(@conn, @banner.utm_url) %>
+      <%= link @banner.title, to: cms_static_page_path(@conn, @banner.utm_url), class: "u-linked-card__primary-link" %>
     </h2>
     <%= if @banner.banner_type == :important do %>
       <p><%= @banner.blurb %></p>

--- a/apps/site/lib/site_web/templates/page/_banner_content.html.eex
+++ b/apps/site/lib/site_web/templates/page/_banner_content.html.eex
@@ -1,10 +1,10 @@
 <div class="<%= banner_content_class(@banner) %>">
   <div class="m-banner__top">
     <div class="m-banner__category u-small-caps">
-      <%= @banner.category %>
+      <%= link_category(@banner.category)%>
     </div>
     <h2 class="h2 m-banner__title m-banner__title--<%= @banner.banner_type %>">
-      <%= @banner.title %>
+      <%= link @banner.title, to: cms_static_page_path(@conn, @banner.utm_url) %>
     </h2>
     <%= if @banner.banner_type == :important do %>
       <p><%= @banner.blurb %></p>

--- a/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
+++ b/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
@@ -8,20 +8,18 @@
       <div id="whats-happening-<%= tag %>" class="row m-whats-happening__row m-whats-happening__row--<%= tag %>">
         <%= for {item, counter} <- Enum.with_index(@whats_happening_items) do %>
           <div id="whats-happening-<%= tag %>-<%= counter %>" class="homepage-link m-whats-happening__item m-whats-happening__item--<%= if @promoted do "promoted" else "secondary" end %>">
-            <%= link to: cms_static_page_path(@conn, (item.utm_url)) || "/" do %>
-              <%= if item.image do %>
-                <div class="m-whats-happening__image">
-                  <%= img_tag(item.image.url, alt: item.image.alt) %>
-                </div>
-              <% end %>
-              <div class="m-whats-happening-_description">
-                <div class="m-whats-happening__category u-small-caps"><%= item.category %></div>
-                <h3 class="m-whats-happening__title"><%= item.title %></h3>
-                <%= if @promoted do %>
-                  <div><%= item.blurb %></div>
-                <% end %>
+            <%= if item.image do %>
+              <div class="m-whats-happening__image">
+                <%= img_tag(item.image.url, alt: item.image.alt) %>
               </div>
             <% end %>
+            <div class="m-whats-happening-_description">
+              <div class="m-whats-happening__category u-small-caps"><a href="#cat"><%= item.category %></a></div>
+              <h3 class="m-whats-happening__title"><%= link item.title, to: cms_static_page_path(@conn, (item.utm_url)) || "/" %></h3>
+              <%= if @promoted do %>
+                <div><%= item.blurb %></div>
+              <% end %>
+            </div>
           </div>
         <% end %>
       </div>

--- a/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
+++ b/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
@@ -14,8 +14,12 @@
               </div>
             <% end %>
             <div class="m-whats-happening-_description">
-              <div class="m-whats-happening__category u-small-caps"><%= link_category(item.category)%></div>
-              <h3 class="m-whats-happening__title"><%= link item.title, to: cms_static_page_path(@conn, (item.utm_url)) || "/" %></h3>
+              <div class="m-whats-happening__category u-small-caps">
+                <%= link_category(item.category)%>
+              </div>
+              <h3 class="m-whats-happening__title">
+                <%= link item.title, to: cms_static_page_path(@conn, (item.utm_url)) || "/" %>
+              </h3>
               <%= if @promoted do %>
                 <div><%= item.blurb %></div>
               <% end %>

--- a/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
+++ b/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
@@ -14,7 +14,7 @@
               </div>
             <% end %>
             <div class="m-whats-happening-_description">
-              <div class="m-whats-happening__category u-small-caps"><a href="#cat"><%= item.category %></a></div>
+              <div class="m-whats-happening__category u-small-caps"><%= linked_category(item.category)%></div>
               <h3 class="m-whats-happening__title"><%= link item.title, to: cms_static_page_path(@conn, (item.utm_url)) || "/" %></h3>
               <%= if @promoted do %>
                 <div><%= item.blurb %></div>

--- a/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
+++ b/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
@@ -14,7 +14,7 @@
               </div>
             <% end %>
             <div class="m-whats-happening-_description">
-              <div class="m-whats-happening__category u-small-caps"><%= linked_category(item.category)%></div>
+              <div class="m-whats-happening__category u-small-caps"><%= link_category(item.category)%></div>
               <h3 class="m-whats-happening__title"><%= link item.title, to: cms_static_page_path(@conn, (item.utm_url)) || "/" %></h3>
               <%= if @promoted do %>
                 <div><%= item.blurb %></div>

--- a/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
+++ b/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
@@ -7,7 +7,11 @@
     <div class="container page-section">
       <div id="whats-happening-<%= tag %>" class="row m-whats-happening__row m-whats-happening__row--<%= tag %>">
         <%= for {item, counter} <- Enum.with_index(@whats_happening_items) do %>
-          <div id="whats-happening-<%= tag %>-<%= counter %>" class="homepage-link m-whats-happening__item m-whats-happening__item--<%= if @promoted do "promoted" else "secondary" end %>">
+          <div id="whats-happening-<%= tag %>-<%= counter %>" class="
+            homepage-link
+            m-whats-happening__item
+            m-whats-happening__item--<%= if @promoted do "promoted" else "secondary" end %>
+            u-linked-card">
             <%= if item.image do %>
               <div class="m-whats-happening__image">
                 <%= img_tag(item.image.url, alt: item.image.alt) %>
@@ -18,7 +22,7 @@
                 <%= link_category(item.category)%>
               </div>
               <h3 class="m-whats-happening__title">
-                <%= link item.title, to: cms_static_page_path(@conn, (item.utm_url)) || "/" %>
+                <%= link item.title, to: cms_static_page_path(@conn, (item.utm_url)) || "/", class: "u-linked-card__primary-link" %>
               </h3>
               <%= if @promoted do %>
                 <div><%= item.blurb %></div>

--- a/apps/site/lib/site_web/views/helpers/cms_helpers.ex
+++ b/apps/site/lib/site_web/views/helpers/cms_helpers.ex
@@ -5,6 +5,7 @@ defmodule SiteWeb.CMSHelpers do
 
   import SiteWeb.ViewHelpers, only: [route_to_class: 1]
   import CSSHelpers, only: [string_to_class: 1]
+  import Phoenix.HTML.Link
 
   alias CMS.API
   alias Routes.Repo
@@ -25,4 +26,12 @@ defmodule SiteWeb.CMSHelpers do
   def cms_route_to_class(%{group: "custom", mode: mode}), do: string_to_class(mode)
   def cms_route_to_class(%{group: "mode", id: mode}), do: string_to_class(mode)
   def cms_route_to_class(%{id: id}), do: id |> Repo.get() |> route_to_class()
+
+  @doc """
+  Map certain CMS content categories to index pages of that content.
+  If no match is found, simply output the original string category.
+  """
+  @spec linked_category(String.t()) :: String.t() | Phoenix.HTML.safe()
+  def linked_category("Projects"), do: link("Projects", to: "/projects")
+  def linked_category(category), do: category
 end

--- a/apps/site/lib/site_web/views/helpers/cms_helpers.ex
+++ b/apps/site/lib/site_web/views/helpers/cms_helpers.ex
@@ -32,6 +32,14 @@ defmodule SiteWeb.CMSHelpers do
   If no match is found, simply output the original string category.
   """
   @spec link_category(String.t()) :: String.t() | Phoenix.HTML.safe()
-  def link_category("Projects" = cat), do: link(cat, to: "/projects", title: "View all #{cat}")
-  def link_category(category), do: category
+  def link_category("Projects" = text) do
+    link(
+      text,
+      to: "/projects",
+      title: "View all #{text}",
+      class: "u-linked-card__secondary-link"
+    )
+  end
+
+  def link_category(text), do: text
 end

--- a/apps/site/lib/site_web/views/helpers/cms_helpers.ex
+++ b/apps/site/lib/site_web/views/helpers/cms_helpers.ex
@@ -31,7 +31,7 @@ defmodule SiteWeb.CMSHelpers do
   Map certain CMS content categories to index pages of that content.
   If no match is found, simply output the original string category.
   """
-  @spec linked_category(String.t()) :: String.t() | Phoenix.HTML.safe()
-  def linked_category("Projects"), do: link("Projects", to: "/projects")
-  def linked_category(category), do: category
+  @spec link_category(String.t()) :: String.t() | Phoenix.HTML.safe()
+  def link_category("Projects" = cat), do: link(cat, to: "/projects", title: "View all #{cat}")
+  def link_category(category), do: category
 end

--- a/apps/site/lib/site_web/views/page_view.ex
+++ b/apps/site/lib/site_web/views/page_view.ex
@@ -1,7 +1,7 @@
 defmodule SiteWeb.PageView do
   @moduledoc false
   import Phoenix.HTML.Tag
-  import SiteWeb.CMSHelpers, only: [cms_route_to_class: 1]
+  import SiteWeb.CMSHelpers
 
   alias CMS.Page.NewsEntry
   alias CMS.Partial.Banner

--- a/apps/site/lib/site_web/views/partial_view.ex
+++ b/apps/site/lib/site_web/views/partial_view.ex
@@ -96,7 +96,8 @@ defmodule SiteWeb.PartialView do
     Enum.join(
       [
         Keyword.get(opts, :class, ""),
-        "c-content-teaser"
+        "c-content-teaser",
+        "u-linked-card"
       ],
       " "
     )
@@ -149,7 +150,9 @@ defmodule SiteWeb.PartialView do
     ]
   end
 
-  defp teaser_title(teaser), do: link(teaser.title, to: teaser.path)
+  defp teaser_title(teaser) do
+    link(teaser.title, to: teaser.path, class: "u-linked-card__primary-link")
+  end
 
   defp teaser_topic(teaser), do: link_category(teaser.topic)
 

--- a/apps/site/lib/site_web/views/partial_view.ex
+++ b/apps/site/lib/site_web/views/partial_view.ex
@@ -7,7 +7,7 @@ defmodule SiteWeb.PartialView do
   alias SiteWeb.PartialView.SvgIconWithCircle
 
   import SiteWeb.CMSView, only: [file_description: 1]
-  import SiteWeb.CMSHelpers, only: [cms_route_to_class: 1]
+  import SiteWeb.CMSHelpers
   import SiteWeb.CMS.ParagraphView, only: [render_paragraph: 2]
 
   defdelegate fa_icon_for_file_type(mime), to: Site.FontAwesomeHelpers
@@ -81,9 +81,12 @@ defmodule SiteWeb.PartialView do
   """
   @spec teaser(Teaser.t()) :: Phoenix.HTML.Safe.t()
   def teaser(%Teaser{} = teaser, opts \\ []) do
-    link(
-      teaser_link_content(teaser),
-      to: teaser.path,
+    content_tag(
+      :div,
+      [
+        render_teaser_image(teaser),
+        teaser_text(teaser)
+      ],
       class: teaser_class(opts)
     )
   end
@@ -97,14 +100,6 @@ defmodule SiteWeb.PartialView do
       ],
       " "
     )
-  end
-
-  @spec teaser_link_content(Teaser.t()) :: Phoenix.HTML.Safe.t() | [Phoenix.HTML.Safe.t()]
-  defp teaser_link_content(%Teaser{} = teaser) do
-    [
-      render_teaser_image(teaser),
-      teaser_text(teaser)
-    ]
   end
 
   def render_teaser_image(%Teaser{image: nil}) do
@@ -141,18 +136,22 @@ defmodule SiteWeb.PartialView do
 
   defp teaser_text(%Teaser{topic: nil} = teaser) do
     [
-      content_tag(:h3, [teaser.title], class: "h3 c-content-teaser__title"),
+      content_tag(:h3, [teaser_title(teaser)], class: "h3 c-content-teaser__title"),
       content_tag(:div, [teaser.text], class: "c-content-teaser__text")
     ]
   end
 
   defp teaser_text(teaser) do
     [
-      content_tag(:div, [teaser.topic], class: "c-content-teaser__topic u-small-caps"),
-      content_tag(:h3, [teaser.title], class: "h3 c-content-teaser__title"),
+      content_tag(:div, [teaser_topic(teaser)], class: "c-content-teaser__topic u-small-caps"),
+      content_tag(:h3, [teaser_title(teaser)], class: "h3 c-content-teaser__title"),
       content_tag(:div, [teaser.text], class: "c-content-teaser__text")
     ]
   end
+
+  defp teaser_title(teaser), do: link(teaser.title, to: teaser.path)
+
+  defp teaser_topic(teaser), do: link_category(teaser.topic)
 
   @doc """
   Renders a news entry. Take two options:


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Make Projects category headers link to /projects](https://app.asana.com/0/555089885850811/1134372917205057)

Create a nested utility class to render certain blocks of content as "cards" -- with a primary link covering the entire block, and secondary link(s) which can be clicked on for alternate navigation.

Applied to:
- Homepage: Main Banner
- Homepage: All primary and secondary "What's Happening" item blocks
- Hub and Line Schedule pages: sidebar project teasers

Bonus:
- ~When the secondary link is hovered, its `title` attribute text is shown for greater context~

![image](https://user-images.githubusercontent.com/688435/63541967-2d6e3000-c4ed-11e9-8682-1e4f3e79b012.png)
