### PR TITLE
Depict branches on schedules line diagram

### DIFF
--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -6,16 +6,16 @@ $line-width: 10px;
     border-bottom: 0;
     display: flex;
     padding: $base-spacing;
-  
+
     &:last-child {
       border-bottom: $border;
     }
   }
-  
+
   .m-schedule-diagram__content {
     flex-grow: 1;
   }
-  
+
   .m-schedule-diagram__card {
     align-items: flex-start;
     display: flex;
@@ -27,7 +27,7 @@ $line-width: 10px;
 
   .m-schedule-diagram__stop-name {
     font-weight: bold;
-  
+
     h4 {
       margin-top: $base-spacing / -4;
     }
@@ -36,14 +36,14 @@ $line-width: 10px;
   .m-schedule-diagram__connections {
     .m-schedule-diagram__connection {
       margin: 0 ($base-spacing / 8);
-  
-      .c-svg__icon {
-        height: $base-spacing;
-        vertical-align: middle;
-        width: $base-spacing;
-      }
     }
-  
+
+    .c-svg__icon {
+      height: $base-spacing;
+      vertical-align: middle;
+      width: $base-spacing;
+    }
+
     a {
       display: inline-block;
       line-height: 0;
@@ -51,7 +51,7 @@ $line-width: 10px;
       vertical-align: top;
     }
   }
-  
+
   .m-schedule-diagram__features {
     .m-schedule-diagram__feature-icon {
       height: $base-spacing;
@@ -59,7 +59,7 @@ $line-width: 10px;
       margin-left: $base-spacing / 4;
       width: $base-spacing;
     }
-  
+
     .c-icon__cr-zone {
       font-size: $base-spacing * .7;
       vertical-align: text-top;
@@ -116,6 +116,8 @@ $line-width: 10px;
     circle {
       fill: $white;
       stroke: currentColor;
+      stroke-width: 0;
+      transform-origin: 50%;
     }
 
     path {
@@ -131,9 +133,18 @@ $line-width: 10px;
     transform: translateY(28px);
   }
 
+  .m-schedule-diagram__line--terminus circle {
+    stroke-width: 1.15px !important;
+  }
+
+  // first stop
+  .m-schedule-diagram__stop:first-child circle {
+    transform: translateY(3px) scale(1.15);
+  }
+
   // last stop
   .m-schedule-diagram__stop:last-child circle {
-    transform: translateY(34px);
+    transform: translateY(35px) scale(1.15);
   }
 }
 
@@ -144,7 +155,7 @@ $line-width: 10px;
     height: $base-spacing * 2;
 
     circle {
-      transform: translateY(34px);
+      transform: translateY(35px) scale(1.15);
     }
   }
 }
@@ -153,14 +164,17 @@ $line-width: 10px;
   // first stop on branch
   .m-schedule-diagram__line + .m-schedule-diagram__line--terminus {
     margin-top: $base-spacing * 2;
+
+    circle {
+      transform: translateY(3px) scale(1.15);
+    }
   }
 
-  // last stop on branch
-  .m-schedule-diagram__line + .m-schedule-diagram__line--merge {
-    height: $base-spacing * 2;
+  .m-schedule-diagram__lines--merging .m-schedule-diagram__line-bend {
+    transform: scaleY(-1) translateY(calc(-#{$base-spacing * 2} - 10px));
   }
 
-  .m-schedule-diagram__line--merge .m-schedule-diagram__line-bend {
-    transform: scaleY(-1) translateY(-50px);
+  .m-schedule-diagram__lines--merging .m-schedule-diagram__line:not(:first-child) {
+    height: calc(#{$base-spacing * 2} + 10px);
   }
 }

--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -1,89 +1,89 @@
-.m-schedule-diagram__stop {
-  border: $border;
-  border-bottom: 0;
-  display: flex;
-  padding: $base-spacing;
-
-  &:last-child {
-    border-bottom: $border;
-  }
-}
-
-.m-schedule-line-diagram__content {
-  flex-grow: 1;
-}
-
-.m-schedule-line-diagram__card {
-  align-items: flex-start;
-  display: flex;
-}
-
-.m-schedule-line-diagram__stop-name {
-  font-weight: bold;
-
-  h4 {
-    margin-top: $base-spacing / -4;
-  }
-}
-
-.m-schedule-line-diagram__connections {
-  .m-schedule-line-diagram__connection {
-    margin: 0 ($base-spacing / 8);
-
-    .c-svg__icon {
-      height: $base-spacing;
-      vertical-align: middle;
-      width: $base-spacing;
-    }
-  }
-
-  a {
-    display: inline-block;
-    line-height: 0;
-    max-height: $base-spacing * 1.5;
-    vertical-align: top;
-  }
-}
-
-.m-schedule-line-diagram__features {
-  .m-schedule-line-diagram__feature-icon {
-    height: $base-spacing;
-    line-height: $base-spacing;
-    margin-left: $base-spacing / 4;
-    width: $base-spacing;
-  }
-
-  .c-icon__cr-zone {
-    font-size: $base-spacing * .7;
-    vertical-align: text-top;
-    width: auto;
-  }
-}
-
-.m-schedule-line-diagram__card-left {
-  flex-grow: 1;
-}
-
-.m-schedule-line-diagram__footer {
-  text-align: center;
-
-  .btn {
-    padding: unset;
-  }
-}
-
-//
-//  Schedule line diagram
-//
-//  .m-schedule-diagram__lines contains all the
-//  graphics for the line diagram, and uses negative
-//  margins to counter the padding from its parent
-//  .m-schedule-diagram__stop.
-//  A .m-schedule-diagram__line is drawn for each
-//  branch, and creates the line. Stop circles are SVGs.
 $line-width: 10px;
 
 .m-schedule-diagram {
+  .m-schedule-diagram__stop {
+    border: $border;
+    border-bottom: 0;
+    display: flex;
+    padding: $base-spacing;
+  
+    &:last-child {
+      border-bottom: $border;
+    }
+  }
+  
+  .m-schedule-diagram__content {
+    flex-grow: 1;
+  }
+  
+  .m-schedule-diagram__card {
+    align-items: flex-start;
+    display: flex;
+  }
+
+  .m-schedule-diagram__card-left {
+    flex-grow: 1;
+  }
+
+  .m-schedule-diagram__stop-name {
+    font-weight: bold;
+  
+    h4 {
+      margin-top: $base-spacing / -4;
+    }
+  }
+
+  .m-schedule-diagram__connections {
+    .m-schedule-diagram__connection {
+      margin: 0 ($base-spacing / 8);
+  
+      .c-svg__icon {
+        height: $base-spacing;
+        vertical-align: middle;
+        width: $base-spacing;
+      }
+    }
+  
+    a {
+      display: inline-block;
+      line-height: 0;
+      max-height: $base-spacing * 1.5;
+      vertical-align: top;
+    }
+  }
+  
+  .m-schedule-diagram__features {
+    .m-schedule-diagram__feature-icon {
+      height: $base-spacing;
+      line-height: $base-spacing;
+      margin-left: $base-spacing / 4;
+      width: $base-spacing;
+    }
+  
+    .c-icon__cr-zone {
+      font-size: $base-spacing * .7;
+      vertical-align: text-top;
+      width: auto;
+    }
+  }
+
+  .m-schedule-diagram__footer {
+    text-align: center;
+
+    .btn {
+      padding: unset;
+    }
+  }
+
+  //
+  //  Schedule line diagram
+  //
+  //  .m-schedule-diagram__lines contains all the
+  //  graphics for the line diagram, and uses negative
+  //  margins to counter the padding from its parent
+  //  .m-schedule-diagram__stop.
+  //  A .m-schedule-diagram__line is drawn for each
+  //  branch, and creates the line. Stop circles are SVGs.
   .m-schedule-diagram__lines {
     display: flex;
     margin: calc(-#{$base-spacing} - #{$border-width}*2) 0;

--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -90,7 +90,7 @@ $line-width: 10px;
     margin-right: $base-spacing;
 
     svg {
-      height: 0; // remove browser default height
+      height: auto; // remove browser default height
       overflow: visible;
     }
 

--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -1,13 +1,16 @@
-.m-schedule-line-diagram__stop {
+.m-schedule-diagram__stop {
   border: $border;
   border-bottom: 0;
+  display: flex;
   padding: $base-spacing;
-  padding-left: $base-spacing * 3;
-  position: relative;
 
   &:last-child {
     border-bottom: $border;
   }
+}
+
+.m-schedule-line-diagram__content {
+  flex-grow: 1;
 }
 
 .m-schedule-line-diagram__card {
@@ -43,10 +46,6 @@
 }
 
 .m-schedule-line-diagram__features {
-  align-items: center;
-  display: flex;
-  justify-content: flex-end;
-
   .m-schedule-line-diagram__feature-icon {
     height: $base-spacing;
     line-height: $base-spacing;
@@ -56,6 +55,7 @@
 
   .c-icon__cr-zone {
     font-size: $base-spacing * .7;
+    vertical-align: text-top;
     width: auto;
   }
 }
@@ -72,27 +72,67 @@
   }
 }
 
-.m-schedule-line-diagram__line {
-  background-color: currentColor;
-  bottom: -$base-spacing * 1.5;
-  left: $base-spacing;
-  line-height: 0;
-  margin-bottom: -1px; // removes spacing
-  position: absolute;
-  top: $base-spacing * 1.5;
-  width: 10px;
-  z-index: 1;
+//
+//  Schedule line diagram
+//
+//  .m-schedule-diagram__lines contains all the
+//  graphics for the line diagram, and uses negative
+//  margins to counter the padding from its parent
+//  .m-schedule-diagram__stop.
+//  A .m-schedule-diagram__line is drawn for each
+//..branch, and creates the line. Stop circles are SVGs.
+$line-width: 10px;
 
-  .m-schedule-line-diagram__stop:last-child & {
-    height: 0;
+.m-schedule-diagram {
+  .m-schedule-diagram__lines {
+    display: flex;
+    margin: calc(-#{$base-spacing} - #{$border-width}*2) 0;
+    margin-right: $base-spacing;
+
+    svg {
+      height: 0; // remove browser default height
+      overflow: visible;
+    }
+
+    circle {
+      fill: $white;
+      stroke: currentColor;
+      stroke-width: 2;
+      z-index: 2;
+    }
+
+    path {
+      fill: none;
+      stroke: currentColor;
+      stroke-linejoin: round;
+      stroke-width: $line-width;
+    }
   }
 
-  svg {
-    overflow: visible;
+  .m-schedule-diagram__line {
+    background-color: currentColor;
+    width: $line-width;
   }
 
-  circle {
-    fill: $white;
-    stroke: currentColor;
+  .m-schedule-diagram__stop:last-child .m-schedule-diagram__line {
+    height: $base-spacing * 2;
+  }
+
+  .m-schedule-diagram__stop:first-child .m-schedule-diagram__lines {
+    margin-top: $base-spacing;
+  }
+}
+
+.m-schedule-diagram--with-branches {
+  .m-schedule-diagram__line--branch {
+    margin-left: $line-width;
+  }
+
+  .m-schedule-diagram__stop--branch-start .m-schedule-diagram__line--branch:last-child {
+    margin-top: $base-spacing * 2;
+  }
+
+  .m-schedule-diagram__stop--branch-end .m-schedule-diagram__line:last-child {
+    height: $base-spacing * 2;
   }
 }

--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -23,6 +23,10 @@ $line-width: 10px;
 
   .m-schedule-diagram__card-left {
     flex-grow: 1;
+
+    .c-svg__icon-alerts-triangle svg > path:first-of-type {
+      fill: currentColor;
+    }
   }
 
   .m-schedule-diagram__stop-name {
@@ -134,7 +138,7 @@ $line-width: 10px;
   }
 
   .m-schedule-diagram__line--terminus circle {
-    stroke-width: 1.15px !important;
+    stroke-width: 1.15px;
   }
 
   // first stop

--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -80,7 +80,7 @@
 //  margins to counter the padding from its parent
 //  .m-schedule-diagram__stop.
 //  A .m-schedule-diagram__line is drawn for each
-//..branch, and creates the line. Stop circles are SVGs.
+//  branch, and creates the line. Stop circles are SVGs.
 $line-width: 10px;
 
 .m-schedule-diagram {
@@ -88,17 +88,34 @@ $line-width: 10px;
     display: flex;
     margin: calc(-#{$base-spacing} - #{$border-width}*2) 0;
     margin-right: $base-spacing;
+  }
 
-    svg {
-      height: auto; // remove browser default height
-      overflow: visible;
+  .m-schedule-diagram__line {
+    background-color: currentColor;
+    width: $line-width;
+
+    + .m-schedule-diagram__line {
+      margin-left: $line-width;
     }
+  }
+
+  // first stop
+  .m-schedule-diagram__stop:first-child .m-schedule-diagram__lines {
+    margin-top: $base-spacing;
+  }
+
+  // last stop
+  .m-schedule-diagram__stop:last-child .m-schedule-diagram__lines {
+    height: $base-spacing * 2;
+  }
+
+  // stop circle
+  .m-schedule-diagram__line-stop {
+    overflow: visible;
 
     circle {
       fill: $white;
       stroke: currentColor;
-      stroke-width: 2;
-      z-index: 2;
     }
 
     path {
@@ -109,30 +126,41 @@ $line-width: 10px;
     }
   }
 
-  .m-schedule-diagram__line {
-    background-color: currentColor;
-    width: $line-width;
+  .m-schedule-diagram__line--merge circle,
+  .m-schedule-diagram__line--stop circle {
+    transform: translateY(28px);
   }
 
-  .m-schedule-diagram__stop:last-child .m-schedule-diagram__line {
-    height: $base-spacing * 2;
-  }
-
-  .m-schedule-diagram__stop:first-child .m-schedule-diagram__lines {
-    margin-top: $base-spacing;
+  // last stop
+  .m-schedule-diagram__stop:last-child circle {
+    transform: translateY(34px);
   }
 }
 
-.m-schedule-diagram--with-branches {
-  .m-schedule-diagram__line--branch {
-    margin-left: $line-width;
-  }
+// flips from default tree branching direction
+.m-schedule-diagram--outward {
+  // last stop on branch
+  .m-schedule-diagram__line + .m-schedule-diagram__line--terminus {
+    height: $base-spacing * 2;
 
-  .m-schedule-diagram__stop--branch-start .m-schedule-diagram__line--branch:last-child {
+    circle {
+      transform: translateY(34px);
+    }
+  }
+}
+
+.m-schedule-diagram--inward {
+  // first stop on branch
+  .m-schedule-diagram__line + .m-schedule-diagram__line--terminus {
     margin-top: $base-spacing * 2;
   }
 
-  .m-schedule-diagram__stop--branch-end .m-schedule-diagram__line:last-child {
+  // last stop on branch
+  .m-schedule-diagram__line + .m-schedule-diagram__line--merge {
     height: $base-spacing * 2;
+  }
+
+  .m-schedule-diagram__line--merge .m-schedule-diagram__line-bend {
+    transform: scaleY(-1) translateY(-50px);
   }
 }

--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -23,10 +23,6 @@ $line-width: 10px;
 
   .m-schedule-diagram__card-left {
     flex-grow: 1;
-
-    .c-svg__icon-alerts-triangle svg > path:first-of-type {
-      fill: currentColor;
-    }
   }
 
   .m-schedule-diagram__stop-name {
@@ -77,6 +73,10 @@ $line-width: 10px;
     .btn {
       padding: unset;
     }
+  }
+
+  .c-svg__icon-alerts-triangle path:not(:nth-child(1)) {
+    fill: currentColor;
   }
 
   //

--- a/apps/site/assets/package-lock.json
+++ b/apps/site/assets/package-lock.json
@@ -1649,7 +1649,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1670,12 +1671,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1690,17 +1693,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1817,7 +1823,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1829,6 +1836,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1843,6 +1851,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1850,12 +1859,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1874,6 +1885,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1954,7 +1966,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1966,6 +1979,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -2051,7 +2065,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -2087,6 +2102,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -2106,6 +2122,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -2149,12 +2166,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -2416,7 +2435,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2437,12 +2457,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2457,17 +2479,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2584,7 +2609,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2596,6 +2622,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2610,6 +2637,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -2617,12 +2645,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -2641,6 +2671,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -2721,7 +2752,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -2733,6 +2765,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -2818,7 +2851,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -2854,6 +2888,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -2873,6 +2908,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -2916,12 +2952,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -3209,7 +3247,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3230,12 +3269,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3250,17 +3291,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3377,7 +3421,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3389,6 +3434,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3403,6 +3449,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3410,12 +3457,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3434,6 +3483,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3514,7 +3564,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3526,6 +3577,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3611,7 +3663,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3647,6 +3700,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3666,6 +3720,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3709,12 +3764,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -3985,7 +4042,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -4006,12 +4064,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4026,17 +4086,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -4153,7 +4216,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -4165,6 +4229,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -4179,6 +4244,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -4186,12 +4252,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -4210,6 +4278,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -4290,7 +4359,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -4302,6 +4372,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4387,7 +4458,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -4423,6 +4495,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4442,6 +4515,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -4485,12 +4559,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -4891,6 +4967,12 @@
       "requires": {
         "@types/geojson": "*"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
     },
     "@types/mkdirp": {
       "version": "0.3.29",
@@ -10101,7 +10183,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10122,12 +10205,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10142,17 +10227,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10269,7 +10357,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10281,6 +10370,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10295,6 +10385,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10302,12 +10393,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -10326,6 +10419,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10406,7 +10500,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10418,6 +10513,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10503,7 +10599,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10539,6 +10636,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10558,6 +10656,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10601,12 +10700,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -12743,7 +12844,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -12764,12 +12866,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12784,17 +12888,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -12911,7 +13018,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -12923,6 +13031,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -12937,6 +13046,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -12944,12 +13054,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12968,6 +13080,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -13048,7 +13161,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13060,6 +13174,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -13145,7 +13260,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -13181,6 +13297,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13200,6 +13317,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -13243,12 +13361,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -14590,7 +14710,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14611,12 +14732,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14631,17 +14754,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14758,7 +14884,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14770,6 +14897,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14784,6 +14912,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -14791,12 +14920,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14815,6 +14946,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -14895,7 +15027,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14907,6 +15040,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14992,7 +15126,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -15028,6 +15163,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -15047,6 +15183,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -15090,12 +15227,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -15426,7 +15565,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -15447,12 +15587,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -15467,17 +15609,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -15594,7 +15739,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -15606,6 +15752,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -15620,6 +15767,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -15627,12 +15775,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -15651,6 +15801,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -15731,7 +15882,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -15743,6 +15895,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -15828,7 +15981,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -15864,6 +16018,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -15883,6 +16038,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -15926,12 +16082,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -40,6 +40,7 @@
     "@types/enzyme-to-json": "^1.5.3",
     "@types/googlemaps": "^3.30.16",
     "@types/jest": "^24.0.9",
+    "@types/lodash": "^4.14.149",
     "@types/phoenix": "^1.4.0",
     "@types/react": "^16.8.3",
     "@types/react-dom": "^16.8.0",

--- a/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
@@ -133,11 +133,6 @@ describe("LineDiagram", () => {
     const line = wrapper.find(".m-schedule-diagram__lines").first();
     expect(line.prop("style")!.color).toBe("#F00B42");
   });
-
-  it("does not detect and render branches", () => {
-    expect(wrapper.exists(".m-schedule-diagram--with-branches")).toBeFalsy();
-    expect(wrapper.exists(".m-schedule-diagram__line--branch")).toBeFalsy();
-  });
 });
 
 describe("LineDiagram with branches", () => {
@@ -166,31 +161,29 @@ describe("LineDiagram with branches", () => {
     expect(wrapper.debug()).toMatchSnapshot();
   });
 
-  it("detects and renders branches", () => {
-    expect(wrapper.exists(".m-schedule-diagram--with-branches")).toBeTruthy();
-    expect(wrapper.exists(".m-schedule-diagram__line--branch")).toBeTruthy();
-  });
-
   it("shows branch name", () => {
     expect(wrapper.find(".u-small-caps").text()).toEqual("Lowell Two Line");
   });
 
-  it("renders branches distinctly at start/ends", () => {
-    const branchEnd = wrapper
-      .find(
-        ".m-schedule-diagram__stop--branch-end .m-schedule-diagram__line--branch"
-      )
-      .first();
-    const branchStart = wrapper
-      .find(
-        ".m-schedule-diagram__stop--branch-start .m-schedule-diagram__line--branch"
-      )
-      .first();
+  it("renders different parts of branches", () => {
+    const terminus = wrapper
+      .find(".m-schedule-diagram__line--terminus")
+      .first().html();
+    const merge = wrapper
+      .find(".m-schedule-diagram__line--merge")
+      .first().html();
+    const stop = wrapper
+      .find(".m-schedule-diagram__line--stop")
+      .first().html();
     const line = wrapper
-      .find(".m-schedule-diagram__line:not(.m-schedule-diagram__line--branch)")
-      .first();
-    expect(line.html()).not.toEqual(branchStart.html());
-    expect(line.html()).not.toEqual(branchEnd.html());
-    expect(branchStart.html()).not.toEqual(branchEnd.html());
+      .find(".m-schedule-diagram__line--line")
+      .first().html();
+
+    expect(terminus).not.toEqual(stop);
+    expect(terminus).not.toEqual(line);
+    expect(terminus).not.toEqual(merge);
+    expect(stop).not.toEqual(merge);
+    expect(stop).not.toEqual(line);
+    expect(line).not.toEqual(merge);
   });
 });

--- a/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
@@ -168,16 +168,20 @@ describe("LineDiagram with branches", () => {
   it("renders different parts of branches", () => {
     const terminus = wrapper
       .find(".m-schedule-diagram__line--terminus")
-      .first().html();
+      .first()
+      .html();
     const merge = wrapper
       .find(".m-schedule-diagram__line--merge")
-      .first().html();
+      .first()
+      .html();
     const stop = wrapper
       .find(".m-schedule-diagram__line--stop")
-      .first().html();
+      .first()
+      .html();
     const line = wrapper
       .find(".m-schedule-diagram__line--line")
-      .first().html();
+      .first()
+      .html();
 
     expect(terminus).not.toEqual(stop);
     expect(terminus).not.toEqual(line);

--- a/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
@@ -92,9 +92,7 @@ describe("LineDiagram", () => {
   });
 
   it("has a tooltip for a transit connection", () => {
-    const stopConnections = wrapper.find(
-      ".m-schedule-diagram__connections a"
-    );
+    const stopConnections = wrapper.find(".m-schedule-diagram__connections a");
     stopConnections.forEach(connectionLink => {
       const props = connectionLink.props();
       expect(props.title).toBeTruthy();
@@ -118,9 +116,7 @@ describe("LineDiagram", () => {
       const names = connections.find("a").map(c => c.props().title);
       expect(names).toEqual(expectedNames);
 
-      const features = wrapper
-        .find(".m-schedule-diagram__features")
-        .at(index);
+      const features = wrapper.find(".m-schedule-diagram__features").at(index);
 
       const featureNames = features
         .find("span[data-toggle='tooltip']")
@@ -170,10 +166,6 @@ describe("LineDiagram with branches", () => {
       .find(".m-schedule-diagram__line--terminus")
       .first()
       .html();
-    const merge = wrapper
-      .find(".m-schedule-diagram__line--merge")
-      .first()
-      .html();
     const stop = wrapper
       .find(".m-schedule-diagram__line--stop")
       .first()
@@ -185,9 +177,6 @@ describe("LineDiagram with branches", () => {
 
     expect(terminus).not.toEqual(stop);
     expect(terminus).not.toEqual(line);
-    expect(terminus).not.toEqual(merge);
-    expect(stop).not.toEqual(merge);
     expect(stop).not.toEqual(line);
-    expect(line).not.toEqual(merge);
   });
 });

--- a/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
@@ -9,6 +9,7 @@ import {
 } from "../components/__schedule";
 import * as routePatternsByDirection from "./routePatternsByDirectionData.json";
 import lineDiagramData from "./lineDiagramData.json"; // Not a full line diagram
+import lineDiagramWithBranchesData from "./lineDiagramWithBranchesData.json"; // Not a full line diagram
 
 const route = {
   type: 3,
@@ -129,7 +130,67 @@ describe("LineDiagram", () => {
   );
 
   it("uses the route color", () => {
-    const line = wrapper.find(".m-schedule-line-diagram__line").first();
+    const line = wrapper.find(".m-schedule-diagram__lines").first();
     expect(line.prop("style")!.color).toBe("#F00B42");
+  });
+
+  it("does not detect and render branches", () => {
+    expect(wrapper.exists(".m-schedule-diagram--with-branches")).toBeFalsy();
+    expect(wrapper.exists(".m-schedule-diagram__line--branch")).toBeFalsy();
+  });
+});
+
+describe("LineDiagram with branches", () => {
+  let wrapper: ReactWrapper;
+  beforeEach(() => {
+    wrapper = mount(
+      <LineDiagram
+        lineDiagram={lineDiagramWithBranchesData as LineDiagramStop[]}
+        route={route}
+        directionId={directionId}
+        routePatternsByDirection={
+          routePatternsByDirection as RoutePatternsByDirection
+        }
+        services={[]}
+        ratingEndDate="2020-03-14"
+        stops={{ 0: stops, 1: stops }}
+      />
+    );
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it("renders and matches snapshot", () => {
+    expect(wrapper.debug()).toMatchSnapshot();
+  });
+
+  it("detects and renders branches", () => {
+    expect(wrapper.exists(".m-schedule-diagram--with-branches")).toBeTruthy();
+    expect(wrapper.exists(".m-schedule-diagram__line--branch")).toBeTruthy();
+  });
+
+  it("shows branch name", () => {
+    expect(wrapper.find(".u-small-caps").text()).toEqual("Lowell Two Line");
+  });
+
+  it("renders branches distinctly at start/ends", () => {
+    const branchEnd = wrapper
+      .find(
+        ".m-schedule-diagram__stop--branch-end .m-schedule-diagram__line--branch"
+      )
+      .first();
+    const branchStart = wrapper
+      .find(
+        ".m-schedule-diagram__stop--branch-start .m-schedule-diagram__line--branch"
+      )
+      .first();
+    const line = wrapper
+      .find(".m-schedule-diagram__line:not(.m-schedule-diagram__line--branch)")
+      .first();
+    expect(line.html()).not.toEqual(branchStart.html());
+    expect(line.html()).not.toEqual(branchEnd.html());
+    expect(branchStart.html()).not.toEqual(branchEnd.html());
   });
 });

--- a/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
@@ -69,9 +69,9 @@ describe("LineDiagram", () => {
   });
 
   it("has buttons to view schedules for each stop", () => {
-    const stopCards = wrapper.find(".m-schedule-line-diagram__stop");
+    const stopCards = wrapper.find(".m-schedule-diagram__stop");
     const buttons = stopCards.map(card =>
-      card.find(".m-schedule-line-diagram__footer button")
+      card.find(".m-schedule-diagram__footer button")
     );
     expect(buttons.map(node => node.text())).toEqual(
       Array.from({ length: buttons.length }, () => "View schedule")
@@ -81,7 +81,7 @@ describe("LineDiagram", () => {
   it("opens a closeable modal after clicking button", () => {
     expect(wrapper.exists(".schedule-finder__modal-header")).toBeFalsy();
     wrapper
-      .find(".m-schedule-line-diagram__footer > button")
+      .find(".m-schedule-diagram__footer > button")
       .last()
       .simulate("click");
     expect(wrapper.exists(".schedule-finder__modal-header")).toBeTruthy();
@@ -93,7 +93,7 @@ describe("LineDiagram", () => {
 
   it("has a tooltip for a transit connection", () => {
     const stopConnections = wrapper.find(
-      ".m-schedule-line-diagram__connections a"
+      ".m-schedule-diagram__connections a"
     );
     stopConnections.forEach(connectionLink => {
       const props = connectionLink.props();
@@ -112,14 +112,14 @@ describe("LineDiagram", () => {
     "has appropriate tooltip content for stop $index",
     ({ index, expectedNames, expectedFeatures }) => {
       const connections = wrapper
-        .find(".m-schedule-line-diagram__connections")
+        .find(".m-schedule-diagram__connections")
         .at(index);
 
       const names = connections.find("a").map(c => c.props().title);
       expect(names).toEqual(expectedNames);
 
       const features = wrapper
-        .find(".m-schedule-line-diagram__features")
+        .find(".m-schedule-diagram__features")
         .at(index);
 
       const featureNames = features

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LineDiagram renders and matches snapshot 1`] = `
+exports[`LineDiagram for CR with branches going inward renders and matches snapshot 1`] = `
 "<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}}>
   <h3>
-    Stops
+    Stations
   </h3>
-  <div className=\\"m-schedule-diagram m-schedule-diagram--outward\\">
+  <div className=\\"m-schedule-diagram m-schedule-diagram--inward\\">
     <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines \\">
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
@@ -18,21 +18,17 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
         <div className=\\"m-schedule-diagram__card\\">
           <div className=\\"m-schedule-diagram__card-left\\">
             <div className=\\"m-schedule-diagram__stop-name\\">
-              <a href=\\"/stops/5547\\">
+              <strong className=\\"u-small-caps\\">
+                Destination
+                 Line
+              </strong>
+              <a href=\\"/stops/tree-destination\\">
                 <h4>
-                  Elm St opp Haskell Ave
+                  Destination
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-diagram__connections\\">
-              <Component href=\\"/schedules/110/line\\" tooltipText=\\"Route 110\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/110/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 110\\" title=\\"Route 110\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    110
-                  </span>
-                </a>
-              </Component>
-            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
           </div>
           <div className=\\"m-schedule-diagram__features\\" />
         </div>
@@ -55,21 +51,13 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
         <div className=\\"m-schedule-diagram__card\\">
           <div className=\\"m-schedule-diagram__card-left\\">
             <div className=\\"m-schedule-diagram__stop-name\\">
-              <a href=\\"/stops/place-tufts\\">
+              <a href=\\"/stops/tree-stopA\\">
                 <h4>
-                  Tufts Medical Center
+                  Stop A
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-diagram__connections\\">
-              <Component href=\\"/schedules/741/line\\" tooltipText=\\"Silver Line SL1\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/741/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Silver Line SL1\\" title=\\"Silver Line SL1\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--silver-line\\">
-                    SL1
-                  </span>
-                </a>
-              </Component>
-            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
           </div>
           <div className=\\"m-schedule-diagram__features\\" />
         </div>
@@ -82,78 +70,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
     </div>
     <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines \\">
-        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
-            <circle r=\\"4\\" cx=\\"50%\\" />
-          </svg>
-        </div>
-      </div>
-      <div className=\\"m-schedule-diagram__content\\">
-        <div className=\\"m-schedule-diagram__card\\">
-          <div className=\\"m-schedule-diagram__card-left\\">
-            <div className=\\"m-schedule-diagram__stop-name\\">
-              <a href=\\"/stops/place-north\\">
-                <h4>
-                  North Station
-                </h4>
-              </a>
-            </div>
-            <div className=\\"m-schedule-diagram__connections\\">
-              <Component href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Orange Line\\" title=\\"Orange Line\\">
-                  <span className=\\"m-schedule-diagram__connection\\">
-                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/Green-C/line\\" tooltipText=\\"Green Line C\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/Green-C/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line C\\" title=\\"Green Line C\\">
-                  <span className=\\"m-schedule-diagram__connection\\">
-                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/Green-E/line\\" tooltipText=\\"Green Line E\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/Green-E/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line E\\" title=\\"Green Line E\\">
-                  <span className=\\"m-schedule-diagram__connection\\">
-                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/CR-Fitchburg/line\\" tooltipText=\\"Commuter Rail\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/CR-Fitchburg/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Commuter Rail\\" title=\\"Commuter Rail\\">
-                  <span className=\\"m-schedule-diagram__connection\\">
-                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-                  </span>
-                </a>
-              </Component>
-            </div>
-          </div>
-          <div className=\\"m-schedule-diagram__features\\">
-            <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
-              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
-                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              </span>
-            </Component>
-            <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
-                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              </span>
-            </Component>
-            <span className=\\"c-icon__cr-zone m-schedule-diagram__feature-icon\\">
-              Zone 1A
-            </span>
-          </div>
-        </div>
-        <div className=\\"m-schedule-diagram__footer\\">
-          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
-            View schedule
-          </button>
-        </div>
-      </div>
-    </div>
-    <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
           <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
             <circle r=\\"4\\" cx=\\"50%\\" />
@@ -164,166 +81,17 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
         <div className=\\"m-schedule-diagram__card\\">
           <div className=\\"m-schedule-diagram__card-left\\">
             <div className=\\"m-schedule-diagram__stop-name\\">
-              <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              <span className=\\"sr-only\\">
-                Service alert or delay
-              </span>
-               
-              <a href=\\"/stops/place-alfcl\\">
+              <strong className=\\"u-small-caps\\">
+                Other Destination
+                 Line
+              </strong>
+              <a href=\\"/stops/tree-other-destination\\">
                 <h4>
-                  Alewife
+                  Other Destination
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-diagram__connections\\">
-              <Component href=\\"/schedules/62/line\\" tooltipText=\\"Route 62\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 62\\" title=\\"Route 62\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    62
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/67/line\\" tooltipText=\\"Route 67\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 67\\" title=\\"Route 67\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    67
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/76/line\\" tooltipText=\\"Route 76\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/76/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 76\\" title=\\"Route 76\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    76
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/79/line\\" tooltipText=\\"Route 79\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/79/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 79\\" title=\\"Route 79\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    79
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/84/line\\" tooltipText=\\"Route 84\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/84/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 84\\" title=\\"Route 84\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    84
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/350/line\\" tooltipText=\\"Route 350\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/350/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 350\\" title=\\"Route 350\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    350
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/351/line\\" tooltipText=\\"Route 351\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/351/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 351\\" title=\\"Route 351\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    351
-                  </span>
-                </a>
-              </Component>
-            </div>
-          </div>
-          <div className=\\"m-schedule-diagram__features\\">
-            <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
-              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
-                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              </span>
-            </Component>
-            <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
-                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              </span>
-            </Component>
-          </div>
-        </div>
-        <div className=\\"m-schedule-diagram__footer\\">
-          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
-            View schedule
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-  <WrappedModal openState={false} closeModal={[Function: closeModal]} ariaLabel={{...}}>
-    <Modal openState={false} closeModal={[Function: closeModal]} ariaLabel={{...}} priorPadding=\\"0px\\" paddingRight={0} />
-  </WrappedModal>
-</LineDiagram>"
-`;
-
-exports[`LineDiagram with branches renders and matches snapshot 1`] = `
-"<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}}>
-  <h3>
-    Stops
-  </h3>
-  <div className=\\"m-schedule-diagram m-schedule-diagram--outward\\">
-    <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
-        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
-            <circle r=\\"4\\" cx=\\"50%\\" />
-          </svg>
-        </div>
-      </div>
-      <div className=\\"m-schedule-diagram__content\\">
-        <div className=\\"m-schedule-diagram__card\\">
-          <div className=\\"m-schedule-diagram__card-left\\">
-            <div className=\\"m-schedule-diagram__stop-name\\">
-              <a href=\\"/stops/5547\\">
-                <h4>
-                  Elm St opp Haskell Ave
-                </h4>
-              </a>
-            </div>
-            <div className=\\"m-schedule-diagram__connections\\">
-              <Component href=\\"/schedules/110/line\\" tooltipText=\\"Route 110\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/110/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 110\\" title=\\"Route 110\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    110
-                  </span>
-                </a>
-              </Component>
-            </div>
-          </div>
-          <div className=\\"m-schedule-diagram__features\\" />
-        </div>
-        <div className=\\"m-schedule-diagram__footer\\">
-          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
-            View schedule
-          </button>
-        </div>
-      </div>
-    </div>
-    <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
-        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
-            <circle r=\\"4\\" cx=\\"50%\\" />
-          </svg>
-        </div>
-      </div>
-      <div className=\\"m-schedule-diagram__content\\">
-        <div className=\\"m-schedule-diagram__card\\">
-          <div className=\\"m-schedule-diagram__card-left\\">
-            <div className=\\"m-schedule-diagram__stop-name\\">
-              <a href=\\"/stops/place-tufts\\">
-                <h4>
-                  Tufts Medical Center
-                </h4>
-              </a>
-            </div>
-            <div className=\\"m-schedule-diagram__connections\\">
-              <Component href=\\"/schedules/741/line\\" tooltipText=\\"Silver Line SL1\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/741/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Silver Line SL1\\" title=\\"Silver Line SL1\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--silver-line\\">
-                    SL1
-                  </span>
-                </a>
-              </Component>
-            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
           </div>
           <div className=\\"m-schedule-diagram__features\\" />
         </div>
@@ -348,19 +116,175 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
         <div className=\\"m-schedule-diagram__card\\">
           <div className=\\"m-schedule-diagram__card-left\\">
             <div className=\\"m-schedule-diagram__stop-name\\">
-              <a href=\\"/stops/place-fake\\">
+              <a href=\\"/stops/tree-stop2\\">
                 <h4>
-                  Fake Station
+                  Stop 2
                 </h4>
               </a>
             </div>
             <div className=\\"m-schedule-diagram__connections\\" />
           </div>
-          <div className=\\"m-schedule-diagram__features\\">
-            <span className=\\"c-icon__cr-zone m-schedule-diagram__feature-icon\\">
-              Zone 1A
-            </span>
+          <div className=\\"m-schedule-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
+              <a href=\\"/stops/tree-stop1\\">
+                <h4>
+                  Stop 1
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
           </div>
+          <div className=\\"m-schedule-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
+              <a href=\\"/stops/tree-origin\\">
+                <h4>
+                  Origin
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
+          </div>
+          <div className=\\"m-schedule-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <WrappedModal openState={false} closeModal={[Function: closeModal]} ariaLabel={{...}}>
+    <Modal openState={false} closeModal={[Function: closeModal]} ariaLabel={{...}} priorPadding=\\"0px\\" paddingRight={0} />
+  </WrappedModal>
+</LineDiagram>"
+`;
+
+exports[`LineDiagram with branches going outward renders and matches snapshot 1`] = `
+"<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}}>
+  <h3>
+    Stops
+  </h3>
+  <div className=\\"m-schedule-diagram m-schedule-diagram--outward\\">
+    <div className=\\"m-schedule-diagram__stop\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
+              <a href=\\"/stops/tree-origin\\">
+                <h4>
+                  Origin
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
+          </div>
+          <div className=\\"m-schedule-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
+              <a href=\\"/stops/tree-stop1\\">
+                <h4>
+                  Stop 1
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
+          </div>
+          <div className=\\"m-schedule-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines m-schedule-diagram__lines--merging\\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <path className=\\"m-schedule-diagram__line-bend\\" d=\\"M5,10 v-10 h-20\\" />
+            <circle r=\\"4\\" cx=\\"50%\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
+              <a href=\\"/stops/tree-stop2\\">
+                <h4>
+                  Stop 2
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
+          </div>
+          <div className=\\"m-schedule-diagram__features\\" />
         </div>
         <div className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -383,12 +307,151 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
           <div className=\\"m-schedule-diagram__card-left\\">
             <div className=\\"m-schedule-diagram__stop-name\\">
               <strong className=\\"u-small-caps\\">
-                Lowell Two
-                 Line
+                Other Destination
+                 Branch
               </strong>
-              <a href=\\"/stops/place-north\\">
+              <a href=\\"/stops/tree-other-destination\\">
                 <h4>
-                  Lowell Two
+                  Other Destination
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
+          </div>
+          <div className=\\"m-schedule-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
+              <a href=\\"/stops/tree-stopA\\">
+                <h4>
+                  Stop A
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
+          </div>
+          <div className=\\"m-schedule-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
+              <strong className=\\"u-small-caps\\">
+                Destination
+                 Branch
+              </strong>
+              <a href=\\"/stops/tree-destination\\">
+                <h4>
+                  Destination
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
+          </div>
+          <div className=\\"m-schedule-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <WrappedModal openState={false} closeModal={[Function: closeModal]} ariaLabel={{...}}>
+    <Modal openState={false} closeModal={[Function: closeModal]} ariaLabel={{...}} priorPadding=\\"0px\\" paddingRight={0} />
+  </WrappedModal>
+</LineDiagram>"
+`;
+
+exports[`LineDiagram without branches renders and matches snapshot 1`] = `
+"<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}}>
+  <h3>
+    Stops
+  </h3>
+  <div className=\\"m-schedule-diagram m-schedule-diagram--outward\\">
+    <div className=\\"m-schedule-diagram__stop\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
+              <a href=\\"/stops/line-origin\\">
+                <h4>
+                  Origin
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-diagram__connections\\" />
+          </div>
+          <div className=\\"m-schedule-diagram__features\\">
+            <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
+              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
+                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              </span>
+            </Component>
+          </div>
+        </div>
+        <div className=\\"m-schedule-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
+              <a href=\\"/stops/line-stop1\\">
+                <h4>
+                  Stop 1
                 </h4>
               </a>
             </div>
@@ -407,36 +470,63 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
                   </span>
                 </a>
               </Component>
-              <Component href=\\"/schedules/Green-E/line\\" tooltipText=\\"Green Line E\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/Green-E/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line E\\" title=\\"Green Line E\\">
-                  <span className=\\"m-schedule-diagram__connection\\">
-                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+            </div>
+          </div>
+          <div className=\\"m-schedule-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
+              <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              <span className=\\"sr-only\\">
+                Service alert or delay
+              </span>
+               
+              <a href=\\"/stops/line-stop2\\">
+                <h4>
+                  Stop 2
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-diagram__connections\\">
+              <Component href=\\"/schedules/62/line\\" tooltipText=\\"Route 62\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 62\\" title=\\"Route 62\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
+                    62
                   </span>
                 </a>
               </Component>
-              <Component href=\\"/schedules/CR-Fitchburg/line\\" tooltipText=\\"Commuter Rail\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/CR-Fitchburg/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Commuter Rail\\" title=\\"Commuter Rail\\">
-                  <span className=\\"m-schedule-diagram__connection\\">
-                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              <Component href=\\"/schedules/67/line\\" tooltipText=\\"Route 67\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 67\\" title=\\"Route 67\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
+                    67
                   </span>
                 </a>
               </Component>
             </div>
           </div>
           <div className=\\"m-schedule-diagram__features\\">
-            <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
-              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
-                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              </span>
-            </Component>
             <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
                 <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               </span>
             </Component>
-            <span className=\\"c-icon__cr-zone m-schedule-diagram__feature-icon\\">
-              Zone 1A
-            </span>
           </div>
         </div>
         <div className=\\"m-schedule-diagram__footer\\">
@@ -458,64 +548,17 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
         <div className=\\"m-schedule-diagram__card\\">
           <div className=\\"m-schedule-diagram__card-left\\">
             <div className=\\"m-schedule-diagram__stop-name\\">
-              <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              <span className=\\"sr-only\\">
-                Service alert or delay
-              </span>
-               
-              <a href=\\"/stops/place-alfcl\\">
+              <a href=\\"/stops/line-destination\\">
                 <h4>
-                  Alewife
+                  Destination
                 </h4>
               </a>
             </div>
             <div className=\\"m-schedule-diagram__connections\\">
-              <Component href=\\"/schedules/62/line\\" tooltipText=\\"Route 62\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 62\\" title=\\"Route 62\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    62
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/67/line\\" tooltipText=\\"Route 67\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 67\\" title=\\"Route 67\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    67
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/76/line\\" tooltipText=\\"Route 76\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/76/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 76\\" title=\\"Route 76\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    76
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/79/line\\" tooltipText=\\"Route 79\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/79/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 79\\" title=\\"Route 79\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    79
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/84/line\\" tooltipText=\\"Route 84\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/84/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 84\\" title=\\"Route 84\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    84
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/350/line\\" tooltipText=\\"Route 350\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/350/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 350\\" title=\\"Route 350\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    350
-                  </span>
-                </a>
-              </Component>
-              <Component href=\\"/schedules/351/line\\" tooltipText=\\"Route 351\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/351/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 351\\" title=\\"Route 351\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
-                    351
+              <Component href=\\"/schedules/BOAT-A/line\\" tooltipText=\\"Atlantis\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/BOAT-A/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Atlantis\\" title=\\"Atlantis\\">
+                  <span className=\\"m-schedule-diagram__connection\\">
+                    <span className=\\"notranslate c-svg__icon-bus-small\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </a>
               </Component>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -10,7 +10,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
         <div className=\\"m-schedule-diagram__line\\">
           <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"-16\\" />
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"2\\" />
           </svg>
         </div>
       </div>
@@ -47,7 +47,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
         <div className=\\"m-schedule-diagram__line\\">
           <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"14\\" />
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"26\\" />
           </svg>
         </div>
       </div>
@@ -84,7 +84,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
         <div className=\\"m-schedule-diagram__line\\">
           <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"-16\\" />
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"2\\" />
           </svg>
         </div>
       </div>
@@ -156,7 +156,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
         <div className=\\"m-schedule-diagram__line\\">
           <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"-16\\" />
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"2\\" />
           </svg>
         </div>
       </div>
@@ -264,7 +264,7 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
         <div className=\\"m-schedule-diagram__line\\">
           <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"-16\\" />
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"2\\" />
           </svg>
         </div>
       </div>
@@ -302,8 +302,8 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
         <div className=\\"m-schedule-diagram__line\\" />
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--branch\\">
           <svg>
-            <path d=\\"\\\\n                            M-10,-60\\\\n                            h 15 \\\\n                            v 46\\\\n                          \\" />
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"-16\\" />
+            <path d=\\"\\\\n                            M-10,-30\\\\n                            h 15 \\\\n                            v 36\\\\n                          \\" />
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"2\\" />
           </svg>
         </div>
       </div>
@@ -341,7 +341,7 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
         <div className=\\"m-schedule-diagram__line\\" />
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--branch\\">
           <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"14\\" />
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"26\\" />
           </svg>
         </div>
       </div>
@@ -375,7 +375,7 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
         <div className=\\"m-schedule-diagram__line\\" />
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--branch\\">
           <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"14\\" />
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"26\\" />
           </svg>
         </div>
       </div>
@@ -451,7 +451,7 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
         <div className=\\"m-schedule-diagram__line\\">
           <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"14\\" />
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"26\\" />
           </svg>
         </div>
       </div>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -14,29 +14,29 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
           </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__content\\">
-        <div className=\\"m-schedule-line-diagram__card\\">
-          <div className=\\"m-schedule-line-diagram__card-left\\">
-            <div className=\\"m-schedule-line-diagram__stop-name\\">
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/5547\\">
                 <h4>
                   Elm St opp Haskell Ave
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-line-diagram__connections\\">
+            <div className=\\"m-schedule-diagram__connections\\">
               <Component href=\\"/schedules/110/line\\" tooltipText=\\"Route 110\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/110/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 110\\" title=\\"Route 110\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     110
                   </span>
                 </a>
               </Component>
             </div>
           </div>
-          <div className=\\"m-schedule-line-diagram__features\\" />
+          <div className=\\"m-schedule-diagram__features\\" />
         </div>
-        <div className=\\"m-schedule-line-diagram__footer\\">
+        <div className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
             View schedule
           </button>
@@ -51,29 +51,29 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
           </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__content\\">
-        <div className=\\"m-schedule-line-diagram__card\\">
-          <div className=\\"m-schedule-line-diagram__card-left\\">
-            <div className=\\"m-schedule-line-diagram__stop-name\\">
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/place-tufts\\">
                 <h4>
                   Tufts Medical Center
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-line-diagram__connections\\">
+            <div className=\\"m-schedule-diagram__connections\\">
               <Component href=\\"/schedules/741/line\\" tooltipText=\\"Silver Line SL1\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/741/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Silver Line SL1\\" title=\\"Silver Line SL1\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--silver-line\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--silver-line\\">
                     SL1
                   </span>
                 </a>
               </Component>
             </div>
           </div>
-          <div className=\\"m-schedule-line-diagram__features\\" />
+          <div className=\\"m-schedule-diagram__features\\" />
         </div>
-        <div className=\\"m-schedule-line-diagram__footer\\">
+        <div className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
             View schedule
           </button>
@@ -88,64 +88,64 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
           </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__content\\">
-        <div className=\\"m-schedule-line-diagram__card\\">
-          <div className=\\"m-schedule-line-diagram__card-left\\">
-            <div className=\\"m-schedule-line-diagram__stop-name\\">
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/place-north\\">
                 <h4>
                   North Station
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-line-diagram__connections\\">
+            <div className=\\"m-schedule-diagram__connections\\">
               <Component href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Orange Line\\" title=\\"Orange Line\\">
-                  <span className=\\"m-schedule-line-diagram__connection\\">
+                  <span className=\\"m-schedule-diagram__connection\\">
                     <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/Green-C/line\\" tooltipText=\\"Green Line C\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/Green-C/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line C\\" title=\\"Green Line C\\">
-                  <span className=\\"m-schedule-line-diagram__connection\\">
+                  <span className=\\"m-schedule-diagram__connection\\">
                     <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/Green-E/line\\" tooltipText=\\"Green Line E\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/Green-E/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line E\\" title=\\"Green Line E\\">
-                  <span className=\\"m-schedule-line-diagram__connection\\">
+                  <span className=\\"m-schedule-diagram__connection\\">
                     <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/CR-Fitchburg/line\\" tooltipText=\\"Commuter Rail\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/CR-Fitchburg/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Commuter Rail\\" title=\\"Commuter Rail\\">
-                  <span className=\\"m-schedule-line-diagram__connection\\">
+                  <span className=\\"m-schedule-diagram__connection\\">
                     <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </a>
               </Component>
             </div>
           </div>
-          <div className=\\"m-schedule-line-diagram__features\\">
+          <div className=\\"m-schedule-diagram__features\\">
             <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
-                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               </span>
             </Component>
             <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
-                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               </span>
             </Component>
-            <span className=\\"c-icon__cr-zone m-schedule-line-diagram__feature-icon\\">
+            <span className=\\"c-icon__cr-zone m-schedule-diagram__feature-icon\\">
               Zone 1A
             </span>
           </div>
         </div>
-        <div className=\\"m-schedule-line-diagram__footer\\">
+        <div className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
             View schedule
           </button>
@@ -160,10 +160,10 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
           </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__content\\">
-        <div className=\\"m-schedule-line-diagram__card\\">
-          <div className=\\"m-schedule-line-diagram__card-left\\">
-            <div className=\\"m-schedule-line-diagram__stop-name\\">
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
               <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               <span className=\\"sr-only\\">
                 Service alert or delay
@@ -175,72 +175,72 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-line-diagram__connections\\">
+            <div className=\\"m-schedule-diagram__connections\\">
               <Component href=\\"/schedules/62/line\\" tooltipText=\\"Route 62\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 62\\" title=\\"Route 62\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     62
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/67/line\\" tooltipText=\\"Route 67\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 67\\" title=\\"Route 67\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     67
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/76/line\\" tooltipText=\\"Route 76\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/76/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 76\\" title=\\"Route 76\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     76
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/79/line\\" tooltipText=\\"Route 79\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/79/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 79\\" title=\\"Route 79\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     79
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/84/line\\" tooltipText=\\"Route 84\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/84/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 84\\" title=\\"Route 84\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     84
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/350/line\\" tooltipText=\\"Route 350\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/350/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 350\\" title=\\"Route 350\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     350
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/351/line\\" tooltipText=\\"Route 351\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/351/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 351\\" title=\\"Route 351\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     351
                   </span>
                 </a>
               </Component>
             </div>
           </div>
-          <div className=\\"m-schedule-line-diagram__features\\">
+          <div className=\\"m-schedule-diagram__features\\">
             <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
-                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               </span>
             </Component>
             <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
-                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               </span>
             </Component>
           </div>
         </div>
-        <div className=\\"m-schedule-line-diagram__footer\\">
+        <div className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
             View schedule
           </button>
@@ -268,29 +268,29 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
           </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__content\\">
-        <div className=\\"m-schedule-line-diagram__card\\">
-          <div className=\\"m-schedule-line-diagram__card-left\\">
-            <div className=\\"m-schedule-line-diagram__stop-name\\">
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/5547\\">
                 <h4>
                   Elm St opp Haskell Ave
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-line-diagram__connections\\">
+            <div className=\\"m-schedule-diagram__connections\\">
               <Component href=\\"/schedules/110/line\\" tooltipText=\\"Route 110\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/110/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 110\\" title=\\"Route 110\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     110
                   </span>
                 </a>
               </Component>
             </div>
           </div>
-          <div className=\\"m-schedule-line-diagram__features\\" />
+          <div className=\\"m-schedule-diagram__features\\" />
         </div>
-        <div className=\\"m-schedule-line-diagram__footer\\">
+        <div className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
             View schedule
           </button>
@@ -307,29 +307,29 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
           </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__content\\">
-        <div className=\\"m-schedule-line-diagram__card\\">
-          <div className=\\"m-schedule-line-diagram__card-left\\">
-            <div className=\\"m-schedule-line-diagram__stop-name\\">
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/place-tufts\\">
                 <h4>
                   Tufts Medical Center
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-line-diagram__connections\\">
+            <div className=\\"m-schedule-diagram__connections\\">
               <Component href=\\"/schedules/741/line\\" tooltipText=\\"Silver Line SL1\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/741/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Silver Line SL1\\" title=\\"Silver Line SL1\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--silver-line\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--silver-line\\">
                     SL1
                   </span>
                 </a>
               </Component>
             </div>
           </div>
-          <div className=\\"m-schedule-line-diagram__features\\" />
+          <div className=\\"m-schedule-diagram__features\\" />
         </div>
-        <div className=\\"m-schedule-line-diagram__footer\\">
+        <div className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
             View schedule
           </button>
@@ -345,25 +345,25 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
           </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__content\\">
-        <div className=\\"m-schedule-line-diagram__card\\">
-          <div className=\\"m-schedule-line-diagram__card-left\\">
-            <div className=\\"m-schedule-line-diagram__stop-name\\">
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/place-fake\\">
                 <h4>
                   Fake Station
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-line-diagram__connections\\" />
+            <div className=\\"m-schedule-diagram__connections\\" />
           </div>
-          <div className=\\"m-schedule-line-diagram__features\\">
-            <span className=\\"c-icon__cr-zone m-schedule-line-diagram__feature-icon\\">
+          <div className=\\"m-schedule-diagram__features\\">
+            <span className=\\"c-icon__cr-zone m-schedule-diagram__feature-icon\\">
               Zone 1A
             </span>
           </div>
         </div>
-        <div className=\\"m-schedule-line-diagram__footer\\">
+        <div className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
             View schedule
           </button>
@@ -379,10 +379,10 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
           </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__content\\">
-        <div className=\\"m-schedule-line-diagram__card\\">
-          <div className=\\"m-schedule-line-diagram__card-left\\">
-            <div className=\\"m-schedule-line-diagram__stop-name\\">
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
               <strong className=\\"u-small-caps\\">
                 Lowell Two
                  Line
@@ -393,54 +393,54 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-line-diagram__connections\\">
+            <div className=\\"m-schedule-diagram__connections\\">
               <Component href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Orange Line\\" title=\\"Orange Line\\">
-                  <span className=\\"m-schedule-line-diagram__connection\\">
+                  <span className=\\"m-schedule-diagram__connection\\">
                     <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/Green-C/line\\" tooltipText=\\"Green Line C\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/Green-C/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line C\\" title=\\"Green Line C\\">
-                  <span className=\\"m-schedule-line-diagram__connection\\">
+                  <span className=\\"m-schedule-diagram__connection\\">
                     <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/Green-E/line\\" tooltipText=\\"Green Line E\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/Green-E/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line E\\" title=\\"Green Line E\\">
-                  <span className=\\"m-schedule-line-diagram__connection\\">
+                  <span className=\\"m-schedule-diagram__connection\\">
                     <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/CR-Fitchburg/line\\" tooltipText=\\"Commuter Rail\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/CR-Fitchburg/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Commuter Rail\\" title=\\"Commuter Rail\\">
-                  <span className=\\"m-schedule-line-diagram__connection\\">
+                  <span className=\\"m-schedule-diagram__connection\\">
                     <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </a>
               </Component>
             </div>
           </div>
-          <div className=\\"m-schedule-line-diagram__features\\">
+          <div className=\\"m-schedule-diagram__features\\">
             <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
-                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               </span>
             </Component>
             <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
-                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               </span>
             </Component>
-            <span className=\\"c-icon__cr-zone m-schedule-line-diagram__feature-icon\\">
+            <span className=\\"c-icon__cr-zone m-schedule-diagram__feature-icon\\">
               Zone 1A
             </span>
           </div>
         </div>
-        <div className=\\"m-schedule-line-diagram__footer\\">
+        <div className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
             View schedule
           </button>
@@ -455,10 +455,10 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
           </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__content\\">
-        <div className=\\"m-schedule-line-diagram__card\\">
-          <div className=\\"m-schedule-line-diagram__card-left\\">
-            <div className=\\"m-schedule-line-diagram__stop-name\\">
+      <div className=\\"m-schedule-diagram__content\\">
+        <div className=\\"m-schedule-diagram__card\\">
+          <div className=\\"m-schedule-diagram__card-left\\">
+            <div className=\\"m-schedule-diagram__stop-name\\">
               <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               <span className=\\"sr-only\\">
                 Service alert or delay
@@ -470,72 +470,72 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
                 </h4>
               </a>
             </div>
-            <div className=\\"m-schedule-line-diagram__connections\\">
+            <div className=\\"m-schedule-diagram__connections\\">
               <Component href=\\"/schedules/62/line\\" tooltipText=\\"Route 62\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 62\\" title=\\"Route 62\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     62
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/67/line\\" tooltipText=\\"Route 67\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 67\\" title=\\"Route 67\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     67
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/76/line\\" tooltipText=\\"Route 76\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/76/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 76\\" title=\\"Route 76\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     76
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/79/line\\" tooltipText=\\"Route 79\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/79/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 79\\" title=\\"Route 79\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     79
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/84/line\\" tooltipText=\\"Route 84\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/84/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 84\\" title=\\"Route 84\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     84
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/350/line\\" tooltipText=\\"Route 350\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/350/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 350\\" title=\\"Route 350\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     350
                   </span>
                 </a>
               </Component>
               <Component href=\\"/schedules/351/line\\" tooltipText=\\"Route 351\\" tooltipOptions={{...}}>
                 <a href=\\"/schedules/351/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 351\\" title=\\"Route 351\\">
-                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                     351
                   </span>
                 </a>
               </Component>
             </div>
           </div>
-          <div className=\\"m-schedule-line-diagram__features\\">
+          <div className=\\"m-schedule-diagram__features\\">
             <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
-                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               </span>
             </Component>
             <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
-                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
               </span>
             </Component>
           </div>
         </div>
-        <div className=\\"m-schedule-line-diagram__footer\\">
+        <div className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
             View schedule
           </button>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -24,6 +24,7 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
               </strong>
               <a href=\\"/stops/tree-destination\\">
                 <h4>
+                   
                   Destination
                 </h4>
               </a>
@@ -53,6 +54,7 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/tree-stopA\\">
                 <h4>
+                   
                   Stop A
                 </h4>
               </a>
@@ -87,6 +89,7 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
               </strong>
               <a href=\\"/stops/tree-other-destination\\">
                 <h4>
+                   
                   Other Destination
                 </h4>
               </a>
@@ -118,6 +121,7 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/tree-stop2\\">
                 <h4>
+                   
                   Stop 2
                 </h4>
               </a>
@@ -147,6 +151,7 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/tree-stop1\\">
                 <h4>
+                   
                   Stop 1
                 </h4>
               </a>
@@ -176,6 +181,7 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/tree-origin\\">
                 <h4>
+                   
                   Origin
                 </h4>
               </a>
@@ -218,6 +224,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/tree-origin\\">
                 <h4>
+                   
                   Origin
                 </h4>
               </a>
@@ -247,6 +254,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/tree-stop1\\">
                 <h4>
+                   
                   Stop 1
                 </h4>
               </a>
@@ -278,6 +286,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/tree-stop2\\">
                 <h4>
+                   
                   Stop 2
                 </h4>
               </a>
@@ -312,6 +321,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
               </strong>
               <a href=\\"/stops/tree-other-destination\\">
                 <h4>
+                   
                   Other Destination
                 </h4>
               </a>
@@ -341,6 +351,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/tree-stopA\\">
                 <h4>
+                   
                   Stop A
                 </h4>
               </a>
@@ -374,6 +385,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
               </strong>
               <a href=\\"/stops/tree-destination\\">
                 <h4>
+                   
                   Destination
                 </h4>
               </a>
@@ -416,6 +428,7 @@ exports[`LineDiagram without branches renders and matches snapshot 1`] = `
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/line-origin\\">
                 <h4>
+                   
                   Origin
                 </h4>
               </a>
@@ -451,6 +464,7 @@ exports[`LineDiagram without branches renders and matches snapshot 1`] = `
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/line-stop1\\">
                 <h4>
+                   
                   Stop 1
                 </h4>
               </a>
@@ -493,13 +507,14 @@ exports[`LineDiagram without branches renders and matches snapshot 1`] = `
         <div className=\\"m-schedule-diagram__card\\">
           <div className=\\"m-schedule-diagram__card-left\\">
             <div className=\\"m-schedule-diagram__stop-name\\">
-              <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              <span className=\\"sr-only\\">
-                Service alert or delay
-              </span>
-               
               <a href=\\"/stops/line-stop2\\">
                 <h4>
+                  <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                  <span className=\\"sr-only\\">
+                    Service alert or delay
+                  </span>
+                   
+                   
                   Stop 2
                 </h4>
               </a>
@@ -550,6 +565,7 @@ exports[`LineDiagram without branches renders and matches snapshot 1`] = `
             <div className=\\"m-schedule-diagram__stop-name\\">
               <a href=\\"/stops/line-destination\\">
                 <h4>
+                   
                   Destination
                 </h4>
               </a>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -7,9 +7,9 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
   </h3>
   <div className=\\"m-schedule-diagram m-schedule-diagram--outward\\">
     <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
             <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
@@ -44,9 +44,9 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
       </div>
     </div>
     <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
             <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
@@ -81,9 +81,9 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
       </div>
     </div>
     <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
             <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
@@ -153,9 +153,9 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
       </div>
     </div>
     <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
             <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
@@ -261,9 +261,9 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
   </h3>
   <div className=\\"m-schedule-diagram m-schedule-diagram--outward\\">
     <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
             <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
@@ -298,11 +298,9 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
       </div>
     </div>
     <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--merge\\" />
-        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--merge\\">
-          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
-            <path className=\\"m-schedule-diagram__line-bend\\" d=\\"M-15,-30 h 20 v 60\\" />
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
             <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
@@ -337,10 +335,11 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
       </div>
     </div>
     <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines m-schedule-diagram__lines--merging\\">
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <path className=\\"m-schedule-diagram__line-bend\\" d=\\"M5,10 v-10 h-20\\" />
             <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
@@ -371,10 +370,10 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
       </div>
     </div>
     <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
             <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
@@ -448,9 +447,9 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
       </div>
     </div>
     <div className=\\"m-schedule-diagram__stop\\">
-      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines \\">
         <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+          <svg viewBox=\\"0 10 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
             <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -5,12 +5,12 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
   <h3>
     Stops
   </h3>
-  <div className=\\"m-schedule-diagram m-schedule-diagram\\">
-    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                \\\\n                m-schedule-diagram__stop--branch-start\\\\n              \\">
+  <div className=\\"m-schedule-diagram m-schedule-diagram--outward\\">
+    <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-        <div className=\\"m-schedule-diagram__line\\">
-          <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"2\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
+          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
       </div>
@@ -43,11 +43,11 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                \\\\n                \\\\n              \\">
+    <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-        <div className=\\"m-schedule-diagram__line\\">
-          <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"26\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
+          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
       </div>
@@ -80,11 +80,11 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                \\\\n                m-schedule-diagram__stop--branch-start\\\\n              \\">
+    <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-        <div className=\\"m-schedule-diagram__line\\">
-          <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"2\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
+          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
       </div>
@@ -152,11 +152,11 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                m-schedule-diagram__stop--branch-end\\\\n                m-schedule-diagram__stop--branch-start\\\\n              \\">
+    <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-        <div className=\\"m-schedule-diagram__line\\">
-          <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"2\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
+          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
       </div>
@@ -259,12 +259,12 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
   <h3>
     Stops
   </h3>
-  <div className=\\"m-schedule-diagram m-schedule-diagram--with-branches\\">
-    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                \\\\n                m-schedule-diagram__stop--branch-start\\\\n              \\">
+  <div className=\\"m-schedule-diagram m-schedule-diagram--outward\\">
+    <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-        <div className=\\"m-schedule-diagram__line\\">
-          <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"2\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
+          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
       </div>
@@ -297,13 +297,13 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div className=\\"m-schedule-diagram__stop \\\\n                m-schedule-diagram__stop--branch\\\\n                \\\\n                m-schedule-diagram__stop--branch-start\\\\n              \\">
+    <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-        <div className=\\"m-schedule-diagram__line\\" />
-        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--branch\\">
-          <svg>
-            <path d=\\"\\\\n                            M-10,-30\\\\n                            h 15 \\\\n                            v 36\\\\n                          \\" />
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"2\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--merge\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--merge\\">
+          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <path className=\\"m-schedule-diagram__line-bend\\" d=\\"M-15,-30 h 20 v 60\\" />
+            <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
       </div>
@@ -336,12 +336,12 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div className=\\"m-schedule-diagram__stop \\\\n                m-schedule-diagram__stop--branch\\\\n                \\\\n                \\\\n              \\">
+    <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-        <div className=\\"m-schedule-diagram__line\\" />
-        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--branch\\">
-          <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"26\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
+          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
       </div>
@@ -370,12 +370,12 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div className=\\"m-schedule-diagram__stop \\\\n                m-schedule-diagram__stop--branch\\\\n                m-schedule-diagram__stop--branch-end\\\\n                \\\\n              \\">
+    <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-        <div className=\\"m-schedule-diagram__line\\" />
-        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--branch\\">
-          <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"26\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
+          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
       </div>
@@ -447,11 +447,11 @@ exports[`LineDiagram with branches renders and matches snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                m-schedule-diagram__stop--branch-end\\\\n                \\\\n              \\">
+    <div className=\\"m-schedule-diagram__stop\\">
       <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-        <div className=\\"m-schedule-diagram__line\\">
-          <svg>
-            <circle r=\\"4\\" cx=\\"5\\" cy=\\"26\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
+          <svg viewBox=\\"0 9 10 10\\" height=\\"10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <circle r=\\"4\\" cx=\\"50%\\" />
           </svg>
         </div>
       </div>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -5,237 +5,542 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
   <h3>
     Stops
   </h3>
-  <div className=\\"m-schedule-line-diagram__stop\\">
-    <div style={{...}} className=\\"m-schedule-line-diagram__line\\">
-      <svg>
-        <g transform=\\"translate(0 -4)\\">
-          <circle cx=\\"5\\" cy=\\"5\\" r=\\"4\\" strokeWidth=\\"2\\" />
-        </g>
-      </svg>
-    </div>
-    <div className=\\"m-schedule-line-diagram__card\\">
-      <div className=\\"m-schedule-line-diagram__card-left\\">
-        <div className=\\"m-schedule-line-diagram__stop-name\\">
-          <a href=\\"/stops/5547\\">
-            <h4>
-              Elm St opp Haskell Ave
-            </h4>
-          </a>
-        </div>
-        <div className=\\"m-schedule-line-diagram__connections\\">
-          <Component href=\\"/schedules/110/line\\" tooltipText=\\"Route 110\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/110/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 110\\" title=\\"Route 110\\">
-              <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
-                110
-              </span>
-            </a>
-          </Component>
+  <div className=\\"m-schedule-diagram m-schedule-diagram\\">
+    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                \\\\n                m-schedule-diagram__stop--branch-start\\\\n              \\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+        <div className=\\"m-schedule-diagram__line\\">
+          <svg>
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"-16\\" />
+          </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__features\\" />
+      <div className=\\"m-schedule-line-diagram__content\\">
+        <div className=\\"m-schedule-line-diagram__card\\">
+          <div className=\\"m-schedule-line-diagram__card-left\\">
+            <div className=\\"m-schedule-line-diagram__stop-name\\">
+              <a href=\\"/stops/5547\\">
+                <h4>
+                  Elm St opp Haskell Ave
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-line-diagram__connections\\">
+              <Component href=\\"/schedules/110/line\\" tooltipText=\\"Route 110\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/110/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 110\\" title=\\"Route 110\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    110
+                  </span>
+                </a>
+              </Component>
+            </div>
+          </div>
+          <div className=\\"m-schedule-line-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-line-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
     </div>
-    <div className=\\"m-schedule-line-diagram__footer\\">
-      <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
-        View schedule
-      </button>
+    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                \\\\n                \\\\n              \\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+        <div className=\\"m-schedule-diagram__line\\">
+          <svg>
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"14\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-line-diagram__content\\">
+        <div className=\\"m-schedule-line-diagram__card\\">
+          <div className=\\"m-schedule-line-diagram__card-left\\">
+            <div className=\\"m-schedule-line-diagram__stop-name\\">
+              <a href=\\"/stops/place-tufts\\">
+                <h4>
+                  Tufts Medical Center
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-line-diagram__connections\\">
+              <Component href=\\"/schedules/741/line\\" tooltipText=\\"Silver Line SL1\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/741/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Silver Line SL1\\" title=\\"Silver Line SL1\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--silver-line\\">
+                    SL1
+                  </span>
+                </a>
+              </Component>
+            </div>
+          </div>
+          <div className=\\"m-schedule-line-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-line-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                \\\\n                m-schedule-diagram__stop--branch-start\\\\n              \\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+        <div className=\\"m-schedule-diagram__line\\">
+          <svg>
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"-16\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-line-diagram__content\\">
+        <div className=\\"m-schedule-line-diagram__card\\">
+          <div className=\\"m-schedule-line-diagram__card-left\\">
+            <div className=\\"m-schedule-line-diagram__stop-name\\">
+              <a href=\\"/stops/place-north\\">
+                <h4>
+                  North Station
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-line-diagram__connections\\">
+              <Component href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Orange Line\\" title=\\"Orange Line\\">
+                  <span className=\\"m-schedule-line-diagram__connection\\">
+                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/Green-C/line\\" tooltipText=\\"Green Line C\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/Green-C/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line C\\" title=\\"Green Line C\\">
+                  <span className=\\"m-schedule-line-diagram__connection\\">
+                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/Green-E/line\\" tooltipText=\\"Green Line E\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/Green-E/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line E\\" title=\\"Green Line E\\">
+                  <span className=\\"m-schedule-line-diagram__connection\\">
+                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/CR-Fitchburg/line\\" tooltipText=\\"Commuter Rail\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/CR-Fitchburg/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Commuter Rail\\" title=\\"Commuter Rail\\">
+                  <span className=\\"m-schedule-line-diagram__connection\\">
+                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                  </span>
+                </a>
+              </Component>
+            </div>
+          </div>
+          <div className=\\"m-schedule-line-diagram__features\\">
+            <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
+              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
+                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              </span>
+            </Component>
+            <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
+              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              </span>
+            </Component>
+            <span className=\\"c-icon__cr-zone m-schedule-line-diagram__feature-icon\\">
+              Zone 1A
+            </span>
+          </div>
+        </div>
+        <div className=\\"m-schedule-line-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                m-schedule-diagram__stop--branch-end\\\\n                m-schedule-diagram__stop--branch-start\\\\n              \\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+        <div className=\\"m-schedule-diagram__line\\">
+          <svg>
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"-16\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-line-diagram__content\\">
+        <div className=\\"m-schedule-line-diagram__card\\">
+          <div className=\\"m-schedule-line-diagram__card-left\\">
+            <div className=\\"m-schedule-line-diagram__stop-name\\">
+              <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              <span className=\\"sr-only\\">
+                Service alert or delay
+              </span>
+               
+              <a href=\\"/stops/place-alfcl\\">
+                <h4>
+                  Alewife
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-line-diagram__connections\\">
+              <Component href=\\"/schedules/62/line\\" tooltipText=\\"Route 62\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 62\\" title=\\"Route 62\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    62
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/67/line\\" tooltipText=\\"Route 67\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 67\\" title=\\"Route 67\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    67
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/76/line\\" tooltipText=\\"Route 76\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/76/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 76\\" title=\\"Route 76\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    76
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/79/line\\" tooltipText=\\"Route 79\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/79/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 79\\" title=\\"Route 79\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    79
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/84/line\\" tooltipText=\\"Route 84\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/84/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 84\\" title=\\"Route 84\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    84
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/350/line\\" tooltipText=\\"Route 350\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/350/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 350\\" title=\\"Route 350\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    350
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/351/line\\" tooltipText=\\"Route 351\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/351/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 351\\" title=\\"Route 351\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    351
+                  </span>
+                </a>
+              </Component>
+            </div>
+          </div>
+          <div className=\\"m-schedule-line-diagram__features\\">
+            <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
+              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
+                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              </span>
+            </Component>
+            <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
+              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              </span>
+            </Component>
+          </div>
+        </div>
+        <div className=\\"m-schedule-line-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
     </div>
   </div>
-  <div className=\\"m-schedule-line-diagram__stop\\">
-    <div style={{...}} className=\\"m-schedule-line-diagram__line\\">
-      <svg>
-        <g transform=\\"translate(0 -4)\\">
-          <circle cx=\\"5\\" cy=\\"5\\" r=\\"4\\" strokeWidth=\\"2\\" />
-        </g>
-      </svg>
-    </div>
-    <div className=\\"m-schedule-line-diagram__card\\">
-      <div className=\\"m-schedule-line-diagram__card-left\\">
-        <div className=\\"m-schedule-line-diagram__stop-name\\">
-          <a href=\\"/stops/place-tufts\\">
-            <h4>
-              Tufts Medical Center
-            </h4>
-          </a>
-        </div>
-        <div className=\\"m-schedule-line-diagram__connections\\">
-          <Component href=\\"/schedules/741/line\\" tooltipText=\\"Silver Line SL1\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/741/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Silver Line SL1\\" title=\\"Silver Line SL1\\">
-              <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--silver-line\\">
-                SL1
-              </span>
-            </a>
-          </Component>
+  <WrappedModal openState={false} closeModal={[Function: closeModal]} ariaLabel={{...}}>
+    <Modal openState={false} closeModal={[Function: closeModal]} ariaLabel={{...}} priorPadding=\\"0px\\" paddingRight={0} />
+  </WrappedModal>
+</LineDiagram>"
+`;
+
+exports[`LineDiagram with branches renders and matches snapshot 1`] = `
+"<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}}>
+  <h3>
+    Stops
+  </h3>
+  <div className=\\"m-schedule-diagram m-schedule-diagram--with-branches\\">
+    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                \\\\n                m-schedule-diagram__stop--branch-start\\\\n              \\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+        <div className=\\"m-schedule-diagram__line\\">
+          <svg>
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"-16\\" />
+          </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__features\\" />
-    </div>
-    <div className=\\"m-schedule-line-diagram__footer\\">
-      <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
-        View schedule
-      </button>
-    </div>
-  </div>
-  <div className=\\"m-schedule-line-diagram__stop\\">
-    <div style={{...}} className=\\"m-schedule-line-diagram__line\\">
-      <svg>
-        <g transform=\\"translate(0 -4)\\">
-          <circle cx=\\"5\\" cy=\\"5\\" r=\\"4\\" strokeWidth=\\"2\\" />
-        </g>
-      </svg>
-    </div>
-    <div className=\\"m-schedule-line-diagram__card\\">
-      <div className=\\"m-schedule-line-diagram__card-left\\">
-        <div className=\\"m-schedule-line-diagram__stop-name\\">
-          <a href=\\"/stops/place-north\\">
-            <h4>
-              North Station
-            </h4>
-          </a>
+      <div className=\\"m-schedule-line-diagram__content\\">
+        <div className=\\"m-schedule-line-diagram__card\\">
+          <div className=\\"m-schedule-line-diagram__card-left\\">
+            <div className=\\"m-schedule-line-diagram__stop-name\\">
+              <a href=\\"/stops/5547\\">
+                <h4>
+                  Elm St opp Haskell Ave
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-line-diagram__connections\\">
+              <Component href=\\"/schedules/110/line\\" tooltipText=\\"Route 110\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/110/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 110\\" title=\\"Route 110\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    110
+                  </span>
+                </a>
+              </Component>
+            </div>
+          </div>
+          <div className=\\"m-schedule-line-diagram__features\\" />
         </div>
-        <div className=\\"m-schedule-line-diagram__connections\\">
-          <Component href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Orange Line\\" title=\\"Orange Line\\">
-              <span className=\\"m-schedule-line-diagram__connection\\">
-                <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              </span>
-            </a>
-          </Component>
-          <Component href=\\"/schedules/Green-C/line\\" tooltipText=\\"Green Line C\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/Green-C/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line C\\" title=\\"Green Line C\\">
-              <span className=\\"m-schedule-line-diagram__connection\\">
-                <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              </span>
-            </a>
-          </Component>
-          <Component href=\\"/schedules/Green-E/line\\" tooltipText=\\"Green Line E\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/Green-E/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line E\\" title=\\"Green Line E\\">
-              <span className=\\"m-schedule-line-diagram__connection\\">
-                <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              </span>
-            </a>
-          </Component>
-          <Component href=\\"/schedules/CR-Fitchburg/line\\" tooltipText=\\"Commuter Rail\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/CR-Fitchburg/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Commuter Rail\\" title=\\"Commuter Rail\\">
-              <span className=\\"m-schedule-line-diagram__connection\\">
-                <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              </span>
-            </a>
-          </Component>
+        <div className=\\"m-schedule-line-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__features\\">
-        <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
-          <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
-            <span className=\\"notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-          </span>
-        </Component>
-        <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-          <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
-            <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-          </span>
-        </Component>
-        <span className=\\"c-icon__cr-zone m-schedule-line-diagram__feature-icon\\">
-          Zone 1A
-        </span>
-      </div>
     </div>
-    <div className=\\"m-schedule-line-diagram__footer\\">
-      <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
-        View schedule
-      </button>
-    </div>
-  </div>
-  <div className=\\"m-schedule-line-diagram__stop\\">
-    <div style={{...}} className=\\"m-schedule-line-diagram__line\\">
-      <svg>
-        <g transform=\\"translate(0 -4)\\">
-          <circle cx=\\"5\\" cy=\\"5\\" r=\\"4\\" strokeWidth=\\"2\\" />
-        </g>
-      </svg>
-    </div>
-    <div className=\\"m-schedule-line-diagram__card\\">
-      <div className=\\"m-schedule-line-diagram__card-left\\">
-        <div className=\\"m-schedule-line-diagram__stop-name\\">
-          <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-          <span className=\\"sr-only\\">
-            Service alert or delay
-          </span>
-           
-          <a href=\\"/stops/place-alfcl\\">
-            <h4>
-              Alewife
-            </h4>
-          </a>
-        </div>
-        <div className=\\"m-schedule-line-diagram__connections\\">
-          <Component href=\\"/schedules/62/line\\" tooltipText=\\"Route 62\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 62\\" title=\\"Route 62\\">
-              <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
-                62
-              </span>
-            </a>
-          </Component>
-          <Component href=\\"/schedules/67/line\\" tooltipText=\\"Route 67\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 67\\" title=\\"Route 67\\">
-              <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
-                67
-              </span>
-            </a>
-          </Component>
-          <Component href=\\"/schedules/76/line\\" tooltipText=\\"Route 76\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/76/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 76\\" title=\\"Route 76\\">
-              <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
-                76
-              </span>
-            </a>
-          </Component>
-          <Component href=\\"/schedules/79/line\\" tooltipText=\\"Route 79\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/79/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 79\\" title=\\"Route 79\\">
-              <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
-                79
-              </span>
-            </a>
-          </Component>
-          <Component href=\\"/schedules/84/line\\" tooltipText=\\"Route 84\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/84/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 84\\" title=\\"Route 84\\">
-              <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
-                84
-              </span>
-            </a>
-          </Component>
-          <Component href=\\"/schedules/350/line\\" tooltipText=\\"Route 350\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/350/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 350\\" title=\\"Route 350\\">
-              <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
-                350
-              </span>
-            </a>
-          </Component>
-          <Component href=\\"/schedules/351/line\\" tooltipText=\\"Route 351\\" tooltipOptions={{...}}>
-            <a href=\\"/schedules/351/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 351\\" title=\\"Route 351\\">
-              <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
-                351
-              </span>
-            </a>
-          </Component>
+    <div className=\\"m-schedule-diagram__stop \\\\n                m-schedule-diagram__stop--branch\\\\n                \\\\n                m-schedule-diagram__stop--branch-start\\\\n              \\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+        <div className=\\"m-schedule-diagram__line\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--branch\\">
+          <svg>
+            <path d=\\"\\\\n                            M-10,-60\\\\n                            h 15 \\\\n                            v 46\\\\n                          \\" />
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"-16\\" />
+          </svg>
         </div>
       </div>
-      <div className=\\"m-schedule-line-diagram__features\\">
-        <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
-          <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
-            <span className=\\"notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-          </span>
-        </Component>
-        <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-          <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
-            <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-          </span>
-        </Component>
+      <div className=\\"m-schedule-line-diagram__content\\">
+        <div className=\\"m-schedule-line-diagram__card\\">
+          <div className=\\"m-schedule-line-diagram__card-left\\">
+            <div className=\\"m-schedule-line-diagram__stop-name\\">
+              <a href=\\"/stops/place-tufts\\">
+                <h4>
+                  Tufts Medical Center
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-line-diagram__connections\\">
+              <Component href=\\"/schedules/741/line\\" tooltipText=\\"Silver Line SL1\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/741/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Silver Line SL1\\" title=\\"Silver Line SL1\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--silver-line\\">
+                    SL1
+                  </span>
+                </a>
+              </Component>
+            </div>
+          </div>
+          <div className=\\"m-schedule-line-diagram__features\\" />
+        </div>
+        <div className=\\"m-schedule-line-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
       </div>
     </div>
-    <div className=\\"m-schedule-line-diagram__footer\\">
-      <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
-        View schedule
-      </button>
+    <div className=\\"m-schedule-diagram__stop \\\\n                m-schedule-diagram__stop--branch\\\\n                \\\\n                \\\\n              \\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+        <div className=\\"m-schedule-diagram__line\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--branch\\">
+          <svg>
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"14\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-line-diagram__content\\">
+        <div className=\\"m-schedule-line-diagram__card\\">
+          <div className=\\"m-schedule-line-diagram__card-left\\">
+            <div className=\\"m-schedule-line-diagram__stop-name\\">
+              <a href=\\"/stops/place-fake\\">
+                <h4>
+                  Fake Station
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-line-diagram__connections\\" />
+          </div>
+          <div className=\\"m-schedule-line-diagram__features\\">
+            <span className=\\"c-icon__cr-zone m-schedule-line-diagram__feature-icon\\">
+              Zone 1A
+            </span>
+          </div>
+        </div>
+        <div className=\\"m-schedule-line-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop \\\\n                m-schedule-diagram__stop--branch\\\\n                m-schedule-diagram__stop--branch-end\\\\n                \\\\n              \\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+        <div className=\\"m-schedule-diagram__line\\" />
+        <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--branch\\">
+          <svg>
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"14\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-line-diagram__content\\">
+        <div className=\\"m-schedule-line-diagram__card\\">
+          <div className=\\"m-schedule-line-diagram__card-left\\">
+            <div className=\\"m-schedule-line-diagram__stop-name\\">
+              <strong className=\\"u-small-caps\\">
+                Lowell Two
+                 Line
+              </strong>
+              <a href=\\"/stops/place-north\\">
+                <h4>
+                  Lowell Two
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-line-diagram__connections\\">
+              <Component href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Orange Line\\" title=\\"Orange Line\\">
+                  <span className=\\"m-schedule-line-diagram__connection\\">
+                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/Green-C/line\\" tooltipText=\\"Green Line C\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/Green-C/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line C\\" title=\\"Green Line C\\">
+                  <span className=\\"m-schedule-line-diagram__connection\\">
+                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/Green-E/line\\" tooltipText=\\"Green Line E\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/Green-E/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Green Line E\\" title=\\"Green Line E\\">
+                  <span className=\\"m-schedule-line-diagram__connection\\">
+                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/CR-Fitchburg/line\\" tooltipText=\\"Commuter Rail\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/CR-Fitchburg/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Commuter Rail\\" title=\\"Commuter Rail\\">
+                  <span className=\\"m-schedule-line-diagram__connection\\">
+                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                  </span>
+                </a>
+              </Component>
+            </div>
+          </div>
+          <div className=\\"m-schedule-line-diagram__features\\">
+            <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
+              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
+                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              </span>
+            </Component>
+            <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
+              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              </span>
+            </Component>
+            <span className=\\"c-icon__cr-zone m-schedule-line-diagram__feature-icon\\">
+              Zone 1A
+            </span>
+          </div>
+        </div>
+        <div className=\\"m-schedule-line-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className=\\"m-schedule-diagram__stop \\\\n                \\\\n                m-schedule-diagram__stop--branch-end\\\\n                \\\\n              \\">
+      <div style={{...}} className=\\"m-schedule-diagram__lines\\">
+        <div className=\\"m-schedule-diagram__line\\">
+          <svg>
+            <circle r=\\"4\\" cx=\\"5\\" cy=\\"14\\" />
+          </svg>
+        </div>
+      </div>
+      <div className=\\"m-schedule-line-diagram__content\\">
+        <div className=\\"m-schedule-line-diagram__card\\">
+          <div className=\\"m-schedule-line-diagram__card-left\\">
+            <div className=\\"m-schedule-line-diagram__stop-name\\">
+              <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              <span className=\\"sr-only\\">
+                Service alert or delay
+              </span>
+               
+              <a href=\\"/stops/place-alfcl\\">
+                <h4>
+                  Alewife
+                </h4>
+              </a>
+            </div>
+            <div className=\\"m-schedule-line-diagram__connections\\">
+              <Component href=\\"/schedules/62/line\\" tooltipText=\\"Route 62\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 62\\" title=\\"Route 62\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    62
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/67/line\\" tooltipText=\\"Route 67\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 67\\" title=\\"Route 67\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    67
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/76/line\\" tooltipText=\\"Route 76\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/76/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 76\\" title=\\"Route 76\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    76
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/79/line\\" tooltipText=\\"Route 79\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/79/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 79\\" title=\\"Route 79\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    79
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/84/line\\" tooltipText=\\"Route 84\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/84/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 84\\" title=\\"Route 84\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    84
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/350/line\\" tooltipText=\\"Route 350\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/350/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 350\\" title=\\"Route 350\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    350
+                  </span>
+                </a>
+              </Component>
+              <Component href=\\"/schedules/351/line\\" tooltipText=\\"Route 351\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/351/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"Route 351\\" title=\\"Route 351\\">
+                  <span className=\\"c-icon__bus-pill--small m-schedule-line-diagram__connection u-bg--bus\\">
+                    351
+                  </span>
+                </a>
+              </Component>
+            </div>
+          </div>
+          <div className=\\"m-schedule-line-diagram__features\\">
+            <Component tooltipText=\\"Parking\\" tooltipOptions={{...}}>
+              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
+                <span className=\\"notranslate c-svg__icon-parking-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              </span>
+            </Component>
+            <Component tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
+              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation=\\"true\\" data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+              </span>
+            </Component>
+          </div>
+        </div>
+        <div className=\\"m-schedule-line-diagram__footer\\">
+          <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+            View schedule
+          </button>
+        </div>
+      </div>
     </div>
   </div>
   <WrappedModal openState={false} closeModal={[Function: closeModal]} ariaLabel={{...}}>

--- a/apps/site/assets/ts/schedule/__tests__/lineDiagramData/outward.json
+++ b/apps/site/assets/ts/schedule/__tests__/lineDiagramData/outward.json
@@ -1,0 +1,107 @@
+[
+  {
+    "stop_data": [{ "type": "terminus", "branch": null }],
+    "route_stop": {
+      "zone": null,
+      "stop_features": [],
+      "station_info": {},
+      "route": {},
+      "name": "Origin",
+      "is_terminus?": true,
+      "is_beginning?": true,
+      "id": "tree-origin",
+      "connections": [],
+      "branch": null
+    },
+    "alerts": []
+  },
+  {
+    "stop_data": [
+      { "type": "merge", "branch": "TreeTrunk" },
+      { "type": "merge", "branch": "TreeBranch" }
+    ],
+    "route_stop": {
+      "zone": null,
+      "stop_features": [],
+      "station_info": {},
+      "route": {},
+      "name": "Stop 1",
+      "is_terminus?": false,
+      "is_beginning?": false,
+      "id": "tree-stop1",
+      "connections": [],
+      "branch": null
+    },
+    "alerts": []
+  },
+  {
+    "stop_data": [
+      { "type": "line", "branch": "TreeTrunk" },
+      { "type": "stop", "branch": "TreeBranch" }
+    ],
+    "route_stop": {
+      "zone": null,
+      "stop_features": [],
+      "station_info": {},
+      "route": {},
+      "name": "Stop 2",
+      "is_terminus?": false,
+      "is_beginning?": false,
+      "id": "tree-stop2",
+      "connections": [],
+      "branch": "Origin - Other Destination"
+    },
+    "alerts": []
+  },
+  {
+    "stop_data": [
+      { "type": "line", "branch": "TreeTrunk" },
+      { "type": "terminus", "branch": "TreeBranch" }
+    ],
+    "route_stop": {
+      "zone": null,
+      "stop_features": [],
+      "station_info": {},
+      "route": {},
+      "name": "Other Destination",
+      "is_terminus?": true,
+      "is_beginning?": false,
+      "id": "tree-other-destination",
+      "connections": [],
+      "branch": "Origin - Other Destination"
+    },
+    "alerts": []
+  },
+  {
+    "stop_data": [{ "type": "stop", "branch": "TreeTrunk" }],
+    "route_stop": {
+      "zone": null,
+      "stop_features": [],
+      "station_info": {},
+      "route": {},
+      "name": "Stop A",
+      "is_terminus?": false,
+      "is_beginning?": false,
+      "id": "tree-stopA",
+      "connections": [],
+      "branch": "Origin - Destination"
+    },
+    "alerts": []
+  },
+  {
+    "stop_data": [{ "type": "terminus", "branch": "TreeTrunk" }],
+    "route_stop": {
+      "zone": null,
+      "stop_features": [],
+      "station_info": {},
+      "route": {},
+      "name": "Destination",
+      "is_terminus?": true,
+      "is_beginning?": false,
+      "id": "tree-destination",
+      "connections": [],
+      "branch": "Origin - Destination"
+    },
+    "alerts": []
+  }
+]

--- a/apps/site/assets/ts/schedule/__tests__/lineDiagramData/simple.json
+++ b/apps/site/assets/ts/schedule/__tests__/lineDiagramData/simple.json
@@ -1,0 +1,217 @@
+[
+  {
+    "stop_data": [{ "type": "terminus", "branch": null }],
+    "route_stop": {
+      "zone": null,
+      "stop_features": ["parking_lot"],
+      "station_info": {
+        "parent_id": null,
+        "child_ids": [],
+        "accessibility": [],
+        "address": null,
+        "bike_storage": [],
+        "closed_stop_info": null,
+        "has_charlie_card_vendor?": false,
+        "has_fare_machine?": false,
+        "fare_facilities": [],
+        "id": "line-origin",
+        "is_child?": false,
+        "latitude": 0,
+        "longitude": 0,
+        "municipality": null,
+        "name": "Origin",
+        "note": null,
+        "parking_lots": [],
+        "station?": true,
+        "type": "station"
+      },
+      "route": null,
+      "name": "Origin",
+      "is_terminus?": true,
+      "is_beginning?": true,
+      "id": "line-origin",
+      "connections": [],
+      "closed_stop_info": null,
+      "branch": null
+    },
+    "alerts": [
+      {
+        "priority": "low"
+      }
+    ]
+  },
+  {
+    "stop_data": [{ "type": "stop", "branch": null }],
+    "route_stop": {
+      "zone": null,
+      "stop_features": [],
+      "station_info": {
+        "parent_id": null,
+        "child_ids": [],
+        "accessibility": [],
+        "address": null,
+        "bike_storage": [],
+        "closed_stop_info": null,
+        "has_charlie_card_vendor?": false,
+        "has_fare_machine?": false,
+        "fare_facilities": [],
+        "id": "line-stop1",
+        "is_child?": false,
+        "latitude": 0,
+        "longitude": 0,
+        "municipality": null,
+        "name": "Stop 1",
+        "note": null,
+        "parking_lots": [],
+        "station?": true,
+        "type": "station"
+      },
+      "route": null,
+      "name": "Stop 1",
+      "is_terminus?": false,
+      "is_beginning?": false,
+      "id": "line-stop1",
+      "connections": [
+        {
+          "type": 1,
+          "name": "Orange Line",
+          "long_name": "Orange Line",
+          "id": "Orange",
+          "direction_names": { "0": "Southbound", "1": "Northbound" },
+          "direction_destinations": { "0": "Forest Hills", "1": "Oak Grove" },
+          "description": "rapid_transit",
+          "custom_route?": false
+        },
+        {
+          "type": 0,
+          "name": "Green Line C",
+          "long_name": "Green Line C",
+          "id": "Green-C",
+          "direction_names": { "0": "Westbound", "1": "Eastbound" },
+          "direction_destinations": {
+            "0": "Cleveland Circle",
+            "1": "North Station"
+          },
+          "description": "rapid_transit",
+          "custom_route?": false
+        }
+      ],
+      "closed_stop_info": null,
+      "branch": null
+    },
+    "alerts": []
+  },
+  {
+    "stop_data": [{ "type": "stop", "branch": null }],
+    "route_stop": {
+      "zone": null,
+      "stop_features": ["access"],
+      "station_info": {
+        "parent_id": null,
+        "child_ids": [],
+        "accessibility": [],
+        "address": null,
+        "bike_storage": [],
+        "closed_stop_info": null,
+        "has_charlie_card_vendor?": false,
+        "has_fare_machine?": false,
+        "fare_facilities": [],
+        "id": "line-stop2",
+        "is_child?": false,
+        "latitude": 0,
+        "longitude": 0,
+        "municipality": null,
+        "name": "Stop 2",
+        "note": null,
+        "parking_lots": [],
+        "station?": true,
+        "type": "station"
+      },
+      "route": null,
+      "name": "Stop 2",
+      "is_terminus?": false,
+      "is_beginning?": false,
+      "id": "line-stop2",
+      "connections": [
+        {
+          "type": 3,
+          "name": "62",
+          "long_name": "Bedford VA Hospital - Alewife",
+          "id": "62",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": {
+            "0": "Bedford VA Hospital",
+            "1": "Alewife"
+          },
+          "description": "local_bus",
+          "custom_route?": false
+        },
+        {
+          "type": 3,
+          "name": "67",
+          "long_name": "Turkey Hill - Alewife",
+          "id": "67",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": { "0": "Turkey Hill", "1": "Alewife" },
+          "description": "local_bus",
+          "custom_route?": false
+        }
+      ],
+      "closed_stop_info": null,
+      "branch": null
+    },
+    "alerts": [
+      {
+        "priority": "high"
+      }
+    ]
+  },
+  {
+    "stop_data": [{ "type": "terminus", "branch": null }],
+    "route_stop": {
+      "zone": null,
+      "stop_features": ["parking_lot", "access"],
+      "station_info": {
+        "parent_id": null,
+        "child_ids": [],
+        "accessibility": [],
+        "address": null,
+        "bike_storage": [],
+        "closed_stop_info": null,
+        "has_charlie_card_vendor?": false,
+        "has_fare_machine?": false,
+        "fare_facilities": [],
+        "id": "line-destination",
+        "is_child?": false,
+        "latitude": 0,
+        "longitude": 0,
+        "municipality": null,
+        "name": "Destination",
+        "note": null,
+        "parking_lots": [],
+        "station?": true,
+        "type": "station"
+      },
+      "route": null,
+      "name": "Destination",
+      "is_terminus?": true,
+      "is_beginning?": false,
+      "id": "line-destination",
+      "connections": [
+        {
+          "type": 4,
+          "name": "Atlantis",
+          "long_name": "Boston - Atlantis",
+          "id": "BOAT-A",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": { "0": "Boston", "1": "Atlantis" },
+          "description": "ferry",
+          "custom_route?": false
+        }
+      ],
+      "closed_stop_info": null,
+      "branch": null
+    },
+    "alerts": []
+  }
+]

--- a/apps/site/assets/ts/schedule/__tests__/lineDiagramWithBranchesData.json
+++ b/apps/site/assets/ts/schedule/__tests__/lineDiagramWithBranchesData.json
@@ -1,0 +1,605 @@
+[
+  {
+    "stop_data": [{ "type": "terminus", "branch": null }],
+    "route_stop": {
+      "zone": "1A",
+      "stop_features": ["bus"],
+      "station_info": {
+        "type": "stop",
+        "station?": false,
+        "platform_name": null,
+        "platform_code": null,
+        "parking_lots": [],
+        "parent_id": null,
+        "note": null,
+        "name": "Elm St opp Haskell Ave",
+        "municipality": "Boston",
+        "longitude": -71.033138,
+        "latitude": 42.415684,
+        "is_child?": false,
+        "id": "5547",
+        "has_fare_machine?": false,
+        "has_charlie_card_vendor?": false,
+        "fare_facilities": [],
+        "description": null,
+        "closed_stop_info": null,
+        "child_ids": [],
+        "bike_storage": [],
+        "address": null,
+        "accessibility": ["unknown"]
+      },
+      "route": {
+        "type": 3,
+        "name": "111",
+        "long_name": "Woodlawn - Haymarket",
+        "id": "111",
+        "direction_names": { "0": "Outbound", "1": "Inbound" },
+        "direction_destinations": { "0": "Woodlawn", "1": "Haymarket" },
+        "description": "key_bus_route",
+        "custom_route?": false
+      },
+      "name": "Elm St opp Haskell Ave",
+      "is_terminus?": true,
+      "is_beginning?": true,
+      "id": "5547",
+      "connections": [
+        {
+          "type": 3,
+          "name": "110",
+          "long_name": "Wonderland - Wellington",
+          "id": "110",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": { "0": "Wonderland", "1": "Wellington" },
+          "description": "local_bus",
+          "custom_route?": false
+        }
+      ],
+      "closed_stop_info": null,
+      "branch": null
+    },
+    "alerts": []
+  },
+  {
+    "stop_data": [{ "type": "merge", "branch": "Lowell" }, { "type": "merge", "branch": "Lowell Two" }],
+    "route_stop": {
+      "zone": "",
+      "stop_features": [],
+      "station_info": {},
+      "route": {
+        "type": 1,
+        "name": "Orange Line",
+        "long_name": "Orange Line",
+        "id": "Orange",
+        "direction_names": { "0": "Southbound", "1": "Northbound" },
+        "direction_destinations": { "0": "Forest Hills", "1": "Oak Grove" },
+        "description": "rapid_transit",
+        "custom_route?": false
+      },
+      "name": "Tufts Medical Center",
+      "is_terminus?": false,
+      "is_beginning?": false,
+      "id": "place-tufts",
+      "connections": [
+        {
+          "type": 3,
+          "name": "SL1",
+          "long_name": "Silver Line",
+          "id": "741",
+          "description": "rapid_transit",
+          "custom_route?": false
+        }
+      ],
+      "closed_stop_info": null,
+      "branch": null
+    },
+    "alerts": []
+  },
+  {
+    "stop_data": [{ "type": "line", "branch": "Lowell" }, { "type": "stop", "branch": "Lowell Two" }],
+    "route_stop": {
+      "zone": "1A",
+      "stop_features": [],
+      "station_info": {
+        "type": "station",
+        "station?": true,
+        "platform_name": null,
+        "platform_code": null,
+        "parking_lots": [],
+        "parent_id": null,
+        "note": null,
+        "name": "Fake Station",
+        "municipality": "Boston",
+        "longitude": -71.06129,
+        "latitude": 42.365577,
+        "is_child?": false,
+        "id": "place-fake",
+        "has_fare_machine?": true,
+        "has_charlie_card_vendor?": true,
+        "fare_facilities": [
+          "fare_media_assistant",
+          "fare_vending_machine",
+          "ticket_window"
+        ],
+        "description": null,
+        "closed_stop_info": null,
+        "child_ids": [
+          "70026",
+          "70027",
+          "70205",
+          "70206",
+          "North Station",
+          "North Station-01",
+          "North Station-02",
+          "North Station-03",
+          "North Station-04",
+          "North Station-05",
+          "North Station-06",
+          "North Station-07",
+          "North Station-08",
+          "North Station-09",
+          "North Station-10",
+          "door-north-causewaye",
+          "door-north-causeways",
+          "door-north-crcanal",
+          "door-north-crcauseway",
+          "door-north-crnashua",
+          "door-north-tdgarden",
+          "door-north-valenti"
+        ],
+        "bike_storage": ["bike_storage_rack"],
+        "address": "135 Causeway St, Boston MA 02114",
+        "accessibility": [
+          "accessible",
+          "escalator_both",
+          "elevator",
+          "fully_elevated_platform",
+          "portable_boarding_lift"
+        ]
+      },
+      "route": {
+        "type": 2,
+        "name": "Lowell Line",
+        "long_name": "Lowell Line",
+        "id": "CR-Lowell",
+        "direction_names": { "0": "Outbound", "1": "Inbound" },
+        "direction_destinations": { "0": "Lowell", "1": "North Station" },
+        "description": "commuter_rail",
+        "custom_route?": false
+      },
+      "name": "Fake Station",
+      "is_terminus?": false,
+      "is_beginning?": false,
+      "id": "place-fake",
+      "connections": [],
+      "branch": "Lowell Two"
+    },
+    "alerts": []
+  },
+  {
+    "stop_data": [{ "type": "line", "branch": "Lowell" }, { "type": "terminus", "branch": "Lowell Two" }],
+    "route_stop": {
+      "zone": "1A",
+      "stop_features": [
+        "orange_line",
+        "green_line_c",
+        "green_line_e",
+        "commuter_rail",
+        "access",
+        "parking_lot"
+      ],
+      "station_info": {
+        "type": "station",
+        "station?": true,
+        "platform_name": null,
+        "platform_code": null,
+        "parking_lots": [
+          {
+            "utilization": null,
+            "payment": {
+              "monthly_rate": "$380 restricted",
+              "mobile_app": null,
+              "methods": ["Credit/Debit Card", "Cash"],
+              "daily_rate": "Hourly: 30 Min: $8, 1 hr: $15, 1-2 hrs: $22, 2-3 hrs: $26, 3-12 hrs: $30 | Daily Max: $68 | Events: $48 | Early Bird (in by 9 AM, out by 6 PM): $24 | Nights/Weekends: $10"
+            },
+            "note": "Parking garage is located underneath TD Garden.",
+            "name": "North Station Garage",
+            "manager": {
+              "url": "https://www.propark.com/propark-locator2/north-station-garage/",
+              "phone": "617-222-3042",
+              "name": "ProPark",
+              "contact": "ProPark"
+            },
+            "longitude": -71.06214,
+            "latitude": 42.366083,
+            "capacity": {
+              "type": "Garage",
+              "total": 1275,
+              "overnight": "Unknown",
+              "accessible": 38
+            },
+            "address": null
+          }
+        ],
+        "parent_id": null,
+        "note": null,
+        "name": "North Station",
+        "municipality": "Boston",
+        "longitude": -71.06129,
+        "latitude": 42.365577,
+        "is_child?": false,
+        "id": "place-north",
+        "has_fare_machine?": true,
+        "has_charlie_card_vendor?": true,
+        "fare_facilities": [
+          "fare_media_assistant",
+          "fare_vending_machine",
+          "ticket_window"
+        ],
+        "description": null,
+        "closed_stop_info": null,
+        "child_ids": [
+          "70026",
+          "70027",
+          "70205",
+          "70206",
+          "North Station",
+          "North Station-01",
+          "North Station-02",
+          "North Station-03",
+          "North Station-04",
+          "North Station-05",
+          "North Station-06",
+          "North Station-07",
+          "North Station-08",
+          "North Station-09",
+          "North Station-10",
+          "door-north-causewaye",
+          "door-north-causeways",
+          "door-north-crcanal",
+          "door-north-crcauseway",
+          "door-north-crnashua",
+          "door-north-tdgarden",
+          "door-north-valenti"
+        ],
+        "bike_storage": ["bike_storage_rack"],
+        "address": "135 Causeway St, Boston MA 02114",
+        "accessibility": [
+          "accessible",
+          "escalator_both",
+          "elevator",
+          "fully_elevated_platform",
+          "portable_boarding_lift"
+        ]
+      },
+      "route": {
+        "type": 2,
+        "name": "Lowell Line",
+        "long_name": "Lowell Line",
+        "id": "CR-Lowell",
+        "direction_names": { "0": "Outbound", "1": "Inbound" },
+        "direction_destinations": { "0": "Lowell", "1": "North Station" },
+        "description": "commuter_rail",
+        "custom_route?": false
+      },
+      "name": "Lowell Two",
+      "is_terminus?": true,
+      "is_beginning?": false,
+      "id": "place-north",
+      "connections": [
+        {
+          "type": 1,
+          "name": "Orange Line",
+          "long_name": "Orange Line",
+          "id": "Orange",
+          "direction_names": { "0": "Southbound", "1": "Northbound" },
+          "direction_destinations": { "0": "Forest Hills", "1": "Oak Grove" },
+          "description": "rapid_transit",
+          "custom_route?": false
+        },
+        {
+          "type": 0,
+          "name": "Green Line C",
+          "long_name": "Green Line C",
+          "id": "Green-C",
+          "direction_names": { "0": "Westbound", "1": "Eastbound" },
+          "direction_destinations": {
+            "0": "Cleveland Circle",
+            "1": "North Station"
+          },
+          "description": "rapid_transit",
+          "custom_route?": false
+        },
+        {
+          "type": 0,
+          "name": "Green Line E",
+          "long_name": "Green Line E",
+          "id": "Green-E",
+          "direction_names": { "0": "Westbound", "1": "Eastbound" },
+          "direction_destinations": { "0": "Heath Street", "1": "Lechmere" },
+          "description": "rapid_transit",
+          "custom_route?": false
+        },
+        {
+          "type": 2,
+          "name": "Fitchburg Line",
+          "long_name": "Fitchburg Line",
+          "id": "CR-Fitchburg",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": { "0": "Wachusett", "1": "North Station" },
+          "description": "commuter_rail",
+          "custom_route?": false
+        },
+        {
+          "type": 2,
+          "name": "Haverhill Line",
+          "long_name": "Haverhill Line",
+          "id": "CR-Haverhill",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": { "0": "Haverhill", "1": "North Station" },
+          "description": "commuter_rail",
+          "custom_route?": false
+        },
+        {
+          "type": 2,
+          "name": "Newburyport/Rockport Line",
+          "long_name": "Newburyport/Rockport Line",
+          "id": "CR-Newburyport",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": {
+            "0": "Newburyport or Rockport",
+            "1": "North Station"
+          },
+          "description": "commuter_rail",
+          "custom_route?": false
+        }
+      ],
+      "closed_stop_info": null,
+      "branch": "Lowell Two"
+    },
+    "alerts": []
+  },
+  {
+    "stop_data": [{ "type": "terminus", "branch": "Lowell" }],
+    "route_stop": {
+      "zone": null,
+      "stop_features": ["bus", "access", "parking_lot"],
+      "station_info": {
+        "type": "station",
+        "station?": true,
+        "platform_name": null,
+        "platform_code": null,
+        "parking_lots": [
+          {
+            "utilization": null,
+            "payment": {
+              "monthly_rate": "Monthly passes are not available at MBTA garages.",
+              "mobile_app": null,
+              "methods": ["Tap Card", "Credit/Debit Card", "Cash"],
+              "daily_rate": "Mon-Fri: $9 | Sat-Sun: $3 (Prices are valid for up to 14 hours of parking. After the first 14 hours, the daily rate is $15.)"
+            },
+            "note": null,
+            "name": "Alewife Garage",
+            "manager": {
+              "url": "http://www.parkmbta.com/",
+              "phone": "617-222-3200",
+              "name": "Republic Parking System",
+              "contact": "MBTA Customer Support"
+            },
+            "longitude": -71.142483,
+            "latitude": 42.395428,
+            "capacity": {
+              "type": "Garage",
+              "total": 2471,
+              "overnight": "Available",
+              "accessible": 32
+            },
+            "address": null
+          }
+        ],
+        "parent_id": null,
+        "note": null,
+        "name": "Alewife",
+        "municipality": "Cambridge",
+        "longitude": -71.142483,
+        "latitude": 42.395428,
+        "is_child?": false,
+        "id": "place-alfcl",
+        "has_fare_machine?": true,
+        "has_charlie_card_vendor?": true,
+        "fare_facilities": ["fare_media_assistant", "fare_vending_machine"],
+        "description": null,
+        "closed_stop_info": null,
+        "child_ids": [
+          "141",
+          "70061",
+          "Alewife-01",
+          "Alewife-02",
+          "door-alfcl-alewife",
+          "door-alfcl-busway",
+          "door-alfcl-cambridgepark",
+          "door-alfcl-russell",
+          "door-alfcl-steel"
+        ],
+        "bike_storage": ["bike_storage_cage"],
+        "address": "Alewife Brook Pkwy and Cambridge Park Dr, Cambridge, MA 02140",
+        "accessibility": ["accessible", "escalator_both", "elevator", "ramp"]
+      },
+      "route": {
+        "type": 1,
+        "name": "Red Line",
+        "long_name": "Red Line",
+        "id": "Red",
+        "direction_names": { "0": "Southbound", "1": "Northbound" },
+        "direction_destinations": { "0": "Ashmont/Braintree", "1": "Alewife" },
+        "description": "rapid_transit",
+        "custom_route?": false
+      },
+      "name": "Alewife",
+      "is_terminus?": true,
+      "is_beginning?": false,
+      "id": "place-alfcl",
+      "connections": [
+        {
+          "type": 3,
+          "name": "62",
+          "long_name": "Bedford VA Hospital - Alewife",
+          "id": "62",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": {
+            "0": "Bedford VA Hospital",
+            "1": "Alewife"
+          },
+          "description": "local_bus",
+          "custom_route?": false
+        },
+        {
+          "type": 3,
+          "name": "67",
+          "long_name": "Turkey Hill - Alewife",
+          "id": "67",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": { "0": "Turkey Hill", "1": "Alewife" },
+          "description": "local_bus",
+          "custom_route?": false
+        },
+        {
+          "type": 3,
+          "name": "76",
+          "long_name": "Lincoln Lab/Hanscom Air Force Base - Alewife",
+          "id": "76",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": {
+            "0": "Lincoln Lab/Hanscom Air Force Base",
+            "1": "Alewife"
+          },
+          "description": "local_bus",
+          "custom_route?": false
+        },
+        {
+          "type": 3,
+          "name": "79",
+          "long_name": "Arlington Heights - Alewife",
+          "id": "79",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": {
+            "0": "Arlington Heights",
+            "1": "Alewife"
+          },
+          "description": "local_bus",
+          "custom_route?": false
+        },
+        {
+          "type": 3,
+          "name": "84",
+          "long_name": "Arlmont Village - Alewife",
+          "id": "84",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": { "0": "Arlmont Village", "1": "Alewife" },
+          "description": "commuter_bus",
+          "custom_route?": false
+        },
+        {
+          "type": 3,
+          "name": "350",
+          "long_name": "North Burlington - Alewife",
+          "id": "350",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": { "0": "North Burlington", "1": "Alewife" },
+          "description": "local_bus",
+          "custom_route?": false
+        },
+        {
+          "type": 3,
+          "name": "351",
+          "long_name": "Oak Park/Bedford Woods - Alewife",
+          "id": "351",
+          "direction_names": { "0": "Outbound", "1": "Inbound" },
+          "direction_destinations": {
+            "0": "Oak Park/Bedford Woods",
+            "1": "Alewife"
+          },
+          "description": "commuter_bus",
+          "custom_route?": false
+        }
+      ],
+      "closed_stop_info": null,
+      "branch": null
+    },
+    "alerts": [
+      {
+        "updated_at": "Updated: 10/2/2019 06:58P",
+        "severity": 1,
+        "priority": "low",
+        "lifecycle": "upcoming",
+        "informed_entity": {
+          "trip": [null],
+          "stop": ["70061", "place-alfcl"],
+          "route_type": [1],
+          "route": ["Red"],
+          "entities": [
+            {
+              "trip": null,
+              "stop": "70061",
+              "route_type": 1,
+              "route": "Red",
+              "direction_id": null,
+              "activities": ["board"]
+            },
+            {
+              "trip": null,
+              "stop": "place-alfcl",
+              "route_type": 1,
+              "route": "Red",
+              "direction_id": null,
+              "activities": ["board"]
+            }
+          ],
+          "direction_id": [null],
+          "activities": ["board"]
+        },
+        "id": "335740",
+        "header": "On Saturday, October 19, the main entrance to the Alewife parking garage will close and temporarily relocate for repairs and upgrades. Access to the station will be modified during the closure.",
+        "effect": "station_issue",
+        "description": "Signs will be placed around the facility to direct motorists to the temporary entrance.",
+        "active_period": [["2019-10-19 4:30", null]]
+      },
+      {
+        "updated_at": "Updated: 10/2/2019 06:58P",
+        "severity": 1,
+        "priority": "high",
+        "lifecycle": "ongoing",
+        "informed_entity": {
+          "trip": [null],
+          "stop": ["70061", "place-alfcl"],
+          "route_type": [1],
+          "route": ["Red"],
+          "entities": [
+            {
+              "trip": null,
+              "stop": "70061",
+              "route_type": 1,
+              "route": "Red",
+              "direction_id": null,
+              "activities": ["board"]
+            },
+            {
+              "trip": null,
+              "stop": "place-alfcl",
+              "route_type": 1,
+              "route": "Red",
+              "direction_id": null,
+              "activities": ["board"]
+            }
+          ],
+          "direction_id": [null],
+          "activities": ["board"]
+        },
+        "id": "335741",
+        "header": "On Saturday, October 19, the main entrance to the Alewife parking garage will close and temporarily relocate for repairs and upgrades. Access to the station will be modified during the closure.",
+        "effect": "station_issue",
+        "description": "Signs will be placed around the facility to direct motorists to the temporary entrance.",
+        "active_period": [["2019-10-19 4:30", null]]
+      }
+    ]
+  }
+]

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -80,10 +80,10 @@ const connectionName = (connection: Route): string => {
 };
 
 const StopBranchLabel = (stop: RouteStop): JSX.Element | null =>
-  stop["is_terminus?"] && !!stop.branch ? (
+  stop["is_terminus?"] && !!stop.branch && !!stop.route ? (
     <strong className="u-small-caps">
       {stop.name}
-      {stop.route!.type === 2 ? " Line" : " Branch"}
+      {stop.route.type === 2 ? " Line" : " Branch"}
     </strong>
   ) : null;
 
@@ -99,6 +99,7 @@ const getTreeDirection = (
   // determines if tree should fan out or collect branches as we go down the page
   // use the position of the merge stop to find this. assume default of outward
   const mergeStops = getMergeStops(lineDiagram);
+  let direction: "outward" | "inward" = "outward";
   if (mergeStops) {
     const mergeIndices = mergeStops.map((ms: LineDiagramStop) =>
       lineDiagram.indexOf(ms)
@@ -110,12 +111,12 @@ const getTreeDirection = (
       )
       .map((lds: LineDiagramStop) => lineDiagram.indexOf(lds));
 
-    return branchTerminiIndices.some(i => mergeIndices[0] > i)
+    direction = branchTerminiIndices.some(i => mergeIndices[0] > i)
       ? "inward"
       : "outward";
   }
 
-  return "outward";
+  return direction;
 };
 
 const LineDiagram = ({

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -180,17 +180,17 @@ const LineDiagram = ({
                   </div>
                 ))}
               </div>
-              <div className="m-schedule-line-diagram__content">
-                <div className="m-schedule-line-diagram__card">
-                  <div className="m-schedule-line-diagram__card-left">
-                    <div className="m-schedule-line-diagram__stop-name">
+              <div className="m-schedule-diagram__content">
+                <div className="m-schedule-diagram__card">
+                  <div className="m-schedule-diagram__card-left">
+                    <div className="m-schedule-diagram__stop-name">
                       {StopBranchLabel(routeStop)}
                       {maybeAlert(stopAlerts)}
                       <a href={`/stops/${routeStop.id}`}>
                         <h4>{routeStop.name}</h4>
                       </a>
                     </div>
-                    <div className="m-schedule-line-diagram__connections">
+                    <div className="m-schedule-diagram__connections">
                       {filteredConnections(routeStop.connections).map(
                         (connectingRoute: Route) => (
                           <TooltipWrapper
@@ -205,7 +205,7 @@ const LineDiagram = ({
                             {connectingRoute.type === 3 ? (
                               <span
                                 key={connectingRoute.id}
-                                className={`c-icon__bus-pill--small m-schedule-line-diagram__connection ${busBackgroundClass(
+                                className={`c-icon__bus-pill--small m-schedule-diagram__connection ${busBackgroundClass(
                                   connectingRoute
                                 )}`}
                               >
@@ -214,7 +214,7 @@ const LineDiagram = ({
                             ) : (
                               <span
                                 key={connectingRoute.id}
-                                className="m-schedule-line-diagram__connection"
+                                className="m-schedule-diagram__connection"
                               >
                                 {modeIcon(connectingRoute.id)}
                               </span>
@@ -224,14 +224,14 @@ const LineDiagram = ({
                       )}
                     </div>
                   </div>
-                  <div className="m-schedule-line-diagram__features">
+                  <div className="m-schedule-diagram__features">
                     {routeStop.stop_features.includes("parking_lot") ? (
                       <TooltipWrapper
                         tooltipText="Parking"
                         tooltipOptions={{ placement: "bottom" }}
                       >
                         {parkingIcon(
-                          "c-svg__icon-parking-default m-schedule-line-diagram__feature-icon"
+                          "c-svg__icon-parking-default m-schedule-diagram__feature-icon"
                         )}
                       </TooltipWrapper>
                     ) : null}
@@ -241,18 +241,18 @@ const LineDiagram = ({
                         tooltipOptions={{ placement: "bottom" }}
                       >
                         {accessibleIcon(
-                          "c-svg__icon-acessible-default m-schedule-line-diagram__feature-icon"
+                          "c-svg__icon-acessible-default m-schedule-diagram__feature-icon"
                         )}
                       </TooltipWrapper>
                     ) : null}
                     {routeStop.route!.type === 2 && routeStop.zone && (
-                      <span className="c-icon__cr-zone m-schedule-line-diagram__feature-icon">{`Zone ${
+                      <span className="c-icon__cr-zone m-schedule-diagram__feature-icon">{`Zone ${
                         routeStop.zone
                       }`}</span>
                     )}
                   </div>
                 </div>
-                <div className="m-schedule-line-diagram__footer">
+                <div className="m-schedule-diagram__footer">
                   <button
                     className="btn btn-link"
                     type="button"

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -195,7 +195,7 @@ const LineDiagram = ({
                       <circle
                         r="4"
                         cx="5"
-                        cy={isBranchStart(index) ? "-16" : "14"}
+                        cy={isBranchStart(index) ? "2" : "26"}
                       />
                     </svg>
                   )}
@@ -207,16 +207,16 @@ const LineDiagram = ({
                       {isMergeStop(lineDiagramStop) && (
                         <path
                           d={`
-                            M-10,${isBranchStart(index) ? "-60" : "60"}
+                            M-10,${isBranchStart(index) ? "-30" : "100"}
                             h 15 
-                            v ${isBranchStart(index) ? "46" : "-46"}
+                            v ${isBranchStart(index) ? "36" : "-76"}
                           `}
                         />
                       )}
                       <circle
                         r="4"
                         cx="5"
-                        cy={isBranchStart(index) ? "-16" : "14"}
+                        cy={isBranchStart(index) ? "2" : "26"}
                       />
                     </svg>
                   </div>

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -101,7 +101,8 @@ const branchName = (lineDiagramStop: LineDiagramStop): JSX.Element | null => {
   if (isOnBranch(lineDiagramStop) && isTerminusStop(lineDiagramStop)) {
     return (
       <strong className="u-small-caps">
-        {lineDiagramStop.route_stop.name} Line
+        {lineDiagramStop.route_stop.name}
+        {lineDiagramStop.route_stop.route!.type === 2 ? " Line" : " Branch"}
       </strong>
     );
   }

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -82,7 +82,9 @@ const connectionName = (connection: Route): string => {
 const StopBranchLabel = (stop: RouteStop): JSX.Element | null =>
   stop["is_terminus?"] && !!stop.branch && !!stop.route ? (
     <strong className="u-small-caps">
-      {stop.name}
+      {stop.route.id.startsWith("Green")
+        ? `Green Line ${stop.route.id.split("-")[1]}`
+        : stop.name}
       {stop.route.type === 2 ? " Line" : " Branch"}
     </strong>
   ) : null;

--- a/apps/site/assets/ts/schedule/components/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/LineDiagram.tsx
@@ -222,9 +222,10 @@ const LineDiagram = ({
                   <div className="m-schedule-diagram__card-left">
                     <div className="m-schedule-diagram__stop-name">
                       {StopBranchLabel(routeStop)}
-                      {maybeAlert(stopAlerts)}
                       <a href={`/stops/${routeStop.id}`}>
-                        <h4>{routeStop.name}</h4>
+                        <h4>
+                          {maybeAlert(stopAlerts)} {routeStop.name}
+                        </h4>
                       </a>
                     </div>
                     <div className="m-schedule-diagram__connections">

--- a/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
@@ -71,7 +71,7 @@ const ScheduleDirectionMenu = ({
         />
       )}
       {// Green Line
-      route.type === 0 && route.id.startsWith("Green") && (
+      route.id.startsWith("Green") && (
         <GreenLineSelect
           routeId={route.id}
           dispatch={dispatch}
@@ -79,7 +79,7 @@ const ScheduleDirectionMenu = ({
         />
       )}
       {// Mattapan Trolley
-      route.type === 0 && route.id === "Mattapan" && (
+      route.id === "Mattapan" && (
         <div className="m-schedule-direction__route-pattern">
           {route.direction_destinations[directionId]}
         </div>
@@ -99,7 +99,7 @@ const ScheduleDirectionMenu = ({
           dispatch={dispatch}
         />
       )}
-      {menuOpen && route.type === 0 && (
+      {menuOpen && route.id.startsWith("Green") && (
         <ExpandedGreenMenu directionId={directionId} route={route} />
       )}
     </div>

--- a/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
@@ -71,12 +71,18 @@ const ScheduleDirectionMenu = ({
         />
       )}
       {// Green Line
-      route.type === 0 && (
+      route.type === 0 && route.id.startsWith("Green") && (
         <GreenLineSelect
           routeId={route.id}
           dispatch={dispatch}
           directionId={directionId}
         />
+      )}
+      {// Mattapan Trolley
+      route.type === 0 && route.id === "Mattapan" && (
+        <div className="m-schedule-direction__route-pattern">
+          {route.direction_destinations[directionId]}
+        </div>
       )}
       {// Subway, CR, Ferry
       [1, 2, 4].indexOf(route.type) !== -1 && (

--- a/apps/site/lib/site_web/controllers/schedule/line.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line.ex
@@ -74,7 +74,14 @@ defmodule SiteWeb.ScheduleController.Line do
     |> assign(:route_patterns, route_patterns)
     |> assign(:shape_map, shape_map)
     |> assign(:direction_id, direction_id)
-    |> assign(:all_stops, DiagramHelpers.build_stop_list(branches, direction_id))
+    |> assign(
+      :all_stops,
+      DiagramHelpers.build_stop_list(
+        branches,
+        direction_id,
+        Laboratory.enabled?(conn, :schedule_direction_redesign)
+      )
+    )
     |> assign(:branches, branches)
     |> assign(:route_shapes, route_shapes)
     |> assign(:active_shape, LineHelpers.active_shape(active_shapes, route.type))

--- a/apps/site/lib/site_web/controllers/schedule/line.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line.ex
@@ -1,4 +1,7 @@
 defmodule SiteWeb.ScheduleController.Line do
+  @moduledoc """
+  Actions to support rendering lines for a schedule
+  """
   @behaviour Plug
   import Plug.Conn, only: [assign: 3]
 
@@ -16,6 +19,9 @@ defmodule SiteWeb.ScheduleController.Line do
   alias Stops.{RouteStops, RouteStop, Stop}
 
   defmodule Dependencies do
+    @moduledoc """
+    Actions pulled in from elsewhere
+    """
     defstruct stops_by_route_fn: &StopsRepo.by_route/3
 
     @type t :: %__MODULE__{stops_by_route_fn: StopsRepo.stop_by_route()}

--- a/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
@@ -276,7 +276,7 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
         this_stop,
         all_stops,
         current_and_previous_branches,
-        combine_green_branches
+        combine_green_branches \\ false
       )
 
   def build_branched_stop(

--- a/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
@@ -21,15 +21,21 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
   `branch_name` is used by the green line to display the branch's letter.
 
   """
-  @spec build_stop_list([RouteStops.t()], 0 | 1) :: [stop_with_bubble_info]
-  def build_stop_list([%RouteStops{branch: "Green-" <> _} | _] = branches, direction_id) do
+  @spec build_stop_list([RouteStops.t()], 0 | 1, boolean) :: [stop_with_bubble_info]
+  def build_stop_list(branches, direction_id, combine_green_branches \\ false)
+
+  def build_stop_list(
+        [%RouteStops{branch: "Green-" <> _} | _] = branches,
+        direction_id,
+        combine_green_branches
+      ) do
     branches
     |> Enum.reverse()
-    |> Enum.reduce({[], []}, &reduce_green_branch(&1, &2, direction_id))
-    |> build_green_stop_list(direction_id)
+    |> Enum.reduce({[], []}, &reduce_green_branch(&1, &2, direction_id, combine_green_branches))
+    |> build_green_stop_list(direction_id, combine_green_branches)
   end
 
-  def build_stop_list([%RouteStops{stops: stops}], _direction_id) do
+  def build_stop_list([%RouteStops{stops: stops}], _direction_id, _) do
     stops
     |> EnumHelpers.with_first_last()
     |> Enum.map(fn {stop, is_terminus?} ->
@@ -38,7 +44,7 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
     end)
   end
 
-  def build_stop_list(branches, direction_id) do
+  def build_stop_list(branches, direction_id, _) do
     branches
     |> do_build_stop_list(direction_id)
     |> sort_stop_list(direction_id)
@@ -52,36 +58,38 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
 
   # Reduces each green line branch into a tuple of {stops_on_branches, shared_stops}, which gets parsed
   # by &build_green_stop_list/2.
-  @spec reduce_green_branch(RouteStops.t(), {[RouteStop.t()], [RouteStop.t()]}, 0 | 1) ::
+  @spec reduce_green_branch(RouteStops.t(), {[RouteStop.t()], [RouteStop.t()]}, 0 | 1, boolean) ::
           {[stop_with_bubble_info], [RouteStop.t()]}
-  defp reduce_green_branch(branch, acc, direction_id) do
+  defp reduce_green_branch(branch, acc, direction_id, combine_green_branches) do
     branch
     |> split_green_branch(direction_id)
-    |> parse_green_branch(acc, direction_id, branch.branch)
+    |> parse_green_branch(acc, direction_id, branch.branch, combine_green_branches)
   end
 
   # Pulls together the results of &reduce_green_branches/3 and compiles the full list of Green Line stops
   # in the expected order based on direction_id. Unshared stops have already had their bubble types generated in
   # &parse_green_branch/4; shared stops get their bubble types generated here, after the shared stops have
   # been reduced to a unique list.
-  @spec build_green_stop_list({[stop_with_bubble_info], [RouteStop.t()]}, direction_id) :: [
-          stop_with_bubble_info
-        ]
-  defp build_green_stop_list({branch_stops, shared_stops}, 1) do
+  @spec build_green_stop_list({[stop_with_bubble_info], [RouteStop.t()]}, direction_id, boolean) ::
+          [stop_with_bubble_info]
+  defp build_green_stop_list({branch_stops, shared_stops}, 1, combine_green_branches) do
     shared_stops
     |> dedupe_green_stop_list
-    |> Enum.reduce([], &build_branched_stop(&1, &2, {&1.branch, GreenLine.branch_ids()}))
+    |> Enum.reduce(
+      [],
+      &build_branched_stop(&1, &2, {&1.branch, GreenLine.branch_ids()}, combine_green_branches)
+    )
     |> Kernel.++(branch_stops)
     |> Enum.reverse()
   end
 
-  defp build_green_stop_list({branch_stops, shared_stops}, 0) do
+  defp build_green_stop_list({branch_stops, shared_stops}, 0, combine_green_branches) do
     shared_stops
     |> dedupe_green_stop_list
     |> Enum.reverse()
     |> Enum.reduce(
       Enum.reverse(branch_stops),
-      &build_branched_stop(&1, &2, {&1.branch, GreenLine.branch_ids()})
+      &build_branched_stop(&1, &2, {&1.branch, GreenLine.branch_ids()}, combine_green_branches)
     )
   end
 
@@ -128,11 +136,21 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
           {[RouteStop.t()], [RouteStop.t()]},
           {[stop_with_bubble_info], [RouteStop.t()]},
           direction_id,
-          Route.branch_name()
+          Route.branch_name(),
+          boolean
         ) :: {[stop_with_bubble_info], [RouteStop.t()]}
-  defp parse_green_branch({branch_stops, shared_stops}, acc, direction_id, branch_name) do
+  defp parse_green_branch(
+         {branch_stops, shared_stops},
+         acc,
+         direction_id,
+         branch_name,
+         combine_green_branches
+       ) do
     branch_stops
-    |> Enum.reduce([], &build_branched_stop(&1, &2, {branch_name, GreenLine.branch_ids()}))
+    |> Enum.reduce(
+      [],
+      &build_branched_stop(&1, &2, {branch_name, GreenLine.branch_ids()}, combine_green_branches)
+    )
     |> do_parse_green_branch(shared_stops, acc, direction_id)
   end
 
@@ -190,7 +208,10 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
     stop_list =
       branch_stops
       |> EnumHelpers.with_first_last()
-      |> Enum.reduce(all_stops, &build_branched_stop(&1, &2, {current_branch, branch_names}))
+      |> Enum.reduce(
+        all_stops,
+        &build_branched_stop(&1, &2, {current_branch, branch_names}, false)
+      )
 
     {stop_list, branch_names}
   end
@@ -202,23 +223,38 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
   @spec build_branched_stop(
           RouteStop.t() | {RouteStop.t(), boolean},
           [stop_with_bubble_info],
-          {Route.branch_name(), [Route.branch_name()]}
+          {Route.branch_name(), [Route.branch_name()]},
+          boolean
         ) :: [stop_with_bubble_info]
-  def build_branched_stop(this_stop, all_stops, current_and_previous_branches)
+  def build_branched_stop(
+        this_stop,
+        all_stops,
+        current_and_previous_branches,
+        combine_green_branches
+      )
 
-  def build_branched_stop(stop, branch_stops, {_, ["Green" <> _ | _] = green_branches}) do
-    # Green Line always evaluates all branches on all stops. If the stop should have a bubble for a branch,
-    # &stop_bubble_type/3 returns a valid tuple, otherwise it returns false. The bubble list then gets filtered to
-    # remove anything that's not a tuple.
+  def build_branched_stop(
+        stop,
+        branch_stops,
+        {_, ["Green" <> _ | _] = green_branches},
+        combine_green_branches
+      ) do
     bubble_types =
-      green_branches
-      |> Enum.map(&stop_bubble_type(&1, stop))
-      |> Enum.filter(&is_tuple/1)
+      if combine_green_branches do
+        combined_green_stop_bubble_types(stop)
+      else
+        # Evaluate all branches on all stops. If the stop should have a bubble for a branch,
+        # stop_bubble_type returns a valid tuple, otherwise it returns nil. The bubble list then
+        # gets filtered to remove anything that's not a tuple.
+        green_branches
+        |> Enum.map(&stop_bubble_type(&1, stop))
+        |> Enum.filter(&is_tuple/1)
+      end
 
     [{bubble_types, stop} | branch_stops]
   end
 
-  def build_branched_stop({%RouteStop{is_terminus?: true} = stop, _}, all_stops, {nil, _}) do
+  def build_branched_stop({%RouteStop{is_terminus?: true} = stop, _}, all_stops, {nil, _}, _) do
     # a terminus that's not on a branch is always :terminus
     [{[{nil, :terminus}], stop} | all_stops]
   end
@@ -226,19 +262,20 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
   def build_branched_stop(
         {%RouteStop{is_terminus?: false} = stop, true},
         all_stops,
-        {nil, branches}
+        {nil, branches},
+        _
       ) do
     # If the first or last unbranched stop on a branched route is not a terminus, it's a merge stop.
     # We identify these in order to know where to render the horizontal line connecting a branch to the main line.
     [{Enum.map(branches, &{&1, :merge}), stop} | all_stops]
   end
 
-  def build_branched_stop({%RouteStop{} = stop, _}, all_stops, {nil, _}) do
+  def build_branched_stop({%RouteStop{} = stop, _}, all_stops, {nil, _}, _) do
     # all other unbranched stops are just :stop
     [{[{nil, :stop}], stop} | all_stops]
   end
 
-  def build_branched_stop({%RouteStop{} = stop, _}, all_stops, {current_branch, branches})
+  def build_branched_stop({%RouteStop{} = stop, _}, all_stops, {current_branch, branches}, _)
       when is_binary(current_branch) do
     # when the branch name is not nil, that means that the stop is on a branch. The stop needs to show a bubble for
     # each branch that has already been parsed. We evaluate each branch to determine which bubble type to show:
@@ -262,8 +299,6 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
   Returns a tuple with the stop bubble type, and the name of the branch that the bubble represents.
   """
   @spec stop_bubble_type(String.t(), RouteStop.t()) :: StopBubble.stop_bubble()
-  def stop_bubble_type(bubble_branch_name, stop)
-
   def stop_bubble_type(branch_id, %RouteStop{branch: branch_id, is_terminus?: true}),
     do: {branch_id, :terminus}
 
@@ -299,6 +334,46 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
   end
 
   def stop_bubble_type(branch_id, _stop), do: {branch_id, :line}
+
+  @doc """
+  Alternate bubble generation for the new line diagram, which shows the Green Line as a single
+  branching route instead of four parallel routes.
+  """
+  defp combined_green_stop_bubble_types(%RouteStop{id: id, branch: branch}) do
+    # We need to hard-code the "merge stop" IDs since we don't have data on *which* lines are
+    # merging together at a given stop (and the E line needs a special case anyway because it
+    # merges into 3 other branches we want to represent as a single line).
+    case id do
+      "place-coecl" ->
+        [{nil, :merge}, {"Green-E", :merge}]
+
+      "place-kencl" ->
+        [{"Green-B", :merge}, {"Green-C", :merge}, {"Green-D", :merge}]
+
+      _ ->
+        # Determine which branches should be drawn as lines parallel to this stop's branch.
+        parallel_branches =
+          case branch do
+            nil -> []
+            "Green-B" -> []
+            "Green-C" -> ["Green-B"]
+            "Green-D" -> ["Green-B", "Green-C"]
+            "Green-E" -> [nil]
+          end
+
+        # Determine whether this stop should be drawn as a terminus on its branch. Since we are
+        # presenting everything inbound of Copley as a single combined line, only Lechmere should
+        # be considered a terminus on that segment.
+        stop_bubble =
+          if GreenLine.terminus?(id, branch, 0) or GreenLine.terminus?(id, "Green-E", 1) do
+            {branch, :terminus}
+          else
+            {branch, :stop}
+          end
+
+        Enum.map(parallel_branches, &{&1, :line}) ++ [stop_bubble]
+    end
+  end
 
   @doc """
   Sorts branches and their stops into the correct order to prepare them to be parsed.

--- a/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
@@ -381,14 +381,12 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
 
   def stop_bubble_type(branch_id, _stop), do: {branch_id, :line}
 
-  @doc """
-  Alternate bubble generation for the new line diagram, which shows the Green Line as a single
-  branching route instead of four parallel routes.
-
-  "Merge stop" IDs are hard-coded for the moment since we can't easily get data on *which* lines
-  are merging together at a given stop, and the E line needs a special case since it merges into
-  three other lines we want to represent as a single line.
-  """
+  # Alternate bubble generation for the new line diagram, which shows the Green Line as a single
+  # branching route instead of four parallel routes.
+  #
+  # "Merge stop" IDs are hard-coded for the moment since we can't easily get data on *which* lines
+  # are merging together at a given stop, and the E line needs a special case since it merges into
+  # three other lines we want to represent as a single line.
   defp combined_green_stop_bubble_types(%RouteStop{id: "place-coecl"}) do
     [{nil, :merge}, {"Green-E", :merge}]
   end

--- a/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
@@ -84,14 +84,9 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
          connections
          |> List.insert_at(
            case {stop.route.id, green_indices} do
-             {_, []} ->
-               0
-
-             {"Green-B", _} ->
-               List.first(green_indices)
-
-             _ ->
-               List.last(green_indices) + 1
+             {_, []} -> 0
+             {"Green-B", _} -> List.first(green_indices)
+             _ -> List.last(green_indices) + 1
            end,
            stop.route
          )

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -46,7 +46,12 @@ defmodule SiteWeb.ScheduleController.LineApi do
     active_shapes = LineHelpers.get_active_shapes(route_shapes, route, variant)
     filtered_shapes = LineHelpers.filter_route_shapes(route_shapes, active_shapes, route)
     branches = LineHelpers.get_branches(filtered_shapes, route_stops, route, direction_id)
-    DiagramHelpers.build_stop_list(branches, direction_id)
+
+    DiagramHelpers.build_stop_list(
+      branches,
+      direction_id,
+      Laboratory.enabled?(conn, :schedule_direction_redesign)
+    )
   end
 
   @spec update_route_stop_data({any, Stops.RouteStop.t()}, any, DateTime.t()) :: map()


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Line Diagram | Draw expanded branches](https://app.asana.com/0/385363666817452/1153833236795997/f)

Continuing the schedules line diagram redesign work,



| Red Line Northbound  | Red Line Southbound |
| --- | --- |
| <img width="414" alt="image" src="https://user-images.githubusercontent.com/2136286/71548219-1c409e80-2979-11ea-8ea5-54ba1d64a9d1.png"> | <img width="406" alt="image" src="https://user-images.githubusercontent.com/2136286/71548224-2793ca00-2979-11ea-85de-2773c5f71a8a.png"> |
| **Providence/Stoughton CR**  | **Newburyport/Rockport CR** |
| <img width="370" alt="image" src="https://user-images.githubusercontent.com/2136286/71548262-d59f7400-2979-11ea-990c-9a8e8d38bc73.png"> | <img width="371" alt="image" src="https://user-images.githubusercontent.com/2136286/71548275-041d4f00-297a-11ea-90fa-658c3d1f6513.png"> |

# Caveat: 

<details>
  <summary>The combined Green line page doesn't look consistent -- the underlying data is a bit different on this page currently (mainly having no stops marked as merge stops). We'd also want to consider a more detailed design (or decide if we don't want to support this page altogether).</summary>
  <figure><img width="100%" src="https://user-images.githubusercontent.com/2136286/71548320-a76e6400-297a-11ea-86fe-fd02d94bbb29.png" /></figure>
</details>


