### PR TITLE
Revert "save map zoom as state (#37)"

### DIFF
--- a/apps/site/assets/ts/leaflet/__tests__/MapTest.tsx
+++ b/apps/site/assets/ts/leaflet/__tests__/MapTest.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { mount } from "enzyme";
-import Map, { setZoom } from "../components/Map";
+import Map from "../components/Map";
 import { MapData, MapMarker } from "../components/__mapdata";
 import getBounds from "../bounds";
-import { LeafletEvent } from "leaflet";
 
 /* eslint-disable @typescript-eslint/camelcase */
 const marker: MapMarker = {
@@ -73,15 +72,5 @@ it("it renders using the default center position", () => {
       .find(".leaflet-tile")
       .prop("src")
   ).toBe(`${data.tile_server_url}/osm_tiles/16/19650/23738.png`);
-});
-
-it("sets zoom state on zoom", () => {
-  const dispatch = jest.fn();
-  const zoomEvent: LeafletEvent = {
-    type: "zoom",
-    target: { _zoom: 10 }
-  };
-  setZoom(dispatch)(zoomEvent);
-  expect(dispatch).toHaveBeenCalledWith(10);
 });
 /* eslint-disable @typescript-eslint/camelcase */

--- a/apps/site/assets/ts/leaflet/components/Map.tsx
+++ b/apps/site/assets/ts/leaflet/components/Map.tsx
@@ -1,11 +1,10 @@
-import React, { ReactElement, useState, Dispatch, SetStateAction } from "react";
+import React, { ReactElement } from "react";
 import deepEqual from "fast-deep-equal";
 import {
   Icon,
   LatLngBounds,
   Marker as LeafletMarker,
-  MarkerOptions,
-  LeafletEvent
+  MarkerOptions
 } from "leaflet";
 import Leaflet from "react-leaflet";
 import { MapData, MapMarker, IconOpts } from "./__mapdata";
@@ -48,12 +47,6 @@ const rotateMarker = (
   markerEl.setRotationAngle(angle);
 };
 
-export const setZoom = (
-  setStateZoom: Dispatch<SetStateAction<number | undefined>>
-): ((ev: LeafletEvent) => void) => (ev: LeafletEvent) =>
-  // eslint-disable-next-line no-underscore-dangle
-  setStateZoom(ev.target._zoom);
-
 const Component = ({
   bounds,
   boundsByMarkers,
@@ -65,7 +58,6 @@ const Component = ({
     zoom
   }
 }: Props): ReactElement<HTMLElement> | null => {
-  const [stateZoom, setStateZoom] = useState(zoom === null ? undefined : zoom);
   if (typeof window !== "undefined" && tileServerUrl !== "") {
     /* eslint-disable */
     const leaflet: typeof Leaflet = require("react-leaflet");
@@ -80,12 +72,12 @@ const Component = ({
     const { Map, Marker, Polyline, Popup, TileLayer } = leaflet;
     const boundsOrByMarkers = bounds || (boundsByMarkers && getBounds(markers));
     const position = mapCenter(markers, defaultCenter);
+    const nonNullZoom = zoom === null ? undefined : zoom;
     return (
       <Map
         bounds={boundsOrByMarkers}
         center={position}
-        zoom={stateZoom}
-        onZoom={setZoom(setStateZoom)}
+        zoom={nonNullZoom}
         {...defaultZoomOpts}
       >
         <TileLayer


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Trip planner map issue w/ double clicking](https://app.asana.com/0/555089885850811/1135810086712490)

This reverts commit a8994a9750f07286c57d1b19a4027524ff022269, in order
to fix a bug it introduced where zooming on a map under certain
circumstances would reset its center to downtown Boston.

<br>
Assigned to: @meagonqz 
