### PR TITLE
Add direction to ShuttleDiversion stops

### DIFF
--- a/apps/site/lib/site/shuttle_diversion.ex
+++ b/apps/site/lib/site/shuttle_diversion.ex
@@ -167,6 +167,6 @@ defmodule Site.ShuttleDiversion do
   defp stops(_trip), do: []
 
   defp stops_with_direction(%{attributes: %{"direction_id" => direction_id}} = trip) do
-    trip |> stops() |> Enum.map(& {direction_id, &1})
+    trip |> stops() |> Enum.map(&{direction_id, &1})
   end
 end


### PR DESCRIPTION
Cristen pointed out that we need a `direction_id` on the shuttle stops to be able to show and hide them along with the route when the direction selector is changed.

This only applies to the shuttle stops, since the rail stops are "directionless". In reality we pick an arbitrary direction and only return the rail stops for that direction, but we don't expect to have diversions where the operational rail stops are different depending on the direction of travel.