### PR TITLE
Omit services that are subsets of other services

### DIFF
--- a/apps/site/test/site_web/controllers/schedule/line_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_controller_test.exs
@@ -61,5 +61,36 @@ defmodule SiteWeb.Schedule.LineControllerTest do
       assert length(services) == 1
       refute Enum.member?(services, no_school_service)
     end
+
+    test "omits services that are subsets of another service" do
+      service_date = ~D[2019-05-01]
+
+      subset_service = %Service{
+        start_date: ~D[2019-05-30],
+        end_date: ~D[2019-06-30]
+      }
+
+      superset_service = %Service{
+        start_date: ~D[2019-05-29],
+        end_date: ~D[2019-07-01]
+      }
+
+      unrelated_service = %Service{
+        start_date: ~D[2019-07-02],
+        end_date: ~D[2019-09-02]
+      }
+
+      repo_fn = fn _ ->
+        [
+          subset_service,
+          superset_service,
+          unrelated_service
+        ]
+      end
+
+      services = LineController.services("1", service_date, repo_fn)
+      assert length(services) == 2
+      refute Enum.member?(services, subset_service)
+    end
   end
 end


### PR DESCRIPTION
We have logic in the service picker that gets rid of services with the
same start date, end date, and valid days as another service. However,
there are other cases in which we have two services, one of which is a
subset of another, rather than an exact match. These subsets are
redundant too: omit them.

#### Summary of changes
**Asana Ticket:** [Services Picker | De-dupe services that differ only by what garage they run out of](https://app.asana.com/0/555089885850811/1152227770350437)