### PR TITLE
Get all services in the current rating into the current optgroup

### DIFF
--- a/apps/site/assets/ts/helpers/__tests__/service-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/service-test.ts
@@ -7,7 +7,6 @@ import {
   isCurrentValidService,
   isInFutureRating,
   optGroupComparator,
-  hasIncompleteRating,
   isInFutureService
 } from "../service";
 import { Service, DayInteger } from "../../__v3api";
@@ -193,21 +192,6 @@ describe("groupServicesByDateRating", () => {
     });
   });
 
-  it("lists only typical_service services in the relevant rating as 'current'", () => {
-    const currentKeys = Object.keys(grouped).filter(
-      key => key.split(" ")[0] === ServiceGroupNames.CURRENT.split(" ")[0]
-    );
-    currentKeys.forEach(currentKey => {
-      const currentServices = grouped[currentKey!];
-      currentServices.forEach(service => {
-        expect(service.typicality).toEqual("typical_service");
-        expect(isInCurrentRating(service, testDate)).toBe(
-          !hasIncompleteRating(service)
-        );
-      });
-    });
-  });
-
   it("lists only holiday_service services as 'holiday'", () => {
     grouped[ServiceGroupNames.HOLIDAY].forEach(service => {
       expect(service.typicality).toEqual("holiday_service");
@@ -266,30 +250,6 @@ describe("groupServicesByDateRating", () => {
       });
     });
   });
