### PR TITLE
Don't say CR is "On time" with no scheduled time

### DIFF
--- a/apps/site/assets/ts/components/Headsign.tsx
+++ b/apps/site/assets/ts/components/Headsign.tsx
@@ -57,7 +57,7 @@ const renderTimeCommuterRail = (
   >
     {crTime(data)}
     <div className="m-tnm-sidebar__status">
-      {`${statusForCommuterRail(data)}${trackForCommuterRail(data)}`}
+      {`${statusForCommuterRail(data) || ""}${trackForCommuterRail(data)}`}
     </div>
   </div>
 );

--- a/apps/site/assets/ts/helpers/__tests__/prediction-helpers-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/prediction-helpers-test.ts
@@ -1,0 +1,54 @@
+import { statusForCommuterRail } from "../prediction-helpers";
+import { PredictedOrScheduledTime } from "../../__v3api";
+
+describe("statusForCommuterRail", () => {
+  test("prefers prediction status if available", () => {
+    const data: PredictedOrScheduledTime = {
+      delay: 11,
+      scheduled_time: ["11:00", " ", "AM"],
+      prediction: {
+        status: "Held for reasons",
+        time: ["11:11", " ", "AM"],
+        track: null
+      }
+    };
+
+    expect(statusForCommuterRail(data)).toEqual("Held for reasons");
+  });
+
+  test("indicates a delay if it's 5 minutes or more", () => {
+    const onTime: PredictedOrScheduledTime = {
+      delay: 4,
+      scheduled_time: ["11:00", " ", "AM"],
+      prediction: { status: null, time: ["11:04", " ", "AM"], track: null }
+    };
+    const delayed: PredictedOrScheduledTime = {
+      delay: 5,
+      scheduled_time: ["11:00", " ", "AM"],
+      prediction: { status: null, time: ["11:05", " ", "AM"], track: null }
+    };
+
+    expect(statusForCommuterRail(onTime)).toEqual("On time");
+    expect(statusForCommuterRail(delayed)).toEqual("Delayed 5 min");
+  });
+
+  test("indicates 'on time' as long as there is a scheduled time", () => {
+    const data: PredictedOrScheduledTime = {
+      delay: 4,
+      scheduled_time: ["11:00", " ", "AM"],
+      prediction: null
+    };
+
+    expect(statusForCommuterRail(data)).toEqual("On time");
+  });
+
+  test("returns null if there is no scheduled time to compare to", () => {
+    const data: PredictedOrScheduledTime = {
+      delay: 4,
+      scheduled_time: null,
+      prediction: { status: null, time: ["11:11", " ", "AM"], track: null }
+    };
+
+    expect(statusForCommuterRail(data)).toBeNull();
+  });
+});

