### PR TITLE
Prioritize a high-severity, low-priority alert over vice versa

### DIFF
--- a/apps/alerts/lib/sort.ex
+++ b/apps/alerts/lib/sort.ex
@@ -48,6 +48,7 @@ defmodule Alerts.Sort do
 
   defp sort_key(alert, now) do
     {
+      -high_severity(alert),
       priority(alert),
       effect_index(alert.effect),
       lifecycle_index(alert.lifecycle),
@@ -73,6 +74,12 @@ defmodule Alerts.Sort do
 
   # fallback
   defp effect_index(_), do: unquote(length(@effect_order))
+
+  defp high_severity(%{severity: severity}) when severity >= 7 do
+    severity
+  end
+
+  defp high_severity(_), do: 0
 
   defp updated_at_date(dt) do
     dt

--- a/apps/alerts/test/sort_test.exs
+++ b/apps/alerts/test/sort_test.exs
@@ -87,6 +87,26 @@ defmodule Alerts.SortTest do
       assert sorted_effects == [:snow_route, :access_issue, :access_issue]
     end
 
+    test "prioritizes a high-severity, low-priority alert over vice versa" do
+      {:ok, now, _} = DateTime.from_iso8601("2018-04-03T11:00:00Z")
+
+      alert_prototype = %Alert{
+        effect: :snow_route,
+        lifecycle: "Upcoming",
+        updated_at: new_datetime("2017-06-01T12:00:00-05:00")
+      }
+
+      high_severity_low_priority = %Alert{alert_prototype | priority: :low, severity: 7}
+      low_severity_high_priority = %Alert{alert_prototype | priority: :high, severity: 6}
+      alerts = [low_severity_high_priority, high_severity_low_priority]
+
+      sorted_alerts =
+        alerts
+        |> Alerts.Sort.sort(now)
+
+      assert sorted_alerts == [high_severity_low_priority, low_severity_high_priority]
+    end
+
     def new_datetime(str) do
       Timex.parse!(str, "{ISO:Extended}")
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 For high severity alerts, keep banner placement on all tabs of schedule page (even after it becomes "ongoing")](https://app.asana.com/0/555089885850811/board)

We now jump alerts with a severity of 7 ("up to 30 minutes" delay) or higher to the head of the list of alerts, regardless of its point in the alert lifecycle.

<br>
Assigned to: @meagonqz 
