### PR TITLE
Don't hard-limit diversion teasers in content lists

### DIFF
--- a/apps/cms/lib/partial/paragraph/content_list.ex
+++ b/apps/cms/lib/partial/paragraph/content_list.ex
@@ -224,7 +224,7 @@ defmodule CMS.Partial.Paragraph.ContentList do
   # Limit amount of teasers when certain types are requested
   @spec limit_count_by_type(map) :: map
   defp limit_count_by_type(%{type: [type]} = ingredients)
-       when type in [:project_update, :project, :diversion] do
+       when type in [:project_update, :project] do
     Map.put(ingredients, :items_per_page, 2)
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Diversions | On project pages, Elixir should NOT limit diversions to 2 max](https://app.asana.com/0/555089885850811/1136755693816401)

Release limit of `:diversion` content list results.

![image](https://user-images.githubusercontent.com/688435/63543388-b2a71400-c4f0-11e9-916c-f9e9f8db5000.png)

NOTE: The reusable list used on project pages in the CMS is currently set to 2, so I suggest authors adjust that to whatever they need (this is beyond the scope of this ticket).