### PR TITLE
Line diagram alerts

### DIFF
--- a/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
@@ -249,6 +249,252 @@ export const lineDiagram = [
       branch: null
     },
     alerts: []
+  },
+  {
+    stop_data: [{ type: "terminus", branch: null }],
+    route_stop: {
+      zone: null,
+      stop_features: ["bus", "access", "parking_lot"],
+      station_info: {
+        type: "station",
+        "station?": true,
+        platform_name: null,
+        platform_code: null,
+        parking_lots: [
+          {
+            utilization: null,
+            payment: {
+              monthly_rate: "Monthly passes are not available at MBTA garages.",
+              mobile_app: null,
+              methods: ["Tap Card", "Credit/Debit Card", "Cash"],
+              daily_rate:
+                "Mon-Fri: $9 | Sat-Sun: $3 (Prices are valid for up to 14 hours of parking. After the first 14 hours, the daily rate is $15.)"
+            },
+            note: null,
+            name: "Alewife Garage",
+            manager: {
+              url: "http://www.parkmbta.com/",
+              phone: "617-222-3200",
+              name: "Republic Parking System",
+              contact: "MBTA Customer Support"
+            },
+            longitude: -71.142483,
+            latitude: 42.395428,
+            capacity: {
+              type: "Garage",
+              total: 2471,
+              overnight: "Available",
+              accessible: 32
+            },
+            address: null
+          }
+        ],
+        parent_id: null,
+        note: null,
+        name: "Alewife",
+        longitude: -71.142483,
+        latitude: 42.395428,
+        "is_child?": false,
+        id: "place-alfcl",
+        "has_fare_machine?": true,
+        "has_charlie_card_vendor?": true,
+        fare_facilities: ["fare_media_assistant", "fare_vending_machine"],
+        description: null,
+        closed_stop_info: null,
+        child_ids: [
+          "141",
+          "70061",
+          "Alewife-01",
+          "Alewife-02",
+          "door-alfcl-alewife",
+          "door-alfcl-busway",
+          "door-alfcl-cambridgepark",
+          "door-alfcl-russell",
+          "door-alfcl-steel"
+        ],
+        bike_storage: ["bike_storage_cage"],
+        address:
+          "Alewife Brook Pkwy and Cambridge Park Dr, Cambridge, MA 02140",
+        accessibility: ["accessible", "escalator_both", "elevator", "ramp"]
+      },
+      route: {
+        type: 1,
+        name: "Red Line",
+        long_name: "Red Line",
+        id: "Red",
+        direction_names: { "0": "Southbound", "1": "Northbound" },
+        direction_destinations: { "0": "Ashmont/Braintree", "1": "Alewife" },
+        description: "rapid_transit",
+        "custom_route?": false
+      },
+      name: "Alewife",
+      "is_terminus?": true,
+      "is_beginning?": true,
+      id: "place-alfcl",
+      connections: [
+        {
+          type: 3,
+          name: "62",
+          long_name: "Bedford VA Hospital - Alewife",
+          id: "62",
+          direction_names: { "0": "Outbound", "1": "Inbound" },
+          direction_destinations: {
+            "0": "Bedford VA Hospital",
+            "1": "Alewife"
+          },
+          description: "local_bus",
+          "custom_route?": false
+        },
+        {
+          type: 3,
+          name: "67",
+          long_name: "Turkey Hill - Alewife",
+          id: "67",
+          direction_names: { "0": "Outbound", "1": "Inbound" },
+          direction_destinations: { "0": "Turkey Hill", "1": "Alewife" },
+          description: "local_bus",
+          "custom_route?": false
+        },
+        {
+          type: 3,
+          name: "76",
+          long_name: "Lincoln Lab/Hanscom Air Force Base - Alewife",
+          id: "76",
+          direction_names: { "0": "Outbound", "1": "Inbound" },
+          direction_destinations: {
+            "0": "Lincoln Lab/Hanscom Air Force Base",
+            "1": "Alewife"
+          },
+          description: "local_bus",
+          "custom_route?": false
+        },
+        {
+          type: 3,
+          name: "79",
+          long_name: "Arlington Heights - Alewife",
+          id: "79",
+          direction_names: { "0": "Outbound", "1": "Inbound" },
+          direction_destinations: { "0": "Arlington Heights", "1": "Alewife" },
+          description: "local_bus",
+          "custom_route?": false
+        },
+        {
+          type: 3,
+          name: "84",
+          long_name: "Arlmont Village - Alewife",
+          id: "84",
+          direction_names: { "0": "Outbound", "1": "Inbound" },
+          direction_destinations: { "0": "Arlmont Village", "1": "Alewife" },
+          description: "commuter_bus",
+          "custom_route?": false
+        },
+        {
+          type: 3,
+          name: "350",
+          long_name: "North Burlington - Alewife",
+          id: "350",
+          direction_names: { "0": "Outbound", "1": "Inbound" },
+          direction_destinations: { "0": "North Burlington", "1": "Alewife" },
+          description: "local_bus",
+          "custom_route?": false
+        },
+        {
+          type: 3,
+          name: "351",
+          long_name: "Oak Park/Bedford Woods - Alewife",
+          id: "351",
+          direction_names: { "0": "Outbound", "1": "Inbound" },
+          direction_destinations: {
+            "0": "Oak Park/Bedford Woods",
+            "1": "Alewife"
+          },
+          description: "commuter_bus",
+          "custom_route?": false
+        }
+      ],
+      closed_stop_info: null,
+      branch: null
+    },
+    alerts: [
+      {
+        updated_at: "Updated: 10/2/2019 06:58P",
+        severity: 1,
+        priority: "low",
+        lifecycle: "upcoming",
+        informed_entity: {
+          trip: [null],
+          stop: ["70061", "place-alfcl"],
+          route_type: [1],
+          route: ["Red"],
+          entities: [
+            {
+              trip: null,
+              stop: "70061",
+              route_type: 1,
+              route: "Red",
+              direction_id: null,
+              activities: ["board"]
+            },
+            {
+              trip: null,
+              stop: "place-alfcl",
+              route_type: 1,
+              route: "Red",
+              direction_id: null,
+              activities: ["board"]
+            }
+          ],
+          direction_id: [null],
+          activities: ["board"]
+        },
+        id: "335740",
+        header:
+          "On Saturday, October 19, the main entrance to the Alewife parking garage will close and temporarily relocate for repairs and upgrades. Access to the station will be modified during the closure.",
+        effect: "station_issue",
+        description:
+          "Signs will be placed around the facility to direct motorists to the temporary entrance.",
+        active_period: [["2019-10-19 4:30", null]]
+      },
+      {
+        updated_at: "Updated: 10/2/2019 06:58P",
+        severity: 1,
+        priority: "high",
+        lifecycle: "ongoing",
+        informed_entity: {
+          trip: [null],
+          stop: ["70061", "place-alfcl"],
+          route_type: [1],
+          route: ["Red"],
+          entities: [
+            {
+              trip: null,
+              stop: "70061",
+              route_type: 1,
+              route: "Red",
+              direction_id: null,
+              activities: ["board"]
+            },
+            {
+              trip: null,
+              stop: "place-alfcl",
+              route_type: 1,
+              route: "Red",
+              direction_id: null,
+              activities: ["board"]
+            }
+          ],
+          direction_id: [null],
+          activities: ["board"]
+        },
+        id: "335741",
+        header:
+          "On Saturday, October 19, the main entrance to the Alewife parking garage will close and temporarily relocate for repairs and upgrades. Access to the station will be modified during the closure.",
+        effect: "station_issue",
+        description:
+          "Signs will be placed around the facility to direct motorists to the temporary entrance.",
+        active_period: [["2019-10-19 4:30", null]]
+      }
+    ]
   }
 ] as LineDiagramStop[];
 

