### PR TITLE
Fix broken Stops test due to API updates

### DIFF
--- a/apps/stops/test/api_test.exs
+++ b/apps/stops/test/api_test.exs
@@ -50,6 +50,7 @@ defmodule Stops.ApiTest do
                "South Station-11",
                "South Station-12",
                "South Station-13",
+               "South Station-S",
                "door-sstat-atlantic",
                "door-sstat-bus",
                "door-sstat-dewey",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket.

Fixes broken test due to API changes.
- addition of "South Station-S" for SS Stops