### PR TITLE
Only display relevant alerts on Shuttles tab

### DIFF
--- a/apps/site/lib/site/shuttle_diversion.ex
+++ b/apps/site/lib/site/shuttle_diversion.ex
@@ -1,6 +1,7 @@
 defmodule Site.ShuttleDiversion do
   @moduledoc "Represents and retrieves data about rail-replacement shuttle bus services."
 
+  alias Alerts.Alert
   alias Alerts.Match, as: AlertsMatch
   alias Alerts.Repo, as: Alerts
   alias Routes.Route
@@ -77,10 +78,13 @@ defmodule Site.ShuttleDiversion do
     end
   end
 
-  @enforce_keys [:shapes, :stops]
+  @derive {Poison.Encoder, except: [:alerts]}
+
+  @enforce_keys [:alerts, :shapes, :stops]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
+          alerts: [Alert.t()],
           shapes: [Shape.t()],
           stops: [Stop.t()]
         }
@@ -108,12 +112,13 @@ defmodule Site.ShuttleDiversion do
            unique_trips = unique_trips_by_shape(trips) do
         {:ok,
          %__MODULE__{
+           alerts: ongoing_shuttle_alerts(route_ids, time),
            shapes: build_shapes(route_ids, unique_trips, time),
            stops: build_stops(route_ids, route_stops, unique_trips, time)
          }}
       end
     else
-      {:ok, %__MODULE__{shapes: [], stops: []}}
+      {:ok, %__MODULE__{alerts: [], shapes: [], stops: []}}
     end
   end
 

--- a/apps/site/lib/site_web/templates/schedule/_shuttles.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_shuttles.html.eex
@@ -11,7 +11,7 @@
 
 <div class="row">
   <div class="shuttles__alerts col-md-12">
-    <%= SiteWeb.AlertView.group(alerts: @alerts, route: @route, date_time: @date_time, priority_filter: :high) %>
+    <%= SiteWeb.AlertView.group(alerts: @shuttle_data.alerts, route: @route, date_time: @date_time) %>
   </div>
 
   <div class="shuttles__main col-md-8 col-lg-7">

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -458,7 +458,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
         |> Conn.assign(:route, %Route{id: "Red", type: 1})
         |> Conn.assign(:date_time, ~N[2019-11-25T12:00:00])
 
-      expected = %Site.ShuttleDiversion{shapes: [], stops: []}
+      expected = %Site.ShuttleDiversion{alerts: [], shapes: [], stops: []}
       data = get_shuttle_data(conn)
       assert data == expected
     end


### PR DESCRIPTION
This takes the set of alerts we were already using to determine whether to display the Shuttles tab, and displays it *on* the Shuttles tab.

**Asana Ticket:** [Shuttles | Only show the relevant shuttle alert at top of page](https://app.asana.com/0/477545582537986/1148592031135815/f)

![Screen Shot 2019-12-03 at 3 30 23 PM](https://user-images.githubusercontent.com/394835/70092716-e6fc9700-15ec-11ea-823c-3fe42f7b6607.png)
