### PR TITLE
Mock out ExAWS config in test

### DIFF
--- a/apps/feedback/config/test.exs
+++ b/apps/feedback/config/test.exs
@@ -2,4 +2,5 @@ use Mix.Config
 
 config :feedback,
   time_fetcher: Feedback.FakeDateTime,
+  exaws_config_fn: &Feedback.Test.mock_config/1,
   exaws_perform_fn: &Feedback.Test.mock_perform/2

--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -55,6 +55,8 @@ defmodule Feedback.Mailer do
       |> Mail.put_subject("MBTA Customer Comment Form")
       |> Mail.put_text(body)
 
+    exaws_config_fn = Application.get_env(:feedback, :exaws_config_fn, &ExAws.Config.new/1)
+
     exaws_perform_fn =
       Application.get_env(:feedback, :exaws_perform_fn, &ExAws.Operation.perform/2)
 
@@ -62,7 +64,7 @@ defmodule Feedback.Mailer do
       message
       |> Mail.Renderers.RFC2822.render()
       |> ExAws.SES.send_raw_email()
-      |> exaws_perform_fn.(ExAws.Config.new(:ses))
+      |> exaws_perform_fn.(exaws_config_fn.(:ses))
   end
 
   defp format_name(nil) do

--- a/apps/feedback/lib/test.ex
+++ b/apps/feedback/lib/test.ex
@@ -14,6 +14,10 @@ defmodule Feedback.Test do
     end
   end
 
+  def mock_config(:ses) do
+    :ok
+  end
+
   def mock_perform(%{params: %{"RawMessage.Data" => raw_message}}, _config) do
     parsed_message = raw_message |> Base.decode64!() |> Mail.Parsers.RFC2822.parse()
 


### PR DESCRIPTION
No ticket. Missed one function that should be mocked out in testing; it worked on my machine without it but other engineers ran into trouble.