### PR TITLE
Fix odd regex in Webpack prod config

### DIFF
--- a/apps/site/assets/webpack.config.prod.js
+++ b/apps/site/assets/webpack.config.prod.js
@@ -24,11 +24,11 @@ module.exports = env =>
           // Since all entrypoints are dependent on the app entrypoint
           vendor: {
             name: "vendors",
-            test: /[\\/]node_modules[\\/](?!react*)/
+            test: /[\\/]node_modules[\\/](?!react)/
           },
           react: {
             name: "react",
-            test: /[\\/]node_modules[\\/](react*)/
+            test: /[\\/]node_modules[\\/]react/
           }
         }
       }


### PR DESCRIPTION
These are regexes, not wildcard matching; `react*` matches the string "reac" followed by any number of "t", which is likely not what we want. This was harmless anyway since there was no end anchor on the regex.