### PR TITLE
Log line diagram visibility

### DIFF
--- a/apps/site/assets/static/loaderio-392aa6a67825336b70393c6be61d56ce
+++ b/apps/site/assets/static/loaderio-392aa6a67825336b70393c6be61d56ce
@@ -1,0 +1,1 @@
+loaderio-392aa6a67825336b70393c6be61d56ce

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from "react";
 import { useFetch } from "react-async";
+import { useInterval } from "use-interval";
 import {
   LineDiagramStop,
   LineDiagramVehicle,
@@ -94,6 +95,19 @@ const LineDiagram = ({
     { json: true, watch: directionId }
   );
   const liveData = (maybeLiveData || {}) as LiveDataByStop;
+
+  useFetch(
+    `/schedules/line_api/log_visibility?visibility=${document.visibilityState}`,
+    {}
+  );
+  useInterval(() => {
+    /* istanbul ignore next */
+    fetch(
+      `/schedules/line_api/log_visibility?visibility=${
+        document.visibilityState
+      }`
+    );
+  }, 15000);
 
   const handleStopClick = (stop: RouteStop): (() => void) => () =>
     setModalState({

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -15,6 +15,8 @@ defmodule SiteWeb.ScheduleController.LineApi do
 
   import SiteWeb.StopController, only: [json_safe_alerts: 2]
 
+  require Logger
+
   @typep simple_vehicle :: %{
            id: String.t(),
            headsign: String.t() | nil,
@@ -44,6 +46,11 @@ defmodule SiteWeb.ScheduleController.LineApi do
         update_route_stop_data(stop, conn.assigns.alerts, conn.assigns.date)
       end)
     )
+  end
+
+  def log_visibility(conn, %{"visibility" => visibility}) do
+    _ = Logger.warn("module=#{__MODULE__} visibility=#{visibility}")
+    json(conn, nil)
   end
 
   @doc """

--- a/apps/site/lib/site_web/plugs/static.ex
+++ b/apps/site/lib/site_web/plugs/static.ex
@@ -12,7 +12,7 @@ defmodule SiteWeb.Plugs.Static do
     headers: %{"access-control-allow-origin" => "*"},
     cache_control_for_etags: "public, max-age=86400",
     only:
-      ~w(css fonts images js robots.txt google778e4cfd8ca77f44.html loaderio-b4c35b9431db61b4421fcf03e17c3818),
+      ~w(css fonts images js robots.txt google778e4cfd8ca77f44.html loaderio-b4c35b9431db61b4421fcf03e17c3818 loaderio-392aa6a67825336b70393c6be61d56ce),
     only_matching: ~w(favicon apple-touch-icon)
   )
 

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -133,6 +133,7 @@ defmodule SiteWeb.Router do
     get("/schedules/schedule_api", ScheduleController.ScheduleApi, :show)
     get("/schedules/map_api", ScheduleController.MapApi, :show)
     get("/schedules/line_api", ScheduleController.LineApi, :show)
+    get("/schedules/line_api/log_visibility", ScheduleController.LineApi, :log_visibility)
     get("/schedules/line_api/realtime", ScheduleController.LineApi, :realtime)
     get("/schedules/subway", ModeController, :subway)
     get("/schedules/bus", ModeController, :bus)


### PR DESCRIPTION
We want to get an idea of how much of a reduction in requests we might get by only fetching realtime data in the line diagram when the tab is actually visible. This PR adds an endpoint and a JS callback to "phone home" and report the visibility of the line diagram periodically.

I load-tested this on dev-green and it cruises at 1750 requests/second, runs into trouble at 2000. That should be more than performant enough.