### PR TITLE
Nested paragraph un/publishing and preview support

### DIFF
--- a/apps/cms/lib/helpers.ex
+++ b/apps/cms/lib/helpers.ex
@@ -117,30 +117,30 @@ defmodule CMS.Helpers do
     end
   end
 
-  @spec parse_paragraphs(map, String.t()) :: [Paragraph.t()]
-  def parse_paragraphs(data, target_field \\ "field_paragraphs") do
+  @spec parse_paragraphs(map, map, String.t()) :: [Paragraph.t()]
+  def parse_paragraphs(data, query_params \\ %{}, target_field \\ "field_paragraphs") do
     data
     |> Map.get(target_field, [])
-    |> Enum.filter(&para_is_published/1)
-    |> Enum.map(&Paragraph.from_api/1)
+    |> Enum.filter(&para_is_published(&1, query_params))
+    |> Enum.map(&Paragraph.from_api(&1, query_params))
   end
 
-  @spec para_is_published(map) :: boolean
+  @spec para_is_published(map, map) :: boolean
   # Reusable paragraphs can be deleted, but their parent references may remain
-  defp para_is_published(%{"field_reusable_paragraph" => [nil]}) do
+  defp para_is_published(%{"field_reusable_paragraph" => [nil]}, _query_params) do
     false
   end
 
-  defp para_is_published(%{"field_reusable_paragraph" => reusable}) do
+  defp para_is_published(%{"field_reusable_paragraph" => reusable}, query_params) do
     [%{"status" => status, "paragraphs" => data}] = reusable
 
     case status do
       [%{"value" => false}] -> false
-      _ -> data |> List.first() |> para_is_published()
+      _ -> data |> List.first() |> para_is_published(query_params)
     end
   end
 
-  defp para_is_published(%{"status" => [%{"value" => value}]}) do
+  defp para_is_published(%{"status" => [%{"value" => value}]}, _query_params) do
     value
   end
 

--- a/apps/cms/lib/helpers.ex
+++ b/apps/cms/lib/helpers.ex
@@ -117,6 +117,10 @@ defmodule CMS.Helpers do
     end
   end
 
+  @doc """
+  Expects raw JSON data for a CMS object that contains a paragraphs field.
+  This field value will always be a list of potential paragraphs.
+  """
   @spec parse_paragraphs(map, map, String.t()) :: [Paragraph.t()]
   def parse_paragraphs(data, query_params \\ %{}, target_field \\ "field_paragraphs") do
     data

--- a/apps/cms/lib/page.ex
+++ b/apps/cms/lib/page.ex
@@ -32,44 +32,44 @@ defmodule CMS.Page do
   @doc """
   Expects parsed json from drupal CMS. Should be one item (not array of items)
   """
-  @spec from_api(map, map) :: t
-  def from_api(data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(data, preview_opts \\ []) do
     data
-    |> parse(query_params)
+    |> parse(preview_opts)
     |> fetch_content_lists()
   end
 
-  defp parse(%{"type" => [%{"target_id" => "event"}]} = api_data, _query_params) do
+  defp parse(%{"type" => [%{"target_id" => "event"}]} = api_data, _preview_opts) do
     Event.from_api(api_data)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "landing_page"}]} = api_data, query_params) do
-    Landing.from_api(api_data, query_params)
+  defp parse(%{"type" => [%{"target_id" => "landing_page"}]} = api_data, preview_opts) do
+    Landing.from_api(api_data, preview_opts)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "news_entry"}]} = api_data, _query_params) do
+  defp parse(%{"type" => [%{"target_id" => "news_entry"}]} = api_data, _preview_opts) do
     NewsEntry.from_api(api_data)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "person"}]} = api_data, _query_params) do
+  defp parse(%{"type" => [%{"target_id" => "person"}]} = api_data, _preview_opts) do
     Person.from_api(api_data)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "project"}]} = api_data, query_params) do
-    Project.from_api(api_data, query_params)
+  defp parse(%{"type" => [%{"target_id" => "project"}]} = api_data, preview_opts) do
+    Project.from_api(api_data, preview_opts)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "project_update"}]} = api_data, query_params) do
-    ProjectUpdate.from_api(api_data, query_params)
+  defp parse(%{"type" => [%{"target_id" => "project_update"}]} = api_data, preview_opts) do
+    ProjectUpdate.from_api(api_data, preview_opts)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "redirect"}]} = api_data, _query_params) do
+  defp parse(%{"type" => [%{"target_id" => "redirect"}]} = api_data, _preview_opts) do
     Redirect.from_api(api_data)
   end
 
   # For all other node/content types from the CMS, use a common struct/template
-  defp parse(%{"type" => [%{"target_type" => "node_type"}]} = api_data, query_params) do
-    Basic.from_api(api_data, query_params)
+  defp parse(%{"type" => [%{"target_type" => "node_type"}]} = api_data, preview_opts) do
+    Basic.from_api(api_data, preview_opts)
   end
 
   @spec fetch_content_lists(t) :: t

--- a/apps/cms/lib/page.ex
+++ b/apps/cms/lib/page.ex
@@ -32,44 +32,44 @@ defmodule CMS.Page do
   @doc """
   Expects parsed json from drupal CMS. Should be one item (not array of items)
   """
-  @spec from_api(map) :: t
-  def from_api(data) do
+  @spec from_api(map, map) :: t
+  def from_api(data, query_params \\ %{}) do
     data
-    |> parse()
+    |> parse(query_params)
     |> fetch_content_lists()
   end
 
-  defp parse(%{"type" => [%{"target_id" => "event"}]} = api_data) do
+  defp parse(%{"type" => [%{"target_id" => "event"}]} = api_data, _query_params) do
     Event.from_api(api_data)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "landing_page"}]} = api_data) do
-    Landing.from_api(api_data)
+  defp parse(%{"type" => [%{"target_id" => "landing_page"}]} = api_data, query_params) do
+    Landing.from_api(api_data, query_params)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "news_entry"}]} = api_data) do
+  defp parse(%{"type" => [%{"target_id" => "news_entry"}]} = api_data, _query_params) do
     NewsEntry.from_api(api_data)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "person"}]} = api_data) do
+  defp parse(%{"type" => [%{"target_id" => "person"}]} = api_data, _query_params) do
     Person.from_api(api_data)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "project"}]} = api_data) do
-    Project.from_api(api_data)
+  defp parse(%{"type" => [%{"target_id" => "project"}]} = api_data, query_params) do
+    Project.from_api(api_data, query_params)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "project_update"}]} = api_data) do
-    ProjectUpdate.from_api(api_data)
+  defp parse(%{"type" => [%{"target_id" => "project_update"}]} = api_data, query_params) do
+    ProjectUpdate.from_api(api_data, query_params)
   end
 
-  defp parse(%{"type" => [%{"target_id" => "redirect"}]} = api_data) do
+  defp parse(%{"type" => [%{"target_id" => "redirect"}]} = api_data, _query_params) do
     Redirect.from_api(api_data)
   end
 
   # For all other node/content types from the CMS, use a common struct/template
-  defp parse(%{"type" => [%{"target_type" => "node_type"}]} = api_data) do
-    Basic.from_api(api_data)
+  defp parse(%{"type" => [%{"target_type" => "node_type"}]} = api_data, query_params) do
+    Basic.from_api(api_data, query_params)
   end
 
   @spec fetch_content_lists(t) :: t

--- a/apps/cms/lib/page/basic.ex
+++ b/apps/cms/lib/page/basic.ex
@@ -13,7 +13,7 @@ defmodule CMS.Page.Basic do
       field_value: 2,
       int_or_string_to_int: 1,
       parse_body: 1,
-      parse_paragraphs: 1
+      parse_paragraphs: 2
     ]
 
   defstruct body: HTML.raw(""),
@@ -32,13 +32,13 @@ defmodule CMS.Page.Basic do
           breadcrumbs: [Util.Breadcrumb.t()]
         }
 
-  @spec from_api(map) :: t
-  def from_api(%{} = data) do
+  @spec from_api(map, map) :: t
+  def from_api(%{} = data, query_params \\ %{}) do
     %__MODULE__{
       id: int_or_string_to_int(field_value(data, "nid")),
       title: field_value(data, "title") || "",
       body: parse_body(data),
-      paragraphs: parse_paragraphs(data),
+      paragraphs: parse_paragraphs(data, query_params),
       sidebar_menu: parse_menu_links(data),
       breadcrumbs: Breadcrumbs.build(data)
     }

