### PR TITLE
Use stops for given date in CR timetables

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -113,7 +113,11 @@ defmodule SiteWeb.ScheduleController.TimetableController do
   defp all_stops(conn, _) do
     # we override the default fetch of all_stops to not use the date. We will
     # use the date to fetch the actual schedule data.
-    all_stops = Stops.Repo.by_route(conn.assigns.route.id, conn.assigns.direction_id)
+    all_stops =
+      Stops.Repo.by_route(conn.assigns.route.id, conn.assigns.direction_id,
+        date: conn.assigns.date
+      )
+
     assign(conn, :all_stops, all_stops)
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🦊 🕸️ Foxboro | Fairmount inbound timetable has Dedham Corp Center before Oct 21](https://app.asana.com/0/555089885850811/1142034065520071)

We were fetching the list of `all_stops` for CR timetables without filtering by date, leading to the problem described in the card. Fixed.

<br>
Assigned to: @meagonqz 
