### PR TITLE
Alerts should use url field

### DIFF
--- a/apps/alerts/lib/alert.ex
+++ b/apps/alerts/lib/alert.ex
@@ -1,4 +1,5 @@
 defmodule Alerts.Alert do
+  @moduledoc "Module for representation of an alert, including information such as description, severity or additional URL to learn more"
   alias Alerts.Priority
   alias Alerts.InformedEntitySet, as: IESet
 
@@ -11,7 +12,8 @@ defmodule Alerts.Alert do
             lifecycle: :unknown,
             updated_at: Timex.now(),
             description: "",
-            priority: :low
+            priority: :low,
+            url: ""
 
   @type period_pair :: {DateTime.t() | nil, DateTime.t() | nil}
 
@@ -58,7 +60,8 @@ defmodule Alerts.Alert do
           lifecycle: lifecycle,
           updated_at: DateTime.t(),
           description: String.t() | nil,
-          priority: Priority.priority_level()
+          priority: Priority.priority_level(),
+          url: String.t() | nil
         }
 
   @type icon_type :: :alert | :cancel | :none | :shuttle | :snow

--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -204,6 +204,7 @@ export interface Alert {
   updated_at: string;
   description: string;
   priority: Priority;
+  url: string;
 }
 
 interface DatesNotes {

--- a/apps/site/assets/ts/components/Alerts.tsx
+++ b/apps/site/assets/ts/components/Alerts.tsx
@@ -147,6 +147,18 @@ const alertDescription = (alert: AlertType): ReactElement<HTMLElement> => (
 const Alert = ({ alert }: { alert: AlertType }): ReactElement<HTMLElement> => {
   const [expanded, toggleExpanded] = useState(false);
   const onClick = (): void => toggleExpanded(!expanded);
+  // remove [http:// | https:// | www.] from alert URL:
+  let strippedAlertUrl = alert.url.replace(/(https?:\/\/)?(www\.)?/i, "");
+
+  // capitalize 'mbta' (special case):
+  strippedAlertUrl = strippedAlertUrl.replace(/mbta/gi, "MBTA");
+
+  const headerContent = alert.url
+    ? `${alert.header}<span>&nbsp;</span><a href="${
+        alert.url
+      }" target="_blank">${strippedAlertUrl}</a>`
+    : alert.header;
+
   return (
     <li
       id={`alert-${alert.id}`}
@@ -166,7 +178,7 @@ const Alert = ({ alert }: { alert: AlertType }): ReactElement<HTMLElement> => {
             {humanLabelForAlert(alert) ? alertLabel(alert) : null}
           </div>
           {/* eslint-disable-next-line react/no-danger */}
-          <div dangerouslySetInnerHTML={{ __html: alert.header }} />
+          <div dangerouslySetInnerHTML={{ __html: headerContent }} />
         </div>
         <div className="c-alert-item__top-caret-container">
           {caretIcon(alert.description === "", expanded)}

--- a/apps/site/assets/ts/components/__tests__/AlertsTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/AlertsTest.tsx
@@ -24,7 +24,8 @@ const highAlert: Alert = {
     'Route 170 will be rerouted at certain times during the Marathon on Monday, April 15. More: <a href="https://mbta.com/marathon">mbta.com/marathon</a>',
   effect: "detour",
   description:
-    "<strong>Affected direction:</strong><br />Inbound<br />\r<br /><strong>Affected stops:</strong><br />Meridian St @ West Eagle St"
+    "<strong>Affected direction:</strong><br />Inbound<br />\r<br /><strong>Affected stops:</strong><br />Meridian St @ West Eagle St",
+  url: "https://www.mbta.com"
 };
 
 const lowAlert: Alert = {
@@ -37,7 +38,8 @@ const lowAlert: Alert = {
   id: "00005",
   header: "There is construction at this station.",
   effect: "other",
-  description: ""
+  description: "",
+  url: "https://www.mbta.com"
 };
 
 test("handle click to expand and enter to collapse", () => {

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
@@ -48,7 +48,7 @@ exports[`it renders 1`] = `
                 <div
                   dangerouslySetInnerHTML={
                     Object {
-                      "__html": "Route 170 will be rerouted at certain times during the Marathon on Monday, April 15. More: <a href=\\"https://mbta.com/marathon\\">mbta.com/marathon</a>",
+                      "__html": "Route 170 will be rerouted at certain times during the Marathon on Monday, April 15. More: <a href=\\"https://mbta.com/marathon\\">mbta.com/marathon</a><span>&nbsp;</span><a href=\\"https://www.mbta.com\\" target=\\"_blank\\">MBTA.com</a>",
                     }
                   }
                 />
@@ -132,7 +132,7 @@ exports[`it renders 1`] = `
                 <div
                   dangerouslySetInnerHTML={
                     Object {
-                      "__html": "There is construction at this station.",
+                      "__html": "There is construction at this station.<span>&nbsp;</span><a href=\\"https://www.mbta.com\\" target=\\"_blank\\">MBTA.com</a>",
                     }
                   }
                 />

--- a/apps/site/assets/ts/stop/__tests__/AlertsTabTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/AlertsTabTest.tsx
@@ -18,7 +18,8 @@ const highAlert: Alert = {
     "Route 170 will be rerouted at certain times during the Marathon on Monday, April 15.",
   effect: "detour",
   description:
-    "<strong>Affected direction:</strong><br />Inbound<br />\r<br /><strong>Affected stops:</strong><br />Meridian St @ West Eagle St"
+    "<strong>Affected direction:</strong><br />Inbound<br />\r<br /><strong>Affected stops:</strong><br />Meridian St @ West Eagle St",
+  url: "https://www.mbta.com"
 };
 
 const lowAlert: Alert = {
@@ -31,7 +32,8 @@ const lowAlert: Alert = {
   id: "00005",
   header: "There is construction at this station.",
   effect: "other",
-  description: ""
+  description: "",
+  url: "https://www.mbta.com"
 };
 
 const alertsTab: AlertsTabType = {

--- a/apps/site/assets/ts/stop/__tests__/StopPageTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageTest.tsx
@@ -46,7 +46,8 @@ const lowAlert: Alert = {
   id: "00005",
   header: "There is construction at this station.",
   effect: "other",
-  description: ""
+  description: "",
+  url: "https://www.mbta.com"
 };
 /* eslint-enable typescript/camelcase */
 

--- a/apps/site/lib/site_web/templates/alert/_banner.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_banner.html.eex
@@ -13,6 +13,10 @@
       </div>
       <div>
         <%= replace_urls_with_links(@alert.header) %>
+        <%= if @alert.url != nil && @alert.url != "" do %>
+          <span>&nbsp;</span>
+          <%= replace_urls_with_links(@alert.url) %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/apps/site/lib/site_web/templates/alert/_item.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_item.html.eex
@@ -18,6 +18,10 @@
       </div>
       <div>
         <%= replace_urls_with_links(@alert.header) %>
+        <%= if @alert.url != nil && @alert.url != "" do %>
+          <span>&nbsp;</span>
+          <%= replace_urls_with_links(@alert.url) %>
+        <% end %>
       </div>
     </div>
     <div class="c-alert-item__top-caret-container">

--- a/apps/site/lib/site_web/templates/trip_plan/index.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/index.html.eex
@@ -7,10 +7,8 @@
       <%= case assigns[:query] do %>
         <% %{itineraries: {:ok, itineraries}} -> %>
         <p class="no-trips page-section">
-          We found
-          <%= l = length(itineraries) %>
-          <%= Inflex.inflect("trip", l) %>
-          for you
+          <% l = length(itineraries) %>
+          <%= "We found #{l} #{Inflex.inflect("trip", l)} for you" %>
         </p>
         <p class="instructions page-section"><%= itinerary_explanation(@query, @modes) %></p>
         <% itinerary_data = itinerary_html(itineraries, %{conn: @conn, expanded: @expanded}) %>

--- a/apps/site/lib/site_web/views/alert_view.ex
+++ b/apps/site/lib/site_web/views/alert_view.ex
@@ -202,7 +202,19 @@ defmodule SiteWeb.AlertView do
       end
 
     full_url = ensure_scheme(url)
-    ~s(<a target="_blank" href="#{full_url}">#{url}</a>#{suffix})
+
+    # remove [http:// | https:// | www.] from URL:
+    stripped_url = String.replace(full_url, ~r/(https?:\/\/)?(www\.)?/i, "")
+
+    # capitalize 'mbta' (special case):
+    stripped_url =
+      if String.contains?(stripped_url, "mbta") do
+        String.replace(stripped_url, "mbta", "MBTA")
+      else
+        stripped_url
+      end
+
+    ~s(<a target="_blank" href="#{full_url}">#{stripped_url}</a>#{suffix})
   end
 
   defp ensure_scheme("http://" <> _ = url), do: url

--- a/apps/site/test/site_web/controllers/stop_controller_test.exs
+++ b/apps/site/test/site_web/controllers/stop_controller_test.exs
@@ -147,7 +147,7 @@ defmodule SiteWeb.StopControllerTest do
             "When the Red Sox play evening games at Fenway, trains will run until 10:30 PM to accommodate increased ridership.\r\n\r\nRegular D Branch Service will operate on: \r\nPatriots Day - April 15\r\nMemorial Day - May 27\r\n\r\nThis project is part of the MBTA initiative to bring the Green Line track and signal systems into a state of good repair. Learn more: MBTA.com/GreenLineD\r\n\r\nAffected stops:\r\nNewton Highlands\r\nEliot\r\nWaban\r\nWoodland\r\nRiverside",
           effect: :shuttle,
           header:
-            "Shuttle buses replace Green Line D train service between Riverside and Newton Highlands at about 8:45 PM to end of service on weeknights through July 3. Regular service will operate on Patriot's Day, April 15. More: mbta.com/GLwork",
+            "Shuttle buses replace Green Line D train service between Riverside and Newton Highlands at about 8:45 PM to end of service on weeknights through July 3. Regular service will operate on Patriot's Day, April 15. More: MBTA.com/GLwork",
           id: "303815",
           informed_entity: %Alerts.InformedEntitySet{
             activities: [:board, :exit, :ride],
@@ -205,7 +205,7 @@ defmodule SiteWeb.StopControllerTest do
                    "When the Red Sox play evening games at Fenway, trains will run until 10:30 PM to accommodate increased ridership.<br />\r<br /><strong>Regular D Branch Service will operate on:</strong><br />Patriots Day - April 15<br />Memorial Day - May 27<br />\r<br /><strong>This project is part of the MBTA initiative to bring the Green Line track and signal systems into a state of good repair. Learn more:</strong><br /><a target=\"_blank\" href=\"https://MBTA.com/GreenLineD\">MBTA.com/GreenLineD</a><br />\r<br /><strong>Affected stops:</strong><br />Newton Highlands<br />Eliot<br />Waban<br />Woodland<br />Riverside",
                  effect: :shuttle,
                  header:
-                   "Shuttle buses replace Green Line D train service between Riverside and Newton Highlands at about 8:45 PM to end of service on weeknights through July 3. Regular service will operate on Patriot's Day, April 15. More: <a target=\"_blank\" href=\"https://mbta.com/GLwork\">mbta.com/GLwork</a>",
+                   "Shuttle buses replace Green Line D train service between Riverside and Newton Highlands at about 8:45 PM to end of service on weeknights through July 3. Regular service will operate on Patriot's Day, April 15. More: <a target=\"_blank\" href=\"https://MBTA.com/GLwork\">MBTA.com/GLwork</a>",
                  id: "303815",
                  informed_entity: %Alerts.InformedEntitySet{
                    activities: [:board, :exit, :ride],

--- a/apps/site/test/site_web/views/alert_view_test.exs
+++ b/apps/site/test/site_web/views/alert_view_test.exs
@@ -126,8 +126,7 @@ defmodule SiteWeb.AlertViewTest do
     end
 
     test "linkifies a URL" do
-      expected =
-        raw(~s(before <a target="_blank" href="http://mbta.com">http://mbta.com</a> after))
+      expected = raw(~s(before <a target="_blank" href="http://mbta.com">MBTA.com</a> after))
 
       actual = format_alert_description("before http://mbta.com after")
 
@@ -137,8 +136,7 @@ defmodule SiteWeb.AlertViewTest do
 
   describe "replace_urls_with_links/1" do
     test "does not include a period at the end of the URL" do
-      expected =
-        raw(~s(<a target="_blank" href="http://mbta.com/foo/bar">http://mbta.com/foo/bar</a>.))
+      expected = raw(~s(<a target="_blank" href="http://mbta.com/foo/bar">MBTA.com/foo/bar</a>.))
 
       actual = replace_urls_with_links("http://mbta.com/foo/bar.")
 
@@ -146,8 +144,8 @@ defmodule SiteWeb.AlertViewTest do
     end
 
     test "can replace multiple URLs" do
-      expected = raw(~s(<a target="_blank" href="http://one.com">http://one.com</a> \
-<a target="_blank" href="https://two.net">https://two.net</a>))
+      expected = raw(~s(<a target="_blank" href="http://one.com">one.com</a> \
+<a target="_blank" href="https://two.net">two.net</a>))
       actual = replace_urls_with_links("http://one.com https://two.net")
 
       assert expected == actual
@@ -161,7 +159,7 @@ defmodule SiteWeb.AlertViewTest do
     end
 
     test "adds https:// to the URL if it's mbta.com" do
-      expected = raw(~s(<a target="_blank" href="https://mbta.com/GLwork">mbta.com/GLwork</a>))
+      expected = raw(~s(<a target="_blank" href="https://mbta.com/GLwork">MBTA.com/GLwork</a>))
       actual = replace_urls_with_links("mbta.com/GLwork")
 
       assert expected == actual


### PR DESCRIPTION
**Asana Ticket:** [Alerts | Website should use URL field](https://app.asana.com/0/385363666817452/1116522101105763)
#### Summary of changes
URL coming from Alerts wasn't being taken into account. Now it's being displayed in the header of each alert, in the format [Alert Message] [URL]
<br/>
This contains an unrelated fix for spacing in the Trip Planner, made in passing:
<img width="195" alt="image" src="https://user-images.githubusercontent.com/61979382/76769152-72500180-6772-11ea-839b-6dce7d84a7ad.png">