### PR TITLE
Adjust fares for Foxboro pilot

### DIFF
--- a/apps/fares/lib/fares.ex
+++ b/apps/fares/lib/fares.ex
@@ -1,6 +1,7 @@
 defmodule Fares do
   alias Routes.Route
   alias Stops.Stop
+  alias Zones.Repo
 
   @silver_line_rapid_transit ~w(741 742 743 746)
   @silver_line_rapid_transit_set MapSet.new(@silver_line_rapid_transit)
@@ -37,12 +38,12 @@ defmodule Fares do
   end
 
   def fare_for_stops(:commuter_rail, origin, destination, _, trip_name) do
-    with origin_zone when not is_nil(origin_zone) <- Zones.Repo.get(origin),
-         dest_zone when not is_nil(dest_zone) <- Zones.Repo.get(destination) do
+    with origin_zone when not is_nil(origin_zone) <- Repo.get(origin),
+         dest_zone when not is_nil(dest_zone) <- Repo.get(destination) do
       if trip_name in @foxboro_interzone_set do
-        {:ok, calculate_foxboro_zones(Zones.Repo.get(origin), Zones.Repo.get(destination))}
+        {:ok, calculate_foxboro_zones(Repo.get(origin), Repo.get(destination))}
       else
-        {:ok, calculate_commuter_rail(Zones.Repo.get(origin), Zones.Repo.get(destination))}
+        {:ok, calculate_commuter_rail(Repo.get(origin), Repo.get(destination))}
       end
     else
       _ -> :error

--- a/apps/fares/lib/fares.ex
+++ b/apps/fares/lib/fares.ex
@@ -69,11 +69,11 @@ defmodule Fares do
     {:interzone, "#{total_zones}"}
   end
 
-  def calculate_foxboro_zones(start_zone, "1A") do
+  def calculate_foxboro_zones(start_zone, "1A") when start_zone != "1A" do
     calculate_commuter_rail(start_zone, "1")
   end
 
-  def calculate_foxboro_zones("1A", end_zone) do
+  def calculate_foxboro_zones("1A", end_zone) when end_zone != "1A" do
     calculate_commuter_rail("1", end_zone)
   end
 

--- a/apps/fares/mix.exs
+++ b/apps/fares/mix.exs
@@ -44,6 +44,7 @@ defmodule Fares.Mixfile do
       {:sweet_xml, "~> 0.6.2", only: [:dev, :test]},
       {:repo_cache, in_umbrella: true},
       {:stops, in_umbrella: true},
+      {:schedules, in_umbrella: true},
       {:google_maps, in_umbrella: true},
       {:rstar, github: "armon/erl-rstar"}
     ]

--- a/apps/site/lib/site/base_fare.ex
+++ b/apps/site/lib/site/base_fare.ex
@@ -15,22 +15,28 @@ defmodule Site.BaseFare do
   @default_filters [reduced: nil, duration: :single_trip]
   @default_foxboro_filters [reduced: nil, duration: :round_trip]
 
+  @default_trip %Trip{name: ""}
+
   @spec base_fare(
           Route.t() | map,
-          Stops.Stop.id_t(),
-          Stops.Stop.id_t(),
           Trip.t() | map,
+          Stops.Stop.id_t(),
+          Stops.Stop.id_t(),
           (Keyword.t() -> [Fare.t()])
         ) ::
           String.t() | nil
-  def base_fare(route, origin_id, destination_id, trip \\ %{}, fare_fn \\ &Repo.all/1)
+  def base_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
   def base_fare(nil, _, _, _, _), do: nil
 
-  def base_fare(route, origin_id, destination_id, trip, fare_fn) do
+  def base_fare(route, nil, origin_id, destination_id, fare_fn) do
+    base_fare(route, @default_trip, origin_id, destination_id, fare_fn)
+  end
+
+  def base_fare(route, trip, origin_id, destination_id, fare_fn) do
     route_filters =
       route.type
       |> Route.type_atom()
-      |> name_or_mode_filter(route, origin_id, destination_id, Map.get(trip, :name))
+      |> name_or_mode_filter(route, origin_id, destination_id, trip.name)
 
     default_filters =
       if {:name, :foxboro} in route_filters do

