### PR TITLE
Fix all extant lint failures (except moduledocs)

### DIFF
--- a/apps/cms/bin/validate_fixtures.exs
+++ b/apps/cms/bin/validate_fixtures.exs
@@ -24,9 +24,10 @@ defmodule Drupal do
   end
 
   defp data(route) do
-    with {:ok, data} <- HTTPClient.view(route, []) do
-      data
-    else
+    case HTTPClient.view(route, []) do
+      {:ok, data} ->
+        data
+
       _ ->
         IO.puts("Error requesting data for #{route}!")
         %{}

--- a/apps/site/assets/css/_bootstrap.scss
+++ b/apps/site/assets/css/_bootstrap.scss
@@ -1,8 +1,6 @@
-/*!
- * Bootstrap v4.0.0-alpha.2 (http://getbootstrap.com)
- * Copyright 2011-2015 Twitter, Inc.
- * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
- */
+// Bootstrap v4.0.0-alpha.2 (http://getbootstrap.com)
+// Copyright 2011-2015 Twitter, Inc.
+// Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
 
 // Core variables and mixins
 @import 'node_modules/bootstrap/scss/variables';

--- a/apps/site/assets/css/_button-group.scss
+++ b/apps/site/assets/css/_button-group.scss
@@ -7,8 +7,8 @@
   border-collapse: collapse;
   display: table;
   table-layout: fixed;
-  width: 100%;
   vertical-align: middle;
