### PR TITLE
Add basic antispam measure to contact form

### DIFF
--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -92,12 +92,13 @@ defmodule SiteWeb.CustomerSupportController do
         [
           &validate_comments/1,
           &validate_service/1,
+          &validate_antispam/1,
           &validate_name/1,
           &validate_email/1,
           &validate_privacy/1
         ]
       else
-        [&validate_comments/1, &validate_service/1]
+        [&validate_comments/1, &validate_service/1, &validate_antispam/1]
       end
 
     Site.Validation.validate(validators, params)
@@ -135,6 +136,10 @@ defmodule SiteWeb.CustomerSupportController do
   @spec validate_privacy(map) :: :ok | String.t()
   defp validate_privacy(%{"privacy" => "on"}), do: :ok
   defp validate_privacy(_), do: "privacy"
+
+  @spec validate_antispam(map) :: :ok | String.t()
+  defp validate_antispam(%{"leave_this_alone" => value}) when byte_size(value) > 0, do: "antispam"
+  defp validate_antispam(_), do: :ok
 
   def send_ticket(params) do
     Feedback.Repo.send_ticket(%Feedback.Message{

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -30,7 +30,7 @@
           <% comments_placeholder = "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number." %>
           <%= textarea f, :comments, id: "comments", class: "support-form-text-input form-control", maxlength: "3000",
                                      rows: "3", placeholder: comments_placeholder, required: "required", value: assigns[:comments] %>
-  
+
           <span></span>
           <small class="form-text">3000 characters maximum</small>
         </div>
@@ -100,6 +100,10 @@
               })
             %>
           </div>
+        </div>
+        <div style="display: none" class="form-group contrast">
+          <label for="leave-this-alone">As a security measure, please leave this field blank.</label>
+          <%= text_input f, :leave_this_alone, id: "leave-this-alone", tabindex: -1, autocomplete: "off" %>
         </div>
         <div class="response-time-disclaimer">
           Responses may take up to 5 business days. If this is an emergency, please <%= link("contact the Transit Police", to: "/transit-police") %>.

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -209,6 +209,14 @@ defmodule SiteWeb.CustomerSupportControllerTest do
              ]
     end
 
+    test "prevents submissions when the anti-spam field is filled", %{conn: conn} do
+      params = valid_request_response_data() |> Map.put("leave_this_alone", "spam!")
+
+      conn = post(conn, customer_support_path(conn, :submit), %{"support" => params})
+
+      assert "antispam" in conn.assigns.errors
+    end
+
     test "logs a warning, returns 429, and shows an error when rate limit reached", %{conn: conn} do
       path = customer_support_path(conn, :submit)
 


### PR DESCRIPTION
**Asana Ticket:** [Feedback Form | Address spam issues](https://app.asana.com/0/477545582537986/1145937042305257/f)

This adds an invisible field to the contact form that must _not_ be filled in for the submission to succeed. The image below has the field un-hidden for illustrative purposes (this is also how a screen reader might "see" it, which is why the label is important).

![Screen Shot 2019-11-05 at 11 57 43 AM](https://user-images.githubusercontent.com/394835/68228497-8d8c5280-ffc3-11e9-9026-ab4d8efef6a0.png)

---

I was unable to get Wallaby testing working for this — I could be missing something, but there seems to be an issue with the library where telling it to fill in a non-visible field just doesn't work, but acts as though it worked. I used this code:

```elixir
@tag :wallaby
test "Catches spam bots that fill every available field", %{session: session} do
  session
  |> visit("/customer-support")
  |> fill_in(css("#comments"), with: "Support Form Integration Test")
  |> click(css("label[for=\"service-Suggestion\"]"))
  |> fill_in(css("#leave-this-alone", visible: false), with: "spam!")
  |> click(@submit_button)
  |> assert_text("We had an issue submitting your feedback")
end
```

This "succeeds" at filling in the field, but fails on the `assert_text`, and inspecting the `conn` reveals that the field has an empty value as though it wasn't filled in.