### PR TITLE
use CondensedSchedule in Transit Near Me

### DIFF
--- a/apps/schedules/lib/repo_condensed.ex
+++ b/apps/schedules/lib/repo_condensed.ex
@@ -1,0 +1,129 @@
+defmodule Schedules.RepoCondensed do
+  import Kernel, except: [to_string: 1]
+  use RepoCache, ttl: :timer.hours(1)
+
+  alias Schedules.{Parser, Repo, ScheduleCondensed}
+  alias Stops.Repo, as: StopsRepo
+  alias Routes.Route
+
+  @default_params [
+    include: "trip",
+    "fields[schedule]": "departure_time,drop_off_type,pickup_type,stop_sequence,timepoint",
+    "fields[trip]": "name,headsign,direction_id,bikes_allowed"
+  ]
+
+  @spec by_route_ids([Route.id_t()], Keyword.t()) :: [ScheduleCondensed.t()] | {:error, any}
+  def by_route_ids(route_ids, opts \\ []) when is_list(route_ids) do
+    opts = Keyword.put_new(opts, :date, Util.service_date())
+
+    @default_params
+    |> Keyword.put(:route, Enum.join(route_ids, ","))
+    |> Keyword.put(:date, Keyword.fetch!(opts, :date) |> to_string())
+    |> add_optional_param(opts, :direction_id)
+    |> add_optional_param(opts, :stop_sequences, :stop_sequence)
+    |> add_optional_param(opts, :stop_ids, :stop)
+    |> cache(&all_from_params/1)
+    |> filter_by_min_time(Keyword.get(opts, :min_time))
+  end
+
+  @spec all_from_params(Keyword.t()) :: [Parser.record()] | {:error, any}
+  defp all_from_params(params) do
+    with %JsonApi{data: data} <- V3Api.Schedules.all(params) do
+      data = Enum.filter(data, &valid?/1)
+      Repo.insert_trips_into_cache(data)
+
+      data
+      |> Stream.map(&Parser.parse/1)
+      |> Enum.filter(&has_trip?/1)
+      |> Enum.sort_by(&DateTime.to_unix(elem(&1, 3)))
+      |> build_structs()
+    end
+  end
+
+  defp has_trip?({_, trip_id, _, _, _, _, _, _, _}) when is_nil(trip_id) do
+    false
+  end
+
+  defp has_trip?({_, _, _, _, _, _, _, _, _}) do
+    true
+  end
+
+  defp valid?(%JsonApi.Item{relationships: %{"trip" => [%JsonApi.Item{id: id} | _]}})
+       when not is_nil(id) do
+    true
+  end
+
+  defp valid?(_) do
+    false
+  end
+
+  defp add_optional_param(params, opts, key, param_name \\ nil) do
+    param_name = param_name || key
+
+    case Keyword.fetch(opts, key) do
+      {:ok, value} ->
+        Keyword.put(params, param_name, to_string(value))
+
+      :error ->
+        params
+    end
+  end
+
+  defp to_string(%Date{} = date) do
+    date
+    |> Timex.format!("{ISOdate}")
+  end
+
+  defp to_string(str) when is_binary(str) do
+    str
+  end
+
+  defp to_string(atom) when is_atom(atom) do
+    Atom.to_string(atom)
+  end
+
+  defp to_string(list) when is_list(list) do
+    list
+    |> Enum.map(&to_string/1)
+    |> Enum.join(",")
+  end
+
+  defp to_string(int) when is_integer(int) do
+    Integer.to_string(int)
+  end
+
+  @spec filter_by_min_time([ScheduleCondensed.t()], DateTime.t() | nil) :: [ScheduleCondensed.t()]
+  defp filter_by_min_time(schedules, nil) do
+    schedules
+  end
+
+  defp filter_by_min_time(schedules, %DateTime{} = min_time) do
+    Enum.filter(schedules, fn schedule ->
+      case DateTime.compare(schedule.time, min_time) do
+        :gt -> true
+        :eq -> true
+        :lt -> false
+      end
+    end)
+  end
+
+  defp build_structs(schedules) do
+    schedules
+    |> Enum.map(fn {_, trip_id, stop_id, time, _, _, _, stop_sequence, _} ->
+      Task.async(fn ->
+        trip = Repo.trip(trip_id)
+        stop = StopsRepo.get!(stop_id)
+
+        %ScheduleCondensed{
+          time: time,
+          trip_id: trip_id,
+          route_pattern_id: trip.route_pattern_id,
+          stop_id: stop.parent_id || stop.id,
+          train_number: trip.name,
+          stop_sequence: stop_sequence
+        }
+      end)
+    end)
+    |> Enum.map(&Task.await/1)
+  end
+end

--- a/apps/schedules/lib/repo_condensed.ex
+++ b/apps/schedules/lib/repo_condensed.ex
@@ -10,7 +10,7 @@ defmodule Schedules.RepoCondensed do
   alias Routes.Route
   alias Schedules.{Parser, Repo, ScheduleCondensed}
   alias Stops.Repo, as: StopsRepo
