### PR TITLE
Add version checking to realtime endpoint

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -94,7 +94,9 @@ const LineDiagram = ({
   });
 
   const { data: maybeLiveData } = useSWR(
-    `/schedules/line_api/realtime?id=${route.id}&direction_id=${directionId}`,
+    `/schedules/line_api/realtime?id=${
+      route.id
+    }&direction_id=${directionId}&v=2`,
     url => fetch(url).then(response => response.json()),
     { refreshInterval: 15000 }
   );

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -51,17 +51,24 @@ defmodule SiteWeb.ScheduleController.LineApi do
   The line diagram polls this endpoint for its real-time data.
   """
   @spec realtime(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def realtime(conn, %{"id" => route_id, "direction_id" => direction_id}) do
-    cache_key = {route_id, direction_id, conn.assigns.date}
+  def realtime(conn, %{"id" => route_id, "direction_id" => direction_id} = query_params) do
+    # We added this since we made some alterations to the corresponding
+    # frontend code, and we only want to service requests from the latest
+    # version of said code
+    if query_params["v"] == "2" do
+      cache_key = {route_id, direction_id, conn.assigns.date}
 
-    payload =
-      ConCache.get_or_store(:line_diagram_realtime_cache, cache_key, fn ->
-        do_realtime(route_id, direction_id, conn.assigns.date, conn.assigns.date_time)
-      end)
+      payload =
+        ConCache.get_or_store(:line_diagram_realtime_cache, cache_key, fn ->
+          do_realtime(route_id, direction_id, conn.assigns.date, conn.assigns.date_time)
+        end)
 
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(200, payload)
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(200, payload)
+    else
+      json(conn, %{})
+    end
   end
 
   defp do_realtime(route_id, direction_id, date, now) do


### PR DESCRIPTION
To prevent the odd remaining herd from thundering through our website.