### PR TITLE
Change "Storm service" copy to "Reduced service"

### DIFF
--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceOptGroupTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceOptGroupTest.tsx.snap
@@ -32,7 +32,7 @@ exports[`ServiceOptGroup renders 1`] = `
   <option
     value="BUS319-storm"
   >
-    Storm service, Jul 15 to Jul 15
+    Reduced service, Jul 15 to Jul 15
   </option>
   <option
     value="weekday2020"

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
@@ -66,12 +66,12 @@ Array [
           <option
             value="BUS319-storm"
           >
-            Storm service, Jul 15 to Jul 15
+            Reduced service, Jul 15 to Jul 15
           </option>
           <option
             value="BUS319-storm-1"
           >
-            Storm service, Jul 22 to Jul 23
+            Reduced service, Jul 22 to Jul 23
           </option>
         </optgroup>
       </select>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOptGroup.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOptGroup.tsx
@@ -31,12 +31,12 @@ const ServiceOptGroup = ({
         let optionText = "";
 
         if (service.typicality === "unplanned_disruption") {
-          const stormServicePeriod =
+          const reducedServicePeriod =
             startDate === endDate
               ? shortDate(startDate)
               : startToEnd(startDate, endDate);
 
-          optionText = `Storm service, ${stormServicePeriod}`;
+          optionText = `Reduced service, ${reducedServicePeriod}`;
         } else if (
           service.typicality === "holiday_service" &&
           service.added_dates_notes


### PR DESCRIPTION
Currently services with a `typicality` of `unplanned_disruption` are
labelled "Storm service" in the schedule finder, on the assumption that
we would reserve that typicality for winter storms. Given the
possibility of reduced service due to the COVID pandemic, however, here
we change our copy to the more general "Reduced service", which is still
accurate in case of a storm as well.

#### Summary of changes
**Asana Ticket:** [Change "Storm Service" hardcoded copy in schedule selector to "Reduced Service"](https://app.asana.com/0/555089885850811/1166409415592881)