### PR TITLE
Rename AFC 2.0 to Fare Transformation

### DIFF
--- a/apps/site/lib/site_web/templates/layout/_desktop_menu_more.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_desktop_menu_more.html.eex
@@ -78,7 +78,7 @@
           <%= link "Commuter Rail Positive Train Control", to: project_path(@conn, :show, "commuter-rail-positive-train-control-ptc"), class: "ga-nav-sublink" %>
         </li>
         <li>
-          <%= link "Automated Fare Collection 2.0", to: cms_static_page_path(@conn, "/afc2"), class: "ga-nav-sublink" %>
+          <%= link "Fare Transformation", to: cms_static_page_path(@conn, "/fare-transformation"), class: "ga-nav-sublink" %>
         </li>
         <li>
           <%= link "Green Line Extension", to: "https://www.mass.gov/green-line-extension-project-glx", target: "_blank", class: "ga-nav-sublink" %>

--- a/apps/site/lib/site_web/templates/static_page/about.html.eex
+++ b/apps/site/lib/site_web/templates/static_page/about.html.eex
@@ -26,7 +26,7 @@
     <h2>Improvements & Projects</h2>
     <div class="c-grid-buttons">
       <%= render "_link.html", text: "Commuter Rail Positive Train Control", href: project_path(@conn, :show , "commuter-rail-positive-train-control-ptc"), class: "col-xs-12 col-sm-4" %>
-      <%= render "_link.html", text: "Automated Fare Collection 2.0", href: cms_static_page_path(@conn, "/afc2"), class: "col-xs-12 col-sm-4" %>
+      <%= render "_link.html", text: "Fare Transformation", href: cms_static_page_path(@conn, "/fare-transformation"), class: "col-xs-12 col-sm-4" %>
       <%= render "_link.html", text: "Green Line Extension", href: "https://www.mass.gov/green-line-extension-project-glx", class: "col-xs-12 col-sm-4", target: "_blank" %>
       <%= render "_link.html", text: "Wollaston Station", href: cms_static_page_path(@conn, "/wollaston"), class: "col-xs-12 col-sm-4" %>
       <%= render "_link.html", text: "See All Projects", href: project_path(@conn, :index), class: "col-xs-12 col-sm-4" %>


### PR DESCRIPTION
The old name and vanity URL were being used in a few spots.

#### Summary of changes
**Asana Ticket:** [Fare Transformation | Rename in "More" top nav](https://app.asana.com/0/555089885850811/1152699235340689)