### PR TITLE
Show highest one-way fare in accordion for Trip Planner

### DIFF
--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -24,10 +24,16 @@
     background-color: $brand-primary-lightest-contrast;
     border: 1px solid $brand-primary;
     border-bottom: 0;
+    display: flex;
     font-size: $base-spacing;
+    justify-content: space-between;
     line-height: 1.5;
     margin-top: 0;
     padding: $base-spacing;
+
+    @include media-breakpoint-down(sm) {
+      display: block;
+    }
   }
 
   &-accessible {
@@ -80,5 +86,25 @@
     background-color: $gray-lightest;
     margin-bottom: $base-spacing;
     padding: $base-spacing;
+  }
+
+  &-fares {
+    min-width: 40%;
+    padding-left: $base-spacing;
+    padding-top: 0;
+
+    @include media-breakpoint-down(sm) {
+      padding-left: 0;
+      padding-top: $base-spacing;
+    }
+  }
+
+  &-fare-title {
+    font-size: $font-size-h5;
+    font-weight: bold;
+  }
+
+  &-fare {
+    padding-left: $base-spacing;
   }
 }

--- a/apps/site/assets/ts/trip-plan-results/__tests__/TripPlannerResultsTest.tsx
+++ b/apps/site/assets/ts/trip-plan-results/__tests__/TripPlannerResultsTest.tsx
@@ -7,6 +7,7 @@ import { TileServerUrl } from "../../leaflet/components/__mapdata";
 const html = "<div>Lots of content about the itinerary</div>";
 const tab_html = "<div>HTML for the accordion button</div>";
 const access_html = "<div>Accessible</div>";
