### PR TITLE
Add server check for support form uploads

### DIFF
--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -2,6 +2,8 @@ defmodule SiteWeb.CustomerSupportController do
   use SiteWeb, :controller
   require Logger
 
+  @allowed_attachment_types ~w(image/bmp image/gif image/jpeg image/png image/tiff image/webp)
+
   plug(Turbolinks.Plug.NoCache)
   plug(:set_service_options)
   plug(:assign_ip)
@@ -144,8 +146,6 @@ defmodule SiteWeb.CustomerSupportController do
   end
 
   defp validate_photos(_), do: :ok
-
-  @allowed_attachment_types ~w(image/bmp image/gif image/jpeg image/png image/tiff image/webp)
 
   defp valid_upload?(%Plug.Upload{filename: filename}) do
     MIME.from_path(filename) in @allowed_attachment_types

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -93,12 +93,13 @@ defmodule SiteWeb.CustomerSupportController do
           &validate_comments/1,
           &validate_service/1,
           &validate_antispam/1,
+          &validate_photos/1,
           &validate_name/1,
           &validate_email/1,
           &validate_privacy/1
         ]
       else
-        [&validate_comments/1, &validate_service/1, &validate_antispam/1]
+        [&validate_comments/1, &validate_service/1, &validate_antispam/1, &validate_photos/1]
       end
 
     Site.Validation.validate(validators, params)
@@ -136,6 +137,19 @@ defmodule SiteWeb.CustomerSupportController do
   @spec validate_privacy(map) :: :ok | String.t()
   defp validate_privacy(%{"privacy" => "on"}), do: :ok
   defp validate_privacy(_), do: "privacy"
+
+  @spec validate_photos(map) :: :ok | String.t()
+  defp validate_photos(%{"photos" => photos}) when is_list(photos) do
+    if Enum.all?(photos, &valid_upload?/1), do: :ok, else: "photos"
+  end
+
+  defp validate_photos(_), do: :ok
+
+  @allowed_attachment_types ~w(image/bmp image/gif image/jpeg image/png image/tiff image/webp)
+
+  defp valid_upload?(%Plug.Upload{filename: filename}) do
+    MIME.from_path(filename) in @allowed_attachment_types
+  end
 
   @spec validate_antispam(map) :: :ok | String.t()
   defp validate_antispam(%{"leave_this_alone" => value}) when byte_size(value) > 0, do: "antispam"

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -194,8 +194,8 @@ defmodule SiteWeb.CustomerSupportControllerTest do
       params =
         valid_no_response_data()
         |> Map.put("photos", [
-          %Plug.Upload{filename: "photo-1", path: "/tmp/photo-1.jpg"},
-          %Plug.Upload{filename: "photo-2", path: "/tmp/photo-2.jpg"}
+          %Plug.Upload{filename: "photo-1.jpg", path: "/tmp/upload-1"},
+          %Plug.Upload{filename: "photo-2.jpg", path: "/tmp/upload-2"}
         ])
 
       conn = post(conn, customer_support_path(conn, :submit), %{"support" => params})
@@ -204,8 +204,8 @@ defmodule SiteWeb.CustomerSupportControllerTest do
       attachments = Feedback.Test.latest_message()["attachments"]
 
       assert attachments == [
-               %{"filename" => "photo-1", "path" => "/tmp/photo-1.jpg"},
-               %{"filename" => "photo-2", "path" => "/tmp/photo-2.jpg"}
+               %{"filename" => "photo-1.jpg", "path" => "/tmp/upload-1"},
+               %{"filename" => "photo-2.jpg", "path" => "/tmp/upload-2"}
              ]
     end
 
@@ -215,6 +215,19 @@ defmodule SiteWeb.CustomerSupportControllerTest do
       conn = post(conn, customer_support_path(conn, :submit), %{"support" => params})
 
       assert "antispam" in conn.assigns.errors
+    end
+
+    test "prevents submissions when an upload does not appear to be an image", %{conn: conn} do
+      params =
+        valid_request_response_data()
+        |> Map.put(:photos, [
+          %Plug.Upload{filename: "image.jpg"},
+          %Plug.Upload{filename: "runme.exe"}
+        ])
+
+      conn = post(conn, customer_support_path(conn, :submit), %{"support" => params})
+
+      assert "photos" in conn.assigns.errors
     end
 
     test "logs a warning, returns 429, and shows an error when rate limit reached", %{conn: conn} do


### PR DESCRIPTION
The client side already has validation for trying to attach non-images, so this is mostly an anti-spambot measure to prevent people from throwing viruses into the ticketing system (even though this would require a support person to intentionally download and open them).

The `filename` and `mime_type` of a Plug.Upload are both provided by the user and thus untrusted, but since we ultimately attach the upload to an email using its `filename`, that is what will control how the recipient's computer tries to open it.

**Asana Ticket:** [Feedback Form | Address file type security issue](https://app.asana.com/0/477545582537986/1148399311722825/f)