### PR TITLE
Disable Pronto PR comment reporting

### DIFF
--- a/semaphore/pronto.sh
+++ b/semaphore/pronto.sh
@@ -6,7 +6,7 @@ gem install pronto-scss -v 0.9.1
 gem install pronto-credo -v 0.0.8
 
 # run pronto
-MIX_ENV=test pronto run -f github -c origin/master
+MIX_ENV=test pronto run -c origin/master
 npm run format:check
 npm run tslint
 


### PR DESCRIPTION
As a follow-up to 1bd6412e6, we want to disable all GitHub integration.