### PR TITLE
Update bus connection tooltips

### DIFF
--- a/apps/routes/lib/parser.ex
+++ b/apps/routes/lib/parser.ex
@@ -13,6 +13,7 @@ defmodule Routes.Parser do
       name: name(attributes),
       long_name: attributes["long_name"],
       color: attributes["color"],
+      sort_order: attributes["sort_order"],
       direction_names:
         direction_attrs(attributes["direction_names"], parse_route_patterns(relationships)),
       direction_destinations:

--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -8,6 +8,7 @@ defmodule Routes.Route do
             name: "",
             long_name: "",
             color: "",
+            sort_order: 99_999,
             direction_names: %{0 => "Outbound", 1 => "Inbound"},
             direction_destinations: :unknown,
             description: :unknown,
@@ -20,6 +21,7 @@ defmodule Routes.Route do
           name: String.t(),
           long_name: String.t(),
           color: String.t(),
+          sort_order: non_neg_integer,
           direction_names: %{0 => String.t() | nil, 1 => String.t() | nil},
           direction_destinations: %{0 => String.t(), 1 => String.t()} | :unknown,
           description: gtfs_route_desc,
@@ -207,6 +209,7 @@ defmodule Routes.Route do
         name: name,
         long_name: long_name,
         color: color,
+        sort_order: sort_order,
         direction_names: direction_names,
         direction_destinations: direction_destinations,
         description: description,
@@ -226,6 +229,7 @@ defmodule Routes.Route do
       name: name,
       long_name: long_name,
       color: color,
+      sort_order: sort_order,
       direction_names: %{
         "0" => direction_names[0],
         "1" => direction_names[1]

--- a/apps/routes/test/repo_test.exs
+++ b/apps/routes/test/repo_test.exs
@@ -16,7 +16,8 @@ defmodule Routes.RepoTest do
                color: "DA291C",
                direction_names: %{0 => "Southbound", 1 => "Northbound"},
                direction_destinations: %{0 => "Ashmont/Braintree", 1 => "Alewife"},
-               description: :rapid_transit
+               description: :rapid_transit,
+               sort_order: 10_010
              }
     end
 
@@ -33,7 +34,8 @@ defmodule Routes.RepoTest do
                color: "00843D",
                direction_names: %{0 => "Westbound", 1 => "Eastbound"},
                direction_destinations: %{0 => "Boston College", 1 => "Park Street"},
-               description: :rapid_transit
+               description: :rapid_transit,
+               sort_order: 10_032
              }
     end
 
@@ -49,7 +51,8 @@ defmodule Routes.RepoTest do
                long_name: "Logan Airport Terminals - South Station",
                color: "7C878E",
                direction_destinations: %{0 => "Logan Airport Terminals", 1 => "South Station"},
-               description: :key_bus_route
+               description: :key_bus_route,
+               sort_order: 10_051
              }
     end
 
@@ -65,7 +68,8 @@ defmodule Routes.RepoTest do
                long_name: "Ashmont Station - Ruggles Station via Washington Street",
                color: "FFC72C",
                direction_destinations: %{0 => "Ashmont Station", 1 => "Ruggles Station"},
-               description: :key_bus_route
+               description: :key_bus_route,
+               sort_order: 50_230
              }
     end
 

--- a/apps/routes/test/route_test.exs
+++ b/apps/routes/test/route_test.exs
@@ -197,7 +197,8 @@ defmodule Routes.RouteTest do
         long_name: "Red Line",
         name: "Red Line",
         type: 1,
-        color: "DA291C"
+        color: "DA291C",
+        sort_order: 5
       }
 
       expected = %{
@@ -209,7 +210,8 @@ defmodule Routes.RouteTest do
         long_name: "Red Line",
         name: "Red Line",
         type: 1,
-        color: "DA291C"
+        color: "DA291C",
+        sort_order: 5
       }
 
       assert Route.to_json_safe(route) == expected

--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -83,6 +83,7 @@ export interface Route {
   id: string;
   long_name: string;
   name: string;
+  sort_order?: number;
   type: RouteType;
 }
 

--- a/apps/site/assets/ts/leaflet/components/MapTooltip.tsx
+++ b/apps/site/assets/ts/leaflet/components/MapTooltip.tsx
@@ -1,19 +1,27 @@
 import React, { ReactElement } from "react";
 import { Stop, EnhancedRoute } from "../../__v3api";
 import StopCard from "../../stop/components/StopCard";
+import { RouteWithDirection } from "../../stop/components/__stop";
 
 export interface Props {
   stop: Stop;
+  routesWithDirection?: RouteWithDirection[];
   routes: EnhancedRoute[];
   distanceFormatted?: string;
 }
 
 const MapTooltip = ({
   stop,
+  routesWithDirection,
   routes,
   distanceFormatted
 }: Props): ReactElement<HTMLElement> => (
-  <StopCard routes={routes} stop={stop} distanceFormatted={distanceFormatted} />
+  <StopCard
+    routes={routes}
+    routesWithDirection={routesWithDirection}
+    stop={stop}
+    distanceFormatted={distanceFormatted}
+  />
 );
 
 export default MapTooltip;

