### PR TITLE
Check for nil, as well as blank, train number

### DIFF
--- a/apps/site/lib/site_web/templates/schedule/_line_page_stop_prediction_cr.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line_page_stop_prediction_cr.html.eex
@@ -2,7 +2,7 @@
 <%= unless headsign == nil do %>
   <%= for time_data <- headsign.times do %>
     <% status = if time_data.delay > 5, do: "Delayed #{time_data.delay} min", else: "On time" %>
-    <% train_info = if headsign.train_number != "", do: [" · Train ", headsign.train_number], else: "" %>
+    <% train_info = if headsign.train_number != "" && headsign.train_number != nil, do: [" · Train ", headsign.train_number], else: "" %>
 
     <div class="route-branch-stop-prediction">
       <div>


### PR DESCRIPTION
No ticket.

We check for a blank train number in this view, but not for a nil train
number, leading to crashes at the time of deploying a new rating with
new GTFS trip IDs. Corrected.