### PR TITLE
Show CMS content in sidebar of shuttles page

### DIFF
--- a/apps/site/assets/ts/shuttles/components/ShuttlesPage.tsx
+++ b/apps/site/assets/ts/shuttles/components/ShuttlesPage.tsx
@@ -1,7 +1,5 @@
 import React, { ReactElement } from "react";
 
-const ShuttlesPage = (): ReactElement<HTMLElement> => (
-  <div className="shuttles__main col-xs-10 col-xs-offset-1 col-sm-offset-0 col-sm-12 col-lg-7" />
-);
+const ShuttlesPage = (): ReactElement<HTMLElement> => <div />;
 
 export default ShuttlesPage;

--- a/apps/site/lib/site_web/controllers/schedule/green.ex
+++ b/apps/site/lib/site_web/controllers/schedule/green.ex
@@ -1,7 +1,9 @@
 defmodule SiteWeb.ScheduleController.Green do
   use SiteWeb, :controller
 
+  import SiteWeb.ScheduleController.Line.Helpers, only: [get_shuttle_paragraphs: 1]
   import UrlHelpers, only: [update_url: 2]
+
   alias Schedules.Schedule
   alias SiteWeb.ScheduleController.LineController
   alias SiteWeb.ScheduleView
@@ -58,6 +60,7 @@ defmodule SiteWeb.ScheduleController.Green do
   def shuttles(conn, _params) do
     conn
     |> assign(:tab, "shuttles")
+    |> assign(:paragraphs, get_shuttle_paragraphs(conn))
     |> put_view(ScheduleView)
     |> render("show.html", [])
   end

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -116,7 +116,7 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
     RouteStops.by_direction(stops[route.id], shapes, route, direction_id)
   end
 
-  @spec get_shuttle_paragraphs(Plug.Conn.t()) :: [Phoneix.HTML.safe()]
+  @spec get_shuttle_paragraphs(Plug.Conn.t()) :: [Phoenix.HTML.safe()]
   def get_shuttle_paragraphs(conn) do
     conn
     |> shuttle_paragraphs_by_line()

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -121,7 +121,6 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
     conn
     |> shuttle_paragraphs_by_line()
     |> Enum.map(&get_paragraph/1)
-    |> Enum.map(&post_process_paragraph/1)
     |> Enum.map(&render_paragraph(&1, conn))
   end
 
@@ -140,15 +139,6 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
       end
 
     common_shuttle_paragraphs ++ line_shuttle_paragraphs
