### PR TITLE
Ensure teasers tagged as "Guides" have linked image

### DIFF
--- a/apps/site/lib/site_web/views/partial_view.ex
+++ b/apps/site/lib/site_web/views/partial_view.ex
@@ -1,7 +1,7 @@
 defmodule SiteWeb.PartialView do
   use SiteWeb, :view
 
-  alias CMS.{Field.Image, Partial.Teaser, Repo}
+  alias CMS.{Partial.Teaser, Repo}
   alias Plug.Conn
   alias Routes.Route
   alias SiteWeb.PartialView.SvgIconWithCircle
@@ -76,8 +76,8 @@ defmodule SiteWeb.PartialView do
 
   @doc """
   Renders a CMS content teaser, typically shown on a page's sidebar.
-  Guides only show their image; other content types display the
-  content's title.
+  Guides only show their teaser image; other content types display
+  the content's topic and title below the teaser image.
   """
   @spec teaser(Teaser.t()) :: Phoenix.HTML.Safe.t()
   def teaser(%Teaser{} = teaser, opts \\ []) do
@@ -107,10 +107,16 @@ defmodule SiteWeb.PartialView do
     []
   end
 
-  def render_teaser_image(%Teaser{image: %Image{}} = teaser) do
-    [
-      img_tag(teaser.image.url, alt: teaser.image.alt, class: teaser_image_class(teaser))
-    ]
+  def render_teaser_image(%Teaser{topic: "Guides"} = teaser) do
+    link(do_render_teaser_image(teaser), to: teaser.path)
+  end
+
+  def render_teaser_image(teaser) do
+    do_render_teaser_image(teaser)
+  end
+
+  defp do_render_teaser_image(teaser) do
+    img_tag(teaser.image.url, alt: teaser.image.alt, class: teaser_image_class(teaser))
   end
 
   @spec teaser_image_class(Teaser.t()) :: String.t()

--- a/apps/site/test/site_web/views/partial_view_test.exs
+++ b/apps/site/test/site_web/views/partial_view_test.exs
@@ -157,6 +157,7 @@ defmodule SiteWeb.PartialViewTest do
 
       assert rendered =~ teaser.image.url
       assert rendered =~ teaser.image.alt
+      assert rendered =~ teaser.path
 
       assert Floki.find(rendered, ".sr-only") == [
                {"span", [{"class", "sr-only"}], [teaser.title]}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fix missing link on Guide-tagged teaser images](https://app.asana.com/0/555089885850811/1139717823570505)

In #165 we moved where the link HTML appears to the `h3`, which is not rendered when content is tagged as `Guides`. This adds a clause to wrap that standalone image with a link.

![image](https://user-images.githubusercontent.com/688435/64818019-19ac6b80-d579-11e9-9185-1ebd2e2b82f9.png)
