### PR TITLE
Release the Shuttles tab

### DIFF
--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -26,8 +26,7 @@ config :site, SiteWeb.ViewHelpers, google_tag_manager_id: System.get_env("GOOGLE
 
 config :laboratory,
   features: [
-    {:schedule_direction_redesign, "Schedule direction_redesign", ""},
-    {:shuttles, "Shuttles page", ""}
+    {:schedule_direction_redesign, "Schedule direction_redesign", ""}
   ],
   cookie: [
     # one month,

--- a/apps/site/lib/site_web/controllers/schedule/shuttles_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/shuttles_controller.ex
@@ -3,7 +3,6 @@ defmodule SiteWeb.ScheduleController.ShuttlesController do
 
   use SiteWeb, :controller
 
-  alias SiteWeb.ControllerHelpers
   alias SiteWeb.ScheduleView
 
   import SiteWeb.ScheduleController.Line.Helpers,
@@ -20,7 +19,6 @@ defmodule SiteWeb.ScheduleController.ShuttlesController do
   def show(conn, _) do
     conn
     |> put_view(ScheduleView)
-    |> ControllerHelpers.noindex()
     |> assign(:paragraphs, get_shuttle_paragraphs(conn))
     |> assign(:shuttle_data, get_shuttle_data(conn))
     |> render("show.html", [])

--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -380,7 +380,7 @@ defmodule SiteWeb.ScheduleView do
     ]
 
     tabs =
-      if Laboratory.enabled?(conn, :shuttles) and ShuttleDiversion.active?([route.id], now) do
+      if ShuttleDiversion.active?([route.id], now) do
         [
           %HeaderTab{
             id: "shuttles",

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -1026,10 +1026,6 @@ defmodule SiteWeb.ScheduleViewTest do
   end
 
   describe "route_header_tabs/1" do
-    def set_shuttles_laboratory_flag(conn) do
-      put_req_header(conn, "cookie", "shuttles=true")
-    end
-
     test "returns 4 tabs for commuter rail (1 hidden by css)", %{conn: conn} do
       tabs =
         conn
@@ -1061,11 +1057,10 @@ defmodule SiteWeb.ScheduleViewTest do
       refute tabs =~ "timetable-tab"
     end
 
-    test "includes shuttles tab, if flag set and any shuttle alerts", %{conn: conn} do
+    test "includes shuttles tab if there are any shuttle alerts", %{conn: conn} do
       with_mock Site.ShuttleDiversion, active?: fn _, _ -> true end do
         tabs =
           conn
-          |> set_shuttles_laboratory_flag
           |> assign(:route, %Route{id: "83", type: 3})
           |> assign(:tab, "alerts")
           |> assign(:tab_params, [])
@@ -1080,7 +1075,6 @@ defmodule SiteWeb.ScheduleViewTest do
       with_mock Site.ShuttleDiversion, active?: fn _, _ -> false end do
         tabs =
           conn
-          |> set_shuttles_laboratory_flag
           |> assign(:route, %Route{id: "83", type: 3})
           |> assign(:tab, "alerts")
           |> assign(:tab_params, [])


### PR DESCRIPTION
This removes the feature flag and "noindex" tag from the Shuttles tab, making it generally available.