### PR TITLE
Schedule Finder | Show schedule note on subways

### DIFF
--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -58,6 +58,19 @@
   padding: $base-spacing * 2 $base-spacing;
 }
 
+.m-schedule-page__schedule-notes--modal {
+  margin-top: $base-spacing;
+  padding: $base-spacing;
+
+  .m-schedule-page__schedule-note-title {
+    display: none;
+
+    + .m-schedule-page__schedule-note .m-schedule-page__service {
+      margin-top: 0;
+    }
+  }
+}
+
 .m-schedule-page__schedule-notes--desktop {
   margin-top: $base-spacing * 2;
 
@@ -363,13 +376,29 @@
   font-variant-numeric: tabular-nums;
 }
 
-.schedule-finder__first-last-trip {
+.schedule-finder__first-last-trip--bordered {
   border-top: 3px solid $gray-lightest;
+  padding: ($base-spacing / 2) 0;
+}
+
+.schedule-finder__first-last-trip-label {
+  @extend %u-small-caps;
+  @extend %u-bold;
+  margin-right: $base-spacing;
+  white-space: nowrap;
+
+  @include media-breakpoint-down(xs) {
+    display: block;
+  }
+}
+
+.first-last-trips {
+  align-items: baseline;
   display: flex;
-  justify-content: space-around;
-  // scss-lint:disable DuplicateProperty IE11 doesn't support space-evenly
-  justify-content: space-evenly;
-  padding: $base-spacing / 2;
+}
+
+.first-last-trips__trip:not(:first-child) {
+  margin-left: $base-spacing;
 }
 
 .schedule-table__subtable {

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -87,14 +87,22 @@
   text-decoration: line-through;
 }
 
-.u-small-caps {
+%u-small-caps {
   font-family: $headings-font-family;
   font-size: $font-size-small-caps;
   text-transform: uppercase;
 }
 
-.u-bold {
+.u-small-caps {
+  @extend %u-bold;
+}
+
+%u-bold {
   font-weight: bold;
+}
+
+.u-bold {
+  @extend %u-bold;
 }
 
 .u-no-underline {

--- a/apps/site/assets/ts/helpers/date.ts
+++ b/apps/site/assets/ts/helpers/date.ts
@@ -14,4 +14,11 @@ export const formattedDate = (unformatted: string): string => {
   });
 };
 
+// Returns a time in the form of "05:16 AM"
+export const shortTime = (date: string): string =>
+  new Date(date).toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+
 export default formattedDate;

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
@@ -3,20 +3,28 @@
 exports[`ScheduleTable it renders 1`] = `
 <ScheduleTable>
   <div
-    className="schedule-finder__first-last-trip"
+    className="schedule-finder__first-last-trip--bordered first-last-trips"
   >
     <div
-      className="u-small-caps u-bold"
+      className="first-last-trips__trip"
     >
-      First Trip
+      <span
+        className="schedule-finder__first-last-trip-label"
+      >
+        First Trip
+      </span>
+      05:36 AM
     </div>
-    05:36 AM
     <div
-      className="u-small-caps u-bold"
+      className="first-last-trips__trip"
     >
-      Last Trip
+      <span
+        className="schedule-finder__first-last-trip-label"
+      >
+        Last Trip
+      </span>
+      01:02 AM
     </div>
-    01:02 AM
   </div>
   <table
     className="schedule-table"
@@ -9910,20 +9918,28 @@ exports[`ScheduleTable it renders 1`] = `
 exports[`ScheduleTable it renders CR schedules 1`] = `
 <ScheduleTable>
   <div
-    className="schedule-finder__first-last-trip"
+    className="schedule-finder__first-last-trip--bordered first-last-trips"
   >
     <div
-      className="u-small-caps u-bold"
+      className="first-last-trips__trip"
     >
-      First Trip
+      <span
+        className="schedule-finder__first-last-trip-label"
+      >
+        First Trip
+      </span>
+      04:15 AM
     </div>
-    04:15 AM
     <div
-      className="u-small-caps u-bold"
+      className="first-last-trips__trip"
     >
-      Last Trip
+      <span
+        className="schedule-finder__first-last-trip-label"
+      >
+        Last Trip
+      </span>
+      11:50 PM
     </div>
-    11:50 PM
   </div>
   <table
     className="schedule-table"
@@ -11461,20 +11477,28 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
 exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
 <ScheduleTable>
   <div
-    className="schedule-finder__first-last-trip"
+    className="schedule-finder__first-last-trip--bordered first-last-trips"
   >
     <div
-      className="u-small-caps u-bold"
+      className="first-last-trips__trip"
     >
-      First Trip
+      <span
+        className="schedule-finder__first-last-trip-label"
+      >
+        First Trip
+      </span>
+      04:15 AM
     </div>
-    04:15 AM
     <div
-      className="u-small-caps u-bold"
+      className="first-last-trips__trip"
     >
-      Last Trip
+      <span
+        className="schedule-finder__first-last-trip-label"
+      >
+        Last Trip
+      </span>
+      11:50 PM
     </div>
-    11:50 PM
   </div>
   <table
     className="schedule-table"
@@ -13012,24 +13036,30 @@ exports[`ScheduleTable it renders an empty message 1`] = `
 exports[`ScheduleTable it renders with school trips 1`] = `
 <ScheduleTable>
   <div
-    className="schedule-finder__first-last-trip"
+    className="schedule-finder__first-last-trip--bordered first-last-trips"
   >
     <div
-      className="u-small-caps u-bold"
+      className="first-last-trips__trip"
     >
-      First Trip
+      <span
+        className="schedule-finder__first-last-trip-label"
+      >
+        First Trip
+      </span>
+      05:36 AM
     </div>
-    05:36 AM
     <div
-      className="u-small-caps u-bold"
+      className="first-last-trips__trip"
     >
-      Last Trip
+      <span
+        className="schedule-finder__first-last-trip-label"
+      >
+        Last Trip
+      </span>
+      01:02 AM
     </div>
-    01:02 AM
   </div>
-  <p
-    className="text-center"
-  >
+  <p>
     <strong>
       S
     </strong>

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -5,7 +5,8 @@ import {
   RoutePatternsByDirection,
   LineDiagramStop,
   SimpleStopMap,
-  ServiceInSelector
+  ServiceInSelector,
+  ScheduleNote as ScheduleNoteType
 } from "./__schedule";
 import ScheduleDirectionMenu from "./direction/ScheduleDirectionMenu";
 import ScheduleDirectionButton from "./direction/ScheduleDirectionButton";
@@ -27,6 +28,7 @@ export interface Props {
   ratingEndDate: string;
   stops: SimpleStopMap;
   today: string;
+  scheduleNote?: ScheduleNoteType;
 }
 
 export const fetchMapData = (
@@ -84,7 +86,8 @@ const ScheduleDirection = ({
   services,
   ratingEndDate,
   stops,
-  today
+  today,
+  scheduleNote
 }: Props): ReactElement<HTMLElement> => {
   const defaultRoutePattern = routePatternsByDirection[directionId].slice(
     0,
@@ -178,6 +181,7 @@ const ScheduleDirection = ({
           ratingEndDate={ratingEndDate}
           stops={stops}
           today={today}
+          scheduleNote={scheduleNote}
         />
       )}
     </>

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -5,7 +5,8 @@ import {
   SimpleStopMap,
   RouteStop,
   StopData,
-  ServiceInSelector
+  ServiceInSelector,
+  ScheduleNote as ScheduleNoteType
 } from "../__schedule";
 import SingleStop from "./SingleStop";
 import Modal from "../../../components/Modal";
@@ -22,6 +23,7 @@ interface Props {
   ratingEndDate: string;
   stops: SimpleStopMap;
   today: string;
+  scheduleNote?: ScheduleNoteType;
 }
 
 const getMergeStops = (lineDiagram: LineDiagramStop[]): LineDiagramStop[] =>
@@ -64,7 +66,8 @@ const LineDiagram = ({
   services,
   ratingEndDate,
   stops,
-  today
+  today,
+  scheduleNote
 }: Props): ReactElement<HTMLElement> | null => {
   const routeType = route.type;
   const routeColor: string = route.color || "#000";
@@ -248,6 +251,7 @@ const LineDiagram = ({
             stops={stops[directionId]}
             routePatternsByDirection={routePatternsByDirection}
             today={today}
+            scheduleNote={scheduleNote}
           />
         )}
       </Modal>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/FirstLastTimes.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/FirstLastTimes.tsx
@@ -24,6 +24,10 @@ const FirstLastTimes = ({
     return null;
   }
 
+  // For subway lines, the frequency of trips is lower on Saturdays, but
+  // the first and last trips are the same on Weekdays and Saturdays.
+  // When showing first and last trips use the weekday service,
+  // but label it as "Monday - Saturday".
   const timesList = [
     [
       "Monday - Saturday",

--- a/apps/site/assets/ts/schedule/components/schedule-finder/FirstLastTimes.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/FirstLastTimes.tsx
@@ -1,62 +1,109 @@
-import React, { ReactElement } from "react";
-import { SelectedDirection } from "../ScheduleFinder";
-import { HoursOfOperation } from "../__schedule";
+import React, { ReactElement, useReducer, useEffect } from "react";
+import { SelectedDirection, SelectedOrigin } from "../ScheduleFinder";
+import { reducer } from "../../../helpers/fetch";
+import { shortTime } from "../../../helpers/date";
 
-const getTimes = (
-  hoursOfOperation: HoursOfOperation,
-  serviceType: "week" | "saturday" | "sunday",
-  selectedDirection: SelectedDirection
-): [string, string] => [
-  hoursOfOperation[serviceType][selectedDirection!].first_departure,
-  hoursOfOperation[serviceType][selectedDirection!].last_departure
-];
+type fetchAction =
+  | { type: "FETCH_COMPLETE"; payload: [] }
+  | { type: "FETCH_ERROR" }
+  | { type: "FETCH_STARTED" };
+
+// First and last departures for two sets of services
+const fetchData = (
+  routeId: string,
+  selectedOrigin: SelectedOrigin,
+  selectedDirection: SelectedDirection,
+  dispatch: (action: fetchAction) => void
+): Promise<void> => {
+  dispatch({ type: "FETCH_STARTED" });
+  return (
+    window.fetch &&
+    window
+      .fetch(
+        `/schedules/schedule_api/hours?stop=${selectedOrigin}&route=${routeId}&direction=${selectedDirection}`
+      )
+      .then(response => {
+        if (response.ok) return response.json();
+        throw new Error(response.statusText);
+      })
+      .then(json => dispatch({ type: "FETCH_COMPLETE", payload: json }))
+      // @ts-ignore
+      .catch(() => dispatch({ type: "FETCH_ERROR" }))
+  );
+};
 
 interface Props {
-  hoursOfOperation: HoursOfOperation;
+  routeId: string;
+  selectedOrigin: SelectedOrigin;
   selectedDirection: SelectedDirection;
 }
 
+// TODO Add tests
 const FirstLastTimes = ({
-  hoursOfOperation,
+  routeId,
+  selectedOrigin,
   selectedDirection
 }: Props): ReactElement<HTMLElement> | null => {
-  if (selectedDirection === null) {
-    return null;
-  }
+  const [state, dispatch] = useReducer(reducer, {
+    data: null,
+    isLoading: true,
+    error: false
+  });
+
+  useEffect(
+    () => {
+      fetchData(routeId, selectedOrigin, selectedDirection, dispatch);
+    },
+    [routeId, selectedOrigin, selectedDirection]
+  );
 
   // For subway lines, the frequency of trips is lower on Saturdays, but
   // the first and last trips are the same on Weekdays and Saturdays.
   // When showing first and last trips use the weekday service,
   // but label it as "Monday - Saturday".
-  const timesList = [
-    [
-      "Monday - Saturday",
-      ...getTimes(hoursOfOperation, "week", selectedDirection)
-    ],
-    ["Sunday", ...getTimes(hoursOfOperation, "sunday", selectedDirection)]
-  ];
+  // The data is ordered [sunday, weekday, saturday]
+  const timesList = state.data
+    ? [
+        [
+          "Monday - Saturday",
+          state.data[1].first_departure,
+          state.data[1].last_departure
+        ],
+        ["Sunday", state.data[0].first_departure, state.data[0].last_departure]
+      ]
+    : [];
+
+  const timesDisplay = timesList.map(([label, firstTime, lastTime]) => (
+    <React.Fragment key={label}>
+      <h4>{label}</h4>
+      <div className="first-last-trips">
+        <div className="first-last-trips__trip">
+          <span className="schedule-finder__first-last-trip-label">
+            First Trip
+          </span>
+          {shortTime(firstTime)}
+        </div>
+        <div className="first-last-trips__trip">
+          <span className="schedule-finder__first-last-trip-label">
+            Last Trip
+          </span>
+          {shortTime(lastTime)}
+        </div>
+      </div>
+    </React.Fragment>
+  ));
 
   return (
     <div className="">
-      {timesList.map(([label, firstTime, lastTime]) => (
-        <>
-          <h4>{label}</h4>
-          <div className="first-last-trips">
-            <div className="first-last-trips__trip">
-              <span className="schedule-finder__first-last-trip-label">
-                First Trip
-              </span>
-              {firstTime}
-            </div>
-            <div className="first-last-trips__trip">
-              <span className="schedule-finder__first-last-trip-label">
-                Last Trip
-              </span>
-              {lastTime}
-            </div>
-          </div>
-        </>
-      ))}
+      {state.isLoading && (
+        <div className="c-spinner__container">
+          <div className="c-spinner">Loading...</div>
+        </div>
+      )}
+      {/* istanbul ignore next */ !state.isLoading &&
+        /* istanbul ignore next */ state.data && (
+          /* istanbul ignore next */ <div>{timesDisplay}</div>
+        )}
     </div>
   );
 };

--- a/apps/site/assets/ts/schedule/components/schedule-finder/FirstLastTimes.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/FirstLastTimes.tsx
@@ -1,0 +1,60 @@
+import React, { ReactElement } from "react";
+import { SelectedDirection } from "../ScheduleFinder";
+import { HoursOfOperation } from "../__schedule";
+
+const getTimes = (
+  hoursOfOperation: HoursOfOperation,
+  serviceType: "week" | "saturday" | "sunday",
+  selectedDirection: SelectedDirection
+): [string, string] => [
+  hoursOfOperation[serviceType][selectedDirection!].first_departure,
+  hoursOfOperation[serviceType][selectedDirection!].last_departure
+];
+
+interface Props {
+  hoursOfOperation: HoursOfOperation;
+  selectedDirection: SelectedDirection;
+}
+
+const FirstLastTimes = ({
+  hoursOfOperation,
+  selectedDirection
+}: Props): ReactElement<HTMLElement> | null => {
+  if (selectedDirection === null) {
+    return null;
+  }
+
+  const timesList = [
+    [
+      "Monday - Saturday",
+      ...getTimes(hoursOfOperation, "week", selectedDirection)
+    ],
+    ["Sunday", ...getTimes(hoursOfOperation, "sunday", selectedDirection)]
+  ];
+
+  return (
+    <div className="">
+      {timesList.map(([label, firstTime, lastTime]) => (
+        <>
+          <h4>{label}</h4>
+          <div className="first-last-trips">
+            <div className="first-last-trips__trip">
+              <span className="schedule-finder__first-last-trip-label">
+                First Trip
+              </span>
+              {firstTime}
+            </div>
+            <div className="first-last-trips__trip">
+              <span className="schedule-finder__first-last-trip-label">
+                Last Trip
+              </span>
+              {lastTime}
+            </div>
+          </div>
+        </>
+      ))}
+    </div>
+  );
+};
+
+export default FirstLastTimes;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -5,17 +5,20 @@ import {
   UserInput
 } from "../ScheduleFinder";
 import UpcomingDepartures from "./UpcomingDepartures";
+import ScheduleNote from "../ScheduleNote";
 import { Route, RouteType } from "../../../__v3api";
 import {
   SimpleStop,
   StopPrediction,
   RoutePatternsByDirection,
-  ServiceInSelector
+  ServiceInSelector,
+  ScheduleNote as ScheduleNoteType
 } from "../__schedule";
 import isSilverLine from "../../../helpers/silver-line";
 import { reducer } from "../../../helpers/fetch";
 import ServiceSelector from "./ServiceSelector";
 import { breakTextAtSlash } from "../../../helpers/text";
+import FirstLastTimes from "./FirstLastTimes";
 
 const stopInfo = (
   selectedOrigin: string,
@@ -84,6 +87,7 @@ interface Props {
   stops: SimpleStop[];
   routePatternsByDirection: RoutePatternsByDirection;
   today: string;
+  scheduleNote?: ScheduleNoteType;
 }
 
 const ScheduleModalContent = ({
@@ -100,7 +104,8 @@ const ScheduleModalContent = ({
   ratingEndDate,
   stops,
   routePatternsByDirection,
-  today
+  today,
+  scheduleNote
 }: Props): ReactElement<HTMLElement> | null => {
   const [state, dispatch] = useReducer(reducer, {
     data: null,
@@ -130,6 +135,35 @@ const ScheduleModalContent = ({
       ? "All branches"
       : directionDestinations[selectedDirection];
 
+  let ScheduledTripsOrScheduleNote: ReactElement<HTMLElement>;
+
+  if (scheduleNote) {
+    ScheduledTripsOrScheduleNote = (
+      <>
+        <h3>Daily Schedules</h3>
+        <FirstLastTimes
+          hoursOfOperation={scheduleNote.hours_of_operation!}
+          selectedDirection={selectedDirection}
+        />
+        <ScheduleNote
+          className="m-schedule-page__schedule-notes--modal"
+          scheduleNote={scheduleNote}
+        />
+      </>
+    );
+  } else {
+    ScheduledTripsOrScheduleNote = (
+      <ServiceSelector
+        stopId={selectedOrigin}
+        services={services}
+        ratingEndDate={ratingEndDate}
+        routeId={routeId}
+        directionId={selectedDirection}
+        routePatterns={routePatternsByDirection[selectedDirection]}
+      />
+    );
+  }
+
   return (
     <>
       <div className="schedule-finder__modal-header">
@@ -146,14 +180,7 @@ const ScheduleModalContent = ({
       </div>
       <div>from {stopNameLink(selectedOrigin, stops)}</div>
       <UpcomingDepartures state={state} input={input} />
-      <ServiceSelector
-        stopId={selectedOrigin}
-        services={services}
-        ratingEndDate={ratingEndDate}
-        routeId={routeId}
-        directionId={selectedDirection}
-        routePatterns={routePatternsByDirection[selectedDirection]}
-      />
+      {ScheduledTripsOrScheduleNote}
     </>
   );
 };

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -55,6 +55,7 @@ type fetchAction =
   | { type: "FETCH_ERROR" }
   | { type: "FETCH_STARTED" };
 
+// Upcoming departures
 export const fetchData = (
   routeId: string,
   selectedOrigin: SelectedOrigin,
@@ -142,7 +143,8 @@ const ScheduleModalContent = ({
       <>
         <h3>Daily Schedules</h3>
         <FirstLastTimes
-          hoursOfOperation={scheduleNote.hours_of_operation!}
+          routeId={routeId}
+          selectedOrigin={selectedOrigin}
           selectedDirection={selectedDirection}
         />
         <ScheduleNote

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleTable.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleTable.tsx
@@ -54,18 +54,24 @@ const ScheduleTable = ({
 
   return (
     <>
-      <div className="schedule-finder__first-last-trip">
-        <div className="u-small-caps u-bold">First Trip</div>
-        {firstTrip.departure.time}
+      <div className="schedule-finder__first-last-trip--bordered first-last-trips">
+        <div className="first-last-trips__trip">
+          <span className="schedule-finder__first-last-trip-label">
+            First Trip
+          </span>
+          {firstTrip.departure.time}
+        </div>
         {lastTrip && (
-          <>
-            <div className="u-small-caps u-bold">Last Trip</div>
+          <div className="first-last-trips__trip">
+            <span className="schedule-finder__first-last-trip-label">
+              Last Trip
+            </span>
             {lastTrip.departure.time}
-          </>
+          </div>
         )}
       </div>
       {anySchoolTrips && (
-        <p className="text-center">
+        <p>
           <strong>S</strong> - Does NOT run on school vacation
         </p>
       )}

--- a/apps/site/assets/ts/schedule/schedule-loader.tsx
+++ b/apps/site/assets/ts/schedule/schedule-loader.tsx
@@ -72,7 +72,8 @@ const renderDirectionAndMap = (
     services,
     rating_end_date: ratingEndDate,
     stops,
-    today
+    today,
+    schedule_note: scheduleNote
   } = schedulePageData;
 
   let mapData: MapData | undefined;
@@ -100,6 +101,7 @@ const renderDirectionAndMap = (
       ratingEndDate={ratingEndDate}
       stops={stops}
       today={today}
+      scheduleNote={scheduleNote || undefined}
     />,
     root
   );

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -131,6 +131,7 @@ defmodule SiteWeb.Router do
     get("/schedules", ModeController, :index)
     get("/schedules/predictions_api", ModeController, :predictions_api)
     get("/schedules/schedule_api", ScheduleController.ScheduleApi, :show)
+    get("/schedules/schedule_api/hours", ScheduleController.ScheduleApi, :hours)
     get("/schedules/map_api", ScheduleController.MapApi, :show)
     get("/schedules/line_api", ScheduleController.LineApi, :show)
     get("/schedules/subway", ModeController, :subway)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedule Finder | Show schedule note instead of trips for subway](https://app.asana.com/0/385363666817452/1156654983519748/f)

Note: The official hours of operation published by plans and schedules on the system map is: "Bus and Rapid Transit services run from 5:15 a.m. to 12:30 a.m., Monday– Saturday; Sunday from 6:00 a.m. to 12:30 a.m." -- I'm using this as a stopgap until we refactor and have a reasonable way to fetch the first and last trips down to the minute specific to each origin/direction/destination.