### PR TITLE
Align CI setup with development setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "eslint:fix": "git diff --name-only --diff-filter=dx origin/master... | grep apps/site/assets/js/.*\\.js | xargs apps/site/assets/node_modules/.bin/eslint -c apps/site/assets/.eslintrc.js --fix",
     "format": "cd apps/site/assets && node_modules/.bin/prettier --write \"{js,ts}/**/*.{js,ts,tsx}\"",
     "format:check": "cd apps/site/assets && node_modules/.bin/prettier \"{js,ts}/**/*.{js,ts,tsx}\" --list-different",
-    "ci-install": "cd apps/site/assets && npm ci --no-optional",
     "install": "cd apps/site/assets && npm install --no-optional",
+    "install:ci": "cd apps/site/assets && npm ci --no-optional",
     "test": "mix test && npm run test:js && mix backstop.tests",
     "test:js": "cd apps/site/assets && npm run test",
     "test:jest": "cd apps/site/assets && npm run test:jest",
@@ -28,6 +28,7 @@
     "webpack:analyze": "cd apps/site/assets && npm run webpack:analyze",
     "ts:build": "cd apps/site/assets/ts && npm run ts:build",
     "react:setup": "cd apps/site/react_renderer && npm install",
+    "react:setup:ci": "cd apps/site/react_renderer && npm ci",
     "react:build": "cd apps/site/react_renderer && npx webpack",
     "routes": "cd apps/site && mix phx.routes && cd ../..",
     "dialyzer": "mix dialyzer --halt-exit-status"

--- a/semaphore/backstop.sh
+++ b/semaphore/backstop.sh
@@ -79,7 +79,7 @@ else
     BRANCH=$(git rev-parse --abbrev-ref HEAD)
     FILENAME="$BRANCH.tar.gz"
     tar -czvf "$FILENAME" apps/site/test/backstop_data
-    LINK=$(curl -F "file=@$FILENAME" https://file.io/\?expires\=1d | jq -r .link)
+    LINK=$(curl -F "file=@$FILENAME" https://file.io/\?expires=1d | jq -r .link)
     echo "Backstop report located at $LINK, available for 1 day for a single download."
   fi
   exit 1

--- a/semaphore/build_app.sh
+++ b/semaphore/build_app.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# Note: Must be done in this order, since some Elixir macros generate code from
+# the contents of built frontend assets (e.g. SVG files)
+npm run react:build
+npm run webpack:build
+mix compile --warnings-as-errors

--- a/semaphore/credo.sh
+++ b/semaphore/credo.sh
@@ -6,7 +6,7 @@ function join_by {
 }
 
 fork_point=$(git merge-base --fork-point origin/master)
-changed=$(git diff --name-only $fork_point "*.ex" "*.exs")
+changed=$(git diff --name-only "$fork_point" "*.ex" "*.exs")
 
 if [ -z "$changed" ]; then
   echo "No Elixir files changed relative to origin/master fork point."
@@ -14,11 +14,7 @@ else
   # Since Credo doesn't support running checks only on specified files via the
   # command line, we create a temporary copy of the config file whose `included`
   # contains only the files that have changed.
-  replace=$(join_by \",\" $changed)
-  cp config/.credo.exs config/.changed.exs
-  sed -i.bak -e "s:apps/:$replace:" config/.changed.exs
-  MIX_ENV=test mix credo --config-file config/.changed.exs
-  exit=$?
-  rm config/.changed.exs config/.changed.exs.bak
-  exit $exit
+  replace=$(join_by \",\" "$changed")
+  sed -e "s:apps/:$replace:" < config/.credo.exs > /tmp/.credo.exs
+  mix credo --config-file /tmp/.credo.exs
 fi

--- a/semaphore/mix_test.sh
+++ b/semaphore/mix_test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
-MIX_ENV=test mix coveralls.json -u --exclude=wallaby
-bash <(curl -s https://codecov.io/bash) -t $CODECOV_UPLOAD_TOKEN
+mix coveralls.json -u --exclude=wallaby
+bash <(curl -s https://codecov.io/bash) -t "$CODECOV_UPLOAD_TOKEN"

--- a/semaphore/scss_lint.sh
+++ b/semaphore/scss_lint.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
+set -e
 
 fork_point=$(git merge-base --fork-point origin/master)
-changed=$(git diff --name-only $fork_point apps/site/assets/css)
+changed=$(git diff --name-only "$fork_point" apps/site/assets/css)
 
 if [ -z "$changed" ]; then
   echo "No CSS files changed relative to origin/master fork point."
 else
-  rbenv local 2.4.1
-  gem install scss_lint -v 0.59.0
+  gem install scss_lint -v 0.59.0 --no-document
   scss-lint $changed
 fi

--- a/semaphore/wallaby.sh
+++ b/semaphore/wallaby.sh
@@ -3,7 +3,7 @@ set -e
 
 for i in {1..2}
 do
-  if MIX_ENV=test mix test --only=wallaby
+  if mix test --only=wallaby
   then
     echo "Wallaby tests passed!"
     exit 0


### PR DESCRIPTION
This was a spare-time improvement following on from #332, with the key ideas: **1)** CI should automatically use the same versions of everything we use in development; **2)** we shouldn't spend time compiling the app for CI tasks that don't need it.

The following should be taken with a large chunk of salt since there is high variance in the reported times (sometimes the clock counts up for a minute or two before the first command starts), but the time difference for e.g. linting tasks is significant.

`master` | This Branch
:--:|:--:
![Screen Shot 2020-01-09 at 4 33 44 PM](https://user-images.githubusercontent.com/394835/72107105-ad5f3000-32fe-11ea-9d1a-b1b6f8d4e755.png) | ![Screen Shot 2020-01-09 at 3 47 06 PM](https://user-images.githubusercontent.com/394835/72107111-b05a2080-32fe-11ea-98fb-314ef60432b7.png)

The Dialyzer step is currently taking _longer_ than before due to an issue with the Semaphore cache not persisting the new PLTs. ~Semaphore support has acknowledged that it seems like a problem on their end but have not yet come up with a solution.~

After several weeks of investigation, Semaphore support finally figured out what was making the caching go wrong (disk space exhaustion from our massive repo, basically) and gave me some commands to run, which are included in this PR. Unfortunately since the cache is a shared resource across all branches, to see the benefit we likely have to merge this PR, wait for all extant branches to be up-to-date with master, then reset the cache and see if it works. If it doesn't, I definitely have the attention of Semaphore engineers already and can ask them what's going on.