### PR TITLE
Handle added trips in finder_api

### DIFF
--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -153,6 +153,26 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
                }
              ] = response
     end
+
+    test "can handle added trips", %{conn: conn} do
+      added_prediction = %Prediction{@prediction | schedule_relationship: :added}
+
+      path =
+        finder_api_path(conn, :departures, %{
+          id: "CR-Providence",
+          direction: "0",
+          stop: "place-sstat"
+        })
+
+      response =
+        conn
+        |> assign(:schedules_fn, fn _, _ -> [] end)
+        |> assign(:predictions_fn, fn _ -> [added_prediction] end)
+        |> get(path)
+        |> json_response(200)
+
+      assert [%{"departure" => %{"prediction" => added_prediction, "schedule" => nil}}] = response
+    end
   end
 
   describe "trip/2" do


### PR DESCRIPTION
FinderApi.departures implicitly assumed that all trips have associated
schedules, which is not true of added trips. This assumption led to a
nil creeping into an unexpected place, leading ultimately to an
UndefinedFunctionError. This case is now accounted for.

#### Summary of changes
**Asana Ticket:** [Upcoming Departures 500s if it encounters an added trip](https://app.asana.com/0/555089885850811/1157538555249409)
