### PR TITLE
Add ability to make timetable top header sticky

### DIFF
--- a/apps/site/assets/css/_mixins.scss
+++ b/apps/site/assets/css/_mixins.scss
@@ -354,3 +354,11 @@
     /* stylelint-enable declaration-no-important */
   }
 }
+
+// Pull an element's margins out to the left and right in order to make it span
+// full width of the screen while within a limited-width parent (i.e.
+// .container). Optionally leave space to either side with $cushion.
+@mixin full-width($cushion: 0) {
+  margin-left: calc(50% - 50vw + #{$cushion});
+  margin-right: calc(50% - 50vw + #{$cushion});
+}

--- a/apps/site/assets/css/_timetable.scss
+++ b/apps/site/assets/css/_timetable.scss
@@ -1,4 +1,7 @@
 .m-timetable {
+  max-height: 100vh;
+  overflow: scroll;
+
   @include media-breakpoint-down(sm) {
     margin-left: -$half-gutter;
     margin-right: -$half-gutter;
@@ -58,10 +61,6 @@
   justify-content: space-between;
   padding: $base-spacing / 2;
   text-align: center;
-
-  @include media-breakpoint-down(sm) {
-    justify-content: center;
-  }
 }
 
 .m-timetable__trains-label {
@@ -78,10 +77,6 @@
   font-size: .875rem;
   font-weight: bold;
   padding: $base-spacing / 4 $base-spacing / 2;
-
-  @include media-breakpoint-down(sm) {
-    display: none;
-  }
 
   &:hover {
     border-color: $brand-primary-darkest;
@@ -310,5 +305,55 @@
 [data-sticky-container] {
   [data-sticky] {
     position: relative;
+  }
+}
+
+// enables an extra sticky top header,
+// which is not enabled/supported in IE or Edge. warning: hacky
+.m-timetable--withstickyheader {
+  @include full-width(.5rem);
+
+  height: 100%;
+  overflow: visible;
+  width: 100vw;
+
+  .m-timetable__table-container {
+    border: 0;
+    overflow: visible;
+
+    tr:first-of-type th {
+      box-shadow: 3px 3px transparentize($gray-lighter, .3);
+      position: sticky;
+      top: calc(#{$base-spacing * 3} - 1px);
+
+      &.m-timetable__cell--first-column-header {
+        z-index: 0;
+      }
+    }
+  }
+
+  .m-timetable__cell--first-column[data-absolute] {
+    left: 0;
+    /* stylelint-disable-next-line declaration-no-important */
+    position: sticky !important; // overwrite the inline value added by some javascript triggered by the data-absolute attribute
+  }
+
+  .m-timetable__cell--first-column-header {
+    z-index: 1;
+  }
+
+  .m-timetable__header {
+    border: 0;
+    position: fixed;
+    right: 0;
+    top: 0;
+
+    .m-timetable__trains-label {
+      display: none;
+    }
+  }
+
+  td.hidden-no-js {
+    display: none;
   }
 }

--- a/apps/site/assets/js/timetable-scroll.js
+++ b/apps/site/assets/js/timetable-scroll.js
@@ -17,21 +17,24 @@ export default $ => {
       direction;
 
     // find the container element that will be scrolled
-    const $el = $("[data-sticky-container]");
-
-    // animate the scroll event
-    $el.animate(
-      { scrollLeft: $el.scrollLeft() + offset },
-      {
-        duration: 200,
-        step: () => {
-          state.animating = true;
-        },
-        done: () => {
-          state.animating = false;
+    if ($(".m-timetable--withstickyheader").length) {
+      window.scrollBy(offset, 0); // no animation but it works
+    } else {
+      const $el = $("[data-sticky-container]");
+      // animate the scroll event
+      $el.animate(
+        { scrollLeft: $el.scrollLeft() + offset },
+        {
+          duration: 200,
+          step: () => {
+            state.animating = true;
+          },
+          done: () => {
+            state.animating = false;
+          }
         }
-      }
-    );
+      );
+    }
   };
 
   $(document).on("click", "button[data-scroll='earlier']", () => scroll(-1));

--- a/apps/site/assets/js/timetable-style.js
+++ b/apps/site/assets/js/timetable-style.js
@@ -1,4 +1,4 @@
-let scrollCallback = false;
+import debounce from "../ts/helpers/debounce.ts";
 
 export default () => {
   document.addEventListener("turbolinks:load", adjustTimetableStyle, {
@@ -41,25 +41,20 @@ const resizeRows = () => {
   [...document.querySelectorAll(".js-tt-row")].forEach(resizeRow);
 };
 
-const toggleScrollButtons = event => {
-  if (scrollCallback !== false) {
-    clearTimeout(scrollCallback);
-  }
-  scrollCallback = setTimeout(() => {
-    const maxScrollLeft = event.target.scrollWidth - event.target.clientWidth;
-    const scrollLeft = event.target.scrollLeft;
-    const leftBtnEl = document.querySelector("button[data-scroll='earlier']");
-    const rightBtnEl = document.querySelector("button[data-scroll='later']");
+const toggleScrollButtons = debounce(event => {
+  const maxScrollLeft = event.target.scrollWidth - event.target.clientWidth;
+  const scrollLeft = event.target.scrollLeft;
+  const leftBtnEl = document.querySelector("button[data-scroll='earlier']");
+  const rightBtnEl = document.querySelector("button[data-scroll='later']");
 
-    if (leftBtnEl) {
-      scrollLeft === 0
-        ? leftBtnEl.setAttribute("disabled", "")
-        : leftBtnEl.removeAttribute("disabled");
-    }
-    if (rightBtnEl) {
-      scrollLeft === maxScrollLeft
-        ? rightBtnEl.setAttribute("disabled", "")
-        : rightBtnEl.removeAttribute("disabled");
-    }
-  }, 250);
-};
+  if (leftBtnEl) {
+    scrollLeft === 0
+      ? leftBtnEl.setAttribute("disabled", "")
+      : leftBtnEl.removeAttribute("disabled");
+  }
+  if (rightBtnEl) {
+    scrollLeft === maxScrollLeft
+      ? rightBtnEl.setAttribute("disabled", "")
+      : rightBtnEl.removeAttribute("disabled");
+  }
+}, 250)

--- a/apps/site/assets/js/timetable-style.js
+++ b/apps/site/assets/js/timetable-style.js
@@ -1,4 +1,5 @@
 import debounce from "../ts/helpers/debounce.ts";
+import isMSBrowser from "../ts/helpers/ms-browser.ts";
 
 export default () => {
   document.addEventListener("turbolinks:load", adjustTimetableStyle, {
@@ -9,13 +10,13 @@ export default () => {
 
 const adjustTimetableStyle = () => {
   // return if there is no timetable available
-  const timetableContainerEl = document.getElementById("timetable");
-  if (!timetableContainerEl) {
+  const timetableEl = document.getElementById("timetable");
+  if (!timetableEl) {
     return;
   }
 
   // remove border around container because timetable "hat" is visible
-  timetableContainerEl.style.borderTop = 0;
+  timetableEl.style.borderTop = 0;
 
   // make headers absolutely position so they stick when table is scrolled
   [...document.querySelectorAll("th[data-absolute]")].forEach(headerEl => {
@@ -25,7 +26,12 @@ const adjustTimetableStyle = () => {
   resizeRows();
 
   // register an on-scroll event to enable / disable buttons
-  timetableContainerEl.addEventListener("scroll", toggleScrollButtons);
+  timetableEl.addEventListener("scroll", toggleScrollButtons);
+
+  if (!isMSBrowser()) {
+    // register an on-scroll event to handle toggling extra scrolling headers
+    document.addEventListener("scroll", toggleStickyTableHeaders);
+  }
 };
 
 const resizeRow = rowEl => {
@@ -41,9 +47,11 @@ const resizeRows = () => {
   [...document.querySelectorAll(".js-tt-row")].forEach(resizeRow);
 };
 
-const toggleScrollButtons = debounce(event => {
-  const maxScrollLeft = event.target.scrollWidth - event.target.clientWidth;
-  const scrollLeft = event.target.scrollLeft;
+const toggleScrollButtons = debounce(({ target }) => {
+  // if using sticky table headers, then the target element is the document
+  const scrollArea = target.scrollWidth ? target : target.scrollingElement;
+  const maxScrollLeft = scrollArea.scrollWidth - scrollArea.clientWidth;
+  const scrollLeft = scrollArea.scrollLeft;
   const leftBtnEl = document.querySelector("button[data-scroll='earlier']");
   const rightBtnEl = document.querySelector("button[data-scroll='later']");
 
@@ -53,8 +61,64 @@ const toggleScrollButtons = debounce(event => {
       : leftBtnEl.removeAttribute("disabled");
   }
   if (rightBtnEl) {
-    scrollLeft === maxScrollLeft
+    Math.abs(maxScrollLeft - scrollLeft) <= 1 // this can be off by a pixel sometimes
       ? rightBtnEl.setAttribute("disabled", "")
       : rightBtnEl.removeAttribute("disabled");
   }
-}, 250)
+}, 250);
+
+/**
+ * Make top headings (train numbers) visible in the timetable.
+ * This is done by adding a CSS class under certain conditions.
+ * Scrolls, zooms, and resizes can all cause relative sizes to change
+ * and elements to shift, so activate/deactivate this feature accordingly.
+ */
+const TRIGGER_CLASSNAME = "m-timetable--withstickyheader";
+const wrapperEl = document.querySelector(".m-timetable");
+const timetableEl = document.getElementById("timetable");
+const topHeaderEl = document.querySelector(".m-timetable__header");
+
+const toggleStickyTableHeaders = debounce(event => {
+  if (!wrapperEl || !timetableEl) return; // do nothing if there's no table
+
+  const headerHeight = topHeaderEl.clientHeight;
+  const {
+    top: wrapperTop,
+    bottom: wrapperBottom,
+    height: wrapperHeight
+  } = wrapperEl.getBoundingClientRect();
+
+  // wrapperHeight is 100% the viewport height. if the timetable height
+  // is smaller than this, then sticky headers are not needed
+  const isSticky = wrapperEl.classList.contains(TRIGGER_CLASSNAME);
+  if (timetableEl.getBoundingClientRect().height <= wrapperHeight) {
+    if (isSticky) deactivate();
+    return;
+  }
+
+  const topLeavingView = wrapperTop <= 0;
+  const bottomLeavingView = wrapperBottom <= headerHeight;
+  if (!isSticky && topLeavingView) {
+    activate();
+  } else if (isSticky && (!topLeavingView || bottomLeavingView)) {
+    deactivate();
+  }
+
+  function activate() {
+    wrapperEl.classList.add(TRIGGER_CLASSNAME);
+
+    // register an on-scroll event to enable / disable buttons
+    // in this case the timetableEl no longer can scroll, so
+    // listen on the document
+    document.addEventListener("scroll", toggleScrollButtons);
+    document.dispatchEvent(new Event("scroll"));
+  }
+
+  function deactivate() {
+    wrapperEl.classList.remove(TRIGGER_CLASSNAME);
+    wrapperEl.scrollTop = 0; // scroll the inner timetable back to the top
+    resizeRows();
+    document.removeEventListener("scroll", toggleScrollButtons);
+    timetableEl.dispatchEvent(new Event("scroll"));
+  }
+}, 250);

--- a/apps/site/assets/ts/helpers/__tests__/ms-browser-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/ms-browser-test.ts
@@ -1,0 +1,37 @@
+import isMSBrowser from "../ms-browser";
+
+// examples plucked from
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent and
+// https://developers.whatismybrowser.com/useragents/explore/operating_system_name/windows/
+const examples = {
+  IE:
+    "Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)",
+  IE11:
+    "Mozilla/5.0 CK={} (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko",
+  Edge:
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134",
+  Safari:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1",
+  Opera:
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41",
+  Chrome:
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
+  Firefox:
+    "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"
+};
+
+describe("ms-browser", () => {
+  it.each`
+    browser      | userAgent              | bool
+    ${"IE"}      | ${examples["IE"]}      | ${true}
+    ${"IE11"}    | ${examples["IE11"]}    | ${true}
+    ${"Edge"}    | ${examples["Edge"]}    | ${true}
+    ${"Safari"}  | ${examples["Safari"]}  | ${false}
+    ${"Opera"}   | ${examples["Opera"]}   | ${false}
+    ${"Chrome"}  | ${examples["Chrome"]}  | ${false}
+    ${"Firefox"} | ${examples["Firefox"]} | ${false}
+  `("returns $bool for a $browser user agent", ({ userAgent: ua, bool }) => {
+    const result = isMSBrowser(ua);
+    expect(result).toBe(bool);
+  });
+});

--- a/apps/site/assets/ts/helpers/ms-browser.ts
+++ b/apps/site/assets/ts/helpers/ms-browser.ts
@@ -1,0 +1,15 @@
+/**
+ * Browser hack to detect whether user is using Internet Explorer or Edge
+ * Intended for use in conditionally enabling features
+ */
+
+// We don't support IE < 11, noted in .browserslistrc
+export const isUnsupportedIE = (ua: string): boolean =>
+  ua.indexOf("MSIE ") > -1;
+export const isIE11 = (ua: string): boolean => ua.indexOf("Trident/") > -1;
+export const isMSEdge = (ua: string): boolean => ua.indexOf("Edge/") > -1;
+
+export default function isMSBrowser(userAgent?: string): boolean {
+  const ua = userAgent || window.navigator.userAgent;
+  return isUnsupportedIE(ua) || isIE11(ua) || isMSEdge(ua);
+}

--- a/apps/site/lib/site_web/templates/schedule/_timetable.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_timetable.html.eex
@@ -29,7 +29,7 @@
             <div class="m-timetable__row-header"></div>
           </td>
           <%= for {schedule, index} <- Enum.with_index(@header_schedules) do %>
-            <%= content_tag :th, [scope: "col", class: "m-timetable__header-cell", data: if index == @offset do [scroll: [to: true]] end] do %>
+            <%= content_tag :th, [scope: "col", class: "m-timetable__header-cell #{if index == 0 do "js-tt-first-train" end}", data: if index == @offset do [scroll: [to: true]] end] do %>
               <span class="sr-only">Train <%= schedule.trip.name %></span>
               <span aria-hidden="true"><%= schedule.trip.name %></span>
               <%= if Alerts.Trip.match(@alerts, schedule.trip.id, time: @date, route: @route.id, direction_id: @direction_id) != [] do %>
@@ -89,7 +89,7 @@
             <td class="js-tt-cell hidden-no-js">
               <div class="m-timetable__row-header"></div>
             </td>
-            <%= for schedule <- @header_schedules do %>
+            <%= for {schedule, index} <- Enum.with_index(@header_schedules) do %>
               <%
                 trip_id = schedule.trip.id
                 trip_schedule = @trip_schedules[{trip_id, stop.id} || %{}]
@@ -99,7 +99,7 @@
                 tooltip_attrs = [html: true, toggle: "tooltip"]
               %>
               <%= content_tag :td, [
-                class: "js-tt-cell m-timetable__cell" <> cell_flag_class(trip_schedule) <> cell_via_class(trip_message),
+                class: "js-tt-cell m-timetable__cell #{if index == 0 do "js-tt-first-train" end}" <> cell_flag_class(trip_schedule) <> cell_via_class(trip_message),
                 id: "#{stop.name}-#{trip_id}-tooltip",
                 data: if tooltip do tooltip_attrs ++ [stop: raw(tooltip)] else tooltip_attrs end,
                 title: if tooltip do raw(tooltip) end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [CR Timetable | Header difficult to track](https://app.asana.com/0/385363666817452/950408339997961/f)

Depending on zoom levels / window size, it was possible to lose sight of the top header row while viewing the commute rail timetable. This somewhat hacky change aims to remedy that. As is, **this won't work in IE or Edge**, so those browsers should not see any change to this page.

A few new helpers were also added:

* `isMSBrowser()` for detecting the browser with JavaScript
* `full-width()` Sass mixin

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
