### PR TITLE
Revert: Add basic antispam measure to contact form

### DIFF
--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -1,4 +1,5 @@
 defmodule SiteWeb.CustomerSupportController do
+  @moduledoc "Handles the customer support page and form submissions."
   use SiteWeb, :controller
   require Logger
 

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -94,14 +94,13 @@ defmodule SiteWeb.CustomerSupportController do
         [
           &validate_comments/1,
           &validate_service/1,
-          &validate_antispam/1,
           &validate_photos/1,
           &validate_name/1,
           &validate_email/1,
           &validate_privacy/1
         ]
       else
-        [&validate_comments/1, &validate_service/1, &validate_antispam/1, &validate_photos/1]
+        [&validate_comments/1, &validate_service/1, &validate_photos/1]
       end
 
     Site.Validation.validate(validators, params)
@@ -150,10 +149,6 @@ defmodule SiteWeb.CustomerSupportController do
   defp valid_upload?(%Plug.Upload{filename: filename}) do
     MIME.from_path(filename) in @allowed_attachment_types
   end
-
-  @spec validate_antispam(map) :: :ok | String.t()
-  defp validate_antispam(%{"leave_this_alone" => value}) when byte_size(value) > 0, do: "antispam"
-  defp validate_antispam(_), do: :ok
 
   def send_ticket(params) do
     Feedback.Repo.send_ticket(%Feedback.Message{

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -30,7 +30,7 @@
           <% comments_placeholder = "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number." %>
           <%= textarea f, :comments, id: "comments", class: "support-form-text-input form-control", maxlength: "3000",
                                      rows: "3", placeholder: comments_placeholder, required: "required", value: assigns[:comments] %>
-
+  
           <span></span>
           <small class="form-text">3000 characters maximum</small>
         </div>
@@ -100,10 +100,6 @@
               })
             %>
           </div>
-        </div>
-        <div style="display: none" class="form-group contrast">
-          <label for="leave-this-alone">As a security measure, please leave this field blank.</label>
-          <%= text_input f, :leave_this_alone, id: "leave-this-alone", tabindex: -1, autocomplete: "off" %>
         </div>
         <div class="response-time-disclaimer">
           Responses may take up to 5 business days. If this is an emergency, please <%= link("contact the Transit Police", to: "/transit-police") %>.

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -209,14 +209,6 @@ defmodule SiteWeb.CustomerSupportControllerTest do
              ]
     end
 
-    test "prevents submissions when the anti-spam field is filled", %{conn: conn} do
-      params = valid_request_response_data() |> Map.put("leave_this_alone", "spam!")
-
-      conn = post(conn, customer_support_path(conn, :submit), %{"support" => params})
-
-      assert "antispam" in conn.assigns.errors
-    end
-
     test "prevents submissions when an upload does not appear to be an image", %{conn: conn} do
       params =
         valid_request_response_data()


### PR DESCRIPTION
This reverts commit e4df0132643e4bdf08b1088b7491de44b05f8631.

This was intended as a quick fix to the high volume of spam coming into the helpdesk with all fields filled out as random letters and numbers. They have reported this didn't fix the issue, so it doesn't make sense to keep this code around.