### PR TITLE
Update docs based on onboarding experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 [![Build Status](https://semaphoreci.com/api/v1/mbta/dotcom/branches/master/badge.svg)](https://semaphoreci.com/mbta/dotcom)
+
 # Dotcom
 
 The new face of https://www.mbta.com/
-  - [Getting Started](#getting-started)
-  - [Running the Server](#running-the-server)
-  - [Environment Variables](#environment-variables)
-    - [`V3_API_KEY`](#v3apikey)
-    - [`V3_URL`](#v3url)
-    - [`GOOGLE_API_KEY`](#googleapikey)
-    - [`DRUPAL_ROOT`](#drupalroot)
-    - [`ALGOLIA_APP_ID`, `ALGOLIA_SEARCH_KEY`, and `ALGOLIA_ADMIN_KEY`](#algoliaappid-algoliasearchkey-and-algoliaadminkey)
+
+- [Getting Started](#getting-started)
+- [Running the Server](#running-the-server)
+- [Environment Variables](#environment-variables)
+    - [`V3_API_KEY`](#v3_api_key)
+    - [`V3_URL`](#v3_url)
+    - [`GOOGLE_API_KEY`](#google_api_key)
+    - [`DRUPAL_ROOT`](#drupal_root)
+    - [`ALGOLIA_APP_ID`, `ALGOLIA_SEARCH_KEY`, and `ALGOLIA_ADMIN_KEY`](#algolia_app_id-algolia_search_key-and-algolia_admin_key)
     - [Making the variables available to the app](#making-the-variables-available-to-the-app)
-  - [Additional documentation](#additional-documentation)
+- [Additional documentation](#additional-documentation)
+
 ## Getting Started
 
-1. Request a V3 API key at https://api-v3.mbta.com/. Note that, at any given time, the site may not be compatible with the
-very latest API version. As of this writing, the site is compatible with API version 2019-04-05.
+1. Request a V3 API key at https://dev.api.mbtace.com/, and request an increased
+rate limit for it (someone with access will need to approve this). Note that, at
+any given time, the site may not be compatible with the very latest API version.
 
 1. Install [Homebrew](https://docs.brew.sh/Installation.html):
     ```
@@ -28,7 +32,6 @@ very latest API version. As of this writing, the site is compatible with API ver
 
      ```
      brew install coreutils automake autoconf openssl libyaml readline libxslt libtool unixodbc
-     brew cask install java
      ```
 
    * Add asdf plugins
@@ -48,6 +51,10 @@ very latest API version. As of this writing, the site is compatible with API ver
      ```
 
      If you run into problems, you might have to update the `import-release-team-keyring` script.
+
+   * If running OSX 10.15 Catalina, run `export MACOSX_DEPLOYMENT_TARGET=10.14`.
+     This works around a [known issue](https://github.com/asdf-vm/asdf-erlang/issues/116)
+     with compiling versions of Erlang prior to 22.1.4.
 
    * Run the install:
 
@@ -74,9 +81,10 @@ very latest API version. As of this writing, the site is compatible with API ver
 
 1. Install chromedriver (for Elixir acceptance tests using Wallaby)
     ```
-    brew tap caskroom/cask
     brew cask install chromedriver
     ```
+   Note: `chromedriver` requires Chrome to be installed. If you don't already
+   have it, `brew cask install google-chrome` is an easy way to install it.
 
 1. Install our Elixir dependencies. From the root of this repo:
     ```

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -46,7 +46,6 @@ limited. See below for how to get a Google API Key.
 1. Obtain a Google API key:
     * Go to [Google's API documentation](https://developers.google.com/maps/documentation/javascript/get-api-key)
     * Click on "GET STARTED", create a personal project (e.g. "mbtadotcom").
-        * You have to enter personal billing information for your API key but Google gives you $200 of free credit per month. You can set up budget alerts to email you if you are approaching your free credit limit or set up daily quotas for each API. However, our costs accumulate very slowly in local development so it's not likely that you will approach this limit.
     * Go to [the Google developer credentials page](https://console.developers.google.com/apis/credentials)
     * Use the "Select Project" button at the top of the page to choose your project and then hit "Create Credentials" -> "API Key"
 2. Enable specific APIs:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,16 +1,10 @@
 ## Tests
 
-Run `mix phx.server` to start a server in one window, then open a
-separate window and run `npm test` from the main folder. This will execute
-the following scripts in succession:
-
-* `mix test` — Phoenix tests
+* `mix test` — Elixir tests
 * `npm run test:js` — JS tests
 * `npm run backstop` — Backstop tests (see section below for details)
 
-Note that all tests will run even if one of them fails, and there is no final
-summary at the end, so pay attention to the output while they're running to
-make sure everything passes.
+`npm test` runs all of these in succession.
 
 ### Dialyzer
 
@@ -18,11 +12,6 @@ Dialyzer is a static analysis tool which looks at type information. We use it
 verify our type specifcations and make sure we're calling functions properly.
 
 * `mix dialyzer` — Runs the actual type checks.
-
-Currently, there are some spurious "The variable _ can never match ..."
-errors that can be ignored.
-`npm run dialyzer` will filter out these errors, though there are still a few
-which show up.
 
 ### Pronto
 
@@ -33,11 +22,8 @@ Installing Pronto on Max OS can be challenging because some of its dependencies 
 Follow these instructions to install:
 
 ```
-brew install cmake
-brew install pkg-config
-gem install pronto
-gem install pronto-scss
-gem install pronto-credo
+brew install cmake pkg-config
+gem install pronto pronto-scss pronto-credo
 ```
 
 Run it by calling `pronto run` in the `mbta/dotcom` directory. If there is no output, that means it passed.
@@ -46,7 +32,7 @@ Run it by calling `pronto run` in the `mbta/dotcom` directory. If there is no ou
 
 Our javascript is linted by eslint and formatted by prettier. At this time, only prettier formatting is enforced in CI for javascript. For Typescript, both eslint and prettier are enforced in CI. You can auto-format your javascript and Typescript via `npm run format`, or set it up to autoformat on save in your editor of choice.
 
-If you are using the Prettier plugin for Visual Studio Code, you will want to configure it to use the ignore file  in `apps/site/assets/.prettierignore`. 
+If you are using the Prettier plugin for Visual Studio Code, you will want to configure it to use the ignore file  in `apps/site/assets/.prettierignore`.
 
 ### Backstop Tests
 
@@ -63,12 +49,25 @@ The tests are run against a live application, built in production mode. To make 
 work consistently and do not depend on a specific schedule or realtime vehicle locations, we use
 [WireMock](http://wiremock.org/) to record and playback the V3 API responses.
 
-To run the tests, do the following:
+Prerequisites for running the tests:
 
-* Make sure docker is [installed](https://docs.docker.com/docker-for-mac/install/) and running: we run the tests in docker to ensure we get consistent images across platforms.
-* Run `npm run backstop` which starts up wiremock, a mocked phoenix server, and when those are up, kicks off backstop testing in docker
+* Docker
+  * `brew cask install docker`
+  * Start Docker Desktop from the dock or Applications; this only has to be done
+    once, after which it will auto-start on login by default
+* Wiremock
+  * `brew cask install java --no-quarantine`
+    * This option is currently required on OS X 10.15+ due to Gatekeeper
+      changes. Ref: https://github.com/Homebrew/homebrew-cask/issues/70798
+  * `brew cask install wiremock-standalone`
+* Ensure the [environment variable](ENVIRONMENT.md) `WIREMOCK_PATH` points to
+  the Wiremock JAR file; with brew cask this will be something like
+  `/usr/local/Cellar/wiremock-standalone/<VERSION>/libexec/wiremock-standalone-<VERSION>.jar`
 
-Note: If you are not running on OSX or Windows, you'll need to modify the `STATIC_HOST=host.docker.internal` in the commands.
+Once all the above are in place: `npm run backstop`
+
+Note: If you are not running on OSX or Windows, you'll need to modify the
+`STATIC_HOST=host.docker.internal` in the commands.
 
 ### Other helpful test scripts
 


### PR DESCRIPTION
README changes:

* Specify that an API key should be obtained from `dev.api.mbtace.com` rather than the production site

* Move Java install to the testing docs as it seems this is only needed for Wiremock, which itself is only needed for Backstop

* Add workaround needed for compiling Erlang on OS X 10.15

* Remove manual Caskroom setup — Homebrew does this automatically

* Specify that Chrome must be explicitly installed to use ChromeDriver since it is not auto-installed as a dependency

ENVIRONMENT changes:

* Remove mention of Google billing information since it appears this is not needed (when using an MBTA Google account anyway)

TESTING changes:

* Remove instruction to manually start `phx.server` for testing since all tests pass without doing this (was necessary before?)

* Remove mention of spurious Dialyzer "can never match" errors since these don't appear to be present anymore

* Add explicit Homebrew commands for installing Docker and Wiremock, including `--no-quarantine` flag required for Java on OS X 10.15+
