### PR TITLE
Foxboro | Franklin timetable "via Fairmount Line"

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -73,7 +73,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
   @spec trip_messages(Routes.Route.t(), 0 | 1, Date.t()) :: %{
           {String.t(), String.t()} => String.t()
         }
-  defp trip_messages(%Routes.Route{id: "CR-Haverhill"}, 0, _) do
+  def trip_messages(%Routes.Route{id: "CR-Haverhill"}, 0, _) do
     %{
       {"221", "place-WR-0067"} => "Via",
       {"221", "place-WR-0075"} => "Lowell",
@@ -81,7 +81,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     }
   end
 
-  defp trip_messages(%Routes.Route{id: "CR-Haverhill"}, 1, _) do
+  def trip_messages(%Routes.Route{id: "CR-Haverhill"}, 1, _) do
     %{
       {"208", "place-WR-0085"} => "Via",
       {"208", "place-WR-0075"} => "Lowell",
@@ -89,14 +89,14 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     }
   end
 
-  defp trip_messages(%Routes.Route{id: "CR-Lowell"}, 0, _) do
+  def trip_messages(%Routes.Route{id: "CR-Lowell"}, 0, _) do
     %{
       {"221", "place-NHRML-0218"} => "Via",
       {"221", "place-NHRML-0254"} => "Haverhill"
     }
   end
 
-  defp trip_messages(%Routes.Route{id: "CR-Lowell"}, 1, _) do
+  def trip_messages(%Routes.Route{id: "CR-Lowell"}, 1, _) do
     %{
       {"208", "place-NHRML-0254"} => "Via",
       {"208", "place-NHRML-0218"} => "Haverhill",
@@ -104,7 +104,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     }
   end
 
-  defp trip_messages(%Routes.Route{id: "CR-Franklin"}, 1, date) do
+  def trip_messages(%Routes.Route{id: "CR-Franklin"}, 1, date) do
     case is_atleast_oct_21_2019(date) do
       true ->
         ["740", "746", "748", "750", "754", "726", "758"]
@@ -119,7 +119,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     end
   end
 
-  defp trip_messages(%Routes.Route{id: "CR-Franklin"}, 0, date) do
+  def trip_messages(%Routes.Route{id: "CR-Franklin"}, 0, date) do
     case is_atleast_oct_21_2019(date) do
       true ->
         ["741", "743", "747", "749", "755", "757", "759"]
@@ -131,7 +131,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     end
   end
 
-  defp trip_messages(_, _, _) do
+  def trip_messages(_, _, _) do
     %{}
   end
 

--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -115,23 +115,36 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     %{}
   end
 
-  defp franklin_via_fairmount(train, direction_id) do
+  defp franklin_via_fairmount(train, 1) do
     [
-      List.duplicate(train, 4),
-      stops_for_fairmount(direction_id),
-      ["Via", "Fair-", "mount", "Line"]
+      List.duplicate(train, 3),
+      stops_for_fairmount(1),
+      ["Via", "Fairmount", "Line"]
     ]
-    |> List.zip()
-    |> Enum.map(fn {train, stop, value} -> {{train, stop}, value} end)
+    |> make_via_list()
   end
 
-  defp stops_for_fairmount(direction_id) do
-    stops = ["place-DB-0095", "place-NEC-2203", "place-rugg", "place-bbsta"]
+  defp franklin_via_fairmount(train, 0) do
+    [
+      List.duplicate(train, 4),
+      stops_for_fairmount(0),
+      ["Via", "Fair-", "mount", "Line"]
+    ]
+    |> make_via_list()
+  end
 
-    case direction_id do
-      1 -> stops
-      0 -> Enum.reverse(stops)
-    end
+  defp stops_for_fairmount(1) do
+    ["place-DB-0095", "place-rugg", "place-bbsta"]
+  end
+
+  defp stops_for_fairmount(0) do
+    ["place-bbsta", "place-rugg", "place-NEC-2203", "place-DB-0095"]
+  end
+
+  def make_via_list(list) do
+    list
+    |> List.zip()
+    |> Enum.map(fn {train, stop, value} -> {{train, stop}, value} end)
   end
 
   defp all_stops(conn, _) do

