### PR TITLE
Make shuttle stop locations more accurate

### DIFF
--- a/apps/site/lib/site/shuttle_diversion.ex
+++ b/apps/site/lib/site/shuttle_diversion.ex
@@ -104,7 +104,7 @@ defmodule Site.ShuttleDiversion do
 
       trips_params = [
         "filter[date]": time |> Util.service_date() |> Date.to_iso8601(),
-        include: "route,route_pattern,shape,shape.stops"
+        include: "route,route_pattern,shape,stops"
       ]
 
       with %JsonApi{data: trips} <- TripsHack.by_route(trips_route, trips_params),
@@ -208,7 +208,7 @@ defmodule Site.ShuttleDiversion do
     hd(trip.relationships["route"]).attributes["type"] == 3
   end
 
-  defp stops(%{relationships: %{"shape" => [%{relationships: %{"stops" => stops}}]}}), do: stops
+  defp stops(%{relationships: %{"stops" => stops}}), do: stops
   defp stops(_trip), do: []
 
   defp stops_with_direction(%{attributes: %{"direction_id" => direction_id}} = trip) do


### PR DESCRIPTION
**Asana Ticket:** [🐞  Shuttle map stops are sometimes misplaced](https://app.asana.com/0/385363666817452/1152828697682145/f)

Due to a documentation oversight in the API, we hadn't realized stops could be obtained directly from trips instead of going through shapes. Doing this gives more accurate results, and is preferred anyway since the existence of stops on shapes may be deprecated in the future.

### Before

The shuttle stop at Alewife is incorrectly displayed at the "overall location" of Alewife station.

![Screen Shot 2019-12-26 at 11 20 49 AM](https://user-images.githubusercontent.com/394835/71482657-cda4d000-27d1-11ea-9a25-a5a982a775f6.png)

### After

The shuttle stop is correctly located within the Alewife busway.

![Screen Shot 2019-12-26 at 11 17 21 AM](https://user-images.githubusercontent.com/394835/71482663-d5647480-27d1-11ea-9962-6d2c5893913f.png)
