### PR TITLE
Better rendering of stop filter buttons on XS

### DIFF
--- a/apps/site/assets/css/_stop-page.scss
+++ b/apps/site/assets/css/_stop-page.scss
@@ -144,8 +144,27 @@
   padding: .75 * $base-spacing;
   position: relative;
 
+  @include media-breakpoint-only(xs) {
+
+    .m-tnm-sidebar__filter-header {
+      display: block;
+    }
+
+    .c-mode-filter__filter-btn-group:last-of-type {
+      margin: 0;
+    }
+
+    .m-tnm-sidebar__filter-btn {
+      margin: .25rem .5rem .25rem 0;
+    }
+  }
+
   .m-tnm-sidebar__filter-header {
     display: inline;
+
+    @include media-breakpoint-only(xs) {
+      display: block;
+    }
   }
 }
 

--- a/apps/site/assets/css/_stop-page.scss
+++ b/apps/site/assets/css/_stop-page.scss
@@ -155,7 +155,8 @@
     }
 
     .m-tnm-sidebar__filter-btn {
-      margin: .25rem .5rem .25rem 0;
+      margin: $base-spacing / 4 $base-spacing / 2;
+      margin-left: 0;
     }
   }
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Stops Page | Filters overflow for XS breakpoint](https://app.asana.com/0/555089885850811/1137173248482867)

- Only affects stop page filters
- Bumps buttons to new line under FILTERS header
- Better margin alignment for wrapped buttons

![image](https://user-images.githubusercontent.com/688435/64641584-74f42780-d3da-11e9-9eab-282d783048f4.png)

![image](https://user-images.githubusercontent.com/688435/64641590-7887ae80-d3da-11e9-9799-6a82e9508752.png)