--- a/apps/cms/lib/page/basic.ex
+++ b/apps/cms/lib/page/basic.ex
@@ -32,13 +32,13 @@ defmodule CMS.Page.Basic do
           breadcrumbs: [Util.Breadcrumb.t()]
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(%{} = data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(%{} = data, preview_opts \\ []) do
     %__MODULE__{
       id: int_or_string_to_int(field_value(data, "nid")),
       title: field_value(data, "title") || "",
       body: parse_body(data),
-      paragraphs: parse_paragraphs(data, query_params),
+      paragraphs: parse_paragraphs(data, preview_opts),
       sidebar_menu: parse_menu_links(data),
       breadcrumbs: Breadcrumbs.build(data)
     }

--- a/apps/cms/lib/page/landing.ex
+++ b/apps/cms/lib/page/landing.ex
@@ -35,15 +35,15 @@ defmodule CMS.Page.Landing do
           breadcrumbs: [Util.Breadcrumb.t()]
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(%{} = data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(%{} = data, preview_opts \\ []) do
     %__MODULE__{
       id: field_value(data, "nid"),
       title: field_value(data, "title"),
       hero_desktop: parse_image(data, "field_hero_image_desktop"),
       hero_mobile: parse_image(data, "field_hero_image_mobile"),
       hero_mobile_2x: parse_image(data, "field_hero_image_mobile_2x"),
-      paragraphs: parse_paragraphs(data, query_params),
+      paragraphs: parse_paragraphs(data, preview_opts),
       subtitle: field_value(data, "field_subtitle"),
       breadcrumbs: Breadcrumbs.build(data)
     }

--- a/apps/cms/lib/page/landing.ex
+++ b/apps/cms/lib/page/landing.ex
@@ -5,7 +5,7 @@ defmodule CMS.Page.Landing do
     only: [
       field_value: 2,
       parse_image: 2,
-      parse_paragraphs: 1
+      parse_paragraphs: 2
     ]
 
   alias CMS.Breadcrumbs
@@ -35,15 +35,15 @@ defmodule CMS.Page.Landing do
           breadcrumbs: [Util.Breadcrumb.t()]
         }
 
-  @spec from_api(map) :: t
-  def from_api(%{} = data) do
+  @spec from_api(map, map) :: t
+  def from_api(%{} = data, query_params \\ %{}) do
     %__MODULE__{
       id: field_value(data, "nid"),
       title: field_value(data, "title"),
       hero_desktop: parse_image(data, "field_hero_image_desktop"),
       hero_mobile: parse_image(data, "field_hero_image_mobile"),
       hero_mobile_2x: parse_image(data, "field_hero_image_mobile_2x"),
-      paragraphs: parse_paragraphs(data),
+      paragraphs: parse_paragraphs(data, query_params),
       subtitle: field_value(data, "field_subtitle"),
       breadcrumbs: Breadcrumbs.build(data)
     }

--- a/apps/cms/lib/page/project.ex
+++ b/apps/cms/lib/page/project.ex
@@ -62,8 +62,8 @@ defmodule CMS.Page.Project do
           path_alias: String.t() | nil
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(%{} = data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(%{} = data, preview_opts \\ []) do
     %__MODULE__{
       id: int_or_string_to_int(field_value(data, "nid")),
       body: parse_body(data),
@@ -74,7 +74,7 @@ defmodule CMS.Page.Project do
       files: parse_files(data, "field_files"),
       media_email: field_value(data, "field_media_email"),
       media_phone: field_value(data, "field_media_phone"),
-      paragraphs: parse_paragraphs(data, query_params),
+      paragraphs: parse_paragraphs(data, preview_opts),
       photo_gallery: parse_images(data, "field_photo_gallery"),
       start_year: field_value(data, "field_start_year"),
       status: field_value(data, "field_project_status"),

--- a/apps/cms/lib/page/project.ex
+++ b/apps/cms/lib/page/project.ex
@@ -16,7 +16,7 @@ defmodule CMS.Page.Project do
       parse_files: 2,
       parse_image: 2,
       parse_images: 2,
-      parse_paragraphs: 1,
+      parse_paragraphs: 2,
       path_alias: 1
     ]
 
@@ -62,8 +62,8 @@ defmodule CMS.Page.Project do
           path_alias: String.t() | nil
         }
 
-  @spec from_api(map) :: t
-  def from_api(%{} = data) do
+  @spec from_api(map, map) :: t
+  def from_api(%{} = data, query_params \\ %{}) do
     %__MODULE__{
       id: int_or_string_to_int(field_value(data, "nid")),
       body: parse_body(data),
@@ -74,7 +74,7 @@ defmodule CMS.Page.Project do
       files: parse_files(data, "field_files"),
       media_email: field_value(data, "field_media_email"),
       media_phone: field_value(data, "field_media_phone"),
-      paragraphs: parse_paragraphs(data),
+      paragraphs: parse_paragraphs(data, query_params),
       photo_gallery: parse_images(data, "field_photo_gallery"),
       start_year: field_value(data, "field_start_year"),
       status: field_value(data, "field_project_status"),

--- a/apps/cms/lib/page/project_update.ex
+++ b/apps/cms/lib/page/project_update.ex
@@ -47,15 +47,15 @@ defmodule CMS.Page.ProjectUpdate do
           title: String.t()
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(%{} = data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(%{} = data, preview_opts \\ []) do
     {project_id, project_alias} = parse_project(data)
 
     %__MODULE__{
       id: int_or_string_to_int(field_value(data, "nid")),
       body: parse_body(data),
       image: parse_image(data, "field_image"),
-      paragraphs: parse_paragraphs(data, query_params),
+      paragraphs: parse_paragraphs(data, preview_opts),
       photo_gallery: parse_images(data, "field_photo_gallery"),
       posted_on: parse_date(data, "field_posted_on"),
       project_id: project_id,

--- a/apps/cms/lib/page/project_update.ex
+++ b/apps/cms/lib/page/project_update.ex
@@ -14,7 +14,7 @@ defmodule CMS.Page.ProjectUpdate do
       parse_date: 2,
       parse_image: 2,
       parse_images: 2,
-      parse_paragraphs: 1,
+      parse_paragraphs: 2,
       path_alias: 1
     ]
 
@@ -47,15 +47,15 @@ defmodule CMS.Page.ProjectUpdate do
           title: String.t()
         }
 
-  @spec from_api(map) :: t
-  def from_api(%{} = data) do
+  @spec from_api(map, map) :: t
+  def from_api(%{} = data, query_params \\ %{}) do
     {project_id, project_alias} = parse_project(data)
 
     %__MODULE__{
       id: int_or_string_to_int(field_value(data, "nid")),
       body: parse_body(data),
       image: parse_image(data, "field_image"),
-      paragraphs: parse_paragraphs(data),
+      paragraphs: parse_paragraphs(data, query_params),
       photo_gallery: parse_images(data, "field_photo_gallery"),
       posted_on: parse_date(data, "field_posted_on"),
       project_id: project_id,

--- a/apps/cms/lib/partial/paragraph.ex
+++ b/apps/cms/lib/partial/paragraph.ex
@@ -84,66 +84,68 @@ defmodule CMS.Partial.Paragraph do
           | TitleCardSet
           | Unknown
 
-  @spec from_api(map) :: t
-  def from_api(%{"type" => [%{"target_id" => "entity_reference"}]} = para) do
+  @spec from_api(map, map) :: t
+  def from_api(data, query_params \\ %{})
+
+  def from_api(%{"type" => [%{"target_id" => "entity_reference"}]} = para, _query_params) do
     Callout.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "multi_column"}]} = para) do
-    ColumnMulti.from_api(para)
+  def from_api(%{"type" => [%{"target_id" => "multi_column"}]} = para, query_params) do
+    ColumnMulti.from_api(para, query_params)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "content_list"}]} = para) do
-    ContentList.from_api(para)
+  def from_api(%{"type" => [%{"target_id" => "content_list"}]} = para, query_params) do
+    ContentList.from_api(para, query_params)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "custom_html"}]} = para) do
+  def from_api(%{"type" => [%{"target_id" => "custom_html"}]} = para, _query_params) do
     CustomHTML.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "description_list"}]} = para) do
-    DescriptionList.from_api(para)
+  def from_api(%{"type" => [%{"target_id" => "description_list"}]} = para, query_params) do
+    DescriptionList.from_api(para, query_params)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "fare_card"}]} = para) do
+  def from_api(%{"type" => [%{"target_id" => "fare_card"}]} = para, _query_params) do
     FareCard.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "files_grid"}]} = para) do
+  def from_api(%{"type" => [%{"target_id" => "files_grid"}]} = para, _query_params) do
     FilesGrid.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "people_grid"}]} = para) do
+  def from_api(%{"type" => [%{"target_id" => "people_grid"}]} = para, _query_params) do
     PeopleGrid.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "photo_gallery"}]} = para) do
+  def from_api(%{"type" => [%{"target_id" => "photo_gallery"}]} = para, _query_params) do
     PhotoGallery.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "tabs"}]} = para) do
