### PR TITLE
Attempt Codecov Fix

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,4 @@
 codecov:
-  bot: mbtace
   notify:
     require_ci_to_pass: true
 comment:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
-codecov:
-  notify:
-    require_ci_to_pass: true
 comment:
   behavior: default
   layout: header, diff


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fix Codecov for Dotcom](https://app.asana.com/0/1113179098808463/1149791411919817)

There are multiple ways to configure GitHub integrations with Codecov: One option is to use a [“bot user”](https://docs.codecov.io/docs/team-bot) that authenticates, and another is to use the [GitHub application integration](https://github.com/marketplace/codecov). We were using both in our org, and it was messy. 

So I’m trying to move away from the bot user. Apparently that means removing this line that explicitly tells Codecov to use the bot user instead of the integration.

<br>
Assigned to: @amaisano 
