### PR TITLE
Add endpoint to render route line diagram

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -35,6 +35,12 @@ defmodule SiteWeb.ScheduleController.LineController do
     |> render("show.html", [])
   end
 
+  def line_diagram_api(conn, _) do
+    conn
+    |> put_view(ScheduleView)
+    |> render("_stop_list.html", layout: false)
+  end
+
   def assign_schedule_page_data(conn) do
     service_date = Util.service_date()
 

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -150,6 +150,11 @@ defmodule SiteWeb.Router do
 
     get("/schedules/:route/alerts", ScheduleController.AlertsController, :show, as: :alerts)
     get("/schedules/:route/line", ScheduleController.LineController, :show, as: :line)
+
+    get("/schedules/:route/line/diagram", ScheduleController.LineController, :line_diagram_api,
+      as: :line
+    )
+
     get("/schedules/:route", ScheduleController, :show, as: :schedule)
     get("/schedules/:route/pdf", ScheduleController.Pdf, :pdf, as: :route_pdf)
     get("/style-guide", StyleGuideController, :index)

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -435,4 +435,14 @@ defmodule SiteWeb.ScheduleController.LineTest do
       assert length(conn.assigns.schedule_page_data.services) < services
     end
   end
+
+  describe "line diagram endpoint" do
+    test "renders", %{conn: conn} do
+      conn =
+        conn
+        |> get(line_path(conn, :line_diagram_api, "39"))
+
+      assert html_response(conn, 200) =~ "Forest Hills"
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱Schedules | Directionality - Existing Line Diagram API](https://app.asana.com/0/555089885850811/1127979261717809)

Added an endpoint that renders the existing line-diagram partial with the appropriate data as HTML, to be used in the new directionality feature until we swap in a shiny new line-diagram design.

<br>
Assigned to: @meagonqz 
