### PR TITLE
Fix Elixir tests for spring 2020 rating

### DIFF
--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -364,7 +364,9 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
   defp get_valid_trip_date(route_id) do
     route_id
     |> ServicesRepo.by_route_id()
-    |> List.first()
+    |> Enum.filter(&(&1.type == :weekday))
+    |> Enum.sort_by(& &1.end_date)
+    |> List.last()
     |> Map.get(:end_date)
     |> Date.to_iso8601()
   end

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -11,12 +11,14 @@ defmodule SiteWeb.ScheduleController.LineTest do
 
   @deps %SiteWeb.ScheduleController.Line.Dependencies{}
 
+  @base_end_date ~D[2020-12-08]
+
   @thirtynine_services [
     %Service{
       added_dates: [],
       added_dates_notes: %{},
       description: "Weekday schedule",
-      end_date: ~D[2020-03-13],
+      end_date: Date.add(@base_end_date, 5),
       id: "BUS120-3-Wdy-02",
       name: "Weekday",
       removed_dates: [
@@ -44,7 +46,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       added_dates: [],
       added_dates_notes: %{},
       description: "Weekday schedule",
-      end_date: ~D[2020-03-13],
+      end_date: Date.add(@base_end_date, 5),
       id: "BUS120-Z-Wdy-02",
       name: "Weekday",
       removed_dates: [
@@ -148,7 +150,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       added_dates: [],
       added_dates_notes: %{},
       description: "Saturday schedule",
-      end_date: ~D[2020-03-14],
+      end_date: Date.add(@base_end_date, 6),
       id: "WinterSaturday",
       name: "Saturday",
       removed_dates: [],
@@ -162,7 +164,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       added_dates: [],
       added_dates_notes: %{},
       description: "Sunday schedule",
-      end_date: ~D[2020-03-08],
+      end_date: @base_end_date,
       id: "WinterSunday",
       name: "Sunday",
       removed_dates: [],
@@ -199,7 +201,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       added_dates: [],
       added_dates_notes: %{},
       description: "Weekday schedule",
-      end_date: ~D[2020-03-13],
+      end_date: Date.add(@base_end_date, 5),
       id: "WinterWeekday",
       name: "Weekday",
       removed_dates: [

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -8,6 +8,7 @@ defmodule SiteWeb.ScheduleControllerTest do
   alias Stops.RouteStops
 
   @moduletag :external
+  @test_origin "66"
 
   describe "Bus" do
     test "all stops is assigned for a route", %{conn: conn} do
@@ -23,15 +24,15 @@ defmodule SiteWeb.ScheduleControllerTest do
     end
 
     test "has the origin when it has been selected", %{conn: conn} do
-      conn = get(conn, trip_view_path(conn, :show, "1", origin: "2167", direction_id: "1"))
+      conn = get(conn, trip_view_path(conn, :show, "1", origin: @test_origin, direction_id: "1"))
       html_response(conn, 200)
-      assert conn.assigns.origin.id == "2167"
+      assert conn.assigns.origin.id == @test_origin
     end
 
     test "finds a trip when origin has been selected", %{conn: conn} do
-      conn = get(conn, trip_view_path(conn, :show, "1", origin: "2167", direction_id: "1"))
+      conn = get(conn, trip_view_path(conn, :show, "1", origin: @test_origin, direction_id: "1"))
       html_response(conn, 200)
-      assert conn.assigns.origin.id == "2167"
+      assert conn.assigns.origin.id == @test_origin
       assert conn.assigns.trip_info
     end
 
@@ -39,11 +40,15 @@ defmodule SiteWeb.ScheduleControllerTest do
       conn =
         get(
           conn,
-          trip_view_path(conn, :show, "1", origin: "2167", destination: "82", direction_id: "1")
+          trip_view_path(conn, :show, "1",
+            origin: @test_origin,
+            destination: "82",
+            direction_id: "1"
+          )
         )
 
       html_response(conn, 200)
-      assert conn.assigns.origin.id == "2167"
+      assert conn.assigns.origin.id == @test_origin
       assert conn.assigns.destination.id == "82"
       assert conn.assigns.trip_info
       assert conn.assigns.schedules != nil


### PR DESCRIPTION
Some tweaks to fix Elixir tests. Backstop ones still broken and need re-recording.
