### PR TITLE
Show only 5 teasers max in the News section

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/cms.ex
+++ b/apps/site/lib/site_web/controllers/schedule/cms.ex
@@ -50,10 +50,10 @@ defmodule SiteWeb.ScheduleController.CMS do
           |> Enum.map(&set_utm_params(&1, route))
         end
 
-      non_duplicated_teasers =
-        Enum.uniq_by(teasers ++ mode_teasers, fn teaser -> teaser.title end)
-
-      Enum.sort_by(non_duplicated_teasers, & &1.date, &(Timex.compare(&1, &2) == 1))
+      (teasers ++ mode_teasers)
+      |> Enum.uniq_by(fn teaser -> teaser.title end)
+      |> Enum.sort_by(& &1.date, &(Timex.compare(&1, &2) == 1))
+      |> Enum.slice(0, 5)
     end
 
     conn

--- a/apps/site/test/site_web/controllers/schedule/cms_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/cms_test.exs
@@ -37,6 +37,8 @@ defmodule SiteWeb.ScheduleController.CMSTest do
                "utm_source" => "schedule",
                "utm_term" => "subway"
              }
+
+      assert Enum.count(conn.assigns.news) <= 5
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱️Schedules | Display news entries for the specific route AND its parent mode](https://app.asana.com/0/555089885850811/1169031641902619)

The news section on the right will only contain a maximum of 5 teasers.



