### PR TITLE
Teaser endpoint argument changes

### DIFF
--- a/apps/cms/lib/api/static.ex
+++ b/apps/cms/lib/api/static.ex
@@ -379,7 +379,7 @@ defmodule CMS.API.Static do
     {:ok, []}
   end
 
-  def view("/cms/teasers/guides", _) do
+  def view("/cms/teasers/guides" <> _, _) do
     {:ok, teaser_basic_page_response()}
   end
 
@@ -423,7 +423,7 @@ defmodule CMS.API.Static do
     {:ok, teaser_event_response()}
   end
 
-  def view("/cms/teasers/" <> route_id, params) when route_id != "NotFound" do
+  def view("/cms/teasers/" <> arguments, params) when arguments != "any/NotFound" do
     filtered =
       teaser_response()
       |> filter_teasers(params)

--- a/apps/cms/lib/repo.ex
+++ b/apps/cms/lib/repo.ex
@@ -260,9 +260,9 @@ defmodule CMS.Repo do
       case Enum.into(opts, %{}) do
         %{route_id: route_id, topic: topic} -> "/#{topic}/#{route_id}"
         %{mode: mode, topic: topic} -> "/#{topic}/#{mode}"
-        %{topic: topic} -> "/#{topic}"
-        %{mode: mode} -> "/#{mode}"
-        %{route_id: route_id} -> "/#{route_id}"
+        %{topic: topic} -> "/#{topic}/any"
+        %{mode: mode} -> "/any/#{mode}"
+        %{route_id: route_id} -> "/any/#{route_id}"
         %{args: args} -> "/" <> Enum.join(args, "/")
         _ -> nil
       end

--- a/apps/cms/priv/landing_page_with_all_paragraphs.json
+++ b/apps/cms/priv/landing_page_with_all_paragraphs.json
@@ -7150,6 +7150,7 @@
         }
       ],
       "field_terms": [],
+      "field_routes": [],
       "field_type_logic": []
     }
   ],

--- a/apps/cms/test/paragraph/content_list_test.exs
+++ b/apps/cms/test/paragraph/content_list_test.exs
@@ -81,30 +81,21 @@ defmodule CMS.Partial.Paragraph.ContentListTest do
       opts =
         cms_map(
           terms: nil,
+          routes: nil,
           term_depth: 4
         )
 
       assert opts == []
     end
 
-    test "If the default term depth is found, discard depth and compose arguments" do
-      opts =
-        cms_map(
-          terms: [123, 321],
-          term_depth: 4
-        )
+    test "All arguments must be set if terms are present" do
+      tag_only = cms_map(terms: 123, routes: nil, term_depth: 3)
+      route_only = cms_map(terms: nil, routes: 321, term_depth: 3)
+      both_terms = cms_map(terms: 123, routes: 321, term_depth: 3)
 
-      assert opts == [args: [123, 321]]
-    end
-
-    test "If we are using a non-standard depth, all arguments must be set if terms are present" do
-      no_terms = cms_map(terms: nil, term_depth: 3)
-      one_term = cms_map(terms: [123], term_depth: 3)
-      two_terms = cms_map(terms: [123, 321], term_depth: 3)
-
-      assert no_terms == []
-      assert one_term == [args: [123, "any", 3]]
-      assert two_terms == [args: [123, 321, 3]]
+      assert tag_only == [args: [123, "any", 3]]
+      assert route_only == [args: ["any", 321, 3]]
+      assert both_terms == [args: [123, 321, 3]]
     end
   end
 
@@ -167,6 +158,7 @@ defmodule CMS.Partial.Paragraph.ContentListTest do
     opts =
       cms_map(
         terms: nil,
+        routes: nil,
         term_depth: 4,
         number_of_items: 5,
         content_type: "event",
@@ -206,8 +198,8 @@ defmodule CMS.Partial.Paragraph.ContentListTest do
     {"#{k}", [%{"value" => v}]}
   end
 
-  defp cms_field({:terms = k, terms}) do
-    {"field_#{k}", Enum.map(terms, &%{"target_id" => &1})}
+  defp cms_field({k, term}) when k in [:terms, :routes] do
+    {"field_#{k}", [%{"target_id" => term}]}
   end
 
   defp cms_field({k, v}) do

--- a/apps/cms/test/paragraph_test.exs
+++ b/apps/cms/test/paragraph_test.exs
@@ -285,7 +285,7 @@ defmodule CMS.ParagraphTest do
     assert %ColumnMultiHeader{} = header
 
     assert %{
-             terms: [],
+             terms: [nil, nil],
              term_depth: 4,
              items_per_page: 5,
              type: [:project_update],


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Teasers endpoint serving incorrect Content List results](https://app.asana.com/0/555089885850811/1137138645355009)

Prepare for changes in https://github.com/mbta/cms/pull/301 (**deploy this FIRST**)
- Always fill both slots for term arguments in request: `/cms/teasers/<tag>/<route>`
- If either argument is unnecessary, fill with default wildcard `"any"`
- Simplify logic for building this part of the content list recipe