### PR TITLE
Use SL pills instead of round SL icons in one spot

### DIFF
--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
@@ -69,7 +69,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -123,14 +123,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -171,14 +167,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -219,14 +211,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -267,14 +255,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -315,14 +299,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -363,14 +343,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -411,14 +387,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -459,14 +431,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -507,14 +475,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -555,14 +519,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -603,14 +563,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -651,14 +607,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -699,7 +651,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -743,14 +695,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -791,7 +739,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -835,14 +783,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -883,7 +827,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -927,14 +871,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -975,14 +915,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1023,7 +959,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -1067,14 +1003,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1115,7 +1047,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -1159,14 +1091,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1207,14 +1135,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1255,7 +1179,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -1299,14 +1223,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1347,7 +1267,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -1391,14 +1311,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1439,7 +1355,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -1483,14 +1399,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1531,7 +1443,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -1575,14 +1487,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1623,14 +1531,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1671,7 +1575,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -1715,14 +1619,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1763,7 +1663,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -1807,14 +1707,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1855,7 +1751,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -1899,14 +1795,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1947,14 +1839,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -1995,7 +1883,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -2039,14 +1927,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2087,7 +1971,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -2131,14 +2015,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2179,7 +2059,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -2223,14 +2103,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2271,14 +2147,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2319,7 +2191,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -2363,14 +2235,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2411,7 +2279,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -2455,14 +2323,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2503,14 +2367,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2551,7 +2411,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -2595,14 +2455,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2643,7 +2499,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -2687,14 +2543,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2735,7 +2587,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -2779,14 +2631,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2827,7 +2675,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -2871,14 +2719,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -2919,7 +2763,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -2963,7 +2807,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -3007,14 +2851,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3055,7 +2895,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -3099,14 +2939,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3147,7 +2983,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -3191,14 +3027,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3239,7 +3071,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -3283,7 +3115,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -3327,14 +3159,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3375,14 +3203,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3423,14 +3247,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3471,7 +3291,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -3515,14 +3335,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3563,7 +3379,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -3607,14 +3423,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3655,14 +3467,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3703,7 +3511,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -3747,14 +3555,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3795,14 +3599,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3843,14 +3643,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3891,14 +3687,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3939,14 +3731,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -3987,7 +3775,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -4031,14 +3819,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4079,7 +3863,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -4123,14 +3907,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4171,14 +3951,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4219,7 +3995,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -4263,14 +4039,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4311,14 +4083,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4359,7 +4127,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -4403,14 +4171,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4451,14 +4215,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4499,14 +4259,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4547,7 +4303,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -4591,7 +4347,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -4635,14 +4391,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4683,14 +4435,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4731,14 +4479,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4779,14 +4523,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4827,14 +4567,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4875,14 +4611,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4923,14 +4655,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -4971,14 +4699,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5019,14 +4743,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5067,14 +4787,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5115,14 +4831,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5163,14 +4875,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5211,14 +4919,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5259,7 +4963,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -5303,14 +5007,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5351,7 +5051,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -5395,7 +5095,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -5439,14 +5139,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5487,7 +5183,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -5531,14 +5227,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5579,7 +5271,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -5623,14 +5315,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5671,7 +5359,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -5715,14 +5403,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5763,7 +5447,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -5807,14 +5491,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5855,7 +5535,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -5899,14 +5579,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5947,14 +5623,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -5995,7 +5667,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -6039,14 +5711,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6087,7 +5755,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -6131,14 +5799,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6179,7 +5843,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -6223,14 +5887,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6271,14 +5931,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6319,7 +5975,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -6363,14 +6019,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6411,7 +6063,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -6455,14 +6107,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6503,7 +6151,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -6547,14 +6195,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6595,14 +6239,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6643,7 +6283,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -6687,14 +6327,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6735,7 +6371,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -6779,14 +6415,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6827,7 +6459,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -6871,14 +6503,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6919,14 +6547,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -6967,7 +6591,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -7011,14 +6635,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7059,7 +6679,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -7103,14 +6723,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7151,14 +6767,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7199,7 +6811,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -7243,14 +6855,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7291,7 +6899,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -7335,14 +6943,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7383,14 +6987,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7431,7 +7031,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -7475,14 +7075,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7523,7 +7119,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -7567,14 +7163,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7615,14 +7207,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7663,7 +7251,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -7707,14 +7295,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7755,14 +7339,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7803,14 +7383,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7851,14 +7427,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7899,14 +7471,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7947,14 +7515,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -7995,14 +7559,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8043,14 +7603,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8091,14 +7647,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8139,14 +7691,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8187,14 +7735,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8235,14 +7779,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8283,7 +7823,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -8327,14 +7867,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8375,14 +7911,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8423,14 +7955,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8471,7 +7999,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -8515,7 +8043,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -8559,7 +8087,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -8603,14 +8131,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8651,14 +8175,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8699,7 +8219,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -8743,14 +8263,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8791,14 +8307,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8839,7 +8351,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -8883,7 +8395,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -8927,14 +8439,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -8975,14 +8483,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9023,14 +8527,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9071,14 +8571,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9119,14 +8615,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9167,14 +8659,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9215,7 +8703,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -9259,14 +8747,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9307,14 +8791,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9355,14 +8835,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9403,14 +8879,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9451,14 +8923,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9499,14 +8967,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9547,14 +9011,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9595,14 +9055,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9643,14 +9099,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9691,14 +9143,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9739,7 +9187,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -9783,14 +9231,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9831,14 +9275,10 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -9879,7 +9319,7 @@ exports[`ScheduleTable it renders 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -13093,7 +12533,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -13144,14 +12584,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13199,14 +12635,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13254,14 +12686,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13309,14 +12737,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13364,14 +12788,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13419,14 +12839,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13474,14 +12890,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13529,14 +12941,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13584,14 +12992,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13639,14 +13043,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13694,14 +13094,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13749,14 +13145,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13800,7 +13192,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -13851,14 +13243,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -13902,7 +13290,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -13953,14 +13341,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14004,7 +13388,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -14055,14 +13439,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14110,14 +13490,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14161,7 +13537,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -14212,14 +13588,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14263,7 +13635,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -14314,14 +13686,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14369,14 +13737,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14420,7 +13784,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -14471,14 +13835,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14522,7 +13882,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -14573,14 +13933,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14624,7 +13980,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -14675,14 +14031,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14726,7 +14078,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -14777,14 +14129,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14832,14 +14180,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14883,7 +14227,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -14934,14 +14278,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -14985,7 +14325,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -15036,14 +14376,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15087,7 +14423,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -15138,14 +14474,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15193,14 +14525,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15244,7 +14572,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -15295,14 +14623,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15346,7 +14670,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -15397,14 +14721,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15448,7 +14768,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -15499,14 +14819,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15554,14 +14870,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15605,7 +14917,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -15656,14 +14968,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15707,7 +15015,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -15758,14 +15066,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15813,14 +15117,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15864,7 +15164,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -15915,14 +15215,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -15966,7 +15262,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -16017,14 +15313,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -16068,7 +15360,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -16119,14 +15411,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -16170,7 +15458,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -16221,14 +15509,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -16272,7 +15556,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -16319,7 +15603,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -16370,14 +15654,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -16421,7 +15701,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -16472,14 +15752,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -16523,7 +15799,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -16574,14 +15850,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -16625,7 +15897,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -16672,7 +15944,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -16723,14 +15995,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -16778,14 +16046,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -16833,14 +16097,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -16884,7 +16144,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -16935,14 +16195,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -16986,7 +16242,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -17037,14 +16293,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17092,14 +16344,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17143,7 +16391,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -17194,14 +16442,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17249,14 +16493,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17304,14 +16544,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17359,14 +16595,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17414,14 +16646,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17465,7 +16693,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -17516,14 +16744,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17567,7 +16791,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -17618,14 +16842,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17673,14 +16893,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17724,7 +16940,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -17775,14 +16991,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17830,14 +17042,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17881,7 +17089,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -17932,14 +17140,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -17987,14 +17191,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18042,14 +17242,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18093,7 +17289,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -18140,7 +17336,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -18191,14 +17387,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18246,14 +17438,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18301,14 +17489,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18356,14 +17540,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18411,14 +17591,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18466,14 +17642,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18521,14 +17693,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18576,14 +17744,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18631,14 +17795,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18686,14 +17846,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18741,14 +17897,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18796,14 +17948,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18851,14 +17999,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -18902,7 +18046,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -18953,14 +18097,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -19004,7 +18144,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -19051,7 +18191,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -19102,14 +18242,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -19153,7 +18289,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -19204,14 +18340,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -19255,7 +18387,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -19306,14 +18438,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -19357,7 +18485,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -19408,14 +18536,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -19459,7 +18583,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -19510,14 +18634,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -19561,7 +18681,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -19612,14 +18732,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -19667,14 +18783,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -19718,7 +18830,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -19769,14 +18881,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -19820,7 +18928,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -19871,14 +18979,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -19922,7 +19026,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -19973,14 +19077,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20028,14 +19128,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20079,7 +19175,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -20130,14 +19226,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20181,7 +19273,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -20232,14 +19324,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20283,7 +19371,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -20334,14 +19422,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20389,14 +19473,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20440,7 +19520,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -20491,14 +19571,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20542,7 +19618,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -20593,14 +19669,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20644,7 +19716,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -20695,14 +19767,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20750,14 +19818,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20801,7 +19865,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -20852,14 +19916,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -20903,7 +19963,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -20954,14 +20014,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21009,14 +20065,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21060,7 +20112,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -21111,14 +20163,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21162,7 +20210,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -21213,14 +20261,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21268,14 +20312,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21319,7 +20359,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -21370,14 +20410,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21421,7 +20457,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -21472,14 +20508,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21527,14 +20559,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21578,7 +20606,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -21629,14 +20657,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21684,14 +20708,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21739,14 +20759,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21794,14 +20810,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21849,14 +20861,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21904,14 +20912,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -21959,14 +20963,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22014,14 +21014,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22069,14 +21065,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22124,14 +21116,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22179,14 +21167,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22234,14 +21218,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22285,7 +21265,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -22336,14 +21316,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22391,14 +21367,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22446,14 +21418,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22497,7 +21465,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -22544,7 +21512,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -22591,7 +21559,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -22642,14 +21610,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22697,14 +21661,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22748,7 +21708,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -22799,14 +21759,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22854,14 +21810,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -22905,7 +21857,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -22952,7 +21904,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -23003,14 +21955,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23058,14 +22006,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23113,14 +22057,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23168,14 +22108,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23223,14 +22159,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23278,14 +22210,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23329,7 +22257,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -23380,14 +22308,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23435,14 +22359,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23490,14 +22410,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23545,14 +22461,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23600,14 +22512,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23655,14 +22563,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23710,14 +22614,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23765,14 +22665,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23820,14 +22716,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23875,14 +22767,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -23926,7 +22814,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>
@@ -23977,14 +22865,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -24032,14 +22916,10 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  aria-hidden="false"
-                  className="notranslate c-svg__icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                >
+                  SL2
+                </span>
                  
                 Drydock
               </td>
@@ -24083,7 +22963,7 @@ exports[`ScheduleTable it renders with school trips 1`] = `
                 className="schedule-table__td"
               >
                 <span
-                  className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill"
+                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
                 >
                   Silver Line Way - South Station
                 </span>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
@@ -47,6 +47,25 @@ export const fetchData = (
   );
 };
 
