### PR TITLE
Revert "Poll for live data only when page is visible"

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from "react";
-import { useInterval } from "use-interval";
 import { useFetch } from "react-async";
+import { useInterval } from "use-interval";
 
 import {
   LineDiagramStop,
@@ -105,11 +105,9 @@ const LineDiagram = ({
     { json: true, watch: directionId }
   );
   const liveData = (maybeLiveData || {}) as LiveDataByStop;
-
   useInterval(() => {
-    requestAnimationFrame(() => {
-      if (!document.hidden && !liveDataIsLoading) reloadLiveData();
-    });
+    /* istanbul ignore next */
+    if (!liveDataIsLoading) reloadLiveData();
   }, 15000);
 
   const handleStopClick = (stop: RouteStop): void => {


### PR DESCRIPTION
This reverts commit 8900bd518b2051c5104228a4ba5ae0d02f7e5aab. We suspect
that this may be making more requests than it is meant to, and it's only
auxiliary to the cache in making the realtime endpoint more performant.
