### PR TITLE
Fix React key warnings in new line diagram

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
@@ -36,8 +36,8 @@ const ExpandableBranch = ({
               style={{ color: `#${color}` }}
             >
               <>
-                {times(branchData[0].stop_data.length - 1, () => (
-                  <div className="m-schedule-diagram__line" />
+                {times(branchData[0].stop_data.length - 1, index => (
+                  <div key={index} className="m-schedule-diagram__line" />
                 ))}
                 <div className="m-schedule-diagram__line m-schedule-diagram__line--collapsed">
                   <div className="m-schedule-diagram__collapsed-icon">

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -212,7 +212,12 @@ const LineDiagram = ({
 
               // is an array of 1-2 stops; show as expanded
               return (
-                <div className="m-schedule-diagram__expanded">
+                <div
+                  key={`${stopOrStops[0].route_stop.id}-${
+                    stopOrStops.length
+                  }-stops`}
+                  className="m-schedule-diagram__expanded"
+                >
                   {stopOrStops.map((stop, stopIdx) => (
                     <SingleStop
                       key={stop.route_stop.id}


### PR DESCRIPTION
A couple of elements in arrays didn't have unique keys, causing warnings from React.