### PR TITLE
Normalized addresses in trip planner

### DIFF
--- a/apps/site/test/site_web/controllers/static_file_controller_test.exs
+++ b/apps/site/test/site_web/controllers/static_file_controller_test.exs
@@ -40,7 +40,7 @@ defmodule SiteWeb.StaticFileControllerTest do
     Application.put_env(:cms, :drupal, new_config)
 
     on_exit(fn ->
-      Application.put_env(:cms, :drual, old_config)
+      Application.put_env(:cms, :drupal, old_config)
     end)
   end
 end

--- a/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
+++ b/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
@@ -304,7 +304,7 @@ defmodule SiteWeb.TripPlanControllerTest do
       assert html_response(conn, 200) =~ "two different locations"
     end
 
-    test "doesn't renders an error if longitudes and latitudes are unique", %{conn: conn} do
+    test "doesn't render an error if longitudes and latitudes are unique", %{conn: conn} do
       params = %{
         "date_time" => @system_time,
         "plan" => %{
@@ -558,6 +558,22 @@ defmodule SiteWeb.TripPlanControllerTest do
         )
 
       assert Enum.count(afternoon_conn.assigns.itinerary_row_lists) == 2
+    end
+
+    test "normalizes address", %{conn: conn} do
+      params = %{
+        "date_time" => @system_time,
+        "plan" => %{
+          "date_time" => @afternoon,
+          "from" => "15 pemberton street, cambridge ma",
+          "to" => "115 prospect St, cambridge"
+        }
+      }
+
+      conn = get(conn, trip_plan_path(conn, :index, params))
+      assert html_response(conn, 200)
+      assert conn.assigns.query.from.name == "Geocoded 15 pemberton street, cambridge ma"
+      assert conn.assigns.query.to.name == "Geocoded 115 prospect St, cambridge"
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🗺️ Trip Planner | Use normalized, not raw, addresses in output](https://app.asana.com/0/555089885850811/1158824251239697)

To make sure "from" and "to" locations contain real values, a small pre-processing is done to properly show said locations in a more normalized way.

Before:
![image](https://user-images.githubusercontent.com/61979382/81240375-3cdace00-8fd5-11ea-886e-3547f38c3caa.png)
<br/>
After:
<img width="932" alt="image" src="https://user-images.githubusercontent.com/61979382/81240514-9511d000-8fd5-11ea-8f21-80fe0d5d644f.png">
