### PR TITLE
Remove nonexistent field from API requests

### DIFF
--- a/apps/predictions/lib/repo.ex
+++ b/apps/predictions/lib/repo.ex
@@ -6,7 +6,7 @@ defmodule Predictions.Repo do
 
   @default_params [
     "fields[prediction]":
-      "track,status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence",
+      "status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence",
     "fields[trip]": "direction_id,headsign,name,bikes_allowed",
     "fields[stop]": "platform_code",
     include: "trip,stop"

--- a/apps/site/test/mappings/mapping-predictions-O5C18.json
+++ b/apps/site/test/mappings/mapping-predictions-O5C18.json
@@ -1,7 +1,7 @@
 {
   "id" : "ac6ea4c3-19f9-329c-aff6-3c972e451ff1",
   "request" : {
-    "url" : "/predictions/?direction_id=0&stop=place-sstat&route=CR-Kingston&fields%5Bprediction%5D=track%2Cstatus%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
+    "url" : "/predictions/?direction_id=0&stop=place-sstat&route=CR-Kingston&fields%5Bprediction%5D=status%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
     "method" : "GET"
   },
   "response" : {

--- a/apps/site/test/mappings/mapping-predictions-YmT5j.json
+++ b/apps/site/test/mappings/mapping-predictions-YmT5j.json
@@ -1,7 +1,7 @@
 {
   "id" : "6e3c4dbe-6c92-3a37-a126-a3b839fa8b7b",
   "request" : {
-    "url" : "/predictions/?direction_id=0&stop=102&route=1&fields%5Bprediction%5D=track%2Cstatus%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
+    "url" : "/predictions/?direction_id=0&stop=102&route=1&fields%5Bprediction%5D=status%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
     "method" : "GET"
   },
   "response" : {

--- a/apps/site/test/mappings/mapping-predictions-ejxGG.json
+++ b/apps/site/test/mappings/mapping-predictions-ejxGG.json
@@ -1,7 +1,7 @@
 {
   "id" : "2bd82382-e6b0-332f-acaa-d1a69a8a1717",
   "request" : {
-    "url" : "/predictions/?direction_id=0&route=CR-Kingston&fields%5Bprediction%5D=track%2Cstatus%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
+    "url" : "/predictions/?direction_id=0&route=CR-Kingston&fields%5Bprediction%5D=status%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
     "method" : "GET"
   },
   "response" : {

--- a/apps/site/test/mappings/mapping-predictions-hUsIX.json
+++ b/apps/site/test/mappings/mapping-predictions-hUsIX.json
@@ -1,7 +1,7 @@
 {
   "id" : "dfa00fbc-feac-3685-b369-9f8c24b2d222",
   "request" : {
-    "url" : "/predictions/?direction_id=0&route=1&fields%5Bprediction%5D=track%2Cstatus%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
+    "url" : "/predictions/?direction_id=0&route=1&fields%5Bprediction%5D=status%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
     "method" : "GET"
   },
   "response" : {

--- a/apps/site/test/mappings/mapping-predictions-jfMR8.json
+++ b/apps/site/test/mappings/mapping-predictions-jfMR8.json
@@ -1,7 +1,7 @@
 {
   "id" : "693baf35-66a3-3e82-8413-93127df58c31",
   "request" : {
-    "url" : "/predictions/?trip=&stop=&fields%5Bprediction%5D=track%2Cstatus%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
+    "url" : "/predictions/?trip=&stop=&fields%5Bprediction%5D=status%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
     "method" : "GET"
   },
   "response" : {

--- a/apps/site/test/mappings/mapping-predictions-zepnZ.json
+++ b/apps/site/test/mappings/mapping-predictions-zepnZ.json
@@ -1,7 +1,7 @@
 {
   "id" : "b8bb46e7-13de-3144-a4c3-33faf1956012",
   "request" : {
-    "url" : "/predictions/?direction_id=1&stop=place-sstat&route=Red&fields%5Bprediction%5D=track%2Cstatus%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
+    "url" : "/predictions/?direction_id=1&stop=place-sstat&route=Red&fields%5Bprediction%5D=status%2Cdeparture_time%2Carrival_time%2Cdirection_id%2Cschedule_relationship%2Cstop_sequence&fields%5Btrip%5D=direction_id%2Cheadsign%2Cname%2Cbikes_allowed&fields%5Bstop%5D=platform_code&include=trip%2Cstop",
     "method" : "GET"
   },
   "response" : {


### PR DESCRIPTION
Version 2018-07-23 of the API removed the `track` field from Prediction resources, but we were still (harmlessly) requesting it.

This doesn't touch the `track` field on our own `Prediction` structs, as that is still populated by the `Parser` which now looks at the associated `Stop` resource.