### PR TITLE
Speed up schedule API by replacing Timex

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
@@ -108,10 +108,42 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
     %{schedules: schedules, duration: Timex.diff(last, first, :minutes)}
   end
 
+  def format_time(time) do
+    hour =
+      cond do
+        time.hour == 0 -> 12
+        time.hour > 12 -> time.hour - 12
+        true -> time.hour
+      end
+
+    hour_string =
+      if hour < 10 do
+        "0#{hour}"
+      else
+        Integer.to_string(hour)
+      end
+
+    minute_string =
+      if time.minute < 10 do
+        "0#{time.minute}"
+      else
+        Integer.to_string(time.minute)
+      end
+
+    meridian_string =
+      if time.hour < 12 do
+        "AM"
+      else
+        "PM"
+      end
+
+    "#{hour_string}:#{minute_string} #{meridian_string}"
+  end
+
   def formatted_time(%{schedules: schedules, duration: duration}) do
     time_formatted_schedules =
       schedules
-      |> Enum.map(&Map.update!(&1, :time, fn time -> Timex.format!(time, "{0h12}:{m} {AM}") end))
+      |> Enum.map(&Map.update!(&1, :time, fn time -> format_time(time) end))
 
     %{schedules: time_formatted_schedules, duration: duration}
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔧 Figure out if PR#99 is where our run_queue problems started](https://app.asana.com/0/555089885850811/1135859689901524)

My current theory about the high level of run-queue alerts is that the schedule API created in PR#99 is the root of the problem. It's slow enough that it seems plausible that, if we happen to get a handful of users all hitting that endpoint at the same time, processes could get backed up behind it.

Profiling showed the main culprit to be our old friend `Timex.format`. Replaced that with a handrolled time-formatting function. I can't say whether or not this will actually fix the run-queue problems, but it definitely makes the schedule API much faster--on my machine, fetching schedules for the 39, this branch cut about 30% off the processing time for the API request, and over 50% for the 111.

<br>
Assigned to: @meagonqz 
