### PR TITLE
Improve default bounds for shuttle maps

### DIFF
--- a/apps/site/assets/ts/shuttles/__tests__/ShuttlesPageTest.tsx
+++ b/apps/site/assets/ts/shuttles/__tests__/ShuttlesPageTest.tsx
@@ -46,7 +46,7 @@ jest.mock("react-leaflet/lib/Map");
 let wrapper: ShallowWrapper;
 let greenWrapper: ShallowWrapper;
 
-/* use shallow instead of mount. mount throws Uncaught [RangeError: Maximum call stack size exceeded] 
+/* use shallow instead of mount. mount throws Uncaught [RangeError: Maximum call stack size exceeded]
 from a dependency, fast-deep-equal, used to memoize the Map component ShuttlesMap is based on. */
 beforeEach(() => {
   wrapper = shallow(
@@ -152,10 +152,10 @@ it("the shuttles page <select> lists affected stops only", () => {
   expect(options).toEqual(affectedStops);
 });
 
-it("the shuttles page detail map by default centers first affected stop", () => {
+it("the shuttles page detail map by default views first affected stop", () => {
   let map = wrapper.find(ShuttlesMap).at(1);
   const firstStation = diversionsData.stops
     .sort()
     .filter(s => s.type === "rail_affected")[0];
-  expect(map.prop("centerStop")!.id).toEqual(firstStation.id);
+  expect(map.prop("selectedStop")!.id).toEqual(firstStation.id);
 });

--- a/apps/site/assets/ts/shuttles/__tests__/__snapshots__/ShuttlesMapTest.tsx.snap
+++ b/apps/site/assets/ts/shuttles/__tests__/__snapshots__/ShuttlesMapTest.tsx.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`the shuttles map with a centerStop prop matches snapshot 1`] = `
-"<ShuttlesMap tileServerUrl=\\"https://mbta-map-tiles-dev.s3.amazonaws.com\\" shapes={{...}} stops={{...}} centerStop={{...}}>
+exports[`the shuttles map with a selected stop matches snapshot 1`] = `
+"<ShuttlesMap tileServerUrl=\\"https://mbta-map-tiles-dev.s3.amazonaws.com\\" shapes={{...}} stops={{...}} selectedStop={{...}}>
   <div className=\\"m-shuttles-map\\">
     <Component mapData={{...}} bounds={{...}} boundsByMarkers={false}>
-      <Map bounds={{...}} center={{...}} zoom={18} maxZoom={18} minZoom={9} scrollWheelZoom={false} style={{...}} />
+      <Map bounds={{...}} center={{...}} zoom={[undefined]} maxZoom={18} minZoom={9} scrollWheelZoom={false} style={{...}} />
     </Component>
   </div>
 </ShuttlesMap>"
 `;
 
-exports[`the shuttles map without a center prop matches snapshot 1`] = `
+exports[`the shuttles map without a selected stop matches snapshot 1`] = `
 "<ShuttlesMap tileServerUrl=\\"https://mbta-map-tiles-dev.s3.amazonaws.com\\" shapes={{...}} stops={{...}}>
   <div className=\\"m-shuttles-map\\">
     <Component mapData={{...}} bounds={{...}} boundsByMarkers={false}>
-      <Map bounds={{...}} center={{...}} zoom={13} maxZoom={18} minZoom={9} scrollWheelZoom={false} style={{...}} />
+      <Map bounds={{...}} center={{...}} zoom={[undefined]} maxZoom={18} minZoom={9} scrollWheelZoom={false} style={{...}} />
     </Component>
   </div>
 </ShuttlesMap>"

--- a/apps/site/assets/ts/shuttles/components/ShuttlesMap.tsx
+++ b/apps/site/assets/ts/shuttles/components/ShuttlesMap.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { latLng, latLngBounds } from "leaflet";
+import { latLng, LatLngBounds, latLngBounds } from "leaflet";
 import { Stop, Shape } from "./__shuttles";
 import Map from "../../leaflet/components/Map";
 import {
@@ -65,21 +65,25 @@ const makePolylines = (shapes: Shape[]): Polyline[] =>
     weight: shape.is_shuttle_route ? 4 : 6
   }));
 
-const boundsFromStops = (stops: Stop[], selectedStop: Stop | undefined) => {
+const boundsFromStops = (
+  stops: Stop[],
+  selectedStop: Stop | undefined
+): LatLngBounds => {
   let includedStops;
   const padding = 0.2;
 
   if (selectedStop) {
     // If a stop is selected, include that stop and the nearest shuttle stop.
-    const { latitude, longitude } = selectedStop,
-      selectedStopLocation = latLng(latitude, longitude),
-      shuttleStopsByDistance = stops
-        .filter(stop => stop.type === "shuttle")
-        .sort(
-          (a, b) =>
-            selectedStopLocation.distanceTo([a.latitude, a.longitude]) -
-            selectedStopLocation.distanceTo([b.latitude, b.longitude])
-        );
+    const { latitude, longitude } = selectedStop;
+    const selectedStopLocation = latLng(latitude, longitude);
+
+    const shuttleStopsByDistance = stops
+      .filter(stop => stop.type === "shuttle")
+      .sort(
+        (a, b) =>
+          selectedStopLocation.distanceTo([a.latitude, a.longitude]) -
+          selectedStopLocation.distanceTo([b.latitude, b.longitude])
+      );
 
     includedStops = [selectedStop, shuttleStopsByDistance[0]];
   } else {
@@ -102,8 +106,8 @@ const ShuttlesMap = ({
     const bounds = boundsFromStops(stops, selectedStop);
 
     // the MapData interface requires a center value
-    const { lng: longitude, lat: latitude } = bounds.getCenter(),
-      defaultCenter = { longitude, latitude };
+    const { lng: longitude, lat: latitude } = bounds.getCenter();
+    const defaultCenter = { longitude, latitude };
 
     /* eslint-disable @typescript-eslint/camelcase */
     const mapData: MapData = {

--- a/apps/site/assets/ts/shuttles/components/ShuttlesMap.tsx
+++ b/apps/site/assets/ts/shuttles/components/ShuttlesMap.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement } from "react";
-import { latLng, LatLngBounds, latLngBounds } from "leaflet";
 import { Stop, Shape } from "./__shuttles";
 import Map from "../../leaflet/components/Map";
 import {
@@ -103,6 +102,9 @@ const ShuttlesMap = ({
   tileServerUrl
 }: Props): ReactElement<HTMLElement> | null => {
   if (typeof window !== "undefined") {
+    // eslint-disable-next-line global-require
+    const { latLng, LatLngBounds, latLngBounds } = require("leaflet");
+
     const bounds = boundsFromStops(stops, selectedStop);
 
     // the MapData interface requires a center value

--- a/apps/site/assets/ts/shuttles/components/ShuttlesMap.tsx
+++ b/apps/site/assets/ts/shuttles/components/ShuttlesMap.tsx
@@ -64,12 +64,10 @@ const makePolylines = (shapes: Shape[]): Polyline[] =>
     weight: shape.is_shuttle_route ? 4 : 6
   }));
 
-const boundsFromStops = (
-  stops: Stop[],
-  selectedStop: Stop | undefined
-): LatLngBounds => {
-  // eslint-disable-next-line global-require
-  const { latLng, LatLngBounds, latLngBounds } = require("leaflet");
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const boundsFromStops = (stops: Stop[], selectedStop: Stop | undefined) => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+  const { latLng, latLngBounds } = require("leaflet");
 
   let includedStops;
   const padding = 0.2;

--- a/apps/site/assets/ts/shuttles/components/ShuttlesMap.tsx
+++ b/apps/site/assets/ts/shuttles/components/ShuttlesMap.tsx
@@ -68,6 +68,9 @@ const boundsFromStops = (
   stops: Stop[],
   selectedStop: Stop | undefined
 ): LatLngBounds => {
+  // eslint-disable-next-line global-require
+  const { latLng, LatLngBounds, latLngBounds } = require("leaflet");
+
   let includedStops;
   const padding = 0.2;
 
@@ -102,9 +105,6 @@ const ShuttlesMap = ({
   tileServerUrl
 }: Props): ReactElement<HTMLElement> | null => {
   if (typeof window !== "undefined") {
-    // eslint-disable-next-line global-require
-    const { latLng, LatLngBounds, latLngBounds } = require("leaflet");
-
     const bounds = boundsFromStops(stops, selectedStop);
 
     // the MapData interface requires a center value

--- a/apps/site/assets/ts/shuttles/components/ShuttlesPage.tsx
+++ b/apps/site/assets/ts/shuttles/components/ShuttlesPage.tsx
@@ -77,7 +77,7 @@ const ShuttlesPage: React.FC<Props> = ({
         tileServerUrl={tileServerUrl}
         shapes={displayedShapes}
         stops={displayedStops}
-        centerStop={selectedStop}
+        selectedStop={selectedStop}
       />
     </div>
   );

--- a/semaphore/backstop.sh
+++ b/semaphore/backstop.sh
@@ -51,7 +51,7 @@ set -e
 if [[ $ENABLE_RECORDING == "true" ]]; then
   SENTRY_REPORTING_ENV="test" npm run server:mocked:record 1>/dev/null 2>/dev/null &
 else
-  SENTRY_REPORTING_ENV="test" npm run server:mocked &
+  SENTRY_REPORTING_ENV="test" npm run server:mocked 1>/dev/null 2>/dev/null &
 fi
 SERVER_PID=$!
 

--- a/semaphore/backstop.sh
+++ b/semaphore/backstop.sh
@@ -51,7 +51,7 @@ set -e
 if [[ $ENABLE_RECORDING == "true" ]]; then
   SENTRY_REPORTING_ENV="test" npm run server:mocked:record 1>/dev/null 2>/dev/null &
 else
-  SENTRY_REPORTING_ENV="test" npm run server:mocked 1>/dev/null 2>/dev/null &
+  SENTRY_REPORTING_ENV="test" npm run server:mocked &
 fi
 SERVER_PID=$!
 


### PR DESCRIPTION
**Asana Ticket:** [🐞 Shuttle detail map is sometimes too zoomed-in](https://app.asana.com/0/385363666817452/1152815245059801/f)

I investigated doing the "quick fix" described in this ticket, but found that the required zoom levels for the detail map to be usable varied widely from stop to stop. Some required a zoom of 15 to even reach the nearest shuttle stop, but some required a zoom of 18 to prevent everything from being clustered too close together to tell what was going on.

Based on this, I decided to do the nicer thing and auto-fit to the nearest shuttle stop, which wasn't too much effort.

This also adds a default padding of 20% to the auto-fit (applies to the main map too), which really improves the initial appearance of both maps, in terms of having enough surrounding context to tell what's happening on the route.

### Main Map

Before | After
:---:|:---:
![Screen Shot 2019-12-26 at 3 06 42 PM](https://user-images.githubusercontent.com/394835/71489584-4452c500-27f4-11ea-8e2a-37c49939800e.png) | ![Screen Shot 2019-12-26 at 3 06 15 PM](https://user-images.githubusercontent.com/394835/71489588-474db580-27f4-11ea-9427-3ea7b31a9ada.png)
![Screen Shot 2019-12-26 at 3 07 09 PM](https://user-images.githubusercontent.com/394835/71489651-a90e1f80-27f4-11ea-9e9c-642d5c15d896.png) | ![Screen Shot 2019-12-26 at 3 09 19 PM](https://user-images.githubusercontent.com/394835/71489655-ac091000-27f4-11ea-8bd6-3e43d875927d.png)

### Detail Map

Before | After
:---:|:---:
![Screen Shot 2019-12-26 at 3 07 31 PM](https://user-images.githubusercontent.com/394835/71489769-3f424580-27f5-11ea-9da5-6299852f3f03.png) | ![Screen Shot 2019-12-26 at 3 09 15 PM](https://user-images.githubusercontent.com/394835/71489771-41a49f80-27f5-11ea-9558-e4621805b66a.png)
![Screen Shot 2019-12-26 at 3 36 27 PM](https://user-images.githubusercontent.com/394835/71489808-829cb400-27f5-11ea-8712-e6e83a7cd7f8.png) | ![Screen Shot 2019-12-26 at 3 36 10 PM](https://user-images.githubusercontent.com/394835/71489814-88929500-27f5-11ea-955a-b45313b6aaae.png)
