### PR TITLE
Poll for live data only when page is visible

### DIFF
--- a/apps/site/assets/ts/jest.config.js
+++ b/apps/site/assets/ts/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: "ts-jest",
+  clearMocks: true,
   collectCoverage: true,
   collectCoverageFrom: [
     "**/*.{ts,tsx}",

--- a/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { mount, ReactWrapper } from "enzyme";
+import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
 import { cloneDeep, merge } from "lodash";
 import LineDiagram from "../components/line-diagram/LineDiagram";
 import { EnhancedRoute, RouteType } from "../../__v3api";
@@ -16,12 +16,21 @@ import simpleLiveData from "./lineDiagramData/live-data.json";
 const lineDiagram = (simpleLineDiagram as unknown) as LineDiagramStop[];
 let lineDiagramBranchingOut = (outwardLineDiagram as unknown) as LineDiagramStop[];
 
-jest.mock("react-async", () => {
-  return {
-    useFetch: jest.fn(() => ({ data: simpleLiveData, reload: () => {} }))
-  };
+// Mock useInterval to instead call the function immediately
+jest.mock("use-interval", () => {
+  return { useInterval: jest.fn((fn: () => void) => fn()) };
 });
-jest.mock("use-interval");
+
+// Mock useFetch to return fixture data with a spy-able reload function
+const liveDataReload = jest.fn();
+const useFetch = jest.fn().mockImplementation(() => ({
+  data: simpleLiveData,
+  isLoading: false,
+  reload: liveDataReload
+}));
+jest.mock("react-async", () => {
+  return { useFetch: () => useFetch() };
+});
 
 const route = {
   type: 3 as RouteType,
@@ -344,5 +353,74 @@ describe("LineDiagram for CR with branches going inward", () => {
       ".c-expandable-block__panel .m-schedule-diagram__stop"
     );
     expect(moreStops.exists()).toBeTruthy();
+  });
+});
+
+describe("LineDiagram live data", () => {
+  const animationFrameSpy = jest.spyOn(window, "requestAnimationFrame");
+  const documentHiddenSpy = jest.spyOn(document, "hidden", "get");
+
+  let wrapper: ShallowWrapper;
+
+  const mountComponent = () => {
+    wrapper = shallow(
+      <LineDiagram
+        lineDiagram={lineDiagram}
+        route={route as EnhancedRoute}
+        directionId={directionId}
+        routePatternsByDirection={
+          routePatternsByDirection as RoutePatternsByDirection
+        }
+        services={[]}
+        stops={{ 0: stops, 1: stops }}
+        today="2019-12-05"
+        scheduleNote={null}
+      />
+    );
+  };
+
+  it("polls for live data using an animation frame request", () => {
+    animationFrameSpy.mockImplementation(fn => {
+      fn(0);
+      return 1;
+    });
+    mountComponent();
+
+    expect(liveDataReload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not poll for live data when no animation frame occurs", () => {
+    animationFrameSpy.mockImplementation(fn => {
+      return 1;
+    });
+    mountComponent();
+
+    expect(liveDataReload).not.toHaveBeenCalled();
+  });
+
+  it("does not poll for live data when the page is not visible", () => {
+    animationFrameSpy.mockImplementation(fn => {
+      fn(0);
+      return 1;
+    });
+    documentHiddenSpy.mockReturnValue(true);
+    mountComponent();
+
+    expect(liveDataReload).not.toHaveBeenCalled();
+  });
+
+  it("does not poll for live data when another request is in flight", () => {
+    animationFrameSpy.mockImplementation(fn => {
+      fn(0);
+      return 1;
+    });
+    useFetch.mockImplementationOnce(() => ({
+      data: {},
+      isLoading: true,
+      reload: liveDataReload
+    }));
+    mountComponent();
+
+    expect(liveDataReload).not.toHaveBeenCalled();
   });
 });

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from "react";
-import { useFetch } from "react-async";
 import { useInterval } from "use-interval";
+import { useFetch } from "react-async";
 
 import {
   LineDiagramStop,
@@ -105,9 +105,11 @@ const LineDiagram = ({
     { json: true, watch: directionId }
   );
   const liveData = (maybeLiveData || {}) as LiveDataByStop;
+
   useInterval(() => {
-    /* istanbul ignore next */
-    if (!liveDataIsLoading) reloadLiveData();
+    requestAnimationFrame(() => {
+      if (!document.hidden && !liveDataIsLoading) reloadLiveData();
+    });
   }, 15000);
 
   const handleStopClick = (stop: RouteStop): void => {


### PR DESCRIPTION
**Asana Ticket:** [Line Diagram | Only poll when page is visible](https://app.asana.com/0/555089885850811/1160944420414819/f)

⚠️ Due to the need to restore the old polling code in order to implement this, it should not be merged until we also restore the old `realtime` endpoint with caching in place.