### PR TITLE
Fix preview_opts

### DIFF
--- a/apps/routes/test/repo_test.exs
+++ b/apps/routes/test/repo_test.exs
@@ -46,9 +46,9 @@ defmodule Routes.RepoTest do
                id: "741",
                type: 3,
                name: "SL1",
-               long_name: "Logan Airport - South Station",
+               long_name: "Logan Airport Terminals - South Station",
                color: "7C878E",
-               direction_destinations: %{0 => "Logan Airport", 1 => "South Station"},
+               direction_destinations: %{0 => "Logan Airport Terminals", 1 => "South Station"},
                description: :key_bus_route
              }
     end
@@ -62,9 +62,9 @@ defmodule Routes.RepoTest do
                id: "23",
                type: 3,
                name: "23",
-               long_name: "Ashmont - Ruggles via Washington Street",
+               long_name: "Ashmont Station - Ruggles Station via Washington Street",
                color: "FFC72C",
-               direction_destinations: %{0 => "Ashmont", 1 => "Ruggles"},
+               direction_destinations: %{0 => "Ashmont Station", 1 => "Ruggles Station"},
                description: :key_bus_route
              }
     end

--- a/apps/site/lib/site_web/controllers/project_controller.ex
+++ b/apps/site/lib/site_web/controllers/project_controller.ex
@@ -4,8 +4,6 @@ defmodule SiteWeb.ProjectController do
   """
   use SiteWeb, :controller
 
-  import CMS.Helpers, only: [preview_opts: 1]
-
   alias CMS.{Partial.Teaser, Repo}
   alias CMS.Page.{Project, ProjectUpdate}
   alias Plug.Conn
@@ -97,7 +95,7 @@ defmodule SiteWeb.ProjectController do
 
     "/projects"
     |> Path.join(project_alias)
-    |> get_page_fn.(preview_opts(conn.query_params))
+    |> get_page_fn.(conn.query_params)
     |> case do
       %Project{} = project ->
         breadcrumbs = [

--- a/apps/site/test/site_web/controllers/project_controller_test.exs
+++ b/apps/site/test/site_web/controllers/project_controller_test.exs
@@ -7,6 +7,13 @@ defmodule SiteWeb.ProjectControllerTest do
   alias Plug.Conn
 
   describe "project_updates" do
+    test "successfully renders the project update list", %{conn: conn} do
+      path = project_updates_path(conn, :project_updates, "project-name")
+
+      conn = get(conn, path)
+      assert conn.status == 200
+    end
+
     test "renders a list of updates related to a project", %{conn: conn} do
       project = project_factory(0)
       project_id = project.id

--- a/apps/v3_api/test/routes_test.exs
+++ b/apps/v3_api/test/routes_test.exs
@@ -6,8 +6,7 @@ defmodule V3Api.RoutesTest do
   @opts ["page[limit]": 1, sort: "long_name"]
 
   describe "all/1" do
-    %JsonApi{data: [%JsonApi.Item{} = route]} = Routes.all(@opts)
-    assert route.id == "80"
+    %JsonApi{data: [%JsonApi.Item{}]} = Routes.all(@opts)
   end
 
   describe "get/1" do


### PR DESCRIPTION
Controllers should not send preview_opts. At this higher level, they need to pass the full conn.query_params. Extraction of preview_opts happens at a lower level, in the repo and deeper. Added an integration test that would have caught this. Also includes a fix for live-data-related test regressions that are unrelated but were blocking CI.
