### PR TITLE
Add Loader.io permission token

### DIFF
--- a/apps/site/assets/static/loaderio-b4c35b9431db61b4421fcf03e17c3818
+++ b/apps/site/assets/static/loaderio-b4c35b9431db61b4421fcf03e17c3818
@@ -1,0 +1,1 @@
+loaderio-b4c35b9431db61b4421fcf03e17c3818

--- a/apps/site/lib/site_web/plugs/static.ex
+++ b/apps/site/lib/site_web/plugs/static.ex
@@ -11,7 +11,8 @@ defmodule SiteWeb.Plugs.Static do
     gzip: true,
     headers: %{"access-control-allow-origin" => "*"},
     cache_control_for_etags: "public, max-age=86400",
-    only: ~w(css fonts images js robots.txt google778e4cfd8ca77f44.html),
+    only:
+      ~w(css fonts images js robots.txt google778e4cfd8ca77f44.html loaderio-b4c35b9431db61b4421fcf03e17c3818),
     only_matching: ~w(favicon apple-touch-icon)
   )
 


### PR DESCRIPTION
This static file validates to Loader.io that we own dev.mbtace.com,
allowing us to run Loader.io tests against it