-  end
-
-  @spec post_process_paragraph(Paragraph.t()) :: Paragraph.t()
-  defp post_process_paragraph(%ContentList{} = content_list) do
-    ContentList.fetch_teasers(content_list)
-  end
-
-  defp post_process_paragraph(normal_paragraph) do
-    normal_paragraph
   end
 
   @spec get_green_branch(

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -137,6 +137,7 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
         "Red" -> ["paragraphs/custom-html/shuttles-sidebar-red-line"]
         "Orange" -> ["paragraphs/custom-html/shuttles-sidebar-orange-line"]
         "Green" -> ["paragraphs/custom-html/shuttles-sidebar-green-line"]
+        _ -> []
       end
 
     common_shuttle_paragraphs ++ line_shuttle_paragraphs

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -3,8 +3,6 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
   Helpers for the line page
   """
 
-  alias CMS.Partial.Paragraph
-  alias CMS.Partial.Paragraph.ContentList
   alias Routes.Repo, as: RoutesRepo
   alias Routes.{Route, Shape}
   alias Stops.Repo, as: StopsRepo

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -127,16 +127,15 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
 
   @spec shuttle_paragraphs_by_line(Plug.Conn.t()) :: [binary()]
   defp shuttle_paragraphs_by_line(conn) do
-    common_shuttle_paragraphs = [
-      "paragraphs/content-list/shuttles-sidebar-project",
-      "paragraphs/custom-html/shuttles-boilerplate"
-    ]
+    common_shuttle_paragraphs = ["paragraphs/custom-html/shuttles-boilerplate"]
 
     line_shuttle_paragraphs =
       case conn.assigns.route.id do
         "Red" -> ["paragraphs/custom-html/shuttles-sidebar-red-line"]
         "Orange" -> ["paragraphs/custom-html/shuttles-sidebar-orange-line"]
         "Green" -> ["paragraphs/custom-html/shuttles-sidebar-green-line"]
+        "Green-B" -> ["paragraphs/custom-html/shuttles-sidebar-green-line-b"]
+        "Green-D" -> ["paragraphs/custom-html/shuttles-sidebar-green-line-d"]
         _ -> []
       end
 

--- a/apps/site/lib/site_web/controllers/schedule/shuttles_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/shuttles_controller.ex
@@ -3,7 +3,16 @@ defmodule SiteWeb.ScheduleController.ShuttlesController do
 
   use SiteWeb, :controller
 
+  alias CMS.Partial.Paragraph.ContentList
   alias SiteWeb.ScheduleView
+
+  import CMS.Repo, only: [get_paragraph: 1]
+  import SiteWeb.CMS.ParagraphView, only: [render_paragraph: 2]
+
+  @common_paragraphs [
+    "paragraphs/content-list/shuttles-sidebar-project",
+    "paragraphs/custom-html/shuttles-boilerplate"
+  ]
 
   plug(SiteWeb.Plugs.Route)
   plug(SiteWeb.ScheduleController.Defaults)
@@ -11,7 +20,9 @@ defmodule SiteWeb.ScheduleController.ShuttlesController do
   plug(SiteWeb.Plugs.AlertsByTimeframe)
   plug(SiteWeb.ScheduleController.RouteBreadcrumbs)
   plug(:tab_name)
+  plug(:paragraphs)
 
+  @spec show(Plug.Conn.t(), any) :: Plug.Conn.t()
   def show(conn, _) do
     conn
     |> put_view(ScheduleView)
@@ -20,4 +31,32 @@ defmodule SiteWeb.ScheduleController.ShuttlesController do
 
   defp alerts(conn, _), do: assign_alerts(conn, filter_by_direction?: false)
   defp tab_name(conn, _), do: assign(conn, :tab, "shuttles")
+  defp paragraphs(conn, _), do: assign(conn, :paragraphs, get_and_render_paragraphs(conn))
+
+  defp get_and_render_paragraphs(conn) do
+    conn
+    |> paragraphs_by_line()
+    |> Enum.map(&get_paragraph/1)
+    |> Enum.map(&post_process_paragraph/1)
+    |> Enum.map(&render_paragraph(&1, conn))
+  end
+
+  defp paragraphs_by_line(conn) do
+    line_paragraphs =
+      case conn.assigns.route.id do
+        "Red" -> ["paragraphs/custom-html/shuttles-sidebar-red-line"]
+        "Orange" -> ["paragraphs/custom-html/shuttles-sidebar-orange-line"]
+        "Green" -> ["paragraphs/custom-html/shuttles-sidebar-green-line"]
+      end
+
+    @common_paragraphs ++ line_paragraphs
+  end
+
+  defp post_process_paragraph(%ContentList{} = content_list) do
+    ContentList.fetch_teasers(content_list)
+  end
+
+  defp post_process_paragraph(normal_paragraph) do
+    normal_paragraph
+  end
 end

--- a/apps/site/lib/site_web/controllers/schedule/shuttles_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/shuttles_controller.ex
@@ -3,16 +3,9 @@ defmodule SiteWeb.ScheduleController.ShuttlesController do
 
   use SiteWeb, :controller
 
-  alias CMS.Partial.Paragraph.ContentList
   alias SiteWeb.ScheduleView
 
-  import CMS.Repo, only: [get_paragraph: 1]
-  import SiteWeb.CMS.ParagraphView, only: [render_paragraph: 2]
-
-  @common_paragraphs [
-    "paragraphs/content-list/shuttles-sidebar-project",
-    "paragraphs/custom-html/shuttles-boilerplate"
-  ]
+  import SiteWeb.ScheduleController.Line.Helpers, only: [get_shuttle_paragraphs: 1]
 
   plug(SiteWeb.Plugs.Route)
   plug(SiteWeb.ScheduleController.Defaults)
@@ -20,43 +13,15 @@ defmodule SiteWeb.ScheduleController.ShuttlesController do
   plug(SiteWeb.Plugs.AlertsByTimeframe)
   plug(SiteWeb.ScheduleController.RouteBreadcrumbs)
   plug(:tab_name)
-  plug(:paragraphs)
 
   @spec show(Plug.Conn.t(), any) :: Plug.Conn.t()
   def show(conn, _) do
     conn
     |> put_view(ScheduleView)
+    |> assign(:paragraphs, get_shuttle_paragraphs(conn))
     |> render("show.html", [])
   end
 
   defp alerts(conn, _), do: assign_alerts(conn, filter_by_direction?: false)
   defp tab_name(conn, _), do: assign(conn, :tab, "shuttles")
-  defp paragraphs(conn, _), do: assign(conn, :paragraphs, get_and_render_paragraphs(conn))
-
-  defp get_and_render_paragraphs(conn) do
-    conn
-    |> paragraphs_by_line()
-    |> Enum.map(&get_paragraph/1)
-    |> Enum.map(&post_process_paragraph/1)
-    |> Enum.map(&render_paragraph(&1, conn))
-  end
-
-  defp paragraphs_by_line(conn) do
-    line_paragraphs =
-      case conn.assigns.route.id do
-        "Red" -> ["paragraphs/custom-html/shuttles-sidebar-red-line"]
-        "Orange" -> ["paragraphs/custom-html/shuttles-sidebar-orange-line"]
-        "Green" -> ["paragraphs/custom-html/shuttles-sidebar-green-line"]
-      end
-
-    @common_paragraphs ++ line_paragraphs
-  end
-
-  defp post_process_paragraph(%ContentList{} = content_list) do
-    ContentList.fetch_teasers(content_list)
-  end
-
-  defp post_process_paragraph(normal_paragraph) do
-    normal_paragraph
-  end
 end

--- a/apps/site/lib/site_web/templates/schedule/_shuttles.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_shuttles.html.eex
@@ -9,5 +9,8 @@
   <%= Site.React.render("ShuttlesPage", %{}) %>
 </div>
 
+<%= if !Enum.empty?(@paragraphs) do %>
 <div class="shuttles__sidebar col-xs-offset-1 col-xs-10 col-sm-offset-0 col-sm-12 col-lg-offset-8 col-lg-4">
+  <%= @paragraphs %>
 </div>
+<% end %>

--- a/apps/site/lib/site_web/templates/schedule/_shuttles.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_shuttles.html.eex
@@ -5,12 +5,16 @@
   <script defer src="<%= static_url(@conn, "/js/shuttles.js") %>"></script>
 <% end %>
 
-<div id="react-shuttles-root">
-  <%= Site.React.render("ShuttlesPage", %{}) %>
-</div>
+<div class="row">
+  <div class="shuttles__main col-xs-10 col-xs-offset-1 col-sm-12 col-sm-offset-0 col-md-8 col-lg-7">
+    <div id="react-shuttles-root">
+      <%= Site.React.render("ShuttlesPage", %{}) %>
+    </div>
+  </div>
 
-<%= if !Enum.empty?(@paragraphs) do %>
-<div class="shuttles__sidebar col-xs-offset-1 col-xs-10 col-sm-offset-0 col-sm-12 col-lg-offset-8 col-lg-4">
-  <%= @paragraphs %>
+  <%= if !Enum.empty?(@paragraphs) do %>
+  <div class="shuttles__sidebar col-xs-10 col-xs-offset-1 col-sm-12 col-sm-offset-0 col-md-4 col-lg-offset-1">
+    <%= @paragraphs %>
+  </div>
+  <% end %>
 </div>
-<% end %>

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -434,6 +434,18 @@ defmodule SiteWeb.ScheduleControllerTest do
       refute Enum.empty?(stops)
       assert Floki.find(stops, ".fa-check") == []
     end
+
+    test "assigned :paragraphs key is available to shuttles template", %{conn: conn} do
+      conn = get(conn, shuttles_path(conn, :show, "Red"))
+
+      assert Map.has_key?(conn.assigns, :paragraphs)
+      assert is_list(conn.assigns.paragraphs)
+
+      green_conn = get(conn, green_path(conn, :shuttles))
+
+      assert Map.has_key?(green_conn.assigns, :paragraphs)
+      assert is_list(green_conn.assigns.paragraphs)
+    end
   end
 
   describe "tab redirects" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Shuttles | Show BBT boilerplate in sidebar](https://app.asana.com/0/555089885850811/1148592031135767)

- Each of the three lines (red, orange, green) share 1-2 common paragraphs, and are output on each line's shuttle tab regardless of line.
- Add a switch to load certain, other paragraphs based on line name
- Fully render these paragraphs and show in sidebar if there is at least one

Testing: Connect your `DRUPAL_ROOT` env var to `https://live-mbta.pantheonsite.io`

![image](https://user-images.githubusercontent.com/688435/68897458-8b30a380-06fb-11ea-9ada-077797e02e72.png)
