### PR TITLE
Fix readability of weekend-selected dates on calendar

### DIFF
--- a/apps/site/assets/css/_schedule.scss
+++ b/apps/site/assets/css/_schedule.scss
@@ -396,6 +396,7 @@ a {
 }
 
 .schedule-selected,
+.schedule-weekend.schedule-selected,
 .schedule-today {
   @extend %button-selected-color;
 }

--- a/apps/site/assets/css/_schedule.scss
+++ b/apps/site/assets/css/_schedule.scss
@@ -396,9 +396,8 @@ a {
 }
 
 .schedule-selected,
-.schedule-weekend.schedule-selected,
 .schedule-today {
-  @extend %button-selected-color;
+  @include button-selected-color;
 }
 
 .schedule-next-month {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | selected date on the calendar hard to read](https://app.asana.com/0/555089885850811/1132719231879592)

Increases specificity of `.schedule-selected` selector so that selected weekend dates use dark blue styling, making the white text readable.

![image](https://user-images.githubusercontent.com/688435/63454139-35a86b80-c418-11e9-9f1b-f182c7005f95.png)
