### PR TITLE
Log warning for prediction with nil trip

### DIFF
--- a/apps/site/lib/site/realtime_schedule.ex
+++ b/apps/site/lib/site/realtime_schedule.ex
@@ -20,6 +20,8 @@ defmodule Site.RealtimeSchedule do
   alias Stops.Repo, as: StopsRepo
   alias Stops.Stop
 
+  require Logger
+
   # the long timeout is to address a worst-case scenario of cold schedule cache
   @long_timeout 15_000
 
@@ -298,6 +300,8 @@ defmodule Site.RealtimeSchedule do
 
   @spec shrink_predicted_schedule(PredictedSchedule.t(), DateTime.t()) :: map
   defp shrink_predicted_schedule(%{schedule: schedule, prediction: prediction}, now) do
+    _ = log_warning_if_missing_trip(prediction)
+
     %{
       prediction:
         prediction
@@ -306,6 +310,13 @@ defmodule Site.RealtimeSchedule do
         |> do_shrink_predicted_schedule(),
       schedule: schedule |> format_schedule_time() |> do_shrink_predicted_schedule()
     }
+  end
+
+  def log_warning_if_missing_trip(prediction) do
+    _ =
+      if prediction && prediction.trip == nil do
+        Logger.warn("prediction_without_trip prediction=#{inspect(prediction)}")
+      end
   end
 
   @spec add_trip_headsign(map) :: map | nil

--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -281,4 +281,13 @@ defmodule Site.RealtimeScheduleTest do
 
     assert actual == expected
   end
+
+  test "log_warning_if_missing_trip/1 logs warning if prediction has no trip" do
+    log_messages =
+      ExUnit.CaptureLog.capture_log(fn ->
+        RealtimeSchedule.log_warning_if_missing_trip(%Prediction{trip: nil})
+      end)
+
+    assert log_messages =~ "prediction_without_trip"
+  end
 end


### PR DESCRIPTION
Although all predictions should have a trip ID, some are getting fetched
by the realtime schedule endpoint without one. To help the data team
debug this, we've added a bit of logging for when that happens.

#### Summary of changes
**Asana Ticket:** [Log a warning to Splunk whenever the realtime schedule endpoint encounters a prediction without a trip.](https://app.asana.com/0/555089885850811/1167515632160323)
