### PR TITLE
Fix intermittent react renderer test failure

### DIFF
--- a/apps/site/lib/site/react/react.ex
+++ b/apps/site/lib/site/react/react.ex
@@ -6,7 +6,6 @@ defmodule Site.React do
   use Supervisor
   alias Phoenix.HTML
 
-  @timeout 10_000
   @pool_name :react_render
   @default_pool_size 4
 
@@ -17,14 +16,6 @@ defmodule Site.React do
   def start_link do
     opts = [pool_size: @default_pool_size]
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
-  end
-
-  @doc """
-  Stops the react renderer worker pool.
-  """
-  @spec stop() :: :ok
-  def stop do
-    Supervisor.stop(__MODULE__)
   end
 
   @spec render(String.t(), map) :: HTML.safe()
@@ -52,7 +43,7 @@ defmodule Site.React do
         )
       end)
 
-    Task.await(task, @timeout)
+    Task.await(task)
   end
 
   @doc """

--- a/apps/site/test/site/lib/react_test.exs
+++ b/apps/site/test/site/lib/react_test.exs
@@ -4,7 +4,6 @@ defmodule Site.ReactTest do
   alias ExUnit.CaptureLog
   alias GoogleMaps.Geocode.Address
   alias Site.{React, TransitNearMe}
-  alias Site.React.Worker
 
   @address %Address{
     latitude: 42.352271,
@@ -85,32 +84,6 @@ defmodule Site.ReactTest do
 
       assert log =~
                ~r/react_renderer component=TransitNearMe Cannot read property 'filter' of undefined/
-    end
-  end
-
-  describe "init/1" do
-    test "initialize the process" do
-      assert {:ok,
-              {%{intensity: 3, period: 5, strategy: :one_for_one},
-               [
-                 {:react_render,
-                  {:poolboy, :start_link,
-                   [
-                     [
-                       name: {:local, :react_render},
-                       worker_module: Worker,
-                       size: 1,
-                       max_overflow: 0
-                     ],
-                     []
-                   ]}, :permanent, 5000, :worker, [:poolboy]}
-               ]}} = React.init(pool_size: 1)
-    end
-  end
-
-  describe "stop/0" do
-    test "stops the process" do
-      assert :ok = React.stop()
     end
   end
 


### PR DESCRIPTION
Previously, in over half of test runs, a random test in `ReactTest` would fail with a `Task.await` timeout. The cause seems to be that we were starting a copy of the renderer process within one of the tests, which somehow interfered with the "real" process. At least, when this test is deleted, the intermittent failure disappears. The reason may have something to do with Poolboy, but it's hard to pursue further than that as Poolboy is written in Erlang and has zero documentation.

Since this test doesn't appear to provide much value, and neither does the one that stops the process, we can probably safely remove them. `React.stop` was only used in this test, so it can be deleted as well.

Finally, this change also removes a 10000ms timeout on the `Task.await` call that could never be reached. This is because the `GenServer.call` within the task was not given a timeout parameter, and so would time out after the default of 5000ms. This is also what `Task.await` defaults to, so removing the parameter aligns the timeout values.