### PR TITLE
Tighten up CR Fare Finder and Foxboro Special Event fare

### DIFF
--- a/apps/fares/lib/fare.ex
+++ b/apps/fares/lib/fare.ex
@@ -14,6 +14,7 @@ defmodule Fares.Fare do
           | :student_card
           | :senior_card
           | :paper_ferry
+          | :special_event
   @type reduced :: nil | :student | :senior_disabled | :any
   @type duration :: :single_trip | :round_trip | :day | :week | :weekend | :month | :invalid
   @type t :: %__MODULE__{

--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -398,7 +398,7 @@ defmodule Fares.FareInfo do
         mode: :commuter_rail,
         name: :foxboro,
         duration: :round_trip,
-        media: [:cash, :mticket],
+        media: [:mticket, :special_event, :cash],
         reduced: nil,
         cents: dollars_to_cents(round_trip)
       }

--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -398,7 +398,7 @@ defmodule Fares.FareInfo do
         mode: :commuter_rail,
         name: :foxboro,
         duration: :round_trip,
-        media: [:commuter_ticket, :cash],
+        media: [:cash, :mticket],
         reduced: nil,
         cents: dollars_to_cents(round_trip)
       }

--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -29,6 +29,7 @@ defmodule Fares.Format do
   def media(:senior_card), do: "Senior CharlieCard or TAP ID"
   def media(:student_card), do: "Student CharlieCard"
   def media(:paper_ferry), do: "Paper Ferry Ticket"
+  def media(:special_event), do: "Special Event Ticket"
 
   @doc "Formats the customers that are served by the given fare based on reduced type"
   @spec customers(Fare.t() | Fare.reduced()) :: String.t()

--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -89,7 +89,7 @@ defmodule Fares.Format do
   def name(:commuter_ferry_logan), do: "Commuter Ferry to Logan Airport"
   def name({:zone, zone}), do: "Zone #{zone}"
   def name({:interzone, zone}), do: "Interzone #{zone}"
-  def name(:foxboro), do: "Foxboro"
+  def name(:foxboro), do: "Foxboro Special Event"
   def name(:free_fare), do: "Free Fare for SL1 Trips from Airport Stops"
   def name(:ada_ride), do: "ADA Ride"
   def name(:premium_ride), do: "Premium Ride"

--- a/apps/site/lib/site/content_rewriters/liquid_objects/fare.ex
+++ b/apps/site/lib/site/content_rewriters/liquid_objects/fare.ex
@@ -80,7 +80,8 @@ defmodule Site.ContentRewriters.LiquidObjects.Fare do
     "charlie_ticket",
     "commuter_ticket",
     "mticket",
-    "paper_ferry"
+    "paper_ferry",
+    "special_event"
   ]
 
   @fare_reduced [

--- a/apps/site/lib/site_web/controllers/fare/commuter.ex
+++ b/apps/site/lib/site_web/controllers/fare/commuter.ex
@@ -50,6 +50,6 @@ defmodule SiteWeb.FareController.Commuter do
   defp foxboro?(a, b) when @foxboro in [a, b], do: true
   defp foxboro?(_, _), do: false
 
-  @spec foxboro_pilot?(Calendar.date()) :: boolean
+  @spec foxboro_pilot?(Date.t()) :: boolean
   defp foxboro_pilot?(current_date), do: Date.compare(current_date, @pilot_launch_date) != :lt
 end

--- a/apps/site/lib/site_web/controllers/fare/commuter.ex
+++ b/apps/site/lib/site_web/controllers/fare/commuter.ex
@@ -18,7 +18,7 @@ defmodule SiteWeb.FareController.Commuter do
         standard_fares = get_fares(fare_name)
 
         if foxboro?(origin.id, destination.id) do
-          standard_fares ++ get_fares(:foxboro)
+          get_fares(:foxboro) ++ standard_fares
         else
           standard_fares
         end

--- a/apps/site/lib/site_web/views/fare/description.ex
+++ b/apps/site/lib/site_web/views/fare/description.ex
@@ -3,6 +3,7 @@ defmodule SiteWeb.FareView.Description do
 
   import Phoenix.HTML.Link
   import Phoenix.HTML.Tag, only: [content_tag: 2]
+  import Phoenix.HTML.Link, only: [link: 2]
   import SiteWeb.ViewHelpers, only: [cms_static_page_path: 2]
   import Util.AndOr
 
@@ -374,7 +375,11 @@ defmodule SiteWeb.FareView.Description do
   end
 
   defp valid_commuter_zones(:foxboro) do
-    "to Gillette Stadium for special events"
+    [
+      "to ",
+      link("Gillette Stadium", to: "/gillette"),
+      " for special events"
+    ]
   end
 
   def transfers(fare) do

--- a/apps/site/test/site_web/controllers/fare/commuter_test.exs
+++ b/apps/site/test/site_web/controllers/fare/commuter_test.exs
@@ -9,6 +9,7 @@ defmodule SiteWeb.FareController.CommuterTest do
 
     valid_fares =
       conn
+      |> assign(:date, ~D[2019-10-21])
       |> assign(:origin, origin)
       |> assign(:destination, destination)
       |> Commuter.fares()
@@ -17,12 +18,27 @@ defmodule SiteWeb.FareController.CommuterTest do
     refute Enum.any?(valid_fares, fn fare -> match?(%Fares.Fare{name: :foxboro}, fare) end)
   end
 
-  test "includes Foxboro special event fare if selection includes Foxboro", %{conn: conn} do
+  test "show only Foxboro special event fare if selection includes Foxboro", %{conn: conn} do
     origin = Stops.Repo.get("place-sstat")
     destination = Stops.Repo.get("place-FS-0049")
 
     valid_fares =
       conn
+      |> assign(:date, ~D[2019-10-20])
+      |> assign(:origin, origin)
+      |> assign(:destination, destination)
+      |> Commuter.fares()
+
+    assert valid_fares == Fares.Repo.all(name: :foxboro)
+  end
+
+  test "includes Zone 4 fares for Foxboro if pilot has launched", %{conn: conn} do
+    origin = Stops.Repo.get("place-sstat")
+    destination = Stops.Repo.get("place-FS-0049")
+
+    valid_fares =
+      conn
+      |> assign(:date, ~D[2019-10-21])
       |> assign(:origin, origin)
       |> assign(:destination, destination)
       |> Commuter.fares()


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Exclude Zone 4 fares from CR Fare Finder prior to Foxboro Pilot launch date](https://app.asana.com/0/555089885850811/1144031495137785)

Follow on to https://github.com/mbta/dotcom/pull/239
- place special events fare first
- change label of fare to include "Special Event" verbiage
- link Gillette stadium to destination page
- correct media information for $20 fare (new `:special_event` media ticket)
- date-gate Zone 4 fares prior to Foxboro Pilot launch

![image](https://user-images.githubusercontent.com/688435/66520767-cf56d580-eab7-11e9-893d-bcc12b62ea76.png)
