### PR TITLE
Reduce height of glitched line diagram div

### DIFF
--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -424,6 +424,10 @@ $line-width: 8px; // width of the colored line in the diagram
   .m-schedule-diagram__lines--merging .m-schedule-diagram__line:not(:first-child) {
     height: calc(#{$base-spacing * 2} + 10px);
   }
+
+  .m-schedule-diagram__line:not(:first-child) {
+    height: calc(100%  - 15px);
+  }
 }
 
 // stop filter


### PR DESCRIPTION
----

#### Summary of changes
**Asana Ticket:** [Line diagram visual glitch on Providence line](https://app.asana.com/0/385363666817452/1161660843757401/f)

I used the calc function to take the computed height and reduce it by 15px. This fixes the visual glitch.