### PR TITLE
Render multi-day storm schedule dates correctly

### DIFF
--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -45,6 +45,9 @@ export const groupByType = (
   return { ...acc, [currentServiceType]: updatedGroup };
 };
 
+const startToEnd = (startDateObject: Date, endDateObject: Date): string =>
+  `${formattedDate(startDateObject)} to ${formattedDate(endDateObject)}`;
+
 export const groupServiceByDate = (
   service: ServiceWithServiceDate,
   ratingEndDate: string
@@ -81,10 +84,15 @@ export const groupServiceByDate = (
         ? "current"
         : "future";
 
+    const stormServicePeriod =
+      startDate === endDate
+        ? formattedDate(startDateObject)
+        : startToEnd(startDateObject, endDateObject);
+
     return [
       {
         type,
-        servicePeriod: formattedDate(new Date(startDateObject)),
+        servicePeriod: stormServicePeriod,
         service
       }
     ];
@@ -133,7 +141,7 @@ export const serviceDate = (
       return `starts ${formattedDate(startDateObject)}`;
     }
   }
-  return `${formattedDate(startDateObject)} to ${formattedDate(endDateObject)}`;
+  return startToEnd(startDateObject, endDateObject);
 };
 
 type MonthInteger = number | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;

--- a/apps/site/assets/ts/schedule/__tests__/ServiceSelectorTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ServiceSelectorTest.tsx
@@ -103,11 +103,27 @@ const services: ServiceInSelector[] = [
     added_dates_notes: {},
     added_dates: [],
     "default_service?": false
+  },
+  {
+    valid_days: [1, 2, 3, 4, 5],
+    typicality: "unplanned_disruption",
+    type: "weekday",
+    start_date: "2019-07-22",
+    service_date: "2019-07-09",
+    removed_dates_notes: {},
+    removed_dates: [],
+    name: "Weekday",
+    id: "BUS319-storm-1",
+    end_date: "2019-07-23",
+    description: "Storm (reduced service)",
+    added_dates_notes: {},
+    added_dates: [],
+    "default_service?": false
   }
 ];
 
 describe("ServiceSelector", () => {
-  it("it renders", () => {
+  it("renders", () => {
     createReactRoot();
     const tree = renderer.create(
       <ServiceSelector

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ServiceSelector it renders 1`] = `
+exports[`ServiceSelector renders 1`] = `
 Array [
   <h3>
     Daily Schedule
@@ -71,6 +71,12 @@ Array [
           >
             Storm service, 
             July 15
+          </option>
+          <option
+            value="BUS319-storm-1"
+          >
+            Storm service, 
+            July 22 to July 23
           </option>
         </optgroup>
       </select>


### PR DESCRIPTION
It's possible for a storm schedule to span several days; however, to
this point, we were implicitly assuming that all storm schedules are one
day long and only showing the start date. Corrected for storm schedules
that span multiple days.

#### Summary of changes
**Asana Ticket:** [❄️ Service picker should be able to handle multi-day snow schedule](https://app.asana.com/0/555089885850811/1157331058180041)