### PR TITLE
Re-enable realtime line diagram data

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from "react";
 import { useFetch } from "react-async";
+import { useInterval } from "use-interval";
 
 import {
   LineDiagramStop,
@@ -93,14 +94,21 @@ const LineDiagram = ({
     modalOpen: false
   });
 
-  const { data: maybeLiveData } = useFetch(
-    `/schedules/line_api/predictions_and_vehicles?id=${
-      route.id
-    }&direction_id=${directionId}`,
+  const {
+    data: maybeLiveData,
+    isLoading: liveDataIsLoading,
+    // @ts-ignore https://github.com/async-library/react-async/issues/244
+    reload: reloadLiveData
+  } = useFetch(
+    `/schedules/line_api/realtime?id=${route.id}&direction_id=${directionId}`,
     {},
     { json: true, watch: directionId }
   );
   const liveData = (maybeLiveData || {}) as LiveDataByStop;
+  useInterval(() => {
+    /* istanbul ignore next */
+    if (!liveDataIsLoading) reloadLiveData();
+  }, 15000);
 
   const handleStopClick = (stop: RouteStop): void => {
     const { "is_beginning?": isBeginning, "is_terminus?": isTerminus } = stop;

--- a/apps/site/lib/site/application.ex
+++ b/apps/site/lib/site/application.ex
@@ -17,6 +17,10 @@ defmodule Site.Application do
 
     children = [
       # Start the endpoint when the application starts
+      supervisor(ConCache, [
+        [ttl: :timer.seconds(60), ttl_check: :timer.seconds(5)],
+        [name: :line_diagram_realtime_cache]
+      ]),
       supervisor(SiteWeb.Endpoint, []),
       supervisor(Site.GreenLine.Supervisor, []),
       supervisor(Site.Stream.Vehicles, []),

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -50,14 +50,27 @@ defmodule SiteWeb.ScheduleController.LineApi do
   Provides predictions and vehicle information for a given route and direction, organized by stop.
   The line diagram polls this endpoint for its real-time data.
   """
-  @spec predictions_and_vehicles(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def predictions_and_vehicles(conn, %{"id" => route_id, "direction_id" => direction_id}) do
+  @spec realtime(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def realtime(conn, %{"id" => route_id, "direction_id" => direction_id}) do
+    cache_key = {route_id, direction_id, conn.assigns.date}
+
+    payload =
+      ConCache.get_or_store(:line_diagram_realtime_cache, cache_key, fn ->
+        do_realtime(route_id, direction_id, conn.assigns.date, conn.assigns.date_time)
+      end)
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, payload)
+  end
+
+  defp do_realtime(route_id, direction_id, date, now) do
     headsigns_by_stop =
       TransitNearMe.time_data_for_route_by_stop(
         route_id,
         String.to_integer(direction_id),
-        date: conn.assigns.date,
-        now: conn.assigns.date_time
+        date: date,
+        now: now
       )
 
     vehicles_by_stop =
@@ -80,7 +93,7 @@ defmodule SiteWeb.ScheduleController.LineApi do
       end)
       |> Enum.into(%{})
 
-    json(conn, combined_data_by_stop)
+    Jason.encode!(combined_data_by_stop)
   end
 
   @spec update_route_stop_data({any, RouteStop.t()}, any, DateTime.t()) :: map()

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -134,11 +134,9 @@ defmodule SiteWeb.Router do
     get("/schedules/map_api", ScheduleController.MapApi, :show)
     get("/schedules/line_api", ScheduleController.LineApi, :show)
 
-    get(
-      "/schedules/line_api/predictions_and_vehicles",
-      ScheduleController.LineApi,
-      :predictions_and_vehicles
-    )
+    get("/schedules/line_api/predictions_and_vehicles", ScheduleController.LineApi, :realtime)
+
+    get("/schedules/line_api/realtime", ScheduleController.LineApi, :realtime)
 
     get("/schedules/subway", ModeController, :subway)
     get("/schedules/bus", ModeController, :bus)

--- a/apps/site/mix.exs
+++ b/apps/site/mix.exs
@@ -57,7 +57,8 @@ defmodule Site.Mixfile do
       :util,
       :trip_plan,
       :services,
-      :route_patterns
+      :route_patterns,
+      :con_cache
     ]
 
     apps =
@@ -110,6 +111,7 @@ defmodule Site.Mixfile do
       {:hammer, "~> 4.0"},
       {:poolboy, "~> 1.5"},
       {:wallaby, "~> 0.22", runtime: false, only: :test},
+      {:con_cache, "~> 0.12.0"},
       {:stops, in_umbrella: true},
       {:routes, in_umbrella: true},
       {:alerts, in_umbrella: true},

--- a/apps/site/test/site_web/controllers/line_api_test.exs
+++ b/apps/site/test/site_web/controllers/line_api_test.exs
@@ -9,12 +9,12 @@ defmodule SiteWeb.LineApiTest do
     end
   end
 
-  describe "predictions_and_vehicles" do
+  describe "realtime" do
     test "success response", %{conn: conn} do
       conn =
         get(
           conn,
-          line_api_path(conn, :predictions_and_vehicles, %{"id" => "Red", "direction_id" => "1"})
+          line_api_path(conn, :realtime, %{"id" => "Red", "direction_id" => "1"})
         )
 
       assert %{"place-brdwy" => %{"headsigns" => _, "vehicles" => _}} = json_response(conn, 200)


### PR DESCRIPTION
This re-enables both the polling of the realtime endpoint and the
caching of same, only this time with the correct options.

#### Summary of changes
**Asana Ticket:** [Restore caching and polling to realtime endpoint](https://app.asana.com/0/555089885850811/1164530949166961)
