### PR TITLE
support {{ route:x }} liquid replacements

### DIFF
--- a/apps/site/lib/site/content_rewriters/liquid_objects/route.ex
+++ b/apps/site/lib/site/content_rewriters/liquid_objects/route.ex
@@ -1,0 +1,33 @@
+defmodule Site.ContentRewriters.LiquidObjects.Route do
+  @moduledoc """
+
+  This module converts a string-based route name into its long_name string.
+
+  """
+
+  alias Routes.{Repo, Route}
+
+  @type request_error :: {:error, {:empty | :unmatched, String.t()}}
+  @type request_tuple :: {:ok, String.t()}
+
+  @spec route_request(String.t()) :: {:ok, String.t()} | request_error
+  def route_request(string) do
+    string
+    |> compose_args()
+    |> request_route()
+    |> process_results()
+  end
+
+  @spec compose_args(String.t()) :: request_tuple | request_error
+  defp compose_args(""), do: {:error, {:empty, "no input"}}
+  defp compose_args(route), do: {:ok, route}
+
+  @spec request_route(request_tuple | request_error) :: Route.t() | request_error | nil
+  defp request_route({:ok, route}), do: Repo.get(route)
+  defp request_route(error), do: error
+
+  @spec process_results(Route.t() | request_error | nil) :: {:ok, String.t()} | request_error
+  defp process_results(nil), do: {:error, {:unmatched, "no route match"}}
+  defp process_results(%Route{} = route), do: {:ok, route.long_name}
+  defp process_results(error), do: error
+end

--- a/apps/site/test/site/content_rewriters/liquid_objects/route_test.exs
+++ b/apps/site/test/site/content_rewriters/liquid_objects/route_test.exs
@@ -3,7 +3,7 @@ defmodule Site.ContentRewriters.LiquidObjects.RouteTest do
 
   import Site.ContentRewriters.LiquidObjects.Route
 
-  alias Routes.{Repo, Route}
+  alias Routes.Repo
 
   describe "route_request/1" do
     test "it handles route requests for a valid/existing route ID" do

--- a/apps/site/test/site/content_rewriters/liquid_objects/route_test.exs
+++ b/apps/site/test/site/content_rewriters/liquid_objects/route_test.exs
@@ -1,0 +1,25 @@
+defmodule Site.ContentRewriters.LiquidObjects.RouteTest do
+  use ExUnit.Case, async: true
+
+  import Site.ContentRewriters.LiquidObjects.Route
+
+  alias Routes.{Repo, Route}
+
+  describe "route_request/1" do
+    test "it handles route requests for a valid/existing route ID" do
+      assert "83"
+             |> Repo.get()
+             |> Map.get(:long_name) == "Rindge Avenue - Central Square, Cambridge"
+
+      assert route_request("83") == {:ok, "Rindge Avenue - Central Square, Cambridge"}
+    end
+
+    test "it reports when there are no results (valid request, but no repo matches)" do
+      assert route_request("999") == {:error, {:unmatched, "no route match"}}
+    end
+
+    test "it handles a blank request (no filters provided)" do
+      assert route_request("") == {:error, {:empty, "no input"}}
+    end
+  end
+end

--- a/apps/site/test/site/content_rewriters/liquid_objects/route_test.exs
+++ b/apps/site/test/site/content_rewriters/liquid_objects/route_test.exs
@@ -7,11 +7,7 @@ defmodule Site.ContentRewriters.LiquidObjects.RouteTest do
 
   describe "route_request/1" do
     test "it handles route requests for a valid/existing route ID" do
-      assert "83"
-             |> Repo.get()
-             |> Map.get(:long_name) == "Rindge Avenue - Central Square, Cambridge"
-
-      assert route_request("83") == {:ok, "Rindge Avenue - Central Square, Cambridge"}
+      assert route_request("83") == {:ok, "83" |> Repo.get() |> Map.get(:long_name)}
     end
 
     test "it reports when there are no results (valid request, but no repo matches)" do

--- a/apps/site/test/site/content_rewriters/liquid_objects_test.exs
+++ b/apps/site/test/site/content_rewriters/liquid_objects_test.exs
@@ -8,6 +8,7 @@ defmodule Site.ContentRewriters.LiquidObjectsTest do
 
   alias SiteWeb.PartialView.SvgIconWithCircle
   alias Fares.{Format, Repo}
+  alias Routes
 
   describe "replace/1" do
     test "it replaces fa- prefixed objects" do
@@ -65,6 +66,10 @@ defmodule Site.ContentRewriters.LiquidObjectsTest do
 
       assert replace(~s(fare:cash)) ==
                ~s({{ <span class="text-danger">missing mode/name</span> fare:cash }})
+    end
+
+    test "it handles route requests" do
+      assert replace(~s(route:83)) == "83" |> Routes.Repo.get() |> Map.get(:long_name)
     end
 
     test "it returns a liquid object when not otherwise handled" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Create liquid replacements for route long name](https://app.asana.com/0/555089885850811/1135428663528491)

- **Input**: `{{ route:83 }}`
- **Output**: `Rindge Avenue - Central Square, Cambridge`
- Tolerant of missing route id and no route match found
- Compatible with error handling and reporting functions
