### PR TITLE
Fix alert badge not appearing on combined GL page

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/green.ex
+++ b/apps/site/lib/site_web/controllers/schedule/green.ex
@@ -11,7 +11,7 @@ defmodule SiteWeb.ScheduleController.Green do
   plug(:route)
   plug(SiteWeb.Plugs.DateInRating)
   plug(SiteWeb.ScheduleController.DatePicker)
-  plug(:green_alerts)
+  plug(:assign_alerts)
   plug(SiteWeb.Plugs.AlertsByTimeframe)
   plug(SiteWeb.ScheduleController.Defaults)
   plug(:stops_on_routes)
@@ -153,14 +153,6 @@ defmodule SiteWeb.ScheduleController.Green do
     conn
     |> assign(:predictions, predictions)
     |> assign(:vehicle_predictions, vehicle_predictions)
-  end
-
-  def green_alerts(conn, _opts) do
-    assign(
-      conn,
-      :alerts,
-      Alerts.Repo.by_route_id_and_type("Green", 0, conn.assigns.date_time)
-    )
   end
 
   def vehicle_locations(conn, opts) do


### PR DESCRIPTION
This occurred because the custom `green_alerts` function used here did not populate the `all_alerts_count` assign, which is used on the other line pages to display the Alerts tab badge.

Since `green_alerts` appears to be a subset of `assign_alerts` which would normally assign the alert count, and that function seems to work fine on the combined Green Line page, we can replace it wholesale.

**Asana Ticket:** [Bug  | Alerts badge missing on /schedules/Green](https://app.asana.com/0/477545582537986/1149844956579553/f)