### PR TITLE
Schedule Finder | "View schedules" doesn't work for combo GL

### DIFF
--- a/apps/site/assets/ts/schedule/components/schedule-finder/TripDetails.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TripDetails.tsx
@@ -42,6 +42,9 @@ const TripSummary = ({
   </tr>
 );
 
+const allTimesHaveSchedule = (tripInfo: TripInfo): boolean =>
+  tripInfo.times.every(time => !!time.schedule);
+
 export const TripDetails = ({
   state,
   showFare
@@ -56,12 +59,14 @@ export const TripDetails = ({
     );
   }
 
+  const errorLoadingTrip = (
+    <p>
+      <em>Error loading trip details. Please try again later.</em>
+    </p>
+  );
+
   if (error) {
-    return (
-      <p>
-        <em>Error loading trip details. Please try again later.</em>
-      </p>
-    );
+    return errorLoadingTrip;
   }
 
   if (!tripInfo) return null;
@@ -91,15 +96,17 @@ export const TripDetails = ({
         </tr>
       </thead>
       <tbody className="schedule-table__subtable-tbody">
-        {tripInfo.times.map((departure, index: number) => (
-          <TripStop
-            departure={departure}
-            index={index}
-            showFare={showFare}
-            routeType={tripInfo.route_type}
-            key={departure.schedule.stop.id}
-          />
-        ))}
+        {allTimesHaveSchedule(tripInfo)
+          ? tripInfo.times.map((departure, index: number) => (
+              <TripStop
+                departure={departure}
+                index={index}
+                showFare={showFare}
+                routeType={tripInfo.route_type}
+                key={departure.schedule.stop.id}
+              />
+            ))
+          : errorLoadingTrip}
       </tbody>
     </table>
   );

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
@@ -43,7 +43,7 @@ const TripStop = ({
   const { schedule } = departure;
 
   /* istanbul ignore next */
-  if (!schedule.stop) return null;
+  if (!schedule || !schedule.stop) return null;
 
   return (
     <tr key={`${schedule.stop.id}`} className="schedule-table__subtable-row">

--- a/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
@@ -29,6 +29,13 @@ interface Props {
 const hasPredictions = (journeys: EnhancedJourney[]): boolean =>
   journeys.filter(journey => journey.realtime.prediction !== null).length > 0;
 
+// Sometimes using the route.id from the journey is desired over the route.id
+// from input (e.g. so we can get trips for "Green-D" instead of "Green")
+const getAdjustedInput = (
+  input: UserInput,
+  journey: EnhancedJourney
+): UserInput => ({ ...input, ...{ route: journey.route.id } });
+
 export const RoutePillSmall = ({
   route
 }: {
@@ -122,7 +129,7 @@ const TableRow = ({
 
   return (
     <Accordion
-      input={input}
+      input={getAdjustedInput(input, journey)}
       journey={journey}
       contentComponent={contentComponent}
     />
@@ -168,7 +175,7 @@ export const UpcomingDepartures = ({
             {journeys.map((journey: EnhancedJourney, idx: number) => (
               <TableRow
                 journey={journey}
-                input={input}
+                input={getAdjustedInput(input, journey)}
                 // eslint-disable-next-line react/no-array-index-key
                 key={idx}
               />

--- a/apps/site/lib/site_web/controllers/schedule/finder_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/finder_api.ex
@@ -358,18 +358,22 @@ defmodule SiteWeb.ScheduleController.FinderApi do
     )
   end
 
-  defp maybe_add_delay(%{prediction: nil} = schedule_and_prediction) do
-    schedule_and_prediction
-  end
+  def maybe_add_delay(%{prediction: nil} = schedule_and_prediction),
+    do: schedule_and_prediction
 
-  defp maybe_add_delay(%{prediction: %{time: nil}} = schedule_and_prediction) do
-    schedule_and_prediction
-  end
+  def maybe_add_delay(%{prediction: %{time: nil}} = schedule_and_prediction),
+    do: schedule_and_prediction
 
-  defp maybe_add_delay(
-         %{schedule: %{time: schedule_time}, prediction: %{time: prediction_time}} =
-           schedule_and_prediction
-       ) do
+  def maybe_add_delay(%{schedule: nil} = schedule_and_prediction),
+    do: schedule_and_prediction
+
+  def maybe_add_delay(%{schedule: %{time: nil}} = schedule_and_prediction),
+    do: schedule_and_prediction
+
+  def maybe_add_delay(
+        %{schedule: %{time: schedule_time}, prediction: %{time: prediction_time}} =
+          schedule_and_prediction
+      ) do
     delay = DateTime.diff(prediction_time, schedule_time)
     Map.put_new(schedule_and_prediction, :delay, delay)
   end

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -87,6 +87,22 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
       assert [%{"departure" => %{"time" => _}}] = response
       assert [%{"route" => %{"type" => 2}}] = response
     end
+
+    test "handles journeys for combined Green Line", %{conn: conn} do
+      route_id = "Green"
+      date = Util.now() |> Date.to_iso8601()
+      conn = assign(conn, :date, date)
+
+      journey =
+        %{id: route_id, direction: "0", stop: "place-boyls"}
+        |> get_valid_journeys(conn)
+        |> List.first()
+
+      assert %{"trip" => %{"id" => _}, "route" => %{"id" => _}} = journey
+      assert %{"departure" => %{"schedule" => %{"time" => date_time_string}}} = journey
+      assert {:ok, date_time, _} = DateTime.from_iso8601(date_time_string)
+      assert date == date_time |> DateTime.to_date() |> Date.to_iso8601()
+    end
   end
 
   describe "departures/2" do

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -7,6 +7,7 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
   alias Routes.Route
   alias Services.Repo, as: ServicesRepo
   alias Schedules.{Schedule, Trip}
+  alias SiteWeb.ScheduleController.FinderApi
   alias Stops.Stop
 
   @now Util.now()
@@ -264,6 +265,29 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
 
       assert %{"times" => [processed_prediction | _]} = response
       assert %{"prediction" => %{"time" => nil}} = processed_prediction
+    end
+  end
+
+  describe "maybe_add_delay/1" do
+    test "doesn't choke on missing schedules" do
+      prediction_without_schedule = %{
+        prediction: @prediction,
+        schedule: nil
+      }
+
+      assert FinderApi.maybe_add_delay(prediction_without_schedule) == prediction_without_schedule
+    end
+
+    test "doesn't choke on schedule missing time" do
+      schedule_without_time = %Schedule{@schedule | time: nil}
+
+      prediction_and_schedule_without_time = %{
+        prediction: @prediction,
+        schedule: schedule_without_time
+      }
+
+      assert FinderApi.maybe_add_delay(prediction_and_schedule_without_time) ==
+               prediction_and_schedule_without_time
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedule Finder | "View schedules" doesn't work for combo GL](https://app.asana.com/0/385363666817452/1156654983519751/f)

We added some logic to enable us to use the appropriate route ID (e.g. "Green-D" instead of "Green") so that the appropriate API calls will return results!

Also includes some additional safeguards for added trips, where the modal opened from "View schedules" might show errors or abruptly close when a(n added) trip triggers backend errors or  provides a prediction for Upcoming Depatures but no schedule to populate the Accordion.