### PR TITLE
Disable Pronto GitHub PR status reporting

### DIFF
--- a/semaphore/pronto.sh
+++ b/semaphore/pronto.sh
@@ -6,7 +6,7 @@ gem install pronto-scss -v 0.9.1
 gem install pronto-credo -v 0.0.8
 
 # run pronto
-MIX_ENV=test pronto run -f github github_status -c origin/master
+MIX_ENV=test pronto run -f github -c origin/master
 npm run format:check
 npm run tslint
 


### PR DESCRIPTION
This is a quick fix for Pronto breaking all our builds because its access token was removed. The relevant step is now green on this branch in Semaphore.