### PR TITLE
Change selector order, show terminus circle stroke

### DIFF
--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -162,11 +162,6 @@ $line-width: 8px; // width of the colored line in the diagram
     fill: currentColor;
   }
 
-  // stops at the edge of the <div> need a stroke to be visible
-  .m-schedule-diagram__line--terminus circle {
-    stroke-width: 1.15px;
-  }
-
   // stops along the diagram are SVG circles
   .m-schedule-diagram__line-stop {
     // override Bootstrap setting overflow:hidden for SVGs by default
@@ -177,6 +172,11 @@ $line-width: 8px; // width of the colored line in the diagram
       stroke: currentColor;
       stroke-width: 0;
     }
+  }
+
+  // stops at the edge of the <div> need a stroke to be visible
+  .m-schedule-diagram__line--terminus circle {
+    stroke-width: 1.15px;
   }
 }
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Line Diagram | Terminus stops have lost their outlines](https://app.asana.com/0/385363666817452/1162964521241689/f)

I had inadvertently disturbed the CSS cascade, and Backstop failed to detect this change.
