### PR TITLE
Add conditional display of schedule note to modal

### DIFF
--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -58,6 +58,19 @@
   padding: $base-spacing * 2 $base-spacing;
 }
 
+.m-schedule-page__schedule-notes--modal {
+  margin-top: $base-spacing;
+  padding: $base-spacing;
+
+  .m-schedule-page__schedule-note-title {
+    display: none;
+
+    + .m-schedule-page__schedule-note .m-schedule-page__service {
+      margin-top: 0;
+    }
+  }
+}
+
 .m-schedule-page__schedule-notes--desktop {
   margin-top: $base-spacing * 2;
 

--- a/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
@@ -81,6 +81,7 @@ describe("LineDiagram without branches", () => {
         ratingEndDate="2020-03-14"
         stops={{ 0: stops, 1: stops }}
         today="2019-12-05"
+        scheduleNote={null}
       />
     );
   });
@@ -188,6 +189,7 @@ describe("LineDiagram with branches going outward", () => {
         ratingEndDate="2020-03-14"
         stops={{ 0: stops, 1: stops }}
         today="2019-12-05"
+        scheduleNote={null}
       />
     );
   });
@@ -273,6 +275,7 @@ describe("LineDiagram for CR with branches going inward", () => {
         ratingEndDate="2020-03-14"
         stops={{ 0: stops, 1: stops }}
         today="2019-12-05"
+        scheduleNote={null}
       />
     );
   });

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -143,6 +143,7 @@ const getComponent = () => (
     ratingEndDate="2020-03-14"
     stops={{ stops }}
     today="2019-12-05"
+    scheduleNote={null}
   />
 );
 
@@ -158,6 +159,7 @@ const getSubwayComponent = () => (
     ratingEndDate="2020-03-14"
     stops={{ stops }}
     today="2019-12-05"
+    scheduleNote={null}
   />
 );
 
@@ -173,6 +175,7 @@ const getStaticMapComponent = () => (
     ratingEndDate="2020-03-14"
     stops={{ stops }}
     today="2019-12-05"
+    scheduleNote={null}
   />
 );
 
