### PR TITLE
Fix new schedules being a blank page in IE11

### DIFF
--- a/apps/site/assets/babel.config.js
+++ b/apps/site/assets/babel.config.js
@@ -8,4 +8,4 @@ module.exports = {
       }
     ]
   ]
-};
+}

--- a/apps/site/assets/tsconfig.webpack.json
+++ b/apps/site/assets/tsconfig.webpack.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig",
   "exclude": [
     "**/__tests__/**/*",
-    "node_modules",
     "vendor/",
     "ts/ts-build/"
   ]

--- a/apps/site/assets/webpack.config.base.js
+++ b/apps/site/assets/webpack.config.base.js
@@ -6,6 +6,20 @@ const webpack = require("webpack");
 const path = require("path");
 const postcssPresetEnv = require("postcss-preset-env");
 
+const babelLoader = {
+  loader: "babel-loader",
+  options: {
+    configFile: "./babel.config.js"
+  }
+};
+
+const tsLoader = {
+  loader: "ts-loader",
+  options: {
+    configFile: "tsconfig.webpack.json"
+  }
+};
+
 module.exports = {
   entry: {
     app: ["./js/app-entry.js"],
@@ -33,22 +47,17 @@ module.exports = {
       {
         test: /\.(ts|tsx)$/,
         exclude: [/node_modules/],
-        use: [
-          { loader: "babel-loader" },
-          {
-            loader: "ts-loader",
-            options: {
-              configFile: "tsconfig.webpack.json"
-            }
-          }
-        ]
+        use: [babelLoader, tsLoader]
       },
       {
         test: /\.(js)$/,
         exclude: [/node_modules/, path.resolve(__dirname, "ts/")],
-        use: {
-          loader: "babel-loader"
-        }
+        use: babelLoader
+      },
+      {
+        // https://docs.react-async.com/getting-started/installation#transpiling-for-legacy-browsers
+        test: /\/node_modules\/react-async\//,
+        use: [babelLoader, tsLoader]
       },
       {
         test: /\.svg$/,


### PR DESCRIPTION
**Asana Ticket:** [🐞 New schedules page is blank in IE11](https://app.asana.com/0/385363666817452/1159531751432025/f)

So as not to mess with our existing Webpack config at all, this creates a new config that explicitly compiles `react-async` using the same options. I've tested this using CBT and it allows IE11 to load the line diagram, though unfortunately the live data is still missing (and it's very unclear why).