### PR TITLE
Mark as "current" if service in rating date range

### DIFF
--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -42,7 +42,21 @@ const isInCurrentService = (
 ): boolean => {
   const serviceStartDate = stringToDateObject(service.start_date);
   const serviceEndDate = stringToDateObject(service.end_date);
-  return currentDate >= serviceStartDate && currentDate <= serviceEndDate;
+  const inServiceDates =
+    currentDate >= serviceStartDate && currentDate <= serviceEndDate;
+  // FIXME: Considering the rating date range is here as a workaround to allow
+  // relevant weekday services to show as "current" during school vacation weeks
+  // (reflecting real world weekday schedule behavior), as the relevant weekday
+  // service can have service start/end dates in the future, but within the
+  // current rating.
+  if (service.rating_start_date && service.rating_end_date) {
+    const ratingStartDate = stringToDateObject(service.rating_start_date!);
+    const ratingEndDate = stringToDateObject(service.rating_end_date!);
+    const inRatingDates =
+      currentDate >= ratingStartDate && currentDate <= ratingEndDate;
+    return inServiceDates || inRatingDates;
+  }
+  return inServiceDates;
 };
 
 export const isCurrentValidService = (
@@ -136,8 +150,7 @@ export const groupServicesByDateRating = (
       return ServiceGroupNames.CURRENT;
     }
     if (
-      (hasIncompleteRating(service) ||
-        !isInFutureRating(service, currentDate)) &&
+      hasIncompleteRating(service) &&
       isInFutureService(service, currentDate)
     ) {
       return ServiceGroupNames.FUTURE;


### PR DESCRIPTION
Take two on tackling the issue noted in #391 with a hopefully better approach. 

Because we filter out `Weekday (no school)` services (as of #307 ), the frontend has no logical manner in which to determine what the day's valid current service is when it happens to be a Weekday (no school) day (as was/is the case every weekday this week after Monday). 

As happens to be the case, the regular weekday service, whose regular weekday schedules do apply this week, has a service start date next week, e.g. it is not in effect now and thus not considered a current service.

Handling this case deserves a more robust approach, but in the meantime we don't want to show customers "there is no service" when the regular weekday schedules are applicable. This change makes use of the fact that that future weekday service is part of this rating to mark it as "current" and have it show as desired in the ServiceSelector.
