### PR TITLE
Adjust nomenclature for CMS content

### DIFF
--- a/apps/site/assets/ts/__cms.d.ts
+++ b/apps/site/assets/ts/__cms.d.ts
@@ -1,4 +1,4 @@
-export interface SimpleProject {
+export interface Teaser {
   date: string;
   id: number;
   image: Image | null;

--- a/apps/site/assets/ts/projects/__tests__/BannerTest.tsx
+++ b/apps/site/assets/ts/projects/__tests__/BannerTest.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { mount } from "enzyme";
 import { createReactRoot } from "../../app/helpers/testUtils";
-import { SimpleProject } from "../components/__projects";
+import { Teaser as Project } from "../../__cms";
 import Banner, { cmsRouteToClass } from "../components/Banner";
 
-const bannerTeaser: SimpleProject = {
+const bannerTeaser: Project = {
   title: "Better Bus Project",
   text:
     "Too many of our bus routes still fail to live up to our own standards. Through the Better Bus Project, we are changing that.",

--- a/apps/site/assets/ts/projects/__tests__/MoreProjectsTableTest.tsx
+++ b/apps/site/assets/ts/projects/__tests__/MoreProjectsTableTest.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { mount } from "enzyme";
 import { createReactRoot } from "../../app/helpers/testUtils";
-import { SimpleProject as Project } from "../components/__projects";
+import { Teaser as Project } from "../../__cms";
 import MoreProjectsTable, {
   tableHeaderText
 } from "../components/MoreProjectsTable";

--- a/apps/site/assets/ts/projects/__tests__/ProjectUpdateListTest.tsx
+++ b/apps/site/assets/ts/projects/__tests__/ProjectUpdateListTest.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { SimpleProject as Project } from "../components/__projects";
+import { Teaser as Project } from "../../__cms";
 import { createReactRoot } from "../../app/helpers/testUtils";
 import ProjectUpdateList from "../components/ProjectUpdateList";
 

--- a/apps/site/assets/ts/projects/__tests__/ProjectsPageTest.tsx
+++ b/apps/site/assets/ts/projects/__tests__/ProjectsPageTest.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { createReactRoot } from "../../app/helpers/testUtils";
-import { SimpleProject as Project } from "../components/__projects";
+import { Teaser as Project } from "../../__cms";
 import ProjectsPage, {
   fetchMoreProjects,
   updateSelectedMode

--- a/apps/site/assets/ts/projects/__tests__/SubwayFilterTest.tsx
+++ b/apps/site/assets/ts/projects/__tests__/SubwayFilterTest.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { createReactRoot } from "../../app/helpers/testUtils";
-import { SimpleProject as Project } from "../components/__projects";
 import SubwayFilter from "../components/SubwayFilter";
 
 import {

--- a/apps/site/assets/ts/projects/components/Banner.tsx
+++ b/apps/site/assets/ts/projects/components/Banner.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { SimpleProject as Project, Route } from "./__projects";
+import { Teaser as Project, Route } from "../../__cms";
 import { formattedDate } from "../../helpers/date";
 import { routeToCSSClass } from "../../helpers/css";
 

--- a/apps/site/assets/ts/projects/components/FeaturedProject.tsx
+++ b/apps/site/assets/ts/projects/components/FeaturedProject.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react";
 import RoutePillList from "./RoutePillList";
-import { SimpleProject as Project } from "./__projects";
+import { Teaser as Project } from "../../__cms";
 import { formattedDate } from "../../helpers/date";
 
 interface Props {

--- a/apps/site/assets/ts/projects/components/FeaturedProjectsList.tsx
+++ b/apps/site/assets/ts/projects/components/FeaturedProjectsList.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { SimpleProject as Project } from "./__projects";
+import { Teaser as Project } from "../../__cms";
 import FeaturedProjectsRow from "./FeaturedProjectsRow";
 
 interface Props {

--- a/apps/site/assets/ts/projects/components/FeaturedProjectsRow.tsx
+++ b/apps/site/assets/ts/projects/components/FeaturedProjectsRow.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { SimpleProject as Project } from "./__projects";
+import { Teaser as Project } from "../../__cms";
 import FeaturedProject from "./FeaturedProject";
 
 interface Props {

--- a/apps/site/assets/ts/projects/components/MoreProjectsRow.tsx
+++ b/apps/site/assets/ts/projects/components/MoreProjectsRow.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
 import { isSilverLine } from "../../helpers/silver-line";
 import formattedDate from "../../helpers/date";
-import { SimpleProject as Project, Route } from "./__projects";
+import { Teaser as Project, Route } from "../../__cms";
 import RouteIcon from "./RouteIcon";
 
 interface Props extends Project {

--- a/apps/site/assets/ts/projects/components/ProjectUpdateList.tsx
+++ b/apps/site/assets/ts/projects/components/ProjectUpdateList.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { SimpleProject as Project } from "./__projects";
+import { Teaser as Project } from "../../__cms";
 import formattedDate from "../../helpers/date";
 import RoutePillList from "./RoutePillList";
 

--- a/apps/site/assets/ts/projects/components/ProjectsPage.tsx
+++ b/apps/site/assets/ts/projects/components/ProjectsPage.tsx
@@ -5,7 +5,7 @@ import FilterAndSearch from "./FilterAndSearch";
 import MoreProjectsTable from "./MoreProjectsTable";
 import ProjectUpdateList from "./ProjectUpdateList";
 import { Mode } from "../../__v3api";
-import { SimpleProject as Project } from "./__projects";
+import { Teaser as Project } from "../../__cms";
 
 interface Props {
   initialBanner: Project | null;

--- a/apps/site/assets/ts/projects/components/RoutePillList.tsx
+++ b/apps/site/assets/ts/projects/components/RoutePillList.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
 import RouteIcon from "./RouteIcon";
 import RoutePill from "./RoutePill";
-import { Route } from "./__projects";
+import { Route } from "../../__cms";
 import { isSilverLine } from "../../helpers/silver-line";
 
 interface Props {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket.

I noticed we are conflating Projects (or "SimpleProjects") to a universal Teaser object/type. Doing this so in the future it's clearer that a Teaser can be more than just a Project-specific type.

- Moves typing to global scale, as Teasers can be relative and used by any page and context
- Continue to cast Teasers as SimpleProjects within the context of the Projects feature