### PR TITLE
Show static ferry map on new line diagram

### DIFF
--- a/apps/site/assets/ts/leaflet/components/__mapdata.d.ts
+++ b/apps/site/assets/ts/leaflet/components/__mapdata.d.ts
@@ -47,3 +47,8 @@ export interface MapData {
   width: number;
   zoom: number | null;
 }
+
+export interface StaticMapData {
+  img_src: string;
+  pdf_url: string;
+}

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -13,7 +13,7 @@ import ScheduleDirection, {
   fetchMapData
 } from "../components/ScheduleDirection";
 import { EnhancedRoute } from "../../__v3api";
-import { MapData } from "../../leaflet/components/__mapdata";
+import { MapData, StaticMapData } from "../../leaflet/components/__mapdata";
 import {
   ShapesById,
   LineDiagramStop,
@@ -124,6 +124,11 @@ const mapData: MapData = {
     latitude: 42.360718
   }
 };
+
+const staticMapData: StaticMapData = {
+  img_src: "http://example.com/map.png",
+  pdf_url: "http://example.com/map.pdf"
+};
 /* eslint-enable typescript/camelcase */
 
 const getComponent = () => (
@@ -144,6 +149,20 @@ const getSubwayComponent = () => (
   <ScheduleDirection
     mapData={mapData}
     route={{ ...route, type: 1 }}
+    directionId={directionId}
+    routePatternsByDirection={routePatternsByDirection}
+    shapesById={shapesById}
+    lineDiagram={lineDiagram}
+    services={[]}
+    ratingEndDate="2020-03-14"
+    stops={{ stops }}
+  />
+);
+
+const getStaticMapComponent = () => (
+  <ScheduleDirection
+    staticMapData={staticMapData}
+    route={{ ...route, type: 4 }}
     directionId={directionId}
     routePatternsByDirection={routePatternsByDirection}
     shapesById={shapesById}
@@ -194,6 +213,12 @@ it("renders a bus component", () => {
 it("renders a subway component", () => {
   createReactRoot();
   const tree = mount(getSubwayComponent());
+  expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
+});
+
+it("renders with a static map", () => {
+  createReactRoot();
+  const tree = mount(getStaticMapComponent());
   expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
 });
 

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -9,7 +9,9 @@ import {
   State,
   MenuAction as Action
 } from "../components/direction/reducer";
-import ScheduleDirection, { fetchData } from "../components/ScheduleDirection";
+import ScheduleDirection, {
+  fetchMapData
+} from "../components/ScheduleDirection";
 import { EnhancedRoute } from "../../__v3api";
 import { MapData } from "../../leaflet/components/__mapdata";
 import {
@@ -183,13 +185,13 @@ const getGreenLineComponent = () => {
   );
 };
 
-it("it renders a bus component", () => {
+it("renders a bus component", () => {
   createReactRoot();
   const tree = mount(getComponent());
   expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
 });
 
-it("it renders a subway component", () => {
+it("renders a subway component", () => {
   createReactRoot();
   const tree = mount(getSubwayComponent());
   expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
@@ -303,7 +305,7 @@ it("reducer can change state correctly for showAllRoutePatterns", () => {
   expect(nextState.routePatternMenuAll).toEqual(true);
 });
 
-describe("fetchData", () => {
+describe("fetchMapData", () => {
   it("fetches data", () => {
     const spy = jest.fn();
     window.fetch = jest.fn().mockImplementation(
@@ -318,7 +320,7 @@ describe("fetchData", () => {
         )
     );
 
-    return fetchData("1", 0, "2", spy).then(() => {
+    return fetchMapData("1", 0, "2", spy).then(() => {
       expect(window.fetch).toHaveBeenCalledWith(
         "/schedules/map_api?id=1&direction_id=0&variant=2"
       );
@@ -346,7 +348,7 @@ describe("fetchData", () => {
         )
     );
 
-    return fetchData("1", 0, "2", spy).then(() => {
+    return fetchMapData("1", 0, "2", spy).then(() => {
       expect(window.fetch).toHaveBeenCalledWith(
         "/schedules/map_api?id=1&direction_id=0&variant=2"
       );
@@ -366,7 +368,7 @@ it("can render green line", () => {
   expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
 });
 
-it("can change route for bus green line with click", () => {
+it("can change route for green line with click", () => {
   const stubFn = jest
     .spyOn(window.location, "assign")
     .mockImplementation(url => url);

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -60,7 +60,7 @@ exports[`can render green line 1`] = `
 </ScheduleDirection>
 `;
 
-exports[`it renders a bus component 1`] = `
+exports[`renders a bus component 1`] = `
 <ScheduleDirection>
   <div
     className="m-schedule-direction"
@@ -109,7 +109,7 @@ exports[`it renders a bus component 1`] = `
 </ScheduleDirection>
 `;
 
-exports[`it renders a subway component 1`] = `
+exports[`renders a subway component 1`] = `
 <ScheduleDirection>
   <div
     className="m-schedule-direction"

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -152,3 +152,744 @@ exports[`renders a subway component 1`] = `
   </div>
 </ScheduleDirection>
 `;
+
+exports[`renders with a static map 1`] = `
+<ScheduleDirection>
+  <div
+    className="m-schedule-direction"
+  >
+    <div
+      className="m-schedule-direction__direction"
+      id="direction-name"
+    >
+      Inbound
+    </div>
+    <ScheduleDirectionMenu>
+      <div
+        className="js-m-schedule-click-boundary"
+      >
+        <div
+          className="m-schedule-direction__route-pattern"
+        >
+          End
+        </div>
+      </div>
+    </ScheduleDirectionMenu>
+    <ScheduleDirectionButton>
+      <button
+        className="m-schedule-direction__button btn btn-primary"
+        onClick={[Function]}
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          className="notranslate m-schedule-direction__icon"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+        Change Direction
+      </button>
+    </ScheduleDirectionButton>
+  </div>
+  <img
+    alt="route 1 route map"
+    className="img-fluid"
+    src="http://example.com/map.png"
+  />
+  <a
+    href="http://example.com/map.pdf"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <i
+      aria-hidden="true"
+      className="fa fa-search-plus"
+    />
+    View map as a PDF
+  </a>
+  <LineDiagram>
+    <h3>
+      Stops
+    </h3>
+    <div
+      className="m-schedule-diagram m-schedule-diagram--outward"
+    >
+      <div
+        className="m-schedule-diagram__stop"
+        key="5547"
+      >
+        <div
+          className="m-schedule-diagram__lines "
+          style={
+            Object {
+              "color": "#undefined",
+            }
+          }
+        >
+          <div
+            className="m-schedule-diagram__line m-schedule-diagram__line--terminus"
+            key="5547-terminus-null"
+          >
+            <svg
+              className="m-schedule-diagram__line-stop"
+              height="10"
+              viewBox="0 10 10 10"
+            >
+              <circle
+                cx="50%"
+                r="4"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          className="m-schedule-diagram__content"
+        >
+          <div
+            className="m-schedule-diagram__card"
+          >
+            <div
+              className="m-schedule-diagram__card-left"
+            >
+              <div
+                className="m-schedule-diagram__stop-name"
+              >
+                <a
+                  href="/stops/5547"
+                >
+                  <h4>
+                     
+                    Elm St opp Haskell Ave
+                  </h4>
+                </a>
+              </div>
+              <div
+                className="m-schedule-diagram__connections"
+              >
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Route 110"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/110/line"
+                    title="Route 110"
+                  >
+                    <span
+                      className="c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus"
+                      key="110"
+                    >
+                      110
+                    </span>
+                  </a>
+                </Component>
+              </div>
+            </div>
+            <div
+              className="m-schedule-diagram__features"
+            />
+          </div>
+          <div
+            className="m-schedule-diagram__footer"
+          >
+            <button
+              className="btn btn-link"
+              onClick={[Function]}
+              type="button"
+            >
+              View schedule
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="m-schedule-diagram__stop"
+        key="place-tufts"
+      >
+        <div
+          className="m-schedule-diagram__lines "
+          style={
+            Object {
+              "color": "#undefined",
+            }
+          }
+        >
+          <div
+            className="m-schedule-diagram__line m-schedule-diagram__line--stop"
+            key="place-tufts-stop-Lowell"
+          >
+            <svg
+              className="m-schedule-diagram__line-stop"
+              height="10"
+              viewBox="0 10 10 10"
+            >
+              <circle
+                cx="50%"
+                r="4"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          className="m-schedule-diagram__content"
+        >
+          <div
+            className="m-schedule-diagram__card"
+          >
+            <div
+              className="m-schedule-diagram__card-left"
+            >
+              <div
+                className="m-schedule-diagram__stop-name"
+              >
+                <a
+                  href="/stops/place-tufts"
+                >
+                  <h4>
+                     
+                    Tufts Medical Center
+                  </h4>
+                </a>
+              </div>
+              <div
+                className="m-schedule-diagram__connections"
+              >
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Silver Line SL1"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/741/line"
+                    title="Silver Line SL1"
+                  >
+                    <span
+                      className="c-icon__bus-pill--small m-schedule-diagram__connection u-bg--silver-line"
+                      key="741"
+                    >
+                      SL1
+                    </span>
+                  </a>
+                </Component>
+              </div>
+            </div>
+            <div
+              className="m-schedule-diagram__features"
+            />
+          </div>
+          <div
+            className="m-schedule-diagram__footer"
+          >
+            <button
+              className="btn btn-link"
+              onClick={[Function]}
+              type="button"
+            >
+              View schedule
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="m-schedule-diagram__stop"
+        key="place-north"
+      >
+        <div
+          className="m-schedule-diagram__lines "
+          style={
+            Object {
+              "color": "#undefined",
+            }
+          }
+        >
+          <div
+            className="m-schedule-diagram__line m-schedule-diagram__line--stop"
+            key="place-north-stop-Lowell"
+          >
+            <svg
+              className="m-schedule-diagram__line-stop"
+              height="10"
+              viewBox="0 10 10 10"
+            >
+              <circle
+                cx="50%"
+                r="4"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          className="m-schedule-diagram__content"
+        >
+          <div
+            className="m-schedule-diagram__card"
+          >
+            <div
+              className="m-schedule-diagram__card-left"
+            >
+              <div
+                className="m-schedule-diagram__stop-name"
+              >
+                <a
+                  href="/stops/place-north"
+                >
+                  <h4>
+                     
+                    North Station
+                  </h4>
+                </a>
+              </div>
+              <div
+                className="m-schedule-diagram__connections"
+              >
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Orange Line"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/Orange/line"
+                    title="Orange Line"
+                  >
+                    <span
+                      className="m-schedule-diagram__connection"
+                      key="Orange"
+                    >
+                      <span
+                        aria-hidden="false"
+                        className="notranslate c-svg__icon"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "SVG",
+                          }
+                        }
+                      />
+                    </span>
+                  </a>
+                </Component>
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Green Line C"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/Green-C/line"
+                    title="Green Line C"
+                  >
+                    <span
+                      className="m-schedule-diagram__connection"
+                      key="Green-C"
+                    >
+                      <span
+                        aria-hidden="false"
+                        className="notranslate c-svg__icon"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "SVG",
+                          }
+                        }
+                      />
+                    </span>
+                  </a>
+                </Component>
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Green Line E"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/Green-E/line"
+                    title="Green Line E"
+                  >
+                    <span
+                      className="m-schedule-diagram__connection"
+                      key="Green-E"
+                    >
+                      <span
+                        aria-hidden="false"
+                        className="notranslate c-svg__icon"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "SVG",
+                          }
+                        }
+                      />
+                    </span>
+                  </a>
+                </Component>
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Commuter Rail"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/CR-Fitchburg/line"
+                    title="Commuter Rail"
+                  >
+                    <span
+                      className="m-schedule-diagram__connection"
+                      key="CR-Fitchburg"
+                    >
+                      <span
+                        aria-hidden="false"
+                        className="notranslate c-svg__icon"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "SVG",
+                          }
+                        }
+                      />
+                    </span>
+                  </a>
+                </Component>
+              </div>
+            </div>
+            <div
+              className="m-schedule-diagram__features"
+            >
+              <Component>
+                <span
+                  data-animation="true"
+                  data-original-title="Parking"
+                  data-placement="bottom"
+                  data-selector="true"
+                  data-toggle="tooltip"
+                  data-trigger="hover focus"
+                  title="Parking"
+                >
+                  <span
+                    aria-hidden="false"
+                    className="notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "SVG",
+                      }
+                    }
+                  />
+                </span>
+              </Component>
+              <Component>
+                <span
+                  data-animation="true"
+                  data-original-title="Accessible"
+                  data-placement="bottom"
+                  data-selector="true"
+                  data-toggle="tooltip"
+                  data-trigger="hover focus"
+                  title="Accessible"
+                >
+                  <span
+                    aria-hidden="false"
+                    className="notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "SVG",
+                      }
+                    }
+                  />
+                </span>
+              </Component>
+              <span
+                className="c-icon__cr-zone m-schedule-diagram__feature-icon"
+              >
+                Zone 1A
+              </span>
+            </div>
+          </div>
+          <div
+            className="m-schedule-diagram__footer"
+          >
+            <button
+              className="btn btn-link"
+              onClick={[Function]}
+              type="button"
+            >
+              View schedule
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="m-schedule-diagram__stop"
+        key="place-alfcl"
+      >
+        <div
+          className="m-schedule-diagram__lines "
+          style={
+            Object {
+              "color": "#undefined",
+            }
+          }
+        >
+          <div
+            className="m-schedule-diagram__line m-schedule-diagram__line--terminus"
+            key="place-alfcl-terminus-null"
+          >
+            <svg
+              className="m-schedule-diagram__line-stop"
+              height="10"
+              viewBox="0 10 10 10"
+            >
+              <circle
+                cx="50%"
+                r="4"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          className="m-schedule-diagram__content"
+        >
+          <div
+            className="m-schedule-diagram__card"
+          >
+            <div
+              className="m-schedule-diagram__card-left"
+            >
+              <div
+                className="m-schedule-diagram__stop-name"
+              >
+                <a
+                  href="/stops/place-alfcl"
+                >
+                  <h4>
+                    <span
+                      aria-hidden="false"
+                      className="notranslate c-svg__icon-alerts-triangle"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "SVG",
+                        }
+                      }
+                    />
+                    <span
+                      className="sr-only"
+                    >
+                      Service alert or delay
+                    </span>
+                     
+                     
+                    Alewife
+                  </h4>
+                </a>
+              </div>
+              <div
+                className="m-schedule-diagram__connections"
+              >
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Route 62"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/62/line"
+                    title="Route 62"
+                  >
+                    <span
+                      className="c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus"
+                      key="62"
+                    >
+                      62
+                    </span>
+                  </a>
+                </Component>
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Route 67"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/67/line"
+                    title="Route 67"
+                  >
+                    <span
+                      className="c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus"
+                      key="67"
+                    >
+                      67
+                    </span>
+                  </a>
+                </Component>
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Route 76"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/76/line"
+                    title="Route 76"
+                  >
+                    <span
+                      className="c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus"
+                      key="76"
+                    >
+                      76
+                    </span>
+                  </a>
+                </Component>
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Route 79"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/79/line"
+                    title="Route 79"
+                  >
+                    <span
+                      className="c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus"
+                      key="79"
+                    >
+                      79
+                    </span>
+                  </a>
+                </Component>
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Route 84"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/84/line"
+                    title="Route 84"
+                  >
+                    <span
+                      className="c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus"
+                      key="84"
+                    >
+                      84
+                    </span>
+                  </a>
+                </Component>
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Route 350"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/350/line"
+                    title="Route 350"
+                  >
+                    <span
+                      className="c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus"
+                      key="350"
+                    >
+                      350
+                    </span>
+                  </a>
+                </Component>
+                <Component>
+                  <a
+                    data-animation="false"
+                    data-original-title="Route 351"
+                    data-placement="bottom"
+                    data-selector="true"
+                    data-toggle="tooltip"
+                    data-trigger="hover focus"
+                    href="/schedules/351/line"
+                    title="Route 351"
+                  >
+                    <span
+                      className="c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus"
+                      key="351"
+                    >
+                      351
+                    </span>
+                  </a>
+                </Component>
+              </div>
+            </div>
+            <div
+              className="m-schedule-diagram__features"
+            >
+              <Component>
+                <span
+                  data-animation="true"
+                  data-original-title="Parking"
+                  data-placement="bottom"
+                  data-selector="true"
+                  data-toggle="tooltip"
+                  data-trigger="hover focus"
+                  title="Parking"
+                >
+                  <span
+                    aria-hidden="false"
+                    className="notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "SVG",
+                      }
+                    }
+                  />
+                </span>
+              </Component>
+              <Component>
+                <span
+                  data-animation="true"
+                  data-original-title="Accessible"
+                  data-placement="bottom"
+                  data-selector="true"
+                  data-toggle="tooltip"
+                  data-trigger="hover focus"
+                  title="Accessible"
+                >
+                  <span
+                    aria-hidden="false"
+                    className="notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "SVG",
+                      }
+                    }
+                  />
+                </span>
+              </Component>
+            </div>
+          </div>
+          <div
+            className="m-schedule-diagram__footer"
+          >
+            <button
+              className="btn btn-link"
+              onClick={[Function]}
+              type="button"
+            >
+              View schedule
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <WrappedModal>
+      <Modal />
+    </WrappedModal>
+  </LineDiagram>
+</ScheduleDirection>
+`;

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -14,7 +14,7 @@ import ScheduleDirectionMenu from "./direction/ScheduleDirectionMenu";
 import ScheduleDirectionButton from "./direction/ScheduleDirectionButton";
 import { reducer as fetchReducer } from "../../helpers/fetch";
 import { menuReducer, FetchAction } from "./direction/reducer";
-import { MapData } from "../../leaflet/components/__mapdata";
+import { MapData, StaticMapData } from "../../leaflet/components/__mapdata";
 import Map from "../components/Map";
 import LineDiagram from "../components/LineDiagram";
 
@@ -23,7 +23,8 @@ export interface Props {
   directionId: DirectionId;
   shapesById: ShapesById;
   routePatternsByDirection: RoutePatternsByDirection;
-  mapData: MapData;
+  mapData?: MapData;
+  staticMapData?: StaticMapData;
   lineDiagram: LineDiagramStop[];
   services: ServiceWithServiceDate[];
   ratingEndDate: string;
@@ -80,6 +81,7 @@ const ScheduleDirection = ({
   shapesById,
   routePatternsByDirection,
   mapData,
+  staticMapData,
   lineDiagram,
   services,
   ratingEndDate,
@@ -107,9 +109,11 @@ const ScheduleDirection = ({
   const shapeId = state.shape ? state.shape.id : defaultRoutePattern.shape_id;
   useEffect(
     () => {
-      fetchMapData(route.id, state.directionId, shapeId, dispatchMapData);
+      if (!staticMapData) {
+        fetchMapData(route.id, state.directionId, shapeId, dispatchMapData);
+      }
     },
-    [route, state.directionId, shapeId]
+    [route, state.directionId, shapeId, staticMapData]
   );
   const [lineState, dispatchLineData] = useReducer(fetchReducer, {
     data: lineDiagram,
@@ -141,12 +145,29 @@ const ScheduleDirection = ({
         />
         <ScheduleDirectionButton dispatch={dispatch} />
       </div>
-      {mapState.data && (
+      {!staticMapData && mapState.data && (
         <Map
           channel={`vehicles:${route.id}:${state.directionId}`}
           data={mapState.data}
           shapeId={shapeId}
         />
+      )}
+      {staticMapData && (
+        <>
+          <img
+            src={staticMapData.img_src}
+            alt={`${route.name} route map`}
+            className="img-fluid"
+          />
+          <a
+            href={staticMapData.pdf_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <i className="fa fa-search-plus" aria-hidden="true" />
+            View map as a PDF
+          </a>
+        </>
       )}
       {lineState.data && (
         <LineDiagram

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -12,7 +12,7 @@ import {
 } from "./__schedule";
 import ScheduleDirectionMenu from "./direction/ScheduleDirectionMenu";
 import ScheduleDirectionButton from "./direction/ScheduleDirectionButton";
-import { reducer as mapDataReducer } from "../../helpers/fetch";
+import { reducer as fetchReducer } from "../../helpers/fetch";
 import { menuReducer, FetchAction } from "./direction/reducer";
 import { MapData } from "../../leaflet/components/__mapdata";
 import Map from "../components/Map";
@@ -30,7 +30,7 @@ export interface Props {
   stops: SimpleStopMap;
 }
 
-export const fetchData = (
+export const fetchMapData = (
   routeId: string,
   directionId: DirectionId,
   shapeId: string,
@@ -99,7 +99,7 @@ const ScheduleDirection = ({
     routePatternMenuAll: false,
     itemFocus: null
   });
-  const [mapState, dispatchMapData] = useReducer(mapDataReducer, {
+  const [mapState, dispatchMapData] = useReducer(fetchReducer, {
     data: mapData,
     isLoading: false,
     error: false
@@ -107,11 +107,11 @@ const ScheduleDirection = ({
   const shapeId = state.shape ? state.shape.id : defaultRoutePattern.shape_id;
   useEffect(
     () => {
-      fetchData(route.id, state.directionId, shapeId, dispatchMapData);
+      fetchMapData(route.id, state.directionId, shapeId, dispatchMapData);
     },
     [route, state.directionId, shapeId]
   );
-  const [lineState, dispatchLineData] = useReducer(mapDataReducer, {
+  const [lineState, dispatchLineData] = useReducer(fetchReducer, {
     data: lineDiagram,
     isLoading: false,
     error: false

--- a/apps/site/assets/ts/schedule/schedule-loader.tsx
+++ b/apps/site/assets/ts/schedule/schedule-loader.tsx
@@ -5,7 +5,7 @@ import ScheduleNote from "./components/ScheduleNote";
 import ScheduleDirection from "./components/ScheduleDirection";
 import Map from "./components/Map";
 import { SchedulePageData } from "./components/__schedule";
-import { MapData } from "../leaflet/components/__mapdata";
+import { MapData, StaticMapData } from "../leaflet/components/__mapdata";
 import ScheduleFinder from "./components/ScheduleFinder";
 
 const renderMap = (): void => {
@@ -72,9 +72,18 @@ const renderDirectionAndMap = (
     stops
   } = schedulePageData;
 
+  let mapData: MapData | undefined;
   const mapDataEl = document.getElementById("js-map-data");
-  if (!mapDataEl) return;
-  const mapData: MapData = JSON.parse(mapDataEl.innerHTML);
+  if (mapDataEl) {
+    mapData = JSON.parse(mapDataEl.innerHTML);
+  }
+
+  let staticMapData: StaticMapData | undefined;
+  const staticDataEl = document.getElementById("static-map-data");
+  if (staticDataEl) {
+    staticMapData = JSON.parse(staticDataEl.innerHTML);
+  }
+
   ReactDOM.render(
     <ScheduleDirection
       directionId={directionId}
@@ -82,6 +91,7 @@ const renderDirectionAndMap = (
       routePatternsByDirection={routePatternsByDirection}
       shapesById={shapesById}
       mapData={mapData}
+      staticMapData={staticMapData}
       lineDiagram={lineDiagram}
       services={services}
       ratingEndDate={ratingEndDate}

--- a/apps/site/lib/site_web/templates/schedule/_line.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line.html.eex
@@ -55,15 +55,22 @@
             active_shape: @active_shape,
             show_variant_selector: assigns[:show_variant_selector]
           %>
-
         <% end %>
+
         <div class="line-map-container">
+          <% map_pdf_url = @route.type |> Routes.Route.type_atom() |> MapHelpers.map_pdf_url() %>
           <%= if display_map_link?(@route.type) do %>
-            <img src="<%= @map_img_src %>" class="img-fluid">
-            <a href="<%= @route.type |> Routes.Route.type_atom() |> MapHelpers.map_pdf_url() %>" target="_blank">
-              <%= fa "search-plus" %>
-              View map as a PDF
-            </a>
+            <%= if redesign_direction? do %>
+              <script id="static-map-data" type="text/plain">
+                <%= raw Poison.encode!(%{img_src: @map_img_src, pdf_url: map_pdf_url}) %>
+              </script>
+            <% else %>
+              <img src="<%= @map_img_src %>" class="img-fluid">
+              <a href="<%= map_pdf_url %>" target="_blank">
+                <%= fa "search-plus" %>
+                View map as a PDF
+              </a>
+            <% end %>
           <% else %>
             <%= render "_line_map.html",
               conn: @conn,


### PR DESCRIPTION
**Asana Ticket:** [Line Diagram | Ferry](https://app.asana.com/0/385363666817452/1120016688269892/f)

Introducing a `StaticMapData` type: If this prop is given to `ScheduleDirection`, it will replicate the "static map image with PDF link" behavior from the old line diagram, and not attempt to fetch dynamic map data. Currently this only occurs for ferries, which is determined by the server-side `display_map_link?` helper.