### PR TITLE
Schedules call to /api/teasers should use array value for :type

### DIFF
--- a/apps/site/lib/site_web/controllers/mode_controller.ex
+++ b/apps/site/lib/site_web/controllers/mode_controller.ex
@@ -94,7 +94,7 @@ defmodule SiteWeb.ModeController do
 
   @spec guides :: [Teaser.t()]
   defp guides do
-    [type: :page, topic: "guides", sidebar: 1]
+    [type: [:page], topic: "guides", sidebar: 1]
     |> Repo.teasers()
     |> Enum.map(&utm_url/1)
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules call to /api/teasers should use array value for :type](https://app.asana.com/0/399597520748778/1154795529418209)

A while back we added support for querying multiple content :type values. Drupal requires this to be sent as an array instead of a single binary value now, or else the results will not be as expected.

We had updated most instances of this in the codebase, but missed this one.

See #116 and mbta/cms#286
