### PR TITLE
Fix shuttle data including normal route shapes

### DIFF
--- a/apps/site/lib/site/shuttle_diversion.ex
+++ b/apps/site/lib/site/shuttle_diversion.ex
@@ -99,7 +99,7 @@ defmodule Site.ShuttleDiversion do
 
       trips_params = [
         "filter[date]": time |> Util.service_date() |> Date.to_iso8601(),
-        include: "route,service,shape,shape.stops"
+        include: "route,route_pattern,shape,shape.stops"
       ]
 
       with %JsonApi{data: trips} <- TripsHack.by_route(trips_route, trips_params),
@@ -199,7 +199,7 @@ defmodule Site.ShuttleDiversion do
   defp shuttle_related?(trip) do
     # Typicality 4 indicates major changes in service due to a planned disruption. This might not
     # always mean there's a shuttle service, but it's the best identifying attribute we have.
-    hd(trip.relationships["service"]).attributes["schedule_typicality"] == 4
+    hd(trip.relationships["route_pattern"]).attributes["typicality"] == 4
   end
 
   defp shuttle_route?(trip) do


### PR DESCRIPTION
**Asana Ticket:** [🐞 BUG | Shuttles | Map shows extraneous polylines](https://app.asana.com/0/477545582537986/1150937129144553/f)

This occurred because, when we run normal service for part of a day and shuttle service for the rest, all of those trips are grouped under one Service with a `schedule_typicality` of 4, despite only part of the day being "atypical". We should instead look at the RoutePattern, which has a typicality of 1 for the normal un-shuttled trips.