--- a/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
@@ -63,7 +63,8 @@ export const lineDiagram = [
       ],
       closed_stop_info: null,
       branch: null
-    }
+    },
+    alerts: []
   },
   {
     stop_data: [{ type: "stop", branch: "Lowell" }],
@@ -246,7 +247,8 @@ export const lineDiagram = [
       ],
       closed_stop_info: null,
       branch: null
-    }
+    },
+    alerts: []
   }
 ] as LineDiagramStop[];
 

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -161,5 +161,103 @@ Array [
       </div>
     </div>
   </div>,
+  <div
+    className="m-schedule-line-diagram__stop"
+  >
+    <div
+      className="m-schedule-line-diagram__card-left"
+    >
+      <div
+        className="m-schedule-line-diagram__stop-name"
+      >
+        <span
+          aria-hidden="false"
+          className="notranslate c-svg__icon-alerts-triangle"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+        <span
+          className="sr-only"
+        >
+          Service alert or delay
+        </span>
+         
+        Alewife
+      </div>
+      <div />
+      <div
+        className="m-schedule-line-diagram__connections"
+      >
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          62
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          67
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          76
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          79
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          84
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          350
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          351
+        </span>
+      </div>
+    </div>
+    <div>
+      <div
+        className="m-schedule-line-diagram__features"
+      >
+        <span
+          aria-hidden="false"
+          className="notranslate c-svg__icon-parking-default"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+        <span
+          aria-hidden="false"
+          className="notranslate c-svg__icon-acessible-default"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div>
+        <div>
+          
+          terminus
+        </div>
+      </div>
+    </div>
+  </div>,
 ]
 `;

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -12,7 +12,6 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         Elm St opp Haskell Ave
-         
       </div>
       <div />
       <div
@@ -53,7 +52,6 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         North Station
-         
       </div>
       <div />
       <div

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -12,6 +12,7 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         Elm St opp Haskell Ave
+         
       </div>
       <div />
       <div
@@ -52,6 +53,7 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         North Station
+         
       </div>
       <div />
       <div

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -161,6 +161,104 @@ Array [
       </div>
     </div>
   </div>,
+  <div
+    className="m-schedule-line-diagram__stop"
+  >
+    <div
+      className="m-schedule-line-diagram__card-left"
+    >
+      <div
+        className="m-schedule-line-diagram__stop-name"
+      >
+        <span
+          aria-hidden="false"
+          className="notranslate c-svg__icon-alerts-triangle"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+        <span
+          className="sr-only"
+        >
+          Service alert or delay
+        </span>
+         
+        Alewife
+      </div>
+      <div />
+      <div
+        className="m-schedule-line-diagram__connections"
+      >
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          62
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          67
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          76
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          79
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          84
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          350
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          351
+        </span>
+      </div>
+    </div>
+    <div>
+      <div
+        className="m-schedule-line-diagram__features"
+      >
+        <span
+          aria-hidden="false"
+          className="notranslate c-svg__icon-parking-default"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+        <span
+          aria-hidden="false"
+          className="notranslate c-svg__icon-acessible-default"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div>
+        <div>
+          
+          terminus
+        </div>
+      </div>
+    </div>
+  </div>,
 ]
 `;
 

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -12,7 +12,6 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         Elm St opp Haskell Ave
-         
       </div>
       <div />
       <div
