### PR TITLE
Include "diversion" content type in search results and autocomplete

### DIFF
--- a/apps/site/assets/js/algolia-facets.js
+++ b/apps/site/assets/js/algolia-facets.js
@@ -91,7 +91,13 @@ export class AlgoliaFacets {
         item: {
           id: "page",
           name: "Pages",
-          facets: ["page", "search_result", "landing_page", "person"],
+          facets: [
+            "page",
+            "search_result",
+            "landing_page",
+            "person",
+            "diversion"
+          ],
           icon: this._faIcon("fa-info")
         }
       },

--- a/apps/site/assets/js/algolia-global-search.js
+++ b/apps/site/assets/js/algolia-global-search.js
@@ -232,6 +232,7 @@ AlgoliaGlobalSearch.DEFAULT_PARAMS = {
     facetFilters: [
       [
         "_content_type:page",
+        "_content_type:diversion",
         "_content_type:search_result",
         "_content_type:landing_page",
         "_content_type:person"

--- a/apps/site/assets/js/algolia-homepage-search.js
+++ b/apps/site/assets/js/algolia-homepage-search.js
@@ -46,6 +46,7 @@ const PARAMS = {
       [
         "_content_type:page",
         "_content_type:search_result",
+        "_content_type:diversion",
         "_content_type:landing_page",
         "_content_type:person",
         "_content_type:project",

--- a/apps/site/assets/js/test/algolia-result_test.js
+++ b/apps/site/assets/js/test/algolia-result_test.js
@@ -70,6 +70,16 @@ describe("AlgoliaResult", () => {
         }
       }
     },
+    diversion: {
+      _content_type: "diversion",
+      _content_url: "/diversions/diversion-1",
+      content_title: "Diversion Title",
+      _highlightResult: {
+        content_title: {
+          value: "Diversion Title"
+        }
+      }
+    },
     person: {
       _content_type: "person",
       _content_url: "/people/person",
@@ -395,6 +405,10 @@ describe("AlgoliaResult", () => {
         "fa-info"
       );
       assert.include(
+        AlgoliaResult.getIcon(drupalHits.diversion, "drupal"),
+        "fa-info"
+      );
+      assert.include(
         AlgoliaResult.getIcon(drupalHits.person, "drupal"),
         "fa-user"
       );
@@ -561,6 +575,9 @@ describe("AlgoliaResult", () => {
         expect(
           AlgoliaResult.getTitle(drupalHits.landingPage, "drupal")
         ).to.equal("Landing Page Title");
+        expect(AlgoliaResult.getTitle(drupalHits.diversion, "drupal")).to.equal(
+          "Diversion Title"
+        );
         expect(AlgoliaResult.getTitle(drupalHits.person, "drupal")).to.equal(
           "Person Name"
         );
@@ -606,6 +623,9 @@ describe("AlgoliaResult", () => {
       );
       expect(AlgoliaResult.getUrl(drupalHits.landingPage, "drupal")).to.equal(
         "/landing_page"
+      );
+      expect(AlgoliaResult.getUrl(drupalHits.diversion, "drupal")).to.equal(
+        "/diversions/diversion-1"
       );
       expect(AlgoliaResult.getUrl(drupalHits.person, "drupal")).to.equal(
         "/people/person"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Diversions don't show up in search results](https://app.asana.com/0/399597520748778/1139274691030753)

Include this this type of Drupal content in search results.

![image](https://user-images.githubusercontent.com/688435/66507944-2b146500-ea9e-11e9-81b6-0ac33826ce77.png)
