### PR TITLE
🐞 IE11 Line Diagram | Height of certain elements is wrong

### DIFF
--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -188,7 +188,6 @@ $line-width: 8px; // width of the colored line in the diagram
     fill: $white;
     stroke: currentColor;
     stroke-width: 0;
-    transform-origin: 50%;
   }
 }
 
@@ -197,18 +196,9 @@ $line-width: 8px; // width of the colored line in the diagram
   stroke-width: 1.15px;
 }
 
-.m-schedule-diagram__line--stop {
-  @include circleposition(60px);
-}
-
 // the very first stop - line should begin at the stop
 .m-schedule-diagram > .m-schedule-diagram__stop:first-child .m-schedule-diagram__lines {
   margin-top: $base-spacing;
-}
-
-// any first stop (includes branches)
-.m-schedule-diagram__stop:first-child .m-schedule-diagram__line--terminus {
-  @include circleposition(65px);
 }
 
 // any last stop (includes branches)
@@ -421,8 +411,6 @@ $line-width: 8px; // width of the colored line in the diagram
 
   // first stop on branch
   .m-schedule-diagram__line + .m-schedule-diagram__line--terminus {
-    @include circleposition(65px);
-
     margin-top: $base-spacing * 2;
   }
 

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -10,8 +10,8 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
       <div className=\\"m-schedule-diagram__stop m-schedule-diagram__stop--origin m-schedule-diagram__stop--terminus\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"5\\" cx=\\"50%\\" cy=\\"-66px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"5\\" cx=\\"50%\\" cy=\\"-3px\\" />
             </svg>
           </div>
         </div>
@@ -52,7 +52,7 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
                 <div className=\\"m-schedule-diagram__lines m-schedule-diagram__lines--collapsed\\" style={{...}}>
                   <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--collapsed\\">
                     <div className=\\"m-schedule-diagram__collapsed-icon\\">
-                      <svg viewBox=\\"0 0 10 30\\" className=\\"m-schedule-diagram__line-stop\\">
+                      <svg viewBox=\\"0 0 10 30\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"30px\\" className=\\"m-schedule-diagram__line-stop\\">
                         <circle r=\\"4\\" cy=\\"10\\" cx=\\"50%\\" />
                         <circle r=\\"4\\" cy=\\"20\\" cx=\\"50%\\" />
                         <circle r=\\"4\\" cy=\\"30\\" cx=\\"50%\\" />
@@ -83,8 +83,8 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"5\\" cx=\\"50%\\" cy=\\"-66px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"5\\" cx=\\"50%\\" cy=\\"-3px\\" />
             </svg>
           </div>
         </div>
@@ -122,8 +122,8 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
           <div style={{...}} className=\\"m-schedule-diagram__lines\\">
             <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
             <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-              <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-                <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+              <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+                <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
               </svg>
             </div>
           </div>
@@ -158,8 +158,8 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"5\\" cx=\\"50%\\" cy=\\"-66px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"5\\" cx=\\"50%\\" cy=\\"-3px\\" />
             </svg>
           </div>
         </div>
@@ -202,7 +202,7 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
                   <div className=\\"m-schedule-diagram__line\\" />
                   <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--collapsed\\">
                     <div className=\\"m-schedule-diagram__collapsed-icon\\">
-                      <svg viewBox=\\"0 0 10 30\\" className=\\"m-schedule-diagram__line-stop\\">
+                      <svg viewBox=\\"0 0 10 30\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"30px\\" className=\\"m-schedule-diagram__line-stop\\">
                         <circle r=\\"4\\" cy=\\"10\\" cx=\\"50%\\" />
                         <circle r=\\"4\\" cy=\\"20\\" cx=\\"50%\\" />
                         <circle r=\\"4\\" cy=\\"30\\" cx=\\"50%\\" />
@@ -232,8 +232,8 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
       <div className=\\"m-schedule-diagram__stop\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
           </div>
         </div>
@@ -265,8 +265,8 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
       <div className=\\"m-schedule-diagram__stop\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
           </div>
         </div>
