### PR TITLE
fix issues causing 500 errors in realtime API

### DIFF
--- a/apps/schedules/lib/repo_condensed.ex
+++ b/apps/schedules/lib/repo_condensed.ex
@@ -15,6 +15,9 @@ defmodule Schedules.RepoCondensed do
   alias Stops.Repo, as: StopsRepo
   alias V3Api.Schedules, as: SchedulesApi
 
+  # the long timeout is to address a worst-case scenario of cold schedule cache
+  @long_timeout 15_000
+
   @default_params [
     include: "trip",
     "fields[schedule]": "departure_time,drop_off_type,pickup_type,stop_sequence,timepoint",
@@ -133,6 +136,6 @@ defmodule Schedules.RepoCondensed do
         }
       end)
     end)
-    |> Enum.map(&Task.await/1)
+    |> Enum.map(&Task.await(&1, @long_timeout))
   end
 end

--- a/apps/site/lib/site/realtime_schedule.ex
+++ b/apps/site/lib/site/realtime_schedule.ex
@@ -236,8 +236,8 @@ defmodule Site.RealtimeSchedule do
   end
 
   @spec build_output(map, [route_with_patterns_t], map, map, map, DateTime.t()) :: [map]
-  defp build_output(%{message: message}, _, _, _, _, _) do
-    IO.inspect(message)
+  defp build_output(%{message: _message}, _, _, _, _, _) do
+    %{}
   end
 
   defp build_output(stops, route_with_patterns, schedules, predictions, alert_counts, now) do

--- a/apps/site/lib/site/realtime_schedule.ex
+++ b/apps/site/lib/site/realtime_schedule.ex
@@ -84,7 +84,7 @@ defmodule Site.RealtimeSchedule do
     stop_ids
     |> Enum.map(
       &Task.async(fn ->
-        {&1, &1 |> stops_fn.() |> stop_fields}
+        {&1, &1 |> stops_fn.() |> stop_fields()}
       end)
     )
     |> Enum.into(%{}, &Task.await/1)

--- a/apps/site/lib/site/realtime_schedule.ex
+++ b/apps/site/lib/site/realtime_schedule.ex
@@ -236,10 +236,6 @@ defmodule Site.RealtimeSchedule do
   end
 
   @spec build_output(map, [route_with_patterns_t], map, map, map, DateTime.t()) :: [map]
-  defp build_output(%{message: _message}, _, _, _, _, _) do
-    %{}
-  end
-
   defp build_output(stops, route_with_patterns, schedules, predictions, alert_counts, now) do
     route_with_patterns
     |> Enum.map(fn {stop_id, route, route_patterns} ->

--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -154,7 +154,7 @@ defmodule Site.RealtimeScheduleTest do
     }
   ]
 
-  test "stop_data/3" do
+  test "stop_data/3 returns stop" do
     opts = [
       stops_fn: fn _ -> @stop end,
       routes_fn: fn _ -> @route_with_patterns end,
@@ -251,6 +251,25 @@ defmodule Site.RealtimeScheduleTest do
         }
       }
     ]
+
+    RealtimeSchedule.clear_cache()
+    actual = RealtimeSchedule.stop_data(stops, @now, opts)
+
+    assert actual == expected
+  end
+
+  test "stop_data/3 returns nil" do
+    opts = [
+      stops_fn: fn _ -> nil end,
+      routes_fn: fn _ -> [] end,
+      predictions_fn: fn _ -> [] end,
+      schedules_fn: fn _, _ -> [] end,
+      alerts_fn: fn _, _ -> [] end
+    ]
+
+    stops = [@stop.id]
+
+    expected = []
 
     RealtimeSchedule.clear_cache()
     actual = RealtimeSchedule.stop_data(stops, @now, opts)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** NO TICKET

This is an odd issue... basically, deploys have been failing because during the heath check stage of new servers instances, enough 500 errors are generated that the server instance fails the check and the deploy rolls back.

The odd thing about this is that it seems that the errors are not appearing in Splunk. The number of 500 errors recorded there vs the number of 500 responses I can see in the AWS Elastic Beanstalk Heath console do not correlate.

I found this issue by downloading a log file from Beanstalk directly. That should be investigated in . a separate ticket.

What is happening here is somehow a value that is not a valid stop_id is being passed and the application is crashing because that is an unhandled case.

<br>
Assigned to: @phildarnowsky 
