### PR TITLE
fix fullstory and informizely, make mbta_id readable by JS

### DIFF
--- a/apps/site/assets/js/fullstory.js
+++ b/apps/site/assets/js/fullstory.js
@@ -1,7 +1,7 @@
 import * as Cookies from "./cookies";
 
 export default function fullstory() {
-  const MODULO_SAMPLE = 25;
+  const MODULO_SAMPLE = 50;
   const id = getUniqueId();
 
   // Only execute the fullstory code if the id is a multiple of the selected modulo
@@ -13,10 +13,10 @@ export default function fullstory() {
 // This is the snippet that was generqated by Full Story. No changes were made to
 // this auto-generated code
 function fullStoryInit() {
-  window["_fs_debug"] = false;
-  window["_fs_host"] = "fullstory.com";
-  window["_fs_org"] = "AQKVD";
-  window["_fs_namespace"] = "FS";
+  window._fs_debug = false;
+  window._fs_host = "fullstory.com";
+  window._fs_org = "AQKVD";
+  window._fs_namespace = "FS";
   (function(m, n, e, t, l, o, g, y) {
     if (e in m) {
       if (m.console && m.console.log) {
@@ -33,7 +33,7 @@ function fullStoryInit() {
     g.q = [];
     o = n.createElement(t);
     o.async = 1;
-    o.src = "https://" + _fs_host + "/s/fs.js";
+    o.src = `https://${_fs_host}/s/fs.js`;
     y = n.getElementsByTagName(t)[0];
     y.parentNode.insertBefore(o, y);
     g.identify = function(i, v) {
@@ -62,7 +62,7 @@ function fullStoryInit() {
     };
 
     g.clearUserCookie = function() {};
-  })(window, document, window["_fs_namespace"], "script", "user");
+  })(window, document, window._fs_namespace, "script", "user");
 }
 
 function getUniqueId() {

--- a/apps/site/lib/site_web/plugs/cookies.ex
+++ b/apps/site/lib/site_web/plugs/cookies.ex
@@ -10,7 +10,7 @@ defmodule SiteWeb.Plugs.Cookies do
   @route_cookie_name "mbta_visited_routes"
 
   @id_cookie_options [
-    http_only: true,
+    http_only: false,
     # 20 years
     max_age: 20 * 365 * 24 * 60 * 60
   ]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔧 FullStory and Informizely throttling investigation](https://app.asana.com/0/555089885850811/1134544942021189)

- fullstory and informizely stopped working properly because they need to read the mbta_id cookie value from Javascript
- we had previously set `http_only` for that cookie, making it impossible to read by modern browsers
- this changes `http_only` to false, now it can be read
- allowing this to be read is not a security issue because the value is meaningless, just unique to a session and not tied back to any user identifiable information
- fullstory's original throttling value was restored because this should make it go back to normal

I verified locally that making this change allows the value to be read and the fullstory code to be initiated.

<br>
Assigned to: @amaisano 
