### PR TITLE
Rework how we handle holidays in the schedule finder

### DIFF
--- a/apps/site/assets/ts/helpers/__tests__/service-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/service-test.ts
@@ -1,5 +1,4 @@
 import {
-  serviceDays,
   serviceDate,
   groupServiceByDate,
   groupByType,
@@ -39,45 +38,6 @@ const serviceWithDate: ServiceWithServiceDate = {
   service_date: "2019-06-25",
   name: "weekday"
 };
-
-describe("serviceDays", () => {
-  it("returns an empty string for weekends", () => {
-    const saturday: Service = {
-      ...service,
-      description: "Saturday schedule",
-      type: "saturday",
-      valid_days: [6]
-    };
-    expect(serviceDays(saturday)).toBe("");
-
-    const sunday: Service = {
-      ...service,
-      description: "Sunday schedule",
-      type: "sunday",
-      valid_days: [7]
-    };
-    expect(serviceDays(sunday)).toBe("");
-  });
-
-  it("returns a single day in parentheses", () => {
-    const friday: Service = { ...service, valid_days: [5] };
-    expect(serviceDays(friday)).toBe("Friday");
-  });
-
-  it("returns consecutive days as Monday - Friday", () => {
-    expect(serviceDays(service)).toBe("Monday - Friday");
-    const monToWed: Service = { ...service, valid_days: [1, 2, 3] };
-    expect(serviceDays(monToWed)).toBe("Monday - Wednesday");
-
-    const wedToFri: Service = { ...service, valid_days: [3, 4, 5] };
-    expect(serviceDays(wedToFri)).toBe("Wednesday - Friday");
-  });
-
-  it("lists all non-consecutive days", () => {
-    const monWedFri: Service = { ...service, valid_days: [1, 3, 5] };
-    expect(serviceDays(monWedFri)).toBe("Monday, Wednesday, Friday");
-  });
-});
 
 const currentService = {
   ...serviceWithDate,

--- a/apps/site/assets/ts/helpers/__tests__/service-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/service-test.ts
@@ -75,61 +75,74 @@ describe("serviceDate", () => {
 describe("groupServiceByDate", () => {
   it("groups current schedules with the proper service period", () => {
     const groupedService = groupServiceByDate(currentService);
-    expect(groupedService).toEqual({
-      type: "current",
-      servicePeriod: "ends July 28",
-      service: currentService
-    });
+    expect(groupedService).toEqual([
+      {
+        type: "current",
+        servicePeriod: "ends July 28",
+        service: currentService
+      }
+    ]);
   });
 
   it("groups upcoming schedules as future with proper service period", () => {
     const groupedService = groupServiceByDate(upcomingService);
-    expect(groupedService).toEqual({
-      type: "future",
-      servicePeriod: "starts July 1",
-      service: upcomingService
-    });
+    expect(groupedService).toEqual([
+      {
+        type: "future",
+        servicePeriod: "starts July 1",
+        service: upcomingService
+      }
+    ]);
   });
 
   it("groups holiday schedules with proper service period", () => {
-    const groupedService = groupServiceByDate({
-      ...service,
-      service_date: "06-25-19"
-    });
-    expect(groupedService).toEqual({
-      type: "holiday",
-      servicePeriod: "on June 25",
-      service: { ...service, service_date: "06-25-19" }
-    });
+    const groupedService = groupServiceByDate(holidayService);
+    expect(groupedService).toEqual([
+      {
+        type: "holiday",
+        servicePeriod: "St. Transit's Day, June 25",
+        service: holidayService
+      }
+    ]);
   });
+
   it("marks future schedules as future", () => {
     const groupedService = groupServiceByDate({
       ...currentService,
       start_date: "2019-01-01",
       end_date: "2019-01-02"
     });
-    expect(groupedService).toEqual({
-      type: "future",
-      servicePeriod: "January 1 to January 2",
-      service: {
-        ...currentService,
-        start_date: "2019-01-01",
-        end_date: "2019-01-02"
+    expect(groupedService).toEqual([
+      {
+        type: "future",
+        servicePeriod: "January 1 to January 2",
+        service: {
+          ...currentService,
+          start_date: "2019-01-01",
+          end_date: "2019-01-02"
+        }
       }
-    });
+    ]);
   });
 });
 
 const groupServices = (services: ServiceWithServiceDate[]) =>
   services
     .map((service: ServiceWithServiceDate) => groupServiceByDate(service))
+    .reduce((acc, services) => [...acc, ...services])
     .reduce(
       (acc: ServicesKeyedByGroup, currService: ServiceByOptGroup) =>
         groupByType(acc, currService),
       { future: [], current: [], holiday: [] }
     );
 
-const holidayService = { ...service, service_date: "2019-06-25" };
+const holidayService: ServiceWithServiceDate = {
+  ...service,
+  added_dates: ["06-25-19"],
+  added_dates_notes: { "06-25-19": "St. Transit's Day" },
+  service_date: "2019-06-25",
+  typicality: "holiday_service"
+};
 
 describe("getTodaysSchedule", () => {
   it("marks the holiday day as today if there is a holiday", () => {

--- a/apps/site/assets/ts/helpers/__tests__/service-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/service-test.ts
@@ -6,7 +6,12 @@ import {
   ServiceByOptGroup,
   getTodaysSchedule
 } from "../service";
-import { Service, ServiceWithServiceDate, DayInteger } from "../../__v3api";
+import {
+  Service,
+  ServiceWithServiceDate,
+  DayInteger,
+  DatesNotes
+} from "../../__v3api";
 
 const service: Service = {
   added_dates: [],

--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -88,20 +88,24 @@ export const groupByType = (
 
 export const groupServiceByDate = (
   service: ServiceWithServiceDate
-): ServiceByOptGroup => {
+): ServiceByOptGroup[] => {
   const {
     service_date: serviceDate,
     start_date: startDate,
-    end_date: endDate
+    end_date: endDate,
+    added_dates: addedDates,
+    added_dates_notes: addedDatesNotes,
+    typicality
   } = service;
 
-  // Get unix timestamps
-  if (startDate === endDate) {
-    return {
-      type: "holiday",
-      servicePeriod: holidayDate(service),
+  if (typicality === "holiday_service") {
+    return addedDates.map(addedDate => ({
+      type: "holiday" as ServiceOptGroup,
+      servicePeriod: `${addedDatesNotes[addedDate]}, ${formattedDate(
+        new Date(addedDate)
+      )}`,
       service
-    };
+    }));
   }
 
   const startDateObject = new Date(startDate);
@@ -111,28 +115,34 @@ export const groupServiceByDate = (
   const endDateTime = endDateObject.getTime();
 
   if (serviceDateTime >= startDateTime && serviceDateTime <= endDateTime) {
-    return {
-      type: "current",
-      servicePeriod: `ends ${formattedDate(endDateObject)}`,
-      service
-    };
+    return [
+      {
+        type: "current",
+        servicePeriod: `ends ${formattedDate(endDateObject)}`,
+        service
+      }
+    ];
   }
 
   if (serviceDateTime < startDateTime) {
-    return {
-      type: "future",
-      servicePeriod: `starts ${formattedDate(startDateObject)}`,
-      service
-    };
+    return [
+      {
+        type: "future",
+        servicePeriod: `starts ${formattedDate(startDateObject)}`,
+        service
+      }
+    ];
   }
 
-  return {
-    type: "future",
-    servicePeriod: `${formattedDate(startDateObject)} to ${formattedDate(
-      endDateObject
-    )}`,
-    service
-  };
+  return [
+    {
+      type: "future",
+      servicePeriod: `${formattedDate(startDateObject)} to ${formattedDate(
+        endDateObject
+      )}`,
+      service
+    }
+  ];
 };
 
 export const serviceDate = (

--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -162,45 +162,7 @@ export const serviceDate = (
   return `${formattedDate(startDateObject)} to ${formattedDate(endDateObject)}`;
 };
 
-const daysAreConsecutive = (
-  days: DayInteger[],
-  areConsecutive: boolean
-): boolean => {
-  if (!areConsecutive) return areConsecutive;
-  const [day, nextDay, ...rest] = days;
-  if (rest.length === 0) return day + 1 === nextDay;
-  return daysAreConsecutive([nextDay, ...rest], day + 1 === nextDay);
-};
-
-const dayIntegerToString = (day: DayInteger): string =>
-  [
-    "Monday",
-    "Tuesday",
-    "Wednesday",
-    "Thursday",
-    "Friday",
-    "Saturday",
-    "Sunday"
-  ][day - 1];
-
 type MonthInteger = number | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
-
-export const serviceDays = ({
-  type,
-  valid_days: validDays
-}: Service): string => {
-  if (type === "saturday" || type === "sunday") return "";
-
-  if (validDays.length === 1) return `${dayIntegerToString(validDays[0])}`;
-
-  if (daysAreConsecutive(validDays, true)) {
-    return `${dayIntegerToString(validDays[0])} - ${dayIntegerToString(
-      validDays[validDays.length - 1]
-    )}`;
-  }
-
-  return `${validDays.map(dayIntegerToString).join(", ")}`;
-};
 
 export const hasMultipleWeekdaySchedules = (
   services: ServiceWithServiceDate[]

--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -24,10 +24,10 @@ const holidayDate = (service: Service): string => {
   return note || `on ${formattedDate(new Date(service.start_date))}`;
 };
 
-export type ServiceOptGroup = "current" | "holiday" | "future";
+export type ServiceOptGroupName = "current" | "holiday" | "future";
 
 export interface ServiceByOptGroup {
-  type: ServiceOptGroup;
+  type: ServiceOptGroupName;
   servicePeriod: string;
   service: ServiceWithServiceDate;
 }
@@ -74,14 +74,14 @@ export const getTodaysSchedule = (
 };
 
 export type ServicesKeyedByGroup = {
-  [key in ServiceOptGroup]: ServiceByOptGroup[]
+  [key in ServiceOptGroupName]: ServiceByOptGroup[]
 };
 
 export const groupByType = (
   acc: ServicesKeyedByGroup,
   currService: ServiceByOptGroup
 ): ServicesKeyedByGroup => {
-  const currentServiceType: ServiceOptGroup = currService.type;
+  const currentServiceType: ServiceOptGroupName = currService.type;
   const updatedGroup = [...acc[currentServiceType], currService];
   return { ...acc, [currentServiceType]: updatedGroup };
 };
@@ -100,7 +100,7 @@ export const groupServiceByDate = (
 
   if (typicality === "holiday_service") {
     return addedDates.map(addedDate => ({
-      type: "holiday" as ServiceOptGroup,
+      type: "holiday" as ServiceOptGroupName,
       servicePeriod: `${addedDatesNotes[addedDate]}, ${formattedDate(
         new Date(addedDate)
       )}`,

--- a/apps/site/assets/ts/schedule/__tests__/ServiceOptGroupTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ServiceOptGroupTest.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { createReactRoot } from "../../app/helpers/testUtils";
+import ServiceOptGroup from "../components/schedule-finder/ServiceOptGroup";
+
+describe("ServiceOptGroup", () => {
+  it("returns null if no services", () => {
+    createReactRoot();
+    const tree = renderer.create(
+      <ServiceOptGroup
+        group={"holiday"}
+        label={"This label does not appear"}
+        services={[]}
+        multipleWeekdays={false}
+      />
+    );
+    expect(tree.toJSON()).toBeNull();
+  });
+});

--- a/apps/site/assets/ts/schedule/__tests__/ServiceOptionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ServiceOptionTest.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { createReactRoot } from "../../app/helpers/testUtils";
+import { Service } from "../../__v3api";
+import { serviceDays } from "../components/schedule-finder/ServiceOption";
+
+const service: Service = {
+  added_dates: [],
+  added_dates_notes: {},
+  description: "Weekday schedule",
+  end_date: "2019-06-25",
+  id: "BUS319-D-Wdy-02",
+  removed_dates: [],
+  removed_dates_notes: {},
+  start_date: "2019-06-25",
+  type: "weekday",
+  typicality: "typical_service",
+  valid_days: [1, 2, 3, 4, 5],
+  name: "weekday"
+};
+
+describe("serviceDays", () => {
+  it("returns an empty string for weekends", () => {
+    const saturday: Service = {
+      ...service,
+      description: "Saturday schedule",
+      type: "saturday",
+      valid_days: [6]
+    };
+    expect(serviceDays(saturday)).toBe("");
+
+    const sunday: Service = {
+      ...service,
+      description: "Sunday schedule",
+      type: "sunday",
+      valid_days: [7]
+    };
+    expect(serviceDays(sunday)).toBe("");
+  });
+
+  it("returns a single day in parentheses", () => {
+    const friday: Service = { ...service, valid_days: [5] };
+    expect(serviceDays(friday)).toBe("Friday");
+  });
+
+  it("returns consecutive days as Monday - Friday", () => {
+    expect(serviceDays(service)).toBe("Monday - Friday");
+    const monToWed: Service = { ...service, valid_days: [1, 2, 3] };
+    expect(serviceDays(monToWed)).toBe("Monday - Wednesday");
+
+    const wedToFri: Service = { ...service, valid_days: [3, 4, 5] };
+    expect(serviceDays(wedToFri)).toBe("Wednesday - Friday");
+  });
+
+  it("lists all non-consecutive days", () => {
+    const monWedFri: Service = { ...service, valid_days: [1, 3, 5] };
+    expect(serviceDays(monWedFri)).toBe("Monday, Wednesday, Friday");
+  });
+});

--- a/apps/site/assets/ts/schedule/__tests__/ServiceSelectorTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ServiceSelectorTest.tsx
@@ -67,6 +67,21 @@ const services: ServiceWithServiceDate[] = [
     description: "Sunday schedule",
     added_dates_notes: {},
     added_dates: []
+  },
+  {
+    valid_days: [],
+    typicality: "holiday_service",
+    type: "sunday",
+    start_date: "2019-07-07",
+    service_date: "2019-07-09",
+    removed_dates_notes: {},
+    removed_dates: [],
+    name: "Sunday",
+    id: "Bastille-Day",
+    end_date: "2019-08-25",
+    description: "Sunday schedule",
+    added_dates_notes: { "2019-07-14": "Bastille Day" },
+    added_dates: ["2019-07-14"]
   }
 ] as ServiceWithServiceDate[];
 

--- a/apps/site/assets/ts/schedule/__tests__/ServiceSelectorTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ServiceSelectorTest.tsx
@@ -7,7 +7,7 @@ import {
   getDefaultScheduleId
 } from "../components/schedule-finder/ServiceSelector";
 import { ServiceWithServiceDate } from "../../__v3api";
-import { ServiceOptGroup } from "../../helpers/service";
+import { ServiceOptGroupName } from "../../helpers/service";
 
 const services: ServiceWithServiceDate[] = [
   {
@@ -173,26 +173,26 @@ describe("ServiceSelector", () => {
     const servicesByOptGroup = {
       current: [
         {
-          type: "current" as ServiceOptGroup,
+          type: "current" as ServiceOptGroupName,
           servicePeriod: "sometime",
           service: services[0]
         }
       ],
       future: [
         {
-          type: "future" as ServiceOptGroup,
+          type: "future" as ServiceOptGroupName,
           servicePeriod: "sometime",
           service: services[1]
         },
         {
-          type: "future" as ServiceOptGroup,
+          type: "future" as ServiceOptGroupName,
           servicePeriod: "sometime",
           service: services[2]
         }
       ],
       holiday: [
         {
-          type: "holiday" as ServiceOptGroup,
+          type: "holiday" as ServiceOptGroupName,
           servicePeriod: "sometime",
           service: services[3]
         }

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
@@ -56,7 +56,13 @@ Array [
         </optgroup>
         <optgroup
           label="Holiday Schedules"
-        />
+        >
+          <option
+            value="Bastille-Day"
+          >
+            Bastille Day, July 14
+          </option>
+        </optgroup>
         <optgroup
           label="Future Schedules"
         />

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
@@ -63,9 +63,6 @@ Array [
             Bastille Day, July 14
           </option>
         </optgroup>
-        <optgroup
-          label="Future Schedules"
-        />
       </select>
       <span
         aria-hidden="true"

--- a/apps/site/assets/ts/schedule/components/schedule-finder/HolidayServiceOption.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/HolidayServiceOption.tsx
@@ -1,0 +1,16 @@
+import React, { ReactElement } from "react";
+import { ServiceWithServiceDate } from "../../../__v3api";
+
+interface Props {
+  service: ServiceWithServiceDate;
+  servicePeriod: string;
+}
+
+const HolidayServiceOption = ({
+  service,
+  servicePeriod
+}: Props): ReactElement<HTMLElement> => (
+  <option value={service.id}>{servicePeriod}</option>
+);
+
+export default HolidayServiceOption;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOptGroup.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOptGroup.tsx
@@ -1,0 +1,42 @@
+import React, { ReactElement } from "react";
+import ServiceOption from "./ServiceOption";
+import HolidayServiceOption from "./HolidayServiceOption";
+import {
+  ServiceOptGroupName,
+  ServiceByOptGroup
+} from "../../../helpers/service";
+
+interface Props {
+  group: ServiceOptGroupName;
+  label: string;
+  services: ServiceByOptGroup[];
+  multipleWeekdays: boolean;
+}
+
+const ServiceOptGroup = ({
+  group,
+  label,
+  services,
+  multipleWeekdays
+}: Props): ReactElement<HTMLElement> | null => (
+  <optgroup key={group} label={label}>
+    {services.map((service: ServiceByOptGroup) =>
+      group === "holiday" ? (
+        <HolidayServiceOption
+          key={service.service.id + service.servicePeriod}
+          service={service.service}
+          servicePeriod={service.servicePeriod}
+        />
+      ) : (
+        <ServiceOption
+          key={service.service.id + service.servicePeriod}
+          service={service.service}
+          group={group}
+          servicePeriod={service.servicePeriod}
+          multipleWeekdays={multipleWeekdays}
+        />
+      )
+    )}
+  </optgroup>
+);
+export default ServiceOptGroup;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOptGroup.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOptGroup.tsx
@@ -18,25 +18,26 @@ const ServiceOptGroup = ({
   label,
   services,
   multipleWeekdays
-}: Props): ReactElement<HTMLElement> | null => (
-  <optgroup key={group} label={label}>
-    {services.map((service: ServiceByOptGroup) =>
-      group === "holiday" ? (
-        <HolidayServiceOption
-          key={service.service.id + service.servicePeriod}
-          service={service.service}
-          servicePeriod={service.servicePeriod}
-        />
-      ) : (
-        <ServiceOption
-          key={service.service.id + service.servicePeriod}
-          service={service.service}
-          group={group}
-          servicePeriod={service.servicePeriod}
-          multipleWeekdays={multipleWeekdays}
-        />
-      )
-    )}
-  </optgroup>
-);
+}: Props): ReactElement<HTMLElement> | null =>
+  services.length === 0 ? null : (
+    <optgroup key={group} label={label}>
+      {services.map((service: ServiceByOptGroup) =>
+        group === "holiday" ? (
+          <HolidayServiceOption
+            key={service.service.id + service.servicePeriod}
+            service={service.service}
+            servicePeriod={service.servicePeriod}
+          />
+        ) : (
+          <ServiceOption
+            key={service.service.id + service.servicePeriod}
+            service={service.service}
+            group={group}
+            servicePeriod={service.servicePeriod}
+            multipleWeekdays={multipleWeekdays}
+          />
+        )
+      )}
+    </optgroup>
+  );
 export default ServiceOptGroup;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOption.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOption.tsx
@@ -58,7 +58,7 @@ const ServiceOption = ({
     service.type === "weekday" &&
     service.typicality !== "holiday_service";
   return (
-    <option value={service.id} key={service.id}>
+    <option value={service.id}>
       {isMultipleWeekday
         ? `${serviceDays(service)} schedule`
         : service.description}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOption.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOption.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement } from "react";
-import { ServiceOptGroup } from "../../../helpers/service";
+import { ServiceOptGroupName } from "../../../helpers/service";
 import { Service, DayInteger, ServiceWithServiceDate } from "../../../__v3api";
 
 interface Props {
   service: ServiceWithServiceDate;
-  group: ServiceOptGroup;
+  group: ServiceOptGroupName;
   servicePeriod: string;
   multipleWeekdays: boolean;
 }

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOption.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOption.tsx
@@ -1,0 +1,71 @@
+import React, { ReactElement } from "react";
+import { ServiceOptGroup } from "../../../helpers/service";
+import { Service, DayInteger, ServiceWithServiceDate } from "../../../__v3api";
+
+interface Props {
+  service: ServiceWithServiceDate;
+  group: ServiceOptGroup;
+  servicePeriod: string;
+  multipleWeekdays: boolean;
+}
+
+const dayIntegerToString = (day: DayInteger): string =>
+  [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday"
+  ][day - 1];
+
+const daysAreConsecutive = (
+  days: DayInteger[],
+  areConsecutive: boolean
+): boolean => {
+  if (!areConsecutive) return areConsecutive;
+  const [day, nextDay, ...rest] = days;
+  if (rest.length === 0) return day + 1 === nextDay;
+  return daysAreConsecutive([nextDay, ...rest], day + 1 === nextDay);
+};
+
+export const serviceDays = ({
+  type,
+  valid_days: validDays
+}: Service): string => {
+  if (type === "saturday" || type === "sunday") return "";
+
+  if (validDays.length === 1) return `${dayIntegerToString(validDays[0])}`;
+
+  if (daysAreConsecutive(validDays, true)) {
+    return `${dayIntegerToString(validDays[0])} - ${dayIntegerToString(
+      validDays[validDays.length - 1]
+    )}`;
+  }
+
+  return `${validDays.map(dayIntegerToString).join(", ")}`;
+};
+
+const ServiceOption = ({
+  service,
+  group,
+  servicePeriod,
+  multipleWeekdays
+}: Props): ReactElement<HTMLElement> => {
+  const isMultipleWeekday =
+    multipleWeekdays &&
+    service.type === "weekday" &&
+    service.typicality !== "holiday_service";
+  return (
+    <option value={service.id} key={service.id}>
+      {isMultipleWeekday
+        ? `${serviceDays(service)} schedule`
+        : service.description}
+      {group !== "holiday" ? ", " : " "}
+      {servicePeriod}
+    </option>
+  );
+};
+
+export default ServiceOption;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -8,13 +8,13 @@ import {
   getTodaysSchedule,
   ServiceOptGroup,
   ServiceByOptGroup,
-  serviceDays,
   hasMultipleWeekdaySchedules
 } from "../../../helpers/service";
 import { reducer } from "../../../helpers/fetch";
 import ScheduleTable from "./ScheduleTable";
 import { SelectedDirection } from "../ScheduleFinder";
 import { EnhancedRoutePattern, ServiceScheduleInfo } from "../__schedule";
+import ServiceOption from "./ServiceOption";
 
 // until we come up with a good integration test for async with loading
 // some lines in this file have been ignored from codecov
@@ -34,27 +34,6 @@ interface Props {
   directionId: SelectedDirection;
   routePatterns: EnhancedRoutePattern[];
 }
-
-const serviceDescription = (
-  service: ServiceWithServiceDate,
-  group: ServiceOptGroup,
-  servicePeriod: string,
-  multipleWeekdays: boolean
-): ReactElement<HTMLElement> => {
-  const isMultipleWeekday =
-    multipleWeekdays &&
-    service.type === "weekday" &&
-    service.typicality !== "holiday_service";
-  return (
-    <option value={service.id} key={service.id}>
-      {isMultipleWeekday
-        ? `${serviceDays(service)} schedule`
-        : service.description}
-      {group !== "holiday" ? ", " : " "}
-      {servicePeriod}
-    </option>
-  );
-};
 
 const getTodaysScheduleId = (
   servicesByOptGroup: ServicesKeyedByGroup
@@ -181,12 +160,14 @@ export const ServiceSelector = ({
 
               return (
                 <optgroup key={group} label={optGroupTitles[group]}>
-                  {servicesByOptGroup[group].map((service: ServiceByOptGroup) =>
-                    serviceDescription(
-                      service.service,
-                      group,
-                      service.servicePeriod,
-                      multipleWeekdays
+                  {servicesByOptGroup[group].map(
+                    (service: ServiceByOptGroup) => (
+                      <ServiceOption
+                        service={service.service}
+                        group={group}
+                        servicePeriod={service.servicePeriod}
+                        multipleWeekdays={multipleWeekdays}
+                      />
                     )
                   )}
                 </optgroup>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -6,7 +6,7 @@ import {
   groupServiceByDate,
   groupByType,
   getTodaysSchedule,
-  ServiceOptGroup,
+  ServiceOptGroupName,
   ServiceByOptGroup,
   hasMultipleWeekdaySchedules
 } from "../../../helpers/service";
@@ -20,9 +20,9 @@ import HolidayServiceOption from "./HolidayServiceOption";
 // until we come up with a good integration test for async with loading
 // some lines in this file have been ignored from codecov
 
-const optGroupNames: ServiceOptGroup[] = ["current", "holiday", "future"];
+const optGroupNames: ServiceOptGroupName[] = ["current", "holiday", "future"];
 
-const optGroupTitles: { [key in ServiceOptGroup]: string } = {
+const optGroupTitles: { [key in ServiceOptGroupName]: string } = {
   current: "Current Schedules",
   holiday: "Holiday Schedules",
   future: "Future Schedules"
@@ -157,7 +157,7 @@ export const ServiceSelector = ({
               setSelectedServiceId(e.target.value);
             }}
           >
-            {optGroupNames.map((group: ServiceOptGroup) => {
+            {optGroupNames.map((group: ServiceOptGroupName) => {
               const multipleWeekdays = hasMultipleWeekdaySchedules(
                 servicesByOptGroup[group].map(service => service.service)
               );

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -131,7 +131,10 @@ export const ServiceSelector = ({
   if (services.length <= 0) return null;
 
   const servicesByOptGroup: ServicesKeyedByGroup = services
-    .map((service: ServiceWithServiceDate) => groupServiceByDate(service))
+    .reduce(
+      (acc, service) => [...acc, ...groupServiceByDate(service)],
+      [] as ServiceByOptGroup[]
+    )
     .reduce(groupByType, { current: [], holiday: [], future: [] });
 
   const defaultServiceId = getDefaultScheduleId(servicesByOptGroup);

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -14,8 +14,7 @@ import { reducer } from "../../../helpers/fetch";
 import ScheduleTable from "./ScheduleTable";
 import { SelectedDirection } from "../ScheduleFinder";
 import { EnhancedRoutePattern, ServiceScheduleInfo } from "../__schedule";
-import ServiceOption from "./ServiceOption";
-import HolidayServiceOption from "./HolidayServiceOption";
+import ServiceOptGroup from "./ServiceOptGroup";
 
 // until we come up with a good integration test for async with loading
 // some lines in this file have been ignored from codecov
@@ -163,25 +162,13 @@ export const ServiceSelector = ({
               );
 
               return (
-                <optgroup key={group} label={optGroupTitles[group]}>
-                  {servicesByOptGroup[group].map((service: ServiceByOptGroup) =>
-                    group === "holiday" ? (
-                      <HolidayServiceOption
-                        key={service.service.id + service.servicePeriod}
-                        service={service.service}
-                        servicePeriod={service.servicePeriod}
-                      />
-                    ) : (
-                      <ServiceOption
-                        key={service.service.id + service.servicePeriod}
-                        service={service.service}
-                        group={group}
-                        servicePeriod={service.servicePeriod}
-                        multipleWeekdays={multipleWeekdays}
-                      />
-                    )
-                  )}
-                </optgroup>
+                <ServiceOptGroup
+                  key={group}
+                  group={group}
+                  label={optGroupTitles[group]}
+                  services={servicesByOptGroup[group]}
+                  multipleWeekdays={multipleWeekdays}
+                />
               );
             })}
           </select>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -15,6 +15,7 @@ import ScheduleTable from "./ScheduleTable";
 import { SelectedDirection } from "../ScheduleFinder";
 import { EnhancedRoutePattern, ServiceScheduleInfo } from "../__schedule";
 import ServiceOption from "./ServiceOption";
+import HolidayServiceOption from "./HolidayServiceOption";
 
 // until we come up with a good integration test for async with loading
 // some lines in this file have been ignored from codecov
@@ -163,9 +164,16 @@ export const ServiceSelector = ({
 
               return (
                 <optgroup key={group} label={optGroupTitles[group]}>
-                  {servicesByOptGroup[group].map(
-                    (service: ServiceByOptGroup) => (
+                  {servicesByOptGroup[group].map((service: ServiceByOptGroup) =>
+                    group === "holiday" ? (
+                      <HolidayServiceOption
+                        key={service.service.id + service.servicePeriod}
+                        service={service.service}
+                        servicePeriod={service.servicePeriod}
+                      />
+                    ) : (
                       <ServiceOption
+                        key={service.service.id + service.servicePeriod}
                         service={service.service}
                         group={group}
                         servicePeriod={service.servicePeriod}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedule finder | Determine holiday services using typicality](https://app.asana.com/0/555089885850811/1152227770350433)

* We take advantage of the fact that holiday data will soon be more consistent (try this against dev-green) to determine which services represent holidays, and which holidays they represent, in a simpler and more robust manner.
* We drop some of the text out of the `option`s for holidays, bringing them in accordance with the new information design in the finder.