### PR TITLE
Clean up `<dl>`s

### DIFF
--- a/apps/site/assets/css/_description-list.scss
+++ b/apps/site/assets/css/_description-list.scss
@@ -17,12 +17,12 @@
   border-top: 1px solid $gray-light;
   padding-top: 1rem;
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-up(sm) {
     border-top: 1px solid $gray-light;
     padding-left: 0;
   }
 
-  @include media-breakpoint-down(sm) {
+  @include media-breakpoint-only(xs) {
     @include make-col-span(12);
     padding-left: 0;
     padding-right: 0;
@@ -35,12 +35,12 @@
   margin-bottom: 0;
   padding-top: 1rem;
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-up(sm) {
     border-top: 1px solid $gray-light;
     padding-right: 0;
   }
 
-  @include media-breakpoint-down(sm) {
+  @include media-breakpoint-down(xs) {
     @include make-col-span(12);
     padding: 0;
   }

--- a/apps/site/assets/css/_description-list.scss
+++ b/apps/site/assets/css/_description-list.scss
@@ -13,7 +13,7 @@
 
 .dt {
   @include make-col();
-  @include make-col-span(3);
+  @include make-col-span(4);
   border-top: 1px solid $gray-light;
   padding-top: 1rem;
 
@@ -31,7 +31,7 @@
 
 .dd {
   @include make-col();
-  @include make-col-span(9);
+  @include make-col-span(8);
   margin-bottom: 0;
   padding-top: 1rem;
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⭐ Fares | Description list component clean up](https://app.asana.com/0/555089885850811/1106988937203020)

Two small changes to how we render `<dl>` elements:
* Column proportions adjusted from 25%/75% to 33%/66%.
* `<dl>` only renders as single column at XS breakpoint, rather than SM or XS.

<br>
Assigned to: @ryan-mahoney 
