### PR TITLE
Fix disabled scroll bug with Schedule Finder

### DIFF
--- a/apps/site/lib/site/body_tag.ex
+++ b/apps/site/lib/site/body_tag.ex
@@ -33,7 +33,7 @@ defmodule Site.BodyTag do
   end
 
   defp enable_turbolinks?(conn) do
-    is_nil(conn.assigns[:disable_turbolinks]) or Turbolinks.enabled?(conn)
+    is_nil(conn.assigns[:disable_turbolinks])
   end
 
   defp javascript_class(conn) do


### PR DESCRIPTION
This fixes an issue where clicking a link from the Schedule Finder modal (e.g. one of the stops in the schedule) would result in the destination page, and possibly later visited pages, being un-scrollable until a full page reload was performed.

This was caused by the modal setting a `modal-open` class on the `html` element, which then persisted during Turbolinks navigation, which only replaces the `body`. It appears we intended to disable Turbolinks on the pages that open the modal, but the logic was wrong and would keep it enabled if it had ever been enabled on a previous page (without any full page reloads in between).

**Asana Ticket:** [🐞 Bug | Scroll disabled after Schedule Finder navigation](https://app.asana.com/0/477545582537986/1151166129170673/f)