### PR TITLE
Add header sub-paragraphs to Photo Gallery and Accordion ¶ types

### DIFF
--- a/apps/cms/lib/partial/paragraph.ex
+++ b/apps/cms/lib/partial/paragraph.ex
@@ -145,8 +145,8 @@ defmodule CMS.Partial.Paragraph do
     PeopleGrid.from_api(para)
   end
 
-  def from_api(%{"type" => [%{"target_id" => "photo_gallery"}]} = para, _preview_opts) do
-    PhotoGallery.from_api(para)
+  def from_api(%{"type" => [%{"target_id" => "photo_gallery"}]} = para, preview_opts) do
+    PhotoGallery.from_api(para, preview_opts)
   end
 
   def from_api(%{"type" => [%{"target_id" => "tabs"}]} = para, preview_opts) do

--- a/apps/cms/lib/partial/paragraph/accordion.ex
+++ b/apps/cms/lib/partial/paragraph/accordion.ex
@@ -11,12 +11,14 @@ defmodule CMS.Partial.Paragraph.Accordion do
 
   import CMS.Helpers, only: [field_value: 2, parse_paragraphs: 3]
 
-  alias CMS.Partial.Paragraph.AccordionSection
+  alias CMS.Partial.Paragraph.{AccordionSection, ColumnMultiHeader}
 
-  defstruct display: "",
+  defstruct header: nil,
+            display: "",
             sections: []
 
   @type t :: %__MODULE__{
+          header: ColumnMultiHeader.t() | nil,
           display: String.t(),
           sections: [AccordionSection.t()]
         }
@@ -24,8 +26,9 @@ defmodule CMS.Partial.Paragraph.Accordion do
   @spec from_api(map, Keyword.t()) :: t
   def from_api(data, preview_opts \\ []) do
     %__MODULE__{
+      header: data |> parse_paragraphs(preview_opts, "field_multi_column_header") |> List.first(),
       display: field_value(data, "field_tabs_display"),
-      sections: parse_paragraphs(data, preview_opts, "field_tabs")
+      sections: data |> parse_paragraphs(preview_opts, "field_tabs")
     }
   end
 end

--- a/apps/cms/lib/partial/paragraph/photo_gallery.ex
+++ b/apps/cms/lib/partial/paragraph/photo_gallery.ex
@@ -3,17 +3,23 @@ defmodule CMS.Partial.Paragraph.PhotoGallery do
   Represents the Photo Gallery Paragraph type in the CMS. It
   contains a media reference (image) field with multiple values.
   """
-  import CMS.Helpers, only: [parse_images: 2]
+  import CMS.Helpers, only: [parse_images: 2, parse_paragraphs: 3]
 
   alias CMS.Field.Image
+  alias CMS.Partial.Paragraph.ColumnMultiHeader
 
-  defstruct images: []
+  defstruct header: nil,
+            images: []
 
-  @type t :: %__MODULE__{images: [Image.t()]}
+  @type t :: %__MODULE__{
+          header: ColumnMultiHeader.t() | nil,
+          images: [Image.t()]
+        }
 
-  @spec from_api(map) :: t
-  def from_api(data) do
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(data, preview_opts \\ []) do
     %__MODULE__{
+      header: data |> parse_paragraphs(preview_opts, "field_multi_column_header") |> List.first(),
       images: parse_images(data, "field_image")
     }
   end

--- a/apps/cms/priv/landing_page_with_all_paragraphs.json
+++ b/apps/cms/priv/landing_page_with_all_paragraphs.json
@@ -3663,7 +3663,8 @@
         {
           "value": "collapsible"
         }
-      ]
+      ],
+      "field_multi_column_header": []
     },
     {
       "target_id": 4192,

--- a/apps/cms/priv/landing_page_with_all_paragraphs.json
+++ b/apps/cms/priv/landing_page_with_all_paragraphs.json
@@ -6073,7 +6073,8 @@
           "alt": "A Green Line train arrives at an above-ground platform, and riders board in the background.",
           "url": "https://live-mbta.pantheonsite.io/sites/default/files/styles/max_1300x1300/public/projects/glx/existing-green-line/greee-line-train-platform-riders-BU.jpg?itok=fuU9HBUS"
         }
-      ]
+      ],
+      "field_multi_column_header": []
     },
     {
       "target_id": 38,

--- a/apps/cms/test/paragraph_test.exs
+++ b/apps/cms/test/paragraph_test.exs
@@ -177,6 +177,7 @@ defmodule CMS.ParagraphTest do
       api_data = api_paragraph("photo_gallery")
 
       assert %PhotoGallery{
+               header: nil,
                images: [
                  %Image{},
                  %Image{},

--- a/apps/cms/test/paragraph_test.exs
+++ b/apps/cms/test/paragraph_test.exs
@@ -192,6 +192,7 @@ defmodule CMS.ParagraphTest do
       api_data = api_paragraph("tabs")
 
       assert %Accordion{
+               header: nil,
                display: "collapsible",
                sections: [
                  %AccordionSection{} = section1,

--- a/apps/site/lib/site_web/templates/cms/paragraph/_accordion.html.eex
+++ b/apps/site/lib/site_web/templates/cms/paragraph/_accordion.html.eex
@@ -1,3 +1,7 @@
+<%= if @content.header do %>
+  <%= ContentRewriter.rewrite(@content.header.text, @conn) %>
+<% end %>
+
 <%= SiteWeb.PartialView.render("_accordion_ui.html",
   Map.merge(assigns, %{
     multiselectable: false,

--- a/apps/site/lib/site_web/templates/cms/paragraph/_photo_gallery.html.eex
+++ b/apps/site/lib/site_web/templates/cms/paragraph/_photo_gallery.html.eex
@@ -1,3 +1,7 @@
+<%= if @content.header do %>
+  <%= ContentRewriter.rewrite(@content.header.text, @conn) %>
+<% end %>
+
 <figure class="c-media c-media--widget c-media--wide">
   <div class="c-media__content">
     <div class="c-photo-gallery clearfix" data-component="photo-gallery">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Photo galleries + tabbed interfaces should have a header option](https://app.asana.com/0/399597520748778/1156296908503857)

Adds common Header type paragraph inside Photo Gallery and Accordion types. Makes consistent with Multi Column and Descriptive List types.

CMS Ticket: mbta/cms#322
