### PR TITLE
Add holidays for 2020 and 2021

### DIFF
--- a/apps/holiday/lib/repo.ex
+++ b/apps/holiday/lib/repo.ex
@@ -58,17 +58,17 @@ end
 defmodule Holiday.Repo do
   import Holiday.Repo.Helpers
   # from https://www.sec.state.ma.us/cis/cishol/holidx.htm
-  @start_year 2017
+  @start_year 2019
   @holidays [
               # { name, [{month, day}, {month, day}, ...]},
               {"New Years Day", [{1, 1}, {1, 1}, {1, 1}]},
-              {"Martin Luther King Day", [{1, 16}, {1, 15}, {1, 21}]},
-              {"President’s Day", [{2, 20}, {2, 19}, {2, 18}]},
-              {"Patriots’ Day", [{4, 17}, {4, 16}, {4, 15}]},
-              {"Memorial Day", [{5, 29}, {5, 28}, {5, 27}]},
+              {"Martin Luther King Day", [{1, 21}, {1, 20}, {1, 18}]},
+              {"President’s Day", [{2, 18}, {2, 17}, {2, 15}]},
+              {"Patriots’ Day", [{4, 15}, {4, 20}, {4, 19}]},
+              {"Memorial Day", [{5, 27}, {5, 25}, {5, 31}]},
               {"Independence Day", [{7, 4}, {7, 4}, {7, 4}]},
-              {"Labor Day", [{9, 4}, {9, 3}, {9, 2}]},
-              {"Thanksgiving Day", [{11, 23}, {11, 22}, {11, 28}]},
+              {"Labor Day", [{9, 2}, {9, 7}, {9, 6}]},
+              {"Thanksgiving Day", [{11, 28}, {11, 26}, {11, 25}]},
               {"Christmas Day", [{12, 25}, {12, 25}, {12, 25}]}
             ]
             |> Enum.flat_map(&make_holiday(&1, @start_year))

--- a/apps/holiday/test/repo_test.exs
+++ b/apps/holiday/test/repo_test.exs
@@ -12,22 +12,22 @@ defmodule Holiday.RepoTest do
   end
 
   describe "by_date/1" do
-    test "returns Christmas Day on 2018-12-25" do
-      date = ~D[2018-12-25]
+    test "returns Christmas Day on 2019-12-25" do
+      date = ~D[2019-12-25]
       assert Holiday.Repo.by_date(date) == [%Holiday{date: date, name: "Christmas Day"}]
     end
 
-    test "returns nothing for 2018-11-01" do
-      date = ~D[2018-11-01]
+    test "returns nothing for 2020-11-01" do
+      date = ~D[2020-11-01]
       assert Holiday.Repo.by_date(date) == []
     end
   end
 
   describe "holidays_in_month/1" do
     test "returns all holidays in the given month" do
-      for date <- [~D[2018-12-01], ~D[2018-12-25], ~D[2018-12-31]] do
+      for date <- [~D[2019-12-01], ~D[2019-12-25], ~D[2019-12-31]] do
         assert Holiday.Repo.holidays_in_month(date) == [
-                 %Holiday{date: ~D[2018-12-25], name: "Christmas Day"}
+                 %Holiday{date: ~D[2019-12-25], name: "Christmas Day"}
                ]
       end
     end

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -279,8 +279,8 @@ defmodule SiteWeb.ScheduleControllerTest do
       # builds a map
       assert conn.assigns.map_img_src =~ "maps.googleapis.com"
 
-      # assigns 2 holidays
-      assert Enum.count(conn.assigns.holidays) == 2
+      # assigns 3 holidays
+      assert Enum.count(conn.assigns.holidays) == 3
     end
 
     test "Ferry data", %{conn: conn} do
@@ -376,10 +376,10 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert "place-nuniv" in stop_ids
     end
 
-    test "assigns 2 holidays", %{conn: conn} do
+    test "assigns 3 holidays", %{conn: conn} do
       conn = get(conn, line_path(conn, :show, "CR-Fitchburg"))
 
-      assert Enum.count(conn.assigns.holidays) == 2
+      assert Enum.count(conn.assigns.holidays) == 3
     end
 
     test "Bus line with variant", %{conn: conn} do


### PR DESCRIPTION
Here we extend our hardcoded list of holidays to cover 2020 and 2021.

#### Summary of changes
**Asana Ticket:** [Add 2020 (and further) holidays to Holiday.Repo.holidays](https://app.asana.com/0/555089885850811/1152004603671561)

<br>
Assigned to: @amaisano 
