### PR TITLE
Don't reset map center to downtown on first zoom

### DIFF
--- a/apps/site/assets/ts/leaflet/__tests__/MapTest.tsx
+++ b/apps/site/assets/ts/leaflet/__tests__/MapTest.tsx
@@ -76,12 +76,27 @@ it("it renders using the default center position", () => {
 });
 
 it("sets zoom state on zoom", () => {
-  const dispatch = jest.fn();
+  const zoomDispatch = jest.fn();
+  const centerDispatch = jest.fn();
+
   const zoomEvent: LeafletEvent = {
     type: "zoom",
-    target: { _zoom: 10 }
+    target: { getCenter: () => null, getZoom: () => 10 }
   };
-  setZoom(dispatch)(zoomEvent);
-  expect(dispatch).toHaveBeenCalledWith(10);
+  setZoom(zoomDispatch, null, centerDispatch)(zoomEvent);
+  expect(zoomDispatch).toHaveBeenCalledWith(10);
+});
+
+it("sets center state on zoom", () => {
+  const zoomDispatch = jest.fn();
+  const centerDispatch = jest.fn();
+
+  const zoomEvent: LeafletEvent = {
+    type: "zoom",
+    target: { getCenter: () => [2, 3], getZoom: () => null }
+  };
+
+  setZoom(zoomDispatch, null, centerDispatch)(zoomEvent);
+  expect(centerDispatch).toHaveBeenCalledWith([2, 3]);
 });
 /* eslint-disable @typescript-eslint/camelcase */


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Trip planner map issue w/ double clicking](https://app.asana.com/0/555089885850811/1135810086712490)

Here we use a trick similar to https://github.com/mbta/dotcom/pull/37, in which we save off the (calculated) center of the map and save it to the state before zooming causes a re-render. Also we don't set an explicit center if bounds are set on the map, to avoid introducing another bug in the process of fixing the above.

<br>
Assigned to: @meagonqz 