### PR TITLE
Fix Franklin line diagram issues around Foxboro

### DIFF
--- a/apps/stops/test/route_stop_test.exs
+++ b/apps/stops/test/route_stop_test.exs
@@ -134,6 +134,60 @@ defmodule Stops.RouteStopTest do
       assert_branch_names(actual, ["Kingston", "Plymouth", nil, nil, nil])
     end
 
+    test "handles the Foxboro pilot on the Franklin line (outbound)" do
+      route = %Route{id: "CR-Franklin"}
+      shapes = franklin_shapes(0)
+      stops = make_stops(shapes |> Enum.flat_map(& &1.stop_ids) |> Enum.uniq())
+
+      actual = list_from_shapes(shapes, stops, route, 0)
+
+      assert_stop_ids(actual, [
+        "place-sstat",
+        "place-bbsta",
+        "place-rugg",
+        "place-NEC-2203",
+        "place-DB-0095",
+        "place-FB-0109",
+        "place-FB-0118",
+        "place-FS-0049",
+        "place-FB-0125",
+        "place-FB-0143",
+        "place-FB-0148",
+        "place-FB-0166",
+        "place-FB-0191",
+        "place-FB-0230",
+        "place-FB-0275",
+        "place-FB-0303"
+      ])
+    end
+
+    test "handles the Foxboro pilot on the Franklin line (inbound)" do
+      route = %Route{id: "CR-Franklin"}
+      shapes = franklin_shapes(1)
+      stops = make_stops(shapes |> Enum.flat_map(& &1.stop_ids) |> Enum.uniq())
+
+      actual = list_from_shapes(shapes, stops, route, 1)
+
+      assert_stop_ids(actual, [
+        "place-FB-0303",
+        "place-FB-0275",
+        "place-FB-0230",
+        "place-FB-0191",
+        "place-FB-0177",
+        "place-FS-0049",
+        "place-FB-0166",
+        "place-FB-0148",
+        "place-FB-0143",
+        "place-FB-0125",
+        "place-FB-0118",
+        "place-FB-0109",
+        "place-DB-0095",
+        "place-rugg",
+        "place-bbsta",
+        "place-sstat"
+      ])
+    end
+
     test "handles ferry routes with multiple shapes by returning the stops as-is" do
       primary = %Shape{id: "primary"}
       other = %Shape{id: "secondary"}
@@ -169,5 +223,130 @@ defmodule Stops.RouteStopTest do
 
   def assert_branch_names(actual, branch_names) do
     assert Enum.map(actual, & &1.branch) == branch_names
+  end
+
+  defp franklin_shapes(0) do
+    [
+      %Shape{
+        id: "9880006",
+        name: "South Station - Forge Park/495 via Back Bay",
+        stop_ids: [
+          "place-sstat",
+          "place-bbsta",
+          "place-rugg",
+          "place-NEC-2203",
+          "place-DB-0095",
+          "place-FB-0109",
+          "place-FB-0118",
+          "place-FB-0125",
+          "place-FB-0143",
+          "place-FB-0148",
+          "place-FB-0166",
+          "place-FB-0191",
+          "place-FB-0230",
+          "place-FB-0275",
+          "place-FB-0303"
+        ]
+      },
+      %Shape{
+        id: "SouthStationToFoxboroViaBackBay",
+        name: "South Station - Foxboro via Back Bay & Dedham",
+        stop_ids: ["place-sstat", "place-bbsta", "place-FB-0118", "place-FS-0049"]
+      },
+      %Shape{
+        id: "SouthStationToFoxboroViaFairmount",
+        name: "South Station - Foxboro via Fairmount",
+        stop_ids: [
+          "place-sstat",
+          "place-DB-2265",
+          "place-DB-2258",
+          "place-DB-2249",
+          "place-DB-2240",
+          "place-DB-2230",
+          "place-DB-2222",
+          "place-DB-2205",
+          "place-DB-0095",
+          "place-FB-0109",
+          "place-FB-0118",
+          "place-FB-0125",
+          "place-FB-0143",
+          "place-FB-0148",
+          "place-FB-0166",
+          "place-FS-0049"
+        ]
+      }
+    ]
+  end
+
+  defp franklin_shapes(1) do
+    [
+      %Shape{
+        id: "9880005",
+        name: "Forge Park/495 - South Station via Back Bay",
+        stop_ids: [
+          "place-FB-0303",
+          "place-FB-0275",
+          "place-FB-0230",
+          "place-FB-0191",
+          "place-FB-0177",
+          "place-FB-0166",
+          "place-FB-0148",
+          "place-FB-0143",
+          "place-FB-0125",
+          "place-FB-0118",
+          "place-FB-0109",
+          "place-DB-0095",
+          "place-rugg",
+          "place-bbsta",
+          "place-sstat"
+        ]
+      },
+      %Shape{
+        id: "9880002",
+        name: "Forge Park/495 - South Station via Fairmount",
+        stop_ids: [
+          "place-FB-0303",
+          "place-FB-0275",
+          "place-FB-0230",
+          "place-FB-0191",
+          "place-FB-0148",
+          "place-FB-0143",
+          "place-FB-0125",
+          "place-FB-0118",
+          "place-FB-0109",
+          "place-DB-0095",
+          "place-DB-2205",
+          "place-DB-2222",
+          "place-DB-2230",
+          "place-DB-2240",
+          "place-DB-2249",
+          "place-DB-2258",
+          "place-DB-2265",
+          "place-sstat"
+        ]
+      },
+      %Shape{
+        id: "FoxboroToSouthStationViaFairmount",
+        name: "Foxboro - South Station via Fairmount",
+        stop_ids: [
+          "place-FS-0049",
+          "place-FB-0166",
+          "place-FB-0148",
+          "place-FB-0143",
+          "place-FB-0125",
+          "place-FB-0118",
+          "place-FB-0109",
+          "place-DB-0095",
+          "place-DB-2205",
+          "place-DB-2222",
+          "place-DB-2230",
+          "place-DB-2240",
+          "place-DB-2249",
+          "place-DB-2258",
+          "place-DB-2265",
+          "place-sstat"
+        ]
+      }
+    ]
   end
 end


### PR DESCRIPTION
**Asana Ticket:** [Line Diagram | Outbound Franklin Line (Foxboro stops)](https://app.asana.com/0/385363666817452/1154464073332369/f)

* Fixes glitchy/disconnected line diagram in the outbound direction
* Fixes Ruggles and Back Bay not showing up on the inbound direction

It turns out we didn't have a special case for Franklin outbound at all (only inbound), so either the outbound line diagram glitch wasn't a regression, or the data previously didn't require a special case but now does.

While in here I discovered an adjacent issue where the _inbound_ map and line diagram was displaying the trunk stops from the Fairmount line instead of the actual Franklin line. I attempted to fix this so it matches the outbound line diagram.