### PR TITLE
Add direction and date to CR timetable ARIA label

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -22,6 +22,11 @@ defmodule SiteWeb.ScheduleController.TimetableController do
     as: :assign_direction_id
 
   def show(conn, _) do
+    direction_id = conn.assigns[:direction_id]
+    direction_name = conn.assigns.route.direction_names[direction_id]
+
+    {:ok, formatted_date} = Timex.format(conn.assigns.date, "{Mfull} {D}, {YYYY}")
+
     conn
     |> assign(
       :meta_description,
@@ -29,6 +34,8 @@ defmodule SiteWeb.ScheduleController.TimetableController do
         "schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, " <>
         "and connections."
     )
+    |> assign(:direction_name, direction_name)
+    |> assign(:formatted_date, formatted_date)
     |> put_view(ScheduleView)
     |> render("show.html", [])
   end

--- a/apps/site/lib/site_web/templates/schedule/_timetable.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_timetable.html.eex
@@ -20,7 +20,7 @@
       </div>
     </div>
     <div id="timetable" class="m-timetable__table-container" data-sticky-container>
-      <table class="m-timetable__table" aria-label="Timetable for <%= @route.name %>">
+      <table class="m-timetable__table" aria-label="<%= @direction_name %> timetable for <%= @route.name %>, <%= @formatted_date %>">
         <tr>
           <th scope="col" class="m-timetable__cell m-timetable__cell--gray m-timetable__cell--first-column m-timetable__cell--first-column-header" data-absolute>
             <div class="m-timetable__row-header">Stops</div>

--- a/apps/site/test/site_web/views/schedule/timetable_view_test.exs
+++ b/apps/site/test/site_web/views/schedule/timetable_view_test.exs
@@ -63,7 +63,9 @@ defmodule SiteWeb.Schedule.TimetableViewTest do
         vehicle_locations: vehicle_locations,
         trip_messages: trip_messages,
         trip_schedules: trip_schedules,
-        date_time: ~N[2017-03-01T07:29:00]
+        date_time: ~N[2017-03-01T07:29:00],
+        direction_name: "Southeastbound",
+        formatted_date: "March 1, 2017"
       ]
 
       {:ok, %{assigns: assigns}}


### PR DESCRIPTION
The ARIA label for the commuter rail timetable had the route name, which
was useful, but was lacking the direction and date. Added.

#### Summary of changes
**Asana Ticket:** [Timetable | Add direction to table aria label](https://app.asana.com/0/555089885850811/1130340429843892)