### PR TITLE
Specify width to avoid overflow

### DIFF
--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -43,6 +43,7 @@ $line-width: 8px; // width of the colored line in the diagram
 .m-schedule-diagram__stop-content {
   // Take remaining horizontal space unused by visual lines/stops
   flex-grow: 1;
+  width: 100%;
 }
 
 .m-schedule-diagram__stop-heading {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Line Diagram | IE11 stop content width overflows](https://app.asana.com/0/385363666817452/1171464082559329)

Content overflows for IE in Line Diagram when the number of connections is too big. It needs to wrap.

Before:
<img width="921" alt="image" src="https://user-images.githubusercontent.com/61979382/80487233-799a2b80-892a-11ea-93b5-af5e771d47e1.png">


After:
<img width="806" alt="Screen Shot 2020-04-28 at 08 36 33" src="https://user-images.githubusercontent.com/61979382/80487927-94b96b00-892b-11ea-80ed-ff838f8f70ff.png">


This has been checked in IE, Chrome, Firefox and Safari.

