### PR TITLE
Handle missing route in route_to_class function

### DIFF
--- a/apps/site/lib/site_web/views/helpers.ex
+++ b/apps/site/lib/site_web/views/helpers.ex
@@ -181,6 +181,8 @@ defmodule SiteWeb.ViewHelpers do
 
   @doc "Returns a css class: a string with hyphens."
   @spec route_to_class(Routes.Route.t()) :: String.t()
+  def route_to_class(nil), do: ""
+
   def route_to_class(route) do
     route
     |> Routes.Route.to_naive()

--- a/apps/site/test/site_web/views/helpers_test.exs
+++ b/apps/site/test/site_web/views/helpers_test.exs
@@ -105,6 +105,10 @@ defmodule SiteWeb.ViewHelpersTest do
       assert route_to_class(%Routes.Route{type: 3}) == "bus"
       assert route_to_class(%Routes.Route{type: 4}) == "ferry"
     end
+
+    test "no route generates no class" do
+      assert route_to_class(nil) == ""
+    end
   end
 
   describe "mode_summaries/2" do


### PR DESCRIPTION
At least one schedule page 500'ed because this one function was being passed a nil route.