-    Accordion.from_api(para)
+  def from_api(%{"type" => [%{"target_id" => "tabs"}]} = para, query_params) do
+    Accordion.from_api(para, query_params)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "title_card"}]} = para) do
+  def from_api(%{"type" => [%{"target_id" => "title_card"}]} = para, _query_params) do
     DescriptiveLink.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "title_card_set"}]} = para) do
+  def from_api(%{"type" => [%{"target_id" => "title_card_set"}]} = para, _query_params) do
     TitleCardSet.from_api(para)
   end
 
   @doc "This ¶ type has a single paragraph reference within. Get the nested paragraph."
-  def from_api(%{"type" => [%{"target_id" => "from_library"}]} = para) do
-    parse_library_item(para)
+  def from_api(%{"type" => [%{"target_id" => "from_library"}]} = para, query_params) do
+    parse_library_item(para, query_params)
   end
 
   @doc "For directly accessing a reusable paragraph (from paragraphs API endpoint)"
-  def from_api(%{"paragraphs" => [para]}) do
-    from_api(para)
+  def from_api(%{"paragraphs" => [para]}, query_params) do
+    from_api(para, query_params)
   end
 
-  def from_api(unknown_paragraph_type) do
+  def from_api(unknown_paragraph_type, _query_params) do
     Unknown.from_api(unknown_paragraph_type)
   end
 
@@ -159,8 +161,8 @@ defmodule CMS.Partial.Paragraph do
   @spec get_types() :: [name]
   def get_types, do: @types
 
-  @spec parse_header(map) :: t
-  def parse_header(%{} = data) do
+  @spec parse_header(map, map) :: t
+  def parse_header(%{} = data, _query_params) do
     data
     |> Map.get("field_multi_column_header", [])
     |> Enum.map(&ColumnMultiHeader.from_api/1)
@@ -169,14 +171,14 @@ defmodule CMS.Partial.Paragraph do
   end
 
   # Pass through the nested paragraph and host ID
-  @spec parse_library_item(map) :: t
-  defp parse_library_item(data) do
+  @spec parse_library_item(map, map) :: t
+  defp parse_library_item(data, query_params) do
     data
     |> Map.get("field_reusable_paragraph")
     |> List.first()
     |> Map.get("paragraphs")
     |> List.first()
     |> Map.put("parent_id", Map.get(data, "parent_id"))
-    |> from_api()
+    |> from_api(query_params)
   end
 end

--- a/apps/cms/lib/partial/paragraph.ex
+++ b/apps/cms/lib/partial/paragraph.ex
@@ -98,84 +98,84 @@ defmodule CMS.Partial.Paragraph do
           | TitleCardSet
           | Unknown
 
-  @spec from_api(map, map) :: t
-  def from_api(data, query_params \\ %{})
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(data, preview_opts \\ [])
 
-  def from_api(%{"type" => [%{"target_id" => "entity_reference"}]} = para, _query_params) do
+  def from_api(%{"type" => [%{"target_id" => "entity_reference"}]} = para, _preview_opts) do
     Callout.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "multi_column_header"}]} = para, _query_params) do
+  def from_api(%{"type" => [%{"target_id" => "multi_column_header"}]} = para, _preview_opts) do
     ColumnMultiHeader.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "multi_column"}]} = para, query_params) do
-    ColumnMulti.from_api(para, query_params)
+  def from_api(%{"type" => [%{"target_id" => "multi_column"}]} = para, preview_opts) do
+    ColumnMulti.from_api(para, preview_opts)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "column"}]} = para, query_params) do
-    Column.from_api(para, query_params)
+  def from_api(%{"type" => [%{"target_id" => "column"}]} = para, preview_opts) do
+    Column.from_api(para, preview_opts)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "content_list"}]} = para, query_params) do
-    ContentList.from_api(para, query_params)
+  def from_api(%{"type" => [%{"target_id" => "content_list"}]} = para, preview_opts) do
+    ContentList.from_api(para, preview_opts)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "custom_html"}]} = para, _query_params) do
+  def from_api(%{"type" => [%{"target_id" => "custom_html"}]} = para, _preview_opts) do
     CustomHTML.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "definition"}]} = para, _query_params) do
+  def from_api(%{"type" => [%{"target_id" => "definition"}]} = para, _preview_opts) do
     Description.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "description_list"}]} = para, query_params) do
-    DescriptionList.from_api(para, query_params)
+  def from_api(%{"type" => [%{"target_id" => "description_list"}]} = para, preview_opts) do
+    DescriptionList.from_api(para, preview_opts)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "fare_card"}]} = para, query_params) do
-    FareCard.from_api(para, query_params)
+  def from_api(%{"type" => [%{"target_id" => "fare_card"}]} = para, preview_opts) do
+    FareCard.from_api(para, preview_opts)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "files_grid"}]} = para, _query_params) do
+  def from_api(%{"type" => [%{"target_id" => "files_grid"}]} = para, _preview_opts) do
     FilesGrid.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "people_grid"}]} = para, _query_params) do
+  def from_api(%{"type" => [%{"target_id" => "people_grid"}]} = para, _preview_opts) do
     PeopleGrid.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "photo_gallery"}]} = para, _query_params) do
+  def from_api(%{"type" => [%{"target_id" => "photo_gallery"}]} = para, _preview_opts) do
     PhotoGallery.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "tabs"}]} = para, query_params) do
-    Accordion.from_api(para, query_params)
+  def from_api(%{"type" => [%{"target_id" => "tabs"}]} = para, preview_opts) do
+    Accordion.from_api(para, preview_opts)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "tab"}]} = para, query_params) do
-    AccordionSection.from_api(para, query_params)
+  def from_api(%{"type" => [%{"target_id" => "tab"}]} = para, preview_opts) do
+    AccordionSection.from_api(para, preview_opts)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "title_card"}]} = para, _query_params) do
+  def from_api(%{"type" => [%{"target_id" => "title_card"}]} = para, _preview_opts) do
     DescriptiveLink.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "title_card_set"}]} = para, _query_params) do
+  def from_api(%{"type" => [%{"target_id" => "title_card_set"}]} = para, _preview_opts) do
     TitleCardSet.from_api(para)
   end
 
   @doc "This ¶ type has a single paragraph reference within. Get the nested paragraph."
-  def from_api(%{"type" => [%{"target_id" => "from_library"}]} = para, query_params) do
-    parse_library_item(para, query_params)
+  def from_api(%{"type" => [%{"target_id" => "from_library"}]} = para, preview_opts) do
+    parse_library_item(para, preview_opts)
   end
 
   @doc "For directly accessing a reusable paragraph (from paragraphs API endpoint)"
-  def from_api(%{"paragraphs" => [para]}, query_params) do
-    from_api(para, query_params)
+  def from_api(%{"paragraphs" => [para]}, preview_opts) do
+    from_api(para, preview_opts)
   end
 
-  def from_api(unknown_paragraph_type, _query_params) do
+  def from_api(unknown_paragraph_type, _preview_opts) do
     Unknown.from_api(unknown_paragraph_type)
   end
 
@@ -193,13 +193,13 @@ defmodule CMS.Partial.Paragraph do
 
   # Pass through the nested paragraph and host ID
   @spec parse_library_item(map, map) :: t
-  defp parse_library_item(data, query_params) do
+  defp parse_library_item(data, preview_opts) do
     data
     |> Map.get("field_reusable_paragraph")
     |> List.first()
     |> Map.get("paragraphs")
     |> List.first()
     |> Map.put("parent_id", Map.get(data, "parent_id"))
-    |> from_api(query_params)
+    |> from_api(preview_opts)
   end
 end

