### PR TITLE
Surface errors with Wiremock proxying in Backstop

### DIFF
--- a/apps/site/test/mappings/proxy.json
+++ b/apps/site/test/mappings/proxy.json
@@ -2,7 +2,12 @@
   "priority": 100,
   "request": {
     "method": "GET",
-    "urlPattern": ".*"
+    "urlPattern": ".*",
+    "headers" : {
+      "X-WM-Proxy-Url" : {
+        "contains" : "http"
+      }
+    }
   },
   "response": {
     "proxyBaseUrl" : "{{request.headers.X-WM-Proxy-Url}}",


### PR DESCRIPTION
Cleaning out my Dotcom "junk drawer", I came across this small change I think could be useful in debugging Backstop/Wiremock issues. As you can see from the CI results, it doesn't change the status of any current Backstop tests — just adds a "guard" to ensure the proxy-to-the-live-API mapping isn't used unless there is actually a proxy header attached to the request, telling it where to proxy to.

You'll note some extra error output for when requests don't match any mapping. Unfortunately, as far as I can tell, there's no way to format this any better than "kinda broken ASCII tables".