### PR TITLE
Display recommended monthly pass in the trip plan results summary

### DIFF
--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -99,7 +99,8 @@ defmodule Fares.Format do
   def name(:premium_ride), do: "Premium Ride"
   def name(:invalid), do: "Invalid Fare"
 
-  @spec full_name(Fare.t()) :: String.t() | iolist
+  @spec full_name(Fare.t() | nil) :: String.t() | iolist
+  def full_name(nil), do: "Free"
   def full_name(%Fare{mode: :subway, duration: :month}), do: "Monthly LinkPass"
   def full_name(%Fare{mode: :commuter_rail, duration: :weekend}), do: "Weekend Pass"
   def full_name(%Fare{duration: :week}), do: "7-Day Pass"

--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -1,4 +1,7 @@
 defmodule Fares.Format do
+  @moduledoc """
+  Formatting functions for fare data.
+  """
   alias Fares.{Fare, Summary}
 
   @type mode_type :: :bus_subway | :commuter_rail | :ferry

--- a/apps/fares/lib/month.ex
+++ b/apps/fares/lib/month.ex
@@ -11,8 +11,8 @@ defmodule Fares.Month do
   @type fare_fn :: (Keyword.t() -> [Fare.t()])
 
   @spec lowest_pass(
-          Route.t(),
-          Trip.t() | nil,
+          Route.t() | Route.id_t(),
+          Trip.t() | Trip.id_t() | nil,
           Stop.id_t(),
           Stop.id_t(),
           fare_fn()
@@ -21,6 +21,16 @@ defmodule Fares.Month do
   def lowest_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
   def lowest_pass(nil, _, _, _, _), do: nil
 
+  def lowest_pass(route_id, trip, origin_id, destination_id, fare_fn) when is_binary(route_id) do
+    route = Routes.Repo.get(route_id)
+    lowest_pass(route, trip, origin_id, destination_id, fare_fn)
+  end
+
+  def lowest_pass(route, trip_id, origin_id, destination_id, fare_fn) when is_binary(trip_id) do
+    trip = Schedules.Repo.trip(trip_id)
+    lowest_pass(route, trip, origin_id, destination_id, fare_fn)
+  end
+
   def lowest_pass(route, trip, origin_id, destination_id, fare_fn) do
     route
     |> get_fares(trip, origin_id, destination_id, fare_fn)
@@ -28,8 +38,8 @@ defmodule Fares.Month do
   end
 
   @spec highest_pass(
-          Route.t(),
-          Trip.t() | nil,
+          Route.t() | Route.id_t(),
+          Trip.t() | Trip.id_t() | nil,
           Stop.id_t(),
           Stop.id_t(),
           fare_fn()
@@ -37,6 +47,16 @@ defmodule Fares.Month do
           Fare.t() | nil
   def highest_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
   def highest_pass(nil, _, _, _, _), do: nil
+
+  def highest_pass(route_id, trip, origin_id, destination_id, fare_fn) when is_binary(route_id) do
+    route = Routes.Repo.get(route_id)
+    highest_pass(route, trip, origin_id, destination_id, fare_fn)
+  end
+
+  def highest_pass(route, trip_id, origin_id, destination_id, fare_fn) when is_binary(trip_id) do
+    trip = Schedules.Repo.trip(trip_id)
+    highest_pass(route, trip, origin_id, destination_id, fare_fn)
+  end
 
   def highest_pass(route, trip, origin_id, destination_id, fare_fn) do
     route

--- a/apps/fares/lib/month.ex
+++ b/apps/fares/lib/month.ex
@@ -10,7 +10,7 @@ defmodule Fares.Month do
 
   @type fare_fn :: (Keyword.t() -> [Fare.t()])
 
-  @spec lowest_pass(
+  @spec recommended_pass(
           Route.t() | Route.id_t(),
           Trip.t() | Trip.id_t() | nil,
           Stop.id_t(),
@@ -18,26 +18,28 @@ defmodule Fares.Month do
           fare_fn()
         ) ::
           Fare.t() | nil
-  def lowest_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
-  def lowest_pass(nil, _, _, _, _), do: nil
+  def recommended_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def recommended_pass(nil, _, _, _, _), do: nil
 
-  def lowest_pass(route_id, trip, origin_id, destination_id, fare_fn) when is_binary(route_id) do
+  def recommended_pass(route_id, trip, origin_id, destination_id, fare_fn)
+      when is_binary(route_id) do
     route = Routes.Repo.get(route_id)
-    lowest_pass(route, trip, origin_id, destination_id, fare_fn)
+    recommended_pass(route, trip, origin_id, destination_id, fare_fn)
   end
 
-  def lowest_pass(route, trip_id, origin_id, destination_id, fare_fn) when is_binary(trip_id) do
+  def recommended_pass(route, trip_id, origin_id, destination_id, fare_fn)
+      when is_binary(trip_id) do
     trip = Schedules.Repo.trip(trip_id)
-    lowest_pass(route, trip, origin_id, destination_id, fare_fn)
+    recommended_pass(route, trip, origin_id, destination_id, fare_fn)
   end
 
-  def lowest_pass(route, trip, origin_id, destination_id, fare_fn) do
+  def recommended_pass(route, trip, origin_id, destination_id, fare_fn) do
     route
     |> get_fares(trip, origin_id, destination_id, fare_fn)
     |> Enum.min_by(& &1.cents, fn -> nil end)
   end
 
-  @spec highest_pass(
+  @spec base_pass(
           Route.t() | Route.id_t(),
           Trip.t() | Trip.id_t() | nil,
           Stop.id_t(),
@@ -45,20 +47,20 @@ defmodule Fares.Month do
           fare_fn()
         ) ::
           Fare.t() | nil
-  def highest_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
-  def highest_pass(nil, _, _, _, _), do: nil
+  def base_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def base_pass(nil, _, _, _, _), do: nil
 
-  def highest_pass(route_id, trip, origin_id, destination_id, fare_fn) when is_binary(route_id) do
+  def base_pass(route_id, trip, origin_id, destination_id, fare_fn) when is_binary(route_id) do
     route = Routes.Repo.get(route_id)
-    highest_pass(route, trip, origin_id, destination_id, fare_fn)
+    base_pass(route, trip, origin_id, destination_id, fare_fn)
   end
 
-  def highest_pass(route, trip_id, origin_id, destination_id, fare_fn) when is_binary(trip_id) do
+  def base_pass(route, trip_id, origin_id, destination_id, fare_fn) when is_binary(trip_id) do
     trip = Schedules.Repo.trip(trip_id)
-    highest_pass(route, trip, origin_id, destination_id, fare_fn)
+    base_pass(route, trip, origin_id, destination_id, fare_fn)
   end
 
-  def highest_pass(route, trip, origin_id, destination_id, fare_fn) do
+  def base_pass(route, trip, origin_id, destination_id, fare_fn) do
     route
     |> get_fares(trip, origin_id, destination_id, fare_fn)
     |> Enum.max_by(& &1.cents, fn -> nil end)

--- a/apps/fares/lib/month.ex
+++ b/apps/fares/lib/month.ex
@@ -1,0 +1,99 @@
+defmodule Fares.Month do
+  @moduledoc """
+  Calculates the lowest and highest monthly pass fare for a particular trip.
+  """
+
+  alias Fares.{Fare, Repo}
+  alias Routes.Route
+  alias Schedules.Trip
+  alias Stops.Stop
+
+  @type fare_fn :: (Keyword.t() -> [Fare.t()])
+
+  @spec lowest_pass(
+          Route.t(),
+          Trip.t() | nil,
+          Stop.id_t(),
+          Stop.id_t(),
+          fare_fn()
+        ) ::
+          Fare.t() | nil
+  def lowest_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def lowest_pass(nil, _, _, _, _), do: nil
+
+  def lowest_pass(route, trip, origin_id, destination_id, fare_fn) do
+    route
+    |> get_fares(trip, origin_id, destination_id, fare_fn)
+    |> Enum.min_by(& &1.cents, fn -> nil end)
+  end
+
+  @spec highest_pass(
+          Route.t(),
+          Trip.t() | nil,
+          Stop.id_t(),
+          Stop.id_t(),
+          fare_fn()
+        ) ::
+          Fare.t() | nil
+  def highest_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def highest_pass(nil, _, _, _, _), do: nil
+
+  def highest_pass(route, trip, origin_id, destination_id, fare_fn) do
+    route
+    |> get_fares(trip, origin_id, destination_id, fare_fn)
+    |> Enum.max_by(& &1.cents, fn -> nil end)
+  end
+
+  @spec get_fares(Route.t(), Trip.t() | nil, Stop.id_t(), Stop.id_t(), fare_fn()) :: [Fare.t()]
+  defp get_fares(route, trip, origin_id, destination_id, fare_fn) do
+    route_filters =
+      route.type
+      |> Route.type_atom()
+      |> name_or_mode_filter(route, origin_id, destination_id, trip)
+
+    [reduced: nil, duration: :month]
+    |> Keyword.merge(route_filters)
+    |> fare_fn.()
+  end
+
+  @spec name_or_mode_filter(atom(), Route.t(), Stop.id_t(), Stop.id_t(), Trip.t() | nil) ::
+          Keyword.t()
+  defp name_or_mode_filter(:subway, _route, _origin_id, _destination_id, _trip) do
+    [mode: :subway]
+  end
+
+  defp name_or_mode_filter(_, %{description: :rail_replacement_bus}, _, _, _) do
+    [name: :free_fare]
+  end
+
+  defp name_or_mode_filter(_, %{id: "CR-Foxboro"}, _, _, _) do
+    [name: :foxboro]
+  end
+
+  defp name_or_mode_filter(:bus, %{id: route_id}, origin_id, _destination_id, _trip) do
+    name =
+      cond do
+        Fares.inner_express?(route_id) -> :inner_express_bus
+        Fares.outer_express?(route_id) -> :outer_express_bus
+        Fares.silver_line_airport_stop?(route_id, origin_id) -> :free_fare
+        Fares.silver_line_rapid_transit?(route_id) -> :subway
+        true -> :local_bus
+      end
+
+    [name: name]
+  end
+
+  defp name_or_mode_filter(:commuter_rail, _, origin_id, destination_id, trip) do
+    case Fares.fare_for_stops(:commuter_rail, origin_id, destination_id, trip) do
+      {:ok, name} ->
+        [name: name]
+
+      :error ->
+        [mode: :commuter_rail]
+    end
+  end
+
+  defp name_or_mode_filter(:ferry, _, origin_id, destination_id, _) do
+    [name: :ferry |> Fares.fare_for_stops(origin_id, destination_id) |> elem(1)]
+  end
+end

--- a/apps/fares/lib/one_way.ex
+++ b/apps/fares/lib/one_way.ex
@@ -15,7 +15,7 @@ defmodule Fares.OneWay do
 
   @default_trip %Trip{name: "", id: ""}
 
-  @spec lowest_fare(
+  @spec recommended_fare(
           Route.t() | map,
           Trip.t() | map,
           Stops.Stop.id_t(),
@@ -23,20 +23,20 @@ defmodule Fares.OneWay do
           (Keyword.t() -> [Fare.t()])
         ) ::
           Fare.t() | nil
-  def lowest_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
-  def lowest_fare(nil, _, _, _, _), do: nil
+  def recommended_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def recommended_fare(nil, _, _, _, _), do: nil
 
-  def lowest_fare(route, nil, origin_id, destination_id, fare_fn) do
-    lowest_fare(route, @default_trip, origin_id, destination_id, fare_fn)
+  def recommended_fare(route, nil, origin_id, destination_id, fare_fn) do
+    recommended_fare(route, @default_trip, origin_id, destination_id, fare_fn)
   end
 
-  def lowest_fare(route, trip, origin_id, destination_id, fare_fn) do
+  def recommended_fare(route, trip, origin_id, destination_id, fare_fn) do
     route
     |> get_fares(trip, origin_id, destination_id, fare_fn)
     |> Enum.min_by(& &1.cents, fn -> nil end)
   end
 
-  @spec highest_fare(
+  @spec base_fare(
           Route.t() | map,
           Trip.t() | map,
           Stops.Stop.id_t(),
@@ -44,14 +44,14 @@ defmodule Fares.OneWay do
           (Keyword.t() -> [Fare.t()])
         ) ::
           Fare.t() | nil
-  def highest_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
-  def highest_fare(nil, _, _, _, _), do: nil
+  def base_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def base_fare(nil, _, _, _, _), do: nil
 
-  def highest_fare(route, nil, origin_id, destination_id, fare_fn) do
-    highest_fare(route, @default_trip, origin_id, destination_id, fare_fn)
+  def base_fare(route, nil, origin_id, destination_id, fare_fn) do
+    base_fare(route, @default_trip, origin_id, destination_id, fare_fn)
   end
 
-  def highest_fare(route, trip, origin_id, destination_id, fare_fn) do
+  def base_fare(route, trip, origin_id, destination_id, fare_fn) do
     route
     |> get_fares(trip, origin_id, destination_id, fare_fn)
     |> Enum.max_by(& &1.cents, fn -> nil end)

--- a/apps/fares/lib/one_way.ex
+++ b/apps/fares/lib/one_way.ex
@@ -1,4 +1,4 @@
-defmodule Fares.HighestLowestFare do
+defmodule Fares.OneWay do
   @moduledoc """
   Calculates the lowest and highest fare for a particular trip i.e. a regular priced, non-discounted, one-way fare for the given mode.
   Commuter rail and ferry fares distinguish between the possible sets of stops.
@@ -57,7 +57,7 @@ defmodule Fares.HighestLowestFare do
     |> Enum.max_by(& &1.cents, fn -> nil end)
   end
 
-  def get_fares(route, trip, origin_id, destination_id, fare_fn) do
+  defp get_fares(route, trip, origin_id, destination_id, fare_fn) do
     route_filters =
       route.type
       |> Route.type_atom()

--- a/apps/fares/lib/one_way.ex
+++ b/apps/fares/lib/one_way.ex
@@ -22,7 +22,7 @@ defmodule Fares.OneWay do
           Stops.Stop.id_t(),
           (Keyword.t() -> [Fare.t()])
         ) ::
-          String.t() | nil
+          Fare.t() | nil
   def lowest_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
   def lowest_fare(nil, _, _, _, _), do: nil
 
@@ -43,7 +43,7 @@ defmodule Fares.OneWay do
           Stops.Stop.id_t(),
           (Keyword.t() -> [Fare.t()])
         ) ::
-          String.t() | nil
+          Fare.t() | nil
   def highest_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
   def highest_fare(nil, _, _, _, _), do: nil
 

--- a/apps/fares/test/highest_lowest_fare_test.exs
+++ b/apps/fares/test/highest_lowest_fare_test.exs
@@ -13,18 +13,6 @@ defmodule HighestLowestFareTest do
     refute highest_fare(nil, nil, nil, nil)
   end
 
-  test "excludes weekend commuter rail rates" do
-    route = %Route{type: 2}
-    origin_id = "place-north"
-    destination_id = "Haverhill"
-
-    assert %Fares.Fare{cents: 1100, duration: :single_trip} =
-             lowest_fare(route, nil, origin_id, destination_id)
-
-    assert %Fares.Fare{cents: 1100, duration: :single_trip} =
-             highest_fare(route, nil, origin_id, destination_id)
-  end
-
   describe "subway" do
     @route %Route{type: 0}
 
@@ -259,6 +247,18 @@ defmodule HighestLowestFareTest do
 
       assert %Fares.Fare{cents: 401} =
                highest_fare(route, nil, origin_id, destination_id, fare_fn)
+    end
+
+    test "excludes weekend commuter rail rates" do
+      route = %Route{type: 2}
+      origin_id = "place-north"
+      destination_id = "Haverhill"
+
+      assert %Fares.Fare{cents: 1100, duration: :single_trip} =
+               lowest_fare(route, nil, origin_id, destination_id)
+
+      assert %Fares.Fare{cents: 1100, duration: :single_trip} =
+               highest_fare(route, nil, origin_id, destination_id)
     end
 
     test "returns the appropriate fare for Foxboro Special Events" do

--- a/apps/fares/test/highest_lowest_fare_test.exs
+++ b/apps/fares/test/highest_lowest_fare_test.exs
@@ -8,7 +8,7 @@ defmodule HighestLowestFareTest do
 
   @default_filters [reduced: nil, duration: :single_trip]
 
-  test "returns an empty string if no route is provided" do
+  test "returns nil if no route is provided" do
     refute lowest_fare(nil, nil, nil, nil)
     refute highest_fare(nil, nil, nil, nil)
   end

--- a/apps/fares/test/month_test.exs
+++ b/apps/fares/test/month_test.exs
@@ -1,0 +1,317 @@
+defmodule Fares.MonthTest do
+  use ExUnit.Case, async: true
+
+  alias Fares.{Fare, Month}
+  alias Routes.Route
+  alias Schedules.Trip
+
+  @default_filters [reduced: nil, duration: :month]
+
+  describe "nil route" do
+    test "returns nil if no route is provided" do
+      assert Month.lowest_pass(nil, nil, nil, nil) == nil
+      assert Month.highest_pass(nil, nil, nil, nil) == nil
+    end
+  end
+
+  describe "subway" do
+    @subway_route %Route{type: 0}
+
+    @subway_fares [
+      %Fare{
+        additional_valid_modes: [:bus],
+        cents: 9_000,
+        duration: :month,
+        media: [:charlie_card, :charlie_ticket],
+        mode: :subway,
+        name: :subway,
+        price_label: nil,
+        reduced: nil
+      }
+    ]
+
+    test "returns the lowest and highest month pass fares that are not discounted" do
+      fare_fn = fn @default_filters ++ [mode: :subway] -> @subway_fares end
+
+      assert %Fare{cents: 9_000} = Month.lowest_pass(@subway_route, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.highest_pass(@subway_route, nil, nil, nil, fare_fn)
+    end
+  end
+
+  describe "bus" do
+    @bus_fares [
+      %Fare{
+        additional_valid_modes: [],
+        cents: 5_500,
+        duration: :month,
+        media: [:charlie_card, :charlie_ticket],
+        mode: :bus,
+        name: :local_bus,
+        price_label: nil,
+        reduced: nil
+      },
+      %Fare{
+        additional_valid_modes: [],
+        cents: 13_600,
+        duration: :month,
+        media: [:charlie_card, :charlie_ticket],
+        mode: :bus,
+        name: :inner_express_bus,
+        price_label: nil,
+        reduced: nil
+      },
+      %Fare{
+        additional_valid_modes: [],
+        cents: 16_800,
+        duration: :month,
+        media: [:charlie_card, :charlie_ticket],
+        mode: :bus,
+        name: :outer_express_bus,
+        price_label: nil,
+        reduced: nil
+      }
+    ]
+
+    test "returns the lowest and highest month pass fares that are not discounted for the local bus" do
+      local_route = %Route{type: 3, id: "1"}
+
+      fare_fn = fn @default_filters ++ [name: :local_bus] ->
+        Enum.filter(@bus_fares, &(&1.name == :local_bus))
+      end
+
+      assert %Fare{cents: 5_500} = Month.lowest_pass(local_route, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.highest_pass(local_route, nil, nil, nil, fare_fn)
+    end
+
+    test "returns the lowest and highest month pass fares that are not discounted for the inner express bus" do
+      inner_express_route = %Route{type: 3, id: "170"}
+
+      fare_fn = fn @default_filters ++ [name: :inner_express_bus] ->
+        Enum.filter(@bus_fares, &(&1.name == :inner_express_bus))
+      end
+
+      assert %Fare{cents: 13_600} = Month.lowest_pass(inner_express_route, nil, nil, nil, fare_fn)
+
+      assert %Fare{cents: 13_600} =
+               Month.highest_pass(inner_express_route, nil, nil, nil, fare_fn)
+    end
+
+    test "returns the lowest and highest month pass fares that are not discounted for the outer express bus" do
+      outer_express_route = %Route{type: 3, id: "352"}
+
+      fare_fn = fn @default_filters ++ [name: :outer_express_bus] ->
+        Enum.filter(@bus_fares, &(&1.name == :outer_express_bus))
+      end
+
+      assert %Fare{cents: 16_800} = Month.lowest_pass(outer_express_route, nil, nil, nil, fare_fn)
+
+      assert %Fare{cents: 16_800} =
+               Month.highest_pass(outer_express_route, nil, nil, nil, fare_fn)
+    end
+
+    test "returns the lowest and highest subway pass fares for the SL1, SL2, and SL3 routes" do
+      sl1 = %Route{type: 3, id: "741"}
+      sl2 = %Route{type: 3, id: "742"}
+      sl3 = %Route{type: 3, id: "743"}
+
+      fare_fn = fn @default_filters ++ [name: :subway] ->
+        Enum.filter(@subway_fares, &(&1.name == :subway))
+      end
+
+      assert %Fare{cents: 9_000} = Month.lowest_pass(sl1, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.highest_pass(sl1, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.lowest_pass(sl2, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.highest_pass(sl2, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.lowest_pass(sl3, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.highest_pass(sl3, nil, nil, nil, fare_fn)
+    end
+
+    test "returns the lowest and highest bus pass fares for the SL4 and SL5 routes" do
+      sl4 = %Route{type: 3, id: "751"}
+      sl5 = %Route{type: 3, id: "749"}
+
+      fare_fn = fn @default_filters ++ [name: :local_bus] ->
+        Enum.filter(@bus_fares, &(&1.name == :local_bus))
+      end
+
+      assert %Fare{cents: 5_500} = Month.lowest_pass(sl4, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.highest_pass(sl4, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.lowest_pass(sl5, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.highest_pass(sl5, nil, nil, nil, fare_fn)
+    end
+  end
+
+  describe "commuter rail" do
+    test "returns the lowest and highest one-way fares that are not discounted for a trip originating in Zone 1A" do
+      route = %Route{type: 2}
+      origin_id = "place-north"
+      destination_id = "Haverhill"
+
+      fare_fn = fn @default_filters ++ [name: {:zone, "7"}] ->
+        [
+          %Fare{
+            additional_valid_modes: [:subway, :bus, :ferry],
+            cents: 36_000,
+            duration: :month,
+            media: [:commuter_ticket],
+            mode: :commuter_rail,
+            name: {:zone, "7"},
+            price_label: nil,
+            reduced: nil
+          },
+          %Fare{
+            additional_valid_modes: [],
+            cents: 35_000,
+            duration: :month,
+            media: [:mticket],
+            mode: :commuter_rail,
+            name: {:zone, "7"},
+            price_label: nil,
+            reduced: nil
+          }
+        ]
+      end
+
+      assert %Fare{cents: 35_000} =
+               Month.lowest_pass(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fare{cents: 36_000} =
+               Month.highest_pass(route, nil, origin_id, destination_id, fare_fn)
+    end
+
+    test "returns the lowest and highest one-way fares that are not discounted for a trip terminating in Zone 1A" do
+      route = %Route{type: 2}
+      origin_id = "Ballardvale"
+      destination_id = "place-north"
+
+      fare_fn = fn @default_filters ++ [name: {:zone, "4"}] ->
+        [
+          %Fare{
+            additional_valid_modes: [:subway, :bus, :ferry],
+            cents: 28_100,
+            duration: :month,
+            media: [:commuter_ticket],
+            mode: :commuter_rail,
+            name: {:zone, "4"},
+            price_label: nil,
+            reduced: nil
+          },
+          %Fare{
+            additional_valid_modes: [],
+            cents: 27_100,
+            duration: :month,
+            media: [:mticket],
+            mode: :commuter_rail,
+            name: {:zone, "4"},
+            price_label: nil,
+            reduced: nil
+          }
+        ]
+      end
+
+      assert %Fare{cents: 27_100} =
+               Month.lowest_pass(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fare{cents: 28_100} =
+               Month.highest_pass(route, nil, origin_id, destination_id, fare_fn)
+    end
+
+    test "returns an interzone fares that are not discounted for a trip that does not originate/terminate in Zone 1A" do
+      route = %Route{type: 2}
+      origin_id = "Ballardvale"
+      destination_id = "Haverhill"
+
+      fare_fn = fn @default_filters ++ [name: {:interzone, "4"}] ->
+        [
+          %Fare{
+            additional_valid_modes: [:bus],
+            cents: 13_900,
+            duration: :month,
+            media: [:commuter_ticket],
+            mode: :commuter_rail,
+            name: {:interzone, "4"},
+            price_label: nil,
+            reduced: nil
+          },
+          %Fare{
+            additional_valid_modes: [],
+            cents: 12_900,
+            duration: :month,
+            media: [:mticket],
+            mode: :commuter_rail,
+            name: {:interzone, "4"},
+            price_label: nil,
+            reduced: nil
+          }
+        ]
+      end
+
+      assert %Fare{cents: 12_900} =
+               Month.lowest_pass(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fare{cents: 13_900} =
+               Month.highest_pass(route, nil, origin_id, destination_id, fare_fn)
+    end
+
+    test "returns zone-based fares for standard trips on Foxboro pilot" do
+      route = %Route{type: 2, id: "CR-Franklin"}
+      trip_1 = %Trip{name: "751", id: "CR-Weekday-Fall-19-751"}
+      trip_2 = %Trip{name: "759", id: "CR-Weekday-Fall-19-759"}
+
+      assert %Fare{name: {:zone, "4"}} =
+               Month.lowest_pass(route, trip_1, "place-sstat", "place-FS-0049")
+
+      assert %Fare{name: {:interzone, "3"}} =
+               Month.lowest_pass(route, trip_2, "place-FB-0118", "place-FS-0049")
+    end
+
+    test "returns nil if no matching fares found" do
+      route = %Route{type: 2, id: "CapeFlyer"}
+      origin_id = "place-sstat"
+      destination_id = "Hyannis"
+
+      fare_fn = fn _ -> [] end
+
+      assert Month.lowest_pass(route, nil, origin_id, destination_id, fare_fn) == nil
+    end
+  end
+
+  describe "ferry" do
+    test "returns the fares that are not discounted for the correct ferry trip" do
+      route = %Route{type: 4}
+      origin_id = "Boat-Charlestown"
+      destination_id = "Boat-Long-South"
+
+      fare_fn = fn @default_filters ++ [name: :ferry_inner_harbor] ->
+        [
+          %Fare{
+            additional_valid_modes: [:subway, :bus, :commuter_rail],
+            cents: 9_000,
+            duration: :month,
+            media: [:charlie_ticket],
+            mode: :ferry,
+            name: :ferry_inner_harbor,
+            price_label: nil,
+            reduced: nil
+          },
+          %Fare{
+            additional_valid_modes: [],
+            cents: 8_000,
+            duration: :month,
+            media: [:mticket],
+            mode: :ferry,
+            name: :ferry_inner_harbor,
+            price_label: nil,
+            reduced: nil
+          }
+        ]
+      end
+
+      assert %Fare{cents: 8_000} =
+               Month.lowest_pass(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fare{cents: 9_000} =
+               Month.highest_pass(route, nil, origin_id, destination_id, fare_fn)
+    end
+  end
+end

--- a/apps/fares/test/month_test.exs
+++ b/apps/fares/test/month_test.exs
@@ -272,6 +272,17 @@ defmodule Fares.MonthTest do
                Month.lowest_pass(route, trip_2, "place-FB-0118", "place-FS-0049")
     end
 
+    test "accepts a Trip ID" do
+      route = %Route{type: 2, id: "CR-Franklin"}
+      trip_id = "CR-Weekday-Fall-19-751"
+
+      assert %Fare{name: {:zone, "4"}} =
+               Month.lowest_pass(route, trip_id, "place-sstat", "place-FS-0049")
+
+      assert %Fare{name: {:zone, "4"}} =
+               Month.highest_pass(route, trip_id, "place-sstat", "place-FS-0049")
+    end
+
     test "returns nil if no matching fares found" do
       route = %Route{type: 2, id: "CapeFlyer"}
       origin_id = "place-sstat"

--- a/apps/fares/test/month_test.exs
+++ b/apps/fares/test/month_test.exs
@@ -9,8 +9,8 @@ defmodule Fares.MonthTest do
 
   describe "nil route" do
     test "returns nil if no route is provided" do
-      assert Month.lowest_pass(nil, nil, nil, nil) == nil
-      assert Month.highest_pass(nil, nil, nil, nil) == nil
+      assert Month.recommended_pass(nil, nil, nil, nil) == nil
+      assert Month.base_pass(nil, nil, nil, nil) == nil
     end
   end
 
@@ -33,15 +33,15 @@ defmodule Fares.MonthTest do
     test "returns the lowest and highest month pass fares that are not discounted" do
       fare_fn = fn @default_filters ++ [mode: :subway] -> @subway_fares end
 
-      assert %Fare{cents: 9_000} = Month.lowest_pass(@subway_route, nil, nil, nil, fare_fn)
-      assert %Fare{cents: 9_000} = Month.highest_pass(@subway_route, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.recommended_pass(@subway_route, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass(@subway_route, nil, nil, nil, fare_fn)
     end
 
     test "accepts a Route ID" do
       fare_fn = fn @default_filters ++ [mode: :subway] -> @subway_fares end
 
-      assert %Fare{cents: 9_000} = Month.lowest_pass("Red", nil, nil, nil, fare_fn)
-      assert %Fare{cents: 9_000} = Month.highest_pass("Red", nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.recommended_pass("Red", nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass("Red", nil, nil, nil, fare_fn)
     end
   end
 
@@ -86,8 +86,8 @@ defmodule Fares.MonthTest do
         Enum.filter(@bus_fares, &(&1.name == :local_bus))
       end
 
-      assert %Fare{cents: 5_500} = Month.lowest_pass(local_route, nil, nil, nil, fare_fn)
-      assert %Fare{cents: 5_500} = Month.highest_pass(local_route, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.recommended_pass(local_route, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.base_pass(local_route, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest month pass fares that are not discounted for the inner express bus" do
@@ -97,10 +97,10 @@ defmodule Fares.MonthTest do
         Enum.filter(@bus_fares, &(&1.name == :inner_express_bus))
       end
 
-      assert %Fare{cents: 13_600} = Month.lowest_pass(inner_express_route, nil, nil, nil, fare_fn)
-
       assert %Fare{cents: 13_600} =
-               Month.highest_pass(inner_express_route, nil, nil, nil, fare_fn)
+               Month.recommended_pass(inner_express_route, nil, nil, nil, fare_fn)
+
+      assert %Fare{cents: 13_600} = Month.base_pass(inner_express_route, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest month pass fares that are not discounted for the outer express bus" do
@@ -110,10 +110,10 @@ defmodule Fares.MonthTest do
         Enum.filter(@bus_fares, &(&1.name == :outer_express_bus))
       end
 
-      assert %Fare{cents: 16_800} = Month.lowest_pass(outer_express_route, nil, nil, nil, fare_fn)
-
       assert %Fare{cents: 16_800} =
-               Month.highest_pass(outer_express_route, nil, nil, nil, fare_fn)
+               Month.recommended_pass(outer_express_route, nil, nil, nil, fare_fn)
+
+      assert %Fare{cents: 16_800} = Month.base_pass(outer_express_route, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest subway pass fares for the SL1, SL2, and SL3 routes" do
@@ -125,12 +125,12 @@ defmodule Fares.MonthTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fare{cents: 9_000} = Month.lowest_pass(sl1, nil, nil, nil, fare_fn)
-      assert %Fare{cents: 9_000} = Month.highest_pass(sl1, nil, nil, nil, fare_fn)
-      assert %Fare{cents: 9_000} = Month.lowest_pass(sl2, nil, nil, nil, fare_fn)
-      assert %Fare{cents: 9_000} = Month.highest_pass(sl2, nil, nil, nil, fare_fn)
-      assert %Fare{cents: 9_000} = Month.lowest_pass(sl3, nil, nil, nil, fare_fn)
-      assert %Fare{cents: 9_000} = Month.highest_pass(sl3, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.recommended_pass(sl1, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass(sl1, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.recommended_pass(sl2, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass(sl2, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.recommended_pass(sl3, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass(sl3, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest bus pass fares for the SL4 and SL5 routes" do
@@ -141,10 +141,10 @@ defmodule Fares.MonthTest do
         Enum.filter(@bus_fares, &(&1.name == :local_bus))
       end
 
-      assert %Fare{cents: 5_500} = Month.lowest_pass(sl4, nil, nil, nil, fare_fn)
-      assert %Fare{cents: 5_500} = Month.highest_pass(sl4, nil, nil, nil, fare_fn)
-      assert %Fare{cents: 5_500} = Month.lowest_pass(sl5, nil, nil, nil, fare_fn)
-      assert %Fare{cents: 5_500} = Month.highest_pass(sl5, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.recommended_pass(sl4, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.base_pass(sl4, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.recommended_pass(sl5, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.base_pass(sl5, nil, nil, nil, fare_fn)
     end
   end
 
@@ -180,10 +180,10 @@ defmodule Fares.MonthTest do
       end
 
       assert %Fare{cents: 35_000} =
-               Month.lowest_pass(route, nil, origin_id, destination_id, fare_fn)
+               Month.recommended_pass(route, nil, origin_id, destination_id, fare_fn)
 
       assert %Fare{cents: 36_000} =
-               Month.highest_pass(route, nil, origin_id, destination_id, fare_fn)
+               Month.base_pass(route, nil, origin_id, destination_id, fare_fn)
     end
 
     test "returns the lowest and highest one-way fares that are not discounted for a trip terminating in Zone 1A" do
@@ -217,10 +217,10 @@ defmodule Fares.MonthTest do
       end
 
       assert %Fare{cents: 27_100} =
-               Month.lowest_pass(route, nil, origin_id, destination_id, fare_fn)
+               Month.recommended_pass(route, nil, origin_id, destination_id, fare_fn)
 
       assert %Fare{cents: 28_100} =
-               Month.highest_pass(route, nil, origin_id, destination_id, fare_fn)
+               Month.base_pass(route, nil, origin_id, destination_id, fare_fn)
     end
 
     test "returns an interzone fares that are not discounted for a trip that does not originate/terminate in Zone 1A" do
@@ -254,10 +254,10 @@ defmodule Fares.MonthTest do
       end
 
       assert %Fare{cents: 12_900} =
-               Month.lowest_pass(route, nil, origin_id, destination_id, fare_fn)
+               Month.recommended_pass(route, nil, origin_id, destination_id, fare_fn)
 
       assert %Fare{cents: 13_900} =
-               Month.highest_pass(route, nil, origin_id, destination_id, fare_fn)
+               Month.base_pass(route, nil, origin_id, destination_id, fare_fn)
     end
 
     test "returns zone-based fares for standard trips on Foxboro pilot" do
@@ -266,10 +266,10 @@ defmodule Fares.MonthTest do
       trip_2 = %Trip{name: "759", id: "CR-Weekday-Fall-19-759"}
 
       assert %Fare{name: {:zone, "4"}} =
-               Month.lowest_pass(route, trip_1, "place-sstat", "place-FS-0049")
+               Month.recommended_pass(route, trip_1, "place-sstat", "place-FS-0049")
 
       assert %Fare{name: {:interzone, "3"}} =
-               Month.lowest_pass(route, trip_2, "place-FB-0118", "place-FS-0049")
+               Month.recommended_pass(route, trip_2, "place-FB-0118", "place-FS-0049")
     end
 
     test "accepts a Trip ID" do
@@ -277,10 +277,10 @@ defmodule Fares.MonthTest do
       trip_id = "CR-Weekday-Fall-19-751"
 
       assert %Fare{name: {:zone, "4"}} =
-               Month.lowest_pass(route, trip_id, "place-sstat", "place-FS-0049")
+               Month.recommended_pass(route, trip_id, "place-sstat", "place-FS-0049")
 
       assert %Fare{name: {:zone, "4"}} =
-               Month.highest_pass(route, trip_id, "place-sstat", "place-FS-0049")
+               Month.base_pass(route, trip_id, "place-sstat", "place-FS-0049")
     end
 
     test "returns nil if no matching fares found" do
@@ -290,7 +290,7 @@ defmodule Fares.MonthTest do
 
       fare_fn = fn _ -> [] end
 
-      assert Month.lowest_pass(route, nil, origin_id, destination_id, fare_fn) == nil
+      assert Month.recommended_pass(route, nil, origin_id, destination_id, fare_fn) == nil
     end
   end
 
@@ -326,10 +326,9 @@ defmodule Fares.MonthTest do
       end
 
       assert %Fare{cents: 8_000} =
-               Month.lowest_pass(route, nil, origin_id, destination_id, fare_fn)
+               Month.recommended_pass(route, nil, origin_id, destination_id, fare_fn)
 
-      assert %Fare{cents: 9_000} =
-               Month.highest_pass(route, nil, origin_id, destination_id, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass(route, nil, origin_id, destination_id, fare_fn)
     end
   end
 end

--- a/apps/fares/test/month_test.exs
+++ b/apps/fares/test/month_test.exs
@@ -36,6 +36,13 @@ defmodule Fares.MonthTest do
       assert %Fare{cents: 9_000} = Month.lowest_pass(@subway_route, nil, nil, nil, fare_fn)
       assert %Fare{cents: 9_000} = Month.highest_pass(@subway_route, nil, nil, nil, fare_fn)
     end
+
+    test "accepts a Route ID" do
+      fare_fn = fn @default_filters ++ [mode: :subway] -> @subway_fares end
+
+      assert %Fare{cents: 9_000} = Month.lowest_pass("Red", nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.highest_pass("Red", nil, nil, nil, fare_fn)
+    end
   end
 
   describe "bus" do

--- a/apps/fares/test/one_way_test.exs
+++ b/apps/fares/test/one_way_test.exs
@@ -1,10 +1,10 @@
-defmodule HighestLowestFareTest do
+defmodule OneWayTest do
   use ExUnit.Case, async: true
 
   alias Routes.Route
   alias Schedules.Trip
 
-  import Fares.HighestLowestFare
+  import Fares.OneWay
 
   @default_filters [reduced: nil, duration: :single_trip]
 

--- a/apps/fares/test/one_way_test.exs
+++ b/apps/fares/test/one_way_test.exs
@@ -9,8 +9,8 @@ defmodule OneWayTest do
   @default_filters [reduced: nil, duration: :single_trip]
 
   test "returns nil if no route is provided" do
-    refute lowest_fare(nil, nil, nil, nil)
-    refute highest_fare(nil, nil, nil, nil)
+    refute recommended_fare(nil, nil, nil, nil)
+    refute base_fare(nil, nil, nil, nil)
   end
 
   describe "subway" do
@@ -40,8 +40,8 @@ defmodule OneWayTest do
         @subway_fares
       end
 
-      assert %Fares.Fare{cents: 225} = lowest_fare(@route, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 275} = highest_fare(@route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = recommended_fare(@route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 275} = base_fare(@route, nil, nil, nil, fare_fn)
     end
   end
 
@@ -104,8 +104,8 @@ defmodule OneWayTest do
         Enum.filter(@bus_fares, &(&1.name == :local_bus))
       end
 
-      assert %Fares.Fare{cents: 170} = lowest_fare(local_route, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 200} = highest_fare(local_route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 170} = recommended_fare(local_route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 200} = base_fare(local_route, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest one-way trip fare that is not discounted for the inner express bus" do
@@ -115,8 +115,10 @@ defmodule OneWayTest do
         Enum.filter(@bus_fares, &(&1.name == :inner_express_bus))
       end
 
-      assert %Fares.Fare{cents: 400} = lowest_fare(inner_express_route, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 500} = highest_fare(inner_express_route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 400} =
+               recommended_fare(inner_express_route, nil, nil, nil, fare_fn)
+
+      assert %Fares.Fare{cents: 500} = base_fare(inner_express_route, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest one-way trip fare that is not discounted for the outer express bus" do
@@ -126,8 +128,10 @@ defmodule OneWayTest do
         Enum.filter(@bus_fares, &(&1.name == :outer_express_bus))
       end
 
-      assert %Fares.Fare{cents: 525} = lowest_fare(outer_express_route, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 700} = highest_fare(outer_express_route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 525} =
+               recommended_fare(outer_express_route, nil, nil, nil, fare_fn)
+
+      assert %Fares.Fare{cents: 700} = base_fare(outer_express_route, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest subway fare for for SL1 route (id=741)" do
@@ -137,8 +141,8 @@ defmodule OneWayTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = lowest_fare(sl1, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 275} = highest_fare(sl1, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = recommended_fare(sl1, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 275} = base_fare(sl1, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest subway fare for for SL2 route (id=742)" do
@@ -148,8 +152,8 @@ defmodule OneWayTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = lowest_fare(sl2, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 275} = highest_fare(sl2, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = recommended_fare(sl2, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 275} = base_fare(sl2, nil, nil, nil, fare_fn)
     end
 
     test "returns lowest and highest the subway fare for for SL3 route (id=743)" do
@@ -159,8 +163,8 @@ defmodule OneWayTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = lowest_fare(sl3, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 275} = highest_fare(sl3, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = recommended_fare(sl3, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 275} = base_fare(sl3, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest bus fare for for SL4 route (id=751)" do
@@ -170,8 +174,8 @@ defmodule OneWayTest do
         Enum.filter(@bus_fares, &(&1.name == :local_bus))
       end
 
-      assert %Fares.Fare{cents: 170} = lowest_fare(sl4, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 200} = highest_fare(sl4, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 170} = recommended_fare(sl4, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 200} = base_fare(sl4, nil, nil, nil, fare_fn)
     end
   end
 
@@ -195,10 +199,9 @@ defmodule OneWayTest do
       end
 
       assert %Fares.Fare{cents: 1050} =
-               lowest_fare(route, nil, origin_id, destination_id, fare_fn)
+               recommended_fare(route, nil, origin_id, destination_id, fare_fn)
 
-      assert %Fares.Fare{cents: 1050} =
-               highest_fare(route, nil, origin_id, destination_id, fare_fn)
+      assert %Fares.Fare{cents: 1050} = base_fare(route, nil, origin_id, destination_id, fare_fn)
     end
 
     test "returns the lowest and highest one-way fare that is not discounted for a trip terminating in Zone 1A" do
@@ -219,10 +222,10 @@ defmodule OneWayTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 825} = lowest_fare(route, nil, origin_id, destination_id, fare_fn)
-
       assert %Fares.Fare{cents: 825} =
-               highest_fare(route, nil, origin_id, destination_id, fare_fn)
+               recommended_fare(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fares.Fare{cents: 825} = base_fare(route, nil, origin_id, destination_id, fare_fn)
     end
 
     test "returns an interzone fare that is not discounted for a trip that does not originate/terminate in Zone 1A" do
@@ -243,10 +246,10 @@ defmodule OneWayTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 401} = lowest_fare(route, nil, origin_id, destination_id, fare_fn)
-
       assert %Fares.Fare{cents: 401} =
-               highest_fare(route, nil, origin_id, destination_id, fare_fn)
+               recommended_fare(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fares.Fare{cents: 401} = base_fare(route, nil, origin_id, destination_id, fare_fn)
     end
 
     test "excludes weekend commuter rail rates" do
@@ -255,10 +258,10 @@ defmodule OneWayTest do
       destination_id = "Haverhill"
 
       assert %Fares.Fare{cents: 1100, duration: :single_trip} =
-               lowest_fare(route, nil, origin_id, destination_id)
+               recommended_fare(route, nil, origin_id, destination_id)
 
       assert %Fares.Fare{cents: 1100, duration: :single_trip} =
-               highest_fare(route, nil, origin_id, destination_id)
+               base_fare(route, nil, origin_id, destination_id)
     end
 
     test "returns the appropriate fare for Foxboro Special Events" do
@@ -268,16 +271,16 @@ defmodule OneWayTest do
       foxboro_id = "place-FS-0049"
 
       assert %Fares.Fare{cents: 2000, duration: :round_trip} =
-               lowest_fare(route, trip, south_station_id, foxboro_id)
+               recommended_fare(route, trip, south_station_id, foxboro_id)
 
       assert %Fares.Fare{cents: 2000, duration: :round_trip} =
-               highest_fare(route, trip, south_station_id, foxboro_id)
+               base_fare(route, trip, south_station_id, foxboro_id)
 
       assert %Fares.Fare{cents: 2000, duration: :round_trip} =
-               lowest_fare(route, trip, foxboro_id, south_station_id)
+               recommended_fare(route, trip, foxboro_id, south_station_id)
 
       assert %Fares.Fare{cents: 2000, duration: :round_trip} =
-               highest_fare(route, trip, foxboro_id, south_station_id)
+               base_fare(route, trip, foxboro_id, south_station_id)
     end
 
     test "returns zone-based fares for standard trips on Foxboro pilot" do
@@ -286,10 +289,10 @@ defmodule OneWayTest do
       trip_2 = %Trip{name: "759", id: "CR-Weekday-Fall-19-759"}
 
       assert %Fares.Fare{name: {:zone, "4"}} =
-               lowest_fare(route, trip_1, "place-sstat", "place-FS-0049")
+               recommended_fare(route, trip_1, "place-sstat", "place-FS-0049")
 
       assert %Fares.Fare{name: {:interzone, "3"}} =
-               lowest_fare(route, trip_2, "place-FB-0118", "place-FS-0049")
+               recommended_fare(route, trip_2, "place-FB-0118", "place-FS-0049")
     end
 
     test "Zone 1A to 1A reverse commute trips on Foxboro pilot retain original pricing" do
@@ -297,7 +300,7 @@ defmodule OneWayTest do
       trip = %Trip{name: "741", id: "CR-Weekday-Fall-19-741"}
 
       assert %Fares.Fare{name: {:zone, "1A"}} =
-               lowest_fare(route, trip, "origin=place-DB-2240", "place-DB-2222")
+               recommended_fare(route, trip, "origin=place-DB-2240", "place-DB-2222")
     end
 
     test "does not apply pilot/discounted fare for reverse commutes until Fall 2019" do
@@ -305,7 +308,7 @@ defmodule OneWayTest do
       trip = %Trip{name: "743", id: "CR-Weekday-Spring-19-743"}
 
       assert %Fares.Fare{name: {:zone, "3"}} =
-               lowest_fare(route, trip, "place-sstat", "place-FB-0148")
+               recommended_fare(route, trip, "place-sstat", "place-FB-0148")
     end
 
     test "returns interzone fare for reverse commute trips to and from Foxboro" do
@@ -317,10 +320,10 @@ defmodule OneWayTest do
       foxboro_id = "place-FS-0049"
 
       assert %Fares.Fare{name: {:interzone, "4"}} =
-               lowest_fare(route, inbound_trip, foxboro_id, south_station_id)
+               recommended_fare(route, inbound_trip, foxboro_id, south_station_id)
 
       assert %Fares.Fare{name: {:interzone, "4"}} =
-               lowest_fare(route, outbound_trip, south_station_id, foxboro_id)
+               recommended_fare(route, outbound_trip, south_station_id, foxboro_id)
     end
 
     test "returns nil if no matching fares found" do
@@ -330,7 +333,7 @@ defmodule OneWayTest do
 
       fare_fn = fn _ -> [] end
 
-      assert lowest_fare(route, nil, origin_id, destination_id, fare_fn) == nil
+      assert recommended_fare(route, nil, origin_id, destination_id, fare_fn) == nil
     end
 
     test "returns a free fare for any bus shuttle rail replacements" do
@@ -345,10 +348,10 @@ defmodule OneWayTest do
       destination_id = "place-WR-0099"
 
       assert %Fares.Fare{cents: 0, name: :free_fare} =
-               lowest_fare(route, nil, origin_id, destination_id)
+               recommended_fare(route, nil, origin_id, destination_id)
 
       assert %Fares.Fare{cents: 0, name: :free_fare} =
-               highest_fare(route, nil, origin_id, destination_id)
+               base_fare(route, nil, origin_id, destination_id)
     end
   end
 
@@ -371,10 +374,10 @@ defmodule OneWayTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 350} = lowest_fare(route, nil, origin_id, destination_id, fare_fn)
-
       assert %Fares.Fare{cents: 350} =
-               highest_fare(route, nil, origin_id, destination_id, fare_fn)
+               recommended_fare(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fares.Fare{cents: 350} = base_fare(route, nil, origin_id, destination_id, fare_fn)
     end
   end
 end

--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -107,4 +107,8 @@
   &-fare {
     padding-left: $base-spacing;
   }
+
+  &-fare + &-fare-title {
+    margin-top: 1rem;
+  }
 }

--- a/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
@@ -151,7 +151,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
   @spec fares_for_service(map, map, String.t(), String.t()) :: map
   def fares_for_service(route, trip, origin, destination) do
     %{
-      price: route |> OneWay.lowest_fare(trip, origin, destination) |> Format.price(),
+      price: route |> OneWay.recommended_fare(trip, origin, destination) |> Format.price(),
       fare_link:
         fare_link(
           Route.type_atom(route.type),

--- a/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
@@ -7,7 +7,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
   alias Fares.Format
   alias Routes.Route
   alias Schedules.Repo
-  alias Fares.{HighestLowestFare}
+  alias Fares.{OneWay}
   import SiteWeb.ViewHelpers, only: [cms_static_page_path: 2]
 
   def show(conn, %{
@@ -151,7 +151,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
   @spec fares_for_service(map, map, String.t(), String.t()) :: map
   def fares_for_service(route, trip, origin, destination) do
     %{
-      price: route |> HighestLowestFare.lowest_fare(trip, origin, destination) |> Format.price(),
+      price: route |> OneWay.lowest_fare(trip, origin, destination) |> Format.price(),
       fare_link:
         fare_link(
           Route.type_atom(route.type),

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -90,12 +90,12 @@ defmodule SiteWeb.TripPlanController do
     trip = Schedules.Repo.trip(leg.mode.trip_id)
     origin_id = leg.from.stop_id
     destination_id = leg.to.stop_id
-    lowest_fare = OneWay.lowest_fare(route, trip, origin_id, destination_id)
-    highest_fare = OneWay.highest_fare(route, trip, origin_id, destination_id)
+    recommended_fare = OneWay.recommended_fare(route, trip, origin_id, destination_id)
+    base_fare = OneWay.base_fare(route, trip, origin_id, destination_id)
 
     fares = %{
-      highest_one_way_fare: highest_fare,
-      lowest_one_way_fare: lowest_fare
+      highest_one_way_fare: base_fare,
+      lowest_one_way_fare: recommended_fare
     }
 
     mode_with_fares = %TransitDetail{leg.mode | fares: fares}
@@ -124,7 +124,7 @@ defmodule SiteWeb.TripPlanController do
          from: %NamedPosition{stop_id: origin_id},
          to: %NamedPosition{stop_id: destination_id}
        }) do
-    Month.highest_pass(route_id, trip_id, origin_id, destination_id)
+    Month.base_pass(route_id, trip_id, origin_id, destination_id)
   end
 
   @spec lowest_month_pass(Leg.t()) :: Fare.t() | nil
@@ -135,7 +135,7 @@ defmodule SiteWeb.TripPlanController do
          from: %NamedPosition{stop_id: origin_id},
          to: %NamedPosition{stop_id: destination_id}
        }) do
-    Month.lowest_pass(route_id, trip_id, origin_id, destination_id)
+    Month.recommended_pass(route_id, trip_id, origin_id, destination_id)
   end
 
   @spec max_by_cents([Fare.t() | nil]) :: Fare.t() | nil

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -72,8 +72,8 @@ defmodule SiteWeb.TripPlanController do
       legs_with_fares = itinerary.legs |> Enum.map(&leg_with_fares/1)
 
       passes = %{
-        highest_month_pass: highest_highest_month_pass(itinerary),
-        lowest_month_pass: highest_lowest_month_pass(itinerary)
+        base_month_pass: base_month_pass_for_itinerary(itinerary),
+        recommended_month_pass: recommended_month_pass_for_itinerary(itinerary)
       }
 
       %{itinerary | legs: legs_with_fares, passes: passes}
@@ -102,15 +102,15 @@ defmodule SiteWeb.TripPlanController do
     %{leg | mode: mode_with_fares}
   end
 
-  @spec highest_highest_month_pass(Itinerary.t()) :: Fare.t() | nil
-  defp highest_highest_month_pass(%Itinerary{legs: legs}) do
+  @spec base_month_pass_for_itinerary(Itinerary.t()) :: Fare.t() | nil
+  defp base_month_pass_for_itinerary(%Itinerary{legs: legs}) do
     legs
     |> Enum.map(&highest_month_pass/1)
     |> max_by_cents()
   end
 
-  @spec highest_lowest_month_pass(Itinerary.t()) :: Fare.t() | nil
-  defp highest_lowest_month_pass(%Itinerary{legs: legs}) do
+  @spec recommended_month_pass_for_itinerary(Itinerary.t()) :: Fare.t() | nil
+  defp recommended_month_pass_for_itinerary(%Itinerary{legs: legs}) do
     legs
     |> Enum.map(&lowest_month_pass/1)
     |> max_by_cents()

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -4,10 +4,11 @@ defmodule SiteWeb.TripPlanController do
   """
 
   use SiteWeb, :controller
+  alias Fares.{Fare, Month, OneWay}
   alias Routes.Route
   alias Site.TripPlan.{Query, RelatedLink, ItineraryRow, ItineraryRowList}
   alias Site.TripPlan.Map, as: TripPlanMap
-  alias TripPlan.{Itinerary, Leg, PersonalDetail, TransitDetail}
+  alias TripPlan.{Itinerary, Leg, NamedPosition, PersonalDetail, TransitDetail}
 
   plug(:require_google_maps)
   plug(:assign_initial_map)
@@ -41,7 +42,7 @@ defmodule SiteWeb.TripPlanController do
     itineraries =
       query
       |> Query.get_itineraries()
-      |> with_fares()
+      |> with_fares_and_passes()
 
     route_map = routes_for_query(itineraries)
     route_mapper = &Map.get(route_map, &1)
@@ -65,12 +66,17 @@ defmodule SiteWeb.TripPlanController do
     assign(conn, :requires_google_maps?, true)
   end
 
-  @spec with_fares([Itinerary.t()]) :: [Itinerary.t()]
-  defp with_fares(itineraries) do
+  @spec with_fares_and_passes([Itinerary.t()]) :: [Itinerary.t()]
+  defp with_fares_and_passes(itineraries) do
     Enum.map(itineraries, fn itinerary ->
       legs_with_fares = itinerary.legs |> Enum.map(&leg_with_fares/1)
 
-      %{itinerary | legs: legs_with_fares}
+      passes = %{
+        highest_month_pass: highest_highest_month_pass(itinerary),
+        lowest_month_pass: highest_lowest_month_pass(itinerary)
+      }
+
+      %{itinerary | legs: legs_with_fares, passes: passes}
     end)
   end
 
@@ -84,8 +90,8 @@ defmodule SiteWeb.TripPlanController do
     trip = Schedules.Repo.trip(leg.mode.trip_id)
     origin_id = leg.from.stop_id
     destination_id = leg.to.stop_id
-    lowest_fare = Fares.OneWay.lowest_fare(route, trip, origin_id, destination_id)
-    highest_fare = Fares.OneWay.highest_fare(route, trip, origin_id, destination_id)
+    lowest_fare = OneWay.lowest_fare(route, trip, origin_id, destination_id)
+    highest_fare = OneWay.highest_fare(route, trip, origin_id, destination_id)
 
     fares = %{
       highest_one_way_fare: highest_fare,
@@ -95,6 +101,49 @@ defmodule SiteWeb.TripPlanController do
     mode_with_fares = %TransitDetail{leg.mode | fares: fares}
     %{leg | mode: mode_with_fares}
   end
+
+  @spec highest_highest_month_pass(Itinerary.t()) :: Fare.t() | nil
+  defp highest_highest_month_pass(%Itinerary{legs: legs}) do
+    legs
+    |> Enum.map(&highest_month_pass/1)
+    |> max_by_cents()
+  end
+
+  @spec highest_lowest_month_pass(Itinerary.t()) :: Fare.t() | nil
+  defp highest_lowest_month_pass(%Itinerary{legs: legs}) do
+    legs
+    |> Enum.map(&lowest_month_pass/1)
+    |> max_by_cents()
+  end
+
+  @spec highest_month_pass(Leg.t()) :: Fare.t() | nil
+  defp highest_month_pass(%Leg{mode: %PersonalDetail{}}), do: nil
+
+  defp highest_month_pass(%Leg{
+         mode: %TransitDetail{route_id: route_id, trip_id: trip_id},
+         from: %NamedPosition{stop_id: origin_id},
+         to: %NamedPosition{stop_id: destination_id}
+       }) do
+    Month.highest_pass(route_id, trip_id, origin_id, destination_id)
+  end
+
+  @spec lowest_month_pass(Leg.t()) :: Fare.t() | nil
+  defp lowest_month_pass(%Leg{mode: %PersonalDetail{}}), do: nil
+
+  defp lowest_month_pass(%Leg{
+         mode: %TransitDetail{route_id: route_id, trip_id: trip_id},
+         from: %NamedPosition{stop_id: origin_id},
+         to: %NamedPosition{stop_id: destination_id}
+       }) do
+    Month.lowest_pass(route_id, trip_id, origin_id, destination_id)
+  end
+
+  @spec max_by_cents([Fare.t() | nil]) :: Fare.t() | nil
+  defp max_by_cents(fares), do: Enum.max_by(fares, &cents_for_max/1, fn -> nil end)
+
+  @spec cents_for_max(Fare.t() | nil) :: non_neg_integer
+  defp cents_for_max(nil), do: 0
+  defp cents_for_max(%Fare{cents: cents}), do: cents
 
   @spec itinerary_row_lists([Itinerary.t()], route_mapper, map) :: [ItineraryRowList.t()]
   defp itinerary_row_lists(itineraries, route_mapper, plan) do

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -84,8 +84,8 @@ defmodule SiteWeb.TripPlanController do
     trip = Schedules.Repo.trip(leg.mode.trip_id)
     origin_id = leg.from.stop_id
     destination_id = leg.to.stop_id
-    lowest_fare = Fares.HighestLowestFare.lowest_fare(route, trip, origin_id, destination_id)
-    highest_fare = Fares.HighestLowestFare.highest_fare(route, trip, origin_id, destination_id)
+    lowest_fare = Fares.OneWay.lowest_fare(route, trip, origin_id, destination_id)
+    highest_fare = Fares.OneWay.highest_fare(route, trip, origin_id, destination_id)
 
     fares = %{
       highest_one_way_fare: highest_fare,

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
@@ -3,4 +3,4 @@
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--round-trip"><%= @round_trip_total %> round trip</div>
 
 <div class="m-trip-plan-results__itinerary-fare-title">Monthly Pass Fare</div>
-<div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--month"><%= monthly_pass(@itinerary.passes.highest_month_pass) %></div>
+<div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--month"><%= monthly_pass(@itinerary.passes.base_month_pass) %></div>

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
@@ -1,3 +1,6 @@
 <div class="m-trip-plan-results__itinerary-fare-title">Base Fare Estimate</div>
-<div class="m-trip-plan-results__itinerary-fare"><%= @one_way_total %> one way</div>
-<div class="m-trip-plan-results__itinerary-fare"><%= @round_trip_total %> round trip</div>
+<div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--one-way"><%= @one_way_total %> one way</div>
+<div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--round-trip"><%= @round_trip_total %> round trip</div>
+
+<div class="m-trip-plan-results__itinerary-fare-title">Monthly Pass Fare</div>
+<div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--month"><%= monthly_pass(@itinerary.passes.highest_month_pass) %></div>

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -624,10 +624,10 @@ defmodule SiteWeb.TripPlanView do
 
   @spec monthly_pass(Fare.t()) :: String.t()
   def monthly_pass(fare) do
-    "#{zone(fare)}#{Format.media(fare)}: #{Format.price(fare)}"
+    "#{cr_prefix(fare)}#{Format.full_name(fare)}: #{Format.price(fare)}"
   end
 
-  @spec zone(Fare.t()) :: String.t()
-  defp zone(%Fare{mode: :commuter_rail, name: {:zone, zone}}), do: "Commuter Rail Zone #{zone} "
-  defp zone(_), do: ""
+  @spec cr_prefix(Fare.t()) :: String.t()
+  defp cr_prefix(%Fare{mode: :commuter_rail}), do: "Commuter Rail "
+  defp cr_prefix(_), do: ""
 end

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -622,7 +622,9 @@ defmodule SiteWeb.TripPlanView do
     end)
   end
 
-  @spec monthly_pass(Fare.t()) :: String.t()
+  @spec monthly_pass(Fare.t() | nil) :: String.t()
+  def monthly_pass(nil), do: Format.full_name(nil)
+
   def monthly_pass(fare) do
     "#{cr_prefix(fare)}#{Format.full_name(fare)}: #{Format.price(fare)}"
   end

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -8,7 +8,7 @@ defmodule SiteWeb.TripPlanView do
   alias Routes.Route
   alias Phoenix.{HTML, HTML.Form}
   alias SiteWeb.PartialView.SvgIconWithCircle
-  alias Fares.{Format}
+  alias Fares.{Fare, Format}
 
   import Schedules.Repo, only: [end_of_rating: 0]
 
@@ -559,6 +559,7 @@ defmodule SiteWeb.TripPlanView do
       fares_html =
         "_itinerary_fares.html"
         |> render_to_string(
+          itinerary: i,
           one_way_total: Format.price(fare),
           round_trip_total: Format.price(fare * 2)
         )
@@ -619,5 +620,10 @@ defmodule SiteWeb.TripPlanView do
 
       highest_one_way_fare + acc
     end)
+  end
+
+  @spec monthly_pass(Fare.t()) :: String.t()
+  def monthly_pass(fare) do
+    "#{Format.media(fare)}: #{Format.price(fare)}"
   end
 end

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -624,6 +624,10 @@ defmodule SiteWeb.TripPlanView do
 
   @spec monthly_pass(Fare.t()) :: String.t()
   def monthly_pass(fare) do
-    "#{Format.media(fare)}: #{Format.price(fare)}"
+    "#{zone(fare)}#{Format.media(fare)}: #{Format.price(fare)}"
   end
+
+  @spec zone(Fare.t()) :: String.t()
+  defp zone(%Fare{mode: :commuter_rail, name: {:zone, zone}}), do: "Commuter Rail Zone #{zone} "
+  defp zone(_), do: ""
 end

--- a/apps/site/lib/trip_info.ex
+++ b/apps/site/lib/trip_info.ex
@@ -1,7 +1,7 @@
 defmodule TripInfo do
   require Routes.Route
   alias Routes.Route
-  alias Fares.HighestLowestFare
+  alias Fares.OneWay
 
   @moduledoc """
   Wraps the important information about a trip.
@@ -113,7 +113,7 @@ defmodule TripInfo do
     trip = PredictedSchedule.trip(time)
     duration = duration(times, origin_id)
     stop_count = Enum.count(times)
-    base_fare = HighestLowestFare.lowest_fare(route, trip, origin_id, destination_id)
+    base_fare = OneWay.lowest_fare(route, trip, origin_id, destination_id)
 
     %TripInfo{
       route: route,

--- a/apps/site/lib/trip_info.ex
+++ b/apps/site/lib/trip_info.ex
@@ -113,7 +113,7 @@ defmodule TripInfo do
     trip = PredictedSchedule.trip(time)
     duration = duration(times, origin_id)
     stop_count = Enum.count(times)
-    base_fare = OneWay.lowest_fare(route, trip, origin_id, destination_id)
+    base_fare = OneWay.recommended_fare(route, trip, origin_id, destination_id)
 
     %TripInfo{
       route: route,

--- a/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
+++ b/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
@@ -1,8 +1,9 @@
 defmodule SiteWeb.TripPlanControllerTest do
   use SiteWeb.ConnCase
+  alias Fares.Fare
   alias Site.TripPlan.Query
   alias SiteWeb.TripPlanController
-  alias TripPlan.{Api.MockPlanner}
+  alias TripPlan.{Api.MockPlanner, Itinerary, PersonalDetail, TransitDetail}
   import Phoenix.HTML, only: [html_escape: 1, safe_to_string: 1]
   doctest SiteWeb.TripPlanController
 
@@ -288,9 +289,9 @@ defmodule SiteWeb.TripPlanControllerTest do
 
       assert Enum.all?(conn.assigns.itineraries, fn itinerary ->
                Enum.all?(itinerary.legs, fn leg ->
-                 match?(%TripPlan.PersonalDetail{}, leg.mode) ||
+                 match?(%PersonalDetail{}, leg.mode) ||
                    match?(
-                     %TripPlan.TransitDetail{
+                     %TransitDetail{
                        fares: %{
                          highest_one_way_fare: %Fares.Fare{},
                          lowest_one_way_fare: %Fares.Fare{}
@@ -299,6 +300,15 @@ defmodule SiteWeb.TripPlanControllerTest do
                      leg.mode
                    )
                end)
+             end)
+    end
+
+    test "adds monthly pass data to each itinerary", %{conn: conn} do
+      conn = get(conn, trip_plan_path(conn, :index, @good_params))
+
+      assert Enum.all?(conn.assigns.itineraries, fn itinerary ->
+               %Itinerary{passes: %{highest_month_pass: %Fare{}, lowest_month_pass: %Fare{}}} =
+                 itinerary
              end)
     end
 

--- a/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
+++ b/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
@@ -307,7 +307,7 @@ defmodule SiteWeb.TripPlanControllerTest do
       conn = get(conn, trip_plan_path(conn, :index, @good_params))
 
       assert Enum.all?(conn.assigns.itineraries, fn itinerary ->
-               %Itinerary{passes: %{highest_month_pass: %Fare{}, lowest_month_pass: %Fare{}}} =
+               %Itinerary{passes: %{base_month_pass: %Fare{}, recommended_month_pass: %Fare{}}} =
                  itinerary
              end)
     end

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -4,6 +4,7 @@ defmodule SiteWeb.TripPlanViewTest do
   import Phoenix.HTML, only: [safe_to_string: 1]
   import UrlHelpers, only: [update_url: 2]
   import Schedules.Repo, only: [end_of_rating: 0]
+  alias Fares.Fare
   alias Routes.Route
   alias Site.TripPlan.{IntermediateStop, ItineraryRow, Query}
   alias TripPlan.Api.MockPlanner
@@ -525,6 +526,20 @@ closest arrival to 12:00 AM, Thursday, January 1st."
 
   describe "Fares logic" do
     @fares_assigns %{
+      itinerary: %{
+        passes: %{
+          highest_month_pass: %Fare{
+            additional_valid_modes: [:bus],
+            cents: 9_000,
+            duration: :month,
+            media: [:charlie_card, :charlie_ticket],
+            mode: :subway,
+            name: :subway,
+            price_label: nil,
+            reduced: nil
+          }
+        }
+      },
       one_way_total: "$2.90",
       round_trip_total: "$5.80"
     }
@@ -535,8 +550,10 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         |> render(Map.put(@fares_assigns, :conn, conn))
         |> safe_to_string()
 
-      [{_, _, [one_way_fare]}, {_, _, [round_trip_fare]}] =
-        Floki.find(html, ".m-trip-plan-results__itinerary-fare")
+      [{_, _, [one_way_fare]}] = Floki.find(html, ".m-trip-plan-results__itinerary-fare--one-way")
+
+      [{_, _, [round_trip_fare]}] =
+        Floki.find(html, ".m-trip-plan-results__itinerary-fare--round-trip")
 
       assert one_way_fare == "$2.90 one way"
       assert round_trip_fare == "$5.80 round trip"
@@ -628,6 +645,23 @@ closest arrival to 12:00 AM, Thursday, January 1st."
       }
 
       assert get_highest_one_way_fare(itinerary) == 290
+    end
+  end
+
+  describe "monthly_pass" do
+    test "Formats the media type and price" do
+      fare = %Fare{
+        additional_valid_modes: [:bus],
+        cents: 9_000,
+        duration: :month,
+        media: [:charlie_card, :charlie_ticket],
+        mode: :subway,
+        name: :subway,
+        price_label: nil,
+        reduced: nil
+      }
+
+      assert monthly_pass(fare) == "CharlieCard or CharlieTicket: $90.00"
     end
   end
 end

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -661,7 +661,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         reduced: nil
       }
 
-      assert monthly_pass(fare) == "CharlieCard or CharlieTicket: $90.00"
+      assert monthly_pass(fare) == "Monthly LinkPass: $90.00"
     end
 
     test "Includes the zone for CR trips" do
@@ -676,7 +676,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         reduced: nil
       }
 
-      assert monthly_pass(fare) == "Commuter Rail Zone 7 CharlieTicket: $360.00"
+      assert monthly_pass(fare) == "Commuter Rail Zone 7 Monthly Pass: $360.00"
     end
   end
 end

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -663,5 +663,20 @@ closest arrival to 12:00 AM, Thursday, January 1st."
 
       assert monthly_pass(fare) == "CharlieCard or CharlieTicket: $90.00"
     end
+
+    test "Includes the zone for CR trips" do
+      fare = %Fare{
+        additional_valid_modes: [:subway, :bus, :ferry],
+        cents: 36_000,
+        duration: :month,
+        media: [:commuter_ticket],
+        mode: :commuter_rail,
+        name: {:zone, "7"},
+        price_label: nil,
+        reduced: nil
+      }
+
+      assert monthly_pass(fare) == "Commuter Rail Zone 7 CharlieTicket: $360.00"
+    end
   end
 end

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -528,7 +528,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
     @fares_assigns %{
       itinerary: %{
         passes: %{
-          highest_month_pass: %Fare{
+          base_month_pass: %Fare{
             additional_valid_modes: [:bus],
             cents: 9_000,
             duration: :month,

--- a/apps/trip_plan/lib/trip_plan/itinerary.ex
+++ b/apps/trip_plan/lib/trip_plan/itinerary.ex
@@ -27,8 +27,8 @@ defmodule TripPlan.Itinerary do
         }
 
   @type passes :: %{
-          highest_month_pass: Fare.t(),
-          lowest_month_pass: Fare.t()
+          base_month_pass: Fare.t(),
+          recommended_month_pass: Fare.t()
         }
 
   alias TripPlan.NamedPosition

--- a/apps/trip_plan/lib/trip_plan/itinerary.ex
+++ b/apps/trip_plan/lib/trip_plan/itinerary.ex
@@ -6,10 +6,14 @@ defmodule TripPlan.Itinerary do
   travel. Itineraries are separate even if they use the same modes but happen
   at different times of day.
   """
+
+  alias Fares.Fare
+
   @enforce_keys [:start, :stop]
   defstruct [
     :start,
     :stop,
+    :passes,
     legs: [],
     accessible?: false
   ]
@@ -18,8 +22,15 @@ defmodule TripPlan.Itinerary do
           start: DateTime.t(),
           stop: DateTime.t(),
           legs: [TripPlan.Leg.t()],
-          accessible?: boolean
+          accessible?: boolean,
+          passes: passes()
         }
+
+  @type passes :: %{
+          highest_month_pass: Fare.t(),
+          lowest_month_pass: Fare.t()
+        }
+
   alias TripPlan.NamedPosition
 
   @spec destination(t) :: NamedPosition.t()


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Base Fares | Recommend Monthly Passes](https://app.asana.com/0/555089885850811/1162903717356811)

Display recommended monthly pass in the trip plan results summary box. Add a new `Fare.Month` module to support finding monthly passes.

Targets the `feature/base-fares` branch.

Depends on  https://github.com/mbta/dotcom/pull/487

![Screen Shot 2020-05-28 at 16 37 15](https://user-images.githubusercontent.com/42339/83194661-fde8f580-a106-11ea-9442-1b151f945230.png)

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
