### PR TITLE
Revamp schedule finder table styles

### DIFF
--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -253,141 +253,6 @@
   }
 }
 
-.schedule-table {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-}
-
-.schedule-table__header {
-  background: $brand-primary-lightest-contrast;
-  display: flex;
-  font-weight: bold;
-  padding: $base-spacing / 2;
-}
-
-.schedule-table__row {
-  border: $border;
-  display: flex;
-  padding: $base-spacing / 2;
-}
-
-.schedule-table__row--stretch {
-  justify-content: space-between;
-}
-
-// Separate class instead of modifier to avoid complicated nth-child selector
-.schedule-table__row-selected {
-  background: $brand-primary;
-  border: 1px solid $brand-primary;
-  color: $white;
-  display: flex;
-  padding: $base-spacing / 2;
-}
-
-.schedule-table__row:nth-child(even) {
-  background: $gray-bordered-background;
-}
-
-.schedule-table__row:nth-child(odd) {
-  background: $white;
-}
-
-.schedule-table__time-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-}
-
-.schedule-table__time {
-  font-variant-numeric: tabular-nums;
-  text-align: right;
-  white-space: nowrap;
-
-  .schedule-table--upcoming & {
-    font-weight: bold;
-  }
-
-  &--delayed {
-    font-weight: normal;
-    margin-right: $base-spacing / 2;
-    text-align: right;
-    text-decoration: line-through;
-
-    &-future_stop {
-      @include media-breakpoint-only(xs) {
-        margin-right: 0;
-      }
-    }
-  }
-}
-
-.schedule-table__track {
-  text-transform: capitalize;
-}
-
-.schedule-table__row-header {
-  background: $brand-primary-lightest-contrast;
-  display: flex;
-  flex-grow: 1;
-  font-weight: bold;
-  justify-content: space-between;
-  overflow: hidden;
-}
-
-.schedule-table__th--flex-end {
-  flex-grow: 1;
-  margin-right: $base-spacing / 2;
-  text-align: right;
-}
-
-.schedule-table__row-header-label {
-  margin-right: $base-spacing * 3.75;
-}
-
-.schedule-table__row-header-label--small {
-  margin-right: $base-spacing * 2.5;
-}
-
-.schedule-table__row-header-label--tiny {
-  width: $base-spacing * 2;
-}
-
-.schedule-table__row-route {
-  align-items: center;
-  display: inline-flex;
-}
-
-.schedule-table__row-route-pill {
-  font-size: .8 * $base-spacing;
-  margin-right: $base-spacing;
-
-  .u-bg--bus,
-  .u-bg--silver-line {
-    font-weight: bold;
-    padding-left: .5rem;
-    padding-right: .5rem;
-  }
-}
-
-.schedule-table__headsign {
-  .c-svg__icon {
-    margin-right: $base-spacing / 2;
-  }
-}
-
-.schedule-table__td {
-  margin-right: $base-spacing * 3;
-}
-
-.schedule-table__td--tiny {
-  width: $base-spacing * 2;
-}
-
-.schedule-table__tab-num {
-  font-variant-numeric: tabular-nums;
-}
-
 .schedule-finder__first-last-trip {
   border-top: 3px solid $gray-lightest;
   display: flex;
@@ -397,70 +262,120 @@
   padding: $base-spacing / 2;
 }
 
