### PR TITLE
Better handle reduced services in the service picker

### DIFF
--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -114,41 +114,11 @@ export const isInFutureRating = (
   return currentDate <= ratingStartDate && currentDate <= ratingEndDate;
 };
 
-// sometimes a current unplanned_disruption supercedes typical_service.
-// in this case both will be present in services, with most of the same
-// properties. when we don't want to show both services, prefer the unplanned
-export const omitReplacedServices = (services: Service[]): Service[] => {
-  const unplannedServices = services.filter(
-    (s: Service) => s.typicality === "unplanned_disruption"
-  );
-
-  if (unplannedServices.length) {
-    // find the corresponding planned services by these properties
-    const matchers: (keyof Service)[] = [
-      "type",
-      "rating_description",
-      "valid_days"
-    ];
-
-    const matchedServices = services
-      .filter(s => s.typicality === "typical_service")
-      .filter((ts: Service) =>
-        unplannedServices.find((us: Service) =>
-          matchers.every(m => _.isEqual(ts[m], us[m]))
-        )
-      );
-
-    return _.difference(services, matchedServices);
-  }
-
-  return services;
-};
-
 export const groupServicesByDateRating = (
   services: Service[],
   currentDate: Date = new Date()
 ): Dictionary<Service[]> =>
-  _.groupBy(omitReplacedServices(services), (service: Service) => {
+  _.groupBy(services, (service: Service) => {
     if (service.typicality === "holiday_service") {
       return ServiceGroupNames.HOLIDAY;
     }

--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -148,7 +148,8 @@ export const groupServicesByDateRating = (
 
     if (
       isInCurrentRating(service, currentDate) &&
-      service.typicality === "typical_service"
+      (service.typicality === "typical_service" ||
+        service.typicality === "unplanned_disruption")
     ) {
       return `${ServiceGroupNames.CURRENT} (${
         service.rating_description

--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -114,11 +114,41 @@ export const isInFutureRating = (
   return currentDate <= ratingStartDate && currentDate <= ratingEndDate;
 };
 
+// sometimes a current unplanned_disruption supercedes typical_service.
+// in this case both will be present in services, with most of the same
+// properties. when we don't want to show both services, prefer the unplanned
+export const omitReplacedServices = (services: Service[]): Service[] => {
+  const unplannedServices = services.filter(
+    (s: Service) => s.typicality === "unplanned_disruption"
+  );
+
+  if (unplannedServices.length) {
+    // find the corresponding planned services by these properties
+    const matchers: (keyof Service)[] = [
+      "type",
+      "rating_description",
+      "valid_days"
+    ];
+
+    const matchedServices = services
+      .filter(s => s.typicality === "typical_service")
+      .filter((ts: Service) =>
+        unplannedServices.find((us: Service) =>
+          matchers.every(m => _.isEqual(ts[m], us[m]))
+        )
+      );
+
+    return _.difference(services, matchedServices);
+  }
+
+  return services;
+};
+
 export const groupServicesByDateRating = (
   services: Service[],
   currentDate: Date = new Date()
 ): Dictionary<Service[]> =>
-  _.groupBy(services, (service: Service) => {
+  _.groupBy(omitReplacedServices(services), (service: Service) => {
     if (service.typicality === "holiday_service") {
       return ServiceGroupNames.HOLIDAY;
     }

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceOptGroupTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceOptGroupTest.tsx.snap
@@ -32,7 +32,7 @@ exports[`ServiceOptGroup renders 1`] = `
   <option
     value="BUS319-storm"
   >
-    Reduced service, Jul 15 to Jul 15
+    Storm (reduced service)
   </option>
   <option
     value="weekday2020"

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
@@ -31,6 +31,11 @@ Array [
           label="Current Schedules (Test, ends Oct 25)"
         >
           <option
+            value="BUS319-O-Wdy-02"
+          >
+            Weekday schedule, Test
+          </option>
+          <option
             value="BUS319-D-Wdy-02"
           >
             Friday schedule, Test

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
@@ -31,11 +31,6 @@ Array [
           label="Current Schedules (Test, ends Oct 25)"
         >
           <option
-            value="BUS319-O-Wdy-02"
-          >
-            Weekday schedule, Test
-          </option>
-          <option
             value="BUS319-D-Wdy-02"
           >
             Friday schedule, Test

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
@@ -50,6 +50,16 @@ Array [
           >
             Sunday schedule, Test
           </option>
+          <option
+            value="BUS319-storm"
+          >
+            Storm (reduced service)
+          </option>
+          <option
+            value="BUS319-storm-1"
+          >
+            Storm (reduced service)
+          </option>
         </optgroup>
         <optgroup
           label="Holiday Schedules"
@@ -58,20 +68,6 @@ Array [
             value="Bastille-Day"
           >
             Bastille Day, Jul 14
-          </option>
-        </optgroup>
-        <optgroup
-          label="Other Schedules"
-        >
-          <option
-            value="BUS319-storm"
-          >
-            Reduced service, Jul 15 to Jul 15
-          </option>
-          <option
-            value="BUS319-storm-1"
-          >
-            Reduced service, Jul 22 to Jul 23
           </option>
         </optgroup>
       </select>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOptGroup.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOptGroup.tsx
@@ -1,9 +1,5 @@
 import React, { ReactElement } from "react";
-import {
-  ServiceGroupNames,
-  serviceDays,
-  startToEnd
-} from "../../../helpers/service";
+import { ServiceGroupNames, serviceDays } from "../../../helpers/service";
 import { Service } from "../../../__v3api";
 import { shortDate } from "../../../helpers/date";
 
@@ -31,12 +27,7 @@ const ServiceOptGroup = ({
         let optionText = "";
 
         if (service.typicality === "unplanned_disruption") {
-          const reducedServicePeriod =
-            startDate === endDate
-              ? shortDate(startDate)
-              : startToEnd(startDate, endDate);
-
-          optionText = `Reduced service, ${reducedServicePeriod}`;
+          optionText = service.description;
         } else if (
           service.typicality === "holiday_service" &&
           service.added_dates_notes


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update reduced schedules to use the service description, hide validity dates from UI](https://app.asana.com/0/385363666817452/1169855995557655/f)

Prompted by the new abundance of reduced service, this PR cleans up the service picker by implementing the following changes:

* Uses the `service.description`text for services of type `unplanned_disruption`
* Allows services of type `unplanned_disruption` to be listed as "Current"
* Adds logic to omit from the dropdown the service of type `typical_service` that was replaced by the unplanned disruption, if applicable.

| original | updated |
| ------------- | ------------- |
| <img width="714" alt="image" src="https://user-images.githubusercontent.com/2136286/80148773-88c45680-8583-11ea-8234-e735ec097e1f.png"> | <img width="713" alt="image" src="https://user-images.githubusercontent.com/2136286/80148816-9679dc00-8583-11ea-87e0-bf14027207a2.png"> |

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/2136286/80148372-f8861180-8582-11ea-906e-3686f9edc196.png">



---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
