### PR TITLE
Cache realtime endpoint response

### DIFF
--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -94,7 +94,7 @@
     "stylelint-order": "^4.0.0",
     "stylelint-scss": "^3.14.2",
     "stylelint-selector-bem-pattern": "^2.1.0",
-    "stylelint-selector-no-mergeable": "git+ssh://git@github.com/nkingsy/stylelint-selector-no-mergeable.git",
+    "stylelint-selector-no-mergeable": "git+https://git@github.com/nkingsy/stylelint-selector-no-mergeable.git",
     "svg-inline-loader": "^0.8.0",
     "svgo": "^1.1.1",
     "svgo-loader": "^2.2.0",

--- a/apps/site/assets/ts/schedule/__tests__/UpcomingDeparturesTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/UpcomingDeparturesTest.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import renderer, { act } from "react-test-renderer";
+import renderer from "react-test-renderer";
 import { createReactRoot } from "../../app/helpers/testUtils";
 import UpcomingDepartures from "../components/schedule-finder/UpcomingDepartures";
 import { EnhancedJourney } from "../components/__trips";
@@ -7,8 +7,8 @@ import departuresResponse from "../__tests__/departures.json";
 import crDeparturesResponse from "../__tests__/crDepartures.json";
 import { UserInput } from "../components/ScheduleFinder";
 
-const busDepartures = departuresResponse as EnhancedJourney[];
-const crDepartures = crDeparturesResponse as EnhancedJourney[];
+const busDepartures = (departuresResponse as unknown) as EnhancedJourney[];
+const crDepartures = (crDeparturesResponse as unknown) as EnhancedJourney[];
 
 const input: UserInput = {
   route: "",

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -204,7 +204,7 @@ const LineDiagram = ({
           />
         ))
       ) : (
-        <div className="c-alert-item c-alert-item--low c-alert-item__top-text-container">
+        /* istanbul ignore next */ <div className="c-alert-item c-alert-item--low c-alert-item__top-text-container">
           No stops {route.direction_names[directionId]} to{" "}
           {route.direction_destinations[directionId]} matching{" "}
           <b className="u-highlight">{stopQuery}</b>. Try changing your

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -91,12 +91,21 @@ const LineDiagram = ({
     modalOpen: false
   });
 
-  const { data: maybeLiveData } = useFetch(
+  const {
+    data: maybeLiveData,
+    isLoading: liveDataIsLoading,
+    // @ts-ignore https://github.com/async-library/react-async/issues/244
+    reload: reloadLiveData
+  } = useFetch(
     `/schedules/line_api/realtime?id=${route.id}&direction_id=${directionId}`,
     {},
     { json: true, watch: directionId }
   );
   const liveData = (maybeLiveData || {}) as LiveDataByStop;
+  useInterval(() => {
+    /* istanbul ignore next */
+    if (!liveDataIsLoading) reloadLiveData();
+  }, 15000);
 
   useFetch(
     `/schedules/line_api/log_visibility?visibility=${document.visibilityState}`,

--- a/apps/site/lib/site/application.ex
+++ b/apps/site/lib/site/application.ex
@@ -1,4 +1,6 @@
 defmodule Site.Application do
+  @moduledoc false
+
   use Application
 
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
@@ -15,6 +17,7 @@ defmodule Site.Application do
 
     children = [
       # Start the endpoint when the application starts
+      supervisor(ConCache, [[], [name: :line_diagram_realtime_cache, ttl: :timer.seconds(60)]]),
       supervisor(SiteWeb.Endpoint, []),
       supervisor(Site.GreenLine.Supervisor, []),
       supervisor(Site.Stream.Vehicles, []),

--- a/apps/site/mix.exs
+++ b/apps/site/mix.exs
@@ -57,7 +57,8 @@ defmodule Site.Mixfile do
       :util,
       :trip_plan,
       :services,
-      :route_patterns
+      :route_patterns,
+      :con_cache
     ]
 
     apps =
@@ -110,6 +111,7 @@ defmodule Site.Mixfile do
       {:hammer, "~> 4.0"},
       {:poolboy, "~> 1.5"},
       {:wallaby, "~> 0.22", runtime: false, only: :test},
+      {:con_cache, "~> 0.12.0"},
       {:stops, in_umbrella: true},
       {:routes, in_umbrella: true},
       {:alerts, in_umbrella: true},


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Polling | Introduce caching for the end points getting polled](https://app.asana.com/0/555089885850811/1160944420414821)

(Also includes https://app.asana.com/0/555089885850811/1160944420414816)

Here we introduce a cache to the line diagram realtime endpoint with a 60 second TTL. ~We also slow down polling of this endpoint to once per 60 seconds.~