### PR TITLE
Suggest using `direnv` to manage env vars

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -1,0 +1,18 @@
+# Example environment configuration file: copy to `.envrc` (this is git-ignored)
+# and fill in any additional values you need. Will be automatically loaded and
+# unloaded by `direnv` if installed, or execute manually using `source .envrc`.
+
+# export ALGOLIA_ADMIN_KEY=
+# export ALGOLIA_APP_ID=
+# export ALGOLIA_SEARCH_KEY=
+export DRUPAL_ROOT=https://live-mbta.pantheonsite.io
+# export GOOGLE_API_KEY=
+export OPEN_TRIP_PLANNER_URL=https://dev.otp.mbtace.com
+# export STATIC_HOST=
+# export SUPPORT_TICKET_REPLY_EMAIL=
+# export SUPPORT_TICKET_TO_EMAIL=
+# export V3_API_KEY=
+export V3_URL=https://dev.api.mbtace.com
+# export WIREMOCK_PATH=
+export WIREMOCK_PROXY_URL=https://dev.api.mbtace.com
+export WIREMOCK_TRIP_PLAN_PROXY_URL=https://dev.otp.mbtace.com

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ erl_crash.dump
 .ruby-version
 .vscode
 .elixir_ls
+.envrc
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ very latest API version. As of this writing, the site is compatible with API ver
      asdf plugin-add nodejs
      asdf plugin-add ruby
      ```
-     
      You can verify the plugins were installed with `asdf plugin-list`
 
    * Import the Node.js release team's OpenPGP keys to install 'nodejs' plugin:
@@ -70,7 +69,7 @@ very latest API version. As of this writing, the site is compatible with API ver
       nodejs         <version> (set by ~/dotcom/.tool-versions)
       ruby           <version> (set by ~/dotcom/.tool-versions)
      ```
