### PR TITLE
Display CR shuttle buses using a CR row in the schedule table

### DIFF
--- a/apps/site/assets/ts/schedule/__tests__/TableRowTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/TableRowTest.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { mount } from "enzyme";
 import renderer from "react-test-renderer";
 import { createReactRoot } from "../../app/helpers/testUtils";
 import TableRow from "../components/schedule-finder/TableRow";
@@ -66,6 +67,32 @@ describe("TableRow", () => {
       />
     );
     expect(tree).toMatchSnapshot();
+  });
+
+  it("renders a rail replacement bus using a CR row", () => {
+    const body = '<div id="react-root"></div>';
+    document.body.innerHTML = body;
+
+    const railReplacementRoute = {
+      ...journey.route,
+      type: 3,
+      description: "rail_replacement_bus",
+    };
+    const railReplacementJourney = {
+      ...journey,
+      route: railReplacementRoute,
+    } as Journey;
+
+    const wrapper = mount(
+      <TableRow
+        input={input}
+        journey={railReplacementJourney}
+        isSchoolTrip={false}
+        anySchoolTrips={false}
+      />
+    );
+
+    expect(wrapper.find("td.schedule-table__cell").length).toBe(4);
   });
 
   describe("fetchJourney", () => {

--- a/apps/site/assets/ts/schedule/__tests__/TableRowTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/TableRowTest.tsx
@@ -76,11 +76,11 @@ describe("TableRow", () => {
     const railReplacementRoute = {
       ...journey.route,
       type: 3,
-      description: "rail_replacement_bus",
+      description: "rail_replacement_bus"
     };
     const railReplacementJourney = {
       ...journey,
-      route: railReplacementRoute,
+      route: railReplacementRoute
     } as Journey;
 
     const wrapper = mount(

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TableRow.tsx
@@ -174,7 +174,8 @@ const TableRow = ({
   isSchoolTrip
 }: TableRowProps): ReactElement<HTMLElement> | null => {
   const contentComponent =
-    journey.route.type !== 2
+    journey.route.type !== 2 &&
+    journey.route.description !== "rail_replacement_bus"
       ? () => (
           <BusTableRow
             journey={journey}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Schedule Finder | Greenbush shuttles break the table](https://app.asana.com/0/385363666817452/1174808744035779)

Display CR shuttle buses using a CR row in the schedule table

<img width="673" alt="Screen Shot 2020-05-07 at 18 23 00" src="https://user-images.githubusercontent.com/42339/81356023-31070e80-909e-11ea-88ff-f0dcc6cbbaf2.png">


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
