### PR TITLE
Revert "bump up global coverage threshold for statements"

### DIFF
--- a/apps/site/assets/ts/jest.config.js
+++ b/apps/site/assets/ts/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
       branches: 93,
       functions: 95,
       lines: 95,
-      statements: -45 // Since we have SSR checks, this needs to be lenient
+      statements: -40 // Since we have SSR checks, this needs to be lenient
     },
     // The Leaflet API is difficult to test, so we consider a lower
     // threshold acceptable for these modules. However, callbacks in

--- a/apps/site/assets/ts/shuttles/__tests__/DirectionButtonsTest.tsx
+++ b/apps/site/assets/ts/shuttles/__tests__/DirectionButtonsTest.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { mount, ReactWrapper } from "enzyme";
+import DirectionButtons from "../components/DirectionButtons";
+
+const onClick = jest.fn();
+const places = { 0: "Alewife", 1: "Ashmont / Braintree" };
+let wrapper: ReactWrapper;
+beforeEach(() => {
+  wrapper = mount(<DirectionButtons places={places} onClick={onClick} />);
+});
+
+afterEach(() => {
+  wrapper!.unmount();
+});
+
+it.each`
+  index | direction | name
+  ${0}  | ${null}   | ${"All Directions"}
+  ${1}  | ${0}      | ${places["0"]}
+  ${2}  | ${1}      | ${places["1"]}
+`(
+  "the directions button for direction $direction has name $name",
+  ({ index, name }) => {
+    expect(
+      wrapper
+        .find("button")
+        .at(index)
+        .text()
+    ).toEqual(name);
+  }
+);
+
+it.each`
+  index | direction | name
+  ${0}  | ${null}   | ${"All Directions"}
+  ${1}  | ${0}      | ${places["0"]}
+  ${2}  | ${1}      | ${places["1"]}
+`(
+  "the $name button calls onClick with $direction direction",
+  ({ index, direction }) => {
+    const button = wrapper.find("button").at(index);
+    button.simulate("click");
+    wrapper.setProps({}); // updates the onClick mock
+    expect(onClick).toHaveBeenLastCalledWith(direction);
+  }
+);

--- a/apps/site/assets/ts/shuttles/__tests__/ShuttlesPageTest.tsx
+++ b/apps/site/assets/ts/shuttles/__tests__/ShuttlesPageTest.tsx
@@ -8,6 +8,7 @@ import { TileServerUrl } from "../../leaflet/components/__mapdata";
 import ShuttlesMap from "../components/ShuttlesMap";
 import StopDropdown from "../components/StopDropdown";
 import renderer from "react-test-renderer";
+import DirectionButtons from "../components/DirectionButtons";
 
 const diversionsData = _diversionsData as Diversion;
 const tileServerUrl: TileServerUrl =
@@ -85,12 +86,18 @@ it("the shuttles page renders", () => {
 it("the shuttles page shows direction names for combined 'Green' Line", () => {
   destinations(greenRoute).forEach(headsign => {
     expect(
-      greenWrapper.containsMatchingElement(<button>{headsign}</button>)
+      greenWrapper
+        .find(DirectionButtons)
+        .dive()
+        .containsMatchingElement(<button>{headsign}</button>)
     ).toEqual(false);
   });
   names(greenRoute).forEach(name => {
     expect(
-      greenWrapper.containsMatchingElement(<button>{name}</button>)
+      greenWrapper
+        .find(DirectionButtons)
+        .dive()
+        .containsMatchingElement(<button>{name}</button>)
     ).toEqual(true);
   });
 });
@@ -98,13 +105,19 @@ it("the shuttles page shows direction names for combined 'Green' Line", () => {
 it("the shuttles page shows direction destinations for all other lines", () => {
   destinations(route).forEach(headsign => {
     expect(
-      wrapper.containsMatchingElement(<button>{headsign}</button>)
+      wrapper
+        .find(DirectionButtons)
+        .dive()
+        .containsMatchingElement(<button>{headsign}</button>)
     ).toEqual(true);
   });
   names(route).forEach(name => {
-    expect(wrapper.containsMatchingElement(<button>{name}</button>)).toEqual(
-      false
-    );
+    expect(
+      wrapper
+        .find(DirectionButtons)
+        .dive()
+        .containsMatchingElement(<button>{name}</button>)
+    ).toEqual(false);
   });
 });
 
@@ -125,23 +138,6 @@ it("the shuttles page by default shows all shapes", () => {
     }
   );
 });
-
-it.each`
-  index | direction | name
-  ${0}  | ${null}   | ${"All Directions"}
-  ${1}  | ${0}      | ${route.direction_destinations["0"]}
-  ${2}  | ${1}      | ${route.direction_destinations["1"]}
-`(
-  "the shuttles page button for direction $direction has name $name",
-  ({ index, name }) => {
-    expect(
-      wrapper
-        .find("button")
-        .at(index)
-        .text()
-    ).toEqual(name);
-  }
-);
 
 it("the shuttles page <select> lists affected stops only", () => {
   const options = wrapper

--- a/apps/site/assets/ts/shuttles/components/DirectionButtons.tsx
+++ b/apps/site/assets/ts/shuttles/components/DirectionButtons.tsx
@@ -1,0 +1,61 @@
+import React, { ReactElement, useState, useEffect } from "react";
+import { MaybeDirectionId } from "./__shuttles";
+import { DirectionInfo } from "../../__v3api";
+
+interface Props {
+  places: DirectionInfo;
+  onClick: (directionId: MaybeDirectionId) => void;
+}
+
+const DirectionButtons: React.FC<Props> = ({
+  places,
+  onClick
+}: Props): ReactElement<HTMLElement> => {
+  const [selectedDirectionId, setSelectedDirectionId] = useState<
+    MaybeDirectionId
+  >(null);
+
+  useEffect(
+    () => {
+      onClick(selectedDirectionId);
+    },
+    [onClick, selectedDirectionId]
+  );
+
+  const DirectionButton = (
+    directionId: MaybeDirectionId,
+    headsign: string
+  ): JSX.Element => (
+    <button
+      key={`${headsign}`}
+      type="button"
+      className={`btn btn-secondary btn-sm c-btn-group-stackable__btn ${selectedDirectionId ===
+        directionId && "c-btn-group-stackable__btn--active"}`}
+      onClick={() => {
+        setSelectedDirectionId(directionId);
+      }}
+    >
+      {headsign}
+    </button>
+  );
+
+  return (
+    <div
+      className="c-btn-group-stackable"
+      role="group"
+      aria-label="Filter shuttle map by direction"
+    >
+      {DirectionButton(null, "All Directions")}
+      {Object.entries(places)
+        .sort()
+        .map(([directionId, headsign]) =>
+          DirectionButton(
+            parseInt(directionId, 10) as MaybeDirectionId,
+            headsign
+          )
+        )}
+    </div>
+  );
+};
+
+export default DirectionButtons;


### PR DESCRIPTION
Just refactoring some of my test code to allow us to restore the prior setting for Jest test coverage.