### PR TITLE
Fix headsign between stops and tnm

### DIFF
--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -12,7 +12,7 @@ interface DirectionInfo {
 
 export interface Headsign {
   name: string;
-  headsign: string;
+  headsign?: string;
   times: PredictedOrScheduledTime[];
   train_number: string | null;
 }

--- a/apps/site/assets/ts/components/Headsign.tsx
+++ b/apps/site/assets/ts/components/Headsign.tsx
@@ -28,8 +28,9 @@ const renderHeadsignName = ({
 
   const headsignNameClass = `m-tnm-sidebar__headsign-name m-tnm-sidebar__headsign-name--${modifier}`;
 
-  if (headsign.headsign && headsign.headsign.includes(" via ")) {
-    const split = headsign.headsign.split(" via ");
+  const headsignName = headsign.headsign || headsign.name;
+  if (headsignName && headsignName.includes(" via ")) {
+    const split = headsignName.split(" via ");
     return (
       <>
         <div className={headsignNameClass}>{split[0]}</div>
@@ -37,7 +38,7 @@ const renderHeadsignName = ({
       </>
     );
   }
-  return <div className={headsignNameClass}>{headsign.headsign}</div>;
+  return <div className={headsignNameClass}>{headsignName}</div>;
 };
 
 const renderTrainName = (trainName: string): ReactElement<HTMLElement> => (

--- a/apps/site/assets/ts/stop/__tests__/stopData.json
+++ b/apps/site/assets/ts/stop/__tests__/stopData.json
@@ -109,8 +109,7 @@
                       }
                     }
                   ],
-                  "name": "Ashmont",
-                  "headsign": "Ashmont"
+                  "name": "Ashmont"
                 },
                 {
                   "train_number": "",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

The stop cards on stop pages use this Headsign component but their value for name is valid. 

We can't just overwrite the name value for TNM without significant changes to the data transforming javascript (no tests atm). The name value needs to be preserved because it's used as part of a key.

<br>
Assigned to: @NAME
