### PR TITLE
Don't send Phoenix.NotAcceptable errors to Sentry

### DIFF
--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -47,7 +47,8 @@ config :sentry,
   enable_source_code_context: false,
   root_source_code_path: File.cwd!(),
   included_environments: [:prod],
-  json_library: Poison
+  json_library: Poison,
+  filter: Site.SentryFilter
 
 config :site, :former_mbta_site, host: "https://old.mbta.com"
 config :site, tile_server_url: "https://mbta-map-tiles-dev.s3.amazonaws.com"

--- a/apps/site/lib/sentry_filter.ex
+++ b/apps/site/lib/sentry_filter.ex
@@ -1,0 +1,16 @@
+defmodule Site.SentryFilter do
+  @moduledoc """
+  Implement the Sentry.EventFilter behaviour, which allows for preventing
+  arbitrary errors to be sent to Sentry.
+  """
+
+  @behaviour Sentry.EventFilter
+
+  def exclude_exception?(%Phoenix.NotAcceptableError{}, _source) do
+    true
+  end
+
+  def exclude_exception?(_exception, _source) do
+    false
+  end
+end


### PR DESCRIPTION
We get a lot of Phoenix.NotAcceptable errors due to script kiddies
and/or poorly behaving apps. They take up a significant fraction of our
monthly Sentry error allowance. Sentry allows us to filter out arbitrary
errors, so we filter those out now.

#### Summary of changes
**Asana Ticket:** [Investigate Phoenix.NotAcceptableErrors](https://app.asana.com/0/555089885850811/1166771847899433)
