### PR TITLE
Redirect requests for eliminated route 70A

### DIFF
--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -94,6 +94,10 @@ defmodule SiteWeb.Router do
     get("/schedules/448/*path_params", Redirector, to: "/betterbus-440s")
     get("/schedules/449", Redirector, to: "/betterbus-440s")
     get("/schedules/449/*path_params", Redirector, to: "/betterbus-440s")
+    get("/schedules/70a", Redirector, to: "/betterbus-61-70-70A")
+    get("/schedules/70a/*path_params", Redirector, to: "/betterbus-61-70-70A")
+    get("/schedules/70A", Redirector, to: "/betterbus-61-70-70A")
+    get("/schedules/70A/*path_params", Redirector, to: "/betterbus-61-70-70A")
 
     get("/", PageController, :index)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🚍 BBP | Redirect /schedules/* pages of eliminated route 70A](https://app.asana.com/0/555089885850811/1146677757163682)

Eliminate the schedules pages for the 70A, which will no longer run after 12/22.