### PR TITLE
Projects class cleanup (react)

### DIFF
--- a/apps/site/assets/css/_banner.scss
+++ b/apps/site/assets/css/_banner.scss
@@ -160,7 +160,7 @@
   border: 1px solid $brand-primary;
   border-radius: $border-radius;
   display: block;
-  padding: $base-spacing * 0.75;
+  padding: $base-spacing * .75;
 
   &:hover {
     background: $brand-primary-lightest;

--- a/apps/site/assets/css/_banner.scss
+++ b/apps/site/assets/css/_banner.scss
@@ -1,4 +1,4 @@
-.m-banner {
+.c-banner {
   color: inherit;
   display: block;
   margin-top: $base-spacing * 3;
@@ -7,19 +7,19 @@
     color: inherit;
     text-decoration: none;
 
-    .m-banner__title--default {
+    .c-banner__title--default {
       text-decoration: underline;
     }
 
-    .m-banner__cta {
+    .c-banner__cta {
       background: $brand-primary-lightest;
     }
   }
 
   &--responsive {
     @include media-breakpoint-only(xxl) {
-     // banner content is not full width at xxl,
-     // so prevent container from being 100% at that breakpoint.
+      // banner content is not full width at xxl,
+      // so prevent container from being 100% at that breakpoint.
       margin: $base-spacing * 3 auto 0;
       width: map-get($container-max-widths, xxl);
     }
@@ -47,7 +47,7 @@
   }
 }
 
-.m-banner__image {
+.c-banner__image {
   background-position: center;
   background-size: cover;
 
@@ -87,11 +87,11 @@
   }
 }
 
-.m-banner__image--important {
+.c-banner__image--important {
   padding: $base-spacing * 3;
 }
 
-.m-banner__content {
+.c-banner__content {
   background-color: $white;
   display: flex;
   flex-direction: column;
@@ -109,7 +109,6 @@
     width: $col-width * 5;
   }
 
-
   &--responsive {
     @include media-breakpoint-up(sm) {
       min-height: $base-spacing * 20;
@@ -118,17 +117,17 @@
     @include media-breakpoint-up(lg) {
       width: $col-width * 4;
     }
- }
+  }
 }
 
-.m-banner__content--right {
+.c-banner__content--right {
   @include media-breakpoint-up(sm) {
     float: right;
     margin-right: $col-width;
   }
 }
 
-.m-banner__content--default {
+.c-banner__content--default {
   @include media-breakpoint-only(sm) {
     margin-left: $col-width;
   }
@@ -138,7 +137,7 @@
   }
 }
 
-.m-banner__content--important {
+.c-banner__content--important {
   border: $border;
   float: none;
   text-align: center;
@@ -153,15 +152,15 @@
   }
 }
 
-.m-banner__category {
+.c-banner__category {
   font-weight: bold;
 }
 
-.m-banner__cta {
+.c-banner__cta {
   border: 1px solid $brand-primary;
   border-radius: $border-radius;
   display: block;
-  padding: $base-spacing * .75;
+  padding: $base-spacing * 0.75;
 
   &:hover {
     background: $brand-primary-lightest;
@@ -169,7 +168,6 @@
   }
 }
 
-.m-banner__date {
+.c-banner__date {
   font-weight: bold;
 }
-

--- a/apps/site/assets/css/_page.scss
+++ b/apps/site/assets/css/_page.scss
@@ -17,7 +17,6 @@
   color: $white;
 }
 
-
 .pre-container-header {
   @include media-breakpoint-only(xs) {
     display: none;
@@ -55,7 +54,7 @@
   }
 
   @include media-breakpoint-down(xs) {
-    // cover space created by .m-banner__content positioning
+    // cover space created by .c-banner__content positioning
     margin-top: -$base-spacing * 2;
   }
 }

--- a/apps/site/assets/css/project-page.scss
+++ b/apps/site/assets/css/project-page.scss
@@ -22,17 +22,7 @@
   }
 }
 
-.c-project-updates-list {
-  background-color: $brand-primary-lightest-contrast;
-
-  &.u-full-bleed {
-    @include media-breakpoint-up(md) {
-      box-shadow: none;
-    }
-  }
-}
-
-.c-project-update-list__row {
+.m-project-update-list__row {
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;

--- a/apps/site/assets/css/project-page.scss
+++ b/apps/site/assets/css/project-page.scss
@@ -48,18 +48,18 @@
   }
 }
 
-.c-project-update-list__subheader {
+.m-project-update-list__subheader {
   margin-bottom: 1em;
   margin-top: $base-spacing * 1.75;
 }
 
-.c-project-update-list {
+.m-project-update-list {
   @include media-breakpoint-down(md) {
     display: flex;
   }
 }
 
-.c-project-update-list__item {
+.m-project-update-list__item {
   @include media-breakpoint-down(md) {
     flex: 0 0 auto;
     margin-right: $base-spacing;
@@ -71,7 +71,7 @@
   }
 
   &:hover {
-    .c-project-update__title {
+    .m-project-update__title {
       color: $brand-primary;
     }
   }
@@ -81,17 +81,17 @@
   }
 }
 
-.c-project-update__title {
+.m-project-update__title {
   margin: 0 auto;
 }
 
-.c-project-update__photo {
+.m-project-update__photo {
   max-height: 100%;
   max-width: 100%;
   position: relative;
 }
 
-.c-project-update__date {
+.m-project-update__date {
   font-weight: 700;
   margin-top: $base-spacing / 2;
 }
@@ -100,7 +100,7 @@
   margin-top: $base-spacing-lg;
 }
 
-.c-featured-project-list {
+.m-featured-project-list {
   margin-bottom: $base-spacing;
   width: 100%;
 
@@ -109,7 +109,7 @@
   }
 }
 
-.c-featured-project-list__row {
+.m-featured-project-list__row {
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;
@@ -127,13 +127,13 @@
   }
 }
 
-.c-featured-project__route-icon {
+.m-featured-project__route-icon {
   margin-right: $base-spacing * .5;
   margin-top: $base-spacing * .5;
   vertical-align: middle;
 }
 
-.c-featured-project {
+.m-featured-project {
   flex-basis: 0;
   flex-grow: 1;
   margin: 0;
@@ -148,7 +148,7 @@
     text-decoration: none;
   }
 
-  .c-featured-project__title {
+  .m-featured-project__title {
     font-family: $font-family-base;
     font-size: $font-size-h3;
     margin: ($base-spacing / 2) 0 0;
@@ -175,7 +175,7 @@
   }
 
   &:hover {
-    .c-featured-project__title {
+    .m-featured-project__title {
       color: $brand-primary;
     }
   }
@@ -189,7 +189,7 @@
   }
 }
 
-.c-featured-project__image {
+.m-featured-project__image {
   position: relative;
 
   img {
@@ -198,40 +198,40 @@
   }
 }
 
-.c-featured-project__date {
+.m-featured-project__date {
   font-weight: bold;
 }
 
-.c-more-projects-table {
+.m-more-projects-table {
   table-layout: fixed;
   width: 100%;
 }
 
-.c-more-projects-table__thead {
+.m-more-projects-table__thead {
   background-color: $brand-primary-lightest;
 }
 
-.c-more-projects-table__th {
+.m-more-projects-table__th {
   padding-bottom: .75rem;
   padding-top: .75rem;
 }
 
-.c-more-projects-table__th-project,
-.c-more-projects-table__td-project {
+.m-more-projects-table__th-project,
+.m-more-projects-table__td-project {
   width: 50%;
 }
 
-.c-more-projects-table__th-last-updated,
-.c-more-projects-table__td-last-updated {
+.m-more-projects-table__th-last-updated,
+.m-more-projects-table__td-last-updated {
   width: 25%;
 }
 
-.c-more-projects-table__th-status,
-.c-more-projects-table__td-status {
+.m-more-projects-table__th-status,
+.m-more-projects-table__td-status {
   width: 29%;
 }
 
-.c-more-projects-table__thumbnail {
+.m-more-projects-table__thumbnail {
   float: left;
   padding-right: $base-spacing / 2;
 
@@ -244,18 +244,18 @@
   }
 }
 
-.c-more-projects-table__th-project {
+.m-more-projects-table__th-project {
   padding-left: $base-spacing / 2;
 }
 
-.c-more-projects-table__wrapper {
+.m-more-projects-table__wrapper {
   @include media-breakpoint-up(lg) {
     display: inline-block;
     width: 70%;
   }
 }
 
-.c-more-projects-table__tr {
+.m-more-projects-table__tr {
   @include media-breakpoint-up(lg) {
     &:first-child td {
       padding-top: $base-spacing * 1.5;
@@ -263,35 +263,35 @@
   }
 }
 
-.c-more-projects-table__td {
+.m-more-projects-table__td {
   border-bottom: solid $gray-bordered-background 1px;
   padding-bottom: $base-spacing;
   padding-top: $base-spacing;
   vertical-align: top;
 }
 
-.c-more-projects-table__route-icon {
+.m-more-projects-table__route-icon {
   margin-right: .5em;
 }
 
-.c-more-projects-table__updated-and-status {
+.m-more-projects-table__updated-and-status {
   font-size: $font-size-base-sm;
 }
 
-.c-more-projects-table__last-updated {
+.m-more-projects-table__last-updated {
   float: left;
   width: $base-spacing * 9;
 }
 
-.c-more-projects-table__internal-header {
+.m-more-projects-table__internal-header {
   font-weight: bold;
 }
 
-.c-more-projects-table__title {
+.m-more-projects-table__title {
   margin-top: 0;
 }
 
-.c-more-projects__show-more-button {
+.m-more-projects__show-more-button {
   @include media-breakpoint-up(lg) {
     width: $base-spacing * 22;
   }
@@ -305,7 +305,7 @@
   }
 }
 
-.c-more-projects__show-more-button-wrapper {
+.m-more-projects__show-more-button-wrapper {
   text-align: center;
   width: 100%;
 
@@ -318,25 +318,25 @@
   }
 }
 
-.c-more-projects-table__status-wrapper {
+.m-more-projects-table__status-wrapper {
   vertical-align: top;
 }
 
-.c-more-projects-table__status-text {
+.m-more-projects-table__status-text {
   vertical-align: top;
 }
 
-.c-more-projects-table__status-text--complete {
+.m-more-projects-table__status-text--complete {
   color: $brand-success;
 }
 
-.c-more-projects-table__status-icon {
+.m-more-projects-table__status-icon {
   @include media-breakpoint-up(lg) {
     font-size: $font-size-base * 1.5;
   }
 }
 
-.c-more-projects-table__status-icon--contract-awarded {
+.m-more-projects-table__status-icon--contract-awarded {
   color: $brand-primary;
 
   &::before {
@@ -344,7 +344,7 @@
   }
 }
 
-.c-more-projects-table__status-icon--in-progress {
+.m-more-projects-table__status-icon--in-progress {
   color: $brand-primary-light;
 
   &::before {
@@ -352,7 +352,7 @@
   }
 }
 
-.c-more-projects-table__status-icon--complete {
+.m-more-projects-table__status-icon--complete {
   color: $brand-success;
 
   &::before {

--- a/apps/site/assets/ts/projects/__tests__/BannerTest.tsx
+++ b/apps/site/assets/ts/projects/__tests__/BannerTest.tsx
@@ -122,7 +122,7 @@ it("renders with unknown background color if no routes are listed", () => {
       placeholderImageUrl={placeholderImageUrl}
     />
   );
-  const actualSrc = wrapper.find(".m-banner__content").first();
+  const actualSrc = wrapper.find(".c-banner__content").first();
   expect(actualSrc.html()).toContain("u-bg--unknown");
 });
 
@@ -133,7 +133,7 @@ it("renders placeholder image if there is no image", () => {
       placeholderImageUrl={placeholderImageUrl}
     />
   );
-  const actualSrc = wrapper.find(".m-banner__image");
+  const actualSrc = wrapper.find(".c-banner__image");
   expect(actualSrc.first().html()).toContain(placeholderImageUrl);
   expect(actualSrc.last().html()).toContain(placeholderImageUrl);
 });

--- a/apps/site/assets/ts/projects/__tests__/MoreProjectsTableTest.tsx
+++ b/apps/site/assets/ts/projects/__tests__/MoreProjectsTableTest.tsx
@@ -91,6 +91,6 @@ it("triggers event when clicked", () => {
     />
   );
 
-  wrapper.find(".c-more-projects__show-more-button").simulate("click");
+  wrapper.find(".m-more-projects__show-more-button").simulate("click");
   expect(spy).toHaveBeenCalled();
 });

--- a/apps/site/assets/ts/projects/__tests__/__snapshots__/BannerTest.tsx.snap
+++ b/apps/site/assets/ts/projects/__tests__/__snapshots__/BannerTest.tsx.snap
@@ -8,7 +8,7 @@ Array [
     Featured Projects
   </h2>,
   <a
-    className="m-banner m-banner--responsive m-banner--lg-9 m-banner--no-margin-top m-banner--default"
+    className="c-banner c-banner--responsive c-banner--lg-9 c-banner--no-margin-top c-banner--default"
     href="/projects/better-bus-project"
   >
     <div
@@ -18,7 +18,7 @@ Array [
         className="row"
       >
         <div
-          className="m-banner__image m-banner__image--responsive m-banner__image--default"
+          className="c-banner__image c-banner__image--responsive c-banner__image--default"
           style={
             Object {
               "backgroundImage": "url(https://live-mbta.pantheonsite.io/sites/default/files/styles/teaser/public/projects/betterbus/betterbus-banner-large.png?itok=qWyWNEZq)",
@@ -32,22 +32,22 @@ Array [
           </div>
         </div>
         <div
-          className="m-banner__content m-banner__content--responsive-side-by-side m-banner__content--left u-bg--unknown"
+          className="c-banner__content c-banner__content--responsive-side-by-side c-banner__content--left u-bg--unknown"
         >
           <div
-            className="m-banner__top"
+            className="c-banner__top"
           >
             <h2
-              className="h2 m-banner__title m-banner__title--default"
+              className="h2 c-banner__title c-banner__title--default"
             >
               Better Bus Project
             </h2>
           </div>
           <div
-            className="m-banner__bottom"
+            className="c-banner__bottom"
           >
             <span
-              className="m-banner__date"
+              className="c-banner__date"
             >
               Updated 
               July 30, 2019
@@ -63,25 +63,25 @@ Array [
         className="row"
       >
         <div
-          className="m-banner__image m-banner__image--responsive-side-by-side m-banner--responsive-no-margin m-banner__image--default"
+          className="c-banner__image c-banner__image--responsive-side-by-side c-banner--responsive-no-margin c-banner__image--default"
         >
           <div
-            className="m-banner__content m-banner__content--responsive-side-by-side m-banner__content--left u-bg--unknown"
+            className="c-banner__content c-banner__content--responsive-side-by-side c-banner__content--left u-bg--unknown"
           >
             <div
-              className="m-banner__top"
+              className="c-banner__top"
             >
               <h2
-                className="h2 m-banner__title m-banner__title--default"
+                className="h2 c-banner__title c-banner__title--default"
               >
                 Better Bus Project
               </h2>
             </div>
             <div
-              className="m-banner__bottom"
+              className="c-banner__bottom"
             >
               <span
-                className="m-banner__date"
+                className="c-banner__date"
               >
                 Updated 
                 July 30, 2019
@@ -90,7 +90,7 @@ Array [
           </div>
           <img
             alt="Better Bus Project: Making transit better together"
-            className="m-banner__image--by-side"
+            className="c-banner__image--by-side"
             src="https://live-mbta.pantheonsite.io/sites/default/files/styles/teaser/public/projects/betterbus/betterbus-banner-large.png?itok=qWyWNEZq"
           />
           <div
@@ -105,25 +105,25 @@ Array [
       className="hidden-md-down"
     >
       <div
-        className="m-banner__image m-banner__image--responsive-side-by-side m-banner--responsive-no-margin m-banner__image--default"
+        className="c-banner__image c-banner__image--responsive-side-by-side c-banner--responsive-no-margin c-banner__image--default"
       >
         <div
-          className="m-banner__content m-banner__content--responsive-side-by-side m-banner__content--left u-bg--unknown"
+          className="c-banner__content c-banner__content--responsive-side-by-side c-banner__content--left u-bg--unknown"
         >
           <div
-            className="m-banner__top"
+            className="c-banner__top"
           >
             <h2
-              className="h2 m-banner__title m-banner__title--default"
+              className="h2 c-banner__title c-banner__title--default"
             >
               Better Bus Project
             </h2>
           </div>
           <div
-            className="m-banner__bottom"
+            className="c-banner__bottom"
           >
             <span
-              className="m-banner__date"
+              className="c-banner__date"
             >
               Updated 
               July 30, 2019
@@ -132,7 +132,7 @@ Array [
         </div>
         <img
           alt="Better Bus Project: Making transit better together"
-          className="m-banner__image--by-side"
+          className="c-banner__image--by-side"
           src="https://live-mbta.pantheonsite.io/sites/default/files/styles/teaser/public/projects/betterbus/betterbus-banner-large.png?itok=qWyWNEZq"
         />
         <div

--- a/apps/site/assets/ts/projects/__tests__/__snapshots__/FeaturedProjectsListTest.tsx.snap
+++ b/apps/site/assets/ts/projects/__tests__/__snapshots__/FeaturedProjectsListTest.tsx.snap
@@ -2,22 +2,22 @@
 
 exports[`renders 1`] = `
 <div
-  className="c-featured-project-list"
+  className="m-featured-project-list"
 >
   <div
     className="page-section"
   >
     <div
-      className="c-featured-project-list__row"
+      className="m-featured-project-list__row"
     >
       <div
-        className="c-featured-project"
+        className="m-featured-project"
       >
         <a
           href="/choo-choo"
         >
           <div
-            className="c-featured-project__image"
+            className="m-featured-project__image"
           >
             <img
               alt="Picture of a train. Choo choo!"
@@ -25,12 +25,12 @@ exports[`renders 1`] = `
             />
           </div>
           <h3
-            className="c-featured-project__title"
+            className="m-featured-project__title"
           >
             New choo-choos!
           </h3>
           <div
-            className="c-featured-project__date"
+            className="m-featured-project__date"
           >
             Updated on 
             May 1, 2018
@@ -57,13 +57,13 @@ exports[`renders 1`] = `
         </a>
       </div>
       <div
-        className="c-featured-project"
+        className="m-featured-project"
       >
         <a
           href="/fixing-track"
         >
           <div
-            className="c-featured-project__image"
+            className="m-featured-project__image"
           >
             <img
               alt="People fixing track or something"
@@ -71,12 +71,12 @@ exports[`renders 1`] = `
             />
           </div>
           <h3
-            className="c-featured-project__title"
+            className="m-featured-project__title"
           >
             Track fixing
           </h3>
           <div
-            className="c-featured-project__date"
+            className="m-featured-project__date"
           >
             Updated on 
             April 1, 2018
@@ -95,16 +95,16 @@ exports[`renders 1`] = `
       </div>
     </div>
     <div
-      className="c-featured-project-list__row"
+      className="m-featured-project-list__row"
     >
       <div
-        className="c-featured-project"
+        className="m-featured-project"
       >
         <a
           href="/east-station"
         >
           <div
-            className="c-featured-project__image"
+            className="m-featured-project__image"
           >
             <img
               alt="Facade of East Station"
@@ -112,12 +112,12 @@ exports[`renders 1`] = `
             />
           </div>
           <h3
-            className="c-featured-project__title"
+            className="m-featured-project__title"
           >
             East Station opening
           </h3>
           <div
-            className="c-featured-project__date"
+            className="m-featured-project__date"
           >
             Updated on 
             March 1, 2018
@@ -135,13 +135,13 @@ exports[`renders 1`] = `
         </a>
       </div>
       <div
-        className="c-featured-project"
+        className="m-featured-project"
       >
         <a
           href="/east-station"
         >
           <div
-            className="c-featured-project__image"
+            className="m-featured-project__image"
           >
             <img
               alt="MBTA logo"
@@ -149,12 +149,12 @@ exports[`renders 1`] = `
             />
           </div>
           <h3
-            className="c-featured-project__title"
+            className="m-featured-project__title"
           >
             East Station opening
           </h3>
           <div
-            className="c-featured-project__date"
+            className="m-featured-project__date"
           >
             Updated on 
             March 1, 2018

--- a/apps/site/assets/ts/projects/__tests__/__snapshots__/MoreProjectsRowTest.tsx.snap
+++ b/apps/site/assets/ts/projects/__tests__/__snapshots__/MoreProjectsRowTest.tsx.snap
@@ -2,36 +2,36 @@
 
 exports[`renders with route icons and status 1`] = `
 <tr
-  className="c-more-projects-table__tr"
+  className="m-more-projects-table__tr"
 >
   <td
-    className="c-more-projects-table__td c-more-projects-table__td-project"
+    className="m-more-projects-table__td m-more-projects-table__td-project"
   >
     <img
       alt="Picture of the new Mauve Line train"
-      className="hidden-xs-down c-more-projects-table__thumbnail"
+      className="hidden-xs-down m-more-projects-table__thumbnail"
       src="http://cloudfront.com/mbta_pic.gif"
     />
     <div
-      className="c-more-projects-table__wrapper"
+      className="m-more-projects-table__wrapper"
     >
       <a
         href="http://www.mbta.com/new_mauve_line"
       >
         <h3
-          className="c-more-projects-table__title"
+          className="m-more-projects-table__title"
         >
           New Mauve Line trains
         </h3>
       </a>
       <div
-        className="c-more-projects-table__updated-and-status hidden-lg-up"
+        className="m-more-projects-table__updated-and-status hidden-lg-up"
       >
         <div
-          className="c-more-projects-table__last-updated"
+          className="m-more-projects-table__last-updated"
         >
           <span
-            className="c-more-projects-table__internal-header"
+            className="m-more-projects-table__internal-header"
           >
             Last updated
           </span>
@@ -40,7 +40,7 @@ exports[`renders with route icons and status 1`] = `
           <br />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -49,7 +49,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -58,7 +58,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -67,7 +67,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -76,7 +76,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -85,7 +85,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -94,7 +94,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -103,7 +103,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -112,7 +112,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -121,7 +121,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -130,7 +130,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -139,7 +139,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -148,7 +148,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -157,7 +157,7 @@ exports[`renders with route icons and status 1`] = `
           />
           <span
             aria-hidden="false"
-            className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+            className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -166,20 +166,20 @@ exports[`renders with route icons and status 1`] = `
           />
         </div>
         <div
-          className="c-more-projects-table__status"
+          className="m-more-projects-table__status"
         >
           <span
-            className="c-more-projects-table__internal-header"
+            className="m-more-projects-table__internal-header"
           >
             Status
           </span>
           <br />
           <i
-            className="fa c-more-projects-table__status-icon c-more-projects-table__status-icon--contract-awarded"
+            className="fa m-more-projects-table__status-icon m-more-projects-table__status-icon--contract-awarded"
           />
            
           <span
-            className="c-more-projects-table__status-text c-more-projects-table__status-text--contract-awarded"
+            className="m-more-projects-table__status-text m-more-projects-table__status-text--contract-awarded"
           >
             Contract awarded
           </span>
@@ -187,7 +187,7 @@ exports[`renders with route icons and status 1`] = `
       </div>
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -196,7 +196,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -205,7 +205,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -214,7 +214,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -223,7 +223,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -232,7 +232,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -241,7 +241,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -250,7 +250,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -259,7 +259,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -268,7 +268,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -277,7 +277,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -286,7 +286,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -295,7 +295,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -304,7 +304,7 @@ exports[`renders with route icons and status 1`] = `
       />
       <span
         aria-hidden="false"
-        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
         dangerouslySetInnerHTML={
           Object {
             "__html": "SVG",
@@ -314,22 +314,22 @@ exports[`renders with route icons and status 1`] = `
     </div>
   </td>
   <td
-    className="c-more-projects-table__td c-more-projects-table__td-last-updated hidden-md-down"
+    className="m-more-projects-table__td m-more-projects-table__td-last-updated hidden-md-down"
   >
     May 1, 2018
   </td>
   <td
-    className="c-more-projects-table__td c-more-projects-table__td-status hidden-md-down"
+    className="m-more-projects-table__td m-more-projects-table__td-status hidden-md-down"
   >
     <span
-      className="c-more-projects-table__status-wrapper"
+      className="m-more-projects-table__status-wrapper"
     >
       <i
-        className="fa c-more-projects-table__status-icon c-more-projects-table__status-icon--contract-awarded"
+        className="fa m-more-projects-table__status-icon m-more-projects-table__status-icon--contract-awarded"
       />
        
       <span
-        className="c-more-projects-table__status-text c-more-projects-table__status-text--contract-awarded"
+        className="m-more-projects-table__status-text m-more-projects-table__status-text--contract-awarded"
       >
         Contract awarded
       </span>

--- a/apps/site/assets/ts/projects/__tests__/__snapshots__/MoreProjectsTableTest.tsx.snap
+++ b/apps/site/assets/ts/projects/__tests__/__snapshots__/MoreProjectsTableTest.tsx.snap
@@ -9,26 +9,26 @@ Array [
   <div>
     <table
       aria-label="More Projects"
-      className="c-more-projects-table"
+      className="m-more-projects-table"
     >
       <thead
-        className="c-more-projects-table__thead hidden-md-down"
+        className="m-more-projects-table__thead hidden-md-down"
       >
         <tr>
           <th
-            className="c-more-projects-table__th c-more-projects-table__th-project"
+            className="m-more-projects-table__th m-more-projects-table__th-project"
             scope="col"
           >
             Project
           </th>
           <th
-            className="c-more-projects-table__th c-more-projects-table__th-last-updated"
+            className="m-more-projects-table__th m-more-projects-table__th-last-updated"
             scope="col"
           >
             Last Updated
           </th>
           <th
-            className="c-more-projects-table__th c-more-projects-table__th-status"
+            className="m-more-projects-table__th m-more-projects-table__th-status"
             scope="col"
           >
             Status
@@ -36,39 +36,39 @@ Array [
         </tr>
       </thead>
       <tbody
-        className="c-more-projects-table__tbody"
+        className="m-more-projects-table__tbody"
       >
         <tr
-          className="c-more-projects-table__tr"
+          className="m-more-projects-table__tr"
         >
           <td
-            className="c-more-projects-table__td c-more-projects-table__td-project"
+            className="m-more-projects-table__td m-more-projects-table__td-project"
           >
             <img
               alt="Photo of stuff"
-              className="hidden-xs-down c-more-projects-table__thumbnail"
+              className="hidden-xs-down m-more-projects-table__thumbnail"
               src="http://www.example.com/some.gif"
             />
             <div
-              className="c-more-projects-table__wrapper"
+              className="m-more-projects-table__wrapper"
             >
               <a
                 href="http://www.mbta.com/awesome_project"
               >
                 <h3
-                  className="c-more-projects-table__title"
+                  className="m-more-projects-table__title"
                 >
                   The Awesome Project
                 </h3>
               </a>
               <div
-                className="c-more-projects-table__updated-and-status hidden-lg-up"
+                className="m-more-projects-table__updated-and-status hidden-lg-up"
               >
                 <div
-                  className="c-more-projects-table__last-updated"
+                  className="m-more-projects-table__last-updated"
                 >
                   <span
-                    className="c-more-projects-table__internal-header"
+                    className="m-more-projects-table__internal-header"
                   >
                     Last updated
                   </span>
@@ -77,7 +77,7 @@ Array [
                   <br />
                   <span
                     aria-hidden="false"
-                    className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+                    className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
                     dangerouslySetInnerHTML={
                       Object {
                         "__html": "SVG",
@@ -86,7 +86,7 @@ Array [
                   />
                   <span
                     aria-hidden="false"
-                    className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+                    className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
                     dangerouslySetInnerHTML={
                       Object {
                         "__html": "SVG",
@@ -97,7 +97,7 @@ Array [
               </div>
               <span
                 aria-hidden="false"
-                className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+                className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "SVG",
@@ -106,7 +106,7 @@ Array [
               />
               <span
                 aria-hidden="false"
-                className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+                className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "SVG",
@@ -116,25 +116,25 @@ Array [
             </div>
           </td>
           <td
-            className="c-more-projects-table__td c-more-projects-table__td-last-updated hidden-md-down"
+            className="m-more-projects-table__td m-more-projects-table__td-last-updated hidden-md-down"
           >
             June 2, 2018
           </td>
           <td
-            className="c-more-projects-table__td c-more-projects-table__td-status hidden-md-down"
+            className="m-more-projects-table__td m-more-projects-table__td-status hidden-md-down"
           >
             <span
-              className="c-more-projects-table__status-wrapper"
+              className="m-more-projects-table__status-wrapper"
             />
           </td>
         </tr>
       </tbody>
     </table>
     <div
-      className="c-more-projects__show-more-button-wrapper"
+      className="m-more-projects__show-more-button-wrapper"
     >
       <button
-        className="btn btn-secondary c-more-projects__show-more-button"
+        className="btn btn-secondary m-more-projects__show-more-button"
         disabled={false}
         onClick={[Function]}
         type="button"

--- a/apps/site/assets/ts/projects/__tests__/__snapshots__/ProjectUpdateListTest.tsx.snap
+++ b/apps/site/assets/ts/projects/__tests__/__snapshots__/ProjectUpdateListTest.tsx.snap
@@ -3,31 +3,31 @@
 exports[`renders 1`] = `
 Array [
   <h2
-    className="c-projects-header__subheader"
+    className="m-projects-header__subheader"
   >
     Project Updates
   </h2>,
   <div
-    className="c-project-update-list__row"
+    className="m-project-update-list__row"
   >
     <a
-      className="c-project-update-list__item"
+      className="m-project-update-list__item"
       href="/projects/commuter-rail-positive-train-control-ptc/update/ptc-weekly-activities"
     >
       <div>
         <img
           alt="A Commuter Rail train with machinery by its side, the track ties being replaced"
-          className="c-project-update__photo"
+          className="m-project-update__photo"
           src="https://live-mbta.pantheonsite.io/sites/default/files/styles/teaser/public/media/2018-11/commuter-rail-ashland-tie-replacement.jpg?itok=pVKP8vAv"
         />
       </div>
       <div
-        className="c-project-update__date u-small-caps"
+        className="m-project-update__date u-small-caps"
       >
         August 26, 2019
       </div>
       <h3
-        className="c-project-update__title"
+        className="m-project-update__title"
       >
         PTC Weekly Activities
       </h3>
@@ -42,23 +42,23 @@ Array [
       </div>
     </a>
     <a
-      className="c-project-update-list__item"
+      className="m-project-update-list__item"
       href="/projects/wollaston-station-improvements/update/shuttle-service-ends-after-wollaston-reopening"
     >
       <div>
         <img
           alt="Yankee bus shuttle during Wollaston&#039;s renovation"
-          className="c-project-update__photo"
+          className="m-project-update__photo"
           src="https://live-mbta.pantheonsite.io/sites/default/files/styles/teaser/public/projects/wollaston-bus-shuttle-yankee.jpg?itok=kv8lwpvB"
         />
       </div>
       <div
-        className="c-project-update__date u-small-caps"
+        className="m-project-update__date u-small-caps"
       >
         August 24, 2019
       </div>
       <h3
-        className="c-project-update__title"
+        className="m-project-update__title"
       >
         Shuttle Service Ends After Wollaston Reopening
       </h3>
@@ -73,23 +73,23 @@ Array [
       </div>
     </a>
     <a
-      className="c-project-update-list__item"
+      className="m-project-update-list__item"
       href="/projects/early-morning-and-late-night-bus-service-pilots/update/early-morning-and-late-night"
     >
       <div>
         <img
           alt="A bus pulled up to a bus shelter late at night, with a rider walking away, and an ad for late night bus service on the shelter wall, which reads, &quot;Late-night buses. If you&#039;re working late, so are we. Extended bus hours are here for you.&quot;."
-          className="c-project-update__photo"
+          className="m-project-update__photo"
           src="https://live-mbta.pantheonsite.io/sites/default/files/styles/teaser/public/media/2019-08/Bus_Late%20Night%20Bus%20Shelters_2019-6213.jpg?itok=VvFzWkH4"
         />
       </div>
       <div
-        className="c-project-update__date u-small-caps"
+        className="m-project-update__date u-small-caps"
       >
         August 23, 2019
       </div>
       <h3
-        className="c-project-update__title"
+        className="m-project-update__title"
       >
         Early Morning and Late Night Service Becomes Permanent
       </h3>
@@ -108,23 +108,23 @@ Array [
       </div>
     </a>
     <a
-      className="c-project-update-list__item"
+      className="m-project-update-list__item"
       href="/projects/bus-transit-priority/update/brighton-ave-bus-lane"
     >
       <div>
         <img
           alt="A 57 bus travels in a dedicated bus lane on Brighton Ave in Allston, with &quot;Bus Bike Only&quot; prominently stenciled in the dark red lane."
-          className="c-project-update__photo"
+          className="m-project-update__photo"
           src="https://live-mbta.pantheonsite.io/sites/default/files/styles/teaser/public/media/2019-08/Bus_Allston_Dedicated_Lane_2019-4908.jpg?itok=dP6bWBYi"
         />
       </div>
       <div
-        className="c-project-update__date u-small-caps"
+        className="m-project-update__date u-small-caps"
       >
         August 20, 2019
       </div>
       <h3
-        className="c-project-update__title"
+        className="m-project-update__title"
       >
         Brighton Ave Bus Lane
       </h3>

--- a/apps/site/assets/ts/projects/__tests__/__snapshots__/ProjectsPageTest.tsx.snap
+++ b/apps/site/assets/ts/projects/__tests__/__snapshots__/ProjectsPageTest.tsx.snap
@@ -111,7 +111,7 @@ Array [
         Featured Projects
       </h2>
       <a
-        className="m-banner m-banner--responsive m-banner--lg-9 m-banner--no-margin-top m-banner--default"
+        className="c-banner c-banner--responsive c-banner--lg-9 c-banner--no-margin-top c-banner--default"
         href="/projects/better-bus-project"
       >
         <div
@@ -121,7 +121,7 @@ Array [
             className="row"
           >
             <div
-              className="m-banner__image m-banner__image--responsive m-banner__image--default"
+              className="c-banner__image c-banner__image--responsive c-banner__image--default"
               style={
                 Object {
                   "backgroundImage": "url(https://live-mbta.pantheonsite.io/sites/default/files/styles/teaser/public/projects/betterbus/betterbus-banner-large.png?itok=qWyWNEZq)",
@@ -135,22 +135,22 @@ Array [
               </div>
             </div>
             <div
-              className="m-banner__content m-banner__content--responsive-side-by-side m-banner__content--left u-bg--unknown"
+              className="c-banner__content c-banner__content--responsive-side-by-side c-banner__content--left u-bg--unknown"
             >
               <div
-                className="m-banner__top"
+                className="c-banner__top"
               >
                 <h2
-                  className="h2 m-banner__title m-banner__title--default"
+                  className="h2 c-banner__title c-banner__title--default"
                 >
                   Better Bus Project
                 </h2>
               </div>
               <div
-                className="m-banner__bottom"
+                className="c-banner__bottom"
               >
                 <span
-                  className="m-banner__date"
+                  className="c-banner__date"
                 >
                   Updated 
                   July 30, 2019
@@ -166,25 +166,25 @@ Array [
             className="row"
           >
             <div
-              className="m-banner__image m-banner__image--responsive-side-by-side m-banner--responsive-no-margin m-banner__image--default"
+              className="c-banner__image c-banner__image--responsive-side-by-side c-banner--responsive-no-margin c-banner__image--default"
             >
               <div
-                className="m-banner__content m-banner__content--responsive-side-by-side m-banner__content--left u-bg--unknown"
+                className="c-banner__content c-banner__content--responsive-side-by-side c-banner__content--left u-bg--unknown"
               >
                 <div
-                  className="m-banner__top"
+                  className="c-banner__top"
                 >
                   <h2
-                    className="h2 m-banner__title m-banner__title--default"
+                    className="h2 c-banner__title c-banner__title--default"
                   >
                     Better Bus Project
                   </h2>
                 </div>
                 <div
-                  className="m-banner__bottom"
+                  className="c-banner__bottom"
                 >
                   <span
-                    className="m-banner__date"
+                    className="c-banner__date"
                   >
                     Updated 
                     July 30, 2019
@@ -193,7 +193,7 @@ Array [
               </div>
               <img
                 alt="Better Bus Project: Making transit better together"
-                className="m-banner__image--by-side"
+                className="c-banner__image--by-side"
                 src="https://live-mbta.pantheonsite.io/sites/default/files/styles/teaser/public/projects/betterbus/betterbus-banner-large.png?itok=qWyWNEZq"
               />
               <div
@@ -208,25 +208,25 @@ Array [
           className="hidden-md-down"
         >
           <div
-            className="m-banner__image m-banner__image--responsive-side-by-side m-banner--responsive-no-margin m-banner__image--default"
+            className="c-banner__image c-banner__image--responsive-side-by-side c-banner--responsive-no-margin c-banner__image--default"
           >
             <div
-              className="m-banner__content m-banner__content--responsive-side-by-side m-banner__content--left u-bg--unknown"
+              className="c-banner__content c-banner__content--responsive-side-by-side c-banner__content--left u-bg--unknown"
             >
               <div
-                className="m-banner__top"
+                className="c-banner__top"
               >
                 <h2
-                  className="h2 m-banner__title m-banner__title--default"
+                  className="h2 c-banner__title c-banner__title--default"
                 >
                   Better Bus Project
                 </h2>
               </div>
               <div
-                className="m-banner__bottom"
+                className="c-banner__bottom"
               >
                 <span
-                  className="m-banner__date"
+                  className="c-banner__date"
                 >
                   Updated 
                   July 30, 2019
@@ -235,7 +235,7 @@ Array [
             </div>
             <img
               alt="Better Bus Project: Making transit better together"
-              className="m-banner__image--by-side"
+              className="c-banner__image--by-side"
               src="https://live-mbta.pantheonsite.io/sites/default/files/styles/teaser/public/projects/betterbus/betterbus-banner-large.png?itok=qWyWNEZq"
             />
             <div
@@ -247,22 +247,22 @@ Array [
         </div>
       </a>
       <div
-        className="c-featured-project-list"
+        className="m-featured-project-list"
       >
         <div
           className="page-section"
         >
           <div
-            className="c-featured-project-list__row"
+            className="m-featured-project-list__row"
           >
             <div
-              className="c-featured-project"
+              className="m-featured-project"
             >
               <a
                 href="/choo-choo"
               >
                 <div
-                  className="c-featured-project__image"
+                  className="m-featured-project__image"
                 >
                   <img
                     alt="Picture of a train. Choo choo!"
@@ -270,12 +270,12 @@ Array [
                   />
                 </div>
                 <h3
-                  className="c-featured-project__title"
+                  className="m-featured-project__title"
                 >
                   New choo-choos!
                 </h3>
                 <div
-                  className="c-featured-project__date"
+                  className="m-featured-project__date"
                 >
                   Updated on 
                   May 1, 2018
@@ -302,13 +302,13 @@ Array [
               </a>
             </div>
             <div
-              className="c-featured-project"
+              className="m-featured-project"
             >
               <a
                 href="/fixing-track"
               >
                 <div
-                  className="c-featured-project__image"
+                  className="m-featured-project__image"
                 >
                   <img
                     alt="People fixing track or something"
@@ -316,12 +316,12 @@ Array [
                   />
                 </div>
                 <h3
-                  className="c-featured-project__title"
+                  className="m-featured-project__title"
                 >
                   Track fixing
                 </h3>
                 <div
-                  className="c-featured-project__date"
+                  className="m-featured-project__date"
                 >
                   Updated on 
                   April 1, 2018
@@ -340,16 +340,16 @@ Array [
             </div>
           </div>
           <div
-            className="c-featured-project-list__row"
+            className="m-featured-project-list__row"
           >
             <div
-              className="c-featured-project"
+              className="m-featured-project"
             >
               <a
                 href="/east-station"
               >
                 <div
-                  className="c-featured-project__image"
+                  className="m-featured-project__image"
                 >
                   <img
                     alt="Facade of East Station"
@@ -357,12 +357,12 @@ Array [
                   />
                 </div>
                 <h3
-                  className="c-featured-project__title"
+                  className="m-featured-project__title"
                 >
                   East Station opening
                 </h3>
                 <div
-                  className="c-featured-project__date"
+                  className="m-featured-project__date"
                 >
                   Updated on 
                   March 1, 2018
@@ -380,7 +380,7 @@ Array [
               </a>
             </div>
             <div
-              className="c-featured-project"
+              className="m-featured-project"
             />
           </div>
         </div>
@@ -401,26 +401,26 @@ Array [
       <div>
         <table
           aria-label="More Projects"
-          className="c-more-projects-table"
+          className="m-more-projects-table"
         >
           <thead
-            className="c-more-projects-table__thead hidden-md-down"
+            className="m-more-projects-table__thead hidden-md-down"
           >
             <tr>
               <th
-                className="c-more-projects-table__th c-more-projects-table__th-project"
+                className="m-more-projects-table__th m-more-projects-table__th-project"
                 scope="col"
               >
                 Project
               </th>
               <th
-                className="c-more-projects-table__th c-more-projects-table__th-last-updated"
+                className="m-more-projects-table__th m-more-projects-table__th-last-updated"
                 scope="col"
               >
                 Last Updated
               </th>
               <th
-                className="c-more-projects-table__th c-more-projects-table__th-status"
+                className="m-more-projects-table__th m-more-projects-table__th-status"
                 scope="col"
               >
                 Status
@@ -428,39 +428,39 @@ Array [
             </tr>
           </thead>
           <tbody
-            className="c-more-projects-table__tbody"
+            className="m-more-projects-table__tbody"
           >
             <tr
-              className="c-more-projects-table__tr"
+              className="m-more-projects-table__tr"
             >
               <td
-                className="c-more-projects-table__td c-more-projects-table__td-project"
+                className="m-more-projects-table__td m-more-projects-table__td-project"
               >
                 <img
                   alt="Photo of stuff"
-                  className="hidden-xs-down c-more-projects-table__thumbnail"
+                  className="hidden-xs-down m-more-projects-table__thumbnail"
                   src="http://www.example.com/some.gif"
                 />
                 <div
-                  className="c-more-projects-table__wrapper"
+                  className="m-more-projects-table__wrapper"
                 >
                   <a
                     href="http://www.mbta.com/awesome_project"
                   >
                     <h3
-                      className="c-more-projects-table__title"
+                      className="m-more-projects-table__title"
                     >
                       The Awesome Project
                     </h3>
                   </a>
                   <div
-                    className="c-more-projects-table__updated-and-status hidden-lg-up"
+                    className="m-more-projects-table__updated-and-status hidden-lg-up"
                   >
                     <div
-                      className="c-more-projects-table__last-updated"
+                      className="m-more-projects-table__last-updated"
                     >
                       <span
-                        className="c-more-projects-table__internal-header"
+                        className="m-more-projects-table__internal-header"
                       >
                         Last updated
                       </span>
@@ -469,7 +469,7 @@ Array [
                       <br />
                       <span
                         aria-hidden="false"
-                        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+                        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
                         dangerouslySetInnerHTML={
                           Object {
                             "__html": "SVG",
@@ -478,7 +478,7 @@ Array [
                       />
                       <span
                         aria-hidden="false"
-                        className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-lg-up"
+                        className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-lg-up"
                         dangerouslySetInnerHTML={
                           Object {
                             "__html": "SVG",
@@ -489,7 +489,7 @@ Array [
                   </div>
                   <span
                     aria-hidden="false"
-                    className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+                    className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
                     dangerouslySetInnerHTML={
                       Object {
                         "__html": "SVG",
@@ -498,7 +498,7 @@ Array [
                   />
                   <span
                     aria-hidden="false"
-                    className="notranslate c-svg__icon c-more-projects-table__route-icon hidden-md-down"
+                    className="notranslate c-svg__icon m-more-projects-table__route-icon hidden-md-down"
                     dangerouslySetInnerHTML={
                       Object {
                         "__html": "SVG",
@@ -508,25 +508,25 @@ Array [
                 </div>
               </td>
               <td
-                className="c-more-projects-table__td c-more-projects-table__td-last-updated hidden-md-down"
+                className="m-more-projects-table__td m-more-projects-table__td-last-updated hidden-md-down"
               >
                 June 2, 2018
               </td>
               <td
-                className="c-more-projects-table__td c-more-projects-table__td-status hidden-md-down"
+                className="m-more-projects-table__td m-more-projects-table__td-status hidden-md-down"
               >
                 <span
-                  className="c-more-projects-table__status-wrapper"
+                  className="m-more-projects-table__status-wrapper"
                 />
               </td>
             </tr>
           </tbody>
         </table>
         <div
-          className="c-more-projects__show-more-button-wrapper"
+          className="m-more-projects__show-more-button-wrapper"
         >
           <button
-            className="btn btn-secondary c-more-projects__show-more-button"
+            className="btn btn-secondary m-more-projects__show-more-button"
             disabled={false}
             onClick={[Function]}
             type="button"

--- a/apps/site/assets/ts/projects/components/Banner.tsx
+++ b/apps/site/assets/ts/projects/components/Banner.tsx
@@ -29,12 +29,12 @@ const bannerBgClass = (banner: Project): string => {
 };
 
 const bannerContentClass = (banner: Project): string =>
-  `m-banner__content m-banner__content--responsive-side-by-side m-banner__content--left u-bg--${bannerBgClass(
+  `c-banner__content c-banner__content--responsive-side-by-side c-banner__content--left u-bg--${bannerBgClass(
     banner
   )}`;
 
 const bannerUpdated = (banner: Project): ReactElement<HTMLElement> => (
-  <span className="m-banner__date">Updated {formattedDate(banner.date)}</span>
+  <span className="c-banner__date">Updated {formattedDate(banner.date)}</span>
 );
 
 const BannerContent = ({
@@ -43,12 +43,12 @@ const BannerContent = ({
   banner: Project;
 }): ReactElement<HTMLElement> => (
   <div className={bannerContentClass(banner)}>
-    <div className="m-banner__top">
-      <h2 className="h2 m-banner__title m-banner__title--default">
+    <div className="c-banner__top">
+      <h2 className="h2 c-banner__title c-banner__title--default">
         {banner.title}
       </h2>
     </div>
-    <div className="m-banner__bottom">{bannerUpdated(banner)}</div>
+    <div className="c-banner__bottom">{bannerUpdated(banner)}</div>
   </div>
 );
 
@@ -68,7 +68,7 @@ const BannerXS = ({
   <div className="hidden-sm-up">
     <div className="row">
       <div
-        className="m-banner__image m-banner__image--responsive m-banner__image--default"
+        className="c-banner__image c-banner__image--responsive c-banner__image--default"
         style={{
           backgroundImage: `url(${bannerImageURL(banner, placeholderImageUrl)})`
         }}
@@ -87,10 +87,10 @@ const BannerSideBySide = ({
   banner: Project;
   placeholderImageUrl: string;
 }): ReactElement<HTMLElement> => (
-  <div className="m-banner__image m-banner__image--responsive-side-by-side m-banner--responsive-no-margin m-banner__image--default">
+  <div className="c-banner__image c-banner__image--responsive-side-by-side c-banner--responsive-no-margin c-banner__image--default">
     <BannerContent banner={banner} />
     <img
-      className="m-banner__image--by-side"
+      className="c-banner__image--by-side"
       src={bannerImageURL(banner, placeholderImageUrl)}
       alt={bannerImageAlt(banner)}
     />
@@ -143,7 +143,7 @@ const Banner = ({
       <h2 className="c-projects-header__subheader">Featured Projects</h2>
       <a
         href={banner.path}
-        className="m-banner m-banner--responsive m-banner--lg-9 m-banner--no-margin-top m-banner--default"
+        className="c-banner c-banner--responsive c-banner--lg-9 c-banner--no-margin-top c-banner--default"
       >
         <BannerXS banner={banner} placeholderImageUrl={placeholderImageUrl} />
         <BannerSMUp banner={banner} placeholderImageUrl={placeholderImageUrl} />

--- a/apps/site/assets/ts/projects/components/FeaturedProject.tsx
+++ b/apps/site/assets/ts/projects/components/FeaturedProject.tsx
@@ -15,17 +15,17 @@ const FeaturedProject = ({
   const { path, image, title, text, date, routes } = project;
 
   return (
-    <div className="c-featured-project">
+    <div className="m-featured-project">
       <a href={path}>
-        <div className="c-featured-project__image">
+        <div className="m-featured-project__image">
           {(image && <img src={image.url} alt={image.alt} />) || (
             <img src={placeholderImageUrl} alt="MBTA logo" />
           )}
         </div>
 
-        <h3 className="c-featured-project__title">{title}</h3>
+        <h3 className="m-featured-project__title">{title}</h3>
 
-        <div className="c-featured-project__date">
+        <div className="m-featured-project__date">
           Updated on {formattedDate(date)}
         </div>
 

--- a/apps/site/assets/ts/projects/components/FeaturedProjectsList.tsx
+++ b/apps/site/assets/ts/projects/components/FeaturedProjectsList.tsx
@@ -34,7 +34,7 @@ const FeaturedProjectsList = ({
   const groupedProjects = groupPairwise(projects);
 
   return (
-    <div className="c-featured-project-list">
+    <div className="m-featured-project-list">
       <div className="page-section">
         {groupedProjects.map(projectPair => {
           const secondProjectId = projectPair[1] ? projectPair[1].id : "none";

--- a/apps/site/assets/ts/projects/components/FeaturedProjectsRow.tsx
+++ b/apps/site/assets/ts/projects/components/FeaturedProjectsRow.tsx
@@ -22,12 +22,12 @@ const FeaturedProjectsRow = ({
   projectPair,
   placeholderImageUrl
 }: Props): ReactElement<HTMLElement> => (
-  <div className="c-featured-project-list__row">
+  <div className="m-featured-project-list__row">
     {projectToComponent(projectPair[0], placeholderImageUrl)}
     {projectPair[1] ? (
       projectToComponent(projectPair[1], placeholderImageUrl)
     ) : (
-      <div className="c-featured-project" />
+      <div className="m-featured-project" />
     )}
   </div>
 );

--- a/apps/site/assets/ts/projects/components/MoreProjectsRow.tsx
+++ b/apps/site/assets/ts/projects/components/MoreProjectsRow.tsx
@@ -85,37 +85,37 @@ const MoreProjectsRow = ({
 }: Props): ReactElement<HTMLElement> => {
   const normalizedStatus = status ? status.toLowerCase().replace(/ /, "-") : "";
   const statusTextClassName = status
-    ? `c-more-projects-table__status-text--${normalizedStatus}`
+    ? `m-more-projects-table__status-text--${normalizedStatus}`
     : "";
   const statusIconClassName = status
-    ? `c-more-projects-table__status-icon--${normalizedStatus}`
+    ? `m-more-projects-table__status-icon--${normalizedStatus}`
     : "";
 
   return (
-    <tr className="c-more-projects-table__tr">
-      <td className="c-more-projects-table__td c-more-projects-table__td-project">
+    <tr className="m-more-projects-table__tr">
+      <td className="m-more-projects-table__td m-more-projects-table__td-project">
         {(image && (
           <img
             src={image.url}
             alt={image.alt}
-            className="hidden-xs-down c-more-projects-table__thumbnail"
+            className="hidden-xs-down m-more-projects-table__thumbnail"
           />
         )) || (
           <img
             src={placeholderImageUrl}
             alt="MBTA logo"
-            className="hidden-xs-down c-more-projects-table__thumbnail"
+            className="hidden-xs-down m-more-projects-table__thumbnail"
           />
         )}
 
-        <div className="c-more-projects-table__wrapper">
+        <div className="m-more-projects-table__wrapper">
           <a href={path}>
-            <h3 className="c-more-projects-table__title">{title}</h3>
+            <h3 className="m-more-projects-table__title">{title}</h3>
           </a>
 
-          <div className="c-more-projects-table__updated-and-status hidden-lg-up">
-            <div className="c-more-projects-table__last-updated">
-              <span className="c-more-projects-table__internal-header">
+          <div className="m-more-projects-table__updated-and-status hidden-lg-up">
+            <div className="m-more-projects-table__last-updated">
+              <span className="m-more-projects-table__internal-header">
                 Last updated
               </span>
               <br />
@@ -125,22 +125,22 @@ const MoreProjectsRow = ({
                 <RouteIcon
                   key={tag}
                   tag={tag}
-                  extraClasses="c-more-projects-table__route-icon hidden-lg-up"
+                  extraClasses="m-more-projects-table__route-icon hidden-lg-up"
                 />
               ))}
             </div>
 
             {status && (
-              <div className="c-more-projects-table__status">
-                <span className="c-more-projects-table__internal-header">
+              <div className="m-more-projects-table__status">
+                <span className="m-more-projects-table__internal-header">
                   Status
                 </span>
                 <br />
                 <i
-                  className={`fa c-more-projects-table__status-icon ${statusIconClassName}`}
+                  className={`fa m-more-projects-table__status-icon ${statusIconClassName}`}
                 />{" "}
                 <span
-                  className={`c-more-projects-table__status-text ${statusTextClassName}`}
+                  className={`m-more-projects-table__status-text ${statusTextClassName}`}
                 >
                   {status}
                 </span>
@@ -152,25 +152,25 @@ const MoreProjectsRow = ({
             <RouteIcon
               key={tag}
               tag={tag}
-              extraClasses="c-more-projects-table__route-icon hidden-md-down"
+              extraClasses="m-more-projects-table__route-icon hidden-md-down"
             />
           ))}
         </div>
       </td>
 
-      <td className="c-more-projects-table__td c-more-projects-table__td-last-updated hidden-md-down">
+      <td className="m-more-projects-table__td m-more-projects-table__td-last-updated hidden-md-down">
         {formattedDate(date)}
       </td>
 
-      <td className="c-more-projects-table__td c-more-projects-table__td-status hidden-md-down">
-        <span className="c-more-projects-table__status-wrapper">
+      <td className="m-more-projects-table__td m-more-projects-table__td-status hidden-md-down">
+        <span className="m-more-projects-table__status-wrapper">
           {status && (
             <>
               <i
-                className={`fa c-more-projects-table__status-icon ${statusIconClassName}`}
+                className={`fa m-more-projects-table__status-icon ${statusIconClassName}`}
               />{" "}
               <span
-                className={`c-more-projects-table__status-text ${statusTextClassName}`}
+                className={`m-more-projects-table__status-text ${statusTextClassName}`}
               >
                 {status}
               </span>

--- a/apps/site/assets/ts/projects/components/MoreProjectsTable.tsx
+++ b/apps/site/assets/ts/projects/components/MoreProjectsTable.tsx
@@ -41,30 +41,30 @@ const MoreProjectsTable = ({
     <>
       <h2>{tableHeaderText(state)} Projects</h2>
       <div>
-        <table className="c-more-projects-table" aria-label="More Projects">
-          <thead className="c-more-projects-table__thead hidden-md-down">
+        <table className="m-more-projects-table" aria-label="More Projects">
+          <thead className="m-more-projects-table__thead hidden-md-down">
             <tr>
               <th
                 scope="col"
-                className="c-more-projects-table__th c-more-projects-table__th-project"
+                className="m-more-projects-table__th m-more-projects-table__th-project"
               >
                 Project
               </th>
               <th
                 scope="col"
-                className="c-more-projects-table__th c-more-projects-table__th-last-updated"
+                className="m-more-projects-table__th m-more-projects-table__th-last-updated"
               >
                 Last Updated
               </th>
               <th
                 scope="col"
-                className="c-more-projects-table__th c-more-projects-table__th-status"
+                className="m-more-projects-table__th m-more-projects-table__th-status"
               >
                 Status
               </th>
             </tr>
           </thead>
-          <tbody className="c-more-projects-table__tbody">
+          <tbody className="m-more-projects-table__tbody">
             {state.projects.map(project => (
               <MoreProjectsRow
                 key={project.id}
@@ -75,9 +75,9 @@ const MoreProjectsTable = ({
           </tbody>
         </table>
 
-        <div className="c-more-projects__show-more-button-wrapper">
+        <div className="m-more-projects__show-more-button-wrapper">
           <button
-            className="btn btn-secondary c-more-projects__show-more-button"
+            className="btn btn-secondary m-more-projects__show-more-button"
             type="button"
             disabled={state.fetchInProgress}
             onClick={() => fetchMoreProjects(state, setState)}

--- a/apps/site/assets/ts/projects/components/ProjectUpdateList.tsx
+++ b/apps/site/assets/ts/projects/components/ProjectUpdateList.tsx
@@ -14,30 +14,30 @@ const ProjectUpdateList = ({
 }: Props): ReactElement<HTMLElement> | null =>
   projectUpdates.length > 0 ? (
     <>
-      <h2 className="c-projects-header__subheader">Project Updates</h2>
-      <div className="c-project-update-list__row">
+      <h2 className="m-projects-header__subheader">Project Updates</h2>
+      <div className="m-project-update-list__row">
         {projectUpdates.map(
           ({ image, path, title, routes, date, id }: Project) => (
-            <a href={path} className="c-project-update-list__item" key={id}>
+            <a href={path} className="m-project-update-list__item" key={id}>
               <div>
                 {image ? (
                   <img
-                    className="c-project-update__photo"
+                    className="m-project-update__photo"
                     src={image.url}
                     alt={image.alt}
                   />
                 ) : (
                   <img
-                    className="c-project-update__photo"
+                    className="m-project-update__photo"
                     src={placeholderImageUrl}
                     alt="MBTA logo"
                   />
                 )}
               </div>
-              <div className="c-project-update__date u-small-caps">
+              <div className="m-project-update__date u-small-caps">
                 {formattedDate(date)}
               </div>
-              <h3 className="c-project-update__title">{title}</h3>
+              <h3 className="m-project-update__title">{title}</h3>
               <RoutePillList routes={routes} />
             </a>
           )

--- a/apps/site/lib/site_web/templates/page/_banner.html.eex
+++ b/apps/site/lib/site_web/templates/page/_banner.html.eex
@@ -1,5 +1,5 @@
-<div class="m-banner m-banner--responsive m-banner--<%= @banner.banner_type %> u-linked-card">
-  <div class="m-banner__image m-banner__image--responsive m-banner__image--<%= @banner.banner_type %>" style="background-image: url(<%= @banner.thumb.url %>)">
+<div class="c-banner c-banner--responsive c-banner--<%= @banner.banner_type %> u-linked-card">
+  <div class="c-banner__image c-banner__image--responsive c-banner__image--<%= @banner.banner_type %>" style="background-image: url(<%= @banner.thumb.url %>)">
     <div class="sr-only">
       <%= @banner.thumb.alt %>
     </div>

--- a/apps/site/lib/site_web/templates/page/_banner_content.html.eex
+++ b/apps/site/lib/site_web/templates/page/_banner_content.html.eex
@@ -1,9 +1,9 @@
 <div class="<%= banner_content_class(@banner) %>">
-  <div class="m-banner__top">
-    <div class="m-banner__category u-small-caps">
+  <div class="c-banner__top">
+    <div class="c-banner__category u-small-caps">
       <%= link_category(@banner.category)%>
     </div>
-    <h2 class="h2 m-banner__title m-banner__title--<%= @banner.banner_type %>">
+    <h2 class="h2 c-banner__title c-banner__title--<%= @banner.banner_type %>">
       <%= link @banner.title, to: cms_static_page_path(@conn, @banner.utm_url), class: "u-linked-card__primary-link" %>
     </h2>
     <%= if @banner.banner_type == :important do %>
@@ -11,7 +11,7 @@
     <% end %>
   </div>
 
-  <div class="m-banner__bottom">
+  <div class="c-banner__bottom">
     <%= banner_cta(@banner) %>
   </div>
 </div>

--- a/apps/site/lib/site_web/views/page_view.ex
+++ b/apps/site/lib/site_web/views/page_view.ex
@@ -131,10 +131,10 @@ defmodule SiteWeb.PageView do
   defp banner_content_class(%Banner{} = banner) do
     Enum.join(
       [
-        "m-banner__content",
-        "m-banner__content--responsive",
-        "m-banner__content--" <> CSSHelpers.atom_to_class(banner.banner_type),
-        "m-banner__content--" <> CSSHelpers.atom_to_class(banner.text_position)
+        "c-banner__content",
+        "c-banner__content--responsive",
+        "c-banner__content--" <> CSSHelpers.atom_to_class(banner.banner_type),
+        "c-banner__content--" <> CSSHelpers.atom_to_class(banner.text_position)
         | banner_bg_class(banner)
       ],
       " "
@@ -148,7 +148,7 @@ defmodule SiteWeb.PageView do
 
   @spec banner_cta(Banner.t()) :: Phoenix.HTML.Safe.t()
   defp banner_cta(%Banner{banner_type: :important, link: %{title: title}}) do
-    content_tag(:span, title, class: "m-banner__cta")
+    content_tag(:span, title, class: "c-banner__cta")
   end
 
   defp banner_cta(%Banner{}) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Clean up project page CSS classes](https://app.asana.com/0/555089885850811/1137132453918241)

- Elements used exclusively on the projects index page should use an `.m-` prefix (module)
- Elements common to two or more places are considered components and should us a `.c-` prefix
- Removed deprecated selector/class

Followed the rules set previously in our CSS Guidelines wiki (linked in Asana ticket).