### PR TITLE
Revert "Add visibility logging to line diagram"

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useState } from "react";
 import { useFetch } from "react-async";
 import { useInterval } from "use-interval";
+
 import {
   LineDiagramStop,
   LineDiagramVehicle,
@@ -105,19 +106,6 @@ const LineDiagram = ({
   useInterval(() => {
     /* istanbul ignore next */
     if (!liveDataIsLoading) reloadLiveData();
-  }, 15000);
-
-  useFetch(
-    `/schedules/line_api/log_visibility?visibility=${document.visibilityState}`,
-    {}
-  );
-  useInterval(() => {
-    /* istanbul ignore next */
-    fetch(
-      `/schedules/line_api/log_visibility?visibility=${
-        document.visibilityState
-      }`
-    );
   }, 15000);
 
   const handleStopClick = (stop: RouteStop): (() => void) => () =>

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -15,8 +15,6 @@ defmodule SiteWeb.ScheduleController.LineApi do
 
   import SiteWeb.StopController, only: [json_safe_alerts: 2]
 
-  require Logger
-
   @typep simple_vehicle :: %{
            id: String.t(),
            headsign: String.t() | nil,
@@ -46,11 +44,6 @@ defmodule SiteWeb.ScheduleController.LineApi do
         update_route_stop_data(stop, conn.assigns.alerts, conn.assigns.date)
       end)
     )
-  end
-
-  def log_visibility(conn, %{"visibility" => visibility}) do
-    _ = Logger.warn("module=#{__MODULE__} visibility=#{visibility}")
-    json(conn, nil)
   end
 
   @doc """

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -133,7 +133,6 @@ defmodule SiteWeb.Router do
     get("/schedules/schedule_api", ScheduleController.ScheduleApi, :show)
     get("/schedules/map_api", ScheduleController.MapApi, :show)
     get("/schedules/line_api", ScheduleController.LineApi, :show)
-    get("/schedules/line_api/log_visibility", ScheduleController.LineApi, :log_visibility)
     get("/schedules/line_api/realtime", ScheduleController.LineApi, :realtime)
     get("/schedules/subway", ModeController, :subway)
     get("/schedules/bus", ModeController, :bus)


### PR DESCRIPTION
This reverts commit 4a46fbbfcd66dc6283bc4cb2c1539e9259e23a44. We've
established to our satisfaction that it's worth restricting polling of
the line diagram realtime endpoint to when the tab is actually visible.
With that settled, the visibility logging is just wasting resources.

#### Summary of changes
**Asana Ticket:** [🔧 Remove visibility tracking for line diagram](https://app.asana.com/0/555089885850811/1161861385517913)
