### PR TITLE
Omit past services from schedule finder

### DIFF
--- a/apps/site/test/site_web/controllers/schedule/line_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_controller_test.exs
@@ -1,0 +1,38 @@
+defmodule SiteWeb.Schedule.LineControllerTest do
+  use SiteWeb.ConnCase
+  alias Services.Service
+  alias SiteWeb.ScheduleController.LineController
+
+  describe "services/3" do
+    test "omits services in the past" do
+      service_date = ~D[2019-05-01]
+
+      past_service = %Service{
+        start_date: ~D[2019-04-30],
+        end_date: ~D[2019-04-30]
+      }
+
+      current_service = %Service{
+        start_date: ~D[2019-05-01],
+        end_date: ~D[2019-05-01]
+      }
+
+      future_service = %Service{
+        start_date: ~D[2019-05-02],
+        end_date: ~D[2019-05-02]
+      }
+
+      repo_fn = fn _ ->
+        [
+          past_service,
+          current_service,
+          future_service
+        ]
+      end
+
+      services = LineController.services("1", service_date, repo_fn)
+      assert length(services) == 2
+      refute Enum.member?(services, past_service)
+    end
+  end
+end


### PR DESCRIPTION
Services that are over are just noise in the schedule finder: leave them
out.

#### Summary of changes
**Asana Ticket:** [Schedule finder | Don't display past schedules](https://app.asana.com/0/555089885850811/1152227770350445)
