### PR TITLE
Rail replacement shuttles should use :free_fare

### DIFF
--- a/apps/site/lib/site/base_fare.ex
+++ b/apps/site/lib/site/base_fare.ex
@@ -8,7 +8,7 @@ defmodule Site.BaseFare do
   the express fare is always returned.
   """
 
-  alias Fares.Fare
+  alias Fares.{Fare, Repo}
   alias Routes.Route
 
   @default_filters [reduced: nil, duration: :single_trip]
@@ -21,7 +21,7 @@ defmodule Site.BaseFare do
           (Keyword.t() -> [Fare.t()])
         ) ::
           String.t() | nil
-  def base_fare(route, origin_id, destination_id, fare_fn \\ &Fares.Repo.all/1)
+  def base_fare(route, origin_id, destination_id, fare_fn \\ &Repo.all/1)
   def base_fare(nil, _, _, _), do: nil
 
   def base_fare(route, origin_id, destination_id, fare_fn) do
@@ -45,6 +45,10 @@ defmodule Site.BaseFare do
 
   defp name_or_mode_filter(:subway, _route, _origin_id, _destination_id) do
     [mode: :subway]
+  end
+
+  defp name_or_mode_filter(_, %{description: :rail_replacement_bus}, _, _) do
+    [name: :free_fare]
   end
 
   defp name_or_mode_filter(:bus, %{id: route_id}, origin_id, _destination_id) do

--- a/apps/site/test/site/lib/base_fare_test.exs
+++ b/apps/site/test/site/lib/base_fare_test.exs
@@ -259,6 +259,20 @@ defmodule BaseFareTest do
 
       assert base_fare(route, origin_id, destination_id, fare_fn) == nil
     end
+
+    test "returns a free fare for any bus shuttle rail replacements" do
+      route = %Route{
+        description: :rail_replacement_bus,
+        id: "Shuttle-BallardvaleMaldenCenter",
+        name: "Haverhill Line Shuttle",
+        type: 3
+      }
+
+      origin_id = "place-mlmnl"
+      destination_id = "place-WR-0099"
+
+      assert %Fares.Fare{cents: 0, name: :free_fare} = base_fare(route, origin_id, destination_id)
+    end
   end
 
   describe "ferry" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fares | Users know bus shuttles are free](https://app.asana.com/0/555089885850811/1133954832480177)

- any route with `description: :rail_replacement_bus` will return a `:free_fare` base fare instead of a typical bus fare
- affects fare output on both old and new trip info components

![image](https://user-images.githubusercontent.com/688435/63448461-f5db8700-c40b-11e9-887b-dc117126853a.png)

![image](https://user-images.githubusercontent.com/688435/63448468-f83de100-c40b-11e9-956d-da4936d638da.png)
