### PR TITLE
Add highest and lowest fares to each leg of an itinerary

### DIFF
--- a/apps/fares/lib/highest_lowest_fare.ex
+++ b/apps/fares/lib/highest_lowest_fare.ex
@@ -1,4 +1,4 @@
-defmodule Fares.MinMaxFare do
+defmodule Fares.HighestLowestFare do
   @moduledoc """
   Calculates the lowest and highest fare for a particular trip i.e. a regular priced, non-discounted, one-way fare for the given mode.
   Commuter rail and ferry fares distinguish between the possible sets of stops.

--- a/apps/fares/test/highest_lowest_fare_test.exs
+++ b/apps/fares/test/highest_lowest_fare_test.exs
@@ -1,10 +1,10 @@
-defmodule MinMaxFareTest do
+defmodule HighestLowestFareTest do
   use ExUnit.Case, async: true
 
   alias Routes.Route
   alias Schedules.Trip
 
-  import Fares.MinMaxFare
+  import Fares.HighestLowestFare
 
   @default_filters [reduced: nil, duration: :single_trip]
 

--- a/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
@@ -7,7 +7,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
   alias Fares.Format
   alias Routes.Route
   alias Schedules.Repo
-  alias Fares.{MinMaxFare}
+  alias Fares.{HighestLowestFare}
   import SiteWeb.ViewHelpers, only: [cms_static_page_path: 2]
 
   def show(conn, %{
@@ -151,7 +151,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
   @spec fares_for_service(map, map, String.t(), String.t()) :: map
   def fares_for_service(route, trip, origin, destination) do
     %{
-      price: route |> MinMaxFare.lowest_fare(trip, origin, destination) |> Format.price(),
+      price: route |> HighestLowestFare.lowest_fare(trip, origin, destination) |> Format.price(),
       fare_link:
         fare_link(
           Route.type_atom(route.type),

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -84,8 +84,8 @@ defmodule SiteWeb.TripPlanController do
     trip = Schedules.Repo.trip(leg.mode.trip_id)
     origin_id = leg.from.stop_id
     destination_id = leg.to.stop_id
-    lowest_fare = Fares.MinMaxFare.lowest_fare(route, trip, origin_id, destination_id)
-    highest_fare = Fares.MinMaxFare.highest_fare(route, trip, origin_id, destination_id)
+    lowest_fare = Fares.HighestLowestFare.lowest_fare(route, trip, origin_id, destination_id)
+    highest_fare = Fares.HighestLowestFare.highest_fare(route, trip, origin_id, destination_id)
 
     fares = %{
       highest_one_way_fare: highest_fare,

--- a/apps/site/lib/site_web/templates/trip_plan/index.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/index.html.eex
@@ -5,40 +5,40 @@
     <div class="trip-plan-body">
       <link rel="stylesheet" href="<%= static_url(@conn, "/css/map.css") %>" data-turbolinks-track="reload">
       <%= case assigns[:query] do %>
-        <% %{itineraries: {:ok, itineraries}} -> %>
-        <p class="no-trips page-section">
-          <% l = length(itineraries) %>
-          <%= "We found #{l} #{Inflex.inflect("trip", l)} for you" %>
-        </p>
-        <p class="instructions page-section"><%= itinerary_explanation(@query, @modes) %></p>
-        <% itinerary_data = itinerary_html(itineraries, %{conn: @conn, expanded: @expanded}) %>
-        <script id="js-tp-itinerary-data" type="text/plain"><%= raw(Poison.encode!(%{itineraryData: itinerary_data})) %></script>
-        <div id="react-root">
-            <%= unless Enum.empty?(itineraries) do render_react(%{itineraryData: itinerary_data}) end %>
-        </div>
-        <%= if Application.get_env(:site, :dev_server?) do %>
-          <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/tripplanresults.js" %>"></script>
-        <% else %>
-          <script defer src="<%= static_url(@conn, "/js/react.js") %>"></script>
-          <script defer src="<%= static_url(@conn, "/js/tripplanresults.js") %>"></script>
-        <% end %>
-        <% _ -> %>
-          <%= if assigns[:map_info] do %>
-            <% %{map_info: {map_data, map_src} } = assigns %>
-            <% map_data = Map.put(map_data, :tile_server_url, Application.fetch_env!(:site, :tile_server_url)) %>
-            <script id="js-trip-planner-map-data" type="text/plain"><%= raw Poison.encode!(map_data) %></script>
-            <link rel="stylesheet" href="<%= static_url(@conn, "/css/map.css") %>" data-turbolinks-track="reload">
-              <div class="trip-plan-initial-map map" id="react-root"></div>
-                <%= if Application.get_env(:site, :dev_server?) do %>
-                  <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/tripplanner.js" %>"></script>
-                <% else %>
-                  <script defer src="<%= static_url(@conn, "/js/react.js") %>"></script>
-                  <script defer src="<%= static_url(@conn, "/js/tripplanner.js") %>"></script>
-                <% end %>
-                <div class="map-static" style="background-image:url(<%= map_src %>);">
-                  <span class="sr-only">Map of downtown Boston"</span>
-                </div>
-            <% end %>
+       <% %{itineraries: {:ok, _}} -> %>
+          <p class="no-trips page-section">
+            <% l = length(@itineraries) %>
+            <%= "We found #{l} #{Inflex.inflect("trip", l)} for you" %>
+          </p>
+          <p class="instructions page-section"><%= itinerary_explanation(@query, @modes) %></p>
+          <% itinerary_data = itinerary_html(@itineraries, %{conn: @conn, expanded: @expanded}) %>
+          <script id="js-tp-itinerary-data" type="text/plain"><%= raw(Poison.encode!(%{itineraryData: itinerary_data})) %></script>
+          <div id="react-root">
+              <%= unless Enum.empty?(@itineraries) do render_react(%{itineraryData: itinerary_data}) end %>
+          </div>
+          <%= if Application.get_env(:site, :dev_server?) do %>
+            <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/tripplanresults.js" %>"></script>
+          <% else %>
+            <script defer src="<%= static_url(@conn, "/js/react.js") %>"></script>
+            <script defer src="<%= static_url(@conn, "/js/tripplanresults.js") %>"></script>
+          <% end %>
+       <% _ -> %>
+        <%= if assigns[:map_info] do %>
+          <% %{map_info: {map_data, map_src} } = assigns %>
+          <% map_data = Map.put(map_data, :tile_server_url, Application.fetch_env!(:site, :tile_server_url)) %>
+          <script id="js-trip-planner-map-data" type="text/plain"><%= raw Poison.encode!(map_data) %></script>
+          <link rel="stylesheet" href="<%= static_url(@conn, "/css/map.css") %>" data-turbolinks-track="reload">
+            <div class="trip-plan-initial-map map" id="react-root"></div>
+              <%= if Application.get_env(:site, :dev_server?) do %>
+                <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/tripplanner.js" %>"></script>
+              <% else %>
+                <script defer src="<%= static_url(@conn, "/js/react.js") %>"></script>
+                <script defer src="<%= static_url(@conn, "/js/tripplanner.js") %>"></script>
+              <% end %>
+              <div class="map-static" style="background-image:url(<%= map_src %>);">
+                <span class="sr-only">Map of downtown Boston"</span>
+              </div>
+          <% end %>
       <% end %>
     </div>
   </div>

--- a/apps/site/lib/trip_info.ex
+++ b/apps/site/lib/trip_info.ex
@@ -1,7 +1,7 @@
 defmodule TripInfo do
   require Routes.Route
   alias Routes.Route
-  alias Fares.MinMaxFare
+  alias Fares.HighestLowestFare
 
   @moduledoc """
   Wraps the important information about a trip.
