### PR TITLE
Allow a single project/project_update teaser in ContentList

### DIFF
--- a/apps/cms/lib/partial/paragraph/content_list.ex
+++ b/apps/cms/lib/partial/paragraph/content_list.ex
@@ -209,8 +209,8 @@ defmodule CMS.Partial.Paragraph.ContentList do
 
   # Limit amount of teasers when certain types are requested
   @spec limit_count_by_type(map) :: map
-  defp limit_count_by_type(%{type: [type]} = ingredients)
-       when type in [:project_update, :project] do
+  defp limit_count_by_type(%{type: [type], items_per_page: items} = ingredients)
+       when type in [:project_update, :project] and items > 2 do
     Map.put(ingredients, :items_per_page, 2)
   end
 

--- a/apps/cms/test/paragraph/content_list_test.exs
+++ b/apps/cms/test/paragraph/content_list_test.exs
@@ -179,6 +179,16 @@ defmodule CMS.Partial.Paragraph.ContentListTest do
     assert opts == [items_per_page: 5, type: [:event]]
   end
 
+  test "Only enforces an upper limit for project/update teasers" do
+    request_3 = cms_map(content_type: "project", number_of_items: 3)
+    request_2 = cms_map(content_type: "project", number_of_items: 2)
+    request_1 = cms_map(content_type: "project", number_of_items: 1)
+
+    assert request_3 == [items_per_page: 2, type: [:project]]
+    assert request_2 == [items_per_page: 2, type: [:project]]
+    assert request_1 == [items_per_page: 1, type: [:project]]
+  end
+
   defp cms_map(fields) do
     fields
     |> Enum.into(%{}, &cms_field/1)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Softer project/update teaser limit](https://app.asana.com/0/399597520748778/1154510548826576)

Prior to this PR, we were always forcing 2 results when a list of project or project_update teasers was requested -- **even when authors explicitly set it to only show 1 result**. With this PR, we only enforce the 2-item limit if more than 2 items are requested (as originally spec'd by design).