### PR TITLE
Show all vehicles in given direction in map

### DIFF
--- a/apps/site/assets/ts/schedule/__tests__/MapTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/MapTest.tsx
@@ -55,7 +55,9 @@ const data: MapData = {
 
 describe("Schedule Map", () => {
   it("renders", () => {
-    const wrapper = mount(<Map data={data} channel="vehicles:Red:0" />);
+    const wrapper = mount(
+      <Map data={data} channel="vehicles:Red:0" shapeIds={[]} />
+    );
     expect(() => wrapper.render()).not.toThrow();
   });
 });
@@ -77,7 +79,7 @@ describe("reducer", () => {
 
   it("resets markers", () => {
     const result = reducer(
-      { markers: data.markers, shapeId: "1", channel: "vehicle:1:1" },
+      { markers: data.markers, channel: "vehicle:1:1", shapeIds: ["1"] },
       {
         action: {
           event: "reset",
@@ -95,7 +97,7 @@ describe("reducer", () => {
 
   it("adds vehicles", () => {
     const result = reducer(
-      { markers: data.markers, channel: "vehicle:1:1", shapeId: "1" },
+      { markers: data.markers, channel: "vehicle:1:1", shapeIds: ["1"] },
       {
         action: { event: "add", data: [{ marker: newMarker }] },
         channel: "vehicle:1:1"
@@ -108,7 +110,7 @@ describe("reducer", () => {
 
   it("updates markers", () => {
     const result = reducer(
-      { markers: data.markers, channel: "vehicle:1:1", shapeId: "1" },
+      { markers: data.markers, channel: "vehicle:1:1", shapeIds: ["1"] },
       {
         action: {
           event: "update",
@@ -123,9 +125,13 @@ describe("reducer", () => {
     expect(result.markers[0].latitude).toEqual(43.0);
   });
 
-  it("ignores markers from other shapes", () => {
+  it("ignores markers from shapes not given", () => {
     const result = reducer(
-      { markers: data.markers, channel: "vehicle:1:1", shapeId: "1" },
+      {
+        markers: data.markers,
+        channel: "vehicle:1:1",
+        shapeIds: ["1", "2", "4"]
+      },
       {
         action: {
           event: "update",
@@ -140,7 +146,7 @@ describe("reducer", () => {
 
   it("ignores markers from other channels", () => {
     const result = reducer(
-      { markers: data.markers, channel: "vehicle:1:1", shapeId: "2" },
+      { markers: data.markers, channel: "vehicle:1:1", shapeIds: ["2"] },
       {
         action: { event: "update", data: [{ marker: data.markers[0] }] },
         channel: "vehicle:1:0"
@@ -153,7 +159,7 @@ describe("reducer", () => {
   it("doesn't handle unknown events empty data actions", () => {
     expect(() =>
       reducer(
-        { markers: data.markers, channel: "vehicle:1:1", shapeId: "2" },
+        { markers: data.markers, channel: "vehicle:1:1", shapeIds: ["2"] },
         {
           // @ts-ignore
           action: { event: "unsupported", data: [] },
@@ -165,7 +171,7 @@ describe("reducer", () => {
 
   it("handles empty data actions", () => {
     const result = reducer(
-      { markers: data.markers, channel: "vehicle:1:1", shapeId: "2" },
+      { markers: data.markers, channel: "vehicle:1:1", shapeIds: ["2"] },
       {
         action: { event: "update", data: [] },
         channel: "vehicle:1:1"
@@ -177,7 +183,7 @@ describe("reducer", () => {
 
   it("removes markers", () => {
     const result = reducer(
-      { markers: data.markers, channel: "vehicle:1:1", shapeId: "1" },
+      { markers: data.markers, channel: "vehicle:1:1", shapeIds: ["1"] },
       {
         action: { event: "remove", data: [data.markers[0].id!] },
         channel: "vehicle:1:1"

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -438,9 +438,9 @@ describe("fetchMapData", () => {
         )
     );
 
-    return fetchMapData("1", 0, "2", spy).then(() => {
+    return fetchMapData("1", 0, ["2"], spy).then(() => {
       expect(window.fetch).toHaveBeenCalledWith(
-        "/schedules/map_api?id=1&direction_id=0&variant=2"
+        "/schedules/map_api?id=1&direction_id=0"
       );
       expect(spy).toHaveBeenCalledWith({
         type: "FETCH_STARTED"
@@ -466,9 +466,9 @@ describe("fetchMapData", () => {
         )
     );
 
-    return fetchMapData("1", 0, "2", spy).then(() => {
+    return fetchMapData("1", 0, ["2"], spy).then(() => {
       expect(window.fetch).toHaveBeenCalledWith(
-        "/schedules/map_api?id=1&direction_id=0&variant=2"
+        "/schedules/map_api?id=1&direction_id=0"
       );
       expect(spy).toHaveBeenCalledWith({
         type: "FETCH_STARTED"

--- a/apps/site/assets/ts/schedule/schedule-loader.tsx
+++ b/apps/site/assets/ts/schedule/schedule-loader.tsx
@@ -8,7 +8,12 @@ import { SchedulePageData } from "./components/__schedule";
 import { MapData, StaticMapData } from "../leaflet/components/__mapdata";
 import ScheduleFinder from "./components/ScheduleFinder";
 
-const renderMap = (): void => {
+const renderMap = ({
+  route_patterns: routePatternsByDirection,
+  direction_id: directionId
+}: SchedulePageData): void => {
+  const routePatterns = routePatternsByDirection[directionId];
+  const shapeIds = routePatterns.map(routePattern => routePattern.shape_id);
   const mapDataEl = document.getElementById("js-map-data");
   if (!mapDataEl) return;
   const channel = mapDataEl.getAttribute("data-channel-id");
@@ -16,7 +21,10 @@ const renderMap = (): void => {
   const mapEl = document.getElementById("map-root");
   if (!mapEl) throw new Error("cannot find #map-root");
   const mapData: MapData = JSON.parse(mapDataEl.innerHTML);
-  ReactDOM.render(<Map data={mapData} channel={channel} />, mapEl);
+  ReactDOM.render(
+    <Map data={mapData} channel={channel} shapeIds={shapeIds} />,
+    mapEl
+  );
 };
 
 const renderSchedulePage = (schedulePageData: SchedulePageData): void => {
@@ -109,7 +117,7 @@ const renderDirectionAndMap = (
 const renderDirectionOrMap = (schedulePageData: SchedulePageData): void => {
   const root = document.getElementById("react-schedule-direction-root");
   if (!root) {
-    renderMap();
+    renderMap(schedulePageData);
     return;
   }
   renderDirectionAndMap(schedulePageData, root);


### PR DESCRIPTION
On the line page, if you look at a branching subway line such as the RL
northbound or the GL in either direction, you'd see only markers for
one branch. Corrected.

#### Summary of changes
**Asana Ticket:** [Bug | Map missing Southbound Braintree trains](https://app.asana.com/0/555089885850811/1169381171498584)

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