--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -100,14 +100,38 @@ defmodule SiteWeb.ScheduleController.TimetableController do
   end
 
   defp trip_messages(%Routes.Route{id: "CR-Franklin"}, 1) do
-    %{
-      {"790", "place-rugg"} => "Via",
-      {"790", "place-bbsta"} => "Fairmount"
-    }
+    ["740", "746", "748", "750", "754", "726", "758"]
+    |> Enum.flat_map(&franklin_via_fairmount(&1, 1))
+    |> Enum.into(%{})
+  end
+
+  defp trip_messages(%Routes.Route{id: "CR-Franklin"}, 0) do
+    ["741", "743", "747", "749", "755", "757", "759"]
+    |> Enum.flat_map(&franklin_via_fairmount(&1, 0))
+    |> Enum.into(%{})
   end
 
   defp trip_messages(_, _) do
     %{}
+  end
+
+  defp franklin_via_fairmount(train, direction_id) do
+    [
+      List.duplicate(train, 4),
+      stops_for_fairmount(direction_id),
+      ["Via", "Fair-", "mount", "Line"]
+    ]
+    |> List.zip()
+    |> Enum.map(fn {train, stop, value} -> {{train, stop}, value} end)
+  end
+
+  defp stops_for_fairmount(direction_id) do
+    stops = ["place-DB-0095", "place-NEC-2203", "place-rugg", "place-bbsta"]
+
+    case direction_id do
+      1 -> stops
+      0 -> Enum.reverse(stops)
+    end
   end
 
   defp all_stops(conn, _) do

--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -75,6 +75,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
         }
   def trip_messages(%Routes.Route{id: "CR-Haverhill"}, 0, _) do
     %{
+      {"221"} => "Via Lowell Line",
       {"221", "place-WR-0067"} => "Via",
       {"221", "place-WR-0075"} => "Lowell",
       {"221", "place-WR-0085"} => "Line"
@@ -83,6 +84,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
 
   def trip_messages(%Routes.Route{id: "CR-Haverhill"}, 1, _) do
     %{
+      {"208"} => "Via Lowell Line",
       {"208", "place-WR-0085"} => "Via",
       {"208", "place-WR-0075"} => "Lowell",
       {"208", "place-WR-0067"} => "Line"
@@ -91,6 +93,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
 
   def trip_messages(%Routes.Route{id: "CR-Lowell"}, 0, _) do
     %{
+      {"221"} => "Via Haverhill",
       {"221", "place-NHRML-0218"} => "Via",
       {"221", "place-NHRML-0254"} => "Haverhill"
     }
@@ -98,6 +101,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
 
   def trip_messages(%Routes.Route{id: "CR-Lowell"}, 1, _) do
     %{
+      {"208"} => "Via Haverhill",
       {"208", "place-NHRML-0254"} => "Via",
       {"208", "place-NHRML-0218"} => "Haverhill",
       {"208", "place-NHRML-0152"} => "-"
@@ -113,6 +117,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
 
       false ->
         %{
+          {"790"} => "Via Fairmount",
           {"790", "place-rugg"} => "Via",
           {"790", "place-bbsta"} => "Fairmount"
         }
@@ -150,6 +155,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
       ["Via", "Fairmount", "Line"]
     ]
     |> make_via_list()
+    |> Enum.concat([{{train}, "Via Fairmount Line"}])
   end
 
   defp franklin_via_fairmount(train, 0) do
@@ -159,6 +165,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
       ["Via", "Fair-", "mount", "Line"]
     ]
     |> make_via_list()
+    |> Enum.concat([{{train}, "Via Fairmount Line"}])
   end
 
   defp stops_for_fairmount(1) do

--- a/apps/site/lib/site_web/templates/schedule/_timetable.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_timetable.html.eex
@@ -94,6 +94,7 @@
                 trip_id = schedule.trip.id
                 trip_schedule = @trip_schedules[{trip_id, stop.id} || %{}]
                 tooltip = stop_tooltip(trip_schedule)
+                full_trip_message = @trip_messages[{schedule.trip.name}]
                 trip_message = @trip_messages[{schedule.trip.name, stop.id}]
                 tooltip_attrs = [html: true, toggle: "tooltip"]
               %>
@@ -104,7 +105,8 @@
                 title: if tooltip do raw(tooltip) end
               ] do %>
                 <%= if trip_message do %>
