### PR TITLE
Use variant ID in line page URL

### DIFF
--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -288,7 +288,7 @@ it.skip("renders with a static map", () => {
   expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
 });
 
-it("changes direction and updates the query param", () => {
+it("changes direction and updates the query params", () => {
   document.body.innerHTML = body;
   const component = getComponent();
   const wrapper = mount(component);
@@ -301,7 +301,7 @@ it("changes direction and updates the query param", () => {
   expect(window.history.replaceState).toBeCalledWith(
     {},
     "",
-    "/?direction_id=0"
+    "/?direction_id=0&variant=pattern-1"
   );
 });
 
@@ -312,15 +312,22 @@ it("does not allow changing direction when no route patterns", () => {
   expect(wrapper.exists(".m-schedule-direction__button")).toEqual(false);
 });
 
-it("can change route pattern for bus mode", () => {
+it("can change route pattern for bus mode, and updates the query params", () => {
   document.body.innerHTML = body;
   const component = getComponent();
   const wrapper = mount(component);
+  window.history.replaceState = jest.fn();
+
   wrapper.find(".m-schedule-direction__button").simulate("click");
   expect(
     wrapper.find(".m-schedule-direction__route-pattern--clickable").text()
   ).toBe("Pattern 1 SVG");
   expect(wrapper.find(".m-schedule-direction__menu").exists()).toEqual(false);
+  expect(window.history.replaceState).toBeCalledWith(
+    {},
+    "",
+    "/?direction_id=0&variant=pattern-1"
+  );
   wrapper
     .find(".m-schedule-direction__route-pattern--clickable")
     .simulate("click");
@@ -329,6 +336,11 @@ it("can change route pattern for bus mode", () => {
   expect(
     wrapper.find(".m-schedule-direction__route-pattern--clickable").text()
   ).toBe("Pattern 3 SVG");
+  expect(window.history.replaceState).toBeCalledWith(
+    {},
+    "",
+    "/?direction_id=0&variant=pattern-3"
+  );
   wrapper
     .find(".m-schedule-direction__route-pattern--clickable")
     .simulate("click");

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -165,6 +165,7 @@ const getComponent = () => (
     stops={{ stops }}
     today="2019-12-05"
     scheduleNote={null}
+    initialSelectedRoutePatternId={null}
   />
 );
 
@@ -180,6 +181,7 @@ const getSingleDirectionComponent = () => (
     stops={{ stops }}
     today="2019-12-05"
     scheduleNote={null}
+    initialSelectedRoutePatternId={null}
   />
 );
 
@@ -195,6 +197,7 @@ const getSubwayComponent = () => (
     stops={{ stops }}
     today="2019-12-05"
     scheduleNote={null}
+    initialSelectedRoutePatternId={null}
   />
 );
 
@@ -210,6 +213,7 @@ const getStaticMapComponent = () => (
     stops={{ stops }}
     today="2019-12-05"
     scheduleNote={null}
+    initialSelectedRoutePatternId={null}
   />
 );
 
@@ -241,9 +245,26 @@ const getGreenLineComponent = () => {
       stops={{ stops }}
       today="2019-12-05"
       scheduleNote={null}
+      initialSelectedRoutePatternId={null}
     />
   );
 };
+
+const getVariantComponent = () => (
+  <ScheduleDirection
+    route={route}
+    directionId={0}
+    routePatternsByDirection={routePatternsByDirection}
+    shapesById={shapesById}
+    mapData={mapData}
+    lineDiagram={lineDiagram}
+    services={[]}
+    stops={{ stops }}
+    today="2019-12-05"
+    scheduleNote={null}
+    initialSelectedRoutePatternId="pattern-3"
+  />
+);
 
 it("renders a bus component", () => {
   createReactRoot();
@@ -549,4 +570,10 @@ it("can change route for green line with click", () => {
   wrapper
     .find("#route-pattern_Green")
     .simulate("keydown", { key: "ArrowRight" });
+});
+
+it("respects the initially selected pattern ID, if specified", () => {
+  createReactRoot();
+  const tree = mount(getVariantComponent());
+  expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
 });

--- a/apps/site/assets/ts/schedule/__tests__/SchedulePageTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/SchedulePageTest.tsx
@@ -147,7 +147,8 @@ it("it renders", () => {
           shape_map: {},
           route_patterns: {},
           line_diagram: lineDiagram,
-          today: "2019-12-05"
+          today: "2019-12-05",
+          variant: null
         }}
       />
     )
@@ -184,7 +185,8 @@ it("it renders with conditional components", () => {
         shape_map: {},
         route_patterns: {},
         line_diagram: lineDiagram,
-        today: "2019-12-05"
+        today: "2019-12-05",
+        variant: null
       }}
     />
   );

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -956,3 +956,63 @@ exports[`renders with a static map 1`] = `
   </LineDiagram>
 </ScheduleDirection>
 `;
+
+exports[`respects the initially selected pattern ID, if specified 1`] = `
+<ScheduleDirection>
+  <div
+    className="m-schedule-direction"
+  >
+    <div
+      className="m-schedule-direction__direction"
+      id="direction-name"
+    >
+      Outbound
+    </div>
+    <ScheduleDirectionMenu>
+      <div
+        className="js-m-schedule-click-boundary"
+      >
+        <Component>
+          <div
+            className="m-schedule-direction__route-pattern m-schedule-direction__route-pattern--clickable"
+            onClick={[Function]}
+            onKeyUp={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            Pattern 3
+             
+            <span
+              aria-hidden="true"
+              className="notranslate c-svg__icon m-schedule-direction__route-pattern-arrow"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
+              }
+            />
+          </div>
+        </Component>
+      </div>
+    </ScheduleDirectionMenu>
+    <ScheduleDirectionButton>
+      <button
+        className="m-schedule-direction__button btn btn-primary"
+        onClick={[Function]}
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          className="notranslate m-schedule-direction__icon"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+        Change Direction
+      </button>
+    </ScheduleDirectionButton>
+  </div>
+</ScheduleDirection>
+`;

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -28,6 +28,7 @@ export interface Props {
   stops: SimpleStopMap;
   today: string;
   scheduleNote: ScheduleNoteType | null;
+  initialSelectedRoutePatternId: string | null;
 }
 
 export const fetchMapData = (
@@ -85,12 +86,14 @@ const ScheduleDirection = ({
   services,
   stops,
   today,
-  scheduleNote
+  scheduleNote,
+  initialSelectedRoutePatternId
 }: Props): ReactElement<HTMLElement> => {
-  const defaultRoutePattern = routePatternsByDirection[directionId].slice(
-    0,
-    1
-  )[0];
+  const routePatternsInCurrentDirection = routePatternsByDirection[directionId];
+  const defaultRoutePattern =
+    routePatternsInCurrentDirection.find(
+      routePattern => routePattern.id === initialSelectedRoutePatternId
+    ) || routePatternsInCurrentDirection.slice(0, 1)[0];
 
   const reverseDirection = directionId === 0 ? 1 : 0;
   const directionIsChangeable = route.direction_names[reverseDirection] != null;

--- a/apps/site/assets/ts/schedule/components/__schedule.d.ts
+++ b/apps/site/assets/ts/schedule/components/__schedule.d.ts
@@ -47,6 +47,7 @@ export interface SchedulePageData {
   route_patterns: RoutePatternsByDirection;
   line_diagram: LineDiagramStop[];
   today: string;
+  variant: string | null;
 }
 
 interface StopData {

--- a/apps/site/assets/ts/schedule/schedule-loader.tsx
+++ b/apps/site/assets/ts/schedule/schedule-loader.tsx
@@ -71,7 +71,8 @@ const renderDirectionAndMap = (
     services,
     stops,
     today,
-    schedule_note: scheduleNote
+    schedule_note: scheduleNote,
+    variant: initialSelectedRoutePatternId
   } = schedulePageData;
 
   let mapData: MapData | undefined;
@@ -99,6 +100,7 @@ const renderDirectionAndMap = (
       stops={stops}
       today={today}
       scheduleNote={scheduleNote}
+      initialSelectedRoutePatternId={initialSelectedRoutePatternId}
     />,
     root
   );

--- a/apps/site/lib/site_web/controllers/schedule/line.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line.ex
@@ -102,6 +102,7 @@ defmodule SiteWeb.ScheduleController.Line do
     |> assign(:reverse_direction_all_stops_from_route, flatten_route_stops(reverse_route_stops))
     |> assign(:connections, connections(branches))
     |> assign(:time_data_by_stop, time_data_by_stop)
+    |> assign(:variant, variant)
   end
 
   defp flatten_route_stops(route_stops) do

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -82,7 +82,8 @@ defmodule SiteWeb.ScheduleController.LineController do
           Enum.map(conn.assigns.all_stops, fn stop ->
             update_route_stop_data(stop, conn.assigns.alerts, conn.assigns.date)
           end),
-        today: conn.assigns.date_time |> DateTime.to_date() |> Date.to_iso8601()
+        today: conn.assigns.date_time |> DateTime.to_date() |> Date.to_iso8601(),
+        variant: conn.assigns.variant
       }
     )
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Variant parameters in URL](https://app.asana.com/0/555089885850811/1162914752771485)

If you pick a non-default variant on the line page, the URL updates a new `variant` query param accordingly, and that param allows deep-linking to a given variant of a route. This is much the same with what we do about direction IDs in the same URL.