### PR TITLE
Add deprecation note for Title Card Set paragraph type

### DIFF
--- a/apps/cms/lib/partial/paragraph/title_card_set.ex
+++ b/apps/cms/lib/partial/paragraph/title_card_set.ex
@@ -1,5 +1,6 @@
 defmodule CMS.Partial.Paragraph.TitleCardSet do
   @moduledoc """
+  DEPRECATED. Use %DescriptiveLink{} structs inside %Column{} structs instead.
   Represents a collection of Title Cards in the CMS
   """
   defstruct descriptive_links: []

--- a/apps/cms/lib/partial/paragraph/title_card_set.ex
+++ b/apps/cms/lib/partial/paragraph/title_card_set.ex
@@ -1,7 +1,9 @@
 defmodule CMS.Partial.Paragraph.TitleCardSet do
   @moduledoc """
-  DEPRECATED. Use %DescriptiveLink{} structs inside %Column{} structs instead.
-  Represents a collection of Title Cards in the CMS
+  DEPRECATED. This paragraph type is being retained for historical purposes
+  (which is why we're not pulling it), but it is no longer used in any current
+  CMS content (and can no longer be added via the CMS). Use Descriptive Links
+  within a  Multi Column layout instead.
   """
   defstruct descriptive_links: []
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket.

Follow on to mbta/cms#321

This paragraph type is being retained for historical purposes (which is why we're not pulling it), but it is no longer used in any current CMS content (and can no longer be added via the CMS). Use Descriptive Links and MultiColumn layout instead.

Also note that this struct is being hard coded at the bottom of news pages in Elixir land, but that is the only remaining artifact.