### PR TITLE
Hide CR schedule tab (redirect to timetable)

### DIFF
--- a/apps/site/assets/css/_schedule.scss
+++ b/apps/site/assets/css/_schedule.scss
@@ -1033,7 +1033,8 @@ del .trip-list-realtime {
       }
     }
 
-    .info-tab {
+    .info-tab,
+    .schedule-tab {
       @include media-breakpoint-up(sm) {
         display: none;
       }

--- a/apps/site/assets/css/_schedule.scss
+++ b/apps/site/assets/css/_schedule.scss
@@ -1033,8 +1033,7 @@ del .trip-list-realtime {
       }
     }
 
-    .info-tab,
-    .schedule-tab {
+    .info-tab {
       @include media-breakpoint-up(sm) {
         display: none;
       }

--- a/apps/site/assets/css/_stop-bubbles.scss
+++ b/apps/site/assets/css/_stop-bubbles.scss
@@ -352,6 +352,10 @@ $location-line-width: $space-6;
 
 .schedule-link {
   padding-right: $base-spacing;
+
+  .commuter-rail & {
+    display: none;
+  }
 }
 
 .route-branch-stop-link {

--- a/apps/site/lib/site_web/controllers/schedule/trip_view_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/trip_view_controller.ex
@@ -4,6 +4,7 @@ defmodule SiteWeb.ScheduleController.TripViewController do
   """
   use SiteWeb, :controller
   alias Routes.Route
+  alias Zones.Repo
 
   plug(SiteWeb.Plugs.Route)
   plug(SiteWeb.Plugs.DateInRating)
@@ -16,8 +17,8 @@ defmodule SiteWeb.ScheduleController.TripViewController do
   plug(SiteWeb.ScheduleController.ScheduleError)
   plug(:zone_map)
 
-  def show(conn, %{"route" => "CR-" <> _ = route}) do
-    redirect(conn, to: "/schedules/#{route}/timetable")
+  def show(%{assigns: %{route: %Route{type: 2, id: route_id}}, query_params: params} = conn, _) do
+    redirect(conn, to: timetable_path(conn, :show, route_id, params))
   end
 
   def show(conn, _) do
@@ -27,7 +28,7 @@ defmodule SiteWeb.ScheduleController.TripViewController do
   end
 
   defp zone_map(%{assigns: %{route: %Route{type: 2}, all_stops: all_stops}} = conn, _) do
-    assign(conn, :zone_map, Map.new(all_stops, &{&1.id, Zones.Repo.get(&1.id)}))
+    assign(conn, :zone_map, Map.new(all_stops, &{&1.id, Repo.get(&1.id)}))
   end
 
   defp zone_map(conn, _), do: conn

--- a/apps/site/lib/site_web/controllers/schedule/trip_view_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/trip_view_controller.ex
@@ -16,6 +16,10 @@ defmodule SiteWeb.ScheduleController.TripViewController do
   plug(SiteWeb.ScheduleController.ScheduleError)
   plug(:zone_map)
 
+  def show(conn, %{"route" => "CR-" <> _ = route}) do
+    redirect(conn, to: "/schedules/#{route}/timetable")
+  end
+
   def show(conn, _) do
     conn
     |> put_view(SiteWeb.ScheduleView)

--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -368,7 +368,6 @@ defmodule SiteWeb.ScheduleView do
     alerts_link = alerts_path(conn, :show, route.id, tab_params)
 
     tabs = [
-      %HeaderTab{id: "trip-view", name: "Schedule", href: schedule_link},
       %HeaderTab{id: "line", name: "Info & Maps", href: info_link},
       %HeaderTab{
         id: "alerts",
@@ -387,7 +386,9 @@ defmodule SiteWeb.ScheduleView do
           ]
 
         _ ->
-          tabs
+          [
+            %HeaderTab{id: "trip-view", name: "Schedule", href: schedule_link} | tabs
+          ]
       end
 
     HeaderTabs.render_tabs(tabs, selected: conn.assigns.tab, tab_class: route_tab_class(route))

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -1025,7 +1025,7 @@ defmodule SiteWeb.ScheduleViewTest do
   end
 
   describe "route_header_tabs/1" do
-    test "returns 5 tabs for commuter rail (2 hidden by css)", %{conn: conn} do
+    test "returns 4 tabs for commuter rail (1 hidden by css)", %{conn: conn} do
       tabs =
         conn
         |> assign(:route, %Route{type: 2})
@@ -1035,7 +1035,7 @@ defmodule SiteWeb.ScheduleViewTest do
         |> safe_to_string()
 
       assert tabs =~ "info-tab"
-      assert tabs =~ "schedule-tab"
+      refute tabs =~ "schedule-tab"
       assert tabs =~ "info-&amp;-maps-tab"
       assert tabs =~ "timetable-tab"
       assert tabs =~ "alerts-tab"

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -1025,7 +1025,7 @@ defmodule SiteWeb.ScheduleViewTest do
   end
 
   describe "route_header_tabs/1" do
-    test "returns 5 tabs for commuter rail (1 hidden by css)", %{conn: conn} do
+    test "returns 5 tabs for commuter rail (2 hidden by css)", %{conn: conn} do
       tabs =
         conn
         |> assign(:route, %Route{type: 2})


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Foxboro | Franklin AND Fairmount schedule tab doesn't display inbound trips when origin = Foxboro](https://app.asana.com/0/555089885850811/1143031265509297)

- redirects CR route schedules to timetable tab
- hides CR Schedule tab
- hides "Schedules from here" for CR stop list

![image](https://user-images.githubusercontent.com/688435/66394810-06d45d80-e9a4-11e9-9e5d-b51bd51c0d73.png)