--- a/apps/site/lib/site/base_fare.ex
+++ b/apps/site/lib/site/base_fare.ex
@@ -36,7 +36,7 @@ defmodule Site.BaseFare do
     route_filters =
       route.type
       |> Route.type_atom()
-      |> name_or_mode_filter(route, origin_id, destination_id, trip.name)
+      |> name_or_mode_filter(route, origin_id, destination_id, trip)
 
     default_filters =
       if {:name, :foxboro} in route_filters do
@@ -72,9 +72,9 @@ defmodule Site.BaseFare do
     [name: name]
   end
 
-  defp name_or_mode_filter(mode, %{id: route_id}, origin_id, destination_id, trip_name)
+  defp name_or_mode_filter(mode, %{id: route_id}, origin_id, destination_id, trip)
        when mode in [:commuter_rail, :ferry] do
-    case Fares.fare_for_stops(mode, origin_id, destination_id, route_id, trip_name) do
+    case Fares.fare_for_stops(mode, origin_id, destination_id, route_id, trip) do
       {:ok, name} ->
         [name: name]
 

--- a/apps/site/lib/site_web/controllers/fare/commuter.ex
+++ b/apps/site/lib/site_web/controllers/fare/commuter.ex
@@ -41,6 +41,6 @@ defmodule SiteWeb.FareController.Commuter do
 
   defp get_fares(fare_name), do: Fares.Repo.all(name: fare_name)
 
-  defp foxboro?(a, b) when a == @foxboro or b == @foxboro, do: true
+  defp foxboro?(a, b) when @foxboro in [a, b], do: true
   defp foxboro?(_, _), do: false
 end

--- a/apps/site/lib/site_web/controllers/fare/commuter.ex
+++ b/apps/site/lib/site_web/controllers/fare/commuter.ex
@@ -39,8 +39,10 @@ defmodule SiteWeb.FareController.Commuter do
     end
   end
 
+  @spec get_fares(Fares.Fare.fare_name()) :: [Fares.Fare.t()]
   defp get_fares(fare_name), do: Fares.Repo.all(name: fare_name)
 
+  @spec foxboro?(String.t(), String.t()) :: boolean()
   defp foxboro?(a, b) when @foxboro in [a, b], do: true
   defp foxboro?(_, _), do: false
 end

--- a/apps/site/lib/site_web/controllers/fare/commuter.ex
+++ b/apps/site/lib/site_web/controllers/fare/commuter.ex
@@ -8,11 +8,20 @@ defmodule SiteWeb.FareController.Commuter do
   def mode, do: :commuter_rail
 
   @impl true
+
+  @foxboro "place-FS-0049"
+
   def fares(%{assigns: %{origin: origin, destination: destination}})
       when not is_nil(origin) and not is_nil(destination) do
     case Fares.fare_for_stops(:commuter_rail, origin.id, destination.id) do
       {:ok, fare_name} ->
-        Fares.Repo.all(name: fare_name)
+        standard_fares = get_fares(fare_name)
+
+        if foxboro?(origin.id, destination.id) do
+          standard_fares ++ get_fares(:foxboro)
+        else
+          standard_fares
+        end
 
       :error ->
         []
@@ -29,4 +38,9 @@ defmodule SiteWeb.FareController.Commuter do
       Stops.Repo.get!(stop_id)
     end
   end
+
+  defp get_fares(fare_name), do: Fares.Repo.all(name: fare_name)
+
+  defp foxboro?(a, b) when a == @foxboro or b == @foxboro, do: true
+  defp foxboro?(_, _), do: false
 end

--- a/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
@@ -6,7 +6,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
 
   alias Fares.Format
   alias Routes.Route
-  alias Schedules.{Repo, Trip}
+  alias Schedules.Repo
   alias Site.{BaseFare}
   import SiteWeb.ViewHelpers, only: [cms_static_page_path: 2]
 
@@ -97,7 +97,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
     |> Enum.map(
       &Map.merge(
         &1,
-        fares_for_service(origin.route, origin.stop.id, &1.stop.id, origin.trip)
+        fares_for_service(origin.route, origin.trip, origin.stop.id, &1.stop.id)
       )
     )
   end
@@ -148,10 +148,10 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
     %{schedules: time_formatted_schedules, duration: duration}
   end
 
