### PR TITLE
Only consider removed_dates that have a valid note

### DIFF
--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -19,7 +19,13 @@ export const serviceStartDateComparator = (
 const isInRemovedDates = (
   service: Service,
   currentDate: Date = new Date()
-): boolean => service.removed_dates.includes(dateObjectToString(currentDate));
+): boolean => {
+  const date = dateObjectToString(currentDate);
+  // the date must be in the removed_dates list and have a non-null note
+  return (
+    service.removed_dates.includes(date) && !!service.removed_dates_notes[date]
+  );
+};
 
 const isInAddedDates = (
   service: Service,


### PR DESCRIPTION
For a service that looks like this:

```json
{
  "valid_days": [
    1,
    2,
    3,
    4,
    5
  ],
  "typicality": "typical_service",
  "type": "weekday",
  "start_date": "2020-02-07",
  "service_date": "2020-02-18",
  "removed_dates_notes": {
    "2020-02-21": null,
    "2020-02-20": null,
    "2020-02-19": null,
    "2020-02-18": null,
    "2020-02-17": "Washington's Birthday"
  },
  "removed_dates": [
    "2020-02-17",
    "2020-02-18",
    "2020-02-19",
    "2020-02-20",
    "2020-02-21"
  ],
  "rating_start_date": "2019-12-22",
  "rating_end_date": "2020-03-14",
  "rating_description": "Winter",
  "name": "Weekday",
  "id": "BUS120-3-Wdy-02",
  "end_date": "2020-03-13",
  "description": "Weekday schedule",
  "default_service?": false,
  "added_dates_notes": {},
  "added_dates": []
}
```

it won't be considered current and valid for the `removed_dates`. Which works fine on 2020-02-17, where another service is available that's properly marked as a holiday service with the relevant `added_date`. But presents a problem for the other listed `removed_dates`, where other services have not been added, and typical service may exist (in this case the week is a school holiday).

A workaround here is to only consider removed dates with a non-null note, which will prevent the inappropriate "no service for today" message here:

![image](https://user-images.githubusercontent.com/2136286/74780869-77528b80-526e-11ea-9919-47ce220d0fb2.png)

