### PR TITLE
Filter out Franklin shape that was breaking line diagram

### DIFF
--- a/apps/stops/lib/route_stop.ex
+++ b/apps/stops/lib/route_stop.ex
@@ -125,6 +125,18 @@ defmodule Stops.RouteStop do
     |> merge_branch_list(1)
   end
 
+  def list_from_shapes(
+        shapes,
+        stops,
+        %Route{id: "CR-Franklin"} = route,
+        1
+      ) do
+    shapes
+    |> Enum.reject(&(&1.name == "Forge Park/495 - South Station via Back Bay"))
+    |> Enum.map(&do_list_from_shapes(&1.name, &1.stop_ids, stops, route))
+    |> merge_branch_list(1)
+  end
+
   def list_from_shapes(shapes, stops, route, direction_id) do
     shapes
     |> Enum.map(&do_list_from_shapes(&1.name, &1.stop_ids, stops, route))


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🦊 🕸️❗Foxboro | Franklin line diagram is very wrong](https://app.asana.com/0/555089885850811/1142034065520053)

The problem was an extraneous shape; filtering it out restores the line diagram to its proper form.

<br>
Assigned to: @amaisano 
