### PR TITLE
Remove width restriction

### DIFF
--- a/apps/site/assets/css/_route.scss
+++ b/apps/site/assets/css/_route.scss
@@ -10,10 +10,6 @@
 
 .hours-directions {
   margin-bottom: 0;
-
-  @include media-breakpoint-up(md) {
-    width: 75%;
-  }
 }
 
 .hours-direction-name {

--- a/apps/site/assets/css/_route.scss
+++ b/apps/site/assets/css/_route.scss
@@ -10,17 +10,7 @@
 
 .hours-directions {
   margin-bottom: 0;
-}
-
-.hours-direction-name {
-  display: inline-block;
-  width: 40%;
-}
-
-.hours-time {
-  display: inline-block;
-  font-variant-numeric: tabular-nums;
-  text-align: right;
+  text-transform: uppercase;
 }
 
 .commuter-rail-zone {

--- a/apps/site/lib/site_web/templates/schedule/_hours_of_op.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_hours_of_op.html.eex
@@ -2,8 +2,7 @@
   <h3 class="hours-period-heading"><%= schedule_period(period) %></h4>
   <%= for {direction_id, departure} <- [{1, direction_1}, {0, direction_0}] do %>
     <p class="hours-directions">
-      <span class="hours-direction-name"><%= Routes.Route.direction_name(@route, direction_id) %></span>
-      <span class="hours-time"><%= display_departure_range(departure) %></span>
+      <%= Routes.Route.direction_name(@route, direction_id) %>&nbsp;<%= display_departure_range(departure) %>
     </p>
   <% end %>
 <% end %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Bug | Schedules | Hours of Operation missing spacing](https://app.asana.com/0/385363666817452/1165381204331765)
I removed the restriction of width for class `hours-directions` because that was causing the spacing to be nonexistent.
I tested this with different widths but let me know if you still find issues.
