### PR TITLE
Projects | correct date regardless of client timezone

### DIFF
--- a/apps/site/assets/ts/helpers/date.ts
+++ b/apps/site/assets/ts/helpers/date.ts
@@ -9,7 +9,8 @@ export const formattedDate = (unformatted: string): string => {
   return parsedDate.toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",
-    day: "numeric"
+    day: "numeric",
+    timeZone: "UTC"
   });
 };
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Clientside project updated on date is sometimes parsed wrong](https://app.asana.com/0/555089885850811/1136806483144122)

Noticed this while working on my PC on another PR. My snapshots were failing on it because of a timezone issue.

<br>
Assigned to: @phildarnowsky 
