### PR TITLE
Add workaround for D line shuttle diversions

### DIFF
--- a/apps/site/lib/site/shuttle_diversion.ex
+++ b/apps/site/lib/site/shuttle_diversion.ex
@@ -37,6 +37,45 @@ defmodule Site.ShuttleDiversion do
           }
   end
 
+  defmodule TripsHack do
+    @moduledoc """
+    Proxy for `V3Api.Trips.by_route` that works around missing trip data for specific weekday
+    shuttle diversions on the D line, by borrowing the trips from an identical weekend diversion.
+    TODO: Delete after 2019-12-20.
+    """
+
+    @date_with_correct_trips "2019-12-21"
+    @dates_to_correct [
+      "2019-11-20",
+      "2019-11-21",
+      "2019-11-25",
+      "2019-11-26",
+      "2019-12-13",
+      "2019-12-16",
+      "2019-12-17",
+      "2019-12-18",
+      "2019-12-19",
+      "2019-12-20"
+    ]
+
+    @spec by_route(String.t(), keyword) :: JsonApi.t() | {:error, any}
+    def by_route(routes, params \\ []) do
+      route_ids = String.split(routes, ",")
+
+      if "Green-D" in route_ids and params[:"filter[date]"] in @dates_to_correct do
+        d_params = Keyword.put(params, :"filter[date]", @date_with_correct_trips)
+        other_routes = (route_ids -- ["Green-D"]) |> Enum.join(",")
+
+        with %{data: d_trips} <- Trips.by_route("Green-D", d_params),
+             %{data: other_trips} <- Trips.by_route(other_routes, params) do
+          %JsonApi{data: d_trips ++ other_trips}
+        end
+      else
+        Trips.by_route(route_ids, params)
+      end
+    end
+  end
+
   @enforce_keys [:shapes, :stops]
   defstruct @enforce_keys
 
@@ -63,7 +102,7 @@ defmodule Site.ShuttleDiversion do
         include: "route,service,shape,shape.stops"
       ]
 
-      with %JsonApi{data: trips} <- Trips.by_route(trips_route, trips_params),
+      with %JsonApi{data: trips} <- TripsHack.by_route(trips_route, trips_params),
            route_stops when is_list(route_stops) <- Stops.by_routes(true_route_ids, 0),
            relevant_trips = shuttle_related_trips(trips) do
         {:ok,


### PR DESCRIPTION
**Asana Ticket:** [Shuttles | Manually adjust data for Green Line weekday shuttles](https://app.asana.com/0/477545582537986/1150476402898529/f)

This may look like it's doing more work than it needs to, but the idea was to make `TripsHack` a clean drop-in replacement for `V3Api.Trips`, making it as easy as possible to delete it later, even if the rest of the code changes in the meantime.

Tagging @handorff for optional review 🙂