@@ -298,7 +298,7 @@ exports[`LineDiagram for CR with branches going inward renders and matches snaps
       <div className=\\"m-schedule-diagram__stop m-schedule-diagram__stop--destination m-schedule-diagram__stop--terminus\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
               <circle r=\\"5\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
           </div>
@@ -339,8 +339,8 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
       <div className=\\"m-schedule-diagram__stop m-schedule-diagram__stop--origin m-schedule-diagram__stop--terminus\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"5\\" cx=\\"50%\\" cy=\\"-66px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"5\\" cx=\\"50%\\" cy=\\"-3px\\" />
             </svg>
           </div>
         </div>
@@ -372,8 +372,8 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
       <div className=\\"m-schedule-diagram__stop\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
           </div>
         </div>
@@ -405,8 +405,8 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
       <div className=\\"m-schedule-diagram__stop\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
           </div>
         </div>
@@ -445,7 +445,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
                   <div className=\\"m-schedule-diagram__line\\" />
                   <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--collapsed\\">
                     <div className=\\"m-schedule-diagram__collapsed-icon\\">
-                      <svg viewBox=\\"0 0 10 30\\" className=\\"m-schedule-diagram__line-stop\\">
+                      <svg viewBox=\\"0 0 10 30\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"30px\\" className=\\"m-schedule-diagram__line-stop\\">
                         <circle r=\\"4\\" cy=\\"10\\" cx=\\"50%\\" />
                         <circle r=\\"4\\" cy=\\"20\\" cx=\\"50%\\" />
                         <circle r=\\"4\\" cy=\\"30\\" cx=\\"50%\\" />
@@ -477,7 +477,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
               <circle r=\\"5\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
           </div>
@@ -511,8 +511,8 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
           <div style={{...}} className=\\"m-schedule-diagram__lines\\">
             <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
             <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-              <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-                <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+              <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+                <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
               </svg>
             </div>
           </div>
@@ -546,7 +546,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--line\\" />
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
               <circle r=\\"5\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
           </div>
@@ -583,7 +583,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
                 <div className=\\"m-schedule-diagram__lines m-schedule-diagram__lines--collapsed\\" style={{...}}>
                   <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--collapsed\\">
                     <div className=\\"m-schedule-diagram__collapsed-icon\\">
-                      <svg viewBox=\\"0 0 10 30\\" className=\\"m-schedule-diagram__line-stop\\">
+                      <svg viewBox=\\"0 0 10 30\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"30px\\" className=\\"m-schedule-diagram__line-stop\\">
                         <circle r=\\"4\\" cy=\\"10\\" cx=\\"50%\\" />
                         <circle r=\\"4\\" cy=\\"20\\" cx=\\"50%\\" />
                         <circle r=\\"4\\" cy=\\"30\\" cx=\\"50%\\" />
@@ -613,7 +613,7 @@ exports[`LineDiagram with branches going outward renders and matches snapshot 1`
       <div className=\\"m-schedule-diagram__stop m-schedule-diagram__stop--destination m-schedule-diagram__stop--terminus\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
               <circle r=\\"5\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
           </div>
@@ -658,8 +658,8 @@ exports[`LineDiagram without branches renders and matches snapshot 1`] = `
       <div className=\\"m-schedule-diagram__stop m-schedule-diagram__stop--origin m-schedule-diagram__stop--terminus\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"5\\" cx=\\"50%\\" cy=\\"-66px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"5\\" cx=\\"50%\\" cy=\\"-3px\\" />
             </svg>
           </div>
         </div>
@@ -697,8 +697,8 @@ exports[`LineDiagram without branches renders and matches snapshot 1`] = `
       <div className=\\"m-schedule-diagram__stop\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
             <VehicleIcons routeType={3} stopName=\\"Stop 1\\" vehicles={{...}}>
               <div className=\\"m-schedule-diagram__vehicle m-schedule-diagram__vehicle--incoming\\">
@@ -781,8 +781,8 @@ exports[`LineDiagram without branches renders and matches snapshot 1`] = `
       <div className=\\"m-schedule-diagram__stop\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+              <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
             <VehicleIcons routeType={3} stopName=\\"Stop 2\\" vehicles={{...}}>
               <div className=\\"m-schedule-diagram__vehicle m-schedule-diagram__vehicle--in_transit\\">
@@ -861,7 +861,7 @@ exports[`LineDiagram without branches renders and matches snapshot 1`] = `
       <div className=\\"m-schedule-diagram__stop m-schedule-diagram__stop--terminus\\">
         <div style={{...}} className=\\"m-schedule-diagram__lines\\">
           <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--terminus\\">
-            <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
+            <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
               <circle r=\\"5\\" cx=\\"50%\\" cy=\\"32px\\" />
             </svg>
           </div>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -237,11 +237,14 @@ exports[`renders with a static map 1`] = `
             >
               <svg
                 className="m-schedule-diagram__line-stop"
+                height="10px"
+                preserveAspectRatio="xMidYMin slice"
                 viewBox="0 10 10 10"
+                width="100%"
               >
                 <circle
                   cx="50%"
-                  cy="-66px"
+                  cy="-3px"
                   r="5"
                 />
               </svg>
@@ -329,11 +332,14 @@ exports[`renders with a static map 1`] = `
             >
               <svg
                 className="m-schedule-diagram__line-stop"
+                height="10px"
+                preserveAspectRatio="xMidYMin slice"
                 viewBox="0 10 10 10"
+                width="100%"
               >
                 <circle
                   cx="50%"
-                  cy="-32px"
+                  cy="32px"
                   r="4"
                 />
               </svg>
@@ -421,11 +427,14 @@ exports[`renders with a static map 1`] = `
             >
               <svg
                 className="m-schedule-diagram__line-stop"
+                height="10px"
+                preserveAspectRatio="xMidYMin slice"
                 viewBox="0 10 10 10"
+                width="100%"
               >
                 <circle
                   cx="50%"
-                  cy="-32px"
+                  cy="32px"
                   r="4"
                 />
               </svg>
@@ -650,7 +659,10 @@ exports[`renders with a static map 1`] = `
             >
               <svg
                 className="m-schedule-diagram__line-stop"
+                height="10px"
+                preserveAspectRatio="xMidYMin slice"
                 viewBox="0 10 10 10"
+                width="100%"
               >
                 <circle
                   cx="50%"

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/SingleStopTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/SingleStopTest.tsx.snap
@@ -5,8 +5,8 @@ exports[`SingleStop renders and matches snapshot 1`] = `
   <div className=\\"m-schedule-diagram__stop\\">
     <div style={{...}} className=\\"m-schedule-diagram__lines\\">
       <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-        <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-          <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+        <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+          <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
         </svg>
       </div>
     </div>
@@ -41,8 +41,8 @@ exports[`SingleStop renders with Commuter Rail live data 1`] = `
   <div className=\\"m-schedule-diagram__stop\\">
     <div style={{...}} className=\\"m-schedule-diagram__lines\\">
       <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-        <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-          <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+        <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+          <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
         </svg>
         <VehicleIcons routeType={2} stopName=\\"Example Stop\\" vehicles={{...}}>
           <div className=\\"m-schedule-diagram__vehicle m-schedule-diagram__vehicle--in_transit\\">
@@ -117,8 +117,8 @@ exports[`SingleStop renders with live data 1`] = `
   <div className=\\"m-schedule-diagram__stop\\">
     <div style={{...}} className=\\"m-schedule-diagram__lines\\">
       <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-        <svg viewBox=\\"0 10 10 10\\" className=\\"m-schedule-diagram__line-stop\\">
-          <circle r=\\"4\\" cx=\\"50%\\" cy=\\"-32px\\" />
+        <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
+          <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
         </svg>
         <VehicleIcons routeType={{...}} stopName=\\"Example Stop\\" vehicles={{...}}>
           <div className=\\"m-schedule-diagram__vehicle m-schedule-diagram__vehicle--stopped\\">

--- a/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
@@ -43,6 +43,9 @@ const ExpandableBranch = ({
                   <div className="m-schedule-diagram__collapsed-icon">
                     <svg
                       viewBox="0 0 10 30"
+                      preserveAspectRatio="xMidYMin slice"
+                      width="100%"
+                      height="30px"
                       className="m-schedule-diagram__line-stop"
                     >
                       <circle r="4" cy="10" cx="50%" />

--- a/apps/site/assets/ts/schedule/components/line-diagram/SingleStop.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/SingleStop.tsx
@@ -143,12 +143,19 @@ const StopBranchLabel = (stop: RouteStop): JSX.Element | null =>
   ) : null;
 
 const StopGraphic = (isOrigin = false, isTerminus = false): JSX.Element => {
-  let yPosition = "-32px";
-  if (isTerminus) {
-    yPosition = isOrigin ? "-66px" : "32px";
+  // this hardcoded position will be shown in IE, otherwise overwritten by CSS
+  let yPosition = "32px";
+  if (isTerminus && isOrigin) {
+    yPosition = "-3px";
   }
   return (
-    <svg viewBox="0 10 10 10" className="m-schedule-diagram__line-stop">
+    <svg
+      viewBox="0 10 10 10"
+      preserveAspectRatio="xMidYMin slice"
+      width="100%"
+      height="10px"
+      className="m-schedule-diagram__line-stop"
+    >
       <circle r={`${isTerminus ? "5" : "4"}`} cx="50%" cy={yPosition} />
     </svg>
   );

--- a/apps/site/assets/ts/schedule/components/line-diagram/SingleStop.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/SingleStop.tsx
@@ -142,24 +142,22 @@ const StopBranchLabel = (stop: RouteStop): JSX.Element | null =>
     </div>
   ) : null;
 
-const StopGraphic = (isOrigin = false, isTerminus = false): JSX.Element => {
-  // this hardcoded position will be shown in IE, otherwise overwritten by CSS
-  let yPosition = "32px";
-  if (isTerminus && isOrigin) {
-    yPosition = "-3px";
-  }
-  return (
-    <svg
-      viewBox="0 10 10 10"
-      preserveAspectRatio="xMidYMin slice"
-      width="100%"
-      height="10px"
-      className="m-schedule-diagram__line-stop"
-    >
-      <circle r={`${isTerminus ? "5" : "4"}`} cx="50%" cy={yPosition} />
-    </svg>
-  );
-};
+const StopGraphic = (isOrigin = false, isTerminus = false): JSX.Element => (
+  <svg
+    viewBox="0 10 10 10"
+    preserveAspectRatio="xMidYMin slice"
+    width="100%"
+    height="10px"
+    className="m-schedule-diagram__line-stop"
+  >
+    {/* hardcoded cy position will be shown in IE, otherwise overwritten by CSS */}
+    <circle
+      r={isTerminus ? "5" : "4"}
+      cx="50%"
+      cy={isOrigin && isTerminus ? "-3px" : "32px"}
+    />
+  </svg>
+);
 
 const SingleStop = ({
   stop,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 IE11 Line Diagram | Height of certain elements is wrong](https://app.asana.com/0/385363666817452/1159531751432030/f)

Tweaks some of the markup and styles to ensure consistency between how the line diagram looks in IE11 and other browsers.
