### PR TITLE
Adjust naming of destination for Schedule Finder on the combination Green Line

### DIFF
--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -113,9 +113,10 @@ const ScheduleModalContent = ({
     },
     [routeId, selectedDirection, selectedOrigin]
   );
-  if (selectedOrigin === null || selectedDirection === null) return null;
 
-  const destination = directionDestinations[selectedDirection];
+  if (selectedOrigin === null || selectedDirection === null) {
+    return null;
+  }
 
   const input: UserInput = {
     route: routeId,
@@ -123,6 +124,11 @@ const ScheduleModalContent = ({
     date: today,
     direction: selectedDirection
   };
+
+  const destination =
+    routeId === "Green"
+      ? "All branches"
+      : directionDestinations[selectedDirection];
 
   return (
     <>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Schedule Finder | Combo GL has incorrect direction name](https://app.asana.com/0/385363666817452/1156654983519745/f)

Changes this awkward naming in the modal to "All branches" to match the direction picker.

![image](https://user-images.githubusercontent.com/2136286/72290404-1efaef00-361b-11ea-8d45-e17887004b92.png)

