### PR TITLE
Don't 500 on line page with date outside rating

### DIFF
--- a/apps/site/lib/predicted_schedule.ex
+++ b/apps/site/lib/predicted_schedule.ex
@@ -74,6 +74,10 @@ defmodule PredictedSchedule do
     |> Enum.sort_by(sort_fn)
   end
 
+  defp create_map({:error, [%JsonApi.Error{code: "no_service"}]}) do
+    %{}
+  end
+
   defp create_map(predictions_or_schedules) do
     Map.new(predictions_or_schedules, &group_transform/1)
   end

--- a/apps/site/test/predicted_schedule_test.exs
+++ b/apps/site/test/predicted_schedule_test.exs
@@ -211,6 +211,27 @@ defmodule PredictedScheduleTest do
         assert schedule.trip.id == prediction.trip.id
       end
     end
+
+    test "still makes predictions available if date requested is outside of rating" do
+      no_service_error =
+        {:error,
+         [
+           %JsonApi.Error{
+             code: "no_service",
+             detail: nil,
+             meta: %{
+               "end_date" => "2020-03-14",
+               "start_date" => "2019-12-05",
+               "version" => "Winter 2020, 2019-12-12T21:07:05+00:00, version D"
+             },
+             source: %{"parameter" => "date"}
+           }
+         ]}
+
+      grouped_predicted_schedules = group(@predictions, no_service_error)
+      assert grouped_predicted_schedules |> Enum.map(& &1.prediction) == @predictions
+      assert grouped_predicted_schedules |> Enum.map(& &1.schedule) == [nil, nil, nil]
+    end
   end
 
   describe "stop/1" do


### PR DESCRIPTION
As of 65e97eb765d0b0a97e85a09cda3b325905c352d9, the line page accepts a
`date` query param, which enables Backstop testing on that page to work
properly again. However, it also introduced a regression, where if the
date given has no service available in the API, rather than just
returning live predictions, PredictedSchedule.group/3 was choking on the
struct representing the "no service" error. Fixed.

#### Summary of changes
**Asana Ticket:** [Date in params outside of rating shouldn't blow up line page](https://app.asana.com/0/385363666817452/1153779766848073)