### PR TITLE
Update shuttle-tab logic, add tests

### DIFF
--- a/apps/site/lib/site_web/controllers/helpers.ex
+++ b/apps/site/lib/site_web/controllers/helpers.ex
@@ -76,10 +76,11 @@ defmodule SiteWeb.ControllerHelpers do
         opts
       ) do
     filter_by_direction? = Keyword.get(opts, :filter_by_direction?, true)
+    alerts_by_route_id_and_type_fn = Keyword.get(opts, :repo_fn, &Repo.by_route_id_and_type/3)
 
     alerts =
       route_id
-      |> Repo.by_route_id_and_type(route_type, date_time)
+      |> alerts_by_route_id_and_type_fn.(route_type, date_time)
       |> Match.match([%InformedEntity{route_type: route_type}, %InformedEntity{route: route_id}])
 
     filtered_alerts =

--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -546,6 +546,7 @@ defmodule SiteWeb.ScheduleView do
   def timetable_note(_), do: nil
 
   defp shuttle_alert?(conn) do
-    conn.assigns[:alerts] |> Enum.find(&(&1.effect == :shuttle))
+    conn.assigns[:alerts]
+    |> Enum.find(&(&1.effect == :shuttle and &1.lifecycle in [:ongoing, :ongoing_upcoming]))
   end
 end


### PR DESCRIPTION
Here we tweak the logic controlling whether or not the shuttle tab
appears, so that it only appears in the case of an ongoing (or
ongoing_upcoming) alert. We also add test coverage for this logic.

#### Summary of changes
**Asana Ticket:** [Shuttles | Properly test appearance of shuttles tab](https://app.asana.com/0/555089885850811/1149377816922177)

<br>
Assigned to: @digitalcora  