### PR TITLE
Fix shuttle map missing stops in one direction

### DIFF
--- a/apps/site/lib/site/shuttle_diversion.ex
+++ b/apps/site/lib/site/shuttle_diversion.ex
@@ -158,7 +158,6 @@ defmodule Site.ShuttleDiversion do
     trips
     |> Stream.filter(&shuttle_route?/1)
     |> Stream.flat_map(&stops_with_direction/1)
-    |> Stream.uniq_by(fn {_, stop} -> stop.id end)
     |> Enum.map(fn {direction_id, stop} ->
       %Stop{
         id: stop.id,


### PR DESCRIPTION
This fixes an issue I discovered in the process of testing #296, so it does not have a documented Asana ticket as yet.

Some shuttle routes include the same stop ID in both directions, but we were incorrectly uniq-ifying the stops returned from `ShuttleDiversion` by ID, ignoring direction. This uniqueness check does not appear to be necessary anyway, as removing it entirely has the same effect as making the stops unique by stop ID and direction ID.