### PR TITLE
Add transfer note to trip planner itinerary

### DIFF
--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -104,7 +104,8 @@
     font-weight: bold;
   }
 
-  &-fare {
+  &-fare,
+  &-note {
     padding-left: $base-spacing;
   }
 

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
@@ -1,6 +1,6 @@
 <div class="m-trip-plan-results__itinerary-fare-title">Base Fare Estimate</div>
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--one-way"><%= @one_way_total %> one way</div>
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--round-trip"><%= @round_trip_total %> round trip</div>
-
+<div class="m-trip-plan-results__itinerary-note"><%= transfer_note(@itinerary) %></div>
 <div class="m-trip-plan-results__itinerary-fare-title">Monthly Pass Fare</div>
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--month"><%= monthly_pass(@itinerary.passes.base_month_pass) %></div>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Base Fares | Add transfers note (not subway)](https://app.asana.com/0/555089885850811/1169236529454061)

Adds the "Total may be less with transfers" note to the itinerary fare summary. This note is added when the itinerary contains two consecutive transit legs which fit the following:

- Subway to subway **(to be removed upon completion of the Base Fares | Add transfers logic (subway) ticket)**
- Subway to local bus
- Local bus to subway
- Local bus to local bus
- Inner express bus to subway
- Outer express bus to subway
- Inner express bus to local bus
- Outer express bus to local bus

If none of the above are present, then no transfer note will be shown.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
