### PR TITLE
Additional Schedule Finder refactors

### DIFF
--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -191,13 +191,6 @@
   margin: 0 $base-spacing;
 }
 
-.schedule-finder__origin-search {
-  border: 2px solid $brand-primary;
-  border-radius: $border-radius;
-  padding: $base-spacing * .5;
-  width: 100%;
-}
-
 .schedule-finder__origin-modal {
   &.c-modal {
     padding: 0;

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleFinderTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleFinderTest.tsx
@@ -281,12 +281,14 @@ it("opens modal after displaying error", () => {
 
   // perform search
   wrapper
-    .find(".schedule-finder__origin-search")
+    .find(".schedule-finder__origin-search-container input")
     .simulate("change", { target: { value: "Wellington" } });
+  wrapper.setProps({}); // needed to update the `useEffect` in SearchBox
   expect(wrapper.find(".schedule-finder__origin-list-item").length).toBe(1);
   wrapper
-    .find(".schedule-finder__origin-search")
+    .find(".schedule-finder__origin-search-container input")
     .simulate("change", { target: { value: "" } });
+  wrapper.setProps({});
 
   // click origin modal line item
   wrapper

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleTableTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleTableTest.tsx
@@ -3,13 +3,12 @@ import { mount } from "enzyme";
 import serviceData from "./serviceData.json";
 import crServiceData from "./crServiceData.json";
 import ScheduleTable from "../components/schedule-finder/ScheduleTable";
-import { EnhancedRoutePattern } from "../components/__schedule";
+import { EnhancedRoutePattern, UserInput } from "../components/__schedule";
 import {
   createReactRoot,
   enzymeToJsonWithoutProps
 } from "../../app/helpers/testUtils";
 import { Journey } from "../components/__trips.js";
-import { UserInput } from "../components/ScheduleFinder.js";
 
 const journeys: Journey[] = serviceData as Journey[];
 

--- a/apps/site/assets/ts/schedule/__tests__/TableRowTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/TableRowTest.tsx
@@ -4,7 +4,7 @@ import { createReactRoot } from "../../app/helpers/testUtils";
 import TableRow from "../components/schedule-finder/TableRow";
 import { fetchData as fetchJourney } from "../components/schedule-finder/TableRow";
 import { Journey } from "../components/__trips";
-import { UserInput } from "../components/ScheduleFinder";
+import { UserInput } from "../components/__schedule";
 
 const journey = {
   trip: {

--- a/apps/site/assets/ts/schedule/__tests__/UpcomingDeparturesTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/UpcomingDeparturesTest.tsx
@@ -5,7 +5,7 @@ import UpcomingDepartures from "../components/schedule-finder/UpcomingDepartures
 import { EnhancedJourney } from "../components/__trips";
 import departuresResponse from "../__tests__/departures.json";
 import crDeparturesResponse from "../__tests__/crDepartures.json";
-import { UserInput } from "../components/ScheduleFinder";
+import { UserInput } from "../components/__schedule";
 
 const busDepartures = (departuresResponse as unknown) as EnhancedJourney[];
 const crDepartures = (crDeparturesResponse as unknown) as EnhancedJourney[];

--- a/apps/site/assets/ts/schedule/components/ScheduleFinder.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleFinder.tsx
@@ -5,7 +5,9 @@ import {
   SimpleStopMap,
   RoutePatternsByDirection,
   ServiceInSelector,
-  ScheduleNote as ScheduleNoteType
+  ScheduleNote as ScheduleNoteType,
+  SelectedDirection,
+  SelectedOrigin
 } from "./__schedule";
 import { handleReactEnterKeyPress } from "../../helpers/keyboard-events";
 import icon from "../../../static/images/icon-schedule-finder.svg";
@@ -24,16 +26,6 @@ interface Props {
   routePatternsByDirection: RoutePatternsByDirection;
   today: string;
   scheduleNote: ScheduleNoteType | null;
-}
-
-export type SelectedDirection = 0 | 1 | null;
-export type SelectedOrigin = string | null;
-
-export interface UserInput {
-  route: string;
-  origin: string;
-  date: string;
-  direction: SelectedDirection;
 }
 
 interface State {

--- a/apps/site/assets/ts/schedule/components/ScheduleFinder.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleFinder.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState, ChangeEvent } from "react";
+import React, { ReactElement, useState } from "react";
 import { EnhancedRoute, DirectionId } from "../../__v3api";
 import {
   SimpleStop,
@@ -88,13 +88,8 @@ const ScheduleFinder = ({
     selectedService: null
   });
 
-  const handleUpdateOriginSearch = (
-    event: ChangeEvent<HTMLInputElement>
-  ): void => {
-    setState({
-      ...state,
-      originSearch: event.target.value
-    });
+  const handleUpdateOriginSearch = (searchQuery: string): void => {
+    setState({ ...state, originSearch: searchQuery });
   };
 
   const handleSubmitForm = (): void => {

--- a/apps/site/assets/ts/schedule/components/ScheduleFinder.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleFinder.tsx
@@ -33,7 +33,6 @@ interface State {
   modalId: string | null;
   modalOpen: boolean;
   originError: boolean;
-  originSearch: string;
   selectedDirection: SelectedDirection;
   selectedOrigin: SelectedOrigin;
   selectedService: string | null;
@@ -72,17 +71,12 @@ const ScheduleFinder = ({
   const [state, setState] = useState<State>({
     directionError: false,
     originError: false,
-    originSearch: "",
     modalOpen: false,
     modalId: null,
     selectedDirection: validDirections.length === 1 ? validDirections[0] : null,
     selectedOrigin: null,
     selectedService: null
   });
-
-  const handleUpdateOriginSearch = (searchQuery: string): void => {
-    setState({ ...state, originSearch: searchQuery });
-  };
 
   const handleSubmitForm = (): void => {
     if (state.selectedDirection === null || state.selectedOrigin === null) {
@@ -251,10 +245,8 @@ const ScheduleFinder = ({
               <OriginModalContent
                 selectedDirection={state.selectedDirection}
                 selectedOrigin={state.selectedOrigin}
-                originSearch={state.originSearch}
                 stops={stops[state.selectedDirection!] || []}
                 handleChangeOrigin={handleChangeOrigin}
-                handleUpdateOriginSearch={handleUpdateOriginSearch}
                 directionId={directionId}
               />
             )}

--- a/apps/site/assets/ts/schedule/components/__schedule.d.ts
+++ b/apps/site/assets/ts/schedule/components/__schedule.d.ts
@@ -152,3 +152,12 @@ export interface StopPrediction {
   prediction: PredictedOrScheduledTime;
   train_number: string;
 }
+
+export type SelectedDirection = 0 | 1 | null;
+export type SelectedOrigin = string | null;
+export interface UserInput {
+  route: string;
+  origin: string;
+  date: string;
+  direction: SelectedDirection;
+}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/OriginListItem.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/OriginListItem.tsx
@@ -2,8 +2,7 @@ import React, { ReactElement } from "react";
 import { handleReactEnterKeyPress } from "../../../helpers/keyboard-events";
 import renderSvg from "../../../helpers/render-svg";
 import checkIcon from "../../../../static/images/icon-checkmark.svg";
-import { SimpleStop } from "../__schedule";
-import { SelectedOrigin } from "../ScheduleFinder";
+import { SimpleStop, SelectedOrigin } from "../__schedule";
 
 interface OriginListItemProps {
   changeOrigin: Function;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/OriginModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/OriginModalContent.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from "react";
-import { SimpleStop } from "../__schedule";
-import { SelectedOrigin, SelectedDirection } from "../ScheduleFinder";
+import { SimpleStop, SelectedOrigin, SelectedDirection } from "../__schedule";
 import OriginListItem from "./OriginListItem";
 import { DirectionId } from "../../../__v3api";
 import SearchBox from "../../../components/SearchBox";

--- a/apps/site/assets/ts/schedule/components/schedule-finder/OriginModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/OriginModalContent.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement, ChangeEvent } from "react";
+import React, { ReactElement } from "react";
 import { SimpleStop } from "../__schedule";
 import { SelectedOrigin, SelectedDirection } from "../ScheduleFinder";
 import OriginListItem from "./OriginListItem";
 import { DirectionId } from "../../../__v3api";
+import SearchBox from "../../../components/SearchBox";
 
 const stopListSearchFilter = (
   stops: SimpleStop[],
@@ -25,7 +26,7 @@ interface Props {
   selectedDirection: SelectedDirection;
   stops: SimpleStop[];
   handleChangeOrigin: Function;
-  handleUpdateOriginSearch: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleUpdateOriginSearch: (searchQuery: string) => void;
   directionId: DirectionId;
 }
 
@@ -41,17 +42,13 @@ const OriginModalContents = ({
     <p className="schedule-finder__origin-text">
       <strong>Choose an origin stop</strong>
     </p>
-    <div className="schedule-finder__origin-search-container">
-      <input
-        className="schedule-finder__origin-search"
-        id="origin-filter"
-        key="origin-search-input"
-        type="text"
-        onChange={handleUpdateOriginSearch}
-        value={originSearch}
-        placeholder="Filter stops and stations"
-      />
-    </div>
+    <SearchBox
+      id="origin-filter"
+      labelText="Choose an origin stop"
+      className="schedule-finder__origin-search-container"
+      placeholder="Filter stops and stations"
+      onChange={handleUpdateOriginSearch}
+    />
     <p className="schedule-finder__origin-text">Select from the list below.</p>
     <div className="schedule-finder__origin-list">
       {stopListSearchFilter(stops, originSearch).map((stop: SimpleStop) => (

--- a/apps/site/assets/ts/schedule/components/schedule-finder/OriginModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/OriginModalContent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useState } from "react";
 import { SimpleStop, SelectedOrigin, SelectedDirection } from "../__schedule";
 import OriginListItem from "./OriginListItem";
 import { DirectionId } from "../../../__v3api";
@@ -20,47 +20,49 @@ const stopListSearchFilter = (
 };
 
 interface Props {
-  originSearch: string;
   selectedOrigin: SelectedOrigin;
   selectedDirection: SelectedDirection;
   stops: SimpleStop[];
   handleChangeOrigin: Function;
-  handleUpdateOriginSearch: (searchQuery: string) => void;
   directionId: DirectionId;
 }
 
-const OriginModalContents = ({
-  originSearch,
+const OriginModalContent = ({
   selectedOrigin,
   stops,
-  handleChangeOrigin,
-  handleUpdateOriginSearch
-}: Props): ReactElement<HTMLElement> => (
-  <>
-    <br />
-    <p className="schedule-finder__origin-text">
-      <strong>Choose an origin stop</strong>
-    </p>
-    <SearchBox
-      id="origin-filter"
-      labelText="Choose an origin stop"
-      className="schedule-finder__origin-search-container"
-      placeholder="Filter stops and stations"
-      onChange={handleUpdateOriginSearch}
-    />
-    <p className="schedule-finder__origin-text">Select from the list below.</p>
-    <div className="schedule-finder__origin-list">
-      {stopListSearchFilter(stops, originSearch).map((stop: SimpleStop) => (
-        <OriginListItem
-          key={stop.id}
-          stop={stop}
-          changeOrigin={handleChangeOrigin}
-          selectedOrigin={selectedOrigin}
-          lastStop={stops[stops.length - 1]}
-        />
-      ))}
-    </div>
-  </>
-);
+  handleChangeOrigin
+}: Props): ReactElement<HTMLElement> => {
+  const [originSearch, setOriginSearch] = useState("");
 
-export default OriginModalContents;
+  return (
+    <>
+      <br />
+      <p className="schedule-finder__origin-text">
+        <strong>Choose an origin stop</strong>
+      </p>
+      <SearchBox
+        id="origin-filter"
+        labelText="Choose an origin stop"
+        className="schedule-finder__origin-search-container"
+        placeholder="Filter stops and stations"
+        onChange={setOriginSearch}
+      />
+      <p className="schedule-finder__origin-text">
+        Select from the list below.
+      </p>
+      <div className="schedule-finder__origin-list">
+        {stopListSearchFilter(stops, originSearch).map((stop: SimpleStop) => (
+          <OriginListItem
+            key={stop.id}
+            stop={stop}
+            changeOrigin={handleChangeOrigin}
+            selectedOrigin={selectedOrigin}
+            lastStop={stops[stops.length - 1]}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default OriginModalContent;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -1,9 +1,4 @@
 import React, { ReactElement, useReducer, useEffect } from "react";
-import {
-  SelectedDirection,
-  SelectedOrigin,
-  UserInput
-} from "../ScheduleFinder";
 import UpcomingDepartures from "./UpcomingDepartures";
 import { Route, RouteType } from "../../../__v3api";
 import {
@@ -11,7 +6,10 @@ import {
   StopPrediction,
   RoutePatternsByDirection,
   ServiceInSelector,
-  ScheduleNote as ScheduleNoteType
+  ScheduleNote as ScheduleNoteType,
+  SelectedDirection,
+  SelectedOrigin,
+  UserInput
 } from "../__schedule";
 import isSilverLine from "../../../helpers/silver-line";
 import { reducer } from "../../../helpers/fetch";

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleTable.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleTable.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from "react";
 import { EnhancedRoutePattern } from "../__schedule";
 import { Journey } from "../__trips";
 import TableRow from "./TableRow";
-import { UserInput } from "../ScheduleFinder";
+import { UserInput } from "../../components/__schedule";
 
 interface Props {
   journeys: Journey[];

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -10,8 +10,11 @@ import {
 } from "../../../helpers/service";
 import { reducer } from "../../../helpers/fetch";
 import ScheduleTable from "./ScheduleTable";
-import { SelectedDirection } from "../ScheduleFinder";
-import { EnhancedRoutePattern, ServiceInSelector } from "../__schedule";
+import {
+  EnhancedRoutePattern,
+  ServiceInSelector,
+  SelectedDirection
+} from "../__schedule";
 import ServiceOptGroup from "./ServiceOptGroup";
 import { Journey } from "../__trips";
 import { Service } from "../../../__v3api";

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
@@ -5,7 +5,7 @@ import { modeIcon, caret } from "../../../helpers/icon";
 import { handleReactEnterKeyPress } from "../../../helpers/keyboard-events";
 import { breakTextAtSlash } from "../../../helpers/text";
 import { TripDetails } from "./TripDetails";
-import { UserInput } from "../ScheduleFinder";
+import { UserInput } from "../../components/__schedule";
 
 interface TableRowProps {
   input: UserInput;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
@@ -10,7 +10,7 @@ import { Route } from "../../../__v3api";
 import { EnhancedJourney } from "../__trips";
 import { breakTextAtSlash } from "../../../helpers/text";
 import { Accordion } from "./TableRow";
-import { UserInput } from "../ScheduleFinder";
+import { UserInput } from "../../components/__schedule";
 import liveClockSvg from "../../../../static/images/icon-live-clock.svg";
 
 interface State {


### PR DESCRIPTION
**Related to:** [Schedules | Add inputs to schedule finder modal](https://app.asana.com/0/385363666817452/1160795456837881/f)

These are a couple of other refactors that were left on Cristen's schedule-finder-inputs branch (see also #404). Since they are mostly independent of the feature work, and in the interest of keeping changes small and easily reviewed, I've separated them out.