### PR TITLE
Include URL in MBTA alerts

### DIFF
--- a/apps/alerts/lib/alert.ex
+++ b/apps/alerts/lib/alert.ex
@@ -1,4 +1,5 @@
 defmodule Alerts.Alert do
+  @moduledoc "Module for representation of an alert, including information such as description, severity or additional URL to learn more"
   alias Alerts.Priority
   alias Alerts.InformedEntitySet, as: IESet
 
@@ -11,7 +12,8 @@ defmodule Alerts.Alert do
             lifecycle: :unknown,
             updated_at: Timex.now(),
             description: "",
-            priority: :low
+            priority: :low,
+            url: ""
 
   @type period_pair :: {DateTime.t() | nil, DateTime.t() | nil}
 
@@ -58,7 +60,8 @@ defmodule Alerts.Alert do
           lifecycle: lifecycle,
           updated_at: DateTime.t(),
           description: String.t() | nil,
-          priority: Priority.priority_level()
+          priority: Priority.priority_level(),
+          url: String.t() | nil
         }
 
   @type icon_type :: :alert | :cancel | :none | :shuttle | :snow

--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -204,6 +204,7 @@ export interface Alert {
   updated_at: string;
   description: string;
   priority: Priority;
+  url: string;
 }
 
 interface DatesNotes {

--- a/apps/site/assets/ts/components/Alerts.tsx
+++ b/apps/site/assets/ts/components/Alerts.tsx
@@ -147,6 +147,10 @@ const alertDescription = (alert: AlertType): ReactElement<HTMLElement> => (
 const Alert = ({ alert }: { alert: AlertType }): ReactElement<HTMLElement> => {
   const [expanded, toggleExpanded] = useState(false);
   const onClick = (): void => toggleExpanded(!expanded);
+  // remove [http:// | https:// | www] from alert URL:
+  const strippedAlertUrl = (alert.url).replace(/(https?:\/\/)?(www\.)?/i, '');
+  const headerContent = alert.url ? `${alert.header} <a href="${alert.url}" target="_blank">${strippedAlertUrl}</a>` : alert.header;
+
   return (
     <li
       id={`alert-${alert.id}`}
@@ -166,7 +170,7 @@ const Alert = ({ alert }: { alert: AlertType }): ReactElement<HTMLElement> => {
             {humanLabelForAlert(alert) ? alertLabel(alert) : null}
           </div>
           {/* eslint-disable-next-line react/no-danger */}
-          <div dangerouslySetInnerHTML={{ __html: alert.header }} />
+          <div dangerouslySetInnerHTML={{ __html: headerContent }} />
         </div>
         <div className="c-alert-item__top-caret-container">
           {caretIcon(alert.description === "", expanded)}

--- a/apps/site/assets/ts/components/Alerts.tsx
+++ b/apps/site/assets/ts/components/Alerts.tsx
@@ -148,8 +148,12 @@ const Alert = ({ alert }: { alert: AlertType }): ReactElement<HTMLElement> => {
   const [expanded, toggleExpanded] = useState(false);
   const onClick = (): void => toggleExpanded(!expanded);
   // remove [http:// | https:// | www] from alert URL:
-  const strippedAlertUrl = (alert.url).replace(/(https?:\/\/)?(www\.)?/i, '');
-  const headerContent = alert.url ? `${alert.header} <a href="${alert.url}" target="_blank">${strippedAlertUrl}</a>` : alert.header;
+  const strippedAlertUrl = alert.url.replace(/(https?:\/\/)?(www\.)?/i, "");
+  const headerContent = alert.url
+    ? `${alert.header} <a href="${
+        alert.url
+      }" target="_blank">${strippedAlertUrl}</a>`
+    : alert.header;
 
   return (
     <li

--- a/apps/site/assets/ts/components/__tests__/AlertsTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/AlertsTest.tsx
@@ -24,7 +24,8 @@ const highAlert: Alert = {
     'Route 170 will be rerouted at certain times during the Marathon on Monday, April 15. More: <a href="https://mbta.com/marathon">mbta.com/marathon</a>',
   effect: "detour",
   description:
-    "<strong>Affected direction:</strong><br />Inbound<br />\r<br /><strong>Affected stops:</strong><br />Meridian St @ West Eagle St"
+    "<strong>Affected direction:</strong><br />Inbound<br />\r<br /><strong>Affected stops:</strong><br />Meridian St @ West Eagle St",
+  url: "https://www.mbta.com"
 };
 
 const lowAlert: Alert = {
@@ -37,7 +38,8 @@ const lowAlert: Alert = {
   id: "00005",
   header: "There is construction at this station.",
   effect: "other",
-  description: ""
+  description: "",
+  url: "https://www.mbta.com"
 };
 
 test("handle click to expand and enter to collapse", () => {

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
@@ -48,7 +48,7 @@ exports[`it renders 1`] = `
                 <div
                   dangerouslySetInnerHTML={
                     Object {
-                      "__html": "Route 170 will be rerouted at certain times during the Marathon on Monday, April 15. More: <a href=\\"https://mbta.com/marathon\\">mbta.com/marathon</a>",
+                      "__html": "Route 170 will be rerouted at certain times during the Marathon on Monday, April 15. More: <a href=\\"https://mbta.com/marathon\\">mbta.com/marathon</a> <a href=\\"https://www.mbta.com\\" target=\\"_blank\\">mbta.com</a>",
                     }
                   }
                 />
@@ -132,7 +132,7 @@ exports[`it renders 1`] = `
                 <div
                   dangerouslySetInnerHTML={
                     Object {
-                      "__html": "There is construction at this station.",
+                      "__html": "There is construction at this station. <a href=\\"https://www.mbta.com\\" target=\\"_blank\\">mbta.com</a>",
                     }
                   }
                 />

--- a/apps/site/assets/ts/stop/__tests__/AlertsTabTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/AlertsTabTest.tsx
@@ -18,7 +18,8 @@ const highAlert: Alert = {
     "Route 170 will be rerouted at certain times during the Marathon on Monday, April 15.",
   effect: "detour",
   description:
-    "<strong>Affected direction:</strong><br />Inbound<br />\r<br /><strong>Affected stops:</strong><br />Meridian St @ West Eagle St"
+    "<strong>Affected direction:</strong><br />Inbound<br />\r<br /><strong>Affected stops:</strong><br />Meridian St @ West Eagle St",
+  url: "https://www.mbta.com"
 };
 
 const lowAlert: Alert = {
@@ -31,7 +32,8 @@ const lowAlert: Alert = {
   id: "00005",
   header: "There is construction at this station.",
   effect: "other",
-  description: ""
+  description: "",
+  url: "https://www.mbta.com"
 };
 
 const alertsTab: AlertsTabType = {

--- a/apps/site/assets/ts/stop/__tests__/StopPageTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageTest.tsx
@@ -46,7 +46,8 @@ const lowAlert: Alert = {
   id: "00005",
   header: "There is construction at this station.",
   effect: "other",
-  description: ""
+  description: "",
+  url: "https://www.mbta.com"
 };
 /* eslint-enable typescript/camelcase */
 

--- a/apps/site/lib/site_web/templates/alert/_banner.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_banner.html.eex
@@ -13,6 +13,9 @@
       </div>
       <div>
         <%= replace_urls_with_links(@alert.header) %>
+        <%= if @alert.url != nil do %>
+          <%= replace_urls_with_links(@alert.url) %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/apps/site/lib/site_web/templates/alert/_item.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_item.html.eex
@@ -18,6 +18,9 @@
       </div>
       <div>
         <%= replace_urls_with_links(@alert.header) %>
+        <%= if @alert.url != nil do %>
+          <%= replace_urls_with_links(@alert.url) %>
+        <% end %>
       </div>
     </div>
     <div class="c-alert-item__top-caret-container">

--- a/apps/site/lib/site_web/templates/trip_plan/index.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/index.html.eex
@@ -7,10 +7,8 @@
       <%= case assigns[:query] do %>
         <% %{itineraries: {:ok, itineraries}} -> %>
         <p class="no-trips page-section">
-          We found
-          <%= l = length(itineraries) %>
-          <%= Inflex.inflect("trip", l) %>
-          for you
+          <% l = length(itineraries) %>
+          <%= "We found #{l} #{Inflex.inflect("trip", l)} for you" %>
         </p>
         <p class="instructions page-section"><%= itinerary_explanation(@query, @modes) %></p>
         <% itinerary_data = itinerary_html(itineraries, %{conn: @conn, expanded: @expanded}) %>

--- a/apps/site/test/mappings/proxy.json
+++ b/apps/site/test/mappings/proxy.json
@@ -2,7 +2,12 @@
   "priority": 100,
   "request": {
     "method": "GET",
-    "urlPattern": ".*"
+    "urlPattern": ".*",
+    "headers" : {
+      "X-WM-Proxy-Url" : {
+        "contains" : "http"
+      }
+    }
   },
   "response": {
     "proxyBaseUrl" : "{{request.headers.X-WM-Proxy-Url}}",

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -364,7 +364,9 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
   defp get_valid_trip_date(route_id) do
     route_id
     |> ServicesRepo.by_route_id()
-    |> List.first()
+    |> Enum.filter(&(&1.type == :weekday))
+    |> Enum.sort_by(& &1.end_date)
+    |> List.last()
     |> Map.get(:end_date)
     |> Date.to_iso8601()
   end

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -11,12 +11,14 @@ defmodule SiteWeb.ScheduleController.LineTest do
 
   @deps %SiteWeb.ScheduleController.Line.Dependencies{}
 
+  @base_end_date ~D[2020-12-08]
+
   @thirtynine_services [
     %Service{
       added_dates: [],
       added_dates_notes: %{},
       description: "Weekday schedule",
-      end_date: ~D[2020-03-13],
+      end_date: Date.add(@base_end_date, 5),
       id: "BUS120-3-Wdy-02",
       name: "Weekday",
       removed_dates: [
@@ -44,7 +46,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       added_dates: [],
       added_dates_notes: %{},
       description: "Weekday schedule",
-      end_date: ~D[2020-03-13],
+      end_date: Date.add(@base_end_date, 5),
       id: "BUS120-Z-Wdy-02",
       name: "Weekday",
       removed_dates: [
@@ -148,7 +150,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       added_dates: [],
       added_dates_notes: %{},
       description: "Saturday schedule",
-      end_date: ~D[2020-03-14],
+      end_date: Date.add(@base_end_date, 6),
       id: "WinterSaturday",
       name: "Saturday",
       removed_dates: [],
@@ -162,7 +164,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       added_dates: [],
       added_dates_notes: %{},
       description: "Sunday schedule",
-      end_date: ~D[2020-03-08],
+      end_date: @base_end_date,
       id: "WinterSunday",
       name: "Sunday",
       removed_dates: [],
@@ -199,7 +201,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       added_dates: [],
       added_dates_notes: %{},
       description: "Weekday schedule",
-      end_date: ~D[2020-03-13],
+      end_date: Date.add(@base_end_date, 5),
       id: "WinterWeekday",
       name: "Weekday",
       removed_dates: [

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -8,6 +8,7 @@ defmodule SiteWeb.ScheduleControllerTest do
   alias Stops.RouteStops
 
   @moduletag :external
+  @test_origin "66"
 
   describe "Bus" do
     test "all stops is assigned for a route", %{conn: conn} do
@@ -23,15 +24,15 @@ defmodule SiteWeb.ScheduleControllerTest do
     end
 
     test "has the origin when it has been selected", %{conn: conn} do
-      conn = get(conn, trip_view_path(conn, :show, "1", origin: "2167", direction_id: "1"))
+      conn = get(conn, trip_view_path(conn, :show, "1", origin: @test_origin, direction_id: "1"))
       html_response(conn, 200)
-      assert conn.assigns.origin.id == "2167"
+      assert conn.assigns.origin.id == @test_origin
     end
 
     test "finds a trip when origin has been selected", %{conn: conn} do
-      conn = get(conn, trip_view_path(conn, :show, "1", origin: "2167", direction_id: "1"))
+      conn = get(conn, trip_view_path(conn, :show, "1", origin: @test_origin, direction_id: "1"))
       html_response(conn, 200)
-      assert conn.assigns.origin.id == "2167"
+      assert conn.assigns.origin.id == @test_origin
       assert conn.assigns.trip_info
     end
 
@@ -39,11 +40,15 @@ defmodule SiteWeb.ScheduleControllerTest do
       conn =
         get(
           conn,
-          trip_view_path(conn, :show, "1", origin: "2167", destination: "82", direction_id: "1")
+          trip_view_path(conn, :show, "1",
+            origin: @test_origin,
+            destination: "82",
+            direction_id: "1"
+          )
         )
 
       html_response(conn, 200)
-      assert conn.assigns.origin.id == "2167"
+      assert conn.assigns.origin.id == @test_origin
       assert conn.assigns.destination.id == "82"
       assert conn.assigns.trip_info
       assert conn.assigns.schedules != nil

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -27,6 +27,35 @@ verify our type specifications and make sure we're calling functions properly.
 Frontend code is formatted by Prettier. If using the Prettier plugin for Visual
 Studio Code, ensure it uses the ignore file `apps/site/assets/.prettierignore`.
 
+## CrossBrowserTesting
+
+We use this service to test site changes in Internet Explorer 11 without needing
+a local Windows computer or VM.
+
+* [Run a test here!](https://app.crossbrowsertesting.com/livetests/run)
+* Sign in using the shared credentials in **Shared-Website-Dev** in LastPass
+
+Only one person can be running a test using this account at a time; be sure to
+**Stop** your session once you're done with it.
+
+### Testing local changes
+
+If your changes aren't deployed anywhere, you can use the `cbt_tunnels` tool to
+enable CrossBrowserTesting to connect to your local machine.
+
+The easiest way to install this is as a global NPM package:
+
+    npm install -g cbt_tunnels
+
+Then click on the "Local Connection" indicator in the CBT menu bar, copy the
+**Authkey**, and start the tunnel using this command:
+
+    cbt_tunnels --username web-tools@mbtace.com --authkey <AUTHKEY>
+
+If the tunnel is working, the "Local Connection" indicator should flip **ON**.
+You can now start a test using `local` as the domain, and the connection will be
+tunneled to `localhost` on your machine. For example: `http://local:4001/`
+
 ## Backstop
 
 We use [BackstopJS](https://github.com/garris/BackstopJS) to test for unexpected

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,4 +1,4 @@
-## Tests
+# Tests
 
 * `mix test` — Elixir tests
 * `npm run test:js` — JS tests
@@ -8,10 +8,10 @@
 
 ### Dialyzer
 
-Dialyzer is a static analysis tool which looks at type information. We use it
-verify our type specifcations and make sure we're calling functions properly.
+* `mix dialyzer`
 
-* `mix dialyzer` — Runs the actual type checks.
+Dialyzer is a static analysis tool which looks at type information. We use it
+verify our type specifications and make sure we're calling functions properly.
 
 ### Linting
 
@@ -19,26 +19,28 @@ verify our type specifcations and make sure we're calling functions properly.
 * SCSS: `npm run stylelint`
 * TypeScript: `npm run tslint`
 
-### Javascript and Typescript formatting
+### Formatting
 
-Our javascript is linted by eslint and formatted by prettier. At this time, only prettier formatting is enforced in CI for javascript. For Typescript, both eslint and prettier are enforced in CI. You can auto-format your javascript and Typescript via `npm run format`, or set it up to autoformat on save in your editor of choice.
+* Elixir: `mix format`
+* JavaScript/TypeScript: `npm run format`
 
-If you are using the Prettier plugin for Visual Studio Code, you will want to configure it to use the ignore file  in `apps/site/assets/.prettierignore`.
+Frontend code is formatted by Prettier. If using the Prettier plugin for Visual
+Studio Code, ensure it uses the ignore file `apps/site/assets/.prettierignore`.
 
-### Backstop Tests
+## Backstop
 
-We use [BackstopJS](https://github.com/garris/BackstopJS) to test for
-unexpected visual changes. Backstop works by keeping a repository of
-reference images. When you run a backstop test it takes snapshots of the
-pages on your localhost and compares them to those references images.
-If anything has changed then the test will fail. This helps us catch unintended
-changes to the UI (for example a CSS selector that is broader than
-expected). Whenever you make a change that affects the UI, you will need to check
-and if necessary update the backstop images.
+We use [BackstopJS](https://github.com/garris/BackstopJS) to test for unexpected
+visual changes. Backstop works by keeping a repository of reference images. When
+you run a Backstop test, it takes snapshots of pages on your version of the site
+and compares them to those reference images. If anything has changed, the test
+will fail. This helps us catch unintended changes to the UI (for example a CSS
+selector that is broader than expected). Whenever you make a change that affects
+the UI, you will need to check and update the Backstop images if necessary.
 
-The tests are run against a live application, built in production mode. To make sure that the tests
-work consistently and do not depend on a specific schedule or realtime vehicle locations, we use
-[WireMock](http://wiremock.org/) to record and playback the V3 API responses.
+The tests are run against a live application, built in production mode. To make
+sure that the tests work consistently and do not depend on a specific schedule
+or realtime vehicle locations, we use [WireMock](http://wiremock.org/) to record
+and play back the V3 API responses.
 
 Prerequisites for running the tests:
 
@@ -55,19 +57,21 @@ Prerequisites for running the tests:
   the Wiremock JAR file; with brew cask this will be something like
   `/usr/local/Cellar/wiremock-standalone/<VERSION>/libexec/wiremock-standalone-<VERSION>.jar`
 
-Once all the above are in place: `npm run backstop`
+Once all the above are in place:
+
+* `npm run backstop` — run the tests
+* `npm run backstop:record` — run tests with recording of new network requests
+* `npm run backstop:approve` — mark the last set of failed diffs as approved
 
 Note: If you are not running on OSX or Windows, you'll need to modify the
 `STATIC_HOST=host.docker.internal` in the commands.
 
-### Other helpful test scripts
+## Other helpful test scripts
 
-All run from the main folder:
-
-* `npm run backstop:record` - run Backstop tests with recording of new network requests enabled
-* `npm run backstop:approve` - mark failed Backstop diffs as new reference images
-* `npm run webpack:watch` — run webpack-dev-server for local development
-* `npm run webpack:build` — builds the static files for production
 * `semaphore/smoke_test.sh` - tries to hit all the URLs on your server.
   Requires wget (installable with `brew install wget`)
-* `mix run apps/content/bin/validate_fixtures.exs` - compares the attributes in our fixture files to production Drupal API endpoints to see if any are missing. Note that rather than using this script, it is better to update these fixture attributes at the time you are making API changes.
+
+* `mix run apps/content/bin/validate_fixtures.exs` - compares the attributes in
+  our fixture files to production Drupal API endpoints to see if any are
+  missing. Note that rather than using this script, it is better to update these
+  fixture attributes at the time you are making API changes.


### PR DESCRIPTION
**Asana Ticket:** [Alerts | Website should use URL field](https://app.asana.com/0/385363666817452/1116522101105763)
#### Summary of changes
URL coming from Alerts wasn't being taken into account. Now it's being displayed in the header of each alert, in the format [Alert Message] [URL]
<br/>
This contains an unrelated fix for spacing in the Trip Planner, made in passing:
<img width="195" alt="image" src="https://user-images.githubusercontent.com/61979382/76769152-72500180-6772-11ea-839b-6dce7d84a7ad.png">