### PR TITLE
Omit no-school services

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -99,6 +99,7 @@ defmodule SiteWeb.ScheduleController.LineController do
     route_id
     |> services_by_route_id_fn.()
     |> dedup_services()
+    |> Enum.reject(&(&1.name == "Weekday (no school)"))
     |> Enum.reject(&(Date.compare(&1.end_date, service_date) == :lt))
     |> Enum.sort_by(&sort_services_by_date/1)
     |> Enum.map(&Map.put(&1, :service_date, service_date))

--- a/apps/site/test/site_web/controllers/schedule/line_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_controller_test.exs
@@ -34,5 +34,32 @@ defmodule SiteWeb.Schedule.LineControllerTest do
       assert length(services) == 2
       refute Enum.member?(services, past_service)
     end
+
+    test "omits no-school weekday services" do
+      service_date = ~D[2019-05-01]
+
+      school_service = %Service{
+        start_date: ~D[2019-12-11],
+        end_date: ~D[2019-12-11],
+        name: "Weekday"
+      }
+
+      no_school_service = %Service{
+        start_date: ~D[2019-12-12],
+        end_date: ~D[2019-12-12],
+        name: "Weekday (no school)"
+      }
+
+      repo_fn = fn _ ->
+        [
+          school_service,
+          no_school_service
+        ]
+      end
+
+      services = LineController.services("1", service_date, repo_fn)
+      assert length(services) == 1
+      refute Enum.member?(services, no_school_service)
+    end
   end
 end


### PR DESCRIPTION
Due to the way we already call out stops that are skipped on non-school
days in the regular weekday service, it's redundant to show the
no-school services in the service picker as well; leave them out.

#### Summary of changes
**Asana Ticket:** [Services Picker | Filter out services that differ from standard services only in having no school service](https://app.asana.com/0/555089885850811/1152227770350425)