--- a/apps/site/assets/ts/helpers/prediction-helpers.tsx
+++ b/apps/site/assets/ts/helpers/prediction-helpers.tsx
@@ -19,31 +19,35 @@ export const timeForCommuterRail = (
   data: PredictedOrScheduledTime,
   className = ""
 ): ReactElement<HTMLElement> => {
-  // eslint-disable-next-line @typescript-eslint/camelcase
-  const { delay, prediction, scheduled_time } = data;
+  const { delay, prediction, scheduled_time: scheduledTime } = data;
+
   if (delay >= 5 && prediction) {
     return delayForCommuterRail(data, className);
   }
 
-  // eslint-disable-next-line @typescript-eslint/camelcase
-  const time = prediction ? prediction.time : scheduled_time;
+  const time = prediction ? prediction.time : scheduledTime;
 
   return <div className={className}>{time!.join("")}</div>;
 };
 
 export const statusForCommuterRail = ({
   delay,
+  scheduled_time: scheduledTime,
   prediction
-}: PredictedOrScheduledTime): string => {
-  if (delay >= 5) {
-    return `Delayed ${delay} min`;
-  }
+}: PredictedOrScheduledTime): string | null => {
+  // If there is a human-entered status string, prioritize that
+  if (prediction && prediction.status) return prediction.status;
 
-  if (prediction && prediction.status) {
-    return prediction.status;
-  }
+  // Indicate "Delayed" if train is delayed 5+ minutes
+  if (delay >= 5) return `Delayed ${delay} min`;
 
-  return "On time";
+  // Indicate "On time" if train is not "Delayed" and we have a scheduled time
+  // (even if there is no real-time prediction)
+  if (scheduledTime) return "On time";
+
+  // We have just a prediction with no scheduled time, so we can't say whether
+  // the train is on time, delayed, etc.
+  return null;
 };
 
 export const trackForCommuterRail = ({

--- a/apps/site/assets/ts/schedule/__tests__/SingleStopTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/SingleStopTest.tsx
@@ -146,34 +146,6 @@ const crLiveData: LiveData = {
   ]
 };
 
-const crLiveDataNoTrain: LiveData = {
-  headsigns: [
-    {
-      name: "DestC",
-      times: [
-        {
-          delay: 5,
-          prediction: {
-            status: null,
-            time: ["5:05", " ", "PM"],
-            track: null
-          },
-          scheduled_time: ["5:00", " ", "PM"]
-        }
-      ],
-      train_number: null
-    }
-  ],
-  vehicles: [
-    {
-      id: "veh2",
-      headsign: "DestC",
-      status: "in_transit",
-      trip_name: "405"
-    }
-  ]
-};
-
 describe("SingleStop", () => {
   it("renders and matches snapshot", () => {
     let wrapper = mount(
@@ -214,21 +186,6 @@ describe("SingleStop", () => {
         isOrigin={false}
         isDestination={false}
         liveData={crLiveData}
-      />
-    );
-
-    expect(wrapper.debug()).toMatchSnapshot();
-  });
-
-  it("renders with Commuter Rail live data without track or train #", () => {
-    let wrapper = mount(
-      <SingleStop
-        stop={crStop}
-        onClick={() => {}}
-        color="000"
-        isOrigin={false}
-        isDestination={false}
-        liveData={crLiveDataNoTrain}
       />
     );
 

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/SingleStopTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/SingleStopTest.tsx.snap
@@ -87,93 +87,16 @@ exports[`SingleStop renders with Commuter Rail live data 1`] = `
               </div>
               <div className=\\"m-schedule-diagram__cr-prediction-details\\">
                 <span>
-                  DestA ·
+                  DestA
                 </span>
-                 
                 <span>
-                  Train 404 ·
+                   · Train 404
                 </span>
-                 
                 <span>
-                  Track 3 ·
+                   · Track 3
                 </span>
-                 
                 <span>
-                  Delayed 5 min
-                </span>
-              </div>
-            </div>
-          </div>
-        </StopPredictions>
-      </div>
-      <div className=\\"m-schedule-diagram__footer\\">
-        <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
-          View schedule
-        </button>
-      </div>
-    </div>
-  </div>
-</SingleStop>"
-`;
-
-exports[`SingleStop renders with Commuter Rail live data without track or train # 1`] = `
-"<SingleStop stop={{...}} onClick={[Function: onClick]} color=\\"000\\" isOrigin={false} isDestination={false} liveData={{...}}>
-  <div className=\\"m-schedule-diagram__stop\\">
-    <div style={{...}} className=\\"m-schedule-diagram__lines\\">
-      <div className=\\"m-schedule-diagram__line m-schedule-diagram__line--stop\\">
-        <svg viewBox=\\"0 10 10 10\\" preserveAspectRatio=\\"xMidYMin slice\\" width=\\"100%\\" height=\\"10px\\" className=\\"m-schedule-diagram__line-stop\\">
-          <circle r=\\"4\\" cx=\\"50%\\" cy=\\"32px\\" />
-        </svg>
-        <VehicleIcons routeType={2} stopName=\\"Example Stop\\" vehicles={{...}}>
-          <div className=\\"m-schedule-diagram__vehicle m-schedule-diagram__vehicle--in_transit\\">
-            <Component tooltipText=\\"DestC train 405 is on the way to Example Stop\\" tooltipOptions={{...}}>
-              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation=\\"false\\" data-selector=\\"true\\" data-original-title=\\"DestC train 405 is on the way to Example Stop\\" title=\\"DestC train 405 is on the way to Example Stop\\">
-                <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-              </span>
-            </Component>
-          </div>
-        </VehicleIcons>
-      </div>
-    </div>
-    <div className=\\"m-schedule-diagram__stop-content\\">
-      <div className=\\"m-schedule-diagram__stop-heading\\">
-        <div className=\\"m-schedule-diagram__stop-name\\">
-          <a href=\\"/stops/place-xxx\\">
-            <h4>
-              <MatchHighlight text=\\"Example Stop\\" matchQuery={[undefined]}>
-                <span>
-                  Example Stop
-                </span>
-              </MatchHighlight>
-            </h4>
-          </a>
-        </div>
-        <div className=\\"m-schedule-diagram__features\\" />
-      </div>
-      <div className=\\"m-schedule-diagram__stop-details\\">
-        <div className=\\"m-schedule-diagram__connections\\" />
-        <StopPredictions headsigns={{...}} isCommuterRail={true}>
-          <div className=\\"m-schedule-diagram__predictions\\">
-            <div>
-              <div className=\\"m-schedule-diagram__cr-prediction\\">
-                <div className=\\"m-schedule-diagram__cr-prediction-time--delayed\\">
-                  5:00 PM
-                </div>
-                <div className=\\"m-schedule-diagram__cr-prediction-time\\">
-                  5:05 PM
-                </div>
-              </div>
-              <div className=\\"m-schedule-diagram__cr-prediction-details\\">
-                <span>
-                  DestC ·
-                </span>
-                 
-                <span />
-                 
-                <span />
-                 
-                <span>
-                  Delayed 5 min
+                   · Delayed 5 min
                 </span>
               </div>
             </div>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/UpcomingDeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/UpcomingDeparturesTest.tsx.snap
@@ -363,8 +363,7 @@ Array [
             <span
               className="schedule-table__status"
             >
-              Train 515 · 
-              On time
+              Train 515 · On time
             </span>
             <span
               className="schedule-table__track"

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopPredictions.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopPredictions.tsx
@@ -27,6 +27,7 @@ const StopPredictions = ({ headsigns, isCommuterRail }: Props): JSX.Element => {
     predictions = liveHeadsigns.slice(0, 1).map(headsign => {
       const time = headsign.times[0];
       const prediction = time.prediction!;
+      const status = statusForCommuterRail(time);
 
       return (
         <div key={headsign.name}>
@@ -37,12 +38,14 @@ const StopPredictions = ({ headsigns, isCommuterRail }: Props): JSX.Element => {
             )}
           </div>
           <div className="m-schedule-diagram__cr-prediction-details">
-            <span>{`${headsign.name} ·`}</span>{" "}
+            <span>{`${headsign.name}`}</span>
             <span>
-              {headsign.train_number ? `Train ${headsign.train_number} ·` : ""}
-            </span>{" "}
-            <span>{prediction.track ? `Track ${prediction.track} ·` : ""}</span>{" "}
-            <span>{statusForCommuterRail(headsign.times[0])}</span>
+              {headsign.train_number ? ` · Train ${headsign.train_number}` : ""}
+            </span>
+            <span>
+              {prediction.track ? ` · Track ${prediction.track}` : ""}
+            </span>
+            <span>{status ? ` · ${status}` : ""}</span>
           </div>
         </div>
       );

--- a/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
@@ -86,8 +86,11 @@ const CrTableRow = ({
 
   if (realtime.prediction === null) return null;
 
+  const status = statusForCommuterRail(realtime);
   const track = trackForCommuterRail(realtime);
-  const trainNumber = trip.name ? `Train ${trip.name} · ` : "";
+  const trainNumber = trip.name ? `Train ${trip.name}` : null;
+
+  const statusWithTrain = [trainNumber, status].filter(x => x).join(" · ");
 
   return (
     <>
@@ -100,11 +103,7 @@ const CrTableRow = ({
           {timeForCommuterRail(realtime, "schedule-table__time")}
         </div>
         <div className="u-nowrap text-right">
-          <span className="schedule-table__status">
-            {trainNumber}
-            {statusForCommuterRail(realtime)}
-          </span>
-
+          <span className="schedule-table__status">{statusWithTrain}</span>
           <span className="schedule-table__track">
             {track ? ` · ${track}` : ""}
           </span>


### PR DESCRIPTION
This also tweaks the rules for CR status displays: previously "Delayed X min" would override any manually-entered `status` string, but now the latter always takes precedence. This is in line with our published Best Practices for prediction data.

**Asana Ticket:** [CR says "On time" when we don't know the scheduled time](https://app.asana.com/0/385363666817452/1161689987228877/f)