@@ -113,7 +113,7 @@ defmodule TripInfo do
     trip = PredictedSchedule.trip(time)
     duration = duration(times, origin_id)
     stop_count = Enum.count(times)
-    base_fare = MinMaxFare.lowest_fare(route, trip, origin_id, destination_id)
+    base_fare = HighestLowestFare.lowest_fare(route, trip, origin_id, destination_id)
 
     %TripInfo{
       route: route,

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -204,19 +204,6 @@ defmodule SiteWeb.ScheduleControllerTest do
       refute :schedules in Map.keys(conn.assigns)
     end
 
-    test "frequency table does not have negative values for Green Line", %{conn: conn} do
-      conn =
-        get(
-          conn,
-          trip_view_path(conn, :show, "Green", origin: "place-north", vehicle_tooltips: %{})
-        )
-
-      for frequency <- conn.assigns.frequency_table do
-        assert frequency.min_headway > 0
-        assert frequency.max_headway > 0
-      end
-    end
-
     test "assigns schedules, frequency table, and origin for green line", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "Green-C", origin: "place-pktrm"))
       assert conn.assigns.schedules

--- a/apps/trip_plan/lib/trip_plan/transit_detail.ex
+++ b/apps/trip_plan/lib/trip_plan/transit_detail.ex
@@ -2,13 +2,20 @@ defmodule TripPlan.TransitDetail do
   @moduledoc """
   Additional information for legs taken on public transportation
   """
-  defstruct route_id: "",
-            trip_id: "",
-            intermediate_stop_ids: []
+
+  alias Fares.Fare
+
+  defstruct [:fares, route_id: "", trip_id: "", intermediate_stop_ids: []]
 
   @type t :: %__MODULE__{
           route_id: Routes.Route.id_t(),
           trip_id: Schedules.Trip.id_t(),
-          intermediate_stop_ids: [Stops.Stop.id_t()]
+          intermediate_stop_ids: [Stops.Stop.id_t()],
+          fares: fares
+        }
+
+  @type fares :: %{
+          highest_one_way_fare: Fare.t(),
+          lowest_one_way_fare: Fare.t()
         }
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🎫 Trip Planner | Compile fare information for an itinerary](https://app.asana.com/0/555089885850811/1175370216290833)

Add highest and lowest fares to each leg of an itinerary. Not used anywhere yet, but will be in follow-up work.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
