### PR TITLE
Add color attribute to Route for shuttle maps

### DIFF
--- a/apps/routes/lib/parser.ex
+++ b/apps/routes/lib/parser.ex
@@ -10,6 +10,7 @@ defmodule Routes.Parser do
       type: attributes["type"],
       name: name(attributes),
       long_name: attributes["long_name"],
+      color: attributes["color"],
       direction_names: direction_bound_attrs(attributes["direction_names"]),
       direction_destinations: direction_attrs(attributes["direction_destinations"]),
       description: parse_gtfs_desc(attributes["description"])

--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -5,6 +5,7 @@ defmodule Routes.Route do
             type: 0,
             name: "",
             long_name: "",
+            color: "",
             direction_names: %{0 => "Outbound", 1 => "Inbound"},
             direction_destinations: :unknown,
             description: :unknown,
@@ -16,6 +17,7 @@ defmodule Routes.Route do
           type: 0..4,
           name: String.t(),
           long_name: String.t(),
+          color: String.t(),
           direction_names: %{0 => String.t(), 1 => String.t()},
           direction_destinations: %{0 => String.t(), 1 => String.t()} | :unknown,
           description: gtfs_route_desc,
@@ -202,6 +204,7 @@ defmodule Routes.Route do
         type: type,
         name: name,
         long_name: long_name,
+        color: color,
         direction_names: direction_names,
         direction_destinations: direction_destinations,
         description: description,
@@ -220,6 +223,7 @@ defmodule Routes.Route do
       type: type,
       name: name,
       long_name: long_name,
+      color: color,
       direction_names: %{
         "0" => direction_names[0],
         "1" => direction_names[1]

--- a/apps/routes/test/repo_test.exs
+++ b/apps/routes/test/repo_test.exs
@@ -13,6 +13,7 @@ defmodule Routes.RepoTest do
                type: 1,
                name: "Red Line",
                long_name: "Red Line",
+               color: "DA291C",
                direction_names: %{0 => "Southbound", 1 => "Northbound"},
                direction_destinations: %{0 => "Ashmont/Braintree", 1 => "Alewife"},
                description: :rapid_transit
@@ -29,6 +30,7 @@ defmodule Routes.RepoTest do
                type: 0,
                name: "Green Line B",
                long_name: "Green Line B",
+               color: "00843D",
                direction_names: %{0 => "Westbound", 1 => "Eastbound"},
                direction_destinations: %{0 => "Boston College", 1 => "Park Street"},
                description: :rapid_transit
@@ -45,6 +47,7 @@ defmodule Routes.RepoTest do
                type: 3,
                name: "SL1",
                long_name: "Logan Airport - South Station",
+               color: "7C878E",
                direction_destinations: %{0 => "Logan Airport", 1 => "South Station"},
                description: :key_bus_route
              }
@@ -60,6 +63,7 @@ defmodule Routes.RepoTest do
                type: 3,
                name: "23",
                long_name: "Ashmont - Ruggles via Washington Street",
+               color: "FFC72C",
                direction_destinations: %{0 => "Ashmont", 1 => "Ruggles"},
                description: :key_bus_route
              }

--- a/apps/routes/test/route_test.exs
+++ b/apps/routes/test/route_test.exs
@@ -196,7 +196,8 @@ defmodule Routes.RouteTest do
         id: "Red",
         long_name: "Red Line",
         name: "Red Line",
-        type: 1
+        type: 1,
+        color: "DA291C"
       }
 
       expected = %{
@@ -207,7 +208,8 @@ defmodule Routes.RouteTest do
         id: "Red",
         long_name: "Red Line",
         name: "Red Line",
-        type: 1
+        type: 1,
+        color: "DA291C"
       }
 
       assert Route.to_json_safe(route) == expected

--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -23,7 +23,8 @@ defmodule Site.RealtimeScheduleTest do
     id: "Orange",
     long_name: "Orange Line",
     name: "Orange Line",
-    type: 1
+    type: 1,
+    color: "ED8B00"
   }
 
   @route_with_patterns [
@@ -251,7 +252,8 @@ defmodule Site.RealtimeScheduleTest do
           id: "Orange",
           long_name: "Orange Line",
           name: "Orange Line",
-          type: 1
+          type: 1,
+          color: "ED8B00"
         }
       }
     ]

--- a/apps/site/test/site_web/controllers/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/helpers_test.exs
@@ -360,43 +360,6 @@ defmodule SiteWeb.ControllerHelpersTest do
   end
 
   test "green_routes/0" do
-    assert green_routes() == [
-             %Routes.Route{
-               description: :rapid_transit,
-               direction_names: %{0 => "Westbound", 1 => "Eastbound"},
-               direction_destinations: %{0 => "Boston College", 1 => "Park Street"},
-               id: "Green-B",
-               long_name: "Green Line B",
-               name: "Green Line B",
-               type: 0
-             },
-             %Routes.Route{
-               description: :rapid_transit,
-               direction_names: %{0 => "Westbound", 1 => "Eastbound"},
-               direction_destinations: %{0 => "Cleveland Circle", 1 => "North Station"},
-               id: "Green-C",
-               long_name: "Green Line C",
-               name: "Green Line C",
-               type: 0
-             },
-             %Routes.Route{
-               description: :rapid_transit,
-               direction_names: %{0 => "Westbound", 1 => "Eastbound"},
-               direction_destinations: %{0 => "Riverside", 1 => "Government Center"},
-               id: "Green-D",
-               long_name: "Green Line D",
-               name: "Green Line D",
-               type: 0
-             },
-             %Routes.Route{
-               description: :rapid_transit,
-               direction_names: %{0 => "Westbound", 1 => "Eastbound"},
-               direction_destinations: %{0 => "Heath Street", 1 => "Lechmere"},
-               id: "Green-E",
-               long_name: "Green Line E",
-               name: "Green Line E",
-               type: 0
-             }
-           ]
+    assert Enum.map(green_routes(), & &1.id) == ["Green-B", "Green-C", "Green-D", "Green-E"]
   end
 end


### PR DESCRIPTION
This will enable the Shuttles tab to draw the rail lines in the correct colors. The existing line maps use a set of hard-coded colors, which is why we'd never loaded this attribute from the API before.

As a side note, it's concerning how many unrelated tests failed with this change, and even how many different places we have to add the new field within the `routes` app. I think there's a lot of room for improvement and simplification in how we interact with the API.