### PR TITLE
Update Trip Planner fares URLs for bus and subway

### DIFF
--- a/apps/site/lib/site/trip_plan/related_link.ex
+++ b/apps/site/lib/site/trip_plan/related_link.ex
@@ -146,7 +146,8 @@ defmodule Site.TripPlan.RelatedLink do
   end
 
   # if there are multiple fare links, show fare overview link
-  defp simplify_fare_text(fare_links) when Kernel.length(fare_links) > 1, do: [fare_overview_link()]
+  defp simplify_fare_text(fare_links) when Kernel.length(fare_links) > 1,
+    do: [fare_overview_link()]
 
   defp simplify_fare_text([fare_link]) do
     # if there's only one fare link, change the text to "View fare information"

--- a/apps/site/lib/site/trip_plan/related_link.ex
+++ b/apps/site/lib/site/trip_plan/related_link.ex
@@ -123,16 +123,8 @@ defmodule Site.TripPlan.RelatedLink do
     new(["View ", text, " fare information"], url)
   end
 
-  defp fare_link_text(:commuter_rail) do
-    "commuter rail"
-  end
-
-  defp fare_link_text(:ferry) do
-    "ferry"
-  end
-
-  defp fare_link_text(_) do
-    "bus/subway"
+  defp fare_link_text(type) when type in [:commuter_rail, :ferry, :bus, :subway] do
+    Atom.to_string(type) |> String.replace("_", " ")
   end
 
   defp fare_link_url_opts(type, leg, opts) when type in [:commuter_rail, :ferry] do
@@ -150,7 +142,7 @@ defmodule Site.TripPlan.RelatedLink do
   end
 
   defp fare_link_url_opts(type, _leg, _opts) when type in [:bus, :subway] do
-    {:bus_subway, []}
+    {"#{type}-fares", []}
   end
 
   defp simplify_fare_text([fare_link]) do

--- a/apps/site/lib/site/trip_plan/related_link.ex
+++ b/apps/site/lib/site/trip_plan/related_link.ex
@@ -145,6 +145,9 @@ defmodule Site.TripPlan.RelatedLink do
     {"#{type}-fares", []}
   end
 
+  # if there are multiple fare links, show fare overview link
+  defp simplify_fare_text(fare_links) when Kernel.length(fare_links) > 1, do: [fare_overview_link()]
+
   defp simplify_fare_text([fare_link]) do
     # if there's only one fare link, change the text to "View fare information"
     [%{fare_link | text: "View fare information"}]
@@ -152,6 +155,10 @@ defmodule Site.TripPlan.RelatedLink do
 
   defp simplify_fare_text(fare_links) do
     fare_links
+  end
+
+  defp fare_overview_link do
+    new(["View fare information"], "/fares")
   end
 end
 

--- a/apps/site/test/site/trip_plan/related_link_test.exs
+++ b/apps/site/test/site/trip_plan/related_link_test.exs
@@ -40,7 +40,7 @@ defmodule Site.TripPlan.RelatedLinkTest do
       end
     end
 
-    test "with multiple types of fares, returns relevant fare links", %{itinerary: itinerary} do
+    test "with multiple types of fares, returns one link to the fare overview", %{itinerary: itinerary} do
       for _i <- 0..10 do
         itinerary =
           itinerary
@@ -87,14 +87,11 @@ defmodule Site.TripPlan.RelatedLinkTest do
             assert text(fare_link) == "View fare information"
             assert url(fare_link) == expected_url
 
-          text_urls ->
-            # we reverse the lists since the fare links are at the end
-            links_with_expectations = Enum.zip(Enum.reverse(links), Enum.reverse(text_urls))
-
-            for {link, {expected_text, expected_url}} <- links_with_expectations do
-              assert text(link) =~ "View #{expected_text} fare information"
-              assert url(link) == expected_url
-            end
+          _text_urls ->
+             # only one expected
+            fare_link = List.last(links)
+            assert text(fare_link) == "View fare information"
+            assert url(fare_link) == "/fares"
         end
       end
     end

--- a/apps/site/test/site/trip_plan/related_link_test.exs
+++ b/apps/site/test/site/trip_plan/related_link_test.exs
@@ -54,10 +54,10 @@ defmodule Site.TripPlan.RelatedLinkTest do
         expected_text_url = fn leg ->
           case leg.mode do
             %{route_id: "1"} ->
-              {"bus/subway", fare_path(SiteWeb.Endpoint, :show, :bus_subway, [])}
+              {"bus", fare_path(SiteWeb.Endpoint, :show, "bus-fares", [])}
 
             %{route_id: "Blue"} ->
-              {"bus/subway", fare_path(SiteWeb.Endpoint, :show, :bus_subway, [])}
+              {"subway", fare_path(SiteWeb.Endpoint, :show, "subway-fares", [])}
 
             %{route_id: "CR-Lowell"} ->
               {"commuter rail",

--- a/apps/site/test/site/trip_plan/related_link_test.exs
+++ b/apps/site/test/site/trip_plan/related_link_test.exs
@@ -40,7 +40,9 @@ defmodule Site.TripPlan.RelatedLinkTest do
       end
     end
 
-    test "with multiple types of fares, returns one link to the fare overview", %{itinerary: itinerary} do
+    test "with multiple types of fares, returns one link to the fare overview", %{
+      itinerary: itinerary
+    } do
       for _i <- 0..10 do
         itinerary =
           itinerary
@@ -88,7 +90,7 @@ defmodule Site.TripPlan.RelatedLinkTest do
             assert url(fare_link) == expected_url
 
           _text_urls ->
-             # only one expected
+            # only one expected
             fare_link = List.last(links)
             assert text(fare_link) == "View fare information"
             assert url(fare_link) == "/fares"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🎫 Trip Planner | Update fare information URLs](https://app.asana.com/0/555089885850811/1176023923687794)

Turns out these correct URLs are also [hardcoded](https://github.com/mbta/dotcom/blob/c917e4799930b7636a178f01cb1fabc2d8216a97/apps/site/lib/site_web/views/schedule_view.ex#L426) in a [number](https://github.com/mbta/dotcom/blob/98a19925be72ff28a9cffd797b774d1d2ca046bc/apps/site/lib/site_web/views/fare_view.ex#L133) of other [places](https://github.com/mbta/dotcom/blob/8999a512499c2b695aceb44b07458b4553ede8da/apps/site/lib/site_web/templates/schedule/_trip_info.html.eex#L54).

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
