### PR TITLE
Fix URLs not linkifying in alerts on stop pages

### DIFF
--- a/apps/site/assets/ts/components/Alerts.tsx
+++ b/apps/site/assets/ts/components/Alerts.tsx
@@ -165,7 +165,8 @@ const Alert = ({ alert }: { alert: AlertType }): ReactElement<HTMLElement> => {
             {`${effectNameForAlert(alert)} `}
             {humanLabelForAlert(alert) ? alertLabel(alert) : null}
           </div>
-          {alert.header}
+          {/* eslint-disable-next-line react/no-danger */}
+          <div dangerouslySetInnerHTML={{ __html: alert.header }} />
         </div>
         <div className="c-alert-item__top-caret-container">
           {caretIcon(alert.description === "", expanded)}

--- a/apps/site/assets/ts/components/__tests__/AlertsTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/AlertsTest.tsx
@@ -21,7 +21,7 @@ const highAlert: Alert = {
   informed_entity: [],
   id: "304666",
   header:
-    "Route 170 will be rerouted at certain times during the Marathon on Monday, April 15.",
+    'Route 170 will be rerouted at certain times during the Marathon on Monday, April 15. More: <a href="https://mbta.com/marathon">mbta.com/marathon</a>',
   effect: "detour",
   description:
     "<strong>Affected direction:</strong><br />Inbound<br />\r<br /><strong>Affected stops:</strong><br />Meridian St @ West Eagle St"

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
@@ -45,7 +45,13 @@ exports[`it renders 1`] = `
                 >
                   Detour 
                 </div>
-                Route 170 will be rerouted at certain times during the Marathon on Monday, April 15.
+                <div
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "Route 170 will be rerouted at certain times during the Marathon on Monday, April 15. More: <a href=\\"https://mbta.com/marathon\\">mbta.com/marathon</a>",
+                    }
+                  }
+                />
               </div>
               <div
                 className="c-alert-item__top-caret-container"
@@ -123,7 +129,13 @@ exports[`it renders 1`] = `
                     Upcoming
                   </span>
                 </div>
-                There is construction at this station.
+                <div
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "There is construction at this station.",
+                    }
+                  }
+                />
               </div>
               <div
                 className="c-alert-item__top-caret-container"