+  width: 100%;
 
   // Special case because of display: table-cell;
   [class*="c-svg__icon"] {

--- a/apps/site/assets/css/_buttons.scss
+++ b/apps/site/assets/css/_buttons.scss
@@ -23,6 +23,7 @@
 
   &.btn-secondary {
     background-color: transparent;
+
     @include hover {
       background-color: $brand-primary-lightest;
       color: $brand-primary-darkest;

--- a/apps/site/assets/css/_datepicker.scss
+++ b/apps/site/assets/css/_datepicker.scss
@@ -44,8 +44,9 @@
 .datepicker-month-wrap {
   background: $brand-primary-darkest;
   color: $white;
+  // duplicate property required because IE doesn't support `initial`
   height: auto;
-  height: initial;
+  height: initial; // scss-lint:disable DuplicateProperty
   padding: $base-spacing-sm;
 }
 

--- a/apps/site/assets/css/_helpers.scss
+++ b/apps/site/assets/css/_helpers.scss
@@ -34,6 +34,9 @@
 }
 
 .callout-small {
+  padding-bottom: $base-spacing-sm;
+  padding-top: $base-spacing-sm;
+
   .icon-bus,
   .icon-subway,
   .icon-logan-express,
@@ -44,9 +47,6 @@
     top: .125em;
     width: 1.25em;
   }
-
-  padding-bottom: $base-spacing-sm;
-  padding-top: $base-spacing-sm;
 }
 
 .callout-full-height {

--- a/apps/site/assets/css/_map.scss
+++ b/apps/site/assets/css/_map.scss
@@ -50,9 +50,8 @@
 
 .map-static,
 .map-print {
-
-  background-size: cover;
   background-repeat: no-repeat;
+  background-size: cover;
   position: relative;
   width: 100%;
 

--- a/apps/site/assets/css/_modal-component.scss
+++ b/apps/site/assets/css/_modal-component.scss
@@ -34,9 +34,9 @@
 
   @include media-breakpoint-up(md) {
     left: 50%;
+    min-height: 50%;
     transform: translate(-50%, -50%);
     width: 75%;
-    min-height: 50%;
   }
 
   @include media-breakpoint-up(lg) {

--- a/apps/site/assets/css/_search-bar.scss
+++ b/apps/site/assets/css/_search-bar.scss
@@ -29,8 +29,12 @@
 }
 
 .c-search-bar__empty {
+  border-bottom: $border;
+  border-left: $border;
+  border-right: $border;
   display: flex;
   justify-content: space-between;
+  margin-bottom: 0;
   padding: $base-spacing / 2;
 }
 
@@ -56,13 +60,6 @@
 
 .c-search-bar__result-name {
   font-weight: bold;
-}
-
-.c-search-bar__empty {
-  border-bottom: $border;
-  border-left: $border;
-  border-right: $border;
-  margin-bottom: 0;
 }
 
 .c-search-bar--hidden,

--- a/apps/site/assets/css/_shuttles-page.scss
+++ b/apps/site/assets/css/_shuttles-page.scss
@@ -37,7 +37,7 @@
 }
 
 .c-btn-group-stackable__btn--active {
-  @extend .focus;
+  @extend .focus; // scss-lint:disable PlaceholderInExtend
 }
 
 .c-heading-with-control {

--- a/apps/site/assets/css/core.scss
+++ b/apps/site/assets/css/core.scss
@@ -157,23 +157,18 @@ small {
 }
 
 // undo styles in app.html.eex
+// duplicate property required because IE doesn't support `initial`
 .icon {
   height: auto;
-  height: initial;
+  height: initial; // scss-lint:disable DuplicateProperty
   width: auto;
-  width: initial;
+  width: initial; // scss-lint:disable DuplicateProperty
 }
 
 .icon-circle {
   fill: initial;
   stroke: initial;
   stroke-width: initial;
-}
-
-.page-container {
-  flex-basis: auto;
-  flex-grow: 1;
-  flex-shrink: 0;
 }
 
 .station__header,
@@ -185,6 +180,9 @@ small {
 
 .page-container {
   align-self: center;
+  flex-basis: auto;
+  flex-grow: 1;
+  flex-shrink: 0;
   padding: 0 0 $base-spacing * 2;
 }
 

--- a/apps/site/assets/css/style_guide.scss
+++ b/apps/site/assets/css/style_guide.scss
@@ -62,8 +62,8 @@ $padding: 1rem;
   }
 
   .subpage-nav ul {
-    -webkit-padding-start: 0;
     padding: 0 $padding 0 0;
+    -webkit-padding-start: 0;
   }
 
   .component {

--- a/apps/site/lib/site_web/controllers/places_controller.ex
+++ b/apps/site/lib/site_web/controllers/places_controller.ex
@@ -32,9 +32,10 @@ defmodule SiteWeb.PlacesController do
     geocode_by_place_id_fn =
       Map.get(conn.assigns, :geocode_by_place_id_fn, &Geocode.geocode_by_place_id/1)
 
-    with {:ok, results} <- geocode_by_place_id_fn.(place_id) do
-      json(conn, %{result: results |> List.first() |> Poison.encode!()})
-    else
+    case geocode_by_place_id_fn.(place_id) do
+      {:ok, results} ->
+        json(conn, %{result: results |> List.first() |> Poison.encode!()})
+
       {:error, :internal_error} ->
         return_internal_error(conn)
 

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -1,4 +1,5 @@
 defmodule SiteWeb.ScheduleController.LineController do
+  @moduledoc "Handles the page that shows the map and line diagram for a given route."
   use SiteWeb, :controller
   alias Phoenix.HTML
   alias Plug.Conn
@@ -103,14 +104,15 @@ defmodule SiteWeb.ScheduleController.LineController do
     services
     |> Enum.group_by(&{&1.type, &1.typicality})
     |> Enum.flat_map(fn {_, service_group} ->
-      service_group
-      |> Enum.reject(fn service ->
-        Enum.any?(service_group, fn other_service ->
-          other_service != service &&
-            Date.compare(other_service.start_date, service.start_date) != :gt &&
-            Date.compare(other_service.end_date, service.end_date) != :lt
-        end)
-      end)
+      Enum.reject(service_group, &service_completely_overlapped?(&1, service_group))
+    end)
+  end
+
+  defp service_completely_overlapped?(service, services) do
+    Enum.any?(services, fn other_service ->
+      other_service != service &&
+        Date.compare(other_service.start_date, service.start_date) != :gt &&
+        Date.compare(other_service.end_date, service.end_date) != :lt
     end)
   end
 

--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner.ex
@@ -1,4 +1,5 @@
 defmodule TripPlan.Api.OpenTripPlanner do
+  @moduledoc "Fetches data from the OpenTripPlanner API."
   @behaviour TripPlan.Api
   require Logger
   import __MODULE__.Builder, only: [build_params: 3]
@@ -12,20 +13,21 @@ defmodule TripPlan.Api.OpenTripPlanner do
 
   @impl true
   def plan(from, to, opts) do
-    with {:ok, params} <- build_params(from, to, opts),
-         params =
-           Map.merge(
-             params,
-             %{
-               "fromPlace" => location(from),
-               "toPlace" => location(to),
-               "showIntermediateStops" => "true",
-               "format" => "json",
-               "locale" => "en"
-             }
-           ),
-         root_url = params["root_url"] || config(:root_url),
-         full_url = "#{root_url}/otp/routers/default/plan" do
+    with {:ok, params} <- build_params(from, to, opts) do
+      params =
+        Map.merge(
+          params,
+          %{
+            "fromPlace" => location(from),
+            "toPlace" => location(to),
+            "showIntermediateStops" => "true",
+            "format" => "json",
+            "locale" => "en"
+          }
+        )
+
+      root_url = params["root_url"] || config(:root_url)
+      full_url = "#{root_url}/otp/routers/default/plan"
       send_request(full_url, params, &parse_json/1)
     end
   end

--- a/apps/v3_api/lib/v3_api.ex
+++ b/apps/v3_api/lib/v3_api.ex
@@ -1,4 +1,6 @@
 defmodule V3Api do
+  @moduledoc "Handles fetching and caching generic JSON:API responses from the V3 API."
+
   use HTTPoison.Base
   require Logger
   import V3Api.SentryExtra
@@ -15,9 +17,9 @@ defmodule V3Api do
       end)
 
     body = ""
+    opts = Keyword.merge(default_options(), opts)
 
-    with opts = Keyword.merge(default_options(), opts),
-         {time, response} <- timed_get(url, params, opts),
+    with {time, response} <- timed_get(url, params, opts),
          :ok <- log_response(url, params, time, response),
          {:ok, http_response} <- response,
          {:ok, http_response} <- Cache.cache_response(url, params, http_response),


### PR DESCRIPTION
This should make our future commits a bit less noisy if they touch files that happen to have linter failures. There are still ~160 Elixir files that lack moduledocs so Credo will continue to bug us about those, but the time it would take to address all of those in one big batch is prohibitive.