### PR TITLE
Redirect /style-guide to zeroheight

### DIFF
--- a/apps/site/lib/site_web/controllers/style_guide_controller.ex
+++ b/apps/site/lib/site_web/controllers/style_guide_controller.ex
@@ -1,23 +1,25 @@
 defmodule SiteWeb.StyleGuideController do
+  @moduledoc """
+  Defines the behavior of style guide requests.
+  """
   use SiteWeb, :controller
 
   def index(conn, %{"section" => "content"}) do
-    redirect(conn, to: "/cms/content-style-guide")
+    conn
+    |> put_status(301)
+    |> redirect(external: "https://zeroheight.com/2fedee66c/p/43fa10")
   end
 
   def index(conn, %{"section" => "components"}) do
     conn
     |> put_status(301)
-    |> redirect(
-      external:
-        "https://projects.invisionapp.com/dsm/mbta-customer-technology/digital-style-guide"
-    )
+    |> redirect(external: "https://zeroheight.com/2fedee66c/p/36e5cc")
   end
 
   def index(conn, params) when params == %{} do
     conn
-    |> put_layout("style_guide.html")
-    |> render("index.html")
+    |> put_status(301)
+    |> redirect(external: "https://zeroheight.com/2fedee66c")
   end
 
   def index(conn, _params) do

--- a/apps/site/lib/site_web/templates/style_guide/index.html.eex
+++ b/apps/site/lib/site_web/templates/style_guide/index.html.eex
@@ -1,4 +1,0 @@
-<h2>Welcome to the MBTA Web Design Standards!</h2>
-
-<p>Here, you'll find instructions for how to use our UI components and visual styles to create beautiful, consistent experiences across Massachusetts Bay Transportation Authority websites and apps.</p>
-

--- a/apps/site/lib/site_web/views/style_guide_view.ex
+++ b/apps/site/lib/site_web/views/style_guide_view.ex
@@ -1,3 +1,0 @@
-defmodule SiteWeb.StyleGuideView do
-  use SiteWeb, :view
-end

--- a/apps/site/test/site_web/controllers/style_guide_controller_test.exs
+++ b/apps/site/test/site_web/controllers/style_guide_controller_test.exs
@@ -7,27 +7,27 @@ defmodule SiteWeb.StyleGuideControllerTest do
     assert html_response(conn, 404)
   end
 
-  test "top level renders index", %{conn: conn} do
+  test "top level redirects to zeroheight landing page", %{conn: conn} do
     conn = get(conn, "style-guide")
-    assert html_response(conn, 200) =~ "MBTA Tech Style Guide"
+    assert redirected_to(conn, 301) =~ "https://zeroheight.com/2fedee66c"
   end
 
-  test "/style-guide/content redirects to /cms/content-style-guide", %{conn: conn} do
+  test "/style-guide/content redirects to zeroheight content page", %{conn: conn} do
     conn = get(conn, "style-guide/content")
-    assert html_response(conn, 302) =~ "/cms/content-style-guide"
+    assert redirected_to(conn, 301) =~ "https://zeroheight.com/2fedee66c/p/43fa10"
   end
 
-  test "/style-guide/components/* redirects to invision dsg", %{conn: conn} do
+  test "/style-guide/components/* redirects to zeroheight", %{conn: conn} do
     conn = get(conn, "/style-guide/components/typography")
-    assert html_response(conn, 301)
+    assert redirected_to(conn, 301) =~ "https://zeroheight.com/2fedee66c/p/36e5cc"
   end
 
-  test "old /style-guide/content/* links redirect to /cms/content-style-guide/", %{conn: conn} do
+  test "old /style-guide/content/* links redirect to zeroheight content page", %{conn: conn} do
     old_sections = ["audience_goals_tone", "grammar_and_mechanics", "terms"]
 
     for section_string <- old_sections do
       conn = get(conn, "/style-guide/content/#{section_string}")
-      assert html_response(conn, 302) =~ "/cms/content-style-guide"
+      assert redirected_to(conn, 301) =~ "https://zeroheight.com/2fedee66c/p/43fa10"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Retire /style-guide, 301 redirect to zeroheight](https://app.asana.com/0/385363666817452/1160793451440400/f)

The style_guide_controller now redirects requests to corresponding pages on the new zeroheight design site. I also updated the test for this controller to verify that the redirects are happening correctly. A note about the zeroheight slugs, for my reviewers: they seem to function equally well with or without the page title appended to the end with hyphens, i.e. https://zeroheight.com/2fedee66c/p/43fa10 functions just as well as https://zeroheight.com/2fedee66c/p/43fa10-about, which the former redirects to. I elected to include the title but am looking for feedback in that area as to what best practice should be.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?

(I've filled out this template to the best of my ability, this doesn't contain front-end changes so some of them are kind of n/a)
