### PR TITLE
disable Credo.Check.Refactor.MapInto, N/A for 1.8+

### DIFF
--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -109,7 +109,7 @@
         {Credo.Check.Refactor.CyclomaticComplexity, []},
         {Credo.Check.Refactor.FunctionArity, []},
         {Credo.Check.Refactor.LongQuoteBlocks, []},
-        {Credo.Check.Refactor.MapInto, []},
+        {Credo.Check.Refactor.MapInto, false},
         {Credo.Check.Refactor.MatchInCondition, []},
         {Credo.Check.Refactor.NegatedConditionsInUnless, []},
         {Credo.Check.Refactor.NegatedConditionsWithElse, []},


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

This credo check failure has come up in code we've moved around lately. Since we're on 1.8, this check doesn't apply to us, see release notes here:
https://github.com/rrrene/credo/blob/master/CHANGELOG.md#102

We should update credo though. I tried doing that via mix.exs to the latest version and it ran OK via pronto...but I'm concerned about upgrading that right now and introducing a bunch of fix-up work on future branches. We should bite that bullet at some point though, @phildarnowsky up to you which you'd like to do now.

<br>
Assigned to: @phildarnowsky 