-  @spec fares_for_service(map, String.t(), String.t(), Trip.t()) :: map
-  def fares_for_service(route, origin, destination, trip) do
+  @spec fares_for_service(map, map, String.t(), String.t()) :: map
+  def fares_for_service(route, trip, origin, destination) do
     %{
-      price: route |> BaseFare.base_fare(origin, destination, trip) |> Format.price(),
+      price: route |> BaseFare.base_fare(trip, origin, destination) |> Format.price(),
       fare_link:
         fare_link(
           Route.type_atom(route.type),

--- a/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
@@ -6,7 +6,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
 
   alias Fares.Format
   alias Routes.Route
-  alias Schedules.Repo
+  alias Schedules.{Repo, Trip}
   alias Site.{BaseFare}
   import SiteWeb.ViewHelpers, only: [cms_static_page_path: 2]
 
@@ -97,7 +97,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
     |> Enum.map(
       &Map.merge(
         &1,
-        fares_for_service(origin.route, origin.stop.id, &1.stop.id)
+        fares_for_service(origin.route, origin.stop.id, &1.stop.id, origin.trip)
       )
     )
   end
@@ -148,10 +148,10 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
     %{schedules: time_formatted_schedules, duration: duration}
   end
 
-  @spec fares_for_service(map, String.t(), String.t()) :: map
-  def fares_for_service(route, origin, destination) do
+  @spec fares_for_service(map, String.t(), String.t(), Trip.t()) :: map
+  def fares_for_service(route, origin, destination, trip) do
     %{
-      price: route |> BaseFare.base_fare(origin, destination) |> Format.price(),
+      price: route |> BaseFare.base_fare(origin, destination, trip) |> Format.price(),
       fare_link:
         fare_link(
           Route.type_atom(route.type),

--- a/apps/site/lib/trip_info.ex
+++ b/apps/site/lib/trip_info.ex
@@ -113,7 +113,7 @@ defmodule TripInfo do
     trip = PredictedSchedule.trip(time)
     duration = duration(times, origin_id)
     stop_count = Enum.count(times)
-    base_fare = BaseFare.base_fare(route, origin_id, destination_id, trip)
+    base_fare = BaseFare.base_fare(route, trip, origin_id, destination_id)
 
     %TripInfo{
       route: route,

--- a/apps/site/lib/trip_info.ex
+++ b/apps/site/lib/trip_info.ex
@@ -110,9 +110,10 @@ defmodule TripInfo do
        )
        when is_binary(origin_id) and is_binary(destination_id) do
     route = PredictedSchedule.route(time)
+    trip = PredictedSchedule.trip(time)
     duration = duration(times, origin_id)
     stop_count = Enum.count(times)
-    base_fare = BaseFare.base_fare(route, origin_id, destination_id)
+    base_fare = BaseFare.base_fare(route, origin_id, destination_id, trip)
 
     %TripInfo{
       route: route,

--- a/apps/site/test/site/lib/base_fare_test.exs
+++ b/apps/site/test/site/lib/base_fare_test.exs
@@ -276,7 +276,7 @@ defmodule BaseFareTest do
       route = %Route{type: 2, id: "CR-Franklin"}
       trip = %Trip{name: "743", id: "CR-Weekday-Spring-19-743"}
 
-      assert %Fares.Fare{name: {:interzone, "4"}} =
+      assert %Fares.Fare{name: {:zone, "3"}} =
                base_fare(route, trip, "place-sstat", "place-FB-0148")
     end
 

--- a/apps/site/test/site/lib/base_fare_test.exs
+++ b/apps/site/test/site/lib/base_fare_test.exs
@@ -47,7 +47,7 @@ defmodule BaseFareTest do
         @subway_fares
       end
 
-      assert %Fares.Fare{cents: 225} = base_fare(@route, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = base_fare(@route, nil, nil, %{}, fare_fn)
     end
   end
 
@@ -110,7 +110,7 @@ defmodule BaseFareTest do
         Enum.filter(@bus_fares, &(&1.name == :local_bus))
       end
 
-      assert %Fares.Fare{cents: 170} = base_fare(local_route, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 170} = base_fare(local_route, nil, nil, %{}, fare_fn)
     end
 
     test "returns the lowest one-way trip fare that is not discounted for the inner express bus" do
@@ -120,7 +120,7 @@ defmodule BaseFareTest do
         Enum.filter(@bus_fares, &(&1.name == :inner_express_bus))
       end
 
-      assert %Fares.Fare{cents: 400} = base_fare(inner_express_route, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 400} = base_fare(inner_express_route, nil, nil, %{}, fare_fn)
     end
 
     test "returns the lowerst one-way trip fare that is not discounted for the outer express bus" do
@@ -130,7 +130,7 @@ defmodule BaseFareTest do
         Enum.filter(@bus_fares, &(&1.name == :outer_express_bus))
       end
 
-      assert %Fares.Fare{cents: 525} = base_fare(outer_express_route, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 525} = base_fare(outer_express_route, nil, nil, %{}, fare_fn)
     end
 
     test "returns the subway fare for for SL1 route (id=741)" do
@@ -140,7 +140,7 @@ defmodule BaseFareTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = base_fare(sl1, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = base_fare(sl1, nil, nil, %{}, fare_fn)
     end
 
     test "returns the subway fare for for SL2 route (id=742)" do
@@ -150,7 +150,7 @@ defmodule BaseFareTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = base_fare(sl2, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = base_fare(sl2, nil, nil, %{}, fare_fn)
     end
 
     test "returns the subway fare for for SL3 route (id=743)" do
@@ -160,7 +160,7 @@ defmodule BaseFareTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = base_fare(sl3, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = base_fare(sl3, nil, nil, %{}, fare_fn)
     end
 
     test "returns the bus fare for for SL4 route (id=751)" do
@@ -170,7 +170,7 @@ defmodule BaseFareTest do
         Enum.filter(@bus_fares, &(&1.name == :local_bus))
       end
 
-      assert %Fares.Fare{cents: 170} = base_fare(sl4, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 170} = base_fare(sl4, nil, nil, %{}, fare_fn)
     end
   end
 
@@ -193,7 +193,7 @@ defmodule BaseFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 1050} = base_fare(route, origin_id, destination_id, fare_fn)
+      assert %Fares.Fare{cents: 1050} = base_fare(route, origin_id, destination_id, %{}, fare_fn)
     end
 
     test "returns the lowest one-way fare that is not discounted for a trip terminating in Zone 1A" do
@@ -214,7 +214,7 @@ defmodule BaseFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 825} = base_fare(route, origin_id, destination_id, fare_fn)
+      assert %Fares.Fare{cents: 825} = base_fare(route, origin_id, destination_id, %{}, fare_fn)
     end
 
     test "returns an interzone fare that is not discounted for a trip that does not originate/terminate in Zone 1A" do
@@ -235,11 +235,11 @@ defmodule BaseFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 401} = base_fare(route, origin_id, destination_id, fare_fn)
+      assert %Fares.Fare{cents: 401} = base_fare(route, origin_id, destination_id, %{}, fare_fn)
     end
 
     test "returns the appropriate fare for Foxboro" do
-      route = %Route{type: 2}
+      route = %Route{type: 2, id: "CR-Foxboro"}
       south_station_id = "place-sstat"
       foxboro_id = "place-FS-0049"
 
@@ -257,7 +257,7 @@ defmodule BaseFareTest do
 
       fare_fn = fn _ -> [] end
 
-      assert base_fare(route, origin_id, destination_id, fare_fn) == nil
+      assert base_fare(route, origin_id, destination_id, %{}, fare_fn) == nil
     end
 
     test "returns a free fare for any bus shuttle rail replacements" do
@@ -294,7 +294,7 @@ defmodule BaseFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 350} = base_fare(route, origin_id, destination_id, fare_fn)
+      assert %Fares.Fare{cents: 350} = base_fare(route, origin_id, destination_id, %{}, fare_fn)
     end
   end
 end

--- a/apps/site/test/site/lib/base_fare_test.exs
+++ b/apps/site/test/site/lib/base_fare_test.exs
@@ -239,7 +239,7 @@ defmodule BaseFareTest do
       assert %Fares.Fare{cents: 401} = base_fare(route, nil, origin_id, destination_id, fare_fn)
     end
 
-    test "returns the appropriate fare for Foxboro" do
+    test "returns the appropriate fare for Foxboro Special Events" do
       route = %Route{type: 2, id: "CR-Foxboro"}
       trip = %Trip{name: "9743"}
       south_station_id = "place-sstat"
@@ -250,6 +250,33 @@ defmodule BaseFareTest do
 
       assert %Fares.Fare{cents: 2000, duration: :round_trip} =
                base_fare(route, trip, foxboro_id, south_station_id)
+    end
+
+    test "returns zone-based fares for standard trips on Foxboro pilot" do
+      route = %Route{type: 2, id: "CR-Franklin"}
+      trip_1 = %Trip{name: "751"}
+      trip_2 = %Trip{name: "759"}
+
+      assert %Fares.Fare{name: {:zone, "4"}} =
+               base_fare(route, trip_1, "place-sstat", "place-FS-0049")
+
+      assert %Fares.Fare{name: {:interzone, "3"}} =
+               base_fare(route, trip_2, "place-FB-0118", "place-FS-0049")
+    end
+
+    test "returns interzone fare for reverse commute trips to and from Foxboro" do
+      route = %Route{type: 2, id: "CR-Franklin"}
+      inbound_trip = %Trip{name: "750"}
+      outbound_trip = %Trip{name: "741"}
+
+      south_station_id = "place-sstat"
+      foxboro_id = "place-FS-0049"
+
+      assert %Fares.Fare{name: {:interzone, "4"}} =
+               base_fare(route, inbound_trip, foxboro_id, south_station_id)
+
+      assert %Fares.Fare{name: {:interzone, "4"}} =
+               base_fare(route, outbound_trip, south_station_id, foxboro_id)
     end
 
     test "returns nil if no matching fares found" do

--- a/apps/site/test/site/lib/base_fare_test.exs
+++ b/apps/site/test/site/lib/base_fare_test.exs
@@ -264,6 +264,14 @@ defmodule BaseFareTest do
                base_fare(route, trip_2, "place-FB-0118", "place-FS-0049")
     end
 
+    test "Zone 1A to 1A reverse commute trips on Foxboro pilot retain original pricing" do
+      route = %Route{type: 2, id: "CR-Fairmount"}
+      trip = %Trip{name: "741"}
+
+      assert %Fares.Fare{name: {:zone, "1A"}} =
+               base_fare(route, trip, "origin=place-DB-2240", "place-DB-2222")
+    end
+
     test "returns interzone fare for reverse commute trips to and from Foxboro" do
       route = %Route{type: 2, id: "CR-Franklin"}
       inbound_trip = %Trip{name: "750"}

--- a/apps/site/test/site/lib/base_fare_test.exs
+++ b/apps/site/test/site/lib/base_fare_test.exs
@@ -254,8 +254,8 @@ defmodule BaseFareTest do
 
     test "returns zone-based fares for standard trips on Foxboro pilot" do
       route = %Route{type: 2, id: "CR-Franklin"}
-      trip_1 = %Trip{name: "751"}
-      trip_2 = %Trip{name: "759"}
+      trip_1 = %Trip{name: "751", id: "CR-Weekday-Fall-19-751"}
+      trip_2 = %Trip{name: "759", id: "CR-Weekday-Fall-19-759"}
 
       assert %Fares.Fare{name: {:zone, "4"}} =
                base_fare(route, trip_1, "place-sstat", "place-FS-0049")
@@ -266,16 +266,24 @@ defmodule BaseFareTest do
 
     test "Zone 1A to 1A reverse commute trips on Foxboro pilot retain original pricing" do
       route = %Route{type: 2, id: "CR-Fairmount"}
-      trip = %Trip{name: "741"}
+      trip = %Trip{name: "741", id: "CR-Weekday-Fall-19-741"}
 
       assert %Fares.Fare{name: {:zone, "1A"}} =
                base_fare(route, trip, "origin=place-DB-2240", "place-DB-2222")
     end
 
+    test "does not apply pilot/discounted fare for reverse commutes until Fall 2019" do
+      route = %Route{type: 2, id: "CR-Franklin"}
+      trip = %Trip{name: "743", id: "CR-Weekday-Spring-19-743"}
+
+      assert %Fares.Fare{name: {:interzone, "4"}} =
+               base_fare(route, trip, "place-sstat", "place-FB-0148")
+    end
+
     test "returns interzone fare for reverse commute trips to and from Foxboro" do
       route = %Route{type: 2, id: "CR-Franklin"}
-      inbound_trip = %Trip{name: "750"}
-      outbound_trip = %Trip{name: "741"}
+      inbound_trip = %Trip{name: "750", id: "CR-Weekday-Fall-19-750"}
+      outbound_trip = %Trip{name: "741", id: "CR-Weekday-Fall-19-741"}
 
       south_station_id = "place-sstat"
       foxboro_id = "place-FS-0049"

--- a/apps/site/test/site/lib/base_fare_test.exs
+++ b/apps/site/test/site/lib/base_fare_test.exs
@@ -47,7 +47,7 @@ defmodule BaseFareTest do
         @subway_fares
       end
 
-      assert %Fares.Fare{cents: 225} = base_fare(@route, nil, nil, %{}, fare_fn)
+      assert %Fares.Fare{cents: 225} = base_fare(@route, nil, nil, fare_fn)
     end
   end
 
@@ -110,7 +110,7 @@ defmodule BaseFareTest do
         Enum.filter(@bus_fares, &(&1.name == :local_bus))
       end
 
-      assert %Fares.Fare{cents: 170} = base_fare(local_route, nil, nil, %{}, fare_fn)
+      assert %Fares.Fare{cents: 170} = base_fare(local_route, nil, nil, fare_fn)
     end
 
     test "returns the lowest one-way trip fare that is not discounted for the inner express bus" do
@@ -120,7 +120,7 @@ defmodule BaseFareTest do
         Enum.filter(@bus_fares, &(&1.name == :inner_express_bus))
       end
 
-      assert %Fares.Fare{cents: 400} = base_fare(inner_express_route, nil, nil, %{}, fare_fn)
+      assert %Fares.Fare{cents: 400} = base_fare(inner_express_route, nil, nil, fare_fn)
     end
 
     test "returns the lowerst one-way trip fare that is not discounted for the outer express bus" do
@@ -130,7 +130,7 @@ defmodule BaseFareTest do
         Enum.filter(@bus_fares, &(&1.name == :outer_express_bus))
       end
 
-      assert %Fares.Fare{cents: 525} = base_fare(outer_express_route, nil, nil, %{}, fare_fn)
+      assert %Fares.Fare{cents: 525} = base_fare(outer_express_route, nil, nil, fare_fn)
     end
 
     test "returns the subway fare for for SL1 route (id=741)" do
@@ -140,7 +140,7 @@ defmodule BaseFareTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = base_fare(sl1, nil, nil, %{}, fare_fn)
+      assert %Fares.Fare{cents: 225} = base_fare(sl1, nil, nil, fare_fn)
     end
 
     test "returns the subway fare for for SL2 route (id=742)" do
@@ -150,7 +150,7 @@ defmodule BaseFareTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = base_fare(sl2, nil, nil, %{}, fare_fn)
+      assert %Fares.Fare{cents: 225} = base_fare(sl2, nil, nil, fare_fn)
     end
 
     test "returns the subway fare for for SL3 route (id=743)" do
@@ -160,7 +160,7 @@ defmodule BaseFareTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = base_fare(sl3, nil, nil, %{}, fare_fn)
+      assert %Fares.Fare{cents: 225} = base_fare(sl3, nil, nil, fare_fn)
     end
 
     test "returns the bus fare for for SL4 route (id=751)" do
@@ -170,7 +170,7 @@ defmodule BaseFareTest do
         Enum.filter(@bus_fares, &(&1.name == :local_bus))
       end
 
-      assert %Fares.Fare{cents: 170} = base_fare(sl4, nil, nil, %{}, fare_fn)
+      assert %Fares.Fare{cents: 170} = base_fare(sl4, nil, nil, fare_fn)
     end
   end
 
@@ -193,7 +193,7 @@ defmodule BaseFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 1050} = base_fare(route, origin_id, destination_id, %{}, fare_fn)
+      assert %Fares.Fare{cents: 1050} = base_fare(route, origin_id, destination_id, fare_fn)
     end
 
     test "returns the lowest one-way fare that is not discounted for a trip terminating in Zone 1A" do
@@ -214,7 +214,7 @@ defmodule BaseFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 825} = base_fare(route, origin_id, destination_id, %{}, fare_fn)
+      assert %Fares.Fare{cents: 825} = base_fare(route, origin_id, destination_id, fare_fn)
     end
 
     test "returns an interzone fare that is not discounted for a trip that does not originate/terminate in Zone 1A" do
@@ -235,11 +235,11 @@ defmodule BaseFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 401} = base_fare(route, origin_id, destination_id, %{}, fare_fn)
+      assert %Fares.Fare{cents: 401} = base_fare(route, origin_id, destination_id, fare_fn)
     end
 
     test "returns the appropriate fare for Foxboro" do
-      route = %Route{type: 2, id: "CR-Foxboro"}
+      route = %Route{type: 2}
       south_station_id = "place-sstat"
       foxboro_id = "place-FS-0049"
 
@@ -257,7 +257,7 @@ defmodule BaseFareTest do
 
       fare_fn = fn _ -> [] end
 
-      assert base_fare(route, origin_id, destination_id, %{}, fare_fn) == nil
+      assert base_fare(route, origin_id, destination_id, fare_fn) == nil
     end
 
     test "returns a free fare for any bus shuttle rail replacements" do
@@ -294,7 +294,7 @@ defmodule BaseFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 350} = base_fare(route, origin_id, destination_id, %{}, fare_fn)
+      assert %Fares.Fare{cents: 350} = base_fare(route, origin_id, destination_id, fare_fn)
     end
   end
 end

--- a/apps/site/test/site_web/controllers/fare/commuter_test.exs
+++ b/apps/site/test/site_web/controllers/fare/commuter_test.exs
@@ -1,15 +1,33 @@
 defmodule SiteWeb.FareController.CommuterTest do
   use SiteWeb.ConnCase, async: true
 
+  alias SiteWeb.FareController.Commuter
+
   test "finds fares based on origin and destination", %{conn: conn} do
     origin = Stops.Repo.get("place-north")
     destination = Stops.Repo.get("Concord")
 
-    conn =
+    valid_fares =
       conn
       |> assign(:origin, origin)
       |> assign(:destination, destination)
+      |> Commuter.fares()
 
-    assert SiteWeb.FareController.Commuter.fares(conn) == Fares.Repo.all(name: {:zone, "5"})
+    assert valid_fares == Fares.Repo.all(name: {:zone, "5"})
+    refute Enum.any?(valid_fares, fn fare -> match?(%Fares.Fare{name: :foxboro}, fare) end)
+  end
+
+  test "includes Foxboro special event fare if selection includes Foxboro", %{conn: conn} do
+    origin = Stops.Repo.get("place-sstat")
+    destination = Stops.Repo.get("place-FS-0049")
+
+    valid_fares =
+      conn
+      |> assign(:origin, origin)
+      |> assign(:destination, destination)
+      |> Commuter.fares()
+
+    assert Enum.any?(valid_fares, fn fare -> match?(%Fares.Fare{name: {:zone, "4"}}, fare) end)
+    assert Enum.any?(valid_fares, fn fare -> match?(%Fares.Fare{name: :foxboro}, fare) end)
   end
 end

--- a/apps/zones/priv/crzones.csv
+++ b/apps/zones/priv/crzones.csv
@@ -360,3 +360,4 @@ place-WML-0252,6
 place-WR-0228,5
 place-NHRML-0127,2
 place-PB-0194,4
+place-FS-0049,4


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Foxboro | Fix pricing ($20 special event vs. Zone 4 vs. Interzone 4)](https://app.asana.com/0/555089885850811/1140953760634051)

Examines trip name and route id to determine if fares should be adjusted for Foxboro related trips.
- Trip argument added to `base_fare` function. Contains train # for commuter rail.
- If trip train name is on exception list and traveling to/from zone 1A, force it to zone 1
- If any fare request involves the route id of "CR-Foxboro," return the $20 fare
- Fare Finder for CR now prints all Zone 4 fares if a Foxboro station is selected
- Fare Finder continues to output the $20 fare if a Foxboro station is selected
- Updated Schedule Finder to work with this as well

**Schedule Finder**
![image](https://user-images.githubusercontent.com/688435/66338947-2326ba80-e910-11e9-9d33-c422eb5160fd.png)

**Schedule Tab**
![image](https://user-images.githubusercontent.com/688435/66338975-2f127c80-e910-11e9-9aa9-5f9653cd05dd.png)