### PR TITLE
De-escalate node logging

### DIFF
--- a/apps/site/lib/site/react/worker.ex
+++ b/apps/site/lib/site/react/worker.ex
@@ -59,7 +59,7 @@ defmodule Site.React.Worker do
         |> Enum.find(&(!is_nil(&1)))
       end)
 
-    _ = Logger.warn("node_logging req_time milliseconds=#{time / 1_000}")
+    _ = Logger.info("node_logging req_time milliseconds=#{time / 1_000}")
     result
   end
 
@@ -81,12 +81,12 @@ defmodule Site.React.Worker do
   end
 
   def handle_logging(msg) do
-    _ = Logger.warn(inspect(msg))
+    _ = Logger.info(inspect(msg))
     nil
   end
 
   def handle_info(msg, state) do
-    _ = Logger.warn(inspect(msg))
+    _ = Logger.info(inspect(msg))
     {:noreply, state}
   end
 end

--- a/apps/site/lib/site/react/worker.ex
+++ b/apps/site/lib/site/react/worker.ex
@@ -59,7 +59,9 @@ defmodule Site.React.Worker do
         |> Enum.find(&(!is_nil(&1)))
       end)
 
-    _ = Logger.info("node_logging req_time milliseconds=#{time / 1_000}")
+    level = (Mix.env() == :test && :warn) || :info
+
+    _ = Logger.log(level, "node_logging req_time milliseconds=#{time / 1_000}")
     result
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket.

Reduce noise by reserving `node_logging` debug output for the `:test` env only. In all other envs, set it to the `info` level. Logging is preserved, and the test checking for this output continues to work.