### PR TITLE
Update teaser endpoint type/docs

### DIFF
--- a/apps/cms/lib/partial/paragraph/content_list.ex
+++ b/apps/cms/lib/partial/paragraph/content_list.ex
@@ -3,6 +3,8 @@ defmodule CMS.Partial.Paragraph.ContentList do
   A content list paragraph (optionally including a header) from the CMS.
   This paragraph provides a formula for retreiving a dynamic list of
   content items from the CMS via the `/cms/teasers` API endpoint.
+
+  For API documentation, see https://github.com/mbta/cms/blob/master/API.md#teasers
   """
   import CMS.Helpers,
     only: [field_value: 2, int_or_string_to_int: 1, content_type: 1, parse_link: 2]

--- a/apps/cms/lib/repo.ex
+++ b/apps/cms/lib/repo.ex
@@ -210,7 +210,7 @@ defmodule CMS.Repo do
   """
 
   @type teaser_filters :: %{
-          optional(:sidebar) => integer,
+          optional(:sidebar) => 0 | 1,
           optional(:type) => [API.type()],
           optional(:type_op) => String.t(),
           optional(:related_to) => integer,
@@ -218,8 +218,7 @@ defmodule CMS.Repo do
           optional(:only) => integer,
           optional(:items_per_page) => 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 20 | 50,
           optional(:date_op) => String.t(),
-          optional(:date) =>
-            String.t() | [value: String.t()] | [min: String.t(), max: String.t()],
+          optional(:date) => [value: String.t()] | [min: String.t(), max: String.t()],
           optional(:sort_order) => :DESC | :ASC,
           optional(:sort_by) => String.t()
         }

--- a/apps/cms/lib/repo.ex
+++ b/apps/cms/lib/repo.ex
@@ -185,47 +185,21 @@ defmodule CMS.Repo do
   defp handle_revision({:ok, revisions}) when is_list(revisions), do: {:ok, List.first(revisions)}
 
   @doc """
-  Returns a list of teaser items.
+  Returns a list of teaser items. Documentation can be found at
+  https://github.com/mbta/cms/blob/master/API.md#teasers
 
   TYPE
 
   Opts can include :type, which is a list that can contain one
   or more of the API.type() atoms (ex: [:news_entry, :event]).
+  Elixir formats this list into a CMS-compatible URL parameter.
 
   If no types are specified, results can be of mixed types.
 
   To filter by a route include :route_id, for example:
     "/guides/subway" or just "subway"
 
-  To fetch all items that are NOT of a specific type,
-  use [type: [_type], type_op: "not in"]. type_op: "in"
-  is the default value for this filter if not supplied.
-
-  RELATIONSHIPS
-
-  To fetch items related to a given ID, use the "related_to"
-  parameter with an integer value (usually a content ID).
-
-  ITEMS PER PAGE
-
-  Opts can also include :items_per_page, which sets
-  the number of items to return. Default is 5 items.
-  The number can only be 1-10, 20, or 50, otherwise
-  it will be ignored.
-
-  DATE
-
-  If :date is specified, a valid :date_op of ">=" or "<" must
-  also be specified -- both params must always be used together.
-  You may specify a date of "now" to use the current date. You
-  may use "between" as the :date_op value to show all items with
-  compatible dates between :date[min] and :date[max].
-
   SORTING
-
-  Projects, Project Updates, News and Events can all be sorted
-  using the :sort_order and :sort_by filters. Other content types
-  like Basic Page (:page) default to creation date, descending.
 
   If neither :sort_order nor :sort_by are provided, Elixir will
   attempt to fill-in these values according to content :type.


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update CMS API readme/wiki with teaser endpoint info](https://app.asana.com/0/399597520748778/863495051831139)

Endpoint documentation has been added/moved to: https://github.com/mbta/cms/pull/316

Also updated two typespecs which were outdated.