-                  <%= trip_message %>
+                  <div class="sr-only"><%= full_trip_message %></div>
+                  <div aria-hidden="true"><%= trip_message %></div>
                 <% else %>
                   <%= render "_timetable_schedule.html", Map.merge(assigns, %{trip_schedule: trip_schedule, schedule: schedule, stop: stop}) %>
                 <% end %>

--- a/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
@@ -93,6 +93,51 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
     end
   end
 
+  describe "trip_messages/3" do
+    test "returns proper trips for CR Franklin before 10-21" do
+      assert Enum.empty?(trip_messages(%Routes.Route{id: "CR-Franklin"}, 0, ~D[2019-10-20]))
+
+      assert [
+               {"790", "place-bbsta"},
+               {"790", "place-rugg"}
+             ] = Map.keys(trip_messages(%Routes.Route{id: "CR-Franklin"}, 1, ~D[2019-10-20]))
+    end
+
+    test "returns proper trips for CR Franklin on and after 10-21" do
+      assert [
+               "726",
+               "740",
+               "746",
+               "748",
+               "750",
+               "754",
+               "758"
+             ] =
+               %Routes.Route{id: "CR-Franklin"}
+               |> trip_messages(1, ~D[2019-10-22])
+               |> Map.keys()
+               |> Enum.map(&elem(&1, 0))
+               |> Enum.uniq()
+               |> Enum.sort()
+
+      assert [
+               "741",
+               "743",
+               "747",
+               "749",
+               "755",
+               "757",
+               "759"
+             ] ==
+               %Routes.Route{id: "CR-Franklin"}
+               |> trip_messages(0, ~D[2019-10-22])
+               |> Map.keys()
+               |> Enum.map(&elem(&1, 0))
+               |> Enum.uniq()
+               |> Enum.sort()
+    end
+  end
+
   describe "vehicle_schedules/1" do
     test "constructs vehicle data for channel consumption" do
       vehicles =

--- a/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
@@ -98,6 +98,7 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
       assert Enum.empty?(trip_messages(%Routes.Route{id: "CR-Franklin"}, 0, ~D[2019-10-20]))
 
       assert [
+               {"790"},
                {"790", "place-bbsta"},
                {"790", "place-rugg"}
              ] = Map.keys(trip_messages(%Routes.Route{id: "CR-Franklin"}, 1, ~D[2019-10-20]))

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -99,11 +99,10 @@ defmodule SiteWeb.ScheduleControllerTest do
 
     test "assigns trip messages for a few route/directions", %{conn: conn} do
       for {route_id, direction_id, expected_size} <- [
-            {"CR-Lowell", 0, 2},
-            {"CR-Lowell", 1, 3},
-            {"CR-Haverhill", 0, 3},
-            {"CR-Haverhill", 1, 3},
-            {"CR-Franklin", 1, 2}
+            {"CR-Lowell", 0, 3},
+            {"CR-Lowell", 1, 4},
+            {"CR-Haverhill", 0, 4},
+            {"CR-Haverhill", 1, 4}
           ] do
         path = timetable_path(conn, :show, route_id, direction_id: direction_id)
         conn = get(conn, path)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🦊 🕸️❗Foxboro | Franklin timetable should include "via Fairmount Line"  on some trains](https://app.asana.com/0/555089885850811/1142379675259929)

There are 4 stops outbound and 3 stops (no Hyde Park) inbound in the Franklin "schedules". See details in ticket. Summary is that some Franklin non-via schedules include Hyde Park outbound but not inbound. We produce the timetable through the schedules from the API.

<br>
Assigned to: @NAME