@@ -53,7 +52,6 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         North Station
-         
       </div>
       <div />
       <div

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -12,6 +12,7 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         Elm St opp Haskell Ave
+         
       </div>
       <div />
       <div
@@ -52,6 +53,7 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         North Station
+         
       </div>
       <div />
       <div

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/SchedulePageTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/SchedulePageTest.tsx.snap
@@ -161,6 +161,104 @@ Array [
       </div>
     </div>
   </div>,
+  <div
+    className="m-schedule-line-diagram__stop"
+  >
+    <div
+      className="m-schedule-line-diagram__card-left"
+    >
+      <div
+        className="m-schedule-line-diagram__stop-name"
+      >
+        <span
+          aria-hidden="false"
+          className="notranslate c-svg__icon-alerts-triangle"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+        <span
+          className="sr-only"
+        >
+          Service alert or delay
+        </span>
+         
+        Alewife
+      </div>
+      <div />
+      <div
+        className="m-schedule-line-diagram__connections"
+      >
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          62
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          67
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          76
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          79
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          84
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          350
+        </span>
+        <span
+          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        >
+          351
+        </span>
+      </div>
+    </div>
+    <div>
+      <div
+        className="m-schedule-line-diagram__features"
+      >
+        <span
+          aria-hidden="false"
+          className="notranslate c-svg__icon-parking-default"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+        <span
+          aria-hidden="false"
+          className="notranslate c-svg__icon-acessible-default"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div>
+        <div>
+          
+          terminus
+        </div>
+      </div>
+    </div>
+  </div>,
 ]
 `;
 

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/SchedulePageTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/SchedulePageTest.tsx.snap
@@ -12,7 +12,6 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         Elm St opp Haskell Ave
-         
       </div>
       <div />
       <div
@@ -53,7 +52,6 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         North Station
-         
       </div>
       <div />
       <div

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/SchedulePageTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/SchedulePageTest.tsx.snap
@@ -12,6 +12,7 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         Elm St opp Haskell Ave
+         
       </div>
       <div />
       <div
@@ -52,6 +53,7 @@ Array [
         className="m-schedule-line-diagram__stop-name"
       >
         North Station
+         
       </div>
       <div />
       <div

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const maybeAlert = (alerts: Alert[]): ReactElement<HTMLElement> | null => {
-  const highPriorityAlerts = alerts.filter(alert => alert.priority === "low");
+  const highPriorityAlerts = alerts.filter(alert => alert.priority === "high");
   if (highPriorityAlerts.length === 0) return null;
   return (
     <>

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -8,11 +8,19 @@ interface Props {
   lineDiagram: LineDiagramStop[];
 }
 
-const filteredAlerts = (allAlerts: Alert[]): any =>
-  allAlerts.filter(alert => alert.priority === "low");
-
-const alertIcon = (alerts: Alert[]): any =>
-  alerts.map(alert => iconForAlert(alert));
+const maybeAlert = (alerts: Alert[]): ReactElement<HTMLElement> | null => {
+  const highPriorityAlerts = alerts.filter(alert => alert.priority === "low");
+  if (highPriorityAlerts.length == 0) return null;
+  return (
+    <i
+      className="notranslate fa fa-exclamation-triangle"
+      aria-hidden="true"
+      data-toggle="tooltip"
+      title=""
+      data-original-title="Service alert or delay"
+    />
+  );
+};
 
 const maybeTerminus = (stopData: StopData[]): StopData | undefined =>
   stopData.find((stop: StopData) => stop.type === "terminus");
@@ -30,7 +38,7 @@ const LineDiagram = ({
         <div key={routeStop.id} className="m-schedule-line-diagram__stop">
           <div className="m-schedule-line-diagram__card-left">
             <div className="m-schedule-line-diagram__stop-name">
-              {alertIcon(filteredAlerts(stopAlerts))} {routeStop.name}
+              {routeStop.name} {maybeAlert(stopAlerts)}
             </div>
             <div>
               {maybeTerminus(stopData) && maybeTerminus(stopData)!.branch}

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -1,6 +1,11 @@
 import React, { ReactElement } from "react";
 import { LineDiagramStop, StopData } from "./__schedule";
-import { modeIcon, accessibleIcon, parkingIcon } from "../../helpers/icon";
+import {
+  alertIcon,
+  modeIcon,
+  accessibleIcon,
+  parkingIcon
+} from "../../helpers/icon";
 import { Alert, Route } from "../../__v3api";
 
 interface Props {
@@ -8,16 +13,14 @@ interface Props {
 }
 
 const maybeAlert = (alerts: Alert[]): ReactElement<HTMLElement> | null => {
-  const highPriorityAlerts = alerts.filter(alert => alert.priority === "high");
+  const highPriorityAlerts = alerts.filter(alert => alert.priority === "low");
   if (highPriorityAlerts.length === 0) return null;
   return (
-    <i
-      className="notranslate fa fa-exclamation-triangle"
-      aria-hidden="true"
-      data-toggle="tooltip"
-      title=""
-      data-original-title="Service alert or delay"
-    />
+    <>
+      {alertIcon("c-svg__icon-alerts-triangle")}
+      <span className="sr-only">Service alert or delay</span>
+      &nbsp;
+    </>
   );
 };
 
@@ -37,7 +40,8 @@ const LineDiagram = ({
         <div key={routeStop.id} className="m-schedule-line-diagram__stop">
           <div className="m-schedule-line-diagram__card-left">
             <div className="m-schedule-line-diagram__stop-name">
-              {routeStop.name} {maybeAlert(stopAlerts)}
+              {maybeAlert(stopAlerts)}
+              {routeStop.name}
             </div>
             <div>
               {maybeTerminus(stopData) && maybeTerminus(stopData)!.branch}

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const maybeAlert = (alerts: Alert[]): ReactElement<HTMLElement> | null => {
-  const highPriorityAlerts = alerts.filter(alert => alert.priority === "low");
+  const highPriorityAlerts = alerts.filter(alert => alert.priority === "high");
   if (highPriorityAlerts.length == 0) return null;
   return (
     <i

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement } from "react";
 import { LineDiagramStop, StopData } from "./__schedule";
 import { modeIcon, accessibleIcon, parkingIcon } from "../../helpers/icon";
 import { Alert, Route } from "../../__v3api";
-import { iconForAlert } from "../../components/Alerts";
 
 interface Props {
   lineDiagram: LineDiagramStop[];

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -1,12 +1,18 @@
 import React, { ReactElement } from "react";
 import { LineDiagramStop, StopData } from "./__schedule";
 import { modeIcon, accessibleIcon, parkingIcon } from "../../helpers/icon";
-import { Route } from "../../__v3api";
-import Alerts from "../../components/Alerts";
+import { Alert, Route } from "../../__v3api";
+import { iconForAlert } from "../../components/Alerts";
 
 interface Props {
   lineDiagram: LineDiagramStop[];
 }
+
+const filteredAlerts = (allAlerts: Alert[]): any =>
+  allAlerts.filter(alert => alert.priority === "low");
+
+const alertIcon = (alerts: Alert[]): any =>
+  alerts.map(alert => iconForAlert(alert));
 
 const maybeTerminus = (stopData: StopData[]): StopData | undefined =>
   stopData.find((stop: StopData) => stop.type === "terminus");
@@ -24,7 +30,7 @@ const LineDiagram = ({
         <div key={routeStop.id} className="m-schedule-line-diagram__stop">
           <div className="m-schedule-line-diagram__card-left">
             <div className="m-schedule-line-diagram__stop-name">
-              {routeStop.name}
+              {alertIcon(filteredAlerts(stopAlerts))} {routeStop.name}
             </div>
             <div>
               {maybeTerminus(stopData) && maybeTerminus(stopData)!.branch}
@@ -45,7 +51,6 @@ const LineDiagram = ({
             </div>
           </div>
           <div>
-            <Alerts alerts={stopAlerts} />
             <div className="m-schedule-line-diagram__features">
               {routeStop.stop_features.includes("parking_lot")
                 ? parkingIcon("c-svg__icon-parking-default")

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -10,6 +10,8 @@ interface Props {
 const maybeTerminus = (stopData: StopData[]): StopData | undefined =>
   stopData.find((stop: StopData) => stop.type === "terminus");
 
+const maybeAlert = (alerts: Alert[]): boolean => Boolean(alerts.length);
+
 const LineDiagram = ({
   lineDiagram
 }: Props): ReactElement<HTMLElement> | null => (
@@ -44,6 +46,7 @@ const LineDiagram = ({
             </div>
           </div>
           <div>
+            {maybeAlert(stopAlerts)}
             <div className="m-schedule-line-diagram__features">
               {routeStop.stop_features.includes("parking_lot")
                 ? parkingIcon("c-svg__icon-parking-default")

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
 import { LineDiagramStop, StopData } from "./__schedule";
 import { modeIcon, accessibleIcon, parkingIcon } from "../../helpers/icon";
-import { Route } from "../../__v3api";
+import { Alert, Route } from "../../__v3api";
 
 interface Props {
   lineDiagram: LineDiagramStop[];
@@ -15,7 +15,11 @@ const LineDiagram = ({
 }: Props): ReactElement<HTMLElement> | null => (
   <>
     {lineDiagram.map(
-      ({ route_stop: routeStop, stop_data: stopData }: LineDiagramStop) => (
+      ({
+        route_stop: routeStop,
+        stop_data: stopData,
+        alerts: stopAlerts
+      }: LineDiagramStop) => (
         <div key={routeStop.id} className="m-schedule-line-diagram__stop">
           <div className="m-schedule-line-diagram__card-left">
             <div className="m-schedule-line-diagram__stop-name">

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -1,7 +1,8 @@
 import React, { ReactElement } from "react";
 import { LineDiagramStop, StopData } from "./__schedule";
 import { modeIcon, accessibleIcon, parkingIcon } from "../../helpers/icon";
-import { Alert, Route } from "../../__v3api";
+import { Route } from "../../__v3api";
+import Alerts from "../../components/Alerts";
 
 interface Props {
   lineDiagram: LineDiagramStop[];
@@ -9,8 +10,6 @@ interface Props {
 
 const maybeTerminus = (stopData: StopData[]): StopData | undefined =>
   stopData.find((stop: StopData) => stop.type === "terminus");
-
-const maybeAlert = (alerts: Alert[]): boolean => Boolean(alerts.length);
 
 const LineDiagram = ({
   lineDiagram
@@ -46,7 +45,7 @@ const LineDiagram = ({
             </div>
           </div>
           <div>
-            {maybeAlert(stopAlerts)}
+            <Alerts alerts={stopAlerts} />
             <div className="m-schedule-line-diagram__features">
               {routeStop.stop_features.includes("parking_lot")
                 ? parkingIcon("c-svg__icon-parking-default")

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const maybeAlert = (alerts: Alert[]): ReactElement<HTMLElement> | null => {
   const highPriorityAlerts = alerts.filter(alert => alert.priority === "high");
-  if (highPriorityAlerts.length == 0) return null;
+  if (highPriorityAlerts.length === 0) return null;
   return (
     <i
       className="notranslate fa fa-exclamation-triangle"

--- a/apps/site/assets/ts/schedule/components/__schedule.d.ts
+++ b/apps/site/assets/ts/schedule/components/__schedule.d.ts
@@ -1,5 +1,6 @@
 import { TypedRoutes } from "../../stop/components/__stop";
 import {
+  Alert,
   Route,
   PredictedOrScheduledTime,
   EnhancedRoute,
@@ -51,6 +52,7 @@ interface StopData {
 export interface LineDiagramStop {
   stop_data: StopData[];
   route_stop: RouteStop;
+  alerts: Alert[];
 }
 
 interface RouteStopRoute extends Route {

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -27,7 +27,8 @@ defmodule SiteWeb.ScheduleController.LineApi do
     conn =
       conn
       |> assign(:route, LineHelpers.get_route(route_id))
-      |> assign_alerts([])
+      |> assign(:direction_id, direction_id)
+      |> assign_alerts(filter_by_direction?: true)
 
     json(
       conn,

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -12,12 +12,8 @@ defmodule SiteWeb.ScheduleController.LineApi do
 
   import SiteWeb.StopController, only: [json_safe_alerts: 2]
 
-  plug(:alerts)
-
   @type query_param :: String.t() | nil
   @type direction_id :: 0 | 1
-
-  defp alerts(conn, _), do: assign_alerts(conn, [])
 
   def show(conn, %{
         "id" => route_id,
@@ -27,6 +23,11 @@ defmodule SiteWeb.ScheduleController.LineApi do
       get_line_data(conn, route_id, String.to_integer(direction_id), %{
         stops_by_route_fn: &StopsRepo.by_route/3
       })
+
+    conn =
+      conn
+      |> assign(:route, LineHelpers.get_route(route_id))
+      |> assign_alerts([])
 
     json(
       conn,

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -49,11 +49,12 @@ defmodule SiteWeb.ScheduleController.LineApi do
     DiagramHelpers.build_stop_list(branches, direction_id)
   end
 
+  @spec update_route_stop_data({any, Stops.RouteStop.t()}, any, DateTime.t()) :: map()
   def update_route_stop_data({data, %RouteStop{id: stop_id} = map}, alerts, date) do
     %{
-      stop_data: Enum.map(data, fn {key, value} -> %{branch: key, type: value} end),
+      alerts: alerts |> Stop.match(stop_id) |> json_safe_alerts(date),
       route_stop: RouteStop.to_json_safe(map),
-      alerts: alerts |> Stop.match(stop_id) |> json_safe_alerts(date)
+      stop_data: Enum.map(data, fn {key, value} -> %{branch: key, type: value} end)
     }
   end
 end

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -4,13 +4,20 @@ defmodule SiteWeb.ScheduleController.LineApi do
   """
   use SiteWeb, :controller
 
+  alias Alerts.Stop
   alias SiteWeb.ScheduleController.Line.DiagramHelpers
   alias SiteWeb.ScheduleController.Line.Helpers, as: LineHelpers
   alias Stops.Repo, as: StopsRepo
   alias Stops.RouteStop
 
+  import SiteWeb.StopController, only: [json_safe_alerts: 2]
+
+  plug(:alerts)
+
   @type query_param :: String.t() | nil
   @type direction_id :: 0 | 1
+
+  defp alerts(conn, _), do: assign_alerts(conn, [])
 
   def show(conn, %{
         "id" => route_id,
@@ -21,7 +28,12 @@ defmodule SiteWeb.ScheduleController.LineApi do
         stops_by_route_fn: &StopsRepo.by_route/3
       })
 
-    json(conn, Enum.map(line_data, &update_route_stop_data/1))
+    json(
+      conn,
+      Enum.map(line_data, fn stop ->
+        update_route_stop_data(stop, conn.assigns.alerts, conn.assigns.date)
+      end)
+    )
   end
 
   def get_line_data(conn, route_id, direction_id, deps) do
@@ -35,10 +47,11 @@ defmodule SiteWeb.ScheduleController.LineApi do
     DiagramHelpers.build_stop_list(branches, direction_id)
   end
 
-  def update_route_stop_data({data, %RouteStop{} = map}) do
+  def update_route_stop_data({data, %RouteStop{id: stop_id} = map}, alerts, date) do
     %{
       stop_data: Enum.map(data, fn {key, value} -> %{branch: key, type: value} end),
-      route_stop: RouteStop.to_json_safe(map)
+      route_stop: RouteStop.to_json_safe(map),
+      alerts: alerts |> Stop.match(stop_id) |> json_safe_alerts(date)
     }
   end
 end

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -1,6 +1,5 @@
 defmodule SiteWeb.ScheduleController.LineController do
   use SiteWeb, :controller
-  alias Alerts.Stop
   alias Phoenix.HTML
   alias Plug.Conn
   alias Routes.{Group, Route}
@@ -8,9 +7,8 @@ defmodule SiteWeb.ScheduleController.LineController do
   alias Services.Service
   alias Site.ScheduleNote
   alias SiteWeb.{ScheduleView, ViewHelpers}
-  alias Stops.{RouteStop}
 
-  import SiteWeb.StopController, only: [json_safe_alerts: 2]
+  import SiteWeb.ScheduleController.LineApi, only: [update_route_stop_data: 3]
 
   plug(SiteWeb.Plugs.Route)
   plug(SiteWeb.Plugs.DateInRating)
@@ -93,14 +91,6 @@ defmodule SiteWeb.ScheduleController.LineController do
           end)
       }
     )
-  end
-
-  def update_route_stop_data({data, %RouteStop{id: stop_id} = map}, alerts, date) do
-    %{
-      stop_data: Enum.map(data, fn {key, value} -> %{branch: key, type: value} end),
-      route_stop: RouteStop.to_json_safe(map),
-      alerts: alerts |> Stop.match(stop_id) |> json_safe_alerts(date)
-    }
   end
 
   @spec dedup_services([Service.t()]) :: [Service.t()]

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -188,7 +188,7 @@ defmodule SiteWeb.ScheduleController.LineController do
 
   defp tab_name(conn, _), do: assign(conn, :tab, "line")
 
-  defp alerts(conn, _), do: assign_alerts(conn, [])
+  defp alerts(conn, _), do: assign_alerts(conn, filter_by_direction?: true)
 
   defp channel_id(conn, _) do
     assign(conn, :channel, "vehicles:#{conn.assigns.route.id}:#{conn.assigns.direction_id}")

--- a/apps/site/test/site_web/controllers/line_api_test.exs
+++ b/apps/site/test/site_web/controllers/line_api_test.exs
@@ -1,0 +1,18 @@
+defmodule SiteWeb.LineApiTest do
+  use SiteWeb.ConnCase
+
+  describe "Line" do
+    test "success response", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          line_api_path(conn, :show, %{
+            "id" => "Red",
+            "direction_id" => "1"
+          })
+        )
+
+      json_response(conn, 200)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Line Diagram - Stop Component - Alert Icon](https://app.asana.com/0/555089885850811/1141229989083701)

If a stop has any high priority alerts, print the alert icon similar to Trip Planner itinerary. This is just for placement. Final styling to be done on a later pass, along with other stop card elements.

![image](https://user-images.githubusercontent.com/688435/66870472-86979480-ef6f-11e9-8c2c-fc94ed794c51.png)
