### PR TITLE
Handle itineraries with steps without absolute direction

### DIFF
--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
@@ -155,6 +155,8 @@ defmodule TripPlan.Api.OpenTripPlanner.Parser do
     defp parse_absolute_direction(unquote(String.upcase(Atom.to_string(dir)))), do: unquote(dir)
   end
 
+  defp parse_absolute_direction(nil), do: nil
+
   defp id_after_colon(agency_colon_id) do
     [_agency, id] = String.split(agency_colon_id, ":", parts: 2)
     id

--- a/apps/trip_plan/lib/trip_plan/personal_detail.ex
+++ b/apps/trip_plan/lib/trip_plan/personal_detail.ex
@@ -23,7 +23,7 @@ defmodule TripPlan.PersonalDetail.Step do
   @type t :: %__MODULE__{
           distance: float,
           relative_direction: relative_direction,
-          absolute_direction: absolute_direction
+          absolute_direction: absolute_direction | nil
         }
   @type relative_direction ::
           :depart

--- a/apps/trip_plan/test/api/open_trip_planner/parser_test.exs
+++ b/apps/trip_plan/test/api/open_trip_planner/parser_test.exs
@@ -21,9 +21,16 @@ defmodule TripPlan.Api.OpenTripPlanner.ParserTest do
       assert first.stop == Timex.to_datetime(~N[2017-05-19T14:03:19], "America/New_York")
     end
 
-    test "returns an error if JSON is invalid" do
+    test "allows null absoluteDirection" do
       pattern = "absoluteDirection\": \"SOUTH\""
       replacement = "absoluteDirection\": null"
+      json = String.replace(@fixture, pattern, replacement)
+      assert {:ok, _itinerary} = parse_json(json)
+    end
+
+    test "returns an error if JSON is invalid" do
+      pattern = "absoluteDirection\": \"SOUTH\""
+      replacement = "absoluteDirection\": \"UP\""
       json = String.replace(@fixture, pattern, replacement)
       assert {:error, :invalid_json} = parse_json(json)
     end


### PR DESCRIPTION
Steps in an OpenTripPlanner itinerary have an `absoluteDirection` field.
It's valid for that field to be missing, but we don't handle that case
correctly, leading to occasional failures in trip planning. Corrected.

#### Summary of changes
**Asana Ticket:** [Handle OTP steps with a `nil` `absoluteDirection`](https://app.asana.com/0/555089885850811/1150314104323081)

<br>
Assigned to: @amaisano 
