### PR TITLE
Stop list diagram changes with new directionality interface

### DIFF
--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -19,6 +19,7 @@
 
 .m-schedule__map {
   height: $base-spacing * 25;
+  margin-bottom: $base-spacing;
 }
 
 .m-schedule-page__fare {

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -10,7 +10,9 @@ import {
   State,
   MenuAction as Action
 } from "../components/direction/reducer";
-import ScheduleDirection, { fetchMapData } from "../components/ScheduleDirection";
+import ScheduleDirection, {
+  fetchMapData
+} from "../components/ScheduleDirection";
 import { EnhancedRoute } from "../../__v3api";
 import { MapData } from "../../leaflet/components/__mapdata";
 import { RoutePatternsByDirection, ShapesById } from "../components/__schedule";

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -166,6 +166,7 @@ const getComponent = () => (
     routePatternsByDirection={routePatternsByDirection}
     shapesById={shapesById}
     mapData={mapData}
+    stopListHtml={"line diagram content goes here"}
   />
 );
 
@@ -176,6 +177,7 @@ const getSubwayComponent = () => (
     directionId={directionId}
     routePatternsByDirection={routePatternsByDirection}
     shapesById={shapesById}
+    stopListHtml={"line diagram content goes here"}
   />
 );
 

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -10,7 +10,7 @@ import {
   State,
   MenuAction as Action
 } from "../components/direction/reducer";
-import ScheduleDirection, { fetchData } from "../components/ScheduleDirection";
+import ScheduleDirection, { fetchMapData } from "../components/ScheduleDirection";
 import { EnhancedRoute } from "../../__v3api";
 import { MapData } from "../../leaflet/components/__mapdata";
 import { RoutePatternsByDirection, ShapesById } from "../components/__schedule";
@@ -299,7 +299,7 @@ it("reducer can change state correctly for showAllRoutePatterns", () => {
   expect(nextState.routePatternMenuAll).toEqual(true);
 });
 
-describe("fetchData", () => {
+describe("fetchMapData", () => {
   it("fetches data", () => {
     const spy = jest.fn();
     window.fetch = jest.fn().mockImplementation(
@@ -314,7 +314,7 @@ describe("fetchData", () => {
         )
     );
 
-    return fetchData("1", 0, "2", spy).then(() => {
+    return fetchMapData("1", 0, "2", spy).then(() => {
       expect(window.fetch).toHaveBeenCalledWith(
         "/schedules/map_api?id=1&direction_id=0&variant=2"
       );
@@ -342,7 +342,7 @@ describe("fetchData", () => {
         )
     );
 
-    return fetchData("1", 0, "2", spy).then(() => {
+    return fetchMapData("1", 0, "2", spy).then(() => {
       expect(window.fetch).toHaveBeenCalledWith(
         "/schedules/map_api?id=1&direction_id=0&variant=2"
       );

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -44,6 +44,13 @@ exports[`it renders a bus component 1`] = `
       </button>
     </ScheduleDirectionButton>
   </div>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "line diagram content goes here",
+      }
+    }
+  />
 </ScheduleDirection>
 `;
 
@@ -88,5 +95,12 @@ exports[`it renders a subway component 1`] = `
       </button>
     </ScheduleDirectionButton>
   </div>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "line diagram content goes here",
+      }
+    }
+  />
 </ScheduleDirection>
 `;

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -14,6 +14,7 @@ export interface Props {
   shapesById: ShapesById;
   routePatternsByDirection: RoutePatternsByDirection;
   mapData: MapData;
+  stopListHtml: string;
 }
 
 export const fetchData = (
@@ -43,7 +44,8 @@ const ScheduleDirection = ({
   directionId,
   shapesById,
   routePatternsByDirection,
-  mapData
+  mapData,
+  stopListHtml
 }: Props): ReactElement<HTMLElement> => {
   const defaultRoutePattern = routePatternsByDirection[directionId].slice(
     0,
@@ -97,6 +99,7 @@ const ScheduleDirection = ({
           shapeId={shapeId}
         />
       )}
+      <div dangerouslySetInnerHTML={{__html: stopListHtml}} />
     </>
   );
 };

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -43,7 +43,7 @@ export const fetchMapData = (
 export const fetchStopListHtml = (routeId: string, directionId: DirectionId, shapeId: string, setStopListHtml: Dispatch<SetStateAction<string>>): Promise<void> => {
 	const stopListUrl = `/schedules/${routeId}/line/diagram?direction_id=${directionId}&variant=${shapeId}`;
 	return(
-    window
+    window.fetch && window
       .fetch(stopListUrl)
       .then((response: Response) => {
         if (response.ok) return response.text();

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -1,4 +1,11 @@
-import React, { ReactElement, SetStateAction, useReducer, useEffect, useState, Dispatch } from "react";
+import React, {
+  ReactElement,
+  SetStateAction,
+  useReducer,
+  useEffect,
+  useState,
+  Dispatch
+} from "react";
 import { DirectionId, EnhancedRoute } from "../../__v3api";
 import { ShapesById, RoutePatternsByDirection } from "./__schedule";
 import ScheduleDirectionMenu from "./direction/ScheduleDirectionMenu";
@@ -40,20 +47,26 @@ export const fetchMapData = (
   );
 };
 
-export const fetchStopListHtml = (routeId: string, directionId: DirectionId, shapeId: string, setStopListHtml: Dispatch<SetStateAction<string>>): Promise<void> => {
-	const stopListUrl = `/schedules/${routeId}/line/diagram?direction_id=${directionId}&variant=${shapeId}`;
-	return(
-    window.fetch && window
+export const fetchStopListHtml = (
+  routeId: string,
+  directionId: DirectionId,
+  shapeId: string,
+  setStopListHtml: Dispatch<SetStateAction<string>>
+): Promise<void> => {
+  const stopListUrl = `/schedules/${routeId}/line/diagram?direction_id=${directionId}&variant=${shapeId}`;
+  return (
+    window.fetch &&
+    window
       .fetch(stopListUrl)
       .then((response: Response) => {
         if (response.ok) return response.text();
         throw new Error(response.statusText);
       })
       .then((newStopListHtml: string) => {
-        setStopListHtml(newStopListHtml)
+        setStopListHtml(newStopListHtml);
       })
   );
-}
+};
 
 const ScheduleDirection = ({
   route,
@@ -99,6 +112,7 @@ const ScheduleDirection = ({
     [route, state.directionId, shapeId]
   );
 
+  /* eslint-disable react/no-danger */
   return (
     <>
       <div className="m-schedule-direction">
@@ -124,9 +138,10 @@ const ScheduleDirection = ({
           shapeId={shapeId}
         />
       )}
-      <div dangerouslySetInnerHTML={{__html: stopListHtml}} />
+      <div dangerouslySetInnerHTML={{ __html: stopListHtml }} />
     </>
   );
+  /* eslint-enable react/no-danger */
 };
 
 export default ScheduleDirection;

--- a/apps/site/assets/ts/schedule/schedule-loader.tsx
+++ b/apps/site/assets/ts/schedule/schedule-loader.tsx
@@ -66,8 +66,10 @@ const renderDirectionAndMap = (
   } = schedulePageData;
 
   const mapDataEl = document.getElementById("js-map-data");
-  if (!mapDataEl) return;
+  const stopListHtmlEl = document.getElementById("js-initial-stop-list-html");
+  if (!mapDataEl || !stopListHtmlEl) return;
   const mapData: MapData = JSON.parse(mapDataEl.innerHTML);
+  const stopListHtml = JSON.parse(stopListHtmlEl.innerHTML);
   ReactDOM.render(
     <ScheduleDirection
       directionId={directionId}
@@ -75,6 +77,7 @@ const renderDirectionAndMap = (
       routePatternsByDirection={routePatternsByDirection}
       shapesById={shapesById}
       mapData={mapData}
+      stopListHtml={stopListHtml}
     />,
     root
   );

--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -25,9 +25,7 @@ config :logster, :allowed_headers, ["referer"]
 config :site, SiteWeb.ViewHelpers, google_tag_manager_id: System.get_env("GOOGLE_TAG_MANAGER_ID")
 
 config :laboratory,
-  features: [
-    {:schedule_direction_redesign, "Schedule direction_redesign", ""}
-  ],
+  features: [],
   cookie: [
     # one month,
     max_age: 3600 * 24 * 30,

--- a/apps/site/lib/site_web/controllers/schedule/green.ex
+++ b/apps/site/lib/site_web/controllers/schedule/green.ex
@@ -70,6 +70,7 @@ defmodule SiteWeb.ScheduleController.Green do
     |> await_assign_all_default(__MODULE__)
     |> put_view(ScheduleView)
     |> LineController.assign_schedule_page_data()
+    |> LineController.assign_stop_list_html()
     |> render("show.html", [])
   end
 

--- a/apps/site/lib/site_web/controllers/schedule/green.ex
+++ b/apps/site/lib/site_web/controllers/schedule/green.ex
@@ -41,6 +41,18 @@ defmodule SiteWeb.ScheduleController.Green do
 
   def show(conn, _parmas), do: line(conn, [])
 
+  def line_diagram_api(conn, _) do
+    conn
+    |> call_plug(SiteWeb.ScheduleController.HoursOfOperation)
+    |> call_plug(SiteWeb.ScheduleController.Holidays)
+    |> call_plug(SiteWeb.ScheduleController.Line)
+    |> call_plug(SiteWeb.ScheduleController.CMS)
+    |> await_assign_all_default(__MODULE__)
+    |> put_view(ScheduleView)
+    |> LineController.assign_schedule_page_data()
+    |> render("_stop_list.html", layout: false)
+  end
+
   def trip_view(conn, _params) do
     conn
     |> assign(:tab, "trip-view")

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -32,6 +32,7 @@ defmodule SiteWeb.ScheduleController.LineController do
     |> put_view(ScheduleView)
     |> await_assign_all_default(__MODULE__)
     |> assign_schedule_page_data()
+    |> assign_stop_list_html()
     |> render("show.html", [])
   end
 
@@ -85,6 +86,15 @@ defmodule SiteWeb.ScheduleController.LineController do
         shape_map: conn.assigns.shape_map
       }
     )
+  end
+
+  def assign_stop_list_html(conn) do
+    stop_list_html =
+      "_stop_list.html"
+      |> ScheduleView.render(Map.merge(conn.assigns, %{conn: conn}))
+      |> HTML.safe_to_string()
+
+    assign(conn, :stop_list_html, stop_list_html)
   end
 
   @spec dedup_services([Service.t()]) :: [Service.t()]

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -152,6 +152,8 @@ defmodule SiteWeb.Router do
     get("/schedules/:route/alerts", ScheduleController.AlertsController, :show, as: :alerts)
     get("/schedules/:route/line", ScheduleController.LineController, :show, as: :line)
 
+    get("/schedules/Green/line/diagram", ScheduleController.Green, :line_diagram_api)
+
     get("/schedules/:route/line/diagram", ScheduleController.LineController, :line_diagram_api,
       as: :line
     )

--- a/apps/site/lib/site_web/templates/schedule/_line.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line.html.eex
@@ -2,8 +2,6 @@
   <%= raw Poison.encode!(@schedule_page_data) %>
 </script>
 
-<% redesign_direction? = Laboratory.enabled?(@conn, :schedule_direction_redesign) %>
-
 <div class="page-section m-schedule-line">
   <div class="row">
     <div class="col-md-12">
@@ -26,25 +24,8 @@
             route: Routes.Route.to_json_safe(@route), stops: @schedule_page_data[:stops], directionId: @direction_id}) %>
           <% end %>
         </div>
-
-        <%= if redesign_direction? do %>
-          <div id="react-schedule-direction-root">
-          </div>
-        <% else %>
-          <%= render "_line_filters.html",
-            conn: @conn,
-            direction_id: @direction_id,
-            route: @route,
-            origin: assigns[:origin],
-            destination: assigns[:destination],
-            show_date_select?: @show_date_select?,
-            force_six_column: true,
-            route_shapes: @route_shapes,
-            active_shape: @active_shape,
-            show_variant_selector: assigns[:show_variant_selector]
-          %>
-
-        <% end %>
+        <div id="react-schedule-direction-root">
+        </div>
         <div class="line-map-container">
           <%= if display_map_link?(@route.type) do %>
             <img src="<%= @map_img_src %>" class="img-fluid">

--- a/apps/site/lib/site_web/templates/schedule/_line.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line.html.eex
@@ -2,6 +2,10 @@
   <%= raw Poison.encode!(@schedule_page_data) %>
 </script>
 
+<script data-for="stop-list" id="js-initial-stop-list-html" type="text/plain">
+  <%= raw Poison.encode!(@stop_list_html) %>
+</script>
+
 <div class="page-section m-schedule-line">
   <div class="row">
     <div class="col-md-12">
@@ -42,8 +46,6 @@
             %>
           <% end %>
         </div>
-
-        <%= render "_stop_list.html", assigns %>
     </div>
     <% end %>
     <div class="col-xs-12 col-md-5 col-lg-4 col-lg-offset-1">

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -403,38 +403,6 @@ defmodule SiteWeb.ScheduleControllerTest do
       default_shape_id = List.first(Repo.get_shapes("9", direction_id: 1)).id
       assert conn.assigns.active_shape.id == default_shape_id
     end
-
-    test "sets schedule link to current direction for last stop and opposite for all other stops on non-bus lines",
-         %{conn: conn} do
-      response =
-        conn
-        |> get(line_path(conn, :show, "CR-Fitchburg", direction_id: 0))
-        |> html_response(200)
-
-      [last_stop | others] =
-        response
-        |> Floki.find(".schedule-link")
-        |> Enum.reverse()
-
-      assert last_stop |> Floki.attribute("href") |> List.first() =~ "direction_id=1"
-      refute others |> List.last() |> Floki.attribute("href") |> List.first() =~ "direction_id=1"
-
-      Enum.each(
-        others,
-        &assert(&1 |> Floki.attribute("href") |> List.first() =~ "direction_id=0")
-      )
-    end
-
-    test "does not show a checkmark next to any stops", %{conn: conn} do
-      response =
-        conn
-        |> get(line_path(conn, :show, "Red"))
-        |> html_response(200)
-
-      stops = Floki.find(response, ".route-branch-stop-list")
-      refute Enum.empty?(stops)
-      assert Floki.find(stops, ".fa-check") == []
-    end
   end
 
   describe "tab redirects" do

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -311,7 +311,8 @@ defmodule SiteWeb.ScheduleViewTest do
           conn: conn,
           route: route,
           expanded: nil,
-          schedule_page_data: @schedule_page_data
+          schedule_page_data: @schedule_page_data,
+          stop_list_html: ""
         )
 
       assert safe_to_string(actual) =~ "30 minutes"
@@ -337,7 +338,8 @@ defmodule SiteWeb.ScheduleViewTest do
           conn: conn,
           route: route,
           expanded: nil,
-          schedule_page_data: @schedule_page_data
+          schedule_page_data: @schedule_page_data,
+          stop_list_html: ""
         )
 
       refute safe_to_string(actual) =~ "minutes"
@@ -362,7 +364,8 @@ defmodule SiteWeb.ScheduleViewTest do
           conn: conn,
           route: route,
           expanded: nil,
-          schedule_page_data: @schedule_page_data
+          schedule_page_data: @schedule_page_data,
+          stop_list_html: ""
         )
 
       expected = trip_info |> TripInfo.full_status() |> IO.iodata_to_binary()
@@ -385,7 +388,8 @@ defmodule SiteWeb.ScheduleViewTest do
           route: route,
           conn: conn,
           expanded: nil,
-          schedule_page_data: @schedule_page_data
+          schedule_page_data: @schedule_page_data,
+          stop_list_html: ""
         )
 
       assert safe_to_string(actual) =~
@@ -408,7 +412,8 @@ defmodule SiteWeb.ScheduleViewTest do
           route: route,
           conn: conn,
           expanded: nil,
-          schedule_page_data: @schedule_page_data
+          schedule_page_data: @schedule_page_data,
+          stop_list_html: ""
         )
 
       assert safe_to_string(actual) =~ "Round trip fare:"
@@ -430,7 +435,8 @@ defmodule SiteWeb.ScheduleViewTest do
           route: route,
           conn: conn,
           expanded: nil,
-          schedule_page_data: @schedule_page_data
+          schedule_page_data: @schedule_page_data,
+          stop_list_html: ""
         )
 
       rendered = safe_to_string(actual)
@@ -453,7 +459,8 @@ defmodule SiteWeb.ScheduleViewTest do
           route: route,
           conn: conn,
           expanded: "Franklin Line",
-          schedule_page_data: @schedule_page_data
+          schedule_page_data: @schedule_page_data,
+          stop_list_html: ""
         )
 
       rendered = safe_to_string(actual)
@@ -549,62 +556,6 @@ defmodule SiteWeb.ScheduleViewTest do
   describe "_line.html" do
     @shape %Routes.Shape{id: "test", name: "test", stop_ids: [], direction_id: 0}
 
-    test "Bus line with variant filter", %{conn: conn} do
-      route_stop_1 = %RouteStop{
-        id: "stop 1",
-        name: "Stop 1",
-        zone: "1",
-        stop_features: [],
-        connections: []
-      }
-
-      route_stop_2 = %RouteStop{
-        id: "stop 2",
-        name: "Stop 2",
-        zone: "2",
-        stop_features: [],
-        connections: []
-      }
-
-      output =
-        ScheduleView.render(
-          "_line.html",
-          conn:
-            conn
-            |> Conn.fetch_query_params()
-            |> put_private(:phoenix_endpoint, SiteWeb.Endpoint),
-          stop_list_template: "_stop_list.html",
-          all_stops: [{[{nil, :terminus}], route_stop_1}, {[{nil, :terminus}], route_stop_2}],
-          route_shapes: [@shape, @shape],
-          active_shape: @shape,
-          alerts: [],
-          connections: [],
-          channel: "vehicles:1:1",
-          expanded: nil,
-          show_variant_selector: true,
-          map_img_src: nil,
-          holidays: [],
-          branches: [%Stops.RouteStops{branch: nil, stops: [route_stop_1, route_stop_2]}],
-          origin: nil,
-          destination: nil,
-          direction_id: 1,
-          route: %Routes.Route{type: 3, direction_destinations: %{1 => "End"}},
-          date: ~D[2017-01-01],
-          date_time: ~N[2017-03-01T07:29:00],
-          direction_id: 1,
-          reverse_direction_all_stops: [],
-          show_date_select?: false,
-          headsigns: %{0 => [], 1 => []},
-          vehicle_tooltips: %{},
-          featured_content: nil,
-          news: [],
-          dynamic_map_data: %{},
-          schedule_page_data: @schedule_page_data
-        )
-
-      assert safe_to_string(output) =~ "shape-filter"
-    end
-
     test "Bus line without variant filter", %{conn: conn} do
       route_stop_1 = %RouteStop{
         id: "stop 1",
@@ -654,7 +605,8 @@ defmodule SiteWeb.ScheduleViewTest do
           featured_content: nil,
           news: [],
           dynamic_map_data: %{},
-          schedule_page_data: @schedule_page_data
+          schedule_page_data: @schedule_page_data,
+          stop_list_html: ""
         )
 
       refute safe_to_string(output) =~ "shape-filter"
@@ -692,7 +644,8 @@ defmodule SiteWeb.ScheduleViewTest do
           featured_content: nil,
           news: [],
           dynamic_map_data: %{},
-          schedule_page_data: @schedule_page_data
+          schedule_page_data: @schedule_page_data,
+          stop_list_html: ""
         )
 
       assert safe_to_string(output) =~ "There are no scheduled"
@@ -743,7 +696,8 @@ defmodule SiteWeb.ScheduleViewTest do
           featured_content: nil,
           news: [],
           dynamic_map_data: %{},
-          schedule_page_data: @schedule_page_data
+          schedule_page_data: @schedule_page_data,
+          stop_list_html: ""
         )
 
       refute safe_to_string(output) =~


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [React wrapper for existing line diagram and remove flag](https://app.asana.com/0/555089885850811/1141392483330380)

Here we hook up the old static-HTML stop line diagram to the newfangled directionality interface, allowing us to get rid of the flag gating the new interface off and cut over to it permanently.

<br>
Assigned to: @meagonqz 