-.schedule-table__subtable {
+.schedule-table {
   width: 100%;
+
+  &__header {
+    background: $brand-primary-lightest-contrast;
+    border: $border;
+  }
 }
 
-.schedule-table__subtable-trip-info {
-  display: flex;
+.schedule-table__row {
+  border: $border;
+
+  &--expanded {
+    background: $brand-primary;
+    border: 2px solid $brand-primary;
+    color: $white;
+  }
+
+  &:nth-child(even) {
+    background: $gray-bordered-background;
+  }
+
+  &:nth-child(odd) {
+    background: $white;
+  }
 }
 
-.schedule-table__subtable-trip-info-title {
-  margin-right: $base-spacing;
-}
-
-.schedule-table__subtable-trip-info-link {
-  margin-left: $base-spacing;
-}
-
-.schedule-table__subtable-tr {
-  display: flex;
+.schedule-table__cell {
   padding: $base-spacing / 2;
-}
+  vertical-align: top;
 
-.schedule-table__subtable-container {
-  display: flex;
-}
+  &:last-child:not(:first-child) {
+    text-align: right;
+  }
 
-.schedule-table__subtable-data {
-  padding: $base-spacing / 4 0;
+  &--expanded {
+    border: 2px solid $brand-primary;
+  }
+
+  &--headsign {
+    .c-svg__icon {
+      margin-right: $base-spacing / 2;
+    }
+  }
 
   &--right-adjusted {
-    padding-left: $base-spacing / 2;
     text-align: right;
     vertical-align: top;
     white-space: pre;
   }
-}
 
-.schedule-table__subtable-row {
-  border-top: 1px solid $gray-lightest;
-}
+  &--time {
+    width: 12ch;
 
-.schedule-table__subtable-td {
-  border: 2px solid $brand-primary;
-  border-top: 0;
-  padding: $base-spacing / 2;
-  width: 100%;
-}
+    + .u-tabular-nums {
+      width: 8ch;
+    }
+  }
 
-.schedule-table__td--flex-end {
-  flex-grow: 1;
-  margin-right: $base-spacing / 2;
-
-  .schedule-table--upcoming &:last-child {
-    align-self: center;
-    flex-grow: 0;
+  &--tiny {
+    width: 1ch;
   }
 }
 
-.schedule-table--empty {
-  font-weight: bold;
-  text-align: center;
+.trip-details-table {
+  width: 100%;
+
+  .schedule-table__cell {
+    padding: $base-spacing / 4 0;
+  }
+
+  tbody .schedule-table__cell {
+    border-top: $border;
+  }
+
+  &__title {
+    margin-right: $base-spacing;
+  }
+
+  &__link {
+    margin-left: $base-spacing;
+  }
+
+  &__summary .schedule-table__cell {
+    padding: 0;
+  }
 }
 
-.schedule-table__scheduled-bus-pill {
-  vertical-align: middle;
+.schedule-table__times {
+  display: inline-block;
+
+  &--delayed {
+    display: inline-block;
+    margin-right: $base-spacing / 2;
+    text-decoration: line-through;
+
+    &-future_stop {
+      @include media-breakpoint-only(xs) {
+        margin-right: 0;
+      }
+    }
+
+    + .schedule-table__times {
+      font-weight: bold;
+    }
+  }
+}
+
+.schedule-table__track {
+  text-transform: capitalize;
+}
+
+.schedule-table__route-pill {
+  margin-right: $base-spacing / 2;
 }
 
 .schedule-table__upcoming-departures-header {
@@ -492,31 +407,25 @@
     justify-content: space-between;
   }
 
-  .schedule-table__row-route-pill {
-    margin-right: $base-spacing * .5;
-
-    .u-bg--bus,
-    .u-bg--silver-line {
-      padding-left: $base-spacing * .25;
-      padding-right: $base-spacing * .25;
+  .schedule-table__cell {
+    &:not(:last-child) {
+      padding-right: 0;
     }
   }
 
-  .schedule-table__row-header-label {
-    margin-right: $base-spacing * 1.25;
+  .schedule-table__cell--time {
+    width: initial;
+
+    + .u-tabular-nums {
+      width: initial;
+    }
   }
 
-  .schedule-table__td {
-    margin-right: $base-spacing * .5;
-  }
+  .schedule-table__cell--headsign {
+    display: flex;
 
-  .schedule-table__row-header-label--tiny,
-  .schedule-table__td--tiny {
-    width: 2ch;
-  }
-
-  .schedule-table__th--flex-end,
-  .schedule-table__td--flex-end {
-    margin-right: $base-spacing * .25;
+    .c-svg__icon {
+      flex: none;
+    }
   }
 }

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -178,3 +178,7 @@
 .u-highlight {
   background-color: $brand-primary-lightest-contrast;
 }
+
+.u-tabular-nums {
+  font-variant-numeric: tabular-nums;
+}

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ScheduleTableTest.tsx.snap
@@ -24,25 +24,23 @@ exports[`ScheduleTable it renders 1`] = `
     <thead
       className="schedule-table__header"
     >
-      <tr
-        className="schedule-table__row-header"
-      >
+      <tr>
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
           scope="col"
         >
           Departs
         </th>
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
+          colSpan={2}
           scope="col"
         >
-          Destination
-        </th>
-        <th
-          className="schedule-table__th--flex-end"
-          scope="col"
-        >
+          <span
+            className="pull-left"
+          >
+            Destination
+          </span>
           Trip Details
         </th>
       </tr>
@@ -53,7 +51,7 @@ exports[`ScheduleTable it renders 1`] = `
           <tr
             aria-controls="trip-42248754"
             aria-expanded={true}
-            className="schedule-table__row-selected"
+            className="schedule-table__row--expanded"
             onClick={[Function]}
             onKeyPress={[Function]}
             role="button"
@@ -61,24 +59,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:36 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret--white"
@@ -91,11 +92,11 @@ exports[`ScheduleTable it renders 1`] = `
             </td>
           </tr>
           <tr
-            className="schedule-table__subtable-container"
             id="trip-42248754-expanded"
           >
             <td
-              className="schedule-table__subtable-td"
+              className="schedule-table__cell schedule-table__cell--expanded"
+              colSpan={3}
             >
               <Component>
                 <div
@@ -125,24 +126,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:46 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -169,24 +173,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:55 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -213,24 +220,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:03 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -257,24 +267,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:10 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -301,24 +314,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:17 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -345,24 +361,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:24 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -389,24 +408,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:31 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -433,24 +455,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:37 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -477,24 +502,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:43 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -521,24 +549,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:49 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -565,24 +596,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:54 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -609,24 +643,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:59 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -653,24 +690,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:03 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -697,24 +737,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:05 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -741,24 +784,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:09 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -785,24 +831,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:10 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -829,24 +878,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:13 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -873,24 +925,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:14 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -917,24 +972,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:19 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -961,24 +1019,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:21 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1005,24 +1066,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:24 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1049,24 +1113,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:26 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1093,24 +1160,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:27 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1137,24 +1207,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:32 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1181,24 +1254,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:33 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1225,24 +1301,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:37 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1269,24 +1348,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:39 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1313,24 +1395,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:42 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1357,24 +1442,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:44 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1401,24 +1489,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:46 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1445,24 +1536,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:50 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1489,24 +1583,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:51 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1533,24 +1630,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:55 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1577,24 +1677,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:57 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1621,24 +1724,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:59 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1665,24 +1771,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:01 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1709,24 +1818,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:03 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1753,24 +1865,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:07 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1797,24 +1912,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:08 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1841,24 +1959,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:12 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1885,24 +2006,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:15 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1929,24 +2053,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:17 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -1973,24 +2100,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:21 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2017,24 +2147,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:22 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2061,24 +2194,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:25 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2105,24 +2241,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:26 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2149,24 +2288,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:31 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2193,24 +2335,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:33 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2237,24 +2382,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:35 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2281,24 +2429,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:38 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2325,24 +2476,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:39 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2369,24 +2523,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:43 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2413,24 +2570,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:45 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2457,24 +2617,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:48 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2501,24 +2664,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:51 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2545,24 +2711,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:53 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2589,24 +2758,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:56 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2633,24 +2805,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:57 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2677,24 +2852,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:03 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2721,24 +2899,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:05 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2765,24 +2946,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:09 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2809,24 +2993,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:13 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2853,24 +3040,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:14 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2897,24 +3087,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:20 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2941,24 +3134,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:23 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -2985,24 +3181,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:27 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3029,24 +3228,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:31 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3073,24 +3275,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:33 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3117,24 +3322,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:39 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3161,24 +3369,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:40 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3205,24 +3416,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:50 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3249,24 +3463,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:05 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3293,24 +3510,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:17 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3337,24 +3557,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:20 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3381,24 +3604,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:28 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3425,24 +3651,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:35 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3469,24 +3698,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:50 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3513,24 +3745,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:56 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3557,24 +3792,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:05 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3601,24 +3839,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:20 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3645,24 +3886,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:35 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3689,24 +3933,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:50 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3733,24 +3980,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:05 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3777,24 +4027,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:08 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3821,24 +4074,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:14 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3865,24 +4121,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:20 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3909,24 +4168,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:24 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3953,24 +4215,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:34 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -3997,24 +4262,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:36 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4041,24 +4309,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:44 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4085,24 +4356,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:54 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4129,24 +4403,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:02 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4173,24 +4450,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:04 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4217,24 +4497,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:14 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4261,24 +4544,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:24 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4305,24 +4591,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:32 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4349,24 +4638,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:32 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4393,24 +4685,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:34 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4437,24 +4732,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:44 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4481,24 +4779,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:54 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4525,24 +4826,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:04 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4569,24 +4873,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:14 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4613,24 +4920,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:24 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4657,24 +4967,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:33 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4701,24 +5014,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:43 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4745,24 +5061,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:53 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4789,24 +5108,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:02 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4833,24 +5155,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:12 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4877,24 +5202,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:23 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4921,24 +5249,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:32 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -4965,24 +5296,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:45 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5009,24 +5343,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:42 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5053,24 +5390,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:35 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5097,24 +5437,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:52 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5141,24 +5484,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:53 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5185,24 +5531,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:01 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5229,24 +5578,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:03 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5273,24 +5625,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:09 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5317,24 +5672,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:13 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5361,24 +5719,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:19 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5405,24 +5766,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:22 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5449,24 +5813,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:24 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5493,24 +5860,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:27 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5537,24 +5907,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:31 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5581,24 +5954,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:33 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5625,24 +6001,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:38 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5669,24 +6048,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:39 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5713,24 +6095,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:43 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5757,24 +6142,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:45 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5801,24 +6189,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:48 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5845,24 +6236,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:51 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5889,24 +6283,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:53 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5933,24 +6330,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:58 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -5977,24 +6377,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:00 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6021,24 +6424,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:03 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6065,24 +6471,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:06 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6109,24 +6518,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:08 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6153,24 +6565,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:12 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6197,24 +6612,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:13 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6241,24 +6659,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:18 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6285,24 +6706,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:20 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6329,24 +6753,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:23 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6373,24 +6800,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:27 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6417,24 +6847,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:28 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6461,24 +6894,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:32 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6505,24 +6941,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:33 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6549,24 +6988,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:38 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6593,24 +7035,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:41 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6637,24 +7082,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:43 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6681,24 +7129,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:47 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6725,24 +7176,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:48 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6769,24 +7223,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:53 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6813,24 +7270,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:55 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6857,24 +7317,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:58 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6901,24 +7364,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:01 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6945,24 +7411,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:02 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -6989,24 +7458,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:07 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7033,24 +7505,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:09 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7077,24 +7552,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:12 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7121,24 +7599,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:16 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7165,24 +7646,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:17 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7209,24 +7693,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:22 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7253,24 +7740,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:23 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7297,24 +7787,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:27 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7341,24 +7834,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:32 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7385,24 +7881,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:37 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7429,24 +7928,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:42 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7473,24 +7975,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:47 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7517,24 +8022,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:52 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7561,24 +8069,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:57 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7605,24 +8116,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:02 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7649,24 +8163,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:06 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7693,24 +8210,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:12 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7737,24 +8257,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:17 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7781,24 +8304,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:23 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7825,24 +8351,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:25 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7869,24 +8398,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:29 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7913,24 +8445,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:38 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -7957,24 +8492,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:46 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8001,24 +8539,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:49 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8045,24 +8586,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:50 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8089,24 +8633,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:53 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8133,24 +8680,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:59 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8177,24 +8727,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:09 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8221,24 +8774,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:18 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8265,24 +8821,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:25 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8309,24 +8868,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:38 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8353,24 +8915,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:46 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8397,24 +8962,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:48 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8441,24 +9009,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:51 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8485,24 +9056,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:04 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8529,24 +9103,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:17 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8573,24 +9150,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:30 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8617,24 +9197,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:43 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8661,24 +9244,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:56 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8705,24 +9291,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:05 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8749,24 +9338,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:09 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8793,24 +9385,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:22 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8837,24 +9432,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:35 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8881,24 +9479,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:48 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8925,24 +9526,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:01 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -8969,24 +9573,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:14 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9013,24 +9620,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:29 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9057,24 +9667,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:44 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9101,24 +9714,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:59 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9145,24 +9761,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:14 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9189,24 +9808,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:24 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9233,24 +9855,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:30 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9277,24 +9902,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:50 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9321,24 +9949,27 @@ exports[`ScheduleTable it renders 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:02 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9381,31 +10012,29 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
     <thead
       className="schedule-table__header"
     >
-      <tr
-        className="schedule-table__row-header"
-      >
+      <tr>
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
           scope="col"
         >
           Departs
         </th>
         <th
-          className="schedule-table__row-header-label--small"
+          className="schedule-table__cell"
           scope="col"
         >
           Train
         </th>
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
+          colSpan={2}
           scope="col"
         >
-          Destination
-        </th>
-        <th
-          className="schedule-table__th--flex-end"
-          scope="col"
-        >
+          <span
+            className="pull-left"
+          >
+            Destination
+          </span>
           Trip Details
         </th>
       </tr>
@@ -9416,7 +10045,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           <tr
             aria-controls="trip-CR-Weekday-Fall-19-701"
             aria-expanded={true}
-            className="schedule-table__row-selected"
+            className="schedule-table__row--expanded"
             onClick={[Function]}
             onKeyPress={[Function]}
             role="button"
@@ -9424,21 +10053,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  04:15 AM
-                </div>
+                04:15 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 701
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -9454,7 +10079,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret--white"
@@ -9467,11 +10092,11 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
             </td>
           </tr>
           <tr
-            className="schedule-table__subtable-container"
             id="trip-CR-Weekday-Fall-19-701-expanded"
           >
             <td
-              className="schedule-table__subtable-td"
+              className="schedule-table__cell schedule-table__cell--expanded"
+              colSpan={4}
             >
               <Component>
                 <div
@@ -9501,21 +10126,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  06:03 AM
-                </div>
+                06:03 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 741
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -9531,7 +10152,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9558,21 +10179,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  07:05 AM
-                </div>
+                07:05 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 743
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -9588,7 +10205,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9615,21 +10232,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  08:04 AM
-                </div>
+                08:04 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 703
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -9645,7 +10258,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9672,21 +10285,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  08:50 AM
-                </div>
+                08:50 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 745
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -9702,7 +10311,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9729,21 +10338,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  09:40 AM
-                </div>
+                09:40 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 705
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -9759,7 +10364,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9786,21 +10391,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  11:00 AM
-                </div>
+                11:00 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 707
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -9816,7 +10417,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9843,21 +10444,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  11:45 AM
-                </div>
+                11:45 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 747
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -9873,7 +10470,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9900,21 +10497,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  12:20 PM
-                </div>
+                12:20 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 709
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -9930,7 +10523,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -9957,21 +10550,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  01:35 PM
-                </div>
+                01:35 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 711
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -9987,7 +10576,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10014,21 +10603,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  02:40 PM
-                </div>
+                02:40 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 713
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10044,7 +10629,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10071,21 +10656,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  02:45 PM
-                </div>
+                02:45 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 749
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10101,7 +10682,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10128,21 +10709,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  03:40 PM
-                </div>
+                03:40 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 715
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10158,7 +10735,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10185,21 +10762,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  04:15 PM
-                </div>
+                04:15 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 751
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10215,7 +10788,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10242,21 +10815,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  04:40 PM
-                </div>
+                04:40 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 717
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10272,7 +10841,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10299,21 +10868,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  05:03 PM
-                </div>
+                05:03 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 753
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10329,7 +10894,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10356,21 +10921,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  05:20 PM
-                </div>
+                05:20 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 719
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10386,7 +10947,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10413,21 +10974,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  05:45 PM
-                </div>
+                05:45 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 721
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10443,7 +11000,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10470,21 +11027,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  06:20 PM
-                </div>
+                06:20 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 723
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10500,7 +11053,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10527,21 +11080,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  06:30 PM
-                </div>
+                06:30 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 755
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10557,7 +11106,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10584,21 +11133,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  07:50 PM
-                </div>
+                07:50 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 725
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10614,7 +11159,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10641,21 +11186,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  08:15 PM
-                </div>
+                08:15 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 757
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10671,7 +11212,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10698,21 +11239,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  09:10 PM
-                </div>
+                09:10 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 727
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10728,7 +11265,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10755,21 +11292,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  10:00 PM
-                </div>
+                10:00 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 759
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10785,7 +11318,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10812,21 +11345,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  10:30 PM
-                </div>
+                10:30 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 729
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10842,7 +11371,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10869,21 +11398,17 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  11:50 PM
-                </div>
+                11:50 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 731
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -10899,7 +11424,7 @@ exports[`ScheduleTable it renders CR schedules 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -10942,31 +11467,29 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
     <thead
       className="schedule-table__header"
     >
-      <tr
-        className="schedule-table__row-header"
-      >
+      <tr>
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
           scope="col"
         >
           Departs
         </th>
         <th
-          className="schedule-table__row-header-label--small"
+          className="schedule-table__cell"
           scope="col"
         >
           Train
         </th>
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
+          colSpan={2}
           scope="col"
         >
-          Destination
-        </th>
-        <th
-          className="schedule-table__th--flex-end"
-          scope="col"
-        >
+          <span
+            className="pull-left"
+          >
+            Destination
+          </span>
           Trip Details
         </th>
       </tr>
@@ -10985,21 +11508,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  04:15 AM
-                </div>
+                04:15 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 701
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11015,7 +11534,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11042,21 +11561,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  06:03 AM
-                </div>
+                06:03 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 741
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11072,7 +11587,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11099,21 +11614,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  07:05 AM
-                </div>
+                07:05 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 743
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11129,7 +11640,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11156,21 +11667,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  08:04 AM
-                </div>
+                08:04 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 703
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11186,7 +11693,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11213,21 +11720,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  08:50 AM
-                </div>
+                08:50 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 745
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11243,7 +11746,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11270,21 +11773,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  09:40 AM
-                </div>
+                09:40 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 705
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11300,7 +11799,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11327,21 +11826,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  11:00 AM
-                </div>
+                11:00 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 707
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11357,7 +11852,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11384,21 +11879,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  11:45 AM
-                </div>
+                11:45 AM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 747
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11414,7 +11905,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11441,21 +11932,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  12:20 PM
-                </div>
+                12:20 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 709
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11471,7 +11958,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11498,21 +11985,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  01:35 PM
-                </div>
+                01:35 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 711
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11528,7 +12011,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11555,21 +12038,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  02:40 PM
-                </div>
+                02:40 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 713
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11585,7 +12064,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11612,21 +12091,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  02:45 PM
-                </div>
+                02:45 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 749
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11642,7 +12117,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11669,21 +12144,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  03:40 PM
-                </div>
+                03:40 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 715
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11699,7 +12170,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11726,21 +12197,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  04:15 PM
-                </div>
+                04:15 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 751
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11756,7 +12223,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11783,21 +12250,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  04:40 PM
-                </div>
+                04:40 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 717
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11813,7 +12276,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11840,21 +12303,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  05:03 PM
-                </div>
+                05:03 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 753
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11870,7 +12329,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11897,21 +12356,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  05:20 PM
-                </div>
+                05:20 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 719
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11927,7 +12382,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -11954,21 +12409,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  05:45 PM
-                </div>
+                05:45 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 721
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -11984,7 +12435,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12011,21 +12462,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  06:20 PM
-                </div>
+                06:20 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 723
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -12041,7 +12488,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12068,21 +12515,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  06:30 PM
-                </div>
+                06:30 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 755
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -12098,7 +12541,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12125,21 +12568,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  07:50 PM
-                </div>
+                07:50 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 725
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -12155,7 +12594,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12182,21 +12621,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  08:15 PM
-                </div>
+                08:15 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 757
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -12212,7 +12647,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12239,21 +12674,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  09:10 PM
-                </div>
+                09:10 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 727
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -12269,7 +12700,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12296,21 +12727,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  10:00 PM
-                </div>
+                10:00 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 759
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -12326,7 +12753,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12353,21 +12780,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  10:30 PM
-                </div>
+                10:30 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 729
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -12383,7 +12806,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12410,21 +12833,17 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
           >
             <CrTableRow>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
-                <div
-                  className="schedule-table__time"
-                >
-                  11:50 PM
-                </div>
+                11:50 PM
               </td>
               <td
-                className="schedule-table__td schedule-table__tab-num"
+                className="schedule-table__cell u-tabular-nums"
               >
                 731
               </td>
               <td
-                className="schedule-table__headsign"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
                   aria-hidden="false"
@@ -12440,7 +12859,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
               </td>
             </CrTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12462,7 +12881,7 @@ exports[`ScheduleTable it renders CR schedules with school trips 1`] = `
 exports[`ScheduleTable it renders an empty message 1`] = `
 <ScheduleTable>
   <div
-    className="callout schedule-table--empty"
+    className="callout u-bold text-center"
   >
     There is no scheduled service for this time period.
   </div>
@@ -12501,29 +12920,27 @@ exports[`ScheduleTable it renders with school trips 1`] = `
     <thead
       className="schedule-table__header"
     >
-      <tr
-        className="schedule-table__row-header"
-      >
+      <tr>
         <th
-          className="schedule-table__row-header-label--tiny"
+          className="schedule-table__cell"
           scope="col"
         />
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
           scope="col"
         >
           Departs
         </th>
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
+          colSpan={2}
           scope="col"
         >
-          Destination
-        </th>
-        <th
-          className="schedule-table__th--flex-end"
-          scope="col"
-        >
+          <span
+            className="pull-left"
+          >
+            Destination
+          </span>
           Trip Details
         </th>
       </tr>
@@ -12542,27 +12959,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:36 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12589,31 +13009,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:46 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12640,31 +13063,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:55 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12691,31 +13117,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:03 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12742,31 +13171,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:10 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12793,31 +13225,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:17 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12844,31 +13279,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:24 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12895,31 +13333,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:31 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12946,31 +13387,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:37 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -12997,31 +13441,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:43 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13048,31 +13495,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:49 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13099,31 +13549,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:54 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13150,31 +13603,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:59 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13201,27 +13657,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:03 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13248,31 +13707,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:05 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13299,27 +13761,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:09 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13346,31 +13811,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:10 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13397,27 +13865,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:13 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13444,31 +13915,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:14 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13495,31 +13969,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:19 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13546,27 +14023,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:21 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13593,31 +14073,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:24 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13644,27 +14127,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:26 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13691,31 +14177,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:27 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13742,31 +14231,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:32 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13793,27 +14285,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:33 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13840,31 +14335,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:37 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13891,27 +14389,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:39 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13938,31 +14439,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:42 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -13989,27 +14493,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:44 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14036,31 +14543,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:46 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14087,27 +14597,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:50 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14134,31 +14647,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:51 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14185,31 +14701,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:55 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14236,27 +14755,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:57 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14283,31 +14805,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:59 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14334,27 +14859,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:01 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14381,31 +14909,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:03 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14432,27 +14963,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:07 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14479,31 +15013,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:08 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14530,31 +15067,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:12 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14581,27 +15121,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:15 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14628,31 +15171,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:17 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14679,27 +15225,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:21 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14726,31 +15275,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:22 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14777,27 +15329,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:25 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14824,31 +15379,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:26 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14875,31 +15433,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:31 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14926,27 +15487,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:33 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -14973,31 +15537,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:35 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15024,27 +15591,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:38 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15071,31 +15641,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:39 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15122,31 +15695,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:43 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15173,27 +15749,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:45 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15220,31 +15799,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:48 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15271,27 +15853,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:51 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15318,31 +15903,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:53 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15369,27 +15957,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:56 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15416,31 +16007,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:57 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15467,27 +16061,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:03 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15514,31 +16111,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:05 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15565,27 +16165,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:09 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15612,27 +16215,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:13 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15659,31 +16265,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:14 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15710,27 +16319,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:20 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15757,31 +16369,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:23 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15808,27 +16423,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:27 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15855,31 +16473,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:31 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15906,27 +16527,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:33 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -15953,27 +16577,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:39 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16000,31 +16627,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:40 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16051,31 +16681,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:50 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16102,31 +16735,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:05 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16153,27 +16789,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:17 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16200,31 +16839,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:20 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16251,27 +16893,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:28 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16298,31 +16943,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:35 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16349,31 +16997,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:50 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16400,27 +17051,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:56 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16447,31 +17101,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:05 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16498,31 +17155,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:20 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16549,31 +17209,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:35 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16600,31 +17263,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:50 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16651,31 +17317,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:05 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16702,27 +17371,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:08 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16749,31 +17421,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:14 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16800,27 +17475,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:20 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16847,31 +17525,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:24 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16898,31 +17579,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:34 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16949,27 +17633,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:36 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -16996,31 +17683,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:44 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17047,31 +17737,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:54 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17098,27 +17791,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:02 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17145,31 +17841,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:04 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17196,31 +17895,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:14 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17247,31 +17949,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:24 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17298,27 +18003,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:32 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17345,27 +18053,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:32 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17392,31 +18103,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:34 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17443,31 +18157,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:44 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17494,31 +18211,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:54 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17545,31 +18265,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:04 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17596,31 +18319,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:14 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17647,31 +18373,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:24 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17698,31 +18427,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:33 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17749,31 +18481,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:43 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17800,31 +18535,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 02:53 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17851,31 +18589,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:02 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17902,31 +18643,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:12 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -17953,31 +18697,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:23 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18004,31 +18751,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:32 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18055,27 +18805,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:45 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18102,31 +18855,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:42 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18153,27 +18909,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:35 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18200,27 +18959,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:52 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18247,31 +19009,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 03:53 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18298,27 +19063,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:01 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18345,31 +19113,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:03 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18396,27 +19167,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:09 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18443,31 +19217,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:13 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18494,27 +19271,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:19 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18541,31 +19321,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:22 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18592,27 +19375,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:24 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18639,31 +19425,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:27 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18690,27 +19479,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:31 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18737,31 +19529,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:33 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18788,31 +19583,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:38 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18839,27 +19637,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:39 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18886,31 +19687,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:43 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18937,27 +19741,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:45 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -18984,31 +19791,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:48 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19035,27 +19845,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:51 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19082,31 +19895,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:53 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19133,31 +19949,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 04:58 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19184,27 +20003,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:00 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19231,31 +20053,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:03 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19282,27 +20107,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:06 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19329,31 +20157,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:08 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19380,27 +20211,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:12 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19427,31 +20261,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:13 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19478,31 +20315,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:18 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19529,27 +20369,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:20 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19576,31 +20419,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:23 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19627,27 +20473,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:27 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19674,31 +20523,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:28 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19725,27 +20577,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:32 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19772,31 +20627,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:33 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19823,31 +20681,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:38 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19874,27 +20735,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:41 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19921,31 +20785,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:43 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -19972,27 +20839,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:47 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20019,31 +20889,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:48 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20070,31 +20943,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:53 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20121,27 +20997,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:55 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20168,31 +21047,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 05:58 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20219,27 +21101,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:01 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20266,31 +21151,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:02 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20317,31 +21205,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:07 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20368,27 +21259,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:09 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20415,31 +21309,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:12 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20466,27 +21363,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:16 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20513,31 +21413,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:17 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20564,31 +21467,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:22 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20615,27 +21521,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:23 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20662,31 +21571,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:27 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20713,31 +21625,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:32 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20764,31 +21679,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:37 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20815,31 +21733,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:42 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20866,31 +21787,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:47 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20917,31 +21841,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:52 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -20968,31 +21895,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 06:57 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21019,31 +21949,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:02 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21070,31 +22003,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:06 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21121,31 +22057,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:12 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21172,31 +22111,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:17 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21223,31 +22165,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:23 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21274,27 +22219,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:25 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21321,31 +22269,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:29 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21372,31 +22323,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:38 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21423,31 +22377,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:46 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21474,27 +22431,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:49 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21521,27 +22481,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:50 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21568,27 +22531,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:53 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21615,31 +22581,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 07:59 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21666,31 +22635,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:09 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21717,27 +22689,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:18 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21764,31 +22739,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:25 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21815,31 +22793,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:38 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21866,27 +22847,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:46 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21913,27 +22897,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:48 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -21960,31 +22947,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 08:51 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22011,31 +23001,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:04 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22062,31 +23055,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:17 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22113,31 +23109,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:30 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22164,31 +23163,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:43 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22215,31 +23217,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 09:56 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22266,27 +23271,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:05 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22313,31 +23321,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:09 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22364,31 +23375,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:22 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22415,31 +23429,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:35 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22466,31 +23483,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 10:48 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22517,31 +23537,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:01 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22568,31 +23591,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:14 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22619,31 +23645,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:29 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22670,31 +23699,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:44 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22721,31 +23753,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 11:59 PM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22772,31 +23807,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:14 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22823,27 +23861,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:24 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22870,31 +23911,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:30 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22921,31 +23965,34 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               >
                 <strong>
                   S
                 </strong>
               </td>
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 12:50 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--silver-line"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  SL2
+                  <span
+                    className="c-icon__bus-pill--small u-bg--silver-line"
+                  >
+                    SL2
+                  </span>
                 </span>
-                 
                 Drydock
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"
@@ -22972,27 +24019,30 @@ exports[`ScheduleTable it renders with school trips 1`] = `
           >
             <BusTableRow>
               <td
-                className="schedule-table__td--tiny"
+                className="schedule-table__cell schedule-table__cell--tiny"
               />
               <td
-                className="schedule-table__td schedule-table__time"
+                className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
               >
                 01:02 AM
               </td>
               <td
-                className="schedule-table__td"
+                className="schedule-table__cell schedule-table__cell--headsign"
               >
                 <span
-                  className="c-icon__bus-pill--small schedule-table__scheduled-bus-pill u-bg--bus"
+                  className="schedule-table__route-pill m-route-pills"
                 >
-                  Silver Line Way - South Station
+                  <span
+                    className="c-icon__bus-pill--small u-bg--bus"
+                  >
+                    Silver Line Way - South Station
+                  </span>
                 </span>
-                 
                 Silver Line Way
               </td>
             </BusTableRow>
             <td
-              className="schedule-table__td schedule-table__td--flex-end"
+              className="schedule-table__cell schedule-table__cell--tiny"
             >
               <span
                 className="c-expandable-block__header-caret"

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/TableRowTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/TableRowTest.tsx.snap
@@ -11,21 +11,17 @@ exports[`TableRow it renders 1`] = `
   tabIndex={0}
 >
   <td
-    className="schedule-table__td"
+    className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
   >
-    <div
-      className="schedule-table__time"
-    >
-      05:30 AM
-    </div>
+    05:30 AM
   </td>
   <td
-    className="schedule-table__td schedule-table__tab-num"
+    className="schedule-table__cell u-tabular-nums"
   >
     801
   </td>
   <td
-    className="schedule-table__headsign"
+    className="schedule-table__cell schedule-table__cell--headsign"
   >
     <span
       aria-hidden="false"
@@ -40,7 +36,7 @@ exports[`TableRow it renders 1`] = `
     Wickford Junction
   </td>
   <td
-    className="schedule-table__td schedule-table__td--flex-end"
+    className="schedule-table__cell schedule-table__cell--tiny"
   >
     <span
       className="c-expandable-block__header-caret"

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
@@ -2,37 +2,36 @@
 
 exports[`TripDetails displays both scheduled and predicted times for CR if there is a delay of more than 5 minutes 1`] = `
 <table
-  className="schedule-table__subtable"
+  className="trip-details-table"
 >
   <thead>
-    <tr>
+    <tr
+      className="trip-details-table__summary"
+    >
       <td
+        className="schedule-table__cell"
         colSpan={3}
       >
-        <div
-          className="schedule-table__subtable-trip-info"
-        >
-          <div
-            className="schedule-table__subtable-trip-info-title u-small-caps u-bold"
+        <div>
+          <span
+            className="trip-details-table__title u-small-caps u-bold"
           >
             Trip length
-          </div>
+          </span>
           7
            stops, 
           56
            minutes total
         </div>
-        <div
-          className="schedule-table__subtable-trip-info"
-        >
-          <div
-            className="schedule-table__subtable-trip-info-title u-small-caps u-bold"
+        <div>
+          <span
+            className="trip-details-table__title u-small-caps u-bold"
           >
             Fare
-          </div>
+          </span>
           $12.25
           <a
-            className="schedule-table__subtable-trip-info-link"
+            className="trip-details-table__link"
             href="/fares/commuter_rail?destination=place-NEC-1851&origin=place-bbsta"
           >
             View fares
@@ -42,27 +41,23 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
     </tr>
     <tr>
       <th
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
         scope="col"
       >
         Stops
       </th>
       <th
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted"
         scope="col"
       >
         Arrival
       </th>
     </tr>
   </thead>
-  <tbody
-    className="schedule-table__subtable-tbody"
-  >
-    <tr
-      className="schedule-table__subtable-row"
-    >
+  <tbody>
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-bbsta"
@@ -71,10 +66,10 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         <span
-          className="schedule-table__time--delayed schedule-table__time--delayed-future_stop"
+          className="schedule-table__times--delayed schedule-table__times--delayed-future_stop"
         >
           04:00 PM
         </span>
@@ -84,11 +79,9 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         04:01 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-rugg"
@@ -97,16 +90,14 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:04 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-2108"
@@ -115,10 +106,10 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         <span
-          className="schedule-table__time--delayed schedule-table__time--delayed-future_stop"
+          className="schedule-table__times--delayed schedule-table__times--delayed-future_stop"
         >
           04:22 PM
         </span>
@@ -128,11 +119,9 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         04:22 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-2040"
@@ -141,16 +130,14 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:30 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-1969"
@@ -159,10 +146,10 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         <span
-          className="schedule-table__time--delayed schedule-table__time--delayed-future_stop"
+          className="schedule-table__times--delayed schedule-table__times--delayed-future_stop"
         >
           04:38 PM
         </span>
@@ -172,11 +159,9 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         04:39 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-1919"
@@ -185,16 +170,14 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:48 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-1851"
@@ -203,10 +186,10 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         <span
-          className="schedule-table__time--delayed schedule-table__time--delayed-future_stop"
+          className="schedule-table__times--delayed schedule-table__times--delayed-future_stop"
         >
           04:58 PM
         </span>
@@ -230,37 +213,36 @@ exports[`TripDetails it renders an error if fetch failed 1`] = `
 
 exports[`TripDetails it renders trip details for a CR trip 1`] = `
 <table
-  className="schedule-table__subtable"
+  className="trip-details-table"
 >
   <thead>
-    <tr>
+    <tr
+      className="trip-details-table__summary"
+    >
       <td
+        className="schedule-table__cell"
         colSpan={3}
       >
-        <div
-          className="schedule-table__subtable-trip-info"
-        >
-          <div
-            className="schedule-table__subtable-trip-info-title u-small-caps u-bold"
+        <div>
+          <span
+            className="trip-details-table__title u-small-caps u-bold"
           >
             Trip length
-          </div>
+          </span>
           10
            stops, 
           69
            minutes total
         </div>
-        <div
-          className="schedule-table__subtable-trip-info"
-        >
-          <div
-            className="schedule-table__subtable-trip-info-title u-small-caps u-bold"
+        <div>
+          <span
+            className="trip-details-table__title u-small-caps u-bold"
           >
             Fare
-          </div>
+          </span>
           $12.25
           <a
-            className="schedule-table__subtable-trip-info-link"
+            className="trip-details-table__link"
             href="/fares/commuter_rail?destination=place-NEC-1851&origin=place-sstat"
           >
             View fares
@@ -270,33 +252,29 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
     </tr>
     <tr>
       <th
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
         scope="col"
       >
         Stops
       </th>
       <th
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted"
         scope="col"
       >
         Fare
       </th>
       <th
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted"
         scope="col"
       >
         Arrival
       </th>
     </tr>
   </thead>
-  <tbody
-    className="schedule-table__subtable-tbody"
-  >
-    <tr
-      className="schedule-table__subtable-row"
-    >
+  <tbody>
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-sstat"
@@ -305,21 +283,19 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         02:30 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-bbsta"
@@ -328,21 +304,19 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         $2.40
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         02:35 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-rugg"
@@ -351,21 +325,19 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         $2.40
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         02:38 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-2173"
@@ -374,21 +346,19 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         $7.00
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         02:51 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-2139"
@@ -397,21 +367,19 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         $8.00
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         02:57 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-2108"
@@ -420,21 +388,19 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         $8.75
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         03:03 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-2040"
@@ -443,21 +409,19 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         $10.50
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         03:11 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-1969"
@@ -466,21 +430,19 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         $11.00
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         03:19 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-1919"
@@ -489,21 +451,19 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         $11.00
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         03:29 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-NEC-1851"
@@ -512,12 +472,12 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         $12.25
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         03:39 PM
       </td>
@@ -528,37 +488,36 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
 
 exports[`TripDetails it renders trip details for a bus trip 1`] = `
 <table
-  className="schedule-table__subtable"
+  className="trip-details-table"
 >
   <thead>
-    <tr>
+    <tr
+      className="trip-details-table__summary"
+    >
       <td
+        className="schedule-table__cell"
         colSpan={3}
       >
-        <div
-          className="schedule-table__subtable-trip-info"
-        >
-          <div
-            className="schedule-table__subtable-trip-info-title u-small-caps u-bold"
+        <div>
+          <span
+            className="trip-details-table__title u-small-caps u-bold"
           >
             Trip length
-          </div>
+          </span>
           11
            stops, 
           14
            minutes total
         </div>
-        <div
-          className="schedule-table__subtable-trip-info"
-        >
-          <div
-            className="schedule-table__subtable-trip-info-title u-small-caps u-bold"
+        <div>
+          <span
+            className="trip-details-table__title u-small-caps u-bold"
           >
             Fare
-          </div>
+          </span>
           $2.40
           <a
-            className="schedule-table__subtable-trip-info-link"
+            className="trip-details-table__link"
             href="/fares/bus-fares"
           >
             View fares
@@ -568,27 +527,23 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
     </tr>
     <tr>
       <th
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
         scope="col"
       >
         Stops
       </th>
       <th
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted"
         scope="col"
       >
         Arrival
       </th>
     </tr>
   </thead>
-  <tbody
-    className="schedule-table__subtable-tbody"
-  >
-    <tr
-      className="schedule-table__subtable-row"
-    >
+  <tbody>
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-sstat"
@@ -597,16 +552,14 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:46 AM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-crtst"
@@ -615,16 +568,14 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:48 AM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-wtcst"
@@ -633,16 +584,14 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:50 AM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-conrd"
@@ -651,16 +600,14 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:53 AM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/247"
@@ -669,16 +616,14 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:54 AM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/30249"
@@ -687,16 +632,14 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:55 AM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/30250"
@@ -705,16 +648,14 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:56 AM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/30251"
@@ -723,16 +664,14 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:56 AM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/31259"
@@ -741,16 +680,14 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:56 AM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/31258"
@@ -759,16 +696,14 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:57 AM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/31255"
@@ -777,7 +712,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         06:00 AM
       </td>
@@ -788,37 +723,36 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
 
 exports[`TripDetails uses a predicted departure time in preference to a scheduled one 1`] = `
 <table
-  className="schedule-table__subtable"
+  className="trip-details-table"
 >
   <thead>
-    <tr>
+    <tr
+      className="trip-details-table__summary"
+    >
       <td
+        className="schedule-table__cell"
         colSpan={3}
       >
-        <div
-          className="schedule-table__subtable-trip-info"
-        >
-          <div
-            className="schedule-table__subtable-trip-info-title u-small-caps u-bold"
+        <div>
+          <span
+            className="trip-details-table__title u-small-caps u-bold"
           >
             Trip length
-          </div>
+          </span>
           39
            stops, 
           32
            minutes total
         </div>
-        <div
-          className="schedule-table__subtable-trip-info"
-        >
-          <div
-            className="schedule-table__subtable-trip-info-title u-small-caps u-bold"
+        <div>
+          <span
+            className="trip-details-table__title u-small-caps u-bold"
           >
             Fare
-          </div>
+          </span>
           $1.70
           <a
-            className="schedule-table__subtable-trip-info-link"
+            className="trip-details-table__link"
             href="/fares/bus-fares"
           >
             View fares
@@ -828,27 +762,23 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
     </tr>
     <tr>
       <th
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
         scope="col"
       >
         Stops
       </th>
       <th
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted"
         scope="col"
       >
         Arrival
       </th>
     </tr>
   </thead>
-  <tbody
-    className="schedule-table__subtable-tbody"
-  >
-    <tr
-      className="schedule-table__subtable-row"
-    >
+  <tbody>
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/place-forhl"
@@ -857,16 +787,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:39 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/596"
@@ -875,16 +803,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:42 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/597"
@@ -893,16 +819,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:42 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/598"
@@ -911,16 +835,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:43 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/599"
@@ -929,16 +851,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:43 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/600"
@@ -947,16 +867,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:44 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/601"
@@ -965,16 +883,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:45 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/602"
@@ -983,16 +899,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:46 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/797"
@@ -1001,16 +915,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:47 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/798"
@@ -1019,16 +931,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:47 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/799"
@@ -1037,16 +947,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:47 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/800"
@@ -1055,16 +963,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:48 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/801"
@@ -1073,16 +979,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:48 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/802"
@@ -1091,16 +995,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:49 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/803"
@@ -1109,16 +1011,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:49 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/804"
@@ -1127,16 +1027,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:50 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/805"
@@ -1145,16 +1043,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:51 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/806"
@@ -1163,16 +1059,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:53 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/807"
@@ -1181,16 +1075,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:54 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/808"
@@ -1199,16 +1091,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:55 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/810"
@@ -1217,16 +1107,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:56 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/821"
@@ -1235,16 +1123,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:58 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/811"
@@ -1253,16 +1139,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:58 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/822"
@@ -1271,16 +1155,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         04:59 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/823"
@@ -1289,16 +1171,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:00 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/824"
@@ -1307,16 +1187,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:00 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/825"
@@ -1325,16 +1203,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:00 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/826"
@@ -1343,16 +1219,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:01 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/10768"
@@ -1361,16 +1235,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:01 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/827"
@@ -1379,16 +1251,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:01 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/828"
@@ -1397,16 +1267,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:02 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/829"
@@ -1415,16 +1283,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:02 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/830"
@@ -1433,16 +1299,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:02 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/831"
@@ -1451,16 +1315,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:03 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/832"
@@ -1469,16 +1331,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:03 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/618"
@@ -1487,16 +1347,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:05 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/10618"
@@ -1505,16 +1363,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:05 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/10835"
@@ -1523,16 +1379,14 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:09 PM
       </td>
     </tr>
-    <tr
-      className="schedule-table__subtable-row"
-    >
+    <tr>
       <td
-        className="schedule-table__subtable-data"
+        className="schedule-table__cell"
       >
         <a
           href="/stops/10833"
@@ -1541,7 +1395,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         </a>
       </td>
       <td
-        className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+        className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
         05:11 PM
       </td>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/UpcomingDeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/UpcomingDeparturesTest.tsx.snap
@@ -43,13 +43,14 @@ Array [
         className="schedule-table__row-header"
       >
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
           scope="col"
         >
           Destinations
         </th>
         <th
-          className="schedule-table__th--flex-end"
+          className="schedule-table__cell"
+          colSpan={2}
           scope="col"
         >
           Trip Details
@@ -67,32 +68,28 @@ Array [
         tabIndex={0}
       >
         <td
-          className="schedule-table__td schedule-table__td--flex-end"
+          className="schedule-table__cell schedule-table__cell--headsign"
         >
-          <div
-            className="schedule-table__row-route"
+          <span
+            className="schedule-table__route-pill m-route-pills"
           >
-            <div
-              className="schedule-table__row-route-pill m-route-pills"
+            <span
+              className="c-icon__bus-pill--small u-bg--silver-line"
             >
-              <div
-                className="u-bg--silver-line"
-              >
-                SL-2
-              </div>
-            </div>
-            Harvard
-          </div>
+              SL-2
+            </span>
+          </span>
+          Harvard
         </td>
         <td
-          className="schedule-table__time schedule-table__td--flex-end u-bold"
+          className="schedule-table__cell schedule-table__cell--time u-nowrap u-bold text-right"
         >
           8
            
           min
         </td>
         <td
-          className="schedule-table__td schedule-table__td--flex-end"
+          className="schedule-table__cell schedule-table__cell--tiny"
         >
           <span
             className="c-expandable-block__header-caret"
@@ -150,13 +147,14 @@ Array [
         className="schedule-table__row-header"
       >
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
           scope="col"
         >
           Destinations
         </th>
         <th
-          className="schedule-table__th--flex-end"
+          className="schedule-table__cell"
+          colSpan={2}
           scope="col"
         >
           Trip Details
@@ -174,32 +172,28 @@ Array [
         tabIndex={0}
       >
         <td
-          className="schedule-table__td schedule-table__td--flex-end"
+          className="schedule-table__cell schedule-table__cell--headsign"
         >
-          <div
-            className="schedule-table__row-route"
+          <span
+            className="schedule-table__route-pill m-route-pills"
           >
-            <div
-              className="schedule-table__row-route-pill m-route-pills"
+            <span
+              className="c-icon__bus-pill--small u-bg--bus"
             >
-              <div
-                className="u-bg--bus"
-              >
-                1
-              </div>
-            </div>
-            Harvard
-          </div>
+              1
+            </span>
+          </span>
+          Harvard
         </td>
         <td
-          className="schedule-table__time schedule-table__td--flex-end u-bold"
+          className="schedule-table__cell schedule-table__cell--time u-nowrap u-bold text-right"
         >
           8
            
           min
         </td>
         <td
-          className="schedule-table__td schedule-table__td--flex-end"
+          className="schedule-table__cell schedule-table__cell--tiny"
         >
           <span
             className="c-expandable-block__header-caret"
@@ -221,32 +215,28 @@ Array [
         tabIndex={0}
       >
         <td
-          className="schedule-table__td schedule-table__td--flex-end"
+          className="schedule-table__cell schedule-table__cell--headsign"
         >
-          <div
-            className="schedule-table__row-route"
+          <span
+            className="schedule-table__route-pill m-route-pills"
           >
-            <div
-              className="schedule-table__row-route-pill m-route-pills"
+            <span
+              className="c-icon__bus-pill--small u-bg--bus"
             >
-              <div
-                className="u-bg--bus"
-              >
-                1
-              </div>
-            </div>
-            Harvard
-          </div>
+              1
+            </span>
+          </span>
+          Harvard
         </td>
         <td
-          className="schedule-table__time schedule-table__td--flex-end u-bold"
+          className="schedule-table__cell schedule-table__cell--time u-nowrap u-bold text-right"
         >
           9
            
           min
         </td>
         <td
-          className="schedule-table__td schedule-table__td--flex-end"
+          className="schedule-table__cell schedule-table__cell--tiny"
         >
           <span
             className="c-expandable-block__header-caret"
@@ -304,13 +294,14 @@ Array [
         className="schedule-table__row-header"
       >
         <th
-          className="schedule-table__row-header-label"
+          className="schedule-table__cell"
           scope="col"
         >
           Destinations
         </th>
         <th
-          className="schedule-table__th--flex-end"
+          className="schedule-table__cell"
+          colSpan={2}
           scope="col"
         >
           Trip Details
@@ -328,7 +319,7 @@ Array [
         tabIndex={0}
       >
         <td
-          className="schedule-table__headsign"
+          className="schedule-table__cell schedule-table__cell--headsign"
         >
           <span
             aria-hidden="false"
@@ -339,41 +330,26 @@ Array [
               }
             }
           />
-        </td>
-        <td
-          className="schedule-table__headsign"
-        >
+           
           Worcester
         </td>
         <td
-          className="schedule-table__td schedule-table__td--flex-end"
+          className="schedule-table__cell text-right"
         >
           <div
-            className="schedule-table__time-container"
+            className="u-tabular-nums u-nowrap schedule-table__times"
           >
-            <div
-              className="schedule-table__time"
-            >
-              1:55 PM
-            </div>
+            1:55 PM
           </div>
           <div
-            className="u-nowrap text-right"
+            className="u-nowrap"
           >
-            <span
-              className="schedule-table__status"
-            >
-              Train 515 · On time
-            </span>
-            <span
-              className="schedule-table__track"
-            >
-              
-            </span>
+            Train 515 · On time
+            
           </div>
         </td>
         <td
-          className="schedule-table__td schedule-table__td--flex-end"
+          className="schedule-table__cell schedule-table__cell--tiny"
         >
           <span
             className="c-expandable-block__header-caret"

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleTable.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleTable.tsx
@@ -39,7 +39,7 @@ const ScheduleTable = ({
 
   if (journeys.length === 0) {
     return (
-      <div className="callout schedule-table--empty">
+      <div className="callout u-bold text-center">
         There is no scheduled service for this time period.
       </div>
     );
@@ -71,28 +71,20 @@ const ScheduleTable = ({
       )}
       <table className="schedule-table">
         <thead className="schedule-table__header">
-          <tr className="schedule-table__row-header">
+          <tr>
             {anySchoolTrips && (
-              <th
-                scope="col"
-                className="schedule-table__row-header-label--tiny"
-              />
+              <th scope="col" className="schedule-table__cell" />
             )}
-            <th scope="col" className="schedule-table__row-header-label">
+            <th scope="col" className="schedule-table__cell">
               Departs
             </th>
             {firstTrip.route.type === 2 && (
-              <th
-                scope="col"
-                className="schedule-table__row-header-label--small"
-              >
+              <th scope="col" className="schedule-table__cell">
                 Train
               </th>
             )}
-            <th scope="col" className="schedule-table__row-header-label">
-              Destination
-            </th>
-            <th scope="col" className="schedule-table__th--flex-end">
+            <th scope="col" colSpan={2} className="schedule-table__cell">
+              <span className="pull-left">Destination</span>
               Trip Details
             </th>
           </tr>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
@@ -58,11 +58,7 @@ const RouteIcon = ({
     ? "u-bg--silver-line"
     : "u-bg--bus";
   return (
-    <span
-      className={`c-icon__bus-pill--small schedule-table__scheduled-bus-pill ${backgroundClass}`}
-    >
-      {name}
-    </span>
+    <span className={`c-icon__bus-pill--small ${backgroundClass}`}>{name}</span>
   );
 };
 
@@ -77,15 +73,18 @@ const BusTableRow = ({
 }): ReactElement<HTMLElement> => (
   <>
     {anySchoolTrips && (
-      <td className="schedule-table__td--tiny">
+      <td className="schedule-table__cell schedule-table__cell--tiny">
         {isSchoolTrip && <strong>S</strong>}
       </td>
     )}
-    <td className="schedule-table__td schedule-table__time">
+    <td className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums">
       {journey.departure.time}
     </td>
-    <td className="schedule-table__td">
-      {RouteIcon(journey)} {breakTextAtSlash(journey.trip.headsign)}
+    <td className="schedule-table__cell schedule-table__cell--headsign">
+      <span className="schedule-table__route-pill m-route-pills">
+        {RouteIcon(journey)}
+      </span>
+      {breakTextAtSlash(journey.trip.headsign)}
     </td>
   </>
 );
@@ -96,15 +95,15 @@ const CrTableRow = ({
   journey: Journey;
 }): ReactElement<HTMLElement> => (
   <>
-    <td className="schedule-table__td">
-      <div className="schedule-table__time">{journey.departure.time}</div>
+    <td className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums">
+      {journey.departure.time}
     </td>
     {journey.trip.name && (
-      <td className="schedule-table__td schedule-table__tab-num">
+      <td className="schedule-table__cell u-tabular-nums">
         {journey.trip.name}
       </td>
     )}
-    <td className="schedule-table__headsign">
+    <td className="schedule-table__cell schedule-table__cell--headsign">
       {modeIcon(journey.route.id)} {breakTextAtSlash(journey.trip.headsign)}
     </td>
   </>
@@ -138,7 +137,7 @@ export const Accordion = ({
     <>
       <tr
         className={
-          expanded ? "schedule-table__row-selected" : "schedule-table__row"
+          expanded ? "schedule-table__row--expanded" : "schedule-table__row"
         }
         aria-controls={`trip-${tripId}`}
         aria-expanded={expanded}
@@ -148,19 +147,18 @@ export const Accordion = ({
         tabIndex={0}
       >
         {contentComponent()}
-        <td className="schedule-table__td schedule-table__td--flex-end">
-          {caret(
-            `c-expandable-block__header-caret${expanded ? "--white" : ""}`,
-            expanded
-          )}
+        <td className="schedule-table__cell schedule-table__cell--tiny">
+          {expanded
+            ? caret("c-expandable-block__header-caret--white", expanded)
+            : caret("c-expandable-block__header-caret", expanded)}
         </td>
       </tr>
       {expanded && (
-        <tr
-          id={`trip-${tripId}-expanded`}
-          className="schedule-table__subtable-container"
-        >
-          <td className="schedule-table__subtable-td">
+        <tr id={`trip-${tripId}-expanded`}>
+          <td
+            colSpan={journey.route.type === 2 ? 4 : 3}
+            className="schedule-table__cell schedule-table__cell--expanded"
+          >
             <TripDetails state={state} showFare={journey.route.type === 2} />
           </td>
         </tr>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TripDetails.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TripDetails.tsx
@@ -18,23 +18,21 @@ const TripSummary = ({
 }: {
   tripInfo: TripInfo;
 }): ReactElement<HTMLElement> => (
-  <tr>
-    <td colSpan={3}>
-      <div className="schedule-table__subtable-trip-info">
-        <div className="schedule-table__subtable-trip-info-title u-small-caps u-bold">
+  <tr className="trip-details-table__summary">
+    <td colSpan={3} className="schedule-table__cell">
+      <div>
+        <span className="trip-details-table__title u-small-caps u-bold">
           Trip length
-        </div>
+        </span>
         {tripInfo.times.length} stops, {tripInfo.duration} minutes total
       </div>
-      <div className="schedule-table__subtable-trip-info">
-        <div className="schedule-table__subtable-trip-info-title u-small-caps u-bold">
+      <div>
+        <span className="trip-details-table__title u-small-caps u-bold">
           Fare
-        </div>
+        </span>
+
         {tripInfo.fare && tripInfo.fare.price}
-        <a
-          className="schedule-table__subtable-trip-info-link"
-          href={tripInfo.fare.fare_link}
-        >
+        <a className="trip-details-table__link" href={tripInfo.fare.fare_link}>
           View fares
         </a>
       </div>
@@ -72,30 +70,30 @@ export const TripDetails = ({
   if (!tripInfo) return null;
 
   return (
-    <table className="schedule-table__subtable">
+    <table className="trip-details-table">
       <thead>
         <TripSummary tripInfo={tripInfo} />
         <tr>
-          <th scope="col" className="schedule-table__subtable-data">
+          <th scope="col" className="schedule-table__cell">
             Stops
           </th>
           {showFare && (
             <th
               scope="col"
-              className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+              className="schedule-table__cell schedule-table__cell--right-adjusted"
             >
               Fare
             </th>
           )}
           <th
             scope="col"
-            className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted"
+            className="schedule-table__cell schedule-table__cell--right-adjusted"
           >
             Arrival
           </th>
         </tr>
       </thead>
-      <tbody className="schedule-table__subtable-tbody">
+      <tbody>
         {allTimesHaveSchedule(tripInfo)
           ? tripInfo.times.map((departure, index: number) => (
               <TripStop

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
@@ -19,7 +19,7 @@ const formattedDepartureTimes = (
     if (delay && delay >= 300 && prediction && prediction.time) {
       return (
         <>
-          <span className="schedule-table__time--delayed schedule-table__time--delayed-future_stop">
+          <span className="schedule-table__times--delayed schedule-table__times--delayed-future_stop">
             {schedule.time}
           </span>
           <br className="hidden-sm-up" />
@@ -46,18 +46,18 @@ const TripStop = ({
   if (!schedule || !schedule.stop) return null;
 
   return (
-    <tr key={`${schedule.stop.id}`} className="schedule-table__subtable-row">
-      <td className="schedule-table__subtable-data">
+    <tr key={`${schedule.stop.id}`}>
+      <td className="schedule-table__cell">
         <a href={`/stops/${schedule.stop.id}`}>
           {breakTextAtSlash(schedule.stop.name)}
         </a>
       </td>
       {showFare && (
-        <td className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted">
+        <td className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums">
           {index === 0 ? "" : schedule.fare.price}
         </td>
       )}
-      <td className="schedule-table__subtable-data schedule-table__subtable-data--right-adjusted">
+      <td className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums">
         {formattedDepartureTimes(departure, routeType)}
       </td>
     </tr>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
@@ -41,9 +41,11 @@ export const RoutePillSmall = ({
 }: {
   route: Route;
 }): ReactElement<HTMLElement> | null => (
-  <div className="schedule-table__row-route-pill m-route-pills">
-    <div className={modeBgClass(route)}>{route.name}</div>
-  </div>
+  <span className="schedule-table__route-pill m-route-pills">
+    <span className={`c-icon__bus-pill--small ${modeBgClass(route)}`}>
+      {route.name}
+    </span>
+  </span>
 );
 interface TableRowProps {
   input: UserInput;
@@ -58,19 +60,17 @@ const BusTableRow = ({
   const { trip, route, realtime } = journey;
   return (
     <>
-      <td className="schedule-table__td schedule-table__td--flex-end">
-        <div className="schedule-table__row-route">
-          {route.type === 3 ? (
-            <RoutePillSmall route={route} />
-          ) : (
-            <div className="schedule-table__row-route-pill m-route-pills">
-              {modeIcon(route.id)}
-            </div>
-          )}
-          {trip.headsign}
-        </div>
+      <td className="schedule-table__cell schedule-table__cell--headsign">
+        {route.type === 3 ? (
+          <RoutePillSmall route={route} />
+        ) : (
+          <span className="schedule-table__row-route-pill m-route-pills">
+            {modeIcon(route.id)}
+          </span>
+        )}
+        {trip.headsign}
       </td>
-      <td className="schedule-table__time schedule-table__td--flex-end u-bold">
+      <td className="schedule-table__cell schedule-table__cell--time u-nowrap u-bold text-right">
         {realtime.prediction!.time}
       </td>
     </>
@@ -94,19 +94,19 @@ const CrTableRow = ({
 
   return (
     <>
-      <td className="schedule-table__headsign">{modeIcon(route.id)}</td>
-      <td className="schedule-table__headsign">
-        {breakTextAtSlash(trip.headsign)}
+      <td className="schedule-table__cell schedule-table__cell--headsign">
+        {modeIcon(route.id)} {breakTextAtSlash(trip.headsign)}
       </td>
-      <td className="schedule-table__td schedule-table__td--flex-end">
-        <div className="schedule-table__time-container">
-          {timeForCommuterRail(realtime, "schedule-table__time")}
-        </div>
-        <div className="u-nowrap text-right">
-          <span className="schedule-table__status">{statusWithTrain}</span>
-          <span className="schedule-table__track">
-            {track ? ` · ${track}` : ""}
-          </span>
+      <td className="schedule-table__cell text-right">
+        {timeForCommuterRail(
+          realtime,
+          "u-tabular-nums u-nowrap schedule-table__times"
+        )}
+        <div className="u-nowrap">
+          {statusWithTrain}
+          {track && (
+            <span className="schedule-table__track">{` · ${track}`}</span>
+          )}
         </div>
       </td>
     </>
@@ -162,10 +162,10 @@ export const UpcomingDepartures = ({
         <table className="schedule-table schedule-table--upcoming">
           <thead className="schedule-table__header">
             <tr className="schedule-table__row-header">
-              <th scope="col" className="schedule-table__row-header-label">
+              <th scope="col" className="schedule-table__cell">
                 Destinations
               </th>
-              <th scope="col" className="schedule-table__th--flex-end">
+              <th scope="col" colSpan={2} className="schedule-table__cell">
                 Trip Details
               </th>
             </tr>


### PR DESCRIPTION
### Summary of changes
**Asana Ticket:** [Schedule Finder | Missing table column spacing in IE11](https://app.asana.com/0/385363666817452/1166083075512706/f)

- Simplifies markup and CSS
- Removes use of flexbox within tables
- Aligns class names with current [guidelines](https://github.com/mbta/wiki/blob/4185fb315937c1370374a88f0555c32b6d44d090/website/development/guidelines/css_guidelines.md) and [conventions](https://github.com/mbta/wiki/blob/master/website/development/style-guide.md)
- Adds new utility class for tabular number display
- Updates snapshots

### IE screenshots

![anim](https://user-images.githubusercontent.com/2136286/79028607-a85c8780-7b5e-11ea-8a34-36b7af0356dc.gif)

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [ ] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
