### PR TITLE
Fix wrapping time in schedule finder table

### DIFF
--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -417,6 +417,7 @@
   padding: $base-spacing / 4 0;
 
   &--right-adjusted {
+    padding-left: $base-spacing / 2;
     text-align: right;
     vertical-align: top;
     white-space: pre;

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -418,6 +418,8 @@
 
   &--right-adjusted {
     text-align: right;
+    vertical-align: top;
+    white-space: pre;
   }
 }
 

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -362,8 +362,6 @@
 }
 
 .schedule-table__headsign {
-  white-space: nowrap;
-
   .c-svg__icon {
     margin-right: $base-spacing / 4;
   }

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
@@ -101,7 +101,9 @@ exports[`ScheduleTable it renders 1`] = `
                 <thead>
                   <TripInfo>
                     <tr>
-                      <td>
+                      <td
+                        colSpan={3}
+                      >
                         <div
                           className="schedule-table__subtable-trip-info"
                         >
@@ -10847,7 +10849,9 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
                 <thead>
                   <TripInfo>
                     <tr>
-                      <td>
+                      <td
+                        colSpan={3}
+                      >
                         <div
                           className="schedule-table__subtable-trip-info"
                         >

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
@@ -10987,7 +10987,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
                       <a
                         href="/stops/place-DB-2249"
                       >
-                        Four Corners/Geneva
+                        Four Corners/​Geneva
                       </a>
                     </td>
                     <td

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -35,7 +35,7 @@ const routePill = (
       <div
         className={`h1 schedule-finder__modal-route-pill u-bg--${
           isSilverLine(id) ? "silver-line" : "bus"
-          }`}
+        }`}
       >
         {name}
       </div>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -10,6 +10,7 @@ import {
 import isSilverLine from "../../../helpers/silver-line";
 import { reducer } from "../../../helpers/fetch";
 import ServiceSelector from "./ServiceSelector";
+import { breakTextAtSlash } from "../../../helpers/text";
 
 const stopInfo = (
   selectedOrigin: string,
@@ -34,7 +35,7 @@ const routePill = (
       <div
         className={`h1 schedule-finder__modal-route-pill u-bg--${
           isSilverLine(id) ? "silver-line" : "bus"
-        }`}
+          }`}
       >
         {name}
       </div>
@@ -123,7 +124,7 @@ const ScheduleModalContent = ({
             {directionNames[selectedDirection]}
           </div>
           <h2 className="h2" style={{ margin: 0 }}>
-            {destination}
+            {breakTextAtSlash(destination)}
           </h2>
         </div>
       </div>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
@@ -20,7 +20,7 @@ const TripInfo = ({
   const lastTrip = schedules.schedules[schedules.schedules.length - 1];
   return (
     <tr>
-      <td colSpan="3">
+      <td colSpan={3}>
         <div className="schedule-table__subtable-trip-info">
           <div className="schedule-table__subtable-trip-info-title u-small-caps u-bold">
             Trip length

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
@@ -3,6 +3,7 @@ import { ScheduleWithFare, ScheduleInfo } from "../__schedule";
 import { RoutePillSmall } from "./UpcomingDepartures";
 import { modeIcon, caret } from "../../../helpers/icon";
 import { handleReactEnterKeyPress } from "../../../helpers/keyboard-events";
+import { breakTextAtSlash } from "../../../helpers/text";
 
 const totalMinutes = (schedules: ScheduleInfo): string => schedules.duration;
 
@@ -79,7 +80,7 @@ const BusTableRow = ({
           <div className="schedule-table__row-route">
             <RoutePillSmall route={firstSchedule.route} />
           </div>
-          {firstSchedule.trip.headsign}
+          {breakTextAtSlash(firstSchedule.trip.headsign)}
         </td>
         <td className="schedule-table__td schedule-table__td--flex-end">
           {caret(
@@ -112,7 +113,7 @@ const BusTableRow = ({
                   >
                     <td className="schedule-table__subtable-data">
                       <a href={`/stops/${schedule.stop.id}`}>
-                        {schedule.stop.name}
+                        {breakTextAtSlash(schedule.stop.name)}
                       </a>
                     </td>
                     <td className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted">
@@ -165,7 +166,7 @@ const CrTableRow = ({
           </td>
         )}
         <td className="schedule-table__headsign">
-          {modeIcon(firstSchedule.route.id)} {firstSchedule.trip.headsign}
+          {modeIcon(firstSchedule.route.id)} {breakTextAtSlash(firstSchedule.trip.headsign)}
         </td>
         <td className="schedule-table__td schedule-table__td--flex-end">
           {caret(
@@ -204,7 +205,7 @@ const CrTableRow = ({
                     >
                       <td className="schedule-table__subtable-data">
                         <a href={`/stops/${schedule.stop.id}`}>
-                          {schedule.stop.name}
+                          {breakTextAtSlash(schedule.stop.name)}
                         </a>
                       </td>
                       <td className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted">

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
@@ -79,9 +79,7 @@ const BusTableRow = ({
           <div className="schedule-table__row-route">
             <RoutePillSmall route={firstSchedule.route} />
           </div>
-          <span className="schedule-table__headsign">
-            {firstSchedule.trip.headsign}
-          </span>
+          {firstSchedule.trip.headsign}
         </td>
         <td className="schedule-table__td schedule-table__td--flex-end">
           {caret(

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
@@ -166,7 +166,8 @@ const CrTableRow = ({
           </td>
         )}
         <td className="schedule-table__headsign">
-          {modeIcon(firstSchedule.route.id)} {breakTextAtSlash(firstSchedule.trip.headsign)}
+          {modeIcon(firstSchedule.route.id)}{" "}
+          {breakTextAtSlash(firstSchedule.trip.headsign)}
         </td>
         <td className="schedule-table__td schedule-table__td--flex-end">
           {caret(

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
@@ -20,7 +20,7 @@ const TripInfo = ({
   const lastTrip = schedules.schedules[schedules.schedules.length - 1];
   return (
     <tr>
-      <td>
+      <td colSpan="3">
         <div className="schedule-table__subtable-trip-info">
           <div className="schedule-table__subtable-trip-info-title u-small-caps u-bold">
             Trip length
@@ -79,7 +79,9 @@ const BusTableRow = ({
           <div className="schedule-table__row-route">
             <RoutePillSmall route={firstSchedule.route} />
           </div>
-          {firstSchedule.trip.headsign}
+          <span className="schedule-table__headsign">
+            {firstSchedule.trip.headsign}
+          </span>
         </td>
         <td className="schedule-table__td schedule-table__td--flex-end">
           {caret(

--- a/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
@@ -8,6 +8,7 @@ import { modeIcon } from "../../../helpers/icon";
 import { modeBgClass } from "../../../stop/components/RoutePillList";
 import { Route } from "../../../__v3api";
 import { StopPrediction } from "../__schedule";
+import { breakTextAtSlash } from "../../../helpers/text";
 
 interface State {
   data: StopPrediction[] | null;
@@ -29,10 +30,10 @@ export const RoutePillSmall = ({
 }: {
   route: Route;
 }): ReactElement<HTMLElement> | null => (
-  <div className="schedule-table__row-route-pill m-route-pills">
-    <div className={modeBgClass(route)}>{route.name}</div>
-  </div>
-);
+    <div className="schedule-table__row-route-pill m-route-pills">
+      <div className={modeBgClass(route)}>{route.name}</div>
+    </div>
+  );
 interface TableRowProps {
   prediction: StopPrediction;
 }
@@ -68,7 +69,7 @@ const CrTableRow = ({
   return (
     <tr className="schedule-table__row schedule-table__row--stretch">
       <td className="schedule-table__headsign">
-        {modeIcon(prediction.route.id)} {prediction.headsign}
+        {modeIcon(prediction.route.id)} {breakTextAtSlash(prediction.headsign)}
       </td>
       <td>
         <div className="schedule-table__time-container">

--- a/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
@@ -30,10 +30,10 @@ export const RoutePillSmall = ({
 }: {
   route: Route;
 }): ReactElement<HTMLElement> | null => (
-    <div className="schedule-table__row-route-pill m-route-pills">
-      <div className={modeBgClass(route)}>{route.name}</div>
-    </div>
-  );
+  <div className="schedule-table__row-route-pill m-route-pills">
+    <div className={modeBgClass(route)}>{route.name}</div>
+  </div>
+);
 interface TableRowProps {
   prediction: StopPrediction;
 }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Finder Tool - Wrapping times in mobile](https://app.asana.com/0/555089885850811/1137523575743818)

By adding the proper `colspan` of `3` to the "Trip Length" / "Fare" row, the table flexes correctly to fit the times on a single line. **Bonus**: Remove `whitespace: nowrap` on headsigns due to longer headsigns (eg, "Haverhill (Shuttle))" causing page overflow on XS.

**Before / After:**

![image](https://user-images.githubusercontent.com/688435/64710621-492e7b80-d486-11e9-943a-ecfcc9d071aa.png)

**Before / After:**

![image](https://user-images.githubusercontent.com/688435/64886954-5e95d800-d635-11e9-9adc-b7f9bc2c76f4.png)