### PR TITLE
Fix CMS paragraph order being scrambled

### DIFF
--- a/apps/util/test/async_assign_test.exs
+++ b/apps/util/test/async_assign_test.exs
@@ -31,6 +31,6 @@ defmodule Util.AsyncAssignTest do
     assert log =~ "module=#{__MODULE__}"
     assert log =~ "key=hello"
     assert log =~ "error=async_error"
-    assert log =~ "async task timed out"
+    assert log =~ "Async task timed out"
   end
 end

--- a/apps/util/test/util_test.exs
+++ b/apps/util/test/util_test.exs
@@ -313,6 +313,21 @@ defmodule UtilTest do
       assert async_with_timeout([fn -> 5 end, fn -> 6 end], nil, __MODULE__) == [5, 6]
     end
 
+    test "returns results in the same order functions were passed in" do
+      results = Enum.to_list(0..99)
+
+      functions =
+        Enum.map(
+          results,
+          &fn ->
+            :timer.sleep(&1)
+            &1
+          end
+        )
+
+      assert async_with_timeout(functions, nil, __MODULE__) == results
+    end
+
     test "returns the default for a task that runs too long and logs a warning" do
       log =
         capture_log(fn ->
@@ -327,7 +342,7 @@ defmodule UtilTest do
                  ) == [5, :default]
         end)
 
-      assert log =~ "async task timed out"
+      assert log =~ "Async task timed out"
     end
   end
 
@@ -377,9 +392,9 @@ defmodule UtilTest do
                  }
         end)
 
-      assert log =~ "Returning: :long_default"
-      assert log =~ "task exited unexpectedly"
-      refute log =~ "Returning: :short_default"
+      assert log =~ "Defaulting to: :long_default"
+      assert log =~ "exited for reason: :killed"
+      refute log =~ "Defaulting to: :short_default"
     end
   end
 


### PR DESCRIPTION
The issue was that `async_with_timeout`, which accepts a list of functions, was implemented on top of `yield_or_default_many`, which accepts a map where the values are functions. The map values were being collected back into a list, but since maps are not ordered, this result list would not have the same ordering as the input list.

Because the previous approach resulted in this data flow:

```
list -> map -> list -> Task.yield_many -> list -> map -> list
```

We can simplify to this:

```
list -> Task.yield_many -> list
```

**Asana Ticket:** [🐞💧 Paragraphs display in wrong order (follow-up)](https://app.asana.com/0/385363666817452/1153851471078822/f)