### PR TITLE
Remove "Assigned to" from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,3 @@
 **Asana Ticket:** [TICKET_NAME](TICKET_LINK)
 
 [Please include a brief description of what was changed]
-
-<br>
-Assigned to: @NAME


### PR DESCRIPTION

#### Summary of changes
No ticket.

This was redundant with setting reviewers and assignees in Github and
was a source of confusion. Removed.
