### PR TITLE
Don't show schedules or predictions outside rating

### DIFF
--- a/apps/site/test/site/transit_near_me_test.exs
+++ b/apps/site/test/site/transit_near_me_test.exs
@@ -461,5 +461,34 @@ defmodule Site.TransitNearMeTest do
 
       assert %{"place-wimnl" => [%{}]} = actual
     end
+
+    test "return neither schedules nor predictions if date is outside rating" do
+      predictions_fn = fn _ -> [@prediction] end
+
+      schedules_fn = fn _, _ ->
+        {:error,
+         [
+           %JsonApi.Error{
+             code: "no_service",
+             detail: nil,
+             meta: %{
+               "end_date" => "2020-03-14",
+               "start_date" => "2019-12-06",
+               "version" => "Winter 2020, 2019-12-13T17:29:50+00:00, version D"
+             },
+             source: %{"parameter" => "date"}
+           }
+         ]}
+      end
+
+      actual =
+        TransitNearMe.time_data_for_route_by_stop(@route.id, 1,
+          schedules_fn: schedules_fn,
+          predictions_fn: predictions_fn,
+          now: @now
+        )
+
+      assert actual == %{}
+    end
   end
 end


### PR DESCRIPTION
As of 65e97eb, the line page accepts a date query param, which enables
Backstop testing on that page to work properly again. However, it also
introduced a regression, where if the date given has no service
available in the API, rather than just returning live predictions,
TransitNearMe.time_data_for_route_by_stop/3 was choking on the error
struct indicating "no service". Fixed.

#### Summary of changes
**Asana Ticket:** [Date in params outside of rating shouldn't blow up line page](https://app.asana.com/0/555089885850811/1153779766848073)

[Please include a brief description of what was changed]
