### PR TITLE
Rename info tab for CR

### DIFF
--- a/apps/site/assets/css/_schedule.scss
+++ b/apps/site/assets/css/_schedule.scss
@@ -1027,13 +1027,15 @@ del .trip-list-realtime {
   color: $white;
 
   &.u-bg--commuter-rail {
-    .info-\&-maps-tab {
+    .info-\&-maps-tab,
+    .schedule-\&-maps-tab {
       @include media-breakpoint-down(xs) {
         display: none;
       }
     }
 
-    .info-tab {
+    .info-tab,
+    .schedule-tab {
       @include media-breakpoint-up(sm) {
         display: none;
       }

--- a/apps/site/lib/site_web/templates/schedule/_line.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line.html.eex
@@ -18,7 +18,13 @@
     <%= if Enum.empty?(@branches) do %>
       <%= render "_empty.html", date: @date, direction: Routes.Route.direction_name(@route, @direction_id), origin: nil, destination: nil, conn: @conn, error: assigns[:schedule_error] %>
     <% else %>
-        <h2>Info &amp; Maps</h2>
+        <h2>
+          <%= if @route.type == 2 do %>
+            Schedule &amp; Maps
+          <% else %>
+            Info &amp; Maps
+          <% end %>
+        </h2>
 
         <div id="react-schedule-finder-root">
           <%= if @route.type !== 0 and @route.type !== 1 do %>

--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -368,7 +368,6 @@ defmodule SiteWeb.ScheduleView do
     alerts_link = alerts_path(conn, :show, route.id, tab_params)
 
     tabs = [
-      %HeaderTab{id: "line", name: "Info & Maps", href: info_link},
       %HeaderTab{
         id: "alerts",
         name: "Alerts",
@@ -382,12 +381,14 @@ defmodule SiteWeb.ScheduleView do
         2 ->
           [
             %HeaderTab{id: "timetable", name: "Timetable", href: timetable_link},
-            %HeaderTab{id: "line", name: "Info", href: info_link} | tabs
+            %HeaderTab{id: "line", name: "Schedule & Maps", href: info_link},
+            %HeaderTab{id: "line", name: "Schedule", href: info_link} | tabs
           ]
 
         _ ->
           [
-            %HeaderTab{id: "trip-view", name: "Schedule", href: schedule_link} | tabs
+            %HeaderTab{id: "trip-view", name: "Schedule", href: schedule_link},
+            %HeaderTab{id: "line", name: "Info & Maps", href: info_link} | tabs
           ]
       end
 

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -1034,9 +1034,8 @@ defmodule SiteWeb.ScheduleViewTest do
         |> route_header_tabs()
         |> safe_to_string()
 
-      assert tabs =~ "info-tab"
-      refute tabs =~ "schedule-tab"
-      assert tabs =~ "info-&amp;-maps-tab"
+      assert tabs =~ "schedule-tab"
+      assert tabs =~ "schedule-&amp;-maps-tab"
       assert tabs =~ "timetable-tab"
       assert tabs =~ "alerts-tab"
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Rename "Info & Maps" tab](https://app.asana.com/0/555089885850811/1144985353924400)

Change Commuter Rail tabs only:
- Change "Info & Maps" to "Schedule & Maps"
- Shortens to "Schedule" on mobile

![image](https://user-images.githubusercontent.com/688435/66943265-c49cc300-f018-11e9-9643-87fdd11e5e08.png)

![image](https://user-images.githubusercontent.com/688435/66943304-d8482980-f018-11e9-9094-6fc3ffc366ca.png)