### PR TITLE
Yank "No scheduled service for today" notice

### DIFF
--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -42,21 +42,7 @@ const isInCurrentService = (
 ): boolean => {
   const serviceStartDate = stringToDateObject(service.start_date);
   const serviceEndDate = stringToDateObject(service.end_date);
-  const inServiceDates =
-    currentDate >= serviceStartDate && currentDate <= serviceEndDate;
-  // FIXME: Considering the rating date range is here as a workaround to allow
-  // relevant weekday services to show as "current" during school vacation weeks
-  // (reflecting real world weekday schedule behavior), as the relevant weekday
-  // service can have service start/end dates in the future, but within the
-  // current rating.
-  if (service.rating_start_date && service.rating_end_date) {
-    const ratingStartDate = stringToDateObject(service.rating_start_date!);
-    const ratingEndDate = stringToDateObject(service.rating_end_date!);
-    const inRatingDates =
-      currentDate >= ratingStartDate && currentDate <= ratingEndDate;
-    return inServiceDates || inRatingDates;
-  }
-  return inServiceDates;
+  return currentDate >= serviceStartDate && currentDate <= serviceEndDate;
 };
 
 export const isCurrentValidService = (
@@ -150,7 +136,8 @@ export const groupServicesByDateRating = (
       return ServiceGroupNames.CURRENT;
     }
     if (
-      hasIncompleteRating(service) &&
+      (hasIncompleteRating(service) ||
+        !isInFutureRating(service, currentDate)) &&
       isInFutureService(service, currentDate)
     ) {
       return ServiceGroupNames.FUTURE;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -113,17 +113,6 @@ export const ServiceSelector = ({
     <>
       <h3>Daily Schedule</h3>
       <div className="schedule-finder__service-selector">
-        {!isCurrentValidService(defaultService, todayDate) && (
-          <div className="callout schedule-table--empty">
-            There is no scheduled service for today,{" "}
-            {todayDate.toLocaleDateString("en-US", {
-              weekday: "long",
-              month: "short",
-              day: "numeric"
-            })}
-            .
-          </div>
-        )}
         <label htmlFor="service_selector" className="sr-only">
           Schedules
         </label>


### PR DESCRIPTION
The logic around when to display this notice and when not to is trickier
than we first anticipated. To avoid misleading riders, we've pulled that
notice for the moment until we can correct that logic.

#### Summary of changes
**Asana Ticket:** [Suppress "No scheduled service today" message](https://app.asana.com/0/555089885850811/1162903717378782)
