### PR TITLE
Show modal in LineDiagram if schedule_direction parameters exist

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -1,6 +1,10 @@
 import React, { ReactElement, useState } from "react";
+import {
+  useQueryParams,
+  StringParam,
+  updateInLocation
+} from "use-query-params";
 import useSWR from "swr";
-import { updateInLocation } from "use-query-params";
 import {
   LineDiagramStop,
   LineDiagramVehicle,
@@ -93,6 +97,26 @@ const LineDiagram = ({
   );
   const [modalMode, setModalMode] = useState<ModalMode>("schedule");
   const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const [query] = useQueryParams({
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    "schedule_direction[direction_id]": StringParam,
+    "schedule_direction[origin]": StringParam
+  });
+
+  React.useEffect(() => {
+    const newDirection = query["schedule_direction[direction_id]"];
+    const newOrigin = query["schedule_direction[origin]"];
+
+    // modify values in case URL has both parameters:
+    if (newDirection !== undefined && newOrigin !== undefined) {
+      setInitialDirection(newDirection === "0" ? 0 : 1);
+      setInitialOrigin(newOrigin);
+      setModalMode("schedule");
+      setIsOpen(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { data: maybeLiveData } = useSWR(
     `/schedules/line_api/realtime?id=${


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Feature | Modal should appear if LineDiagram parameters are bookmarked](https://app.asana.com/0/555089885850811/1174031499922119)

For bookmarked pages that contain direction and origin, the schedule modal will automatically appear when the page loads.

---
Checked number of commits, their messages and how the page loads in IE. These changes are an enhancement on top of the functionality from #440 

