### PR TITLE
Fix misaligned bus icon on Projects page

### DIFF
--- a/apps/site/assets/ts/projects/__tests__/__snapshots__/FeaturedProjectsListTest.tsx.snap
+++ b/apps/site/assets/ts/projects/__tests__/__snapshots__/FeaturedProjectsListTest.tsx.snap
@@ -41,7 +41,7 @@ exports[`renders 1`] = `
           >
             <span
               aria-hidden="false"
-              className="notranslate c-svg__icon c-featured-project__route-icon"
+              className="notranslate c-svg__icon m-featured-project__route-icon"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "SVG",

--- a/apps/site/assets/ts/projects/__tests__/__snapshots__/ProjectUpdateListTest.tsx.snap
+++ b/apps/site/assets/ts/projects/__tests__/__snapshots__/ProjectUpdateListTest.tsx.snap
@@ -98,7 +98,7 @@ Array [
       >
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon c-featured-project__route-icon"
+          className="notranslate c-svg__icon m-featured-project__route-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -133,7 +133,7 @@ Array [
       >
         <span
           aria-hidden="false"
-          className="notranslate c-svg__icon c-featured-project__route-icon"
+          className="notranslate c-svg__icon m-featured-project__route-icon"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",

--- a/apps/site/assets/ts/projects/__tests__/__snapshots__/ProjectsPageTest.tsx.snap
+++ b/apps/site/assets/ts/projects/__tests__/__snapshots__/ProjectsPageTest.tsx.snap
@@ -286,7 +286,7 @@ Array [
                 >
                   <span
                     aria-hidden="false"
-                    className="notranslate c-svg__icon c-featured-project__route-icon"
+                    className="notranslate c-svg__icon m-featured-project__route-icon"
                     dangerouslySetInnerHTML={
                       Object {
                         "__html": "SVG",

--- a/apps/site/assets/ts/projects/__tests__/__snapshots__/RoutePillListTest.tsx.snap
+++ b/apps/site/assets/ts/projects/__tests__/__snapshots__/RoutePillListTest.tsx.snap
@@ -7,7 +7,7 @@ exports[`component renders 1`] = `
   <span>
     <span
       aria-hidden="false"
-      className="notranslate c-svg__icon c-featured-project__route-icon"
+      className="notranslate c-svg__icon m-featured-project__route-icon"
       dangerouslySetInnerHTML={
         Object {
           "__html": "SVG",

--- a/apps/site/assets/ts/projects/components/RoutePillList.tsx
+++ b/apps/site/assets/ts/projects/components/RoutePillList.tsx
@@ -54,7 +54,7 @@ const RoutePillList = ({ routes }: Props): ReactElement<HTMLElement> => {
               <RouteIcon
                 key="route-pill-bus"
                 tag="bus"
-                extraClasses="c-featured-project__route-icon"
+                extraClasses="m-featured-project__route-icon"
               />
             );
           case "silver-line":
@@ -62,7 +62,7 @@ const RoutePillList = ({ routes }: Props): ReactElement<HTMLElement> => {
               <span key="route-pill-silver-line">
                 <RouteIcon
                   tag="bus"
-                  extraClasses="c-featured-project__route-icon"
+                  extraClasses="m-featured-project__route-icon"
                 />
                 <RoutePill modeName="silver-line" />
               </span>


### PR DESCRIPTION
**Asana Ticket:** [🐞 Bug | System icons misaligned on Project index](https://app.asana.com/0/477545582537986/1145601078296161/f)

In 0f80d0a a number of classnames that started with `c-` were renamed to start with `m-`, but we missed this one spot.

Fixed appearance:

![Screen Shot 2019-10-31 at 3 46 09 PM](https://user-images.githubusercontent.com/394835/67981796-c7daa600-fbf7-11e9-9451-5f084aa40204.png)

Note that since the bus icon now has the correct margins, it can sometimes wrap onto a second line when it didn't before:

![Screen Shot 2019-10-31 at 3 47 07 PM](https://user-images.githubusercontent.com/394835/67981845-e04ac080-fbf7-11e9-89fd-df3bd64da44f.png)

This seems okay to me but, backing up a bit, it seems odd that _only_ buses are represented by an icon here, where other transit modes are spelled out in text. The rest of the page (including the filter buttons at the top and the project list at the bottom) consistently uses icons for all transit modes. Maybe @ingridpierre can shed light on this decision.