+const RouteIcon = ({
+  route: { type, name, id }
+}: Journey): ReactElement<HTMLElement> | undefined => {
+  if (type !== 3) {
+    return modeIcon(id);
+  }
+
+  const backgroundClass = name.startsWith("SL")
+    ? "u-bg--silver-line"
+    : "u-bg--bus";
+  return (
+    <span
+      className={`c-icon__bus-pill--small schedule-table__scheduled-bus-pill ${backgroundClass}`}
+    >
+      {name}
+    </span>
+  );
+};
+
 const BusTableRow = ({
   journey,
   anySchoolTrips,
@@ -66,14 +85,7 @@ const BusTableRow = ({
       {journey.departure.time}
     </td>
     <td className="schedule-table__td">
-      {journey.route.type === 3 && !journey.route.name.startsWith("SL") ? (
-        <span className="c-icon__bus-pill--small u-bg--bus schedule-table__scheduled-bus-pill">
-          {journey.route.name}
-        </span>
-      ) : (
-        modeIcon(journey.route.id)
-      )}{" "}
-      {breakTextAtSlash(journey.trip.headsign)}
+      {RouteIcon(journey)} {breakTextAtSlash(journey.trip.headsign)}
     </td>
   </>
 );


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Change "Silver Line Way-South Station" pill for SLW to regular SL pill](https://app.asana.com/0/555089885850811/1160132048446105)

In the "Daily Schedules" section of the schedule modal, we were using round SL icons, when we should have been using mini-pills in SL color. Fixed.