### PR TITLE
hide /org section from search engines

### DIFF
--- a/apps/site/assets/static/robots.txt
+++ b/apps/site/assets/static/robots.txt
@@ -7,3 +7,4 @@ Disallow: /trip-planner?*
 Disallow: /search?*
 Disallow: /*?*preview*&vid=*
 Disallow: /schedules/*/line?*date*
+Disallow: /org/*

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -12,6 +12,11 @@
     <meta name="author" content="Massachusetts Bay Transportation Authority">
     <%= Turbolinks.cache_meta @conn %>
 
+    <%= # hide any page in /org directory from search engines  
+    if @conn.request_path == "/org" || String.slice(@conn.request_path, 0..4) == "/org/" do %>
+      <meta name="robots" content="noindex, nofollow">
+    <% end %>
+
     <title><%= title_breadcrumbs(@conn) %></title>
     <link rel="apple-touch-icon" href="<%= static_url(@conn, "/images/mbta-logo-t-180.png") %>" type="image/png">
     <link rel="icon" href="<%= static_url(@conn, "/images/mbta-logo-t-favicon.png") %>" sizes="32x32" type="image/png">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No Ticket

Prevent search engines from indexing pages under the `/org` directory.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
