### PR TITLE
Add cleanup function that turns off channel event listeners when component is unmounted

### DIFF
--- a/apps/site/assets/ts/schedule/components/Channel.ts
+++ b/apps/site/assets/ts/schedule/components/Channel.ts
@@ -59,7 +59,7 @@ export const doInitChannel = (id: string): Channel => {
   return channel;
 };
 
-const initChannel = <T>(
+export const initChannel = <T>(
   channelId: string,
   onData: (data: SocketEvent<T>) => void
 ): void => {
@@ -67,4 +67,11 @@ const initChannel = <T>(
   channel.on("data", onData);
 };
 
-export default initChannel;
+// NB: this removes *all* handlers from the channel. We're currently throwing
+// away the reference returned by `channel.on`, so we can't remove a specific
+// handler, but we don't have a use case for that yet.
+export const stopChannel = (id: string): void => {
+  if (window.channels && window.channels[id]) {
+    window.channels[id].off("data");
+  }
+};

--- a/apps/site/assets/ts/schedule/components/Map.tsx
+++ b/apps/site/assets/ts/schedule/components/Map.tsx
@@ -5,7 +5,7 @@ import React, {
   Dispatch,
   useRef
 } from "react";
-import initChannel, { SocketEvent } from "./Channel";
+import { initChannel, stopChannel, SocketEvent } from "./Channel";
 import Map from "../../leaflet/components/Map";
 import getBounds from "../../leaflet/bounds";
 import {
@@ -43,6 +43,11 @@ const setupChannels = (
   initChannel<EventData[]>("vehicles:remove", (action: Action) =>
     dispatch({ action, channel })
   );
+};
+
+const stopChannels = (channel: string): void => {
+  stopChannel(channel);
+  stopChannel("vehicles:remove");
 };
 
 export const iconOpts = (
@@ -188,7 +193,13 @@ export default ({
     markers: data.markers,
     shapeId
   });
-  useEffect(() => setupChannels(channel, dispatch), [channel]);
+  useEffect(
+    () => {
+      setupChannels(channel, dispatch);
+      return () => stopChannels(channel);
+    },
+    [channel, dispatch]
+  );
   const stopMarkers = data.stop_markers
     ? data.stop_markers.map(marker => updateMarker(marker))
     : [];


### PR DESCRIPTION
This is a tiny update mostly aiming to improve the ✨ developer experience ✨ 

This warning shows up on the new schedules page:

![image](https://user-images.githubusercontent.com/2136286/75085683-8dc04780-54f9-11ea-9f44-c3eef5130bc3.png)

We don't want a memory leak! `useEffect()`'s first argument can be used to return a function that will fire when the React component is unmounted, so we use that here to turn off the event listeners that are activated by the `setupChannels` call in the `<Map>` component. At least, I think that's how channels here work. :)
