### PR TITLE
Add helper to generate bus pill icon

### DIFF
--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -40,13 +40,17 @@
   }
 
   &-legs {
-    @include icon-size-inline(1.5em, .1875em);
+    @include icon-size-inline(1.5em, .22em);
     align-items: center;
     display: flex;
     flex-grow: 1;
 
     .fa-angle-right {
       margin: 0 $base-spacing / 4;
+    }
+
+    .c-icon__bus-pill {
+      font-size: .9em;
     }
   }
 

--- a/apps/site/lib/site_web/views/helpers.ex
+++ b/apps/site/lib/site_web/views/helpers.ex
@@ -97,6 +97,16 @@ defmodule SiteWeb.ViewHelpers do
     |> mode_icon(size)
   end
 
+  def bus_icon_pill(route) do
+    bg_class =
+      case Routes.Route.silver_line?(route) do
+        true -> "u-bg--silver-line"
+        _ -> "u-bg--bus"
+      end
+
+    content_tag(:span, route.name, class: "c-icon__bus-pill #{bg_class}")
+  end
+
   @doc """
   Use for links to CMS static content. For now just leaves paths alone,
   but at least earmarks them for easy identification or if we need to change our

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -324,6 +324,10 @@ defmodule SiteWeb.TripPlanView do
   end
 
   @spec icon_for_route(Route.t()) :: Phoenix.HTML.Safe.t()
+  def icon_for_route(%Route{type: 3} = route) do
+    SiteWeb.ViewHelpers.bus_icon_pill(route)
+  end
+
   def icon_for_route(route) do
     svg_icon_with_circle(%SvgIconWithCircle{icon: route})
   end

--- a/apps/site/test/site_web/views/helpers_test.exs
+++ b/apps/site/test/site_web/views/helpers_test.exs
@@ -445,4 +445,33 @@ defmodule SiteWeb.ViewHelpersTest do
       assert icon =~ "c-svg__icon-mattapan-line-default"
     end
   end
+
+  describe "bus_icon_pill/1" do
+    test "for silver line" do
+      icon =
+        %Routes.Route{
+          id: "742",
+          long_name: "Design Center - South Station",
+          name: "SL2",
+          type: 3
+        }
+        |> bus_icon_pill
+        |> safe_to_string
+
+      assert icon =~ "u-bg--silver-line"
+    end
+
+    test "for buses" do
+      icon =
+        %Routes.Route{
+          id: "221",
+          type: 3,
+          name: "221"
+        }
+        |> bus_icon_pill
+        |> safe_to_string
+
+      assert icon =~ "u-bg--bus"
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🎫 Style update | Bus Route Mode Icons](https://app.asana.com/0/385363666817452/1169236529454067/f)

For bus routes, instead of generating the SVG icon in a circle, use a new view helper to create an icon similar to those used [elsewhere in dotcom](https://github.com/mbta/dotcom/blob/master/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx#L45).

For [this trip](https://www.mbta.com/trip-planner?_utf8=%E2%9C%93&plan%5Bfrom%5D=Arlington+Heights+Busway&plan%5Bfrom_latitude%5D=42.424903&plan%5Bfrom_longitude%5D=-71.184975&plan%5Bto%5D=Terminal+C+-+Departures+Level&plan%5Bto_latitude%5D=42.366635&plan%5Bto_longitude%5D=-71.017167&plan%5Btime%5D=depart&plan%5Bdate_time%5D%5Bhour%5D=2&plan%5Bdate_time%5D%5Bminute%5D=10&plan%5Bdate_time%5D%5Bam_pm%5D=PM&plan%5Bdate_time%5D%5Bmonth%5D=5&plan%5Bdate_time%5D%5Bday%5D=26&plan%5Bdate_time%5D%5Byear%5D=2020&plan%5Bmodes%5D%5Bsubway%5D=false&plan%5Bmodes%5D%5Bsubway%5D=true&plan%5Bmodes%5D%5Bcommuter_rail%5D=false&plan%5Bmodes%5D%5Bcommuter_rail%5D=true&plan%5Bmodes%5D%5Bbus%5D=false&plan%5Bmodes%5D%5Bbus%5D=true&plan%5Bmodes%5D%5Bferry%5D=false&plan%5Bmodes%5D%5Bferry%5D=true&plan%5Boptimize_for%5D=best_route#plan_result_focus):

**Before:**

<img width="686" alt="image" src="https://user-images.githubusercontent.com/2136286/82388215-0a829500-9a07-11ea-8d3e-08f64dca2732.png">

**After:**

<img width="673" alt="image" src="https://user-images.githubusercontent.com/2136286/82388223-12dad000-9a07-11ea-86e0-e23ade1270d5.png">


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
