### PR TITLE
Style basics of stop components, fix presentational bugs

### DIFF
--- a/apps/site/assets/css/_icons.scss
+++ b/apps/site/assets/css/_icons.scss
@@ -308,11 +308,12 @@ a {
 
 .c-icon__bus-pill--small {
   border-radius: $base-spacing / 6;
+  display: inline-block;
   font-size: $font-size-base * 2 / 3;
   font-weight: bold;
-  max-height: $base-spacing;
+  height: $base-spacing;
+  line-height: $base-spacing;
   min-width: $base-spacing * 4 / 3;
   padding: 0 $base-spacing / 6;
   text-align: center;
-  vertical-align: middle;
 }

--- a/apps/site/assets/css/_icons.scss
+++ b/apps/site/assets/css/_icons.scss
@@ -300,6 +300,7 @@ a {
 .c-icon__bus-pill {
   border-radius: $base-spacing / 4;
   font-weight: bold;
+  max-height: $base-spacing * 1.5;
   min-width: 2rem;
   padding: 0 $base-spacing / 4;
   text-align: center;

--- a/apps/site/assets/css/_icons.scss
+++ b/apps/site/assets/css/_icons.scss
@@ -306,3 +306,13 @@ a {
   text-align: center;
 }
 
+.c-icon__bus-pill--small {
+  border-radius: $base-spacing / 6;
+  font-size: $font-size-base * 2 / 3;
+  font-weight: bold;
+  max-height: $base-spacing;
+  min-width: $base-spacing * 4 / 3;
+  padding: 0 $base-spacing / 6;
+  text-align: center;
+  vertical-align: middle;
+}

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -416,8 +416,13 @@
 
 .m-schedule-line-diagram__stop {
   border: $border;
+  border-bottom: none;
   display: flex;
   padding: $base-spacing;
+
+  &:last-child {
+    border-bottom: $border;
+  }
 }
 
 .m-schedule-line-diagram__stop-name {

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -433,6 +433,10 @@
   align-items: center;
   display: flex;
   justify-content: flex-end;
+
+  .m-schedule-line-diagram__feature-icon {
+    margin-left: $base-spacing / 4;
+  }
 }
 
 .m-schedule-line-diagram__card-left {

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -416,7 +416,7 @@
 
 .m-schedule-line-diagram__stop {
   border: $border;
-  border-bottom: none;
+  border-bottom: 0;
   display: flex;
   padding: $base-spacing;
 
@@ -429,7 +429,7 @@
   font-weight: bold;
 
   h4 {
-    margin-top: $base-spacing * -0.25;
+    margin-top: $base-spacing / -4;
   }
 }
 

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -459,8 +459,14 @@
 
   .m-schedule-line-diagram__feature-icon {
     height: $base-spacing;
+    line-height: $base-spacing;
     margin-left: $base-spacing / 4;
     width: $base-spacing;
+  }
+
+  .c-icon__cr-zone {
+    font-size: $base-spacing * 0.7;
+    width: auto;
   }
 }
 

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -437,6 +437,10 @@
   .m-schedule-line-diagram__connection {
     margin: 0 ($base-spacing / 4) ($base-spacing / 4) 0;
   }
+
+  a {
+    max-height: $base-spacing * 1.5;
+  }
 }
 
 .m-schedule-line-diagram__features {

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -426,7 +426,12 @@
 
 .m-schedule-line-diagram__connections {
   display: inline-flex;
-  justify-content: center;
+  flex-wrap: wrap;
+  justify-content: left;
+
+  .m-schedule-line-diagram__connection {
+    margin: 0 ($base-spacing / 4) ($base-spacing / 4) 0;
+  }
 }
 
 .m-schedule-line-diagram__features {

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -434,10 +434,6 @@
 }
 
 .m-schedule-line-diagram__connections {
-  display: inline-flex;
-  flex-wrap: wrap;
-  justify-content: left;
-
   .m-schedule-line-diagram__connection {
     margin: 0 ($base-spacing / 4) ($base-spacing / 4) 0;
 
@@ -449,7 +445,10 @@
   }
 
   a {
+    display: inline-block;
+    line-height: 0;
     max-height: $base-spacing * 1.5;
+    vertical-align: top;
   }
 }
 

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -427,6 +427,10 @@
 
 .m-schedule-line-diagram__stop-name {
   font-weight: bold;
+
+  h4 {
+    margin-top: $base-spacing * -0.25;
+  }
 }
 
 .m-schedule-line-diagram__connections {
@@ -436,6 +440,12 @@
 
   .m-schedule-line-diagram__connection {
     margin: 0 ($base-spacing / 4) ($base-spacing / 4) 0;
+
+    .c-svg__icon {
+      height: $base-spacing;
+      vertical-align: middle;
+      width: $base-spacing;
+    }
   }
 
   a {
@@ -449,7 +459,9 @@
   justify-content: flex-end;
 
   .m-schedule-line-diagram__feature-icon {
+    height: $base-spacing;
     margin-left: $base-spacing / 4;
+    width: $base-spacing;
   }
 }
 

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -465,7 +465,7 @@
   }
 
   .c-icon__cr-zone {
-    font-size: $base-spacing * 0.7;
+    font-size: $base-spacing * .7;
     width: auto;
   }
 }

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`LineDiagram it renders 1`] = `
 Array [
+  <h3>
+    Stops
+  </h3>,
   <div
     className="m-schedule-line-diagram__stop"
   >
@@ -14,29 +17,29 @@ Array [
         <a
           href="/stops/5547"
         >
-          Elm St opp Haskell Ave
+          <h4>
+            Elm St opp Haskell Ave
+          </h4>
         </a>
       </div>
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        <a
+          href="/schedules/110/line"
         >
-          110
-        </span>
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            110
+          </span>
+        </a>
       </div>
     </div>
     <div>
       <div
         className="m-schedule-line-diagram__features"
-      >
-        <span
-          className="c-icon__cr-zone m-schedule-line-diagram__feature-icon"
-        >
-          Zone 1A
-        </span>
-      </div>
+      />
     </div>
   </div>,
   <div
@@ -51,64 +54,82 @@ Array [
         <a
           href="/stops/place-north"
         >
-          North Station
+          <h4>
+            North Station
+          </h4>
         </a>
       </div>
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span
-          className="m-schedule-line-diagram__connection"
+        <a
+          href="/schedules/Orange/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
-        <span
-          className="m-schedule-line-diagram__connection"
+            />
+          </span>
+        </a>
+        <a
+          href="/schedules/Green-C/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
-        <span
-          className="m-schedule-line-diagram__connection"
+            />
+          </span>
+        </a>
+        <a
+          href="/schedules/Green-E/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
-        <span
-          className="m-schedule-line-diagram__connection"
+            />
+          </span>
+        </a>
+        <a
+          href="/schedules/CR-Fitchburg/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
+            />
+          </span>
+        </a>
       </div>
     </div>
     <div>
@@ -168,47 +189,77 @@ Array [
         <a
           href="/stops/place-alfcl"
         >
-          Alewife
+          <h4>
+            Alewife
+          </h4>
         </a>
       </div>
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        <a
+          href="/schedules/62/line"
         >
-          62
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            62
+          </span>
+        </a>
+        <a
+          href="/schedules/67/line"
         >
-          67
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            67
+          </span>
+        </a>
+        <a
+          href="/schedules/76/line"
         >
-          76
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            76
+          </span>
+        </a>
+        <a
+          href="/schedules/79/line"
         >
-          79
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            79
+          </span>
+        </a>
+        <a
+          href="/schedules/84/line"
         >
-          84
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            84
+          </span>
+        </a>
+        <a
+          href="/schedules/350/line"
         >
-          350
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            350
+          </span>
+        </a>
+        <a
+          href="/schedules/351/line"
         >
-          351
-        </span>
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            351
+          </span>
+        </a>
       </div>
     </div>
     <div>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -11,9 +11,12 @@ Array [
       <div
         className="m-schedule-line-diagram__stop-name"
       >
-        Elm St opp Haskell Ave
+        <a
+          href="/stops/5547"
+        >
+          Elm St opp Haskell Ave
+        </a>
       </div>
-      <div />
       <div
         className="m-schedule-line-diagram__connections"
       >
@@ -29,16 +32,10 @@ Array [
         className="m-schedule-line-diagram__features"
       >
         <span
-          className="c-icon__cr-zone"
+          className="c-icon__cr-zone m-schedule-line-diagram__feature-icon"
         >
           Zone 1A
         </span>
-      </div>
-      <div>
-        <div>
-          
-          terminus
-        </div>
       </div>
     </div>
   </div>,
@@ -51,13 +48,18 @@ Array [
       <div
         className="m-schedule-line-diagram__stop-name"
       >
-        North Station
+        <a
+          href="/stops/place-north"
+        >
+          North Station
+        </a>
       </div>
-      <div />
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -68,7 +70,9 @@ Array [
             }
           />
         </span>
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -79,7 +83,9 @@ Array [
             }
           />
         </span>
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -90,29 +96,9 @@ Array [
             }
           />
         </span>
-        <span>
-          <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
-              }
-            }
-          />
-        </span>
-        <span>
-          <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
-              }
-            }
-          />
-        </span>
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -131,7 +117,7 @@ Array [
       >
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-parking-default"
+          className="notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -140,7 +126,7 @@ Array [
         />
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-acessible-default"
+          className="notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -148,16 +134,10 @@ Array [
           }
         />
         <span
-          className="c-icon__cr-zone"
+          className="c-icon__cr-zone m-schedule-line-diagram__feature-icon"
         >
           Zone 1A
         </span>
-      </div>
-      <div>
-        <div>
-          Lowell, 
-          stop
-        </div>
       </div>
     </div>
   </div>,
@@ -185,9 +165,12 @@ Array [
           Service alert or delay
         </span>
          
-        Alewife
+        <a
+          href="/stops/place-alfcl"
+        >
+          Alewife
+        </a>
       </div>
-      <div />
       <div
         className="m-schedule-line-diagram__connections"
       >
@@ -234,7 +217,7 @@ Array [
       >
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-parking-default"
+          className="notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -243,19 +226,13 @@ Array [
         />
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-acessible-default"
+          className="notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
             }
           }
         />
-      </div>
-      <div>
-        <div>
-          
-          terminus
-        </div>
       </div>
     </div>
   </div>,

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`LineDiagram it renders 1`] = `
 Array [
+  <h3>
+    Stops
+  </h3>,
   <div
     className="m-schedule-line-diagram__stop"
   >
@@ -14,29 +17,29 @@ Array [
         <a
           href="/stops/5547"
         >
-          Elm St opp Haskell Ave
+          <h4>
+            Elm St opp Haskell Ave
+          </h4>
         </a>
       </div>
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        <a
+          href="/schedules/110/line"
         >
-          110
-        </span>
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            110
+          </span>
+        </a>
       </div>
     </div>
     <div>
       <div
         className="m-schedule-line-diagram__features"
-      >
-        <span
-          className="c-icon__cr-zone m-schedule-line-diagram__feature-icon"
-        >
-          Zone 1A
-        </span>
-      </div>
+      />
     </div>
   </div>,
   <div
@@ -51,64 +54,82 @@ Array [
         <a
           href="/stops/place-north"
         >
-          North Station
+          <h4>
+            North Station
+          </h4>
         </a>
       </div>
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span
-          className="m-schedule-line-diagram__connection"
+        <a
+          href="/schedules/Orange/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
-        <span
-          className="m-schedule-line-diagram__connection"
+            />
+          </span>
+        </a>
+        <a
+          href="/schedules/Green-C/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
-        <span
-          className="m-schedule-line-diagram__connection"
+            />
+          </span>
+        </a>
+        <a
+          href="/schedules/Green-E/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
-        <span
-          className="m-schedule-line-diagram__connection"
+            />
+          </span>
+        </a>
+        <a
+          href="/schedules/CR-Fitchburg/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
+            />
+          </span>
+        </a>
       </div>
     </div>
     <div>
@@ -168,47 +189,77 @@ Array [
         <a
           href="/stops/place-alfcl"
         >
-          Alewife
+          <h4>
+            Alewife
+          </h4>
         </a>
       </div>
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        <a
+          href="/schedules/62/line"
         >
-          62
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            62
+          </span>
+        </a>
+        <a
+          href="/schedules/67/line"
         >
-          67
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            67
+          </span>
+        </a>
+        <a
+          href="/schedules/76/line"
         >
-          76
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            76
+          </span>
+        </a>
+        <a
+          href="/schedules/79/line"
         >
-          79
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            79
+          </span>
+        </a>
+        <a
+          href="/schedules/84/line"
         >
-          84
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            84
+          </span>
+        </a>
+        <a
+          href="/schedules/350/line"
         >
-          350
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            350
+          </span>
+        </a>
+        <a
+          href="/schedules/351/line"
         >
-          351
-        </span>
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            351
+          </span>
+        </a>
       </div>
     </div>
     <div>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -11,9 +11,12 @@ Array [
       <div
         className="m-schedule-line-diagram__stop-name"
       >
-        Elm St opp Haskell Ave
+        <a
+          href="/stops/5547"
+        >
+          Elm St opp Haskell Ave
+        </a>
       </div>
-      <div />
       <div
         className="m-schedule-line-diagram__connections"
       >
@@ -29,16 +32,10 @@ Array [
         className="m-schedule-line-diagram__features"
       >
         <span
-          className="c-icon__cr-zone"
+          className="c-icon__cr-zone m-schedule-line-diagram__feature-icon"
         >
           Zone 1A
         </span>
-      </div>
-      <div>
-        <div>
-          
-          terminus
-        </div>
       </div>
     </div>
   </div>,
@@ -51,13 +48,18 @@ Array [
       <div
         className="m-schedule-line-diagram__stop-name"
       >
-        North Station
+        <a
+          href="/stops/place-north"
+        >
+          North Station
+        </a>
       </div>
-      <div />
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -68,7 +70,9 @@ Array [
             }
           />
         </span>
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -79,7 +83,9 @@ Array [
             }
           />
         </span>
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -90,29 +96,9 @@ Array [
             }
           />
         </span>
-        <span>
-          <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
-              }
-            }
-          />
-        </span>
-        <span>
-          <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
-              }
-            }
-          />
-        </span>
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -131,7 +117,7 @@ Array [
       >
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-parking-default"
+          className="notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -140,7 +126,7 @@ Array [
         />
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-acessible-default"
+          className="notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -148,16 +134,10 @@ Array [
           }
         />
         <span
-          className="c-icon__cr-zone"
+          className="c-icon__cr-zone m-schedule-line-diagram__feature-icon"
         >
           Zone 1A
         </span>
-      </div>
-      <div>
-        <div>
-          Lowell, 
-          stop
-        </div>
       </div>
     </div>
   </div>,
@@ -185,9 +165,12 @@ Array [
           Service alert or delay
         </span>
          
-        Alewife
+        <a
+          href="/stops/place-alfcl"
+        >
+          Alewife
+        </a>
       </div>
-      <div />
       <div
         className="m-schedule-line-diagram__connections"
       >
@@ -234,7 +217,7 @@ Array [
       >
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-parking-default"
+          className="notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -243,19 +226,13 @@ Array [
         />
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-acessible-default"
+          className="notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
             }
           }
         />
-      </div>
-      <div>
-        <div>
-          
-          terminus
-        </div>
       </div>
     </div>
   </div>,

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/SchedulePageTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/SchedulePageTest.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`LineDiagram it renders 1`] = `
 Array [
+  <h3>
+    Stops
+  </h3>,
   <div
     className="m-schedule-line-diagram__stop"
   >
@@ -14,29 +17,29 @@ Array [
         <a
           href="/stops/5547"
         >
-          Elm St opp Haskell Ave
+          <h4>
+            Elm St opp Haskell Ave
+          </h4>
         </a>
       </div>
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        <a
+          href="/schedules/110/line"
         >
-          110
-        </span>
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            110
+          </span>
+        </a>
       </div>
     </div>
     <div>
       <div
         className="m-schedule-line-diagram__features"
-      >
-        <span
-          className="c-icon__cr-zone m-schedule-line-diagram__feature-icon"
-        >
-          Zone 1A
-        </span>
-      </div>
+      />
     </div>
   </div>,
   <div
@@ -51,64 +54,82 @@ Array [
         <a
           href="/stops/place-north"
         >
-          North Station
+          <h4>
+            North Station
+          </h4>
         </a>
       </div>
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span
-          className="m-schedule-line-diagram__connection"
+        <a
+          href="/schedules/Orange/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
-        <span
-          className="m-schedule-line-diagram__connection"
+            />
+          </span>
+        </a>
+        <a
+          href="/schedules/Green-C/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
-        <span
-          className="m-schedule-line-diagram__connection"
+            />
+          </span>
+        </a>
+        <a
+          href="/schedules/Green-E/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
-        <span
-          className="m-schedule-line-diagram__connection"
+            />
+          </span>
+        </a>
+        <a
+          href="/schedules/CR-Fitchburg/line"
         >
           <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+            className="m-schedule-line-diagram__connection"
+          >
+            <span
+              aria-hidden="false"
+              className="notranslate c-svg__icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
-        </span>
+            />
+          </span>
+        </a>
       </div>
     </div>
     <div>
@@ -168,47 +189,77 @@ Array [
         <a
           href="/stops/place-alfcl"
         >
-          Alewife
+          <h4>
+            Alewife
+          </h4>
         </a>
       </div>
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+        <a
+          href="/schedules/62/line"
         >
-          62
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            62
+          </span>
+        </a>
+        <a
+          href="/schedules/67/line"
         >
-          67
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            67
+          </span>
+        </a>
+        <a
+          href="/schedules/76/line"
         >
-          76
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            76
+          </span>
+        </a>
+        <a
+          href="/schedules/79/line"
         >
-          79
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            79
+          </span>
+        </a>
+        <a
+          href="/schedules/84/line"
         >
-          84
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            84
+          </span>
+        </a>
+        <a
+          href="/schedules/350/line"
         >
-          350
-        </span>
-        <span
-          className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            350
+          </span>
+        </a>
+        <a
+          href="/schedules/351/line"
         >
-          351
-        </span>
+          <span
+            className="c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus"
+          >
+            351
+          </span>
+        </a>
       </div>
     </div>
     <div>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/SchedulePageTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/SchedulePageTest.tsx.snap
@@ -11,9 +11,12 @@ Array [
       <div
         className="m-schedule-line-diagram__stop-name"
       >
-        Elm St opp Haskell Ave
+        <a
+          href="/stops/5547"
+        >
+          Elm St opp Haskell Ave
+        </a>
       </div>
-      <div />
       <div
         className="m-schedule-line-diagram__connections"
       >
@@ -29,16 +32,10 @@ Array [
         className="m-schedule-line-diagram__features"
       >
         <span
-          className="c-icon__cr-zone"
+          className="c-icon__cr-zone m-schedule-line-diagram__feature-icon"
         >
           Zone 1A
         </span>
-      </div>
-      <div>
-        <div>
-          
-          terminus
-        </div>
       </div>
     </div>
   </div>,
@@ -51,13 +48,18 @@ Array [
       <div
         className="m-schedule-line-diagram__stop-name"
       >
-        North Station
+        <a
+          href="/stops/place-north"
+        >
+          North Station
+        </a>
       </div>
-      <div />
       <div
         className="m-schedule-line-diagram__connections"
       >
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -68,7 +70,9 @@ Array [
             }
           />
         </span>
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -79,7 +83,9 @@ Array [
             }
           />
         </span>
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -90,29 +96,9 @@ Array [
             }
           />
         </span>
-        <span>
-          <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
-              }
-            }
-          />
-        </span>
-        <span>
-          <span
-            aria-hidden="false"
-            className="notranslate c-svg__icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
-              }
-            }
-          />
-        </span>
-        <span>
+        <span
+          className="m-schedule-line-diagram__connection"
+        >
           <span
             aria-hidden="false"
             className="notranslate c-svg__icon"
@@ -131,7 +117,7 @@ Array [
       >
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-parking-default"
+          className="notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -140,7 +126,7 @@ Array [
         />
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-acessible-default"
+          className="notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -148,16 +134,10 @@ Array [
           }
         />
         <span
-          className="c-icon__cr-zone"
+          className="c-icon__cr-zone m-schedule-line-diagram__feature-icon"
         >
           Zone 1A
         </span>
-      </div>
-      <div>
-        <div>
-          Lowell, 
-          stop
-        </div>
       </div>
     </div>
   </div>,
@@ -185,9 +165,12 @@ Array [
           Service alert or delay
         </span>
          
-        Alewife
+        <a
+          href="/stops/place-alfcl"
+        >
+          Alewife
+        </a>
       </div>
-      <div />
       <div
         className="m-schedule-line-diagram__connections"
       >
@@ -234,7 +217,7 @@ Array [
       >
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-parking-default"
+          className="notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -243,19 +226,13 @@ Array [
         />
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon-acessible-default"
+          className="notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
             }
           }
         />
-      </div>
-      <div>
-        <div>
-          
-          terminus
-        </div>
       </div>
     </div>
   </div>,

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -60,21 +60,25 @@ const LineDiagram = ({
             <div className="m-schedule-line-diagram__connections">
               {filteredConnections(routeStop.connections).map((route: Route) =>
                 route.type === 3 ? (
-                  <span
-                    key={route.id}
-                    className={`c-icon__bus-pill m-schedule-line-diagram__connection ${busBackgroundClass(
-                      route
-                    )}`}
-                  >
-                    {route.name}
-                  </span>
+                  <a href={`/schedules/${route.id}/line`}>
+                    <span
+                      key={route.id}
+                      className={`c-icon__bus-pill m-schedule-line-diagram__connection ${busBackgroundClass(
+                        route
+                      )}`}
+                    >
+                      {route.name}
+                    </span>
+                  </a>
                 ) : (
-                  <span
-                    key={route.id}
-                    className="m-schedule-line-diagram__connection"
-                  >
-                    {modeIcon(route.id)}
-                  </span>
+                  <a href={`/schedules/${route.id}/line`}>
+                    <span
+                      key={route.id}
+                      className="m-schedule-line-diagram__connection"
+                    >
+                      {modeIcon(route.id)}
+                    </span>
+                  </a>
                 )
               )}
             </div>

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -50,13 +50,12 @@ const LineDiagram = ({
 }: Props): ReactElement<HTMLElement> | null => {
   const routeType = lineDiagram[0].route_stop.route!.type;
 
-  return(
+  return (
     <>
       <h3>
-        {routeType === 0 || routeType === 1 || routeType === 2 ?
-          "Stations" :
-          "Stops"
-        }
+        {routeType === 0 || routeType === 1 || routeType === 2
+          ? "Stations"
+          : "Stops"}
       </h3>
       {lineDiagram.map(
         ({ route_stop: routeStop, alerts: stopAlerts }: LineDiagramStop) => (
@@ -64,31 +63,34 @@ const LineDiagram = ({
             <div className="m-schedule-line-diagram__card-left">
               <div className="m-schedule-line-diagram__stop-name">
                 {maybeAlert(stopAlerts)}
-                <a href={`/stops/${routeStop.id}`}><h4>{routeStop.name}</h4></a>
+                <a href={`/stops/${routeStop.id}`}>
+                  <h4>{routeStop.name}</h4>
+                </a>
               </div>
               <div className="m-schedule-line-diagram__connections">
-                {filteredConnections(routeStop.connections).map((route: Route) =>
-                  route.type === 3 ? (
-                    <a href={`/schedules/${route.id}/line`}>
-                      <span
-                        key={route.id}
-                        className={`c-icon__bus-pill--small m-schedule-line-diagram__connection ${busBackgroundClass(
-                          route
-                        )}`}
-                      >
-                        {route.name}
-                      </span>
-                    </a>
-                  ) : (
-                    <a href={`/schedules/${route.id}/line`}>
-                      <span
-                        key={route.id}
-                        className="m-schedule-line-diagram__connection"
-                      >
-                        {modeIcon(route.id)}
-                      </span>
-                    </a>
-                  )
+                {filteredConnections(routeStop.connections).map(
+                  (route: Route) =>
+                    route.type === 3 ? (
+                      <a href={`/schedules/${route.id}/line`}>
+                        <span
+                          key={route.id}
+                          className={`c-icon__bus-pill--small m-schedule-line-diagram__connection ${busBackgroundClass(
+                            route
+                          )}`}
+                        >
+                          {route.name}
+                        </span>
+                      </a>
+                    ) : (
+                      <a href={`/schedules/${route.id}/line`}>
+                        <span
+                          key={route.id}
+                          className="m-schedule-line-diagram__connection"
+                        >
+                          {modeIcon(route.id)}
+                        </span>
+                      </a>
+                    )
                 )}
               </div>
             </div>
@@ -115,7 +117,7 @@ const LineDiagram = ({
         )
       )}
     </>
-  )
-}
+  );
+};
 
 export default LineDiagram;

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -43,9 +43,6 @@ const LineDiagram = ({
               {maybeAlert(stopAlerts)}
               {routeStop.name}
             </div>
-            <div>
-              {maybeTerminus(stopData) && maybeTerminus(stopData)!.branch}
-            </div>
             <div className="m-schedule-line-diagram__connections">
               {routeStop.connections.map((route: Route) =>
                 route.type === 3 && !route.name.startsWith("SL") ? (
@@ -74,16 +71,6 @@ const LineDiagram = ({
                   routeStop.zone
                 }`}</span>
               )}
