### PR TITLE
Fix greedy SCSS selector in linked-card utility class

### DIFF
--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -150,7 +150,12 @@
 .u-linked-card {
   position: relative;
 
-  &__primary-link {
+  a {
+    position: relative;
+    z-index: 2;
+  }
+
+  .u-linked-card__primary-link {
     display: inline-block;
     position: static;
 
@@ -163,10 +168,5 @@
       top: 0;
       z-index: 1;
     }
-  }
-
-  a {
-    position: relative;
-    z-index: 2;
   }
 }

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -152,6 +152,7 @@
 
   &__primary-link {
     display: inline-block;
+    position: static;
 
     &::after {
       bottom: 0;
@@ -164,7 +165,7 @@
     }
   }
 
-  a:not(&__primary-link) {
+  a {
     position: relative;
     z-index: 2;
   }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Safari | Website doesn't render correctly](https://app.asana.com/0/555089885850811/1139044049600985)

Resolves iOS issue by scoping `position: relative` for links only when they are children of the `.u-linked-card` parent element.