-
-  it("annotates future schedules optgroup with rating name and rating start date", () => {
-    // well, only if we have identified a future rating
-    const futureKeys = Object.keys(grouped).filter(
-      key => key.split(" ")[0] === ServiceGroupNames.FUTURE.split(" ")[0]
-    );
-    futureKeys.forEach(futureKey => {
-      grouped[futureKey].forEach(futureService => {
-        const noAnnotation =
-          hasIncompleteRating(futureService) ||
-          (isInFutureService(futureService, testDate) &&
-            !isInFutureRating(futureService, testDate));
-
-        const name = noAnnotation
-          ? ServiceGroupNames.FUTURE
-          : `${ServiceGroupNames.FUTURE} (${
-              futureService.rating_description
-            }, starts ${shortDate(
-              stringToDateObject(futureService.rating_start_date!)
-            )})`;
-        expect(futureKey).toEqual(name);
-      });
-    });
-  });
 });
 
 it("optGroupComparator sorts properly", () => {
@@ -344,13 +304,6 @@ it("isInFutureRating evaluates whether date falls within service future rating d
   expect(
     isInFutureRating(serviceWithoutRating, stringToDateObject("2020-08-08"))
   ).toBe(false);
-});
-
-it("hasIncompleteRating evaluates whether service does not fall within a rating", () => {
-  const serviceWithRating = services[0];
-  const serviceWithoutRating = services[8];
-  expect(hasIncompleteRating(serviceWithoutRating)).toEqual(true);
-  expect(hasIncompleteRating(serviceWithRating)).toEqual(false);
 });
 
 it("hasMultipleWeekdaySchedules indicates presence of multiple weekday schedules", () => {

--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -1,5 +1,10 @@
 import _, { Dictionary } from "lodash";
-import { Service, DayInteger } from "../__v3api";
+import {
+  Service,
+  DayInteger,
+  ServiceType,
+  ServiceTypicality
+} from "../__v3api";
 import { shortDate, stringToDateObject, dateObjectToString } from "./date";
 
 export enum ServiceGroupNames {
@@ -45,6 +50,22 @@ export const isInCurrentService = (
   return currentDate >= serviceStartDate && currentDate <= serviceEndDate;
 };
 
+export const isInCurrentRating = (
+  service: Service,
+  currentDate: Date = new Date()
+): boolean => {
+  if (!service.rating_start_date) {
+    return false;
+  }
+  const ratingStartDate = stringToDateObject(service.rating_start_date!);
+  if (!service.rating_end_date) {
+    // this might be a commuter rail or ferry. treat null rating end as infinite?
+    return currentDate >= ratingStartDate;
+  }
+  const ratingEndDate = stringToDateObject(service.rating_end_date!);
+  return currentDate >= ratingStartDate && currentDate <= ratingEndDate;
+};
+
 export const isCurrentValidService = (
   service: Service,
   currentDate: Date = new Date()
@@ -64,23 +85,11 @@ export const isCurrentValidService = (
     return false;
   }
 
-  // check within service dates
-  return isInCurrentService(service, currentDate);
-};
-
-export const hasIncompleteRating = (service: Service): boolean =>
-  !service.rating_start_date || !service.rating_end_date;
-
-export const isInCurrentRating = (
-  service: Service,
-  currentDate: Date = new Date()
-): boolean => {
-  if (hasIncompleteRating(service)) {
-    return false;
-  }
-  const ratingStartDate = stringToDateObject(service.rating_start_date!);
-  const ratingEndDate = stringToDateObject(service.rating_end_date!);
-  return currentDate >= ratingStartDate && currentDate <= ratingEndDate;
+  // check within rating dates
+  return (
+    isInCurrentRating(service, currentDate) &&
+    isInCurrentService(service, currentDate)
+  );
 };
 
 export const startToEnd = (
@@ -94,25 +103,45 @@ export const isInFutureService = (
 ): boolean => {
   const serviceStartDate = stringToDateObject(service.start_date);
   const serviceEndDate = stringToDateObject(service.end_date);
-  return currentDate <= serviceStartDate && currentDate <= serviceEndDate;
+  return currentDate < serviceStartDate && currentDate < serviceEndDate;
 };
 
 export const isInFutureRating = (
   service: Service,
   currentDate: Date = new Date()
 ): boolean => {
-  if (hasIncompleteRating(service)) {
-    // check for rating start date
-    return service.rating_start_date
-      ? currentDate <= stringToDateObject(service.rating_start_date!)
-      : false;
+  if (!service.rating_end_date) {
+    if (service.rating_start_date) {
+      return currentDate < stringToDateObject(service.rating_start_date!);
+    }
+    return false;
   }
 
   const ratingStartDate = stringToDateObject(service.rating_start_date!);
   const ratingEndDate = stringToDateObject(service.rating_end_date!);
-
-  return currentDate <= ratingStartDate && currentDate <= ratingEndDate;
+  return currentDate < ratingStartDate && currentDate < ratingEndDate;
 };
+
+const areSimilarServices = (service1: Service, service2: Service): boolean => {
+  const properties = [
+    "valid_days",
+    "typicality",
+    "type",
+    "rating_start_date",
+    "rating_end_date",
+    "name",
+    "description"
+  ];
+  return _.every(properties, (p: keyof Service) =>
+    _.isEqual(service2[p], service1[p])
+  );
+};
+
+// If two similar services are present, show only one. Choose the first
+// sequentially (this depends on the input list already being sorted by
+// start_date).
+export const dedupeServices = (services: Service[]): Service[] =>
+  _.uniqWith(services, areSimilarServices);
 
 export const groupServicesByDateRating = (
   services: Service[],
@@ -127,30 +156,25 @@ export const groupServicesByDateRating = (
       return ServiceGroupNames.OTHER;
     }
 
-    // if there's no rating end date, this is probably a CR or Ferry.
-    // don't use the rating in that case.
-    if (
-      hasIncompleteRating(service) &&
-      isInCurrentService(service, currentDate)
-    ) {
-      return ServiceGroupNames.CURRENT;
-    }
-    if (
-      (hasIncompleteRating(service) ||
-        !isInFutureRating(service, currentDate)) &&
-      isInFutureService(service, currentDate)
-    ) {
-      return ServiceGroupNames.FUTURE;
+    // if there's no rating end date, this is probably a CR or Ferry
+    // don't use the rating dates in the returned text in that case.
+    // additionally, prioritize current service/rating in grouping
+    if (!service.rating_end_date) {
+      if (
+        isInCurrentService(service, currentDate) ||
+        isInCurrentRating(service, currentDate)
+      ) {
+        return ServiceGroupNames.CURRENT;
+      }
+      if (isInFutureRating(service, currentDate)) {
+        return ServiceGroupNames.FUTURE;
+      }
     }
 
     const ratingStartDate = stringToDateObject(service.rating_start_date!);
     const ratingEndDate = stringToDateObject(service.rating_end_date!);
 
-    if (
-      isInCurrentRating(service, currentDate) &&
-      (service.typicality === "typical_service" ||
-        service.typicality === "unplanned_disruption")
-    ) {
+    if (isInCurrentRating(service, currentDate)) {
       return `${ServiceGroupNames.CURRENT} (${
         service.rating_description
       }, ends ${shortDate(ratingEndDate)})`;
@@ -172,6 +196,47 @@ const optGroupOrder: { [key: string]: number } = {
   [ServiceGroupNames.FUTURE]: 2,
   [ServiceGroupNames.OTHER]: 1
 };
+
+// sort the service types
+const serviceTypeOrder: { [key in ServiceType]: number } = {
+  weekday: 4,
+  saturday: 3,
+  sunday: 2,
+  other: 1
+};
+
+/* eslint-disable @typescript-eslint/camelcase */
+// sort the service typicalities
+const serviceTypicalityOrder: { [key in ServiceTypicality]: number } = {
+  unplanned_disruption: 4,
+  planned_disruption: 3,
+  holiday_service: 2,
+  extra_service: 1,
+  typical_service: 0,
+  unknown: 0
+};
+/* eslint-enable @typescript-eslint/camelcase */
+
+// enable sorting of services by rating dates,
+// service type, service typicality, and service dates
+export const serviceComparator = (
+  {
+    type: type1,
+    valid_days: validDays1,
+    typicality: typicality1,
+    start_date: date1
+  }: Service,
+  {
+    type: type2,
+    valid_days: validDays2,
+    typicality: typicality2,
+    start_date: date2
+  }: Service
+): number =>
+  serviceTypeOrder[type2] - serviceTypeOrder[type1] ||
+  validDays1[0] - validDays2[0] ||
+  serviceTypicalityOrder[typicality2] - serviceTypicalityOrder[typicality1] ||
+  stringToDateObject(date1).getTime() - stringToDateObject(date2).getTime();
 
 // group names may have extra verbiage
 export const optGroupComparator = (groupA: string, groupB: string): number => {

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/ServiceSelectorTest.tsx.snap
@@ -31,6 +31,11 @@ Array [
           label="Current Schedules (Test, ends Oct 25)"
         >
           <option
+            value="BUS319-storm"
+          >
+            Storm (reduced service)
+          </option>
+          <option
             value="BUS319-O-Wdy-02"
           >
             Weekday schedule, Test
@@ -50,16 +55,6 @@ Array [
             value="BUS319-Q-Su-02"
           >
             Sunday schedule, Test
-          </option>
-          <option
-            value="BUS319-storm"
-          >
-            Storm (reduced service)
-          </option>
-          <option
-            value="BUS319-storm-1"
-          >
-            Storm (reduced service)
           </option>
         </optgroup>
         <optgroup

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOptGroup.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceOptGroup.tsx
@@ -1,5 +1,9 @@
 import React, { ReactElement } from "react";
-import { ServiceGroupNames, serviceDays } from "../../../helpers/service";
+import {
+  ServiceGroupNames,
+  serviceDays,
+  dedupeServices
+} from "../../../helpers/service";
 import { Service } from "../../../__v3api";
 import { shortDate } from "../../../helpers/date";
 
@@ -18,7 +22,7 @@ const ServiceOptGroup = ({
 }: Props): ReactElement<HTMLElement> | null =>
   services.length === 0 ? null : (
     <optgroup label={label}>
-      {services.map(service => {
+      {dedupeServices(services).map(service => {
         const isMultipleWeekday =
           multipleWeekdays &&
           service.type === "weekday" &&

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ServiceSelector.tsx
@@ -6,7 +6,8 @@ import {
   groupServicesByDateRating,
   isCurrentValidService,
   serviceStartDateComparator,
-  optGroupComparator
+  optGroupComparator,
+  serviceComparator
 } from "../../../helpers/service";
 import { reducer } from "../../../helpers/fetch";
 import ScheduleTable from "./ScheduleTable";
@@ -77,14 +78,15 @@ export const ServiceSelector = ({
   const todayDate = stringToDateObject(today);
 
   // By default, show the current day's service
-  const currentServices = services
-    .sort(serviceStartDateComparator)
-    .filter(service => isCurrentValidService(service, todayDate));
+  const sortedServices = services.sort(serviceStartDateComparator);
+  const currentServices = sortedServices.filter(service =>
+    isCurrentValidService(service, todayDate)
+  );
 
   const [defaultSelectedService] = currentServices.length
     ? currentServices
-    : services;
-  const now = currentServices.length ? defaultSelectedService.id : "";
+    : sortedServices;
+  const now = currentServices.length > 0 ? currentServices[0].id : "";
   const [selectedService, setSelectedService] = useState(
     defaultSelectedService
   );
@@ -101,7 +103,7 @@ export const ServiceSelector = ({
   if (services.length <= 0) return null;
 
   const servicesByOptGroup: Dictionary<Service[]> = groupServicesByDateRating(
-    services,
+    sortedServices,
     todayDate
   );
 
@@ -135,7 +137,7 @@ export const ServiceSelector = ({
                   <ServiceOptGroup
                     key={group}
                     label={group}
-                    services={groupedServices}
+                    services={groupedServices.sort(serviceComparator)}
                     multipleWeekdays={hasMultipleWeekdaySchedules(
                       groupedServices
                     )}


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Services Picker | Get all services in the current rating into the current optgroup](https://app.asana.com/0/385363666817452/1170658788930619/f)

Made a few adjustments to the service picker logic to achieve the following:

* Let the upcoming service in the current rating be categorized in the UI as "current"
* Order the service choices to align with the mockup

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
