### PR TITLE
Increase HTTP timeout for API requests in test

### DIFF
--- a/apps/site/config/test.exs
+++ b/apps/site/config/test.exs
@@ -13,6 +13,9 @@ config :logger, level: :warn
 # operations while it updates.
 config :tzdata, :autoupdate, :disabled
 
+# Allow more time for API requests on CI
+config :v3_api, default_timeout: 10_000
+
 config :wallaby,
   screenshot_on_failure: false,
   driver: Wallaby.Experimental.Chrome,


### PR DESCRIPTION
This is aimed at resolving the remaining intermittent test failures we are getting on CI, which are all HTTP timeouts on API requests.