### PR TITLE
Consider private IPs to be canonical hostnames

### DIFF
--- a/apps/site/lib/site_web/plugs/canonical_hostname.ex
+++ b/apps/site/lib/site_web/plugs/canonical_hostname.ex
@@ -23,7 +23,9 @@ defmodule SiteWeb.Plugs.CanonicalHostname do
   def call(%Plug.Conn{host: requested_hostname} = conn, _) do
     canonical_hostname = SiteWeb.Endpoint.config(:url)[:host]
 
-    if requested_hostname != canonical_hostname do
+    if requested_hostname == canonical_hostname or is_private_ip(requested_hostname) do
+      conn
+    else
       rewritten_url =
         Plug.Conn.request_url(conn)
         |> String.replace(requested_hostname, canonical_hostname, global: false)
@@ -32,8 +34,18 @@ defmodule SiteWeb.Plugs.CanonicalHostname do
       |> put_status(:moved_permanently)
       |> redirect(external: rewritten_url)
       |> halt()
-    else
-      conn
+    end
+  end
+
+  # The health checker uses a private IP for a hostname
+  defp is_private_ip(hostname) do
+    case hostname |> String.to_charlist() |> :inet.parse_ipv4_address() do
+      {:ok, {byte0, byte1, _, _}} ->
+        byte0 == 10 or (byte0 == 172 and byte1 >= 16 and byte1 <= 31) or
+          (byte0 == 192 and byte1 == 168)
+
+      _ ->
+        false
     end
   end
 end

--- a/apps/site/test/site_web/plugs/canonical_hostname_test.exs
+++ b/apps/site/test/site_web/plugs/canonical_hostname_test.exs
@@ -11,6 +11,26 @@ defmodule SiteWeb.Plugs.CanonicalHostnameTest do
       assert conn.status != 301
     end
 
+    test "with a local IP address, does nothing" do
+      # Class A
+      conn = %Plug.Conn{default_conn() | host: "10.127.127.127"}
+      assert conn.status != 301
+      conn = SiteWeb.Plugs.CanonicalHostname.call(conn, nil)
+      assert conn.status != 301
+
+      # Class B
+      conn = %Plug.Conn{default_conn() | host: "172.24.127.127"}
+      assert conn.status != 301
+      conn = SiteWeb.Plugs.CanonicalHostname.call(conn, nil)
+      assert conn.status != 301
+
+      # Class C
+      conn = %Plug.Conn{default_conn() | host: "192.168.127.127"}
+      assert conn.status != 301
+      conn = SiteWeb.Plugs.CanonicalHostname.call(conn, nil)
+      assert conn.status != 301
+    end
+
     test "when the hostname doesn't match the canonical hostname, redirects" do
       conn = %Plug.Conn{default_conn() | host: "example.com"}
       assert conn.status != 301


### PR DESCRIPTION
The health checker runs on the same hosts as the application servers and
uses a private IP address to access the /_health endpoint. Whitelist local
IP addresses as well.

No ticket.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
