### PR TITLE
Avoid server-side rendering warning

### DIFF
--- a/apps/site/lib/site_web/templates/schedule/_line.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line.html.eex
@@ -88,7 +88,7 @@
     <div class="col-xs-12 col-md-5 col-lg-4 col-lg-offset-1 m-schedule-line__side-content">
       <% without_schedules = @schedule_page_data |> Map.put(:service_schedules, %{})%>
       <div id="react-root">
-        <%= Site.React.render("SchedulePage", %{schedulePageData: without_schedules}) %>
+        <%= Site.React.render("SchedulePage", %{schedulePageData: without_schedules, selectedDirection: @direction_id}) %>
       </div>
       <link rel="stylesheet" href="<%= static_url(@conn, "/css/map.css") %>" data-turbolinks-track="reload">
       <%= if Application.get_env(:site, :dev_server?) do %>


### PR DESCRIPTION
Fix warning when rendering ScheduleFinderForm (via SchedulePage) in the server

#### This PR is related to the work done in #440 and the Asana ticket
[Schedules | Schedule Finder works with URL parameters](https://app.asana.com/0/555089885850811/1162467761296251)

I left a 'lingering' warning that I had been meaning to fix. Previously we were getting the following warning from the server:
`[warn] react_renderer component=SchedulePage Cannot read property 'map' of undefined`
because there was no direction_id specified.