--- a/apps/cms/lib/partial/paragraph.ex
+++ b/apps/cms/lib/partial/paragraph.ex
@@ -22,11 +22,14 @@ defmodule CMS.Partial.Paragraph do
 
   alias CMS.Partial.Paragraph.{
     Accordion,
+    AccordionSection,
     Callout,
+    Column,
     ColumnMulti,
     ColumnMultiHeader,
     ContentList,
     CustomHTML,
+    Description,
     DescriptionList,
     DescriptiveLink,
     FareCard,
@@ -39,10 +42,14 @@ defmodule CMS.Partial.Paragraph do
 
   @types [
     Accordion,
+    AccordionSection,
     Callout,
+    Column,
     ColumnMulti,
+    ColumnMultiHeader,
     ContentList,
     CustomHTML,
+    Description,
     DescriptionList,
     DescriptiveLink,
     FareCard,
@@ -55,11 +62,14 @@ defmodule CMS.Partial.Paragraph do
 
   @type t ::
           Accordion.t()
+          | AccordionSection.t()
           | Callout.t()
+          | Column.t()
           | ColumnMulti.t()
           | ColumnMultiHeader.t()
           | ContentList.t()
           | CustomHTML.t()
+          | Description.t()
           | DescriptionList.t()
           | DescriptiveLink.t()
           | FareCard.t()
@@ -71,10 +81,14 @@ defmodule CMS.Partial.Paragraph do
 
   @type name ::
           Accordion
+          | AccordionSection
           | Callout
+          | Column
           | ColumnMulti
+          | ColumnMultiHeader
           | ContentList
           | CustomHTML
+          | Description
           | DescriptionList
           | DescriptiveLink
           | FareCard
@@ -91,8 +105,16 @@ defmodule CMS.Partial.Paragraph do
     Callout.from_api(para)
   end
 
+  def from_api(%{"type" => [%{"target_id" => "multi_column_header"}]} = para, _query_params) do
+    ColumnMultiHeader.from_api(para)
+  end
+
   def from_api(%{"type" => [%{"target_id" => "multi_column"}]} = para, query_params) do
     ColumnMulti.from_api(para, query_params)
+  end
+
+  def from_api(%{"type" => [%{"target_id" => "column"}]} = para, query_params) do
+    Column.from_api(para, query_params)
   end
 
   def from_api(%{"type" => [%{"target_id" => "content_list"}]} = para, query_params) do
@@ -103,12 +125,16 @@ defmodule CMS.Partial.Paragraph do
     CustomHTML.from_api(para)
   end
 
+  def from_api(%{"type" => [%{"target_id" => "definition"}]} = para, _query_params) do
+    Description.from_api(para)
+  end
+
   def from_api(%{"type" => [%{"target_id" => "description_list"}]} = para, query_params) do
     DescriptionList.from_api(para, query_params)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "fare_card"}]} = para, _query_params) do
-    FareCard.from_api(para)
+  def from_api(%{"type" => [%{"target_id" => "fare_card"}]} = para, query_params) do
+    FareCard.from_api(para, query_params)
   end
 
   def from_api(%{"type" => [%{"target_id" => "files_grid"}]} = para, _query_params) do
@@ -125,6 +151,10 @@ defmodule CMS.Partial.Paragraph do
 
   def from_api(%{"type" => [%{"target_id" => "tabs"}]} = para, query_params) do
     Accordion.from_api(para, query_params)
+  end
+
+  def from_api(%{"type" => [%{"target_id" => "tab"}]} = para, query_params) do
+    AccordionSection.from_api(para, query_params)
   end
 
   def from_api(%{"type" => [%{"target_id" => "title_card"}]} = para, _query_params) do
@@ -160,15 +190,6 @@ defmodule CMS.Partial.Paragraph do
 
   @spec get_types() :: [name]
   def get_types, do: @types
-
-  @spec parse_header(map, map) :: t
-  def parse_header(%{} = data, _query_params) do
-    data
-    |> Map.get("field_multi_column_header", [])
-    |> Enum.map(&ColumnMultiHeader.from_api/1)
-    # There is only ever 1 header element
-    |> List.first()
-  end
 
   # Pass through the nested paragraph and host ID
   @spec parse_library_item(map, map) :: t

--- a/apps/cms/lib/partial/paragraph/accordion.ex
+++ b/apps/cms/lib/partial/paragraph/accordion.ex
@@ -21,11 +21,11 @@ defmodule CMS.Partial.Paragraph.Accordion do
           sections: [AccordionSection.t()]
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(data, preview_opts \\ []) do
     %__MODULE__{
       display: field_value(data, "field_tabs_display"),
-      sections: parse_paragraphs(data, query_params, "field_tabs")
+      sections: parse_paragraphs(data, preview_opts, "field_tabs")
     }
   end
 end

--- a/apps/cms/lib/partial/paragraph/accordion.ex
+++ b/apps/cms/lib/partial/paragraph/accordion.ex
@@ -9,7 +9,8 @@ defmodule CMS.Partial.Paragraph.Accordion do
 
   """
 
-  import CMS.Helpers, only: [field_value: 2]
+  import CMS.Helpers, only: [field_value: 2, parse_paragraphs: 3]
+
   alias CMS.Partial.Paragraph.AccordionSection
 
   defstruct display: "",
@@ -21,15 +22,10 @@ defmodule CMS.Partial.Paragraph.Accordion do
         }
 
   @spec from_api(map, map) :: t
-  def from_api(data, query_params) do
-    sections =
-      data
-      |> Map.get("field_tabs", [])
-      |> Enum.map(&AccordionSection.from_api(&1, query_params))
-
+  def from_api(data, query_params \\ %{}) do
     %__MODULE__{
       display: field_value(data, "field_tabs_display"),
-      sections: sections
+      sections: parse_paragraphs(data, query_params, "field_tabs")
     }
   end
 end

--- a/apps/cms/lib/partial/paragraph/accordion.ex
+++ b/apps/cms/lib/partial/paragraph/accordion.ex
@@ -20,12 +20,12 @@ defmodule CMS.Partial.Paragraph.Accordion do
           sections: [AccordionSection.t()]
         }
 
-  @spec from_api(map) :: t
-  def from_api(data) do
+  @spec from_api(map, map) :: t
+  def from_api(data, query_params) do
     sections =
       data
       |> Map.get("field_tabs", [])
-      |> Enum.map(&AccordionSection.from_api/1)
+      |> Enum.map(&AccordionSection.from_api(&1, query_params))
 
     %__MODULE__{
       display: field_value(data, "field_tabs_display"),

--- a/apps/cms/lib/partial/paragraph/accordion_section.ex
+++ b/apps/cms/lib/partial/paragraph/accordion_section.ex
@@ -27,12 +27,12 @@ defmodule CMS.Partial.Paragraph.AccordionSection do
           content: [Paragraph.t()]
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(%{} = data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(%{} = data, preview_opts \\ []) do
     %__MODULE__{
       title: field_value(data, "field_label"),
       prefix: "cms-#{field_value(data, "id")}",
-      content: parse_paragraphs(data, query_params, "field_content")
+      content: parse_paragraphs(data, preview_opts, "field_content")
     }
   end
 end

--- a/apps/cms/lib/partial/paragraph/accordion_section.ex
+++ b/apps/cms/lib/partial/paragraph/accordion_section.ex
@@ -12,7 +12,7 @@ defmodule CMS.Partial.Paragraph.AccordionSection do
   import CMS.Helpers,
     only: [
       field_value: 2,
-      parse_paragraphs: 2
+      parse_paragraphs: 3
     ]
 
   alias CMS.Partial.Paragraph
@@ -27,12 +27,12 @@ defmodule CMS.Partial.Paragraph.AccordionSection do
           content: Paragraph.t()
         }
 
-  @spec from_api(map) :: t
-  def from_api(%{} = data) do
+  @spec from_api(map, map) :: t
+  def from_api(%{} = data, query_params) do
     %__MODULE__{
       title: field_value(data, "field_label"),
       prefix: "cms-#{field_value(data, "id")}",
-      content: data |> parse_paragraphs("field_content") |> List.first()
+      content: data |> parse_paragraphs(query_params, "field_content") |> List.first()
     }
   end
 end

--- a/apps/cms/lib/partial/paragraph/accordion_section.ex
+++ b/apps/cms/lib/partial/paragraph/accordion_section.ex
@@ -19,20 +19,20 @@ defmodule CMS.Partial.Paragraph.AccordionSection do
 
   defstruct title: "",
             prefix: "",
-            content: %{}
+            content: []
 
   @type t :: %__MODULE__{
           title: String.t(),
           prefix: String.t(),
-          content: Paragraph.t()
+          content: [Paragraph.t()]
         }
 
   @spec from_api(map, map) :: t
-  def from_api(%{} = data, query_params) do
+  def from_api(%{} = data, query_params \\ %{}) do
     %__MODULE__{
       title: field_value(data, "field_label"),
       prefix: "cms-#{field_value(data, "id")}",
-      content: data |> parse_paragraphs(query_params, "field_content") |> List.first()
+      content: parse_paragraphs(data, query_params, "field_content")
     }
   end
 end

--- a/apps/cms/lib/partial/paragraph/column.ex
+++ b/apps/cms/lib/partial/paragraph/column.ex
@@ -2,6 +2,8 @@ defmodule CMS.Partial.Paragraph.Column do
   @moduledoc """
   An individual column in a ColumnMulti set.
   """
+  import CMS.Helpers, only: [parse_paragraphs: 3]
+
   alias CMS.Partial.Paragraph
 
   defstruct paragraphs: []
@@ -10,15 +12,10 @@ defmodule CMS.Partial.Paragraph.Column do
           paragraphs: [Paragraph.t()]
         }
 
-  @spec from_api(map, Plug.Conn.t()) :: t
-  def from_api(data, conn) do
-    paragraphs =
-      data
-      |> Map.get("field_content", [])
-      |> Enum.map(&Paragraph.from_api(&1, conn))
-
+  @spec from_api(map, map) :: t
+  def from_api(data, query_params \\ %{}) do
     %__MODULE__{
-      paragraphs: paragraphs
+      paragraphs: parse_paragraphs(data, query_params, "field_content")
     }
   end
 end

--- a/apps/cms/lib/partial/paragraph/column.ex
+++ b/apps/cms/lib/partial/paragraph/column.ex
@@ -10,12 +10,12 @@ defmodule CMS.Partial.Paragraph.Column do
           paragraphs: [Paragraph.t()]
         }
 
-  @spec from_api(map) :: t
-  def from_api(data) do
+  @spec from_api(map, Plug.Conn.t()) :: t
+  def from_api(data, conn) do
     paragraphs =
       data
       |> Map.get("field_content", [])
-      |> Enum.map(&Paragraph.from_api/1)
+      |> Enum.map(&Paragraph.from_api(&1, conn))
 
     %__MODULE__{
       paragraphs: paragraphs

--- a/apps/cms/lib/partial/paragraph/column.ex
+++ b/apps/cms/lib/partial/paragraph/column.ex
@@ -12,10 +12,10 @@ defmodule CMS.Partial.Paragraph.Column do
           paragraphs: [Paragraph.t()]
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(data, preview_opts \\ []) do
     %__MODULE__{
-      paragraphs: parse_paragraphs(data, query_params, "field_content")
+      paragraphs: parse_paragraphs(data, preview_opts, "field_content")
     }
   end
 end

--- a/apps/cms/lib/partial/paragraph/column_multi.ex
+++ b/apps/cms/lib/partial/paragraph/column_multi.ex
@@ -18,11 +18,11 @@ defmodule CMS.Partial.Paragraph.ColumnMulti do
           right_rail: boolean
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(data, preview_opts \\ []) do
     %__MODULE__{
-      header: data |> parse_paragraphs(query_params, "field_multi_column_header") |> List.first(),
-      columns: parse_paragraphs(data, query_params, "field_column"),
+      header: data |> parse_paragraphs(preview_opts, "field_multi_column_header") |> List.first(),
+      columns: parse_paragraphs(data, preview_opts, "field_column"),
       display_options: field_value(data, "field_display_options"),
       right_rail: field_value(data, "field_right_rail")
     }

--- a/apps/cms/lib/partial/paragraph/column_multi.ex
+++ b/apps/cms/lib/partial/paragraph/column_multi.ex
@@ -2,8 +2,7 @@ defmodule CMS.Partial.Paragraph.ColumnMulti do
   @moduledoc """
   A set of columns to organize layout on the page.
   """
-  import CMS.Helpers, only: [field_value: 2]
-  import CMS.Partial.Paragraph, only: [parse_header: 2]
+  import CMS.Helpers, only: [field_value: 2, parse_paragraphs: 3]
 
   alias CMS.Partial.Paragraph.{Column, ColumnMultiHeader, DescriptiveLink, FareCard}
 
@@ -21,14 +20,9 @@ defmodule CMS.Partial.Paragraph.ColumnMulti do
 
   @spec from_api(map, map) :: t
   def from_api(data, query_params \\ %{}) do
-    columns =
-      data
-      |> Map.get("field_column", [])
-      |> Enum.map(&Column.from_api(&1, query_params))
-
     %__MODULE__{
-      header: parse_header(data, query_params),
-      columns: columns,
+      header: data |> parse_paragraphs(query_params, "field_multi_column_header") |> List.first(),
+      columns: parse_paragraphs(data, query_params, "field_column"),
       display_options: field_value(data, "field_display_options"),
       right_rail: field_value(data, "field_right_rail")
     }

--- a/apps/cms/lib/partial/paragraph/column_multi.ex
+++ b/apps/cms/lib/partial/paragraph/column_multi.ex
@@ -3,7 +3,7 @@ defmodule CMS.Partial.Paragraph.ColumnMulti do
   A set of columns to organize layout on the page.
   """
   import CMS.Helpers, only: [field_value: 2]
