### PR TITLE
Get services for the merged Green Line

### DIFF
--- a/apps/services/lib/repo.ex
+++ b/apps/services/lib/repo.ex
@@ -14,8 +14,7 @@ defmodule Services.Repo do
   end
 
   def by_route_id("Green", params) do
-    GreenLine.branch_ids()
-    |> Enum.join(",")
+    "Green-B,Green-C,Green-D,Green-E"
     |> by_route_id(params)
   end
 

--- a/apps/services/lib/repo.ex
+++ b/apps/services/lib/repo.ex
@@ -1,5 +1,7 @@
 defmodule Services.Repo do
-  @moduledoc false
+  @moduledoc """
+  Retrieves services for a route.
+  """
 
   use RepoCache, ttl: :timer.hours(1)
   alias Services.Service
@@ -9,6 +11,12 @@ defmodule Services.Repo do
 
   def by_route_id([route_id] = route, params) when is_list(route) do
     by_route_id(route_id, params)
+  end
+
+  def by_route_id("Green", params) do
+    GreenLine.branch_ids()
+    |> Enum.join(",")
+    |> by_route_id(params)
   end
 
   def by_route_id(route_id, params) when is_binary(route_id) do

--- a/apps/services/test/repo_test.exs
+++ b/apps/services/test/repo_test.exs
@@ -5,4 +5,8 @@ defmodule Services.RepoTest do
   test "by_route_id fetches services for a route" do
     assert [%Service{} | _] = Repo.by_route_id("Red")
   end
+
+  test "by_route_id fetches services for the green line" do
+    assert Repo.by_route_id("Green") == Repo.by_route_id("Green-B,Green-C,Green-D,Green-E")
+  end
 end

--- a/apps/site/lib/site_web/channels/vehicle_channel.ex
+++ b/apps/site/lib/site_web/channels/vehicle_channel.ex
@@ -45,14 +45,6 @@ defmodule SiteWeb.VehicleChannel do
     stop_name = get_stop_name(vehicle.stop_id)
     trip = Schedules.Repo.trip(vehicle.trip_id)
 
-    # Sometimes trip is nil, so to avoid errors, we create a "polished" trip:
-    preprocessed_trip =
-      if trip == nil do
-        %{shape_id: nil}
-      else
-        trip
-      end
-
     %{
       data: %{vehicle: vehicle, stop_name: stop_name},
       marker:
@@ -62,14 +54,14 @@ defmodule SiteWeb.VehicleChannel do
           id: vehicle.id,
           icon: "vehicle-bordered-expanded",
           rotation_angle: vehicle.bearing,
-          shape_id: preprocessed_trip.shape_id,
+          shape_id: (trip && trip.shape_id) || nil,
           tooltip_text:
             %VehicleTooltip{
               prediction: nil,
               vehicle: vehicle,
               route: route,
               stop_name: stop_name,
-              trip: preprocessed_trip
+              trip: trip
             }
             |> VehicleHelpers.tooltip()
             |> Floki.text()

--- a/apps/site/lib/site_web/channels/vehicle_channel.ex
+++ b/apps/site/lib/site_web/channels/vehicle_channel.ex
@@ -1,4 +1,7 @@
 defmodule SiteWeb.VehicleChannel do
+  @moduledoc """
+  VehicleChannel module
+  """
   use SiteWeb, :channel
   alias Leaflet.MapData.Marker
   alias Vehicles.Vehicle
@@ -42,6 +45,14 @@ defmodule SiteWeb.VehicleChannel do
     stop_name = get_stop_name(vehicle.stop_id)
     trip = Schedules.Repo.trip(vehicle.trip_id)
 
+    # Sometimes trip is nil, so to avoid errors, we create a "polished" trip:
+    preprocessed_trip =
+      if trip == nil do
+        %{shape_id: nil}
+      else
+        trip
+      end
+
     %{
       data: %{vehicle: vehicle, stop_name: stop_name},
       marker:
@@ -51,14 +62,14 @@ defmodule SiteWeb.VehicleChannel do
           id: vehicle.id,
           icon: "vehicle-bordered-expanded",
           rotation_angle: vehicle.bearing,
-          shape_id: trip.shape_id,
+          shape_id: preprocessed_trip.shape_id,
           tooltip_text:
             %VehicleTooltip{
               prediction: nil,
               vehicle: vehicle,
               route: route,
               stop_name: stop_name,
-              trip: trip
+              trip: preprocessed_trip
             }
             |> VehicleHelpers.tooltip()
             |> Floki.text()

--- a/apps/site/lib/site_web/channels/vehicle_channel.ex
+++ b/apps/site/lib/site_web/channels/vehicle_channel.ex
@@ -54,7 +54,7 @@ defmodule SiteWeb.VehicleChannel do
           id: vehicle.id,
           icon: "vehicle-bordered-expanded",
           rotation_angle: vehicle.bearing,
-          shape_id: (trip && trip.shape_id) || nil,
+          shape_id: trip && trip.shape_id,
           tooltip_text:
             %VehicleTooltip{
               prediction: nil,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Schedule Finder | No scheduled trips found from the merged Green line page](https://app.asana.com/0/555089885850811/1174356662552522)

The logic to retrieve the services for the merged Green line was not receiving the parameter in the right format.
Also tests were added and a pre-processing of trips.<br/>
**Before**:
![image](https://user-images.githubusercontent.com/61979382/81986752-6f547e80-9606-11ea-8b32-fe56f4071acc.png)

**After**:
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/61979382/81986831-901cd400-9606-11ea-9cd2-9b9c03b1fa9d.png">

