### PR TITLE
Support updated CMS API datetime RFC3339 format

### DIFF
--- a/apps/cms/lib/helpers.ex
+++ b/apps/cms/lib/helpers.ex
@@ -68,12 +68,30 @@ defmodule CMS.Helpers do
   end
 
   @spec parse_iso_datetime(String.t()) :: DateTime.t() | nil
+  def parse_iso_datetime(nil) do
+    nil
+  end
+
   def parse_iso_datetime(time) do
-    case Timex.parse(time, "{ISOdate}T{ISOtime}") do
-      {:ok, dt} -> Timex.to_datetime(dt, "Etc/UTC")
-      _ -> nil
+    case String.split(time, ":") do
+      [_date_hr, _min, _sec] ->
+        time
+        |> Timex.parse("{ISOdate}T{ISOtime}")
+        |> do_parse_iso_datetime(:deprecated)
+
+      [_date_hr, _min, _sec, _tz] ->
+        time
+        |> Timex.parse("{ISO:Extended}")
+        |> do_parse_iso_datetime(:extended)
+
+      _ ->
+        nil
     end
   end
+
+  defp do_parse_iso_datetime({:ok, dt}, :deprecated), do: Timex.to_datetime(dt, "Etc/UTC")
+  defp do_parse_iso_datetime({:ok, dt}, :extended), do: dt
+  defp do_parse_iso_datetime(_, _), do: nil
 
   @spec parse_date(map, String.t()) :: Date.t() | nil
   def parse_date(data, field) do

--- a/apps/site/test/site_web/views/cms_view_test.exs
+++ b/apps/site/test/site_web/views/cms_view_test.exs
@@ -2,6 +2,7 @@ defmodule SiteWeb.CMSViewTest do
   use Site.ViewCase, async: true
 
   import SiteWeb.CMSView
+  import CMS.Helpers, only: [parse_iso_datetime: 1]
 
   alias CMS.API.Static
   alias CMS.Field.File
@@ -135,6 +136,17 @@ defmodule SiteWeb.CMSViewTest do
 
       # could also be November 6th, 1:00 AM (test daylight savings)
       expected = "November 5, 2016 1 AM - November 6, 2016 2 AM"
+      assert expected == actual
+    end
+
+    test "with ISO:Extended DateTimes, does not shift timezone" do
+      actual =
+        render_duration(
+          parse_iso_datetime("2016-11-06T01:00:00-04:00"),
+          parse_iso_datetime("2016-11-06T02:00:00-04:00")
+        )
+
+      expected = "November 6, 2016 at 1 AM - 2 AM"
       assert expected == actual
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Event Start Time now includes TZ offset in CMS](https://app.asana.com/0/555089885850811/1135670866855626)

- Adds support for new datetime format w/TZ included
- Maintain support for original format during transition period