-  import CMS.Partial.Paragraph, only: [parse_header: 1]
+  import CMS.Partial.Paragraph, only: [parse_header: 2]
 
   alias CMS.Partial.Paragraph.{Column, ColumnMultiHeader, DescriptiveLink, FareCard}
 
@@ -19,15 +19,15 @@ defmodule CMS.Partial.Paragraph.ColumnMulti do
           right_rail: boolean
         }
 
-  @spec from_api(map) :: t
-  def from_api(data) do
+  @spec from_api(map, map) :: t
+  def from_api(data, query_params \\ %{}) do
     columns =
       data
       |> Map.get("field_column", [])
-      |> Enum.map(&Column.from_api/1)
+      |> Enum.map(&Column.from_api(&1, query_params))
 
     %__MODULE__{
-      header: parse_header(data),
+      header: parse_header(data, query_params),
       columns: columns,
       display_options: field_value(data, "field_display_options"),
       right_rail: field_value(data, "field_right_rail")

--- a/apps/cms/lib/partial/paragraph/content_list.ex
+++ b/apps/cms/lib/partial/paragraph/content_list.ex
@@ -39,8 +39,8 @@ defmodule CMS.Partial.Paragraph.ContentList do
           cta: map()
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(data, preview_opts \\ []) do
     type =
       data
       |> field_value("field_content_type")
@@ -80,7 +80,7 @@ defmodule CMS.Partial.Paragraph.ContentList do
     recipe = combine(ingredients)
 
     %__MODULE__{
-      header: data |> parse_paragraphs(query_params, "field_multi_column_header") |> List.first(),
+      header: data |> parse_paragraphs(preview_opts, "field_multi_column_header") |> List.first(),
       right_rail: field_value(data, "field_right_rail"),
       ingredients: ingredients,
       recipe: recipe,

--- a/apps/cms/lib/partial/paragraph/content_list.ex
+++ b/apps/cms/lib/partial/paragraph/content_list.ex
@@ -7,9 +7,13 @@ defmodule CMS.Partial.Paragraph.ContentList do
   For API documentation, see https://github.com/mbta/cms/blob/master/API.md#teasers
   """
   import CMS.Helpers,
-    only: [field_value: 2, int_or_string_to_int: 1, content_type: 1, parse_link: 2]
-
-  import CMS.Partial.Paragraph, only: [parse_header: 2]
+    only: [
+      field_value: 2,
+      int_or_string_to_int: 1,
+      content_type: 1,
+      parse_link: 2,
+      parse_paragraphs: 3
+    ]
 
   alias CMS.Partial.Paragraph.ColumnMultiHeader
   alias CMS.Partial.Teaser
@@ -76,7 +80,7 @@ defmodule CMS.Partial.Paragraph.ContentList do
     recipe = combine(ingredients)
 
     %__MODULE__{
-      header: parse_header(data, query_params),
+      header: data |> parse_paragraphs(query_params, "field_multi_column_header") |> List.first(),
       right_rail: field_value(data, "field_right_rail"),
       ingredients: ingredients,
       recipe: recipe,

--- a/apps/cms/lib/partial/paragraph/content_list.ex
+++ b/apps/cms/lib/partial/paragraph/content_list.ex
@@ -9,7 +9,7 @@ defmodule CMS.Partial.Paragraph.ContentList do
   import CMS.Helpers,
     only: [field_value: 2, int_or_string_to_int: 1, content_type: 1, parse_link: 2]
 
-  import CMS.Partial.Paragraph, only: [parse_header: 1]
+  import CMS.Partial.Paragraph, only: [parse_header: 2]
 
   alias CMS.Partial.Paragraph.ColumnMultiHeader
   alias CMS.Partial.Teaser
@@ -35,8 +35,8 @@ defmodule CMS.Partial.Paragraph.ContentList do
           cta: map()
         }
 
-  @spec from_api(map) :: t
-  def from_api(data) do
+  @spec from_api(map, map) :: t
+  def from_api(data, query_params \\ %{}) do
     type =
       data
       |> field_value("field_content_type")
@@ -76,7 +76,7 @@ defmodule CMS.Partial.Paragraph.ContentList do
     recipe = combine(ingredients)
 
     %__MODULE__{
-      header: parse_header(data),
+      header: parse_header(data, query_params),
       right_rail: field_value(data, "field_right_rail"),
       ingredients: ingredients,
       recipe: recipe,

--- a/apps/cms/lib/partial/paragraph/description_list.ex
+++ b/apps/cms/lib/partial/paragraph/description_list.ex
@@ -14,11 +14,11 @@ defmodule CMS.Partial.Paragraph.DescriptionList do
           descriptions: [Description.t()]
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(data, preview_opts \\ []) do
     %__MODULE__{
-      header: data |> parse_paragraphs(query_params, "field_multi_column_header") |> List.first(),
-      descriptions: parse_paragraphs(data, query_params, "field_definition")
+      header: data |> parse_paragraphs(preview_opts, "field_multi_column_header") |> List.first(),
+      descriptions: parse_paragraphs(data, preview_opts, "field_definition")
     }
   end
 end

--- a/apps/cms/lib/partial/paragraph/description_list.ex
+++ b/apps/cms/lib/partial/paragraph/description_list.ex
@@ -2,7 +2,7 @@ defmodule CMS.Partial.Paragraph.DescriptionList do
   @moduledoc """
   A description list element (optionally including a header) from the CMS.
   """
-  import CMS.Partial.Paragraph, only: [parse_header: 1]
+  import CMS.Partial.Paragraph, only: [parse_header: 2]
 
   alias CMS.Partial.Paragraph.{ColumnMultiHeader, Description}
 
@@ -14,15 +14,15 @@ defmodule CMS.Partial.Paragraph.DescriptionList do
           descriptions: [Description.t()]
         }
 
-  @spec from_api(map) :: t
-  def from_api(data) do
+  @spec from_api(map, map) :: t
+  def from_api(data, query_params \\ %{}) do
     descriptions =
       data
       |> Map.get("field_definition", [])
       |> Enum.map(&Description.from_api/1)
 
     %__MODULE__{
-      header: parse_header(data),
+      header: parse_header(data, query_params),
       descriptions: descriptions
     }
   end

--- a/apps/cms/lib/partial/paragraph/description_list.ex
+++ b/apps/cms/lib/partial/paragraph/description_list.ex
@@ -2,7 +2,7 @@ defmodule CMS.Partial.Paragraph.DescriptionList do
   @moduledoc """
   A description list element (optionally including a header) from the CMS.
   """
-  import CMS.Partial.Paragraph, only: [parse_header: 2]
+  import CMS.Helpers, only: [parse_paragraphs: 3]
 
   alias CMS.Partial.Paragraph.{ColumnMultiHeader, Description}
 
@@ -16,14 +16,9 @@ defmodule CMS.Partial.Paragraph.DescriptionList do
 
   @spec from_api(map, map) :: t
   def from_api(data, query_params \\ %{}) do
-    descriptions =
-      data
-      |> Map.get("field_definition", [])
-      |> Enum.map(&Description.from_api/1)
-
     %__MODULE__{
-      header: parse_header(data, query_params),
-      descriptions: descriptions
+      header: data |> parse_paragraphs(query_params, "field_multi_column_header") |> List.first(),
+      descriptions: parse_paragraphs(data, query_params, "field_definition")
     }
   end
 end

--- a/apps/cms/lib/partial/paragraph/fare_card.ex
+++ b/apps/cms/lib/partial/paragraph/fare_card.ex
@@ -3,7 +3,7 @@ defmodule CMS.Partial.Paragraph.FareCard do
   Represents a Fare Card paragraph type from the CMS.
   """
 
-  import CMS.Helpers, only: [field_value: 2, parse_link: 2]
+  import CMS.Helpers, only: [field_value: 2, parse_link: 2, parse_paragraphs: 3]
 
   alias CMS.Field.Link
   alias CMS.Partial.Paragraph.CustomHTML
@@ -20,10 +20,10 @@ defmodule CMS.Partial.Paragraph.FareCard do
           show_media: boolean()
         }
 
-  @spec from_api(map) :: t
-  def from_api(data) do
+  @spec from_api(map, map) :: t
+  def from_api(data, query_params \\ %{}) do
     with fare_token <- fare_token(data),
-         note <- note(data) do
+         note <- note(data, query_params) do
       %__MODULE__{
         fare_token: fare_token,
         note: note,
@@ -39,10 +39,9 @@ defmodule CMS.Partial.Paragraph.FareCard do
     |> parse_token()
   end
 
-  defp note(data) do
+  defp note(data, query_params) do
     data
-    |> Map.get("field_fare_notes", [])
-    |> Enum.map(&CustomHTML.from_api/1)
+    |> parse_paragraphs(query_params, "field_fare_notes")
     # There is only ever 1 note element
     |> List.first()
   end

--- a/apps/cms/lib/partial/paragraph/fare_card.ex
+++ b/apps/cms/lib/partial/paragraph/fare_card.ex
@@ -20,10 +20,10 @@ defmodule CMS.Partial.Paragraph.FareCard do
           show_media: boolean()
         }
 
-  @spec from_api(map, map) :: t
-  def from_api(data, query_params \\ %{}) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(data, preview_opts \\ []) do
     with fare_token <- fare_token(data),
-         note <- note(data, query_params) do
+         note <- note(data, preview_opts) do
       %__MODULE__{
         fare_token: fare_token,
         note: note,
@@ -39,9 +39,9 @@ defmodule CMS.Partial.Paragraph.FareCard do
     |> parse_token()
   end
 
-  defp note(data, query_params) do
+  defp note(data, preview_opts) do
     data
-    |> parse_paragraphs(query_params, "field_fare_notes")
+    |> parse_paragraphs(preview_opts, "field_fare_notes")
     # There is only ever 1 note element
     |> List.first()
   end

--- a/apps/cms/lib/repo.ex
+++ b/apps/cms/lib/repo.ex
@@ -30,7 +30,7 @@ defmodule CMS.Repo do
   @spec get_page(String.t(), map) :: Page.t() | {:error, API.error()}
   def get_page(path, query_params \\ %{}) do
     case view_or_preview(path, query_params) do
-      {:ok, api_data} -> Page.from_api(api_data)
+      {:ok, api_data} -> Page.from_api(api_data, query_params)
       {:error, error} -> {:error, error}
     end
   end
@@ -303,10 +303,10 @@ defmodule CMS.Repo do
   def get_paragraph(path, query_params \\ %{}) do
     case view_or_preview(path, query_params) do
       {:ok, api_data} ->
-        Paragraph.from_api(api_data)
+        Paragraph.from_api(api_data, query_params)
 
       {:error, {:redirect, _status, to: new_path}} ->
-        get_paragraph(new_path)
+        get_paragraph(new_path, query_params)
 
       {:error, error} ->
         {:error, error}

--- a/apps/cms/lib/repo.ex
+++ b/apps/cms/lib/repo.ex
@@ -10,6 +10,8 @@ defmodule CMS.Repo do
 
   use RepoCache, ttl: :timer.minutes(1)
 
+  import CMS.Helpers, only: [preview_opts: 1]
+
   alias CMS.Partial.{
     Banner,
     Paragraph,
@@ -30,7 +32,7 @@ defmodule CMS.Repo do
   @spec get_page(String.t(), map) :: Page.t() | {:error, API.error()}
   def get_page(path, query_params \\ %{}) do
     case view_or_preview(path, query_params) do
-      {:ok, api_data} -> Page.from_api(api_data, query_params)
+      {:ok, api_data} -> Page.from_api(api_data, preview_opts(query_params))
       {:error, error} -> {:error, error}
     end
   end
@@ -303,7 +305,7 @@ defmodule CMS.Repo do
   def get_paragraph(path, query_params \\ %{}) do
     case view_or_preview(path, query_params) do
       {:ok, api_data} ->
-        Paragraph.from_api(api_data, query_params)
+        Paragraph.from_api(api_data, preview_opts(query_params))
 
       {:error, {:redirect, _status, to: new_path}} ->
         get_paragraph(new_path, query_params)

--- a/apps/cms/test/helpers_test.exs
+++ b/apps/cms/test/helpers_test.exs
@@ -285,6 +285,7 @@ defmodule CMS.HelpersTest do
         "field_paragraphs" => [
           %{
             "type" => [%{"target_id" => "from_library"}],
+            "status" => [%{"value" => true}],
             "field_reusable_paragraph" => [
               %{
                 "status" => [%{"value" => true}],
@@ -300,6 +301,7 @@ defmodule CMS.HelpersTest do
           },
           %{
             "type" => [%{"target_id" => "from_library"}],
+            "status" => [%{"value" => true}],
             "field_reusable_paragraph" => [
               %{
                 "status" => [%{"value" => false}],
@@ -315,6 +317,7 @@ defmodule CMS.HelpersTest do
           },
           %{
             "type" => [%{"target_id" => "from_library"}],
+            "status" => [%{"value" => true}],
             "field_reusable_paragraph" => [
               %{
                 "status" => [%{"value" => true}],
@@ -346,6 +349,7 @@ defmodule CMS.HelpersTest do
         "field_paragraphs" => [
           %{
             "type" => [%{"target_id" => "from_library"}],
+            "status" => [%{"value" => true}],
             "field_reusable_paragraph" => [nil]
           }
         ]

--- a/apps/cms/test/helpers_test.exs
+++ b/apps/cms/test/helpers_test.exs
@@ -288,7 +288,6 @@ defmodule CMS.HelpersTest do
             "status" => [%{"value" => true}],
             "field_reusable_paragraph" => [
               %{
-                "status" => [%{"value" => true}],
                 "paragraphs" => [
                   %{
                     "status" => [%{"value" => false}],
@@ -301,15 +300,16 @@ defmodule CMS.HelpersTest do
           },
           %{
             "type" => [%{"target_id" => "from_library"}],
-            "status" => [%{"value" => true}],
+            "status" => [%{"value" => false}],
             "field_reusable_paragraph" => [
               %{
-                "status" => [%{"value" => false}],
                 "paragraphs" => [
                   %{
                     "status" => [%{"value" => true}],
                     "type" => [%{"target_id" => "custom_html"}],
-                    "field_custom_html_body" => [%{"value" => "I am not published"}]
+                    "field_custom_html_body" => [
+                      %{"value" => "I am published, but my instance is not"}
+                    ]
                   }
                 ]
               }
@@ -320,12 +320,11 @@ defmodule CMS.HelpersTest do
             "status" => [%{"value" => true}],
             "field_reusable_paragraph" => [
               %{
-                "status" => [%{"value" => true}],
                 "paragraphs" => [
                   %{
                     "status" => [%{"value" => true}],
                     "type" => [%{"target_id" => "custom_html"}],
-                    "field_custom_html_body" => [%{"value" => "I am published"}]
+                    "field_custom_html_body" => [%{"value" => "I and my instance are published"}]
                   }
                 ]
               }
@@ -338,7 +337,29 @@ defmodule CMS.HelpersTest do
 
       assert parsed_map == [
                %CMS.Partial.Paragraph.CustomHTML{
-                 body: HTML.raw("I am published"),
+                 body: HTML.raw("I and my instance are published"),
+                 right_rail: nil
+               }
+             ]
+    end
+
+    test "it shows unpublished paragraphs when the page is in preview mode" do
+      map_data = %{
+        "field_paragraphs" => [
+          %{
+            "status" => [%{"value" => true}],
+            "type" => [%{"target_id" => "custom_html"}],
+            "field_custom_html_body" => [%{"value" => "Unpublished Custom HTML paragraph"}]
+          }
+        ]
+      }
+
+      query_params = %{"preview" => nil, "paragraphs" => true}
+      parsed_map = parse_paragraphs(map_data, query_params)
+
+      assert parsed_map == [
+               %CMS.Partial.Paragraph.CustomHTML{
+                 body: HTML.raw("Unpublished Custom HTML paragraph"),
                  right_rail: nil
                }
              ]

--- a/apps/cms/test/helpers_test.exs
+++ b/apps/cms/test/helpers_test.exs
@@ -354,8 +354,8 @@ defmodule CMS.HelpersTest do
         ]
       }
 
-      query_params = %{"preview" => nil, "paragraphs" => true}
-      parsed_map = parse_paragraphs(map_data, query_params)
+      preview_opts = [preview: true, paragraphs: true]
+      parsed_map = parse_paragraphs(map_data, preview_opts)
 
       assert parsed_map == [
                %CMS.Partial.Paragraph.CustomHTML{
@@ -518,6 +518,13 @@ defmodule CMS.HelpersTest do
       ]
 
       assert [%{id: "limited_service", mode: nil, group: "custom"}] = routes(tags)
+    end
+  end
+
+  describe "preview_opts/1" do
+    test "parses conn.query_params map for CMS preview flags" do
+      query_params = %{"preview" => nil, "foo" => "bar"}
+      assert [page: true, paragraphs: false] = preview_opts(query_params)
     end
   end
 end

--- a/apps/cms/test/paragraph_test.exs
+++ b/apps/cms/test/paragraph_test.exs
@@ -201,8 +201,8 @@ defmodule CMS.ParagraphTest do
       assert section1.title == "Accordion Label 1"
       assert section2.title == "Accordion Label 2"
 
-      assert %CustomHTML{} = section1.content
-      assert %CustomHTML{} = section2.content
+      assert [%CustomHTML{}] = section1.content
+      assert [%CustomHTML{}] = section2.content
     end
 
     test "parses title card (used in DescriptiveLink context)" do

--- a/apps/site/lib/site_web/controllers/page_controller.ex
+++ b/apps/site/lib/site_web/controllers/page_controller.ex
@@ -22,7 +22,7 @@ defmodule SiteWeb.PageController do
   def index(conn, _params) do
     {promoted, remainder} = whats_happening_items()
     banner = banner()
-    fares = fares()
+    fares = fares(conn.query_params)
 
     conn
     |> assign(
@@ -40,9 +40,9 @@ defmodule SiteWeb.PageController do
     |> render("index.html")
   end
 
-  @spec fares :: Paragraph.t() | nil
-  defp fares do
-    case Repo.get_paragraph("paragraphs/multi-column/homepage-fares") do
+  @spec fares(map) :: Paragraph.t() | nil
+  defp fares(query_params) do
+    case Repo.get_paragraph("paragraphs/multi-column/homepage-fares", query_params) do
       {:error, _} -> nil
       result -> result
     end

--- a/apps/site/lib/site_web/controllers/project_controller.ex
+++ b/apps/site/lib/site_web/controllers/project_controller.ex
@@ -4,6 +4,8 @@ defmodule SiteWeb.ProjectController do
   """
   use SiteWeb, :controller
 
+  import CMS.Helpers, only: [preview_opts: 1]
+
   alias CMS.{Partial.Teaser, Repo}
   alias CMS.Page.{Project, ProjectUpdate}
   alias Plug.Conn
@@ -95,7 +97,7 @@ defmodule SiteWeb.ProjectController do
 
     "/projects"
     |> Path.join(project_alias)
-    |> get_page_fn.(conn.query_params)
+    |> get_page_fn.(preview_opts(conn.query_params))
     |> case do
       %Project{} = project ->
         breadcrumbs = [

--- a/apps/site/lib/site_web/controllers/project_controller.ex
+++ b/apps/site/lib/site_web/controllers/project_controller.ex
@@ -90,12 +90,12 @@ defmodule SiteWeb.ProjectController do
   end
 
   def project_updates(conn, %{"project_alias" => project_alias}) do
-    get_page_fn = Map.get(conn.assigns, :get_page_fn, &Repo.get_page/1)
+    get_page_fn = Map.get(conn.assigns, :get_page_fn, &Repo.get_page/2)
     teasers_fn = Map.get(conn.assigns, :teasers_fn, &Repo.teasers/1)
 
     "/projects"
     |> Path.join(project_alias)
-    |> get_page_fn.()
+    |> get_page_fn.(conn.query_params)
     |> case do
       %Project{} = project ->
         breadcrumbs = [

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -9,7 +9,7 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
   alias Stops.Repo, as: StopsRepo
   alias Stops.{RouteStop, RouteStops, Stop}
 
-  import CMS.Repo, only: [get_paragraph: 1]
+  import CMS.Repo, only: [get_paragraph: 2]
   import SiteWeb.CMS.ParagraphView, only: [render_paragraph: 2]
 
   @type query_param :: String.t() | nil
@@ -125,7 +125,7 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
   def get_shuttle_paragraphs(conn) do
     conn
     |> shuttle_paragraphs_by_line()
-    |> Enum.map(&get_paragraph/1)
+    |> Enum.map(&get_paragraph(&1, conn.query_params))
     |> Enum.map(&render_paragraph(&1, conn))
   end
 

--- a/apps/site/lib/site_web/templates/cms/paragraph/_accordion_content.html.eex
+++ b/apps/site/lib/site_web/templates/cms/paragraph/_accordion_content.html.eex
@@ -1,1 +1,5 @@
-<%= render_paragraph_content(@content, @conn) %>
+<%=
+  for content <- @content do
+    render_paragraph_content(content, @conn)
+  end
+%>

--- a/apps/site/lib/site_web/templates/cms/paragraph/_column_multi.html.eex
+++ b/apps/site/lib/site_web/templates/cms/paragraph/_column_multi.html.eex
@@ -10,7 +10,7 @@
 <% end %>
 
 
-<%= if length(@content.columns) > 0 do %>
+<%= if Enum.any?(@content.columns) do %>
   <%= extend_width_if has_cards?, :cards do %>
     <div class="c-multi-column__row row">
       <%= for column <- @content.columns do %>

--- a/apps/site/lib/site_web/templates/cms/paragraph/_column_multi.html.eex
+++ b/apps/site/lib/site_web/templates/cms/paragraph/_column_multi.html.eex
@@ -9,16 +9,19 @@
   </div>
 <% end %>
 
-<%= extend_width_if has_cards?, :cards do %>
-  <div class="c-multi-column__row row">
-    <%= for column <- @content.columns do %>
-      <div class="c-multi-column__column col-sm-6 col-md-<%= grid(@content) %>">
 
-        <%= for paragraph <- column.paragraphs do %>
-          <%= render_paragraph_content(paragraph, @conn) %>
-        <% end %>
+<%= if length(@content.columns) > 0 do %>
+  <%= extend_width_if has_cards?, :cards do %>
+    <div class="c-multi-column__row row">
+      <%= for column <- @content.columns do %>
+        <div class="c-multi-column__column col-sm-6 col-md-<%= grid(@content) %>">
 
-      </div>
-    <% end %>
-  </div>
+          <%= for paragraph <- column.paragraphs do %>
+            <%= render_paragraph_content(paragraph, @conn) %>
+          <% end %>
+
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>

--- a/apps/site/lib/site_web/templates/cms/paragraph/_description_list.html.eex
+++ b/apps/site/lib/site_web/templates/cms/paragraph/_description_list.html.eex
@@ -2,17 +2,19 @@
   <%= ContentRewriter.rewrite(@content.header.text, @conn) %>
 <% end %>
 
-<%= extend_width :table do %>
-  <dl class="dl" role="list">
-    <%= for description <- @content.descriptions do %>
-      <div role="listitem" class="dl--item">
-        <dt class="dt">
-          <%= ContentRewriter.rewrite(description.term, @conn) %>
-        </dt>
-        <dd class="dd">
-          <%= ContentRewriter.rewrite(description.details, @conn) %>
-        </dd>
-      </div>
-    <% end %>
-  </dl>
+<%= if length(@content.descriptions) > 0 do %>
+  <%= extend_width :table do %>
+    <dl class="dl" role="list">
+      <%= for description <- @content.descriptions do %>
+        <div role="listitem" class="dl--item">
+          <dt class="dt">
+            <%= ContentRewriter.rewrite(description.term, @conn) %>
+          </dt>
+          <dd class="dd">
+            <%= ContentRewriter.rewrite(description.details, @conn) %>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+  <% end %>
 <% end %>

--- a/apps/site/lib/site_web/templates/cms/paragraph/_description_list.html.eex
+++ b/apps/site/lib/site_web/templates/cms/paragraph/_description_list.html.eex
@@ -2,7 +2,7 @@
   <%= ContentRewriter.rewrite(@content.header.text, @conn) %>
 <% end %>
 
-<%= if length(@content.descriptions) > 0 do %>
+<%= if Enum.any?(@content.descriptions) do %>
   <%= extend_width :table do %>
     <dl class="dl" role="list">
       <%= for description <- @content.descriptions do %>

--- a/apps/site/lib/site_web/views/paragraph_view.ex
+++ b/apps/site/lib/site_web/views/paragraph_view.ex
@@ -7,7 +7,17 @@ defmodule SiteWeb.CMS.ParagraphView do
   alias CMS.API
   alias CMS.Field.{Image, Link}
   alias CMS.Partial.{Paragraph, Teaser}
-  alias Paragraph.{Callout, ColumnMulti, ContentList, DescriptiveLink, FareCard}
+
+  alias Paragraph.{
+    Accordion,
+    Callout,
+    ColumnMulti,
+    ContentList,
+    DescriptionList,
+    DescriptiveLink,
+    FareCard
+  }
+
   alias Plug.Conn
   alias Site.ContentRewriter
 
@@ -28,6 +38,12 @@ defmodule SiteWeb.CMS.ParagraphView do
   def render_paragraph({:error, _error}, _), do: []
   # Don't render Content List if list has no items
   def render_paragraph(%ContentList{teasers: []}, _), do: []
+  # Don't render Accordion if all tabs are unpublished
+  def render_paragraph(%Accordion{sections: []}, _), do: []
+  # Don't render Multi Column if all column content is unpublished
+  def render_paragraph(%ColumnMulti{header: nil, columns: []}, _), do: []
+  # Don't render Description List if all descriptions are unpublished
+  def render_paragraph(%DescriptionList{header: nil, descriptions: []}, _), do: []
 
   def render_paragraph(paragraph, conn) do
     render(

--- a/apps/site/lib/site_web/views/partial_view.ex
+++ b/apps/site/lib/site_web/views/partial_view.ex
@@ -236,9 +236,9 @@ defmodule SiteWeb.PartialView do
   end
 
   @spec paragraph(String.t(), Conn.t()) :: Phoenix.HTML.Safe.t()
-  def paragraph(path, %Conn{} = conn) do
+  def paragraph(path, conn) do
     path
-    |> Repo.get_paragraph()
+    |> Repo.get_paragraph(conn.query_params)
     |> render_paragraph(conn)
   end
 

--- a/apps/site/lib/site_web/views/partial_view.ex
+++ b/apps/site/lib/site_web/views/partial_view.ex
@@ -1,4 +1,7 @@
 defmodule SiteWeb.PartialView do
+  @moduledoc """
+  Handles rendering of partial components and CMS content.
+  """
   use SiteWeb, :view
 
   alias CMS.{Partial.Teaser, Repo}

--- a/apps/site/test/site_web/controllers/project_controller_test.exs
+++ b/apps/site/test/site_web/controllers/project_controller_test.exs
@@ -19,7 +19,7 @@ defmodule SiteWeb.ProjectControllerTest do
 
       resp =
         conn
-        |> assign(:get_page_fn, fn _ -> project end)
+        |> assign(:get_page_fn, fn _, _ -> project end)
         |> assign(:teasers_fn, teasers_fn)
         |> get(project_updates_path(conn, :project_updates, Project.alias(project)))
         |> html_response(200)
@@ -45,7 +45,7 @@ defmodule SiteWeb.ProjectControllerTest do
 
       resp =
         conn
-        |> assign(:get_page_fn, fn _ -> project end)
+        |> assign(:get_page_fn, fn _, _ -> project end)
         |> assign(:teasers_fn, teasers_fn)
         |> get(project_updates_path(conn, :project_updates, Project.alias(project)))
         |> html_response(200)
@@ -65,7 +65,9 @@ defmodule SiteWeb.ProjectControllerTest do
 
       for status <- [301, 302] do
         conn
-        |> assign(:get_page_fn, fn _ -> {:error, {:redirect, status, to: project.path_alias}} end)
+        |> assign(:get_page_fn, fn _, _ ->
+          {:error, {:redirect, status, to: project.path_alias}}
+        end)
         |> assign(:teasers_fn, fn _ ->
           send(self(), :teasers_fn)
           []
@@ -79,7 +81,7 @@ defmodule SiteWeb.ProjectControllerTest do
 
     test "404s when project 404s", %{conn: conn} do
       conn
-      |> assign(:get_page_fn, fn _ -> {:error, :not_found} end)
+      |> assign(:get_page_fn, fn _, _ -> {:error, :not_found} end)
       |> assign(:teasers_fn, fn _ ->
         send(self(), :teasers_fn)
         []
@@ -92,7 +94,7 @@ defmodule SiteWeb.ProjectControllerTest do
 
     test "returns 502 when repo returns error", %{conn: conn} do
       conn
-      |> assign(:get_page_fn, fn _ -> {:error, :invalid_response} end)
+      |> assign(:get_page_fn, fn _, _ -> {:error, :invalid_response} end)
       |> assign(:teasers_fn, fn _ ->
         send(self(), :teasers_fn)
         []

--- a/apps/site/test/site_web/views/paragraph_view_test.exs
+++ b/apps/site/test/site_web/views/paragraph_view_test.exs
@@ -631,16 +631,20 @@ defmodule SiteWeb.CMS.ParagraphViewTest do
         %AccordionSection{
           title: "{{ icon:subway-red }} Section 1",
           prefix: "cms-10",
-          content: %CustomHTML{
-            body: HTML.raw("<strong>First section's content</strong>")
-          }
+          content: [
+            %CustomHTML{
+              body: HTML.raw("<strong>First section's content</strong>")
+            }
+          ]
         },
         %AccordionSection{
           title: "Section 2",
           prefix: "cms-11",
-          content: %CustomHTML{
-            body: HTML.raw("<strong>Second section's content</strong>")
-          }
+          content: [
+            %CustomHTML{
+              body: HTML.raw("<strong>Second section's content</strong>")
+            }
+          ]
         }
       ]
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Content authors can unpublish nested paragraphs without 500 error](https://app.asana.com/0/553506286097126/1117409475848341)

- Passes query parameters down from page response to paragraph parser
- Pass all nested paragraphs though paragraph parser, rather than direct rendering
- Prevent empty parent paragraphs from rendering when no published children are present
- Update logic for reusable paragraphs: top level type can be unpublished

Related CMS ticket: mbta/cms#318
