### PR TITLE
Redirect users away from canonical hostnames

### DIFF
--- a/apps/site/lib/site_web/endpoint.ex
+++ b/apps/site/lib/site_web/endpoint.ex
@@ -1,4 +1,6 @@
 defmodule SiteWeb.Endpoint do
+  @moduledoc false
+
   use Phoenix.Endpoint, otp_app: :site
 
   @doc """
@@ -23,6 +25,7 @@ defmodule SiteWeb.Endpoint do
     longpoll: [check_origin: Application.get_env(:site, :websocket_check_origin, false)]
   )
 
+  plug(SiteWeb.Plugs.CanonicalHostname)
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phx.digest

--- a/apps/site/lib/site_web/plugs/canonical_hostname.ex
+++ b/apps/site/lib/site_web/plugs/canonical_hostname.ex
@@ -1,0 +1,51 @@
+defmodule SiteWeb.Plugs.CanonicalHostname do
+  @moduledoc """
+  Plug to ensure that the site is only accessed via the canonical hostname.
+  In particular, this will prevent users going to www.mbtace.com.
+
+  There is an exception for the hostname that the mTicket app uses, since
+  we detect that elsewhere in the code to produce some mTicket-specific
+  effects when the site is loaded in mTicket's webview.
+  """
+
+  @mticket_hostname "mticket.mbtace.com"
+
+  import Plug.Conn
+  import Phoenix.Controller, only: [redirect: 2]
+
+  def init(_) do
+  end
+
+  def call(%Plug.Conn{host: @mticket_hostname} = conn, _) do
+    conn
+  end
+
+  def call(%Plug.Conn{host: requested_hostname} = conn, _) do
+    canonical_hostname = System.get_env("HOST") || "localhost"
+
+    if requested_hostname == canonical_hostname or is_private_ip(requested_hostname) do
+      conn
+    else
+      rewritten_url =
+        Plug.Conn.request_url(conn)
+        |> String.replace(requested_hostname, canonical_hostname, global: false)
+
+      conn
+      |> put_status(:moved_permanently)
+      |> redirect(external: rewritten_url)
+      |> halt()
+    end
+  end
+
+  # The health checker uses a private IP for a hostname
+  defp is_private_ip(hostname) do
+    case hostname |> String.to_charlist() |> :inet.parse_ipv4_address() do
+      {:ok, {byte0, byte1, _, _}} ->
+        byte0 == 10 or (byte0 == 172 and byte1 >= 16 and byte1 <= 31) or
+          (byte0 == 192 and byte1 == 168)
+
+      _ ->
+        false
+    end
+  end
+end

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -3,7 +3,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
 
   setup do
     conn =
-      build_conn()
+      default_conn()
       |> put_req_header("x-forwarded-for", "10.108.98.#{Enum.random(0..999)}")
 
     {:ok, conn: conn}

--- a/apps/site/test/site_web/controllers/page_controller_test.exs
+++ b/apps/site/test/site_web/controllers/page_controller_test.exs
@@ -25,7 +25,7 @@ defmodule SiteWeb.PageControllerTest do
 
   test "body gets assigned a js class", %{conn: conn} do
     [body_class] =
-      build_conn()
+      default_conn()
       |> get(page_path(conn, :index))
       |> html_response(200)
       |> Floki.find("body")

--- a/apps/site/test/site_web/controllers/places_controller_test.exs
+++ b/apps/site/test/site_web/controllers/places_controller_test.exs
@@ -207,7 +207,7 @@ defmodule SiteWeb.PlacesControllerTest do
 
   setup do
     conn =
-      build_conn()
+      default_conn()
       |> put_req_header("accept", "application/json")
 
     bypass = Bypass.open()

--- a/apps/site/test/site_web/controllers/transit_near_me_controller_test.exs
+++ b/apps/site/test/site_web/controllers/transit_near_me_controller_test.exs
@@ -136,7 +136,7 @@ defmodule SiteWeb.TransitNearMeControllerTest do
 
   setup do
     conn =
-      build_conn()
+      default_conn()
       |> assign(:location_fn, &location_fn/2)
       |> assign(:data_fn, &data_fn/2)
 

--- a/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
+++ b/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
@@ -51,7 +51,7 @@ defmodule SiteWeb.TripPlanControllerTest do
   }
 
   setup do
-    conn = build_conn() |> put_req_cookie("tp_redesign", "true")
+    conn = default_conn() |> put_req_cookie("tp_redesign", "true")
 
     end_of_rating =
       @system_time

--- a/apps/site/test/site_web/plugs/canonical_hostname_test.exs
+++ b/apps/site/test/site_web/plugs/canonical_hostname_test.exs
@@ -1,0 +1,50 @@
+defmodule SiteWeb.Plugs.CanonicalHostnameTest do
+  @moduledoc false
+  use SiteWeb.ConnCase, async: true
+
+  describe "call/2" do
+    test "with the special mTicket hostname, does nothing" do
+      conn = %Plug.Conn{default_conn() | host: "mticket.mbtace.com"}
+      assert conn.status != 301
+
+      conn = SiteWeb.Plugs.CanonicalHostname.call(conn, nil)
+      assert conn.status != 301
+    end
+
+    test "with a local IP address, does nothing" do
+      # Class A
+      conn = %Plug.Conn{default_conn() | host: "10.127.127.127"}
+      assert conn.status != 301
+      conn = SiteWeb.Plugs.CanonicalHostname.call(conn, nil)
+      assert conn.status != 301
+
+      # Class B
+      conn = %Plug.Conn{default_conn() | host: "172.24.127.127"}
+      assert conn.status != 301
+      conn = SiteWeb.Plugs.CanonicalHostname.call(conn, nil)
+      assert conn.status != 301
+
+      # Class C
+      conn = %Plug.Conn{default_conn() | host: "192.168.127.127"}
+      assert conn.status != 301
+      conn = SiteWeb.Plugs.CanonicalHostname.call(conn, nil)
+      assert conn.status != 301
+    end
+
+    test "when the hostname doesn't match the canonical hostname, redirects" do
+      conn = %Plug.Conn{default_conn() | host: "example.com"}
+      assert conn.status != 301
+
+      conn = SiteWeb.Plugs.CanonicalHostname.call(conn, nil)
+      assert conn.status == 301
+    end
+
+    test "when the hostname matches the canonical hostname, does nothing" do
+      conn = default_conn()
+      assert conn.status != 301
+
+      conn = SiteWeb.Plugs.CanonicalHostname.call(conn, nil)
+      assert conn.status != 301
+    end
+  end
+end

--- a/apps/site/test/site_web/views/error_view_test.exs
+++ b/apps/site/test/site_web/views/error_view_test.exs
@@ -5,7 +5,7 @@ defmodule SiteWeb.ErrorViewTest do
   import Phoenix.Controller
 
   test "adds 'not-found' to body class on 404 pages" do
-    conn = get(build_conn(), "/not-found")
+    conn = get(default_conn(), "/not-found")
     assert html_response(conn, 404) =~ "not-found"
   end
 

--- a/apps/site/test/support/conn_case.ex
+++ b/apps/site/test/support/conn_case.ex
@@ -15,6 +15,13 @@ defmodule SiteWeb.ConnCase do
 
   use ExUnit.CaseTemplate
 
+  def default_conn() do
+    %Plug.Conn{
+      Phoenix.ConnTest.build_conn()
+      | host: "localhost"
+    }
+  end
+
   using do
     quote do
       # Import conveniences for testing with connections
@@ -39,10 +46,12 @@ defmodule SiteWeb.ConnCase do
 
       # The default endpoint for testing
       @endpoint SiteWeb.Endpoint
+
+      import SiteWeb.ConnCase, only: [default_conn: 0]
     end
   end
 
   setup _tags do
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+    {:ok, conn: default_conn()}
   end
 end


### PR DESCRIPTION
This un-reverts 1713c9a53c0060275350af9fb78c05d5e1c856f6 and
3d479fcba1aa86dfe6d35bd43ddf8c8c3de7c5e3. It also includes one fix, to
work around an apparent Phoenix bug whereby
SiteWeb.Endpoint.config(:url)[:host] is not set to the canonical
hostname as it should be. Instead we reach directly for System.get_env.

**Asana Ticket:** [mbtace.com being indexed/viewed by public](https://app.asana.com/0/555089885850811/1169245762828233)


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
