### PR TITLE
Remove direction filter for schedule page alerts

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -239,7 +239,9 @@ defmodule SiteWeb.ScheduleController.LineController do
 
   defp tab_name(conn, _), do: assign(conn, :tab, "line")
 
-  defp alerts(conn, _), do: assign_alerts(conn, filter_by_direction?: true)
+  # Since the line diagram changes direction in React without a page reload, the set of alerts we
+  # show at the top of this page should not be direction-specific.
+  defp alerts(conn, _), do: assign_alerts(conn, filter_by_direction?: false)
 
   defp channel_id(conn, _) do
     assign(conn, :channel, "vehicles:#{conn.assigns.route.id}:#{conn.assigns.direction_id}")


### PR DESCRIPTION
**Asana Ticket:** [⏱ Schedules | Urgent alerts should be at the top of page](https://app.asana.com/0/385363666817452/1120016688269890/f)