### PR TITLE
cache realtime data, reduce TNM polling time

### DIFF
--- a/apps/site/assets/ts/tnm/components/TransitNearMe.tsx
+++ b/apps/site/assets/ts/tnm/components/TransitNearMe.tsx
@@ -148,7 +148,7 @@ const TransitNearMe = ({
         stopsWithDistances.stops.map(stop => stop.id),
         dispatch
       ),
-    45000
+    30000
   );
 
   return (

--- a/apps/site/lib/site/application.ex
+++ b/apps/site/lib/site/application.ex
@@ -18,7 +18,8 @@ defmodule Site.Application do
       supervisor(SiteWeb.Endpoint, []),
       supervisor(Site.GreenLine.Supervisor, []),
       supervisor(Site.Stream.Vehicles, []),
-      supervisor(Site.React, [])
+      supervisor(Site.React, []),
+      supervisor(Site.RealtimeSchedule, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/site/lib/site/realtime_schedule.ex
+++ b/apps/site/lib/site/realtime_schedule.ex
@@ -7,6 +7,8 @@ defmodule Site.RealtimeSchedule do
       are considering route patterns with the same name to be effectively the same
   """
 
+  use RepoCache, ttl: :timer.seconds(30)
+
   alias Predictions.Prediction
   alias Predictions.Repo, as: PredictionsRepo
   alias RoutePatterns.RoutePattern
@@ -42,6 +44,13 @@ defmodule Site.RealtimeSchedule do
 
   @spec stop_data([Stop.id_t()], DateTime.t(), Keyword.t()) :: [map]
   def stop_data(stop_ids, now, opts \\ []) do
+    cache(stop_ids, fn _ ->
+      do_stop_data(stop_ids, now, opts)
+    end)
+  end
+
+  @spec do_stop_data([Stop.id_t()], DateTime.t(), Keyword.t()) :: [map]
+  defp do_stop_data(stop_ids, now, opts) do
     opts = Keyword.merge(@default_opts, opts)
     stops_fn = Keyword.fetch!(opts, :stops_fn)
     routes_fn = Keyword.fetch!(opts, :routes_fn)

--- a/apps/site/lib/site/realtime_schedule.ex
+++ b/apps/site/lib/site/realtime_schedule.ex
@@ -58,22 +58,21 @@ defmodule Site.RealtimeSchedule do
     schedules_fn = Keyword.fetch!(opts, :schedules_fn)
     alerts_fn = Keyword.fetch!(opts, :alerts_fn)
 
-    # stage 1, get stops and routes
-    stops_task = Task.async(fn -> get_stops(stop_ids, stops_fn) end)
+    # stage 1, get routes
     routes_task = Task.async(fn -> get_routes(stop_ids, routes_fn) end)
-    [stops, route_with_patterns] = Enum.map([stops_task, routes_task], &Task.await/1)
+    route_with_patterns = Task.await(routes_task)
 
-    # stage 2, get predictions, schedules, and alerts
+    # stage 2, get stops, predictions, schedules, and alerts
+    stops_task = Task.async(fn -> get_stops(stop_ids, stops_fn) end)
     predictions_task = Task.async(fn -> get_predictions(route_with_patterns, predictions_fn) end)
-
     schedules_task = Task.async(fn -> get_schedules(route_with_patterns, now, schedules_fn) end)
 
     alert_counts_task =
       Task.async(fn -> get_alert_counts(route_with_patterns, now, alerts_fn) end)
 
-    [predictions, schedules, alert_counts] =
+    [stops, predictions, schedules, alert_counts] =
       Enum.map(
-        [predictions_task, schedules_task, alert_counts_task],
+        [stops_task, predictions_task, schedules_task, alert_counts_task],
         &Task.await(&1, @long_timeout)
       )
 

--- a/apps/site/mix.exs
+++ b/apps/site/mix.exs
@@ -126,7 +126,8 @@ defmodule Site.Mixfile do
       {:predictions, in_umbrella: true},
       {:trip_plan, in_umbrella: true},
       {:services, in_umbrella: true},
-      {:route_patterns, in_umbrella: true}
+      {:route_patterns, in_umbrella: true},
+      {:repo_cache, in_umbrella: true}
     ]
   end
 end

--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -252,6 +252,7 @@ defmodule Site.RealtimeScheduleTest do
       }
     ]
 
+    RealtimeSchedule.clear_cache()
     actual = RealtimeSchedule.stop_data(stops, @now, opts)
 
     assert actual == expected


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [TNM: cache result by stop for 30 seconds](https://app.asana.com/0/555089885850811/1138499454939089)

- use `RepoCache` to cache complete JSON response for stops for 30 seconds
- currently, we are only sending a single stop from TNM, so caching the list of stops should be fine for achieving re-use across separate requests.
- the JSON responses are currently anywhere from 1kb to 20kb, as such, I'm not expecting this cache to grow too large as it seems not span more than 1000 stops in a 30 second window
- also, we have recently doubled the dotcom memory and are still typically running at less than 50% of the available memory
- with this cache in place, I reduced the polling time of the frontend

---

Some local time measurements:
http://localhost:4001/api/realtime/stops/?stops=place-welln

Not Cached:
2.402423
1.998292
2.127799

Cached:
0.090732
0.090380
0.097794

<br>
Assigned to: @paulswartz 
