### PR TITLE
Fix linter false positives on CI

### DIFF
--- a/semaphore/credo.sh
+++ b/semaphore/credo.sh
@@ -5,10 +5,11 @@ function join_by {
   local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}";
 }
 
-changed=$(git diff --name-only origin/master "*.ex" "*.exs")
+fork_point=$(git merge-base --fork-point origin/master)
+changed=$(git diff --name-only $fork_point "*.ex" "*.exs")
 
 if [ -z "$changed" ]; then
-  echo "No files changed from origin/master."
+  echo "No files changed relative to origin/master fork point."
 else
   # Since Credo doesn't support running checks only on specified files via the
   # command line, we create a temporary copy of the config file whose `included`

--- a/semaphore/credo.sh
+++ b/semaphore/credo.sh
@@ -9,7 +9,7 @@ fork_point=$(git merge-base --fork-point origin/master)
 changed=$(git diff --name-only $fork_point "*.ex" "*.exs")
 
 if [ -z "$changed" ]; then
-  echo "No files changed relative to origin/master fork point."
+  echo "No Elixir files changed relative to origin/master fork point."
 else
   # Since Credo doesn't support running checks only on specified files via the
   # command line, we create a temporary copy of the config file whose `included`

--- a/semaphore/scss_lint.sh
+++ b/semaphore/scss_lint.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 fork_point=$(git merge-base --fork-point origin/master)
-changed=$(git diff --name-only $fork_point "*.ex" "*.exs")
+changed=$(git diff --name-only $fork_point apps/site/assets/css)
 
 if [ -z "$changed" ]; then
-  echo "No files changed relative to origin/master fork point."
+  echo "No CSS files changed relative to origin/master fork point."
 else
   rbenv local 2.4.1
   gem install scss_lint -v 0.59.0

--- a/semaphore/scss_lint.sh
+++ b/semaphore/scss_lint.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-changed=$(git diff --name-only origin/master apps/site/assets/css)
+fork_point=$(git merge-base --fork-point origin/master)
+changed=$(git diff --name-only $fork_point "*.ex" "*.exs")
 
 if [ -z "$changed" ]; then
-  echo "No CSS files changed from origin/master."
+  echo "No files changed relative to origin/master fork point."
 else
   rbenv local 2.4.1
   gem install scss_lint -v 0.59.0


### PR DESCRIPTION
Since we were diffing the branch against the current tip of master, rather than the point where it diverged from master, linting would flag issues that had actually been resolved in master.