### PR TITLE
Add concurrency to realtime cache

### DIFF
--- a/apps/site/lib/site/application.ex
+++ b/apps/site/lib/site/application.ex
@@ -18,7 +18,11 @@ defmodule Site.Application do
     children = [
       # Start the endpoint when the application starts
       supervisor(ConCache, [
-        [ttl: :timer.seconds(60), ttl_check: :timer.seconds(5)],
+        [
+          ttl: :timer.seconds(60),
+          ttl_check: :timer.seconds(5),
+          ets_options: [read_concurrency: true]
+        ],
         [name: :line_diagram_realtime_cache]
       ]),
       supervisor(SiteWeb.Endpoint, []),


### PR DESCRIPTION
These options should prevent the locking related errors for the realtime API under heavy load. They were present originally, but in removing and restoring the `ttl` options repeatedly I accidentally removed these.