--- a/apps/site/lib/site_web/controllers/stop_controller.ex
+++ b/apps/site/lib/site_web/controllers/stop_controller.ex
@@ -269,6 +269,11 @@ defmodule SiteWeb.StopController do
       end)
     )
     |> Enum.map(
+      &Map.update!(&1, :header, fn header ->
+        HTML.safe_to_string(AlertView.replace_urls_with_links(header))
+      end)
+    )
+    |> Enum.map(
       &Map.update!(&1, :description, fn desc ->
         HTML.safe_to_string(AlertView.format_alert_description(desc))
       end)

--- a/apps/site/lib/site_web/controllers/stop_controller.ex
+++ b/apps/site/lib/site_web/controllers/stop_controller.ex
@@ -256,28 +256,16 @@ defmodule SiteWeb.StopController do
 
   @spec json_safe_alerts([Alert.t()], DateTime.t()) :: [map]
   def json_safe_alerts(alerts, date) do
-    alerts
-    |> Enum.map(&Map.from_struct/1)
-    |> Enum.map(
-      &Map.update!(&1, :active_period, fn active ->
-        Enum.map(active, fn periods -> active_period_to_string(periods) end)
+    Enum.map(alerts, fn alert ->
+      alert
+      |> Map.from_struct()
+      |> Map.update!(:active_period, fn active_periods ->
+        Enum.map(active_periods, &active_period_to_string(&1))
       end)
-    )
-    |> Enum.map(
-      &Map.update!(&1, :updated_at, fn updated ->
-        IO.iodata_to_binary(AlertView.alert_updated(updated, date))
-      end)
-    )
-    |> Enum.map(
-      &Map.update!(&1, :header, fn header ->
-        HTML.safe_to_string(AlertView.replace_urls_with_links(header))
-      end)
-    )
-    |> Enum.map(
-      &Map.update!(&1, :description, fn desc ->
-        HTML.safe_to_string(AlertView.format_alert_description(desc))
-      end)
-    )
+      |> Map.update!(:updated_at, &IO.iodata_to_binary(AlertView.alert_updated(&1, date)))
+      |> Map.update!(:header, &HTML.safe_to_string(AlertView.replace_urls_with_links(&1)))
+      |> Map.update!(:description, &HTML.safe_to_string(AlertView.format_alert_description(&1)))
+    end)
   end
 
   def active_period_to_string({first, last}) do

--- a/apps/site/lib/site_web/views/alert_view.ex
+++ b/apps/site/lib/site_web/views/alert_view.ex
@@ -1,4 +1,5 @@
 defmodule SiteWeb.AlertView do
+  @moduledoc "Helper functions related to displaying Alerts on the web site."
   use SiteWeb, :view
   alias Alerts.{Alert, InformedEntity, InformedEntitySet}
   alias Routes.Route
@@ -206,6 +207,8 @@ defmodule SiteWeb.AlertView do
 
   defp ensure_scheme("http://" <> _ = url), do: url
   defp ensure_scheme("https://" <> _ = url), do: url
+  defp ensure_scheme("mbta.com" <> _ = url), do: "https://" <> url
+  defp ensure_scheme("MBTA.com" <> _ = url), do: "https://" <> url
   defp ensure_scheme(url), do: "http://" <> url
 
   @spec group_header_path(Route.t() | Stop.t()) :: String.t()

--- a/apps/site/test/site_web/controllers/stop_controller_test.exs
+++ b/apps/site/test/site_web/controllers/stop_controller_test.exs
@@ -202,10 +202,10 @@ defmodule SiteWeb.StopControllerTest do
                %{
                  active_period: [["2019-6-20 8:45", "2019-6-21 2:30"]],
                  description:
-                   "When the Red Sox play evening games at Fenway, trains will run until 10:30 PM to accommodate increased ridership.<br />\r<br /><strong>Regular D Branch Service will operate on:</strong><br />Patriots Day - April 15<br />Memorial Day - May 27<br />\r<br /><strong>This project is part of the MBTA initiative to bring the Green Line track and signal systems into a state of good repair. Learn more:</strong><br /><a target=\"_blank\" href=\"http://MBTA.com/GreenLineD\">MBTA.com/GreenLineD</a><br />\r<br /><strong>Affected stops:</strong><br />Newton Highlands<br />Eliot<br />Waban<br />Woodland<br />Riverside",
+                   "When the Red Sox play evening games at Fenway, trains will run until 10:30 PM to accommodate increased ridership.<br />\r<br /><strong>Regular D Branch Service will operate on:</strong><br />Patriots Day - April 15<br />Memorial Day - May 27<br />\r<br /><strong>This project is part of the MBTA initiative to bring the Green Line track and signal systems into a state of good repair. Learn more:</strong><br /><a target=\"_blank\" href=\"https://MBTA.com/GreenLineD\">MBTA.com/GreenLineD</a><br />\r<br /><strong>Affected stops:</strong><br />Newton Highlands<br />Eliot<br />Waban<br />Woodland<br />Riverside",
                  effect: :shuttle,
                  header:
-                   "Shuttle buses replace Green Line D train service between Riverside and Newton Highlands at about 8:45 PM to end of service on weeknights through July 3. Regular service will operate on Patriot's Day, April 15. More: <a target=\"_blank\" href=\"http://mbta.com/GLwork\">mbta.com/GLwork</a>",
+                   "Shuttle buses replace Green Line D train service between Riverside and Newton Highlands at about 8:45 PM to end of service on weeknights through July 3. Regular service will operate on Patriot's Day, April 15. More: <a target=\"_blank\" href=\"https://mbta.com/GLwork\">mbta.com/GLwork</a>",
                  id: "303815",
                  informed_entity: %Alerts.InformedEntitySet{
                    activities: [:board, :exit, :ride],

--- a/apps/site/test/site_web/controllers/stop_controller_test.exs
+++ b/apps/site/test/site_web/controllers/stop_controller_test.exs
@@ -147,7 +147,7 @@ defmodule SiteWeb.StopControllerTest do
             "When the Red Sox play evening games at Fenway, trains will run until 10:30 PM to accommodate increased ridership.\r\n\r\nRegular D Branch Service will operate on: \r\nPatriots Day - April 15\r\nMemorial Day - May 27\r\n\r\nThis project is part of the MBTA initiative to bring the Green Line track and signal systems into a state of good repair. Learn more: MBTA.com/GreenLineD\r\n\r\nAffected stops:\r\nNewton Highlands\r\nEliot\r\nWaban\r\nWoodland\r\nRiverside",
           effect: :shuttle,
           header:
-            "Shuttle buses replace Green Line D train service between Riverside and Newton Highlands at about 8:45 PM to end of service on weeknights through July 3. Regular service will operate on Patriot's Day, April 15.",
+            "Shuttle buses replace Green Line D train service between Riverside and Newton Highlands at about 8:45 PM to end of service on weeknights through July 3. Regular service will operate on Patriot's Day, April 15. More: mbta.com/GLwork",
           id: "303815",
           informed_entity: %Alerts.InformedEntitySet{
             activities: [:board, :exit, :ride],
@@ -205,7 +205,7 @@ defmodule SiteWeb.StopControllerTest do
                    "When the Red Sox play evening games at Fenway, trains will run until 10:30 PM to accommodate increased ridership.<br />\r<br /><strong>Regular D Branch Service will operate on:</strong><br />Patriots Day - April 15<br />Memorial Day - May 27<br />\r<br /><strong>This project is part of the MBTA initiative to bring the Green Line track and signal systems into a state of good repair. Learn more:</strong><br /><a target=\"_blank\" href=\"http://MBTA.com/GreenLineD\">MBTA.com/GreenLineD</a><br />\r<br /><strong>Affected stops:</strong><br />Newton Highlands<br />Eliot<br />Waban<br />Woodland<br />Riverside",
                  effect: :shuttle,
                  header:
-                   "Shuttle buses replace Green Line D train service between Riverside and Newton Highlands at about 8:45 PM to end of service on weeknights through July 3. Regular service will operate on Patriot's Day, April 15.",
+                   "Shuttle buses replace Green Line D train service between Riverside and Newton Highlands at about 8:45 PM to end of service on weeknights through July 3. Regular service will operate on Patriot's Day, April 15. More: <a target=\"_blank\" href=\"http://mbta.com/GLwork\">mbta.com/GLwork</a>",
                  id: "303815",
                  informed_entity: %Alerts.InformedEntitySet{
                    activities: [:board, :exit, :ride],

--- a/apps/site/test/site_web/views/alert_view_test.exs
+++ b/apps/site/test/site_web/views/alert_view_test.exs
@@ -160,6 +160,13 @@ defmodule SiteWeb.AlertViewTest do
       assert expected == actual
     end
 
+    test "adds https:// to the URL if it's mbta.com" do
+      expected = raw(~s(<a target="_blank" href="https://mbta.com/GLwork">mbta.com/GLwork</a>))
+      actual = replace_urls_with_links("mbta.com/GLwork")
+
+      assert expected == actual
+    end
+
     test "does not link short TLDs" do
       expected = raw("a.m.")
       actual = replace_urls_with_links("a.m.")


### PR DESCRIPTION
**Asana Ticket:** [🐞 On station pages, URLs in alerts don't work (display as text only)](https://app.asana.com/0/385363666817452/1158582591739289/f)

Took this opportunity to refactor a bit, and introduced another small change: if a URL being linkified has no scheme and starts with `mbta.com`, we can default to `https` instead of `http` since we know our own website supports HTTPS.