-            </div>
-            <div>
-              {/* eslint-disable react/no-array-index-key */
-              stopData.map((stop: StopData, idx: number) => (
-                <div key={idx}>
-                  {stop.branch ? `${stop.branch}, ` : ""}
-                  {stop.type}
-                </div>
-              ))}
-              {/* eslint-enable react/no-array-index-key */}
             </div>
           </div>
         </div>

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -47,65 +47,75 @@ const busBackgroundClass = (connection: Route): string =>
 
 const LineDiagram = ({
   lineDiagram
-}: Props): ReactElement<HTMLElement> | null => (
-  <>
-    {lineDiagram.map(
-      ({ route_stop: routeStop, alerts: stopAlerts }: LineDiagramStop) => (
-        <div key={routeStop.id} className="m-schedule-line-diagram__stop">
-          <div className="m-schedule-line-diagram__card-left">
-            <div className="m-schedule-line-diagram__stop-name">
-              {maybeAlert(stopAlerts)}
-              <a href={`/stops/${routeStop.id}`}>{routeStop.name}</a>
+}: Props): ReactElement<HTMLElement> | null => {
+  const routeType = lineDiagram[0].route_stop.route!.type;
+
+  return(
+    <>
+      <h3>
+        {routeType === 0 || routeType === 1 || routeType === 2 ?
+          "Stations" :
+          "Stops"
+        }
+      </h3>
+      {lineDiagram.map(
+        ({ route_stop: routeStop, alerts: stopAlerts }: LineDiagramStop) => (
+          <div key={routeStop.id} className="m-schedule-line-diagram__stop">
+            <div className="m-schedule-line-diagram__card-left">
+              <div className="m-schedule-line-diagram__stop-name">
+                {maybeAlert(stopAlerts)}
+                <a href={`/stops/${routeStop.id}`}><h4>{routeStop.name}</h4></a>
+              </div>
+              <div className="m-schedule-line-diagram__connections">
+                {filteredConnections(routeStop.connections).map((route: Route) =>
+                  route.type === 3 ? (
+                    <a href={`/schedules/${route.id}/line`}>
+                      <span
+                        key={route.id}
+                        className={`c-icon__bus-pill m-schedule-line-diagram__connection ${busBackgroundClass(
+                          route
+                        )}`}
+                      >
+                        {route.name}
+                      </span>
+                    </a>
+                  ) : (
+                    <a href={`/schedules/${route.id}/line`}>
+                      <span
+                        key={route.id}
+                        className="m-schedule-line-diagram__connection"
+                      >
+                        {modeIcon(route.id)}
+                      </span>
+                    </a>
+                  )
+                )}
+              </div>
             </div>
-            <div className="m-schedule-line-diagram__connections">
-              {filteredConnections(routeStop.connections).map((route: Route) =>
-                route.type === 3 ? (
-                  <a href={`/schedules/${route.id}/line`}>
-                    <span
-                      key={route.id}
-                      className={`c-icon__bus-pill m-schedule-line-diagram__connection ${busBackgroundClass(
-                        route
-                      )}`}
-                    >
-                      {route.name}
-                    </span>
-                  </a>
-                ) : (
-                  <a href={`/schedules/${route.id}/line`}>
-                    <span
-                      key={route.id}
-                      className="m-schedule-line-diagram__connection"
-                    >
-                      {modeIcon(route.id)}
-                    </span>
-                  </a>
-                )
-              )}
+            <div>
+              <div className="m-schedule-line-diagram__features">
+                {routeStop.stop_features.includes("parking_lot")
+                  ? parkingIcon(
+                      "c-svg__icon-parking-default m-schedule-line-diagram__feature-icon"
+                    )
+                  : null}
+                {routeStop.stop_features.includes("access")
+                  ? accessibleIcon(
+                      "c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
+                    )
+                  : null}
+                {routeStop.route!.type === 2 && routeStop.zone && (
+                  <span className="c-icon__cr-zone m-schedule-line-diagram__feature-icon">{`Zone ${
+                    routeStop.zone
+                  }`}</span>
+                )}
+              </div>
             </div>
           </div>
-          <div>
-            <div className="m-schedule-line-diagram__features">
-              {routeStop.stop_features.includes("parking_lot")
-                ? parkingIcon(
-                    "c-svg__icon-parking-default m-schedule-line-diagram__feature-icon"
-                  )
-                : null}
-              {routeStop.stop_features.includes("access")
-                ? accessibleIcon(
-                    "c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
-                  )
-                : null}
-              {routeStop.route!.type === 2 && routeStop.zone && (
-                <span className="c-icon__cr-zone m-schedule-line-diagram__feature-icon">{`Zone ${
-                  routeStop.zone
-                }`}</span>
-              )}
-            </div>
-          </div>
-        </div>
-      )
-    )}
-  </>
-);
+        )
+      )}
+    </>
+  )
+}
 
 export default LineDiagram;

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -42,6 +42,10 @@ const maybeAlert = (alerts: Alert[]): ReactElement<HTMLElement> | null => {
 const maybeTerminus = (stopData: StopData[]): StopData | undefined =>
   stopData.find((stop: StopData) => stop.type === "terminus");
 
+const busBackgroundClass = (connection: Route): string => (
+  connection.name.startsWith("SL") ? "u-bg--silver-line" : "u-bg--bus"
+);
+
 const LineDiagram = ({
   lineDiagram
 }: Props): ReactElement<HTMLElement> | null => (
@@ -60,10 +64,10 @@ const LineDiagram = ({
             </div>
             <div className="m-schedule-line-diagram__connections">
               {filteredConnections(routeStop.connections).map((route: Route) =>
-                route.type === 3 && !route.name.startsWith("SL") ? (
+                route.type === 3 ? (
                   <span
                     key={route.id}
-                    className="c-icon__bus-pill m-schedule-line-diagram__connection u-bg--bus"
+                    className={"c-icon__bus-pill m-schedule-line-diagram__connection " + busBackgroundClass(route)}
                   >
                     {route.name}
                   </span>

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -12,20 +12,23 @@ interface Props {
   lineDiagram: LineDiagramStop[];
 }
 
-const filteredConnections = (connections: RouteStopRoute[]): RouteStopRoute[] => {
-  const firstCRIndex = connections.findIndex((connection) =>
-    connection.type == 2
+const filteredConnections = (
+  connections: RouteStopRoute[]
+): RouteStopRoute[] => {
+  const firstCRIndex = connections.findIndex(
+    connection => connection.type == 2
   );
-  const firstFerryIndex = connections.findIndex((connection) =>
-    connection.type == 4
+  const firstFerryIndex = connections.findIndex(
+    connection => connection.type == 4
   );
 
-  return connections.filter((connection, index) => (
-    (connection.type != 2 && connection.type != 4) ||
+  return connections.filter(
+    (connection, index) =>
+      (connection.type != 2 && connection.type != 4) ||
       (connection.type == 2 && index == firstCRIndex) ||
       (connection.type == 4 && index == firstFerryIndex)
-  ));
-}
+  );
+};
 
 const maybeAlert = (alerts: Alert[]): ReactElement<HTMLElement> | null => {
   const highPriorityAlerts = alerts.filter(alert => alert.priority === "high");
@@ -42,9 +45,8 @@ const maybeAlert = (alerts: Alert[]): ReactElement<HTMLElement> | null => {
 const maybeTerminus = (stopData: StopData[]): StopData | undefined =>
   stopData.find((stop: StopData) => stop.type === "terminus");
 
-const busBackgroundClass = (connection: Route): string => (
-  connection.name.startsWith("SL") ? "u-bg--silver-line" : "u-bg--bus"
-);
+const busBackgroundClass = (connection: Route): string =>
+  connection.name.startsWith("SL") ? "u-bg--silver-line" : "u-bg--bus";
 
 const LineDiagram = ({
   lineDiagram
@@ -67,12 +69,20 @@ const LineDiagram = ({
                 route.type === 3 ? (
                   <span
                     key={route.id}
-                    className={"c-icon__bus-pill m-schedule-line-diagram__connection " + busBackgroundClass(route)}
+                    className={
+                      "c-icon__bus-pill m-schedule-line-diagram__connection " +
+                      busBackgroundClass(route)
+                    }
                   >
                     {route.name}
                   </span>
                 ) : (
-                  <span key={route.id} className="m-schedule-line-diagram__connection">{modeIcon(route.id)}</span>
+                  <span
+                    key={route.id}
+                    className="m-schedule-line-diagram__connection"
+                  >
+                    {modeIcon(route.id)}
+                  </span>
                 )
               )}
             </div>
@@ -80,10 +90,14 @@ const LineDiagram = ({
           <div>
             <div className="m-schedule-line-diagram__features">
               {routeStop.stop_features.includes("parking_lot")
-                ? parkingIcon("c-svg__icon-parking-default m-schedule-line-diagram__feature-icon")
+                ? parkingIcon(
+                    "c-svg__icon-parking-default m-schedule-line-diagram__feature-icon"
+                  )
                 : null}
               {routeStop.stop_features.includes("access")
-                ? accessibleIcon("c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon")
+                ? accessibleIcon(
+                    "c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
+                  )
                 : null}
               {routeStop.zone && (
                 <span className="c-icon__cr-zone m-schedule-line-diagram__feature-icon">{`Zone ${

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -91,7 +91,7 @@ const LineDiagram = ({
                     "c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
                   )
                 : null}
-              {routeStop.zone && (
+              {routeStop.route!.type === 2 && routeStop.zone && (
                 <span className="c-icon__cr-zone m-schedule-line-diagram__feature-icon">{`Zone ${
                   routeStop.zone
                 }`}</span>

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { LineDiagramStop, RouteStopRoute, StopData } from "./__schedule";
+import { LineDiagramStop, RouteStopRoute } from "./__schedule";
 import {
   alertIcon,
   modeIcon,
@@ -16,17 +16,17 @@ const filteredConnections = (
   connections: RouteStopRoute[]
 ): RouteStopRoute[] => {
   const firstCRIndex = connections.findIndex(
-    connection => connection.type == 2
+    connection => connection.type === 2
   );
   const firstFerryIndex = connections.findIndex(
-    connection => connection.type == 4
+    connection => connection.type === 4
   );
 
   return connections.filter(
     (connection, index) =>
-      (connection.type != 2 && connection.type != 4) ||
-      (connection.type == 2 && index == firstCRIndex) ||
-      (connection.type == 4 && index == firstFerryIndex)
+      (connection.type !== 2 && connection.type !== 4) ||
+      (connection.type === 2 && index === firstCRIndex) ||
+      (connection.type === 4 && index === firstFerryIndex)
   );
 };
 
@@ -42,9 +42,6 @@ const maybeAlert = (alerts: Alert[]): ReactElement<HTMLElement> | null => {
   );
 };
 
-const maybeTerminus = (stopData: StopData[]): StopData | undefined =>
-  stopData.find((stop: StopData) => stop.type === "terminus");
-
 const busBackgroundClass = (connection: Route): string =>
   connection.name.startsWith("SL") ? "u-bg--silver-line" : "u-bg--bus";
 
@@ -53,26 +50,21 @@ const LineDiagram = ({
 }: Props): ReactElement<HTMLElement> | null => (
   <>
     {lineDiagram.map(
-      ({
-        route_stop: routeStop,
-        stop_data: stopData,
-        alerts: stopAlerts
-      }: LineDiagramStop) => (
+      ({ route_stop: routeStop, alerts: stopAlerts }: LineDiagramStop) => (
         <div key={routeStop.id} className="m-schedule-line-diagram__stop">
           <div className="m-schedule-line-diagram__card-left">
             <div className="m-schedule-line-diagram__stop-name">
               {maybeAlert(stopAlerts)}
-              <a href={"/stops/" + routeStop.id}>{routeStop.name}</a>
+              <a href={`/stops/${routeStop.id}`}>{routeStop.name}</a>
             </div>
             <div className="m-schedule-line-diagram__connections">
               {filteredConnections(routeStop.connections).map((route: Route) =>
                 route.type === 3 ? (
                   <span
                     key={route.id}
-                    className={
-                      "c-icon__bus-pill m-schedule-line-diagram__connection " +
-                      busBackgroundClass(route)
-                    }
+                    className={`c-icon__bus-pill m-schedule-line-diagram__connection ${busBackgroundClass(
+                      route
+                    )}`}
                   >
                     {route.name}
                   </span>

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -69,9 +69,9 @@ const LineDiagram = ({
               </div>
               <div className="m-schedule-line-diagram__connections">
                 {filteredConnections(routeStop.connections).map(
-                  (route: Route) =>
-                    route.type === 3 ? (
-                      <a href={`/schedules/${route.id}/line`}>
+                  (route: Route) => (
+                    <a href={`/schedules/${route.id}/line`} key={route.id}>
+                      {route.type === 3 ? (
                         <span
                           key={route.id}
                           className={`c-icon__bus-pill--small m-schedule-line-diagram__connection ${busBackgroundClass(
@@ -80,17 +80,16 @@ const LineDiagram = ({
                         >
                           {route.name}
                         </span>
-                      </a>
-                    ) : (
-                      <a href={`/schedules/${route.id}/line`}>
+                      ) : (
                         <span
                           key={route.id}
                           className="m-schedule-line-diagram__connection"
                         >
                           {modeIcon(route.id)}
                         </span>
-                      </a>
-                    )
+                      )}
+                    </a>
+                  )
                 )}
               </div>
             </div>

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -41,7 +41,7 @@ const LineDiagram = ({
           <div className="m-schedule-line-diagram__card-left">
             <div className="m-schedule-line-diagram__stop-name">
               {maybeAlert(stopAlerts)}
-              {routeStop.name}
+              <a href={"/stops/" + routeStop.id}>{routeStop.name}</a>
             </div>
             <div className="m-schedule-line-diagram__connections">
               {routeStop.connections.map((route: Route) =>

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -72,7 +72,7 @@ const LineDiagram = ({
                     <a href={`/schedules/${route.id}/line`}>
                       <span
                         key={route.id}
-                        className={`c-icon__bus-pill m-schedule-line-diagram__connection ${busBackgroundClass(
+                        className={`c-icon__bus-pill--small m-schedule-line-diagram__connection ${busBackgroundClass(
                           route
                         )}`}
                       >

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -53,7 +53,7 @@ const LineDiagram = ({
                     {route.name}
                   </span>
                 ) : (
-                  <span key={route.id}>{modeIcon(route.id)}</span>
+                  <span key={route.id} className="m-schedule-line-diagram__connection">{modeIcon(route.id)}</span>
                 )
               )}
             </div>

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { LineDiagramStop, StopData } from "./__schedule";
+import { LineDiagramStop, RouteStopRoute, StopData } from "./__schedule";
 import {
   alertIcon,
   modeIcon,
@@ -10,6 +10,21 @@ import { Alert, Route } from "../../__v3api";
 
 interface Props {
   lineDiagram: LineDiagramStop[];
+}
+
+const filteredConnections = (connections: RouteStopRoute[]): RouteStopRoute[] => {
+  const firstCRIndex = connections.findIndex((connection) =>
+    connection.type == 2
+  );
+  const firstFerryIndex = connections.findIndex((connection) =>
+    connection.type == 4
+  );
+
+  return connections.filter((connection, index) => (
+    (connection.type != 2 && connection.type != 4) ||
+      (connection.type == 2 && index == firstCRIndex) ||
+      (connection.type == 4 && index == firstFerryIndex)
+  ));
 }
 
 const maybeAlert = (alerts: Alert[]): ReactElement<HTMLElement> | null => {
@@ -44,7 +59,7 @@ const LineDiagram = ({
               <a href={"/stops/" + routeStop.id}>{routeStop.name}</a>
             </div>
             <div className="m-schedule-line-diagram__connections">
-              {routeStop.connections.map((route: Route) =>
+              {filteredConnections(routeStop.connections).map((route: Route) =>
                 route.type === 3 && !route.name.startsWith("SL") ? (
                   <span
                     key={route.id}

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -61,13 +61,13 @@ const LineDiagram = ({
           <div>
             <div className="m-schedule-line-diagram__features">
               {routeStop.stop_features.includes("parking_lot")
-                ? parkingIcon("c-svg__icon-parking-default")
+                ? parkingIcon("c-svg__icon-parking-default m-schedule-line-diagram__feature-icon")
                 : null}
               {routeStop.stop_features.includes("access")
-                ? accessibleIcon("c-svg__icon-acessible-default")
+                ? accessibleIcon("c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon")
                 : null}
               {routeStop.zone && (
-                <span className="c-icon__cr-zone">{`Zone ${
+                <span className="c-icon__cr-zone m-schedule-line-diagram__feature-icon">{`Zone ${
                   routeStop.zone
                 }`}</span>
               )}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱Schedules | Line Diagram - Stop Component Style](https://app.asana.com/0/555089885850811/1141229989083699)

Added spacing between feature icons and connection icons. Also fixed the following presentational bugs:

* Multiple CR/ferry icons were appearing at stops, whereas only one is desired no matter how many lines connect there.
* Silver Line connections now uses pills rather than icons.
* If a stop had both bus and non-bus connections, the bus connections would get stretched vertically. Fixed.
<br>
Assigned to: @amaisano 
