### PR TITLE
Enable CMS-driven sort_by option

### DIFF
--- a/apps/cms/lib/partial/paragraph/content_list.ex
+++ b/apps/cms/lib/partial/paragraph/content_list.ex
@@ -20,7 +20,7 @@ defmodule CMS.Partial.Paragraph.ContentList do
             teasers: [],
             cta: %{}
 
-  @type order :: :DESC | :ASC
+  @type order :: :DESC | :ASC | nil
 
   @type text_or_nil :: String.t() | nil
 
@@ -59,6 +59,7 @@ defmodule CMS.Partial.Paragraph.ContentList do
       date_op: field_value(data, "field_date_logic"),
       date_min: field_value(data, "field_date"),
       date_max: field_value(data, "field_date_max"),
+      sort_by: data |> field_value("field_sorting"),
       sort_order: data |> field_value("field_sorting_logic") |> order()
     }
 

--- a/apps/cms/lib/repo.ex
+++ b/apps/cms/lib/repo.ex
@@ -227,6 +227,10 @@ defmodule CMS.Repo do
   using the :sort_order and :sort_by filters. Other content types
   like Basic Page (:page) default to creation date, descending.
 
+  If neither :sort_order nor :sort_by are provided, Elixir will
+  attempt to fill-in these values according to content :type.
+  Otherwise, the values provided will be used and passed on.
+
   :sort_by is set automatically when :type requires it.
   :sort_order is DESC by default; only used with :sort_by.
   """
@@ -278,6 +282,10 @@ defmodule CMS.Repo do
   end
 
   @spec teaser_sort(teaser_filters) :: teaser_filters
+  defp teaser_sort(%{sort_by: _, sort_order: _} = params) do
+    params
+  end
+
   defp teaser_sort(%{type: [type]} = params)
        when type in [:news_entry, :event, :project_update, :project] do
     order = Map.get(params, :sort_order, :DESC)

--- a/apps/cms/test/paragraph_test.exs
+++ b/apps/cms/test/paragraph_test.exs
@@ -299,6 +299,7 @@ defmodule CMS.ParagraphTest do
              date_op: "<",
              date_min: nil,
              date_max: nil,
+             sort_by: "field_updated_on_value",
              sort_order: :DESC
            } == ingredients
 
@@ -307,6 +308,7 @@ defmodule CMS.ParagraphTest do
              date_op: "<",
              items_per_page: 2,
              related_to: 3004,
+             sort_by: "field_updated_on_value",
              sort_order: :DESC,
              sticky: "0",
              type: [:project_update]

--- a/apps/cms/test/repo_test.exs
+++ b/apps/cms/test/repo_test.exs
@@ -398,6 +398,21 @@ defmodule CMS.RepoTest do
       end
     end
 
+    test "accepts and passes through given :sort_order and :sort_by options" do
+      mock_view = fn
+        "/cms/teasers", %{type: [:page], sort_by: "changed", sort_order: :ASC} ->
+          {:ok, []}
+      end
+
+      with_mock Static, view: mock_view do
+        Repo.teasers(type: [:page], sort_by: "changed", sort_order: :ASC)
+
+        "/cms/teasers"
+        |> Static.view(%{type: [:page], sort_by: "changed", sort_order: :ASC})
+        |> assert_called()
+      end
+    end
+
     test "sets correct :sort_by and :sort_order options for project_update and news_entry requests" do
       mock_view = fn
         "/cms/teasers",
@@ -462,7 +477,7 @@ defmodule CMS.RepoTest do
       end
     end
 
-    test "drops :sort_by and :sort_order options for invalid sortable types" do
+    test "drops :sort_by and :sort_order options when either option is missing" do
       mock_view = fn
         "/cms/teasers", %{type: [:page]} ->
           {:ok, []}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Diversions | Riders should see the most relevant diversion first](https://app.asana.com/0/555089885850811/1136755693816402)

Elixir integration for mbta/cms#304
- Map and use CMS "field_sort_by" value when requesting teasers
- Both `sort_by` and `sort_order` must be present, else both are stripped from request
- Allows authors to set their own sorting options where needed, rather than relying on hard-coded values in dotcom