### PR TITLE
Fix shuttle data crash for non-Green lines

### DIFF
--- a/apps/site/lib/site/shuttle_diversion.ex
+++ b/apps/site/lib/site/shuttle_diversion.ex
@@ -71,7 +71,7 @@ defmodule Site.ShuttleDiversion do
           %JsonApi{data: d_trips ++ other_trips}
         end
       else
-        Trips.by_route(route_ids, params)
+        Trips.by_route(routes, params)
       end
     end
   end


### PR DESCRIPTION
I made a silly mistake when implementing the Green Line workaround, and did not fully test that it still worked for the other lines.