+const fares_html = "<div>HTML content for fares</div>";
 const tile_server_url: TileServerUrl = "";
 
 const positions: [number, number][] = [
@@ -35,12 +36,12 @@ it("it renders", () => {
   createReactRoot();
   const tree = renderer.create(
     <TripPlannerResults
-      itineraryData={[{ html, access_html, tab_html, id: 1, map }]}
+      itineraryData={[{ html, access_html, fares_html, tab_html, id: 1, map }]}
     />
   );
   tree.update(
     <TripPlannerResults
-      itineraryData={[{ html, access_html, tab_html, id: 1, map }]}
+      itineraryData={[{ html, access_html, fares_html, tab_html, id: 1, map }]}
     />
   );
   expect(tree.toJSON()).toMatchSnapshot();

--- a/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
+++ b/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
@@ -8,18 +8,30 @@ exports[`it renders 1`] = `
     className="m-trip-plan-results__itinerary-header"
   >
     <div
-      className="m-trip-plan-results__itinerary-summary"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "<div>HTML for the accordion button</div>",
+      className="m-trip-plan-results__itinerary-header-content"
+    >
+      <div
+        className="m-trip-plan-results__itinerary-summary"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<div>HTML for the accordion button</div>",
+          }
         }
-      }
-    />
+      />
+      <div
+        className="m-trip-plan-results__itinerary-accessible"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<div>Accessible</div>",
+          }
+        }
+      />
+    </div>
     <div
-      className="m-trip-plan-results__itinerary-accessible"
+      className="m-trip-plan-results__itinerary-fares"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<div>Accessible</div>",
+          "__html": "<div>HTML content for fares</div>",
         }
       }
     />

--- a/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
+++ b/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
@@ -11,7 +11,7 @@ import {
 The following ignored functions are vanilla JS event handlers
 that are for HTML that gets injected into itinerary rows.
 Ideally, all the HTML of this component would be built in React
-which would make it easy to test in this file. Since that HTML is 
+which would make it easy to test in this file. Since that HTML is
 server rendered and injected, it is difficult to test from jest.
 It is being ignored now to prevent a codecov ding.
 */
@@ -75,13 +75,19 @@ const ItineraryAccordion = ({
 }: Props): ReactElement<HTMLElement> => (
   <div className="m-trip-plan-results__itinerary">
     <div className="m-trip-plan-results__itinerary-header">
+      <div className="m-trip-plan-results__itinerary-header-content">
+        <div
+          className="m-trip-plan-results__itinerary-summary"
+          dangerouslySetInnerHTML={{ __html: itinerary.tab_html }} // eslint-disable-line react/no-danger
+        />
+        <div
+          className="m-trip-plan-results__itinerary-accessible"
+          dangerouslySetInnerHTML={{ __html: itinerary.access_html }} // eslint-disable-line react/no-danger
+        />
+      </div>
       <div
-        className="m-trip-plan-results__itinerary-summary"
-        dangerouslySetInnerHTML={{ __html: itinerary.tab_html }} // eslint-disable-line react/no-danger
-      />
-      <div
-        className="m-trip-plan-results__itinerary-accessible"
-        dangerouslySetInnerHTML={{ __html: itinerary.access_html }} // eslint-disable-line react/no-danger
+        className="m-trip-plan-results__itinerary-fares"
+        dangerouslySetInnerHTML={{ __html: itinerary.fares_html }} // eslint-disable-line react/no-danger
       />
     </div>
     <Accordion

--- a/apps/site/assets/ts/trip-plan-results/components/TripPlannerResults.tsx
+++ b/apps/site/assets/ts/trip-plan-results/components/TripPlannerResults.tsx
@@ -9,6 +9,7 @@ export interface Itinerary {
   map: MapData;
   tab_html: string;
   access_html: string;
+  fares_html: string;
 }
 
 interface Props {

--- a/apps/site/lib/site/trip_plan/related_link.ex
+++ b/apps/site/lib/site/trip_plan/related_link.ex
@@ -123,16 +123,8 @@ defmodule Site.TripPlan.RelatedLink do
     new(["View ", text, " fare information"], url)
   end
 
-  defp fare_link_text(:commuter_rail) do
-    "commuter rail"
-  end
-
-  defp fare_link_text(:ferry) do
-    "ferry"
-  end
-
-  defp fare_link_text(_) do
-    "bus/subway"
+  defp fare_link_text(type) when type in [:commuter_rail, :ferry, :bus, :subway] do
+    Atom.to_string(type) |> String.replace("_", " ")
   end
 
   defp fare_link_url_opts(type, leg, opts) when type in [:commuter_rail, :ferry] do
@@ -150,8 +142,12 @@ defmodule Site.TripPlan.RelatedLink do
   end
 
   defp fare_link_url_opts(type, _leg, _opts) when type in [:bus, :subway] do
-    {:bus_subway, []}
+    {"#{type}-fares", []}
   end
+
+  # if there are multiple fare links, show fare overview link
+  defp simplify_fare_text(fare_links) when Kernel.length(fare_links) > 1,
+    do: [fare_overview_link()]
 
   defp simplify_fare_text([fare_link]) do
     # if there's only one fare link, change the text to "View fare information"
@@ -160,6 +156,10 @@ defmodule Site.TripPlan.RelatedLink do
 
   defp simplify_fare_text(fare_links) do
     fare_links
+  end
+
+  defp fare_overview_link do
+    new(["View fare information"], "/fares")
   end
 end
 

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
@@ -1,0 +1,3 @@
+<div class="m-trip-plan-results__itinerary-fare-title">Base Fare Estimate</div>
+<div class="m-trip-plan-results__itinerary-fare"><%= @one_way_total %> one way</div>
+<div class="m-trip-plan-results__itinerary-fare"><%= @round_trip_total %> round trip</div>

--- a/apps/site/test/site/trip_plan/related_link_test.exs
+++ b/apps/site/test/site/trip_plan/related_link_test.exs
@@ -40,7 +40,9 @@ defmodule Site.TripPlan.RelatedLinkTest do
       end
     end
 
-    test "with multiple types of fares, returns relevant fare links", %{itinerary: itinerary} do
+    test "with multiple types of fares, returns one link to the fare overview", %{
+      itinerary: itinerary
+    } do
       for _i <- 0..10 do
         itinerary =
           itinerary
@@ -54,10 +56,10 @@ defmodule Site.TripPlan.RelatedLinkTest do
         expected_text_url = fn leg ->
           case leg.mode do
             %{route_id: "1"} ->
-              {"bus/subway", fare_path(SiteWeb.Endpoint, :show, :bus_subway, [])}
+              {"bus", fare_path(SiteWeb.Endpoint, :show, "bus-fares", [])}
 
             %{route_id: "Blue"} ->
-              {"bus/subway", fare_path(SiteWeb.Endpoint, :show, :bus_subway, [])}
+              {"subway", fare_path(SiteWeb.Endpoint, :show, "subway-fares", [])}
 
             %{route_id: "CR-Lowell"} ->
               {"commuter rail",
@@ -87,14 +89,11 @@ defmodule Site.TripPlan.RelatedLinkTest do
             assert text(fare_link) == "View fare information"
             assert url(fare_link) == expected_url
 
-          text_urls ->
-            # we reverse the lists since the fare links are at the end
-            links_with_expectations = Enum.zip(Enum.reverse(links), Enum.reverse(text_urls))
-
-            for {link, {expected_text, expected_url}} <- links_with_expectations do
-              assert text(link) =~ "View #{expected_text} fare information"
-              assert url(link) == expected_url
-            end
+          _text_urls ->
+            # only one expected
+            fare_link = List.last(links)
+            assert text(fare_link) == "View fare information"
+            assert url(fare_link) == "/fares"
         end
       end
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Base Fares | One-way/base fare trips and total price](https://app.asana.com/0/555089885850811/1162903717356809)

This ticket adds the logic to include an estimation of the fares for the itineraries (one way and round trip):<br/>
<img width="822" alt="image" src="https://user-images.githubusercontent.com/61979382/83139645-b63c7c80-a0ba-11ea-8f21-b5d4bace2480.png">