-  alias V3Api.Schedules, as(SchedulesApi)
+  alias V3Api.Schedules, as: SchedulesApi
 
   @default_params [
     include: "trip",

--- a/apps/schedules/lib/schedule.ex
+++ b/apps/schedules/lib/schedule.ex
@@ -25,6 +25,11 @@ defmodule Schedules.Schedule do
 end
 
 defmodule Schedules.ScheduleCondensed do
+  @moduledoc """
+
+  Light weight alternate to Schedule.t()
+
+  """
   defstruct stop_id: nil,
             time: nil,
             trip_id: nil,

--- a/apps/schedules/lib/schedule.ex
+++ b/apps/schedules/lib/schedule.ex
@@ -24,6 +24,24 @@ defmodule Schedules.Schedule do
   def flag?(%Schedules.Schedule{flag?: value}), do: value
 end
 
+defmodule Schedules.ScheduleCondensed do
+  defstruct stop_id: nil,
+            time: nil,
+            trip_id: nil,
+            route_pattern_id: nil,
+            train_number: nil,
+            stop_sequence: 0
+
+  @type t :: %Schedules.ScheduleCondensed{
+          stop_id: String.t(),
+          time: DateTime.t(),
+          trip_id: String.t(),
+          route_pattern_id: String.t() | nil,
+          train_number: String.t() | nil,
+          stop_sequence: non_neg_integer
+        }
+end
+
 defmodule Schedules.Trip do
   defstruct [
     :id,
@@ -43,7 +61,7 @@ defmodule Schedules.Trip do
           headsign: headsign,
           direction_id: 0 | 1,
           shape_id: String.t() | nil,
-          route_pattern_id: String.t(),
+          route_pattern_id: String.t() | nil,
           bikes_allowed?: boolean
         }
 end

--- a/apps/schedules/lib/schedules.ex
+++ b/apps/schedules/lib/schedules.ex
@@ -7,7 +7,8 @@ defmodule Schedules do
     import Supervisor.Spec, warn: false
 
     children = [
-      Schedules.Repo
+      Schedules.Repo,
+      Schedules.RepoCondensed
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/schedules/test/repo_condensed_test.exs
+++ b/apps/schedules/test/repo_condensed_test.exs
@@ -1,0 +1,78 @@
+defmodule Schedules.RepoCondensedTest do
+  use ExUnit.Case
+  use Timex
+  import Schedules.RepoCondensed
+  alias Schedules.ScheduleCondensed
+
+  describe "by_route_ids/2" do
+    test "can take a route/direction/sequence/date" do
+      response =
+        by_route_ids(
+          ["CR-Lowell"],
+          date: Util.service_date(),
+          direction_id: 1,
+          stop_sequences: "first"
+        )
+
+      assert response != []
+      assert %ScheduleCondensed{} = List.first(response)
+    end
+
+    test "returns the parent station as the stop" do
+      response =
+        by_route_ids(
+          ["Red"],
+          date: Util.service_date(),
+          direction_id: 0,
+          stop_sequences: ["first"]
+        )
+
+      assert response != []
+      assert %{stop_id: "place-alfcl"} = List.first(response)
+    end
+
+    test "filters by min_time when provided" do
+      now = Util.now()
+
+      before_now_fn = fn sched ->
+        case DateTime.compare(sched.time, now) do
+          :gt -> false
+          :eq -> true
+          :lt -> true
+        end
+      end
+
+      unfiltered =
+        by_route_ids(
+          ["Red"],
+          date: Util.service_date(),
+          direction_id: 0
+        )
+
+      before_now = unfiltered |> Enum.filter(before_now_fn) |> Enum.count()
+      assert before_now > 0
+
+      filtered =
+        by_route_ids(
+          ["Red"],
+          date: Util.service_date(),
+          direction_id: 0,
+          min_time: now
+        )
+
+      before_now = filtered |> Enum.filter(before_now_fn) |> Enum.count()
+      assert before_now == 0
+    end
+
+    test "if we get an error from the API, returns an error tuple" do
+      response =
+        by_route_ids(
+          ["CR-Lowell"],
+          date: "1970-01-01",
+          stop: "place-north"
+        )
+
+      assert {:error, _} = response
+    end
+  end
+end

--- a/apps/site/lib/predicted_schedule.ex
+++ b/apps/site/lib/predicted_schedule.ex
@@ -6,13 +6,13 @@ defmodule PredictedSchedule do
   * prediction: The prediction for this trip (optional)
   """
   alias Predictions.Prediction
-  alias Schedules.Schedule
+  alias Schedules.{Schedule, ScheduleCondensed}
 
   defstruct schedule: nil,
             prediction: nil
 
   @type t :: %__MODULE__{
-          schedule: Schedule.t() | nil,
+          schedule: Schedule.t() | ScheduleCondensed.t() | nil,
           prediction: Prediction.t() | nil
         }
 
@@ -78,10 +78,18 @@ defmodule PredictedSchedule do
     Map.new(predictions_or_schedules, &group_transform/1)
   end
 
-  @spec group_transform(Schedule.t() | Prediction.t()) ::
+  @spec group_transform(Schedule.t() | ScheduleCondensed.t() | Prediction.t()) ::
           {{String.t(), String.t(), non_neg_integer}, Schedule.t() | Prediction.t()}
   defp group_transform(%{trip: nil} = ps) do
     {{ps.id, ps.stop.id, ps.stop_sequence}, ps}
+  end
+
+  defp group_transform(%{trip_id: nil} = ps) do
+    {{ps.id, ps.stop.id, ps.stop_sequence}, ps}
+  end
+
+  defp group_transform(%{trip_id: trip_id, stop_id: stop_id, stop_sequence: stop_sequence} = ps) do
+    {{trip_id, stop_id, stop_sequence}, ps}
   end
 
   defp group_transform(ps) do

--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -14,7 +14,6 @@ defmodule Site.RealtimeScheduleTest do
   @now DateTime.from_naive!(~N[2030-02-19T12:00:00], "Etc/UTC")
 
   @stop %Stop{id: "place-ogmnl"}
-  @cr_stop %Stop{id: "place-mlmnl"}
 
   @route %Route{
     custom_route?: false,
@@ -25,17 +24,6 @@ defmodule Site.RealtimeScheduleTest do
     long_name: "Orange Line",
     name: "Orange Line",
     type: 1
-  }
-
-  @cr_route %Route{
-    custom_route?: false,
-    description: :rapid_transit,
-    direction_destinations: %{0 => "North Station", 1 => "Haverhill"},
-    direction_names: %{0 => "Southbound", 1 => "Northbound"},
-    id: "CR-Haverhill",
-    long_name: "Haverhill",
-    name: "Haverhill",
-    type: 2
   }
 
   @route_with_patterns [
@@ -71,30 +59,6 @@ defmodule Site.RealtimeScheduleTest do
      ]}
   ]
 
-  @cr_route_with_patterns [
-    {@cr_route,
-     [
-       %RoutePattern{
-         direction_id: 0,
-         id: "CR-Haverhill-0-0",
-         name: "North Station",
-         representative_trip_id: "x",
-         route_id: "CR-Haverhill",
-         time_desc: nil,
-         typicality: 1
-       },
-       %RoutePattern{
-         direction_id: 1,
-         id: "CR-Haverhill-0-1",
-         name: "Haverhill",
-         representative_trip_id: "y",
-         route_id: "CR-Haverhill",
-         time_desc: nil,
-         typicality: 1
-       }
-     ]}
-  ]
-
   @trip %Trip{
     bikes_allowed?: false,
     direction_id: 1,
@@ -103,16 +67,6 @@ defmodule Site.RealtimeScheduleTest do
     name: "",
     route_pattern_id: "Orange-3-1",
     shape_id: "903_0017"
-  }
-
-  @cr_trip %Trip{
-    bikes_allowed?: false,
-    direction_id: 1,
-    headsign: "North Station",
-    id: "x",
-    name: "Train Number",
-    route_pattern_id: "CR-Haverhill-0-0",
-    shape_id: "x"
   }
 
   @predictions [
@@ -172,20 +126,6 @@ defmodule Site.RealtimeScheduleTest do
       stop_sequence: 1,
       time: @now,
       trip: @trip
-    }
-  ]
-
-  @cr_schedules [
-    %Schedule{
-      early_departure?: true,
-      flag?: false,
-      last_stop?: false,
-      pickup_type: 0,
-      route: @cr_route,
-      stop: @cr_stop,
-      stop_sequence: 1,
-      time: @now,
-      trip: @cr_trip
     }
   ]
 
@@ -315,27 +255,5 @@ defmodule Site.RealtimeScheduleTest do
     actual = RealtimeSchedule.stop_data(stops, @now, opts)
 
     assert actual == expected
-  end
-
-  test "copy_train_number/1" do
-    opts = [
-      stops_fn: fn _ -> @cr_stop end,
-      routes_fn: fn _ -> @cr_route_with_patterns end,
-      predictions_fn: fn _ -> [] end,
-      schedules_fn: fn _, _ -> @cr_schedules end,
-      alerts_fn: fn _, _ -> [] end
-    ]
-
-    stops = [@cr_stop.id]
-
-    assert [
-             %{
-               predicted_schedules_by_route_pattern: %{
-                 "North Station" => %{
-                   predicted_schedules: [%{schedule: %{train_number: "Train Number"}}]
-                 }
-               }
-             }
-           ] = RealtimeSchedule.stop_data(stops, @now, opts)
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Website Perf: Investigate more strategic schedule cache (by route_pattern / stop)](https://app.asana.com/0/555089885850811/1134294684192693)

- create a new schedule-like struct that only contains data needed to display a schedule without any nested structs
- cache the struct (the existing `Schedule.t()` caches the record, and re-builds the struct on every call)

<br>
Assigned to: @meagonqz 
