### PR TITLE
Fix current service validity check

### DIFF
--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceOptGroupTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceOptGroupTest.tsx.snap
@@ -45,9 +45,9 @@ exports[`ServiceOptGroup renders 1`] = `
     Ferry service
   </option>
   <option
-    value="weekday2019-2"
+    value="weekday2020-2"
   >
-    CR service
+    CR service, Test Future Service Incomplete Rating
   </option>
 </optgroup>
 `;


### PR DESCRIPTION
On a holiday when viewing the daily schedules.

Turns this (misleading, though the holiday schedule is still selectable and viewable here):

<img width="790" alt="image" src="https://user-images.githubusercontent.com/2136286/74667155-cb774600-5170-11ea-8a7f-3b5ec76bdd18.png">

Into this (correct):

<img width="807" alt="image" src="https://user-images.githubusercontent.com/2136286/74667251-f497d680-5170-11ea-978f-b8c3e46b6f1d.png">
