### PR TITLE
hotfix: only output image if image exists

### DIFF
--- a/apps/site/lib/site_web/templates/project/updates.html.eex
+++ b/apps/site/lib/site_web/templates/project/updates.html.eex
@@ -8,17 +8,25 @@
     <div class="c-cms__content">
       <div class="c-cms__body">
         <%= for update <- @updates do
-          link([
-            content_tag(:div, img_tag(
-              update.image.url,
-              alt: update.image.alt,
-              class: ["c-content-teaser__image", " ", "c-content-teaser__image--projects"]),
-              class: "m-project-updates__image col-sm-6"),
-            content_tag(:div, [
-              content_tag(:h2, update.title, class: "h3 m-project-updates__title"),
-              content_tag(:p, Timex.format!(update.date, "{Mfull} {D}, {YYYY}"), class: "h4")
-            ], class: "m-project-updates__content col-sm-6")
-          ], to: update.path, class: "m-project-updates__teaser c-content-teaser row")
+          text_content = [
+                content_tag(:h2, update.title, class: "h3 m-project-updates__title"),
+                content_tag(:p, Timex.format!(update.date, "{Mfull} {D}, {YYYY}"), class: "h4")
+              ]
+
+          if update.image do
+            link([
+              content_tag(:div, img_tag(
+                update.image.url,
+                alt: update.image.alt,
+                class: ["c-content-teaser__image", " ", "c-content-teaser__image--projects"]),
+                class: "m-project-updates__image col-sm-6"),
+              content_tag(:div, text_content, class: "m-project-updates__content col-sm-6")
+            ], to: update.path, class: "m-project-updates__teaser c-content-teaser row")
+          else
+            link([
+              content_tag(:div, text_content, class: "m-project-updates__content col-sm-12")
+            ], to: update.path, class: "m-project-updates__teaser c-content-teaser row")
+          end
         end %>
         <%= if Enum.empty?(@updates) do content_tag(:div, "There are no updates at this time.") end %>
         <%= SiteWeb.CMS.ParagraphView.render_paragraph(%DescriptiveLink{


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket.

Quick fix. Some project updates (older ones) may not have images. Content authors have been notified and will fill in the blanks where needed, but this should catch other undiscovered instances.

Eventually there will be a small refactor ticket to make these teasers follow the standard teaser framework, instead of hardcoding them like this.

Sample: https://mbta.com/projects/wollaston-station-improvements/updates