--- a/apps/site/assets/ts/stop/__tests__/StopCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopCardTest.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { mount, ReactWrapper } from "enzyme";
+import StopCard from "../components/StopCard";
+import { EnhancedRoute, DirectionId } from "../../__v3api";
+import stopData from "./stopData.json";
+import {
+  StopPageData,
+  TypedRoutes,
+  RouteWithDirection
+} from "../components/__stop";
+
+const { stop, routes } = JSON.parse(JSON.stringify(stopData)) as StopPageData;
+// mimic the transformation done for the StopMapContainerProp
+const typedRoutes = routes.reduce(
+  (accumulator: EnhancedRoute[], groupedRoutes: TypedRoutes): EnhancedRoute[] =>
+    accumulator.concat(
+      groupedRoutes.routes.map(typedRoute => typedRoute.route)
+    ),
+  []
+);
+
+const routesWithDirection: RouteWithDirection[] = routes.reduce(
+  (
+    accumulator: RouteWithDirection[],
+    groupedRoutes: TypedRoutes
+  ): RouteWithDirection[] =>
+    accumulator.concat(
+      groupedRoutes.routes.map(typedRoute => ({
+        route: typedRoute.route,
+        direction_id: 0 as DirectionId
+      }))
+    ),
+  []
+);
+
+describe("StopCard", () => {
+  let tree: ReactWrapper;
+  let treeWithDirection: ReactWrapper;
+  beforeAll(() => {
+    tree = mount(<StopCard stop={stop} routes={typedRoutes} />);
+    treeWithDirection = mount(
+      <StopCard stop={stop} routesWithDirection={routesWithDirection} />
+    );
+  });
+
+  it("renders with routes", () => {
+    expect(tree.debug()).toMatchSnapshot();
+  });
+
+  it("renders with routes with directions", () => {
+    expect(treeWithDirection.debug()).toMatchSnapshot();
+  });
+
+  describe("for routes without direction", () => {
+    it("does not display direction-specific headsigns", () => {
+      const routeLinkNames = tree
+        .find(".c-stop-card__route-link")
+        .map(link => link.text());
+      routeLinkNames.forEach((name, i) => {
+        expect(name).toEqual(typedRoutes[i].long_name);
+      });
+    });
+  });
+
+  describe("for routes with direction", () => {
+    let routeLinkNamesForDirection: string[];
+
+    beforeEach(() => {
+      routeLinkNamesForDirection = treeWithDirection
+        .find(".c-stop-card__route-link")
+        .map(link => link.text());
+    });
+
+    it("displays bus route headsign for direction", () => {
+      routeLinkNamesForDirection.forEach((name, i) => {
+        if ([1, 2, 3].includes(i)) {
+          // these happen to be our test bus routes
+          expect(name).toEqual(
+            routesWithDirection[i].route.direction_destinations[0]
+          );
+        }
+      });
+    });
+
+    it("displays CR and subway headsigns for both directions", () => {
+      routeLinkNamesForDirection.forEach((name, i) => {
+        if (![1, 2, 3].includes(i)) {
+          expect(name).toEqual(routesWithDirection[i].route.long_name);
+        }
+      });
+    });
+  });
+});

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopCardTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopCardTest.tsx.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StopCard renders with routes 1`] = `
+"<StopCard stop={{...}} routes={{...}}>
+  <div className=\\"c-stop-card\\">
+    <a className=\\"c-stop-card__stop-name\\" href=\\"/stops/place-sstat\\">
+      South Station
+    </a>
+    <a className=\\"m-stop-page__access-icon\\" href=\\"#header-accessibility\\" onClick={[Function: onClick]}>
+      <span className=\\"m-stop-page__icon\\">
+        <span className=\\"notranslate c-svg__icon-accessible-default\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      </span>
+    </a>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/Red\\" className=\\"c-stop-card__route-link\\">
+        Red Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/741\\" className=\\"c-stop-card__route-link\\">
+        Logan Airport - South Station
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/742\\" className=\\"c-stop-card__route-link\\">
+        Design Center - South Station
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/743\\" className=\\"c-stop-card__route-link\\">
+        Chelsea - South Station
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Fairmount\\" className=\\"c-stop-card__route-link\\">
+        Fairmount Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Worcester\\" className=\\"c-stop-card__route-link\\">
+        Framingham/Worcester Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Franklin\\" className=\\"c-stop-card__route-link\\">
+        Franklin Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Greenbush\\" className=\\"c-stop-card__route-link\\">
+        Greenbush Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Kingston\\" className=\\"c-stop-card__route-link\\">
+        Kingston/Plymouth Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Middleborough\\" className=\\"c-stop-card__route-link\\">
+        Middleborough/Lakeville Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Needham\\" className=\\"c-stop-card__route-link\\">
+        Needham Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Providence\\" className=\\"c-stop-card__route-link\\">
+        Providence/Stoughton Line
+      </a>
+    </div>
+  </div>
+</StopCard>"
+`;
+
+exports[`StopCard renders with routes with directions 1`] = `
+"<StopCard stop={{...}} routesWithDirection={{...}}>
+  <div className=\\"c-stop-card\\">
+    <a className=\\"c-stop-card__stop-name\\" href=\\"/stops/place-sstat\\">
+      South Station
+    </a>
+    <a className=\\"m-stop-page__access-icon\\" href=\\"#header-accessibility\\" onClick={[Function: onClick]}>
+      <span className=\\"m-stop-page__icon\\">
+        <span className=\\"notranslate c-svg__icon-accessible-default\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      </span>
+    </a>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/Red?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Red Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/741?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Logan Airport
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/742?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Design Center
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/743?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Chelsea
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Fairmount?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Fairmount Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Worcester?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Framingham/Worcester Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Franklin?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Franklin Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Greenbush?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Greenbush Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Kingston?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Kingston/Plymouth Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Middleborough?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Middleborough/Lakeville Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Needham?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Needham Line
+      </a>
+    </div>
+    <div className=\\"c-stop-card__route\\">
+      <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+      <a href=\\"/schedules/CR-Providence?direction_id=0\\" className=\\"c-stop-card__route-link\\">
+        Providence/Stoughton Line
+      </a>
+    </div>
+  </div>
+</StopCard>"
+`;

--- a/apps/site/assets/ts/stop/__tests__/stopData.json
+++ b/apps/site/assets/ts/stop/__tests__/stopData.json
@@ -29,7 +29,10 @@
         "payment": {
           "monthly_rate": "$150 regular, $445 overnight",
           "mobile_app": null,
-          "methods": ["Credit/Debit Card", "Cash"],
+          "methods": [
+            "Credit/Debit Card",
+            "Cash"
+          ],
           "daily_rate": "Hourly: 30 min: $5, 1 hr: $10, 1.5 hrs: $15, 2 hrs: $20, 2.5 hrs: $25, 3+ hrs: $30 | Daily Max: $30 | Early Bird (in by 8:30 AM, out by 6 PM): $26 | Nights/Weekends: $10"
         },
         "note": null,
@@ -42,7 +45,11 @@
         },
         "longitude": -71.055963,
         "latitude": 42.349838,
-        "capacity": { "type": "Garage", "total": 210, "accessible": 4 },
+        "capacity": {
+          "type": "Garage",
+          "total": 210,
+          "accessible": 4
+        },
         "address": null
       }
     ],
@@ -61,14 +68,17 @@
       "ticket_window"
     ],
     "closed_stop_info": null,
-    "bike_storage": ["bike_storage_cage"],
+    "bike_storage": [
+      "bike_storage_cage"
+    ],
     "address": "700 Atlantic Ave, Boston, MA 02110",
     "accessibility": [
       "accessible",
       "escalator_both",
       "elevator",
       "fully_elevated_platform"
-    ]
+    ],
+    "type": "station"
   },
   "routes": [
     {
@@ -79,7 +89,10 @@
             "name": "Red Line",
             "long_name": "Red Line",
             "id": "Red",
-            "direction_names": { "1": "North", "0": "South" },
+            "direction_names": {
+              "1": "North",
+              "0": "South"
+            },
             "direction_destinations": {
               "1": "Alewife",
               "0": "Ashmont/Braintree"
@@ -97,7 +110,11 @@
                       "scheduled_time": null,
                       "prediction": {
                         "track": "2",
-                        "time": ["3", " ", "min"],
+                        "time": [
+                          "3",
+                          " ",
+                          "min"
+                        ],
                         "status": null
                       }
                     },
@@ -105,7 +122,11 @@
                       "scheduled_time": null,
                       "prediction": {
                         "track": null,
-                        "time": ["13", " ", "min"],
+                        "time": [
+                          "13",
+                          " ",
+                          "min"
+                        ],
                         "status": null
                       }
                     }
@@ -119,7 +140,11 @@
                       "scheduled_time": null,
                       "prediction": {
                         "track": null,
-                        "time": ["9", " ", "min"],
+                        "time": [
+                          "9",
+                          " ",
+                          "min"
+                        ],
                         "status": null
                       }
                     },
@@ -127,7 +152,11 @@
                       "scheduled_time": null,
                       "prediction": {
                         "track": null,
-                        "time": ["21", " ", "min"],
+                        "time": [
+                          "21",
+                          " ",
+                          "min"
+                        ],
                         "status": null
                       }
                     }
@@ -147,7 +176,11 @@
                       "scheduled_time": null,
                       "prediction": {
                         "track": "2",
-                        "time": ["7", " ", "min"],
+                        "time": [
+                          "7",
+                          " ",
+                          "min"
+                        ],
                         "status": null
                       }
                     },
@@ -155,7 +188,11 @@
                       "scheduled_time": null,
                       "prediction": {
                         "track": null,
-                        "time": ["13", " ", "min"],
+                        "time": [
+                          "13",
+                          " ",
+                          "min"
+                        ],
                         "status": null
                       }
                     }
@@ -179,7 +216,10 @@
             "name": "SL1",
             "long_name": "Logan Airport - South Station",
             "id": "741",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
             "direction_destinations": {
               "1": "South Station",
               "0": "Logan Airport"
@@ -194,7 +234,11 @@
                   "train_number": "",
                   "times": [
                     {
-                      "scheduled_time": ["2:30", " ", "AM"],
+                      "scheduled_time": [
+                        "2:30",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -211,7 +255,11 @@
                   "train_number": "",
                   "times": [
                     {
-                      "scheduled_time": ["5:36", " ", "AM"],
+                      "scheduled_time": [
+                        "5:36",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -223,7 +271,11 @@
                   "train_number": "",
                   "times": [
                     {
-                      "scheduled_time": ["5:40", " ", "AM"],
+                      "scheduled_time": [
+                        "5:40",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -242,7 +294,10 @@
             "name": "SL2",
             "long_name": "Design Center - South Station",
             "id": "742",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
             "direction_destinations": {
               "1": "South Station",
               "0": "Design Center"
@@ -257,7 +312,11 @@
                   "train_number": "",
                   "times": [
                     {
-                      "scheduled_time": ["4:17", " ", "AM"],
+                      "scheduled_time": [
+                        "4:17",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -274,7 +333,11 @@
                   "train_number": "",
                   "times": [
                     {
-                      "scheduled_time": ["5:36", " ", "AM"],
+                      "scheduled_time": [
+                        "5:36",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -286,7 +349,11 @@
                   "train_number": "",
                   "times": [
                     {
-                      "scheduled_time": ["5:46", " ", "AM"],
+                      "scheduled_time": [
+                        "5:46",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -305,8 +372,14 @@
             "name": "SL3",
             "long_name": "Chelsea - South Station",
             "id": "743",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
-            "direction_destinations": { "1": "South Station", "0": "Chelsea" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
+            "direction_destinations": {
+              "1": "South Station",
+              "0": "Chelsea"
+            },
             "description": "key_bus_route",
             "custom_route?": false
           },
@@ -317,7 +390,11 @@
                   "train_number": "",
                   "times": [
                     {
-                      "scheduled_time": ["4:17", " ", "AM"],
+                      "scheduled_time": [
+                        "4:17",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -334,7 +411,11 @@
                   "train_number": "",
                   "times": [
                     {
-                      "scheduled_time": ["4:25", " ", "AM"],
+                      "scheduled_time": [
+                        "4:25",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -346,7 +427,11 @@
                   "train_number": "",
                   "times": [
                     {
-                      "scheduled_time": ["5:36", " ", "AM"],
+                      "scheduled_time": [
+                        "5:36",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -370,7 +455,10 @@
             "name": "Fairmount Line",
             "long_name": "Fairmount Line",
             "id": "CR-Fairmount",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
             "direction_destinations": {
               "1": "South Station",
               "0": "Fairmount"
@@ -385,7 +473,11 @@
                   "train_number": "790",
                   "times": [
                     {
-                      "scheduled_time": ["4:55", " ", "AM"],
+                      "scheduled_time": [
+                        "4:55",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -402,7 +494,11 @@
                   "train_number": "751",
                   "times": [
                     {
-                      "scheduled_time": ["6:24", " ", "AM"],
+                      "scheduled_time": [
+                        "6:24",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -421,7 +517,10 @@
             "name": "Framingham/Worcester Line",
             "long_name": "Framingham/Worcester Line",
             "id": "CR-Worcester",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
             "direction_destinations": {
               "1": "South Station",
               "0": "Worcester"
@@ -436,7 +535,11 @@
                   "train_number": "501",
                   "times": [
                     {
-                      "scheduled_time": ["4:40", " ", "AM"],
+                      "scheduled_time": [
+                        "4:40",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -448,7 +551,11 @@
                   "train_number": "583",
                   "times": [
                     {
-                      "scheduled_time": ["5:30", " ", "AM"],
+                      "scheduled_time": [
+                        "5:30",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -460,7 +567,11 @@
                   "train_number": "589",
                   "times": [
                     {
-                      "scheduled_time": ["7:30", " ", "AM"],
+                      "scheduled_time": [
+                        "7:30",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -477,7 +588,11 @@
                   "train_number": "500",
                   "times": [
                     {
-                      "scheduled_time": ["4:45", " ", "AM"],
+                      "scheduled_time": [
+                        "4:45",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -496,7 +611,10 @@
             "name": "Franklin Line",
             "long_name": "Franklin Line",
             "id": "CR-Franklin",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
             "direction_destinations": {
               "1": "South Station",
               "0": "Forge Park/495"
@@ -511,7 +629,11 @@
                   "train_number": "701",
                   "times": [
                     {
-                      "scheduled_time": ["3:50", " ", "AM"],
+                      "scheduled_time": [
+                        "3:50",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -523,7 +645,11 @@
                   "train_number": "741",
                   "times": [
                     {
-                      "scheduled_time": ["6:40", " ", "AM"],
+                      "scheduled_time": [
+                        "6:40",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -535,10 +661,18 @@
                   "train_number": "743",
                   "times": [
                     {
-                      "scheduled_time": ["4:15", " ", "PM"],
+                      "scheduled_time": [
+                        "4:15",
+                        " ",
+                        "PM"
+                      ],
                       "prediction": {
                         "track": null,
-                        "time": ["4:15", " ", "PM"],
+                        "time": [
+                          "4:15",
+                          " ",
+                          "PM"
+                        ],
                         "status": "On time"
                       },
                       "delay": 0
@@ -556,7 +690,11 @@
                   "train_number": "790",
                   "times": [
                     {
-                      "scheduled_time": ["4:55", " ", "AM"],
+                      "scheduled_time": [
+                        "4:55",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -575,7 +713,10 @@
             "name": "Greenbush Line",
             "long_name": "Greenbush Line",
             "id": "CR-Greenbush",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
             "direction_destinations": {
               "1": "South Station",
               "0": "Greenbush"
@@ -590,7 +731,11 @@
                   "train_number": "070",
                   "times": [
                     {
-                      "scheduled_time": ["5:40", " ", "AM"],
+                      "scheduled_time": [
+                        "5:40",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -607,7 +752,11 @@
                   "train_number": "071",
                   "times": [
                     {
-                      "scheduled_time": ["6:54", " ", "AM"],
+                      "scheduled_time": [
+                        "6:54",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -626,7 +775,10 @@
             "name": "Kingston/Plymouth Line",
             "long_name": "Kingston/Plymouth Line",
             "id": "CR-Kingston",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
             "direction_destinations": {
               "1": "South Station",
               "0": "Kingston or Plymouth"
@@ -641,7 +793,11 @@
                   "train_number": "032",
                   "times": [
                     {
-                      "scheduled_time": ["5:30", " ", "AM"],
+                      "scheduled_time": [
+                        "5:30",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -658,7 +814,11 @@
                   "train_number": "033",
                   "times": [
                     {
-                      "scheduled_time": ["7:11", " ", "AM"],
+                      "scheduled_time": [
+                        "7:11",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -670,7 +830,11 @@
                   "train_number": "063",
                   "times": [
                     {
-                      "scheduled_time": ["10:50", " ", "AM"],
+                      "scheduled_time": [
+                        "10:50",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -689,7 +853,10 @@
             "name": "Middleborough/Lakeville Line",
             "long_name": "Middleborough/Lakeville Line",
             "id": "CR-Middleborough",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
             "direction_destinations": {
               "1": "South Station",
               "0": "Middleborough/Lakeville"
@@ -704,7 +871,11 @@
                   "train_number": "002",
                   "times": [
                     {
-                      "scheduled_time": ["5:20", " ", "AM"],
+                      "scheduled_time": [
+                        "5:20",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -721,7 +892,11 @@
                   "train_number": "003",
                   "times": [
                     {
-                      "scheduled_time": ["6:35", " ", "AM"],
+                      "scheduled_time": [
+                        "6:35",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -740,7 +915,10 @@
             "name": "Needham Line",
             "long_name": "Needham Line",
             "id": "CR-Needham",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
             "direction_destinations": {
               "1": "South Station",
               "0": "Needham Heights"
@@ -755,7 +933,11 @@
                   "train_number": "600",
                   "times": [
                     {
-                      "scheduled_time": ["6:05", " ", "AM"],
+                      "scheduled_time": [
+                        "6:05",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -772,7 +954,11 @@
                   "train_number": "601",
                   "times": [
                     {
-                      "scheduled_time": ["7:05", " ", "AM"],
+                      "scheduled_time": [
+                        "7:05",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -791,7 +977,10 @@
             "name": "Providence/Stoughton Line",
             "long_name": "Providence/Stoughton Line",
             "id": "CR-Providence",
-            "direction_names": { "1": "Inbound", "0": "Outbound" },
+            "direction_names": {
+              "1": "Inbound",
+              "0": "Outbound"
+            },
             "direction_destinations": {
               "1": "South Station",
               "0": "Wickford Junction"
@@ -806,7 +995,11 @@
                   "train_number": "802",
                   "times": [
                     {
-                      "scheduled_time": ["4:45", " ", "AM"],
+                      "scheduled_time": [
+                        "4:45",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -823,7 +1016,11 @@
                   "train_number": "8801",
                   "times": [
                     {
-                      "scheduled_time": ["4:58", " ", "AM"],
+                      "scheduled_time": [
+                        "4:58",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -835,7 +1032,11 @@
                   "train_number": "803",
                   "times": [
                     {
-                      "scheduled_time": ["6:31", " ", "AM"],
+                      "scheduled_time": [
+                        "6:31",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -847,7 +1048,11 @@
                   "train_number": "903",
                   "times": [
                     {
-                      "scheduled_time": ["6:57", " ", "AM"],
+                      "scheduled_time": [
+                        "6:57",
+                        " ",
+                        "AM"
+                      ],
                       "prediction": null,
                       "delay": 0
                     }
@@ -871,7 +1076,9 @@
         "address": "1234 Main St., Boston MA",
         "latitude": 42.0,
         "longitude": -71.0,
-        "payment": ["credit_card"],
+        "payment": [
+          "credit_card"
+        ],
         "phone": "617-555-1234"
       },
       "distance": "500 ft"
@@ -894,7 +1101,9 @@
         "closed_stop_info": null,
         "bike_storage": [],
         "address": null,
-        "accessibility": ["accessible"]
+        "accessibility": [
+          "accessible"
+        ]
       },
       "routes_with_direction": [
         {
@@ -904,8 +1113,14 @@
             "long_name": "Harvard - Dudley via Massachusetts Avenue",
             "id": "1",
             "header": "1",
-            "direction_names": { "0": "Outbound", "1": "Inbound" },
-            "direction_destinations": { "0": "Harvard", "1": "Dudley" },
+            "direction_names": {
+              "0": "Outbound",
+              "1": "Inbound"
+            },
+            "direction_destinations": {
+              "0": "Harvard",
+              "1": "Dudley"
+            },
             "description": "key_bus_route",
             "custom_route?": false
           },
@@ -930,7 +1145,9 @@
         "closed_stop_info": null,
         "bike_storage": [],
         "address": null,
-        "accessibility": ["accessible"]
+        "accessibility": [
+          "accessible"
+        ]
       },
       "routes_with_direction": [
         {
@@ -940,7 +1157,10 @@
             "long_name": "Oak Square - University Park or Kendall/MIT",
             "id": "64",
             "header": "64",
-            "direction_names": { "0": "Outbound", "1": "Inbound" },
+            "direction_names": {
+              "0": "Outbound",
+              "1": "Inbound"
+            },
             "direction_destinations": {
               "0": "Oak Square",
               "1": "University Park or Kendall/MIT"
@@ -957,7 +1177,10 @@
             "long_name": "Central Square, Cambridge - Boston Medical Center",
             "id": "701",
             "header": "CT1",
-            "direction_names": { "0": "Outbound", "1": "Inbound" },
+            "direction_names": {
+              "0": "Outbound",
+              "1": "Inbound"
+            },
             "direction_destinations": {
               "0": "Central Square, Cambridge",
               "1": "Boston Medical Center"
@@ -974,7 +1197,10 @@
             "long_name": "Rindge Avenue - Central Square, Cambridge",
             "id": "83",
             "header": "83",
-            "direction_names": { "0": "Outbound", "1": "Inbound" },
+            "direction_names": {
+              "0": "Outbound",
+              "1": "Inbound"
+            },
             "direction_destinations": {
               "0": "Rindge Avenue",
               "1": "Central Square, Cambridge"
@@ -991,7 +1217,10 @@
             "long_name": "Sullivan - Central Square, Cambridge",
             "id": "91",
             "header": "91",
-            "direction_names": { "0": "Outbound", "1": "Inbound" },
+            "direction_names": {
+              "0": "Outbound",
+              "1": "Inbound"
+            },
             "direction_destinations": {
               "0": "Sullivan",
               "1": "Central Square, Cambridge"
@@ -1020,7 +1249,9 @@
         "closed_stop_info": null,
         "bike_storage": [],
         "address": null,
-        "accessibility": ["accessible"]
+        "accessibility": [
+          "accessible"
+        ]
       },
       "routes_with_direction": [
         {
@@ -1030,7 +1261,10 @@
             "long_name": "Central Square, Cambridge - Broadway Station",
             "id": "47",
             "header": "47",
-            "direction_names": { "0": "Outbound", "1": "Inbound" },
+            "direction_names": {
+              "0": "Outbound",
+              "1": "Inbound"
+            },
             "direction_destinations": {
               "0": "Central Square, Cambridge",
               "1": "Broadway Station"
@@ -1047,7 +1281,10 @@
             "long_name": "Oak Square - University Park or Kendall/MIT",
             "id": "64",
             "header": "64",
-            "direction_names": { "0": "Outbound", "1": "Inbound" },
+            "direction_names": {
+              "0": "Outbound",
+              "1": "Inbound"
+            },
             "direction_destinations": {
               "0": "Oak Square",
               "1": "University Park or Kendall/MIT"
@@ -1064,7 +1301,10 @@
             "long_name": "Cedarwood - Central Square, Cambridge",
             "id": "70",
             "header": "70",
-            "direction_names": { "0": "Outbound", "1": "Inbound" },
+            "direction_names": {
+              "0": "Outbound",
+              "1": "Inbound"
+            },
             "direction_destinations": {
               "0": "Cedarwood",
               "1": "Central Square, Cambridge"
@@ -1081,7 +1321,10 @@
             "long_name": "Central Square, Cambridge - Boston Medical Center",
             "id": "701",
             "header": "CT1",
-            "direction_names": { "0": "Outbound", "1": "Inbound" },
+            "direction_names": {
+              "0": "Outbound",
+              "1": "Inbound"
+            },
             "direction_destinations": {
               "0": "Central Square, Cambridge",
               "1": "Boston Medical Center"
@@ -1098,7 +1341,10 @@
             "long_name": "North Waltham - Central Square, Cambridge",
             "id": "70A",
             "header": "70A",
-            "direction_names": { "0": "Outbound", "1": "Inbound" },
+            "direction_names": {
+              "0": "Outbound",
+              "1": "Inbound"
+            },
             "direction_destinations": {
               "0": "North Waltham",
               "1": "Central Square, Cambridge"

--- a/apps/site/assets/ts/stop/components/StopCard.tsx
+++ b/apps/site/assets/ts/stop/components/StopCard.tsx
@@ -10,7 +10,7 @@ const routeNameBasedOnDirection = (
   route: EnhancedRoute,
   directionId: DirectionId | null
 ): string => {
-  if (directionId === null) {
+  if (directionId === null || route.type !== 3) {
     return route.long_name;
   }
 

--- a/apps/site/assets/ts/stop/components/StopMap.tsx
+++ b/apps/site/assets/ts/stop/components/StopMap.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { StopMapData } from "./__stop";
+import { StopMapData, RouteWithDirection } from "./__stop";
 import { SelectedStopType, Dispatch } from "../state";
 import Map from "../../leaflet/components/Map";
 import MapTooltip from "../../leaflet/components/MapTooltip";
@@ -11,6 +11,7 @@ interface Props {
   dispatch: Dispatch;
   selectedStopId: SelectedStopType;
   stop: Stop;
+  routesWithDirection?: RouteWithDirection[];
   routes: EnhancedRoute[];
 }
 
@@ -18,7 +19,8 @@ export default ({
   // eslint-disable-next-line @typescript-eslint/camelcase
   initialData: { map_data: mapData },
   stop,
-  routes
+  routes,
+  routesWithDirection
 }: Props): ReactElement<HTMLElement> => (
   <Map
     mapData={{
@@ -26,7 +28,13 @@ export default ({
       zoom: mapData.zoom || 12,
       markers: mapData.markers.map(marker => ({
         ...marker,
-        tooltip: <MapTooltip stop={stop} routes={routes} />
+        tooltip: (
+          <MapTooltip
+            stop={stop}
+            routes={routes}
+            routesWithDirection={routesWithDirection}
+          />
+        )
       }))
     }}
   />

--- a/apps/site/assets/ts/stop/components/StopMapContainer.tsx
+++ b/apps/site/assets/ts/stop/components/StopMapContainer.tsx
@@ -1,13 +1,14 @@
 import React, { ReactElement } from "react";
 import StopMap from "./StopMap";
 import { Stop, EnhancedRoute } from "../../__v3api";
-import { StopMapData } from "../components/__stop";
+import { StopMapData, RouteWithDirection } from "../components/__stop";
 import { SelectedStopType, Dispatch } from "../state";
 
 interface Props {
   initialData: StopMapData;
   mapId: string;
   stop: Stop;
+  routesWithDirection?: RouteWithDirection[];
   routes: EnhancedRoute[];
   selectedStopId: SelectedStopType;
   dispatch: Dispatch;
@@ -17,6 +18,7 @@ const StopMapContainer = ({
   initialData,
   mapId,
   stop,
+  routesWithDirection,
   routes,
   selectedStopId,
   dispatch
@@ -57,6 +59,7 @@ const StopMapContainer = ({
         initialData={initialData}
         stop={stop}
         routes={routes}
+        routesWithDirection={routesWithDirection}
       />
     </div>
   </div>

--- a/apps/site/assets/ts/stop/components/StopPage.tsx
+++ b/apps/site/assets/ts/stop/components/StopPage.tsx
@@ -41,6 +41,8 @@ export default ({
     street_view_url: streetViewUrl,
     routes,
     // eslint-disable-next-line @typescript-eslint/camelcase
+    routes_with_direction: routesWithDirection,
+    // eslint-disable-next-line @typescript-eslint/camelcase
     retail_locations: retailLocations,
     // eslint-disable-next-line @typescript-eslint/camelcase
     suggested_transfers: suggestedTransfers,
@@ -92,6 +94,7 @@ export default ({
                   ),
                 []
               )}
+              routesWithDirection={routesWithDirection}
               selectedStopId={state.selectedStopId}
               dispatch={dispatch}
             />

--- a/apps/site/assets/ts/stop/components/__stop.d.ts
+++ b/apps/site/assets/ts/stop/components/__stop.d.ts
@@ -33,6 +33,7 @@ export interface StopPageData {
   stop: Stop;
   street_view_url: string | null;
   routes: TypedRoutes[];
+  routes_with_direction?: RouteWithDirection[];
   tabs: Tab[];
   zone_number: string;
   alerts: Alert[];

--- a/apps/site/test/site/map_helpers/markers_test.exs
+++ b/apps/site/test/site/map_helpers/markers_test.exs
@@ -10,7 +10,8 @@ defmodule Site.MapHelpers.MarkersTest do
     long_name: "Red Line",
     name: "Red Line",
     type: 1,
-    color: "DA291C"
+    color: "DA291C",
+    sort_order: 1
   }
 
   @stop %Stops.Stop{

--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -24,7 +24,8 @@ defmodule Site.RealtimeScheduleTest do
     long_name: "Orange Line",
     name: "Orange Line",
     type: 1,
-    color: "ED8B00"
+    color: "ED8B00",
+    sort_order: 99_999
   }
 
   @route_with_patterns [
@@ -253,7 +254,8 @@ defmodule Site.RealtimeScheduleTest do
           long_name: "Orange Line",
           name: "Orange Line",
           type: 1,
-          color: "ED8B00"
+          color: "ED8B00",
+          sort_order: 99_999
         }
       }
     ]

--- a/apps/stops/lib/nearby.ex
+++ b/apps/stops/lib/nearby.ex
@@ -110,9 +110,9 @@ defmodule Stops.Nearby do
   def do_routes_for_stop_direction(_, _), do: :error
 
   @spec merge_routes(String.t(), fun()) :: {:ok | :error, [route_with_direction] | :timeout}
-  defp merge_routes(stop_id, routes_fn) do
+  def merge_routes(stop_id, routes_fn) do
     # Find the routes for a stop in both directions.
-    # Merge the routes such that if a route exists for a stip in both
+    # Merge the routes such that if a route exists for a stop in both
     # directions, set the direction_id to nil
 
     direction_0_task = Task.async(__MODULE__, :routes_for_stop_direction, [routes_fn, stop_id, 0])

--- a/apps/stops/test/nearby_test.exs
+++ b/apps/stops/test/nearby_test.exs
@@ -316,6 +316,26 @@ defmodule Stops.NearbyTest do
     end
   end
 
+  describe "merge_routes/2" do
+    test "sets direction_id for routes present in one direction at stop" do
+      stop_id = "place-kencl"
+      routes_fn = &Routes.Repo.by_stop_and_direction/2
+      {:ok, actual} = merge_routes(stop_id, routes_fn)
+      route_going_1way = Enum.find(actual, &(&1.route.name === "9"))
+
+      refute nil == route_going_1way.direction_id
+    end
+
+    test "sets direction_id to nil for routes present in both directions at stop" do
+      stop_id = "place-kencl"
+      routes_fn = &Routes.Repo.by_stop_and_direction/2
+      {:ok, actual} = merge_routes(stop_id, routes_fn)
+      route_going_2ways = Enum.find(actual, &(&1.route.name === "57A"))
+
+      assert nil == route_going_2ways.direction_id
+    end
+  end
+
   def random_stops(count) do
     Enum.map(1..count, fn _ -> random_stop() end)
   end


### PR DESCRIPTION
**Asana Ticket:** [🐞Stations/Stops | Tooltips for bus connections on map are wrong](https://app.asana.com/0/385363666817452/1147672918652027/f)

Because `<StopCard />` already has a `routesWithDirection` prop to render direction-specific routes, this change lets the `<StopMap />` make use of it. This is done by generating the requisite data from the stop controller and passing it through via `conn.stop_page_data` to `<StopPage />` to `<StopMapContainer />` to `<StopMap />` to `<MapTooltip />` (which will finally pass it to `<StopCard />`).

~The controller code is cobbled together with useful bits of code from elsewhere.~ I expose the `Nearby.merge_routes` function so that I can use it to get directions associated with the stop's routes. ~Much of the rest of the code involves route sorting in order to preserve the current sorting done in the map tooltip (subways first in a certain order, then bus with Silver Lines and CT* buses first, then CR...), otherwise the connections order seem very arbitrary.~ 

This also adds a new attribute from the API into Dotcom's routes - `sort_order` - and uses it to sort the resulting routes.

Note this change will impact stops where there are buses going in only one direction - e.g. it will not change the displayed tooltips at terminals or those big stations where the bus line passes through both ways, as it stands right now.