-     
+
      If you are missing any versions, you should re-run `asdf install`. Related [Github issue about asdf-erlang](https://github.com/asdf-vm/asdf-erlang/issues/57)
 
 1. Install chromedriver (for Elixir acceptance tests using Wallaby)
@@ -104,18 +103,19 @@ very latest API version. As of this writing, the site is compatible with API ver
     npm run webpack:build
     ```
 
-1. Set up the following environment variables (see [Environment Variables](#environment-variables) section)
+1. Set up required environment variables:
+    ```
+    cp .envrc.template .envrc
+    ```
+   Then uncomment the `V3_API_KEY` line and fill it in with the key you obtained
+   in the first step. If you have [direnv] installed, it will automatically load
+   and unload the environment using this file. If not, `source .envrc` will load
+   or update the variables in your shell session manually.
 
-    Required:
-    * `V3_API_KEY`
-    * `V3_URL`
+[direnv]: https://github.com/direnv/direnv
 
-    Suggested, for Google Maps, CMS content, and Algolia search:
-    * `GOOGLE_API_KEY`
-    * `DRUPAL_ROOT`
-    * `ALGOLIA_APP_ID`
-    * `ALGOLIA_ADMIN_KEY`
-    * `ALGOLIA_SEARCH_KEY`
+For details on environment configuration, including optional variables, see
+[ENVIRONMENT.md](docs/ENVIRONMENT.md).
 
 ## Running the Server
 
@@ -123,55 +123,6 @@ Start the server with `mix phx.server`
 
 Then, visit the site at http://localhost:4001/
 
-## Environment Variables
-
-The following variables should be set in your development environment. For additional variables, such as for OpenTripPlanner or Wiremock, see the [additional documentation](docs/ENVIRONMENT.md).
-
-### `V3_API_KEY`
-
-You need to obtain an API key to run the website.
-
-### `V3_URL`
-
-This variable is used to specify which MBTA V3 API server to use.
-
-### `GOOGLE_API_KEY`
-
-This will ensure any part of the site that uses Google's API will not get rate limited. See below for how to get a Google API Key.
-
-1. Obtain a Google API key:
-    * Go to [Google's API documentation](https://developers.google.com/maps/documentation/javascript/get-api-key)
-    * Click on "GET STARTED", create a personal project (e.g. "mbtadotcom"). 
-        * You have to enter personal billing information for your API key but Google gives you $200 of free credit per month. You can set up budget alerts to email you if you are approaching your free credit limit or set up daily quotas for each API. However, our costs accumulate very slowly in local development so it's not likely that you will approach this limit.
-    * Go to [the Google developer credentials page](https://console.developers.google.com/apis/credentials)
-    * Use the "Select Project" button at the top of the page to choose your project and then hit "Create Credentials" -> "API Key"
-2. Enable specific APIs:
-    * Go to the API library for your project (e.g. https://console.developers.google.com/apis/library?project=mbtadotcom)
-    * Using the search box at the top of the page, find "Google Maps Geolocation API"
-    * Click "Enable"
-    * Repeat for
-        * "Places API"
-        * "Maps Javascript API"
-        * "Maps Static API"
-
-### `DRUPAL_ROOT`
-
-This is the url for the CMS. You'll need to set this to view any of the static content on the site.
-
-### `ALGOLIA_APP_ID`, `ALGOLIA_SEARCH_KEY`, and `ALGOLIA_ADMIN_KEY`
-
-These keys are used to interact with the Algolia search api. The values can be found under the `Api Keys` section in Algolia (you'll need to be added as a team member to get access).
-
-`ALGOLIA_APP_ID` is the id of the Algolia account that holds all of our search indexes
-`ALGOLIA_ADMIN_KEY` allows write access and is used by the Algolia app to keep our search indexes updated
-`ALGOLIA_SEARCH_KEY` is a read-only key that is used by the Site app to perform searches from the front-end
-
-### Making the variables available to the app
-
-There are different ways to make sure these variables are in the environment when the application runs:
-
-* Run the server with `env VARIABLE1=value2 VARIABLE2=value2 mix phx.server`. You may want to store them in a file (one per line) and run ```env `cat file_where_you_stored_the_variables` mix phx.server``` instead.
-* Put the line `export VARIABLE=value` somewhere in your `.bash_profile`. Then run the application as normal with `mix phx.server`. Note that this environment variable will be available to anything you run in the terminal now, and if you host your config files publicly on github then you should be careful to not let your API key be publicly visible.
-
 ## Additional documentation
+
 See [docs](docs) for information about [testing](docs/TESTING.md) and other development details.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,4 +1,70 @@
-# Additional Environment Variables
+# Environment Variables
+
+There are many ways to set the environment variables described here:
+
+* The easiest way is to install **[direnv](https://github.com/direnv/direnv)**
+  and copy the `.envrc.template` file in the root of the repo to `.envrc`. Type
+  `direnv allow` and the current contents of the file will be approved, and
+  subsequently loaded and unloaded automatically when you change into and out of
+  the project directory.
+
+* `.envrc` is also a plain shell script, so it can be manually loaded into your
+  shell session by typing `source .envrc`. Note the variables will persist for
+  the rest of the session, even outside the project directory. You can make this
+  happen for all new sessions by adding the line to your `.zshrc` or equivalent,
+  and using an absolute path to the file.
+
+* Run commands prefixed with `env VARIABLE1=value2 VARIABLE2=value2 ...`. This
+  only affects that one command, so can also be used to override values that
+  have been exported using one of the above approaches.
+
+
+## Required
+
+### `V3_URL`
+
+The URL of the MBTA V3 API server, e.g. `https://dev.api.mbtace.com`.
+
+### `V3_API_KEY`
+
+The key to use with the MBTA API (see `README`). This is a practical requirement
+for development since requests without an API key have a very low rate limit.
+
+
+## Optional
+
+### `DRUPAL_ROOT`
+
+The URL for our CMS. You'll need to set this to view any of the static content
+on the site.
+
+### `GOOGLE_API_KEY`
+
+This will ensure any part of the site that uses Google's API will not get rate
+limited. See below for how to get a Google API Key.
+
+1. Obtain a Google API key:
+    * Go to [Google's API documentation](https://developers.google.com/maps/documentation/javascript/get-api-key)
+    * Click on "GET STARTED", create a personal project (e.g. "mbtadotcom").
+        * You have to enter personal billing information for your API key but Google gives you $200 of free credit per month. You can set up budget alerts to email you if you are approaching your free credit limit or set up daily quotas for each API. However, our costs accumulate very slowly in local development so it's not likely that you will approach this limit.
+    * Go to [the Google developer credentials page](https://console.developers.google.com/apis/credentials)
+    * Use the "Select Project" button at the top of the page to choose your project and then hit "Create Credentials" -> "API Key"
+2. Enable specific APIs:
+    * Go to the API library for your project (e.g. https://console.developers.google.com/apis/library?project=mbtadotcom)
+    * Using the search box at the top of the page, find "Google Maps Geolocation API"
+    * Click "Enable"
+    * Repeat for
+        * "Places API"
+        * "Maps Javascript API"
+        * "Maps Static API"
+
+### `ALGOLIA_APP_ID`, `ALGOLIA_SEARCH_KEY`, and `ALGOLIA_ADMIN_KEY`
+
+These keys are used to interact with the Algolia search api. The values can be found under the `Api Keys` section in Algolia (you'll need to be added as a team member to get access).
+
+`ALGOLIA_APP_ID` is the id of the Algolia account that holds all of our search indexes
+`ALGOLIA_ADMIN_KEY` allows write access and is used by the Algolia app to keep our search indexes updated
+`ALGOLIA_SEARCH_KEY` is a read-only key that is used by the Site app to perform searches from the front-end
 
 ### `OPEN_TRIP_PLANNER_URL`
 


### PR DESCRIPTION
This is a quick suggestion based on my experience getting the app set up. The example `.envrc` works with both [`direnv`](https://github.com/direnv/direnv) and `source` out of the box, and serves as a place to document any default values for variables that aren't secrets, such as `V3_URL`.

This also consolidates all info on env vars into the existing `ENVIRONMENT` doc, rather than some of it being in the README. Admittedly this is a separate suggestion and could be split out.