### PR TITLE
Filter out HubStops with no detailed_stop

### DIFF
--- a/apps/site/lib/site_web/templates/stop/_hub_stops.html.eex
+++ b/apps/site/lib/site_web/templates/stop/_hub_stops.html.eex
@@ -2,17 +2,19 @@
   <div class="hub-stop-list">
     <div class="row hub-stop-container">
       <%= for %HubStop{detailed_stop: detailed_stop, image: path, alt_text: alt_text} <- @hubs do %>
-        <div class="hub-stop-link col-md-6 col-xs-12">
-          <% image_path = static_url(@conn, path) %>
-          <%= img_tag("#{image_path}.jpg", class: "img-fluid hidden-sm-down", srcset: "#{image_path}-2x.jpg 760w, #{image_path}.jpg 380w", alt: alt_text) %>
-          <%= link detailed_stop.stop.name, to: stop_path(@conn, :show, detailed_stop.stop.id), class: "hub-stop-name" %>
-          <span class="stop-features-list"><%= feature_icons(detailed_stop)%></span>
-          <%= if detailed_stop.zone do %>
-            <div class="commuter-rail-zone">
-              Zone <%= detailed_stop.zone %>
-            </div>
-          <% end %>
-        </div>
+        <%= if detailed_stop do %>
+          <div class="hub-stop-link col-md-6 col-xs-12">
+            <% image_path = static_url(@conn, path) %>
+            <%= img_tag("#{image_path}.jpg", class: "img-fluid hidden-sm-down", srcset: "#{image_path}-2x.jpg 760w, #{image_path}.jpg 380w", alt: alt_text) %>
+            <%= link detailed_stop.stop.name, to: stop_path(@conn, :show, detailed_stop.stop.id), class: "hub-stop-name" %>
+            <span class="stop-features-list"><%= feature_icons(detailed_stop)%></span>
+            <%= if detailed_stop.zone do %>
+              <div class="commuter-rail-zone">
+                Zone <%= detailed_stop.zone %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Filter out nils from stops page](https://app.asana.com/0/385363666817452/1139538483069465)

On the stops page, some stops are designated "hub" stops, i.e. the main stops on the route in question. For instance, on the Red Line, those are Park, South Station, and DTX.

For reasons not entirely understood, the `detailed_stop` field of the `HubStop` struct can be nil, causing crashes when we try to access fields on it. Those are now filtered.

<br>
Assigned to: @ryan-mahoney 
