### PR TITLE
Prevent 500ing in one unidirectional case

### DIFF
--- a/apps/site/lib/site_web/templates/schedule/_empty.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_empty.html.eex
@@ -1,6 +1,6 @@
 <div class="callout schedule-empty">
   <%= no_trips_message(@error, @origin, @destination, @direction, @date) %>
-  <%= if @date && @date != Util.service_date() do %>
+  <%= if @date && @date != Util.service_date() && @direction do %>
     <div>
       <%= link "View #{String.downcase(@direction)} trips for today", to: update_url(@conn, date: nil) %>
     </div>


### PR DESCRIPTION
Looking at the nonexistent direction of a unidirectional route on a date
other than the current service date was throwing a 500. Corrected by
adding a check that the direction in question is defined.

#### Summary of changes
**Asana Ticket:** [Handle unidirectional bus routes more gracefully](https://app.asana.com/0/555089885850811/1166771847899436)
