### PR TITLE
Clean up past time-dependent logic

### DIFF
--- a/apps/site/lib/site/shuttle_diversion.ex
+++ b/apps/site/lib/site/shuttle_diversion.ex
@@ -68,8 +68,9 @@ defmodule Site.ShuttleDiversion do
       ]
 
       with %JsonApi{data: trips} <- Trips.by_route(trips_route, trips_params),
-           route_stops when is_list(route_stops) <- Stops.by_routes(true_route_ids, 0),
-           unique_trips = unique_trips_by_shape(trips) do
+           route_stops when is_list(route_stops) <- Stops.by_routes(true_route_ids, 0) do
+        unique_trips = unique_trips_by_shape(trips)
+
         {:ok,
          %__MODULE__{
            alerts: ongoing_shuttle_alerts(route_ids, time),

--- a/apps/site/lib/site_web/controllers/fare/commuter.ex
+++ b/apps/site/lib/site_web/controllers/fare/commuter.ex
@@ -10,9 +10,8 @@ defmodule SiteWeb.FareController.Commuter do
   @impl true
 
   @foxboro "place-FS-0049"
-  @pilot_launch_date ~D[2019-10-21]
 
-  def fares(%{assigns: %{origin: origin, destination: destination, date: date}})
+  def fares(%{assigns: %{origin: origin, destination: destination}})
       when not is_nil(origin) and not is_nil(destination) do
     case Fares.fare_for_stops(:commuter_rail, origin.id, destination.id) do
       {:ok, fare_name} ->
@@ -20,9 +19,7 @@ defmodule SiteWeb.FareController.Commuter do
         foxboro_event_fare = get_fares(:foxboro)
 
         if foxboro?(origin.id, destination.id) do
-          if foxboro_pilot?(date),
-            do: foxboro_event_fare ++ standard_fares,
-            else: foxboro_event_fare
+          foxboro_event_fare ++ standard_fares
         else
           standard_fares
         end
@@ -49,7 +46,4 @@ defmodule SiteWeb.FareController.Commuter do
   @spec foxboro?(String.t(), String.t()) :: boolean()
   defp foxboro?(a, b) when @foxboro in [a, b], do: true
   defp foxboro?(_, _), do: false
-
-  @spec foxboro_pilot?(Date.t()) :: boolean
-  defp foxboro_pilot?(current_date), do: Date.compare(current_date, @pilot_launch_date) != :lt
 end

--- a/apps/site/lib/site_web/controllers/fare/commuter.ex
+++ b/apps/site/lib/site_web/controllers/fare/commuter.ex
@@ -1,4 +1,5 @@
 defmodule SiteWeb.FareController.Commuter do
+  @moduledoc "Determines fares for Commuter Rail trips."
   use SiteWeb.FareController.OriginDestinationFareBehavior
 
   @impl true

--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -1,4 +1,5 @@
 defmodule SiteWeb.ScheduleController.TimetableController do
+  @moduledoc "Handles the Timetable tab for commuter rail routes."
   use SiteWeb, :controller
   alias Plug.Conn
   alias Routes.Route

--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -54,10 +54,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     |> assign(:trip_schedules, trip_schedules)
     |> assign(:vehicle_schedules, vehicle_schedules)
     |> assign(:prior_stops, prior_stops)
-    |> assign(
-      :trip_messages,
-      trip_messages(conn.assigns.route, conn.assigns.direction_id, conn.assigns.date)
-    )
+    |> assign(:trip_messages, trip_messages(conn.assigns.route, conn.assigns.direction_id))
     |> assign(:all_stops, all_stops)
   end
 
@@ -70,10 +67,8 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     end
   end
 
-  @spec trip_messages(Routes.Route.t(), 0 | 1, Date.t()) :: %{
-          {String.t(), String.t()} => String.t()
-        }
-  def trip_messages(%Routes.Route{id: "CR-Haverhill"}, 0, _) do
+  @spec trip_messages(Routes.Route.t(), 0 | 1) :: %{{String.t(), String.t()} => String.t()}
+  def trip_messages(%Routes.Route{id: "CR-Haverhill"}, 0) do
     %{
       {"221"} => "Via Lowell Line",
       {"221", "place-WR-0067"} => "Via",
@@ -82,7 +77,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     }
   end
 
-  def trip_messages(%Routes.Route{id: "CR-Haverhill"}, 1, _) do
+  def trip_messages(%Routes.Route{id: "CR-Haverhill"}, 1) do
     %{
       {"208"} => "Via Lowell Line",
       {"208", "place-WR-0085"} => "Via",
@@ -91,7 +86,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     }
   end
 
-  def trip_messages(%Routes.Route{id: "CR-Lowell"}, 0, _) do
+  def trip_messages(%Routes.Route{id: "CR-Lowell"}, 0) do
     %{
       {"221"} => "Via Haverhill",
       {"221", "place-NHRML-0218"} => "Via",
@@ -99,7 +94,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     }
   end
 
-  def trip_messages(%Routes.Route{id: "CR-Lowell"}, 1, _) do
+  def trip_messages(%Routes.Route{id: "CR-Lowell"}, 1) do
     %{
       {"208"} => "Via Haverhill",
       {"208", "place-NHRML-0254"} => "Via",
@@ -108,48 +103,26 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     }
   end
 
-  def trip_messages(%Routes.Route{id: "CR-Franklin"}, 1, date) do
-    case ScheduleView.is_atleast_oct_21_2019?(date) do
-      true ->
-        ["740", "746", "748", "750", "754", "726", "758"]
-        |> Enum.flat_map(&franklin_via_fairmount(&1, 1))
-        |> Enum.into(%{})
-
-      false ->
-        %{
-          {"790"} => "Via Fairmount",
-          {"790", "place-rugg"} => "Via",
-          {"790", "place-bbsta"} => "Fairmount"
-        }
-    end
+  def trip_messages(%Routes.Route{id: "CR-Franklin"}, 1) do
+    ["740", "746", "748", "750", "754", "726", "758"]
+    |> Enum.flat_map(&franklin_via_fairmount(&1, 1))
+    |> Enum.into(%{})
   end
 
-  def trip_messages(%Routes.Route{id: "CR-Franklin"}, 0, date) do
-    case ScheduleView.is_atleast_oct_21_2019?(date) do
-      true ->
-        ["741", "743", "747", "749", "755", "757", "759"]
-        |> Enum.flat_map(&franklin_via_fairmount(&1, 0))
-        |> Enum.into(%{})
-
-      false ->
-        %{}
-    end
+  def trip_messages(%Routes.Route{id: "CR-Franklin"}, 0) do
+    ["741", "743", "747", "749", "755", "757", "759"]
+    |> Enum.flat_map(&franklin_via_fairmount(&1, 0))
+    |> Enum.into(%{})
   end
 
-  def trip_messages(%Routes.Route{id: "CR-Fairmount"} = route, 1, date) do
-    case ScheduleView.is_atleast_oct_21_2019?(date) do
-      true ->
-        %{
-          {"726"} => ScheduleView.timetable_note(%{route: route, direction_id: 1, date: date}),
-          {"726", "place-FS-0049"} => "FRANK"
-        }
-
-      false ->
-        %{}
-    end
+  def trip_messages(%Routes.Route{id: "CR-Fairmount"} = route, 1) do
+    %{
+      {"726"} => ScheduleView.timetable_note(%{route: route, direction_id: 1}),
+      {"726", "place-FS-0049"} => "FRANK"
+    }
   end
 
-  def trip_messages(_, _, _) do
+  def trip_messages(_, _) do
     %{}
   end
 

--- a/apps/site/lib/site_web/templates/schedule/_trip_info.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_trip_info.html.eex
@@ -61,5 +61,4 @@
       </div>
     <% end %>
   <% end %>
-  <%= fare_change_message() %>
 </div>

--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -489,58 +489,37 @@ defmodule SiteWeb.ScheduleView do
     end
   end
 
-  @spec is_atleast_oct_21_2019?(Date.t()) :: boolean
-  def is_atleast_oct_21_2019?(date) do
-    case Date.compare(date, ~D[2019-10-21]) do
-      :lt -> false
-      :eq -> true
-      :gt -> true
-    end
-  end
-
   @spec timetable_note(Conn.t() | map) :: Safe.t() | nil
-  def timetable_note(%{route: %Route{id: "CR-Fairmount"}, direction_id: 1, date: date}) do
-    case is_atleast_oct_21_2019?(date) do
-      true ->
-        content_tag :span, class: "m-timetable__note" do
-          [
-            content_tag(:span, "FRANK: ", class: "m-timetable__cell--via"),
-            content_tag(
-              :span,
-              "Operates from Forge Park. Does not serve Foxboro. "
-            ),
-            link(to: timetable_path(SiteWeb.Endpoint, :show, "CR-Franklin")) do
-              "See the Franklin Line schedule for all stops."
-            end
-          ]
+  def timetable_note(%{route: %Route{id: "CR-Fairmount"}, direction_id: 1}) do
+    content_tag :span, class: "m-timetable__note" do
+      [
+        content_tag(:span, "FRANK: ", class: "m-timetable__cell--via"),
+        content_tag(
+          :span,
+          "Operates from Forge Park. Does not serve Foxboro. "
+        ),
+        link(to: timetable_path(SiteWeb.Endpoint, :show, "CR-Franklin")) do
+          "See the Franklin Line schedule for all stops."
         end
-
-      false ->
-        nil
+      ]
     end
   end
 
-  def timetable_note(%{route: %Route{id: "CR-Foxboro"}, direction_id: _, date: date}) do
-    case is_atleast_oct_21_2019?(date) do
-      true ->
-        content_tag :div, class: "m-timetable__note" do
-          [
-            content_tag(:p, [
-              content_tag(:strong, "Note:"),
-              " Trains depart from Foxboro 30 minutes after conclusion of events"
-            ]),
-            content_tag(:p, [
-              content_tag(:strong, "Note:"),
-              " For regular weekday service to and from Foxboro please visit ",
-              link(to: timetable_path(SiteWeb.Endpoint, :show, "CR-Franklin")) do
-                "Franklin Line/Foxboro Pilot"
-              end
-            ])
-          ]
-        end
-
-      false ->
-        nil
+  def timetable_note(%{route: %Route{id: "CR-Foxboro"}, direction_id: _}) do
+    content_tag :div, class: "m-timetable__note" do
+      [
+        content_tag(:p, [
+          content_tag(:strong, "Note:"),
+          " Trains depart from Foxboro 30 minutes after conclusion of events"
+        ]),
+        content_tag(:p, [
+          content_tag(:strong, "Note:"),
+          " For regular weekday service to and from Foxboro please visit ",
+          link(to: timetable_path(SiteWeb.Endpoint, :show, "CR-Franklin")) do
+            "Franklin Line/Foxboro Pilot"
+          end
+        ])
+      ]
     end
   end
 

--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -29,8 +29,6 @@ defmodule SiteWeb.ScheduleView do
     "Mattapan"
   ]
 
-  @july_1_2019 1_561_953_600
-
   @doc """
   Given a list of schedules, returns a display of the route direction. Assumes all
   schedules have the same route and direction.
@@ -474,19 +472,6 @@ defmodule SiteWeb.ScheduleView do
   defp sort_subway(route_a, route_b) do
     Enum.find_index(@subway_order, fn x -> x == route_a.id end) <
       Enum.find_index(@subway_order, fn x -> x == route_b.id end)
-  end
-
-  @spec fare_change_message(integer) :: Safe.t()
-  def fare_change_message(now \\ System.system_time(:second)) do
-    if now < @july_1_2019 do
-      content_tag :div, class: "trip-fare" do
-        link(to: "/fare-proposal-2019/fare-prices") do
-          "Fares are changing July 1, 2019."
-        end
-      end
-    else
-      []
-    end
   end
 
   @spec timetable_note(Conn.t() | map) :: Safe.t() | nil

--- a/apps/site/test/site_web/controllers/fare/commuter_test.exs
+++ b/apps/site/test/site_web/controllers/fare/commuter_test.exs
@@ -18,21 +18,7 @@ defmodule SiteWeb.FareController.CommuterTest do
     refute Enum.any?(valid_fares, fn fare -> match?(%Fares.Fare{name: :foxboro}, fare) end)
   end
 
-  test "show only Foxboro special event fare if selection includes Foxboro", %{conn: conn} do
-    origin = Stops.Repo.get("place-sstat")
-    destination = Stops.Repo.get("place-FS-0049")
-
-    valid_fares =
-      conn
-      |> assign(:date, ~D[2019-10-20])
-      |> assign(:origin, origin)
-      |> assign(:destination, destination)
-      |> Commuter.fares()
-
-    assert valid_fares == Fares.Repo.all(name: :foxboro)
-  end
-
-  test "includes Zone 4 fares for Foxboro if pilot has launched", %{conn: conn} do
+  test "includes Zone 4 fares for Foxboro if selection includes Foxboro", %{conn: conn} do
     origin = Stops.Repo.get("place-sstat")
     destination = Stops.Repo.get("place-FS-0049")
 

--- a/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
@@ -93,18 +93,8 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
     end
   end
 
-  describe "trip_messages/3" do
-    test "returns proper trips for CR Franklin before 10-21" do
-      assert Enum.empty?(trip_messages(%Routes.Route{id: "CR-Franklin"}, 0, ~D[2019-10-20]))
-
-      assert [
-               {"790"},
-               {"790", "place-bbsta"},
-               {"790", "place-rugg"}
-             ] = Map.keys(trip_messages(%Routes.Route{id: "CR-Franklin"}, 1, ~D[2019-10-20]))
-    end
-
-    test "returns proper trips for CR Franklin on and after 10-21" do
+  describe "trip_messages/2" do
+    test "returns proper messages for CR Franklin" do
       assert [
                "726",
                "740",
@@ -115,7 +105,7 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
                "758"
              ] =
                %Routes.Route{id: "CR-Franklin"}
-               |> trip_messages(1, ~D[2019-10-22])
+               |> trip_messages(1)
                |> Map.keys()
                |> Enum.map(&elem(&1, 0))
                |> Enum.uniq()
@@ -131,22 +121,18 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
                "759"
              ] ==
                %Routes.Route{id: "CR-Franklin"}
-               |> trip_messages(0, ~D[2019-10-22])
+               |> trip_messages(0)
                |> Map.keys()
                |> Enum.map(&elem(&1, 0))
                |> Enum.uniq()
                |> Enum.sort()
     end
 
-    test "returns proper trips for CR Fairmount before 10-21" do
-      assert Enum.empty?(trip_messages(%Routes.Route{id: "CR-Fairmount"}, 1, ~D[2019-10-20]))
-    end
-
-    test "returns proper trips for CR Fairmount on or after 10-21" do
+    test "returns proper messages for CR Fairmount" do
       assert [
                {"726"},
                {"726", "place-FS-0049"}
-             ] = Map.keys(trip_messages(%Routes.Route{id: "CR-Fairmount"}, 1, ~D[2019-10-21]))
+             ] = Map.keys(trip_messages(%Routes.Route{id: "CR-Fairmount"}, 1))
     end
   end
 

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -1162,15 +1162,7 @@ defmodule SiteWeb.ScheduleViewTest do
   end
 
   describe "timetable_note" do
-    test "returns a timetable note for fairmount on or after Oct 21" do
-      assert is_nil(
-               timetable_note(%{
-                 route: %Route{id: "CR-Fairmount"},
-                 direction_id: 1,
-                 date: ~D[2019-10-20]
-               })
-             )
-
+    test "returns a timetable note for fairmount" do
       refute is_nil(
                timetable_note(%{
                  route: %Route{id: "CR-Fairmount"},
@@ -1181,14 +1173,6 @@ defmodule SiteWeb.ScheduleViewTest do
     end
 
     test "returns a timetable note for foxboro" do
-      assert is_nil(
-               timetable_note(%{
-                 route: %Route{id: "CR-Foxboro"},
-                 direction_id: 0,
-                 date: ~D[2019-10-20]
-               })
-             )
-
       refute is_nil(
                timetable_note(%{
                  route: %Route{id: "CR-Foxboro"},

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -542,7 +542,7 @@ defmodule SiteWeb.ScheduleViewTest do
         |> Enum.map(&safe_to_string/1)
         |> IO.iodata_to_binary()
 
-      assert Enum.count(Floki.find(html, ".route-branch-stop-bubble.stop.dotted")) == 0
+      assert Enum.empty?(Floki.find(html, ".route-branch-stop-bubble.stop.dotted"))
     end
   end
 

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -42,8 +42,6 @@ defmodule SiteWeb.ScheduleViewTest do
     trip: @trip,
     stop_name: @stop.name
   }
-  @after_july_1_2019 1_561_953_601
-  @before_july_1_2019 1_561_953_599
   @schedule_page_data %{
     connections: [],
     direction_id: 1,
@@ -1143,21 +1141,6 @@ defmodule SiteWeb.ScheduleViewTest do
   describe "single_trip_fares/1" do
     test "only return summary for single_trip fares" do
       assert single_trip_fares("commuter_rail") == [{"Zones 1A-10", ["$2.40", " – ", "$13.25"]}]
-    end
-  end
-
-  describe "fare_change_message/1" do
-    test "before july 1, 2019" do
-      actual =
-        @before_july_1_2019
-        |> fare_change_message()
-        |> safe_to_string()
-
-      assert actual =~ "Fares are changing"
-    end
-
-    test "after july 1, 2019" do
-      assert fare_change_message(@after_july_1_2019) == []
     end
   end
 


### PR DESCRIPTION
I've noticed a few places in the code where we were making decisions based on whether a certain date had passed (I even wrote one of them), and where the date has now passed so the conditional is no longer needed.

Method: I did a global search for the regex `201[56789]`, excluding tests and fixture data. This website didn't exist prior to 2015, so is unlikely to have any "feature gates" going further back.

Best reviewed as separate commits.