### PR TITLE
Fix missing retail location vendors

### DIFF
--- a/apps/fares/lib/retail_locations_data.ex
+++ b/apps/fares/lib/retail_locations_data.ex
@@ -53,7 +53,7 @@ defmodule Fares.RetailLocations.Data do
 
   def parse_v3_facility(%JsonApi.Item{} = item) do
     location = %Location{
-      name: item.attributes["name"],
+      name: item.attributes["long_name"],
       address: v3_property(item, "address"),
       latitude: item.attributes["latitude"],
       longitude: item.attributes["longitude"],

--- a/apps/fares/test/retail_locations_data_test.exs
+++ b/apps/fares/test/retail_locations_data_test.exs
@@ -20,6 +20,12 @@ defmodule Fares.RetailLocationsDataTest do
       end
     end
 
+    test "all locations have a non-nil name" do
+      for %Location{name: name} <- Data.get() do
+        assert is_binary(name)
+      end
+    end
+
     test "build_r_tree returns a tree with all location data" do
       tree = Data.build_r_tree()
 
@@ -33,7 +39,7 @@ defmodule Fares.RetailLocationsDataTest do
     test "parses a location" do
       item = %JsonApi.Item{
         attributes: %{
-          "name" => "facility_name",
+          "short_name" => "facility_name",
           "latitude" => 32.0,
           "longitude" => -41.0,
           "properties" => [

--- a/apps/fares/test/retail_locations_data_test.exs
+++ b/apps/fares/test/retail_locations_data_test.exs
@@ -20,12 +20,6 @@ defmodule Fares.RetailLocationsDataTest do
       end
     end
 
-    test "all locations have a non-nil name" do
-      for %Location{name: name} <- Data.get() do
-        assert is_binary(name)
-      end
-    end
-
     test "build_r_tree returns a tree with all location data" do
       tree = Data.build_r_tree()
 

--- a/apps/fares/test/retail_locations_data_test.exs
+++ b/apps/fares/test/retail_locations_data_test.exs
@@ -1,6 +1,6 @@
 defmodule Fares.RetailLocationsDataTest do
   use ExUnit.Case, async: true
-  alias Fares.RetailLocations.{Location, Data}
+  alias Fares.RetailLocations.{Data, Location}
 
   describe "Fares.RetailLocationsData" do
     test "get/1 retrieves an array of retail locations data" do
@@ -33,7 +33,7 @@ defmodule Fares.RetailLocationsDataTest do
     test "parses a location" do
       item = %JsonApi.Item{
         attributes: %{
-          "short_name" => "facility_name",
+          "long_name" => "facility_name",
           "latitude" => 32.0,
           "longitude" => -41.0,
           "properties" => [


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [retail sales listings should include vendor name](https://app.asana.com/0/555089885850811/1145005926601595)

V3 API change: use updated key for location name (`long_name`) -- `name` no longer exists.

**BEFORE:**
![image](https://user-images.githubusercontent.com/688435/68414811-e7754f80-015e-11ea-91f6-688454a1a0b9.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/688435/68414726-b8f77480-015e-11ea-89b8-393d94ca6c64.png)