@@ -204,6 +207,7 @@ const getGreenLineComponent = () => {
       ratingEndDate="2020-03-14"
       stops={{ stops }}
       today="2019-12-05"
+      scheduleNote={null}
     />
   );
 };

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleFinderTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleFinderTest.tsx
@@ -164,6 +164,7 @@ it("renders", () => {
         ratingEndDate="2020-03-14"
         routePatternsByDirection={routePatternsByDirection}
         today={today}
+        scheduleNote={null}
       />
     )
     .toJSON();
@@ -182,6 +183,7 @@ it("opens modal after displaying error", () => {
       ratingEndDate="2020-03-14"
       routePatternsByDirection={routePatternsByDirection}
       today={today}
+      scheduleNote={null}
     />
   );
 
@@ -296,6 +298,7 @@ it("modal renders route pill for bus lines", () => {
       ratingEndDate="2020-03-14"
       routePatternsByDirection={routePatternsByDirection}
       today={today}
+      scheduleNote={null}
     />
   );
   subwayWrapper
@@ -322,6 +325,7 @@ it("modal renders route pill for bus lines", () => {
       ratingEndDate="2020-03-14"
       routePatternsByDirection={routePatternsByDirection}
       today={today}
+      scheduleNote={null}
     />
   );
   busWrapper
@@ -348,6 +352,7 @@ it("modal renders route pill for silver line", () => {
       ratingEndDate="2020-03-14"
       routePatternsByDirection={routePatternsByDirection}
       today={today}
+      scheduleNote={null}
     />
   );
   subwayWrapper
@@ -374,6 +379,7 @@ it("modal renders route pill for silver line", () => {
       ratingEndDate="2020-03-14"
       routePatternsByDirection={routePatternsByDirection}
       today={today}
+      scheduleNote={null}
     />
   );
   busWrapper
@@ -400,6 +406,7 @@ it("modal renders route pill for silver line", () => {
       routePatternsByDirection={routePatternsByDirection}
       today={today}
       ratingEndDate={ratingEndDate}
+      scheduleNote={null}
     />
   );
   subwayWrapper
@@ -426,6 +433,7 @@ it("modal renders route pill for silver line", () => {
       routePatternsByDirection={routePatternsByDirection}
       today={today}
       ratingEndDate={ratingEndDate}
+      scheduleNote={null}
     />
   );
   busWrapper

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleModalTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleModalTest.tsx
@@ -7,6 +7,8 @@ import ScheduleModalContent, {
 import { SimpleStop } from "../components/__schedule";
 import { EnhancedJourney } from "../components/__trips";
 import departuresResponse from "../__tests__/departures.json";
+import ScheduleNote from "../components/ScheduleNote";
+import { createReactRoot } from "../../app/helpers/testUtils";
 
 const today = "2019-12-05";
 const route: EnhancedRoute = {
@@ -21,6 +23,15 @@ const route: EnhancedRoute = {
   type: 1
 };
 
+const scheduleNoteData = {
+  offpeak_service: "8-12 minutes",
+  peak_service: "5 minutes",
+  exceptions: [
+    { service: "26 minutes", type: "weekend mornings and late night" }
+  ],
+  alternate_text: null
+};
+
 const stops: SimpleStop[] = [
   { name: "Malden Center", id: "place-mlmnl", is_closed: false, zone: "1" },
   { name: "Wellington", id: "place-welln", is_closed: false, zone: "2" }
@@ -29,7 +40,7 @@ const stops: SimpleStop[] = [
 export const payload: EnhancedJourney[] = departuresResponse as EnhancedJourney[];
 
 describe("ScheduleModal", () => {
-  it("it renders", () => {
+  it("renders", () => {
     let tree;
     act(() => {
       tree = renderer.create(
@@ -42,6 +53,7 @@ describe("ScheduleModal", () => {
           ratingEndDate="2020-03-14"
           routePatternsByDirection={{}}
           today={today}
+          scheduleNote={null}
         />
       );
     });
@@ -49,7 +61,7 @@ describe("ScheduleModal", () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("it doesn't render if selectedOrigin is null", () => {
+  it("doesn't render if selectedOrigin is null", () => {
     let tree;
     act(() => {
       tree = renderer.create(
@@ -62,13 +74,14 @@ describe("ScheduleModal", () => {
           ratingEndDate="2020-03-14"
           routePatternsByDirection={{}}
           today={today}
+          scheduleNote={null}
         />
       );
       expect(tree!.toJSON()).toBeNull();
     });
   });
 
-  it("it doesn't render if selectedDirection is null", () => {
+  it("doesn't render if selectedDirection is null", () => {
     let tree;
     act(() => {
       tree = renderer.create(
@@ -81,10 +94,31 @@ describe("ScheduleModal", () => {
           ratingEndDate="2020-03-14"
           routePatternsByDirection={{}}
           today={today}
+          scheduleNote={null}
         />
       );
       expect(tree!.toJSON()).toBeNull();
     });
+  });
+
+  it("renders with schedule note if present", () => {
+    createReactRoot();
+    const tree = renderer.create(
+      <ScheduleModalContent
+        route={route}
+        stops={stops}
+        selectedOrigin={stops[0].id}
+        selectedDirection={0}
+        services={[]}
+        ratingEndDate="2020-03-14"
+        routePatternsByDirection={{}}
+        today={today}
+        scheduleNote={scheduleNoteData}
+      />
+    );
+    expect(
+      tree.root.findByType(ScheduleNote).props.scheduleNote.offpeak_service
+    ).toBe("8-12 minutes");
   });
 
   describe("fetchData", () => {

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LineDiagram for CR with branches going inward renders and matches snapshot 1`] = `
-"<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}} today=\\"2019-12-05\\">
+"<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}} today=\\"2019-12-05\\" scheduleNote={{...}}>
   <h3 className=\\"m-schedule-diagram__heading\\">
     Stations
   </h3>
@@ -330,7 +330,7 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
 `;
 
 exports[`LineDiagram with branches going outward renders and matches snapshot 1`] = `
-"<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}} today=\\"2019-12-05\\">
+"<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}} today=\\"2019-12-05\\" scheduleNote={{...}}>
   <h3 className=\\"m-schedule-diagram__heading\\">
     Stops
   </h3>
@@ -649,7 +649,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
 `;
 
 exports[`LineDiagram without branches renders and matches snapshot 1`] = `
-"<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}} today=\\"2019-12-05\\">
+"<LineDiagram lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} ratingEndDate=\\"2020-03-14\\" stops={{...}} today=\\"2019-12-05\\" scheduleNote={{...}}>
   <h3 className=\\"m-schedule-diagram__heading\\">
     Stops
   </h3>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleModalTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleModalTest.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ScheduleModal it renders 1`] = `
+exports[`ScheduleModal renders 1`] = `
 Array [
   <div
     className="schedule-finder__modal-header"

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/UpcomingDeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/UpcomingDeparturesTest.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ScheduleModal it renders 1`] = `
+exports[`ScheduleModal renders 1`] = `
 Array [
   <div
     className="schedule-finder__modal-header"

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -5,7 +5,8 @@ import {
   RoutePatternsByDirection,
   LineDiagramStop,
   SimpleStopMap,
-  ServiceInSelector
+  ServiceInSelector,
+  ScheduleNote as ScheduleNoteType
 } from "./__schedule";
 import ScheduleDirectionMenu from "./direction/ScheduleDirectionMenu";
 import ScheduleDirectionButton from "./direction/ScheduleDirectionButton";
@@ -27,6 +28,7 @@ export interface Props {
   ratingEndDate: string;
   stops: SimpleStopMap;
   today: string;
+  scheduleNote: ScheduleNoteType | null;
 }
 
 export const fetchMapData = (
@@ -84,7 +86,8 @@ const ScheduleDirection = ({
   services,
   ratingEndDate,
   stops,
-  today
+  today,
+  scheduleNote
 }: Props): ReactElement<HTMLElement> => {
   const defaultRoutePattern = routePatternsByDirection[directionId].slice(
     0,
@@ -178,6 +181,7 @@ const ScheduleDirection = ({
           ratingEndDate={ratingEndDate}
           stops={stops}
           today={today}
+          scheduleNote={scheduleNote}
         />
       )}
     </>

--- a/apps/site/assets/ts/schedule/components/ScheduleFinder.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleFinder.tsx
@@ -4,7 +4,8 @@ import {
   SimpleStop,
   SimpleStopMap,
   RoutePatternsByDirection,
-  ServiceInSelector
+  ServiceInSelector,
+  ScheduleNote as ScheduleNoteType
 } from "./__schedule";
 import { handleReactEnterKeyPress } from "../../helpers/keyboard-events";
 import icon from "../../../static/images/icon-schedule-finder.svg";
@@ -23,6 +24,7 @@ interface Props {
   stops: SimpleStopMap;
   routePatternsByDirection: RoutePatternsByDirection;
   today: string;
+  scheduleNote: ScheduleNoteType | null;
 }
 
 export type SelectedDirection = 0 | 1 | null;
@@ -65,7 +67,8 @@ const ScheduleFinder = ({
   ratingEndDate,
   stops,
   routePatternsByDirection,
-  today
+  today,
+  scheduleNote
 }: Props): ReactElement<HTMLElement> => {
   const {
     direction_destinations: directionDestinations,
@@ -270,6 +273,7 @@ const ScheduleFinder = ({
                 stops={stops[state.selectedDirection!]}
                 routePatternsByDirection={routePatternsByDirection}
                 today={today}
+                scheduleNote={scheduleNote}
               />
             )}
           </>

--- a/apps/site/assets/ts/schedule/components/SchedulePage.tsx
+++ b/apps/site/assets/ts/schedule/components/SchedulePage.tsx
@@ -47,6 +47,7 @@ const SchedulePage = ({
         directionId={directionId}
         routePatternsByDirection={routePatternsByDirection}
         today={today}
+        scheduleNote={null}
       />
     )}
     <ContentTeasers teasers={teasers} />

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -7,7 +7,8 @@ import {
   SimpleStopMap,
   RouteStop,
   StopData,
-  ServiceInSelector
+  ServiceInSelector,
+  ScheduleNote as ScheduleNoteType
 } from "../__schedule";
 import SingleStop from "./SingleStop";
 import Modal from "../../../components/Modal";
@@ -24,6 +25,7 @@ interface Props {
   ratingEndDate: string;
   stops: SimpleStopMap;
   today: string;
+  scheduleNote: ScheduleNoteType | null;
 }
 
 export interface LiveDataByStop {
@@ -74,7 +76,8 @@ const LineDiagram = ({
   services,
   ratingEndDate,
   stops,
-  today
+  today,
+  scheduleNote
 }: Props): ReactElement<HTMLElement> | null => {
   const routeType = route.type;
   const routeColor: string = route.color || "#000";
@@ -277,6 +280,7 @@ const LineDiagram = ({
             stops={stops[directionId]}
             routePatternsByDirection={routePatternsByDirection}
             today={today}
+            scheduleNote={scheduleNote}
           />
         )}
       </Modal>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -10,12 +10,14 @@ import {
   SimpleStop,
   StopPrediction,
   RoutePatternsByDirection,
-  ServiceInSelector
+  ServiceInSelector,
+  ScheduleNote as ScheduleNoteType
 } from "../__schedule";
 import isSilverLine from "../../../helpers/silver-line";
 import { reducer } from "../../../helpers/fetch";
 import ServiceSelector from "./ServiceSelector";
 import { breakTextAtSlash } from "../../../helpers/text";
+import ScheduleNote from "../ScheduleNote";
 
 const stopInfo = (
   selectedOrigin: string,
@@ -84,6 +86,7 @@ interface Props {
   stops: SimpleStop[];
   routePatternsByDirection: RoutePatternsByDirection;
   today: string;
+  scheduleNote: ScheduleNoteType | null;
 }
 
 const ScheduleModalContent = ({
@@ -100,7 +103,8 @@ const ScheduleModalContent = ({
   ratingEndDate,
   stops,
   routePatternsByDirection,
-  today
+  today,
+  scheduleNote
 }: Props): ReactElement<HTMLElement> | null => {
   const [state, dispatch] = useReducer(reducer, {
     data: null,
@@ -146,14 +150,21 @@ const ScheduleModalContent = ({
       </div>
       <div>from {stopNameLink(selectedOrigin, stops)}</div>
       <UpcomingDepartures state={state} input={input} />
-      <ServiceSelector
-        stopId={selectedOrigin}
-        services={services}
-        ratingEndDate={ratingEndDate}
-        routeId={routeId}
-        directionId={selectedDirection}
-        routePatterns={routePatternsByDirection[selectedDirection]}
-      />
+      {scheduleNote ? (
+        <ScheduleNote
+          className="m-schedule-page__schedule-notes--modal"
+          scheduleNote={scheduleNote}
+        />
+      ) : (
+        <ServiceSelector
+          stopId={selectedOrigin}
+          services={services}
+          ratingEndDate={ratingEndDate}
+          routeId={routeId}
+          directionId={selectedDirection}
+          routePatterns={routePatternsByDirection[selectedDirection]}
+        />
+      )}
     </>
   );
 };

--- a/apps/site/assets/ts/schedule/schedule-loader.tsx
+++ b/apps/site/assets/ts/schedule/schedule-loader.tsx
@@ -53,6 +53,7 @@ const renderSchedulePage = (schedulePageData: SchedulePageData): void => {
         ratingEndDate={ratingEndDate}
         routePatternsByDirection={routePatternsByDirection}
         today={today}
+        scheduleNote={null}
       />,
       document.getElementById("react-schedule-finder-root")
     );
@@ -72,7 +73,8 @@ const renderDirectionAndMap = (
     services,
     rating_end_date: ratingEndDate,
     stops,
-    today
+    today,
+    schedule_note: scheduleNote
   } = schedulePageData;
 
   let mapData: MapData | undefined;
@@ -100,6 +102,7 @@ const renderDirectionAndMap = (
       ratingEndDate={ratingEndDate}
       stops={stops}
       today={today}
+      scheduleNote={scheduleNote}
     />,
     root
   );


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedule Finder | Show schedule note instead of trips for subway](https://app.asana.com/0/385363666817452/1156654983519748/f)

If there is a schedule note present, which should happen on subway lines, the schedule note will display in place of the service picker + daily schedules listing.

<img width="866" alt="image" src="https://user-images.githubusercontent.com/2136286/73307899-21e60a00-41ed-11ea-8474-995003c4e985.png">

It's mostly the same code from #354 so I'm hopeful review will be easy!
