### PR TITLE
Update the display name for a shuttle with no fare

### DIFF
--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -100,7 +100,7 @@ defmodule Fares.Format do
   def name(:invalid), do: "Invalid Fare"
 
   @spec full_name(Fare.t() | nil) :: String.t() | iolist
-  def full_name(nil), do: "Free"
+  def full_name(nil), do: "Shuttle"
   def full_name(%Fare{mode: :subway, duration: :month}), do: "Monthly LinkPass"
   def full_name(%Fare{mode: :commuter_rail, duration: :weekend}), do: "Weekend Pass"
   def full_name(%Fare{duration: :week}), do: "7-Day Pass"

--- a/apps/fares/test/format_test.exs
+++ b/apps/fares/test/format_test.exs
@@ -75,6 +75,35 @@ defmodule Fares.FormatTest do
     end
   end
 
+  describe "full_name/1" do
+    test "gives a name for monthly Subway passes" do
+      assert full_name(%Fare{mode: :subway, duration: :month}) == "Monthly LinkPass"
+    end
+
+    test "gives a name for weekend CR passes" do
+      assert full_name(%Fare{mode: :commuter_rail, duration: :weekend}) == "Weekend Pass"
+    end
+
+    test "gives a name for week and day passes" do
+      assert full_name(%Fare{duration: :week}) == "7-Day Pass"
+      assert full_name(%Fare{duration: :day}) == "1-Day Pass"
+    end
+
+    test "gives a name for ADA and premium rides" do
+      assert full_name(%Fare{name: :ada_ride}) == "ADA Ride Fare"
+      assert full_name(%Fare{name: :premium_ride}) == "Premium Ride Fare"
+    end
+
+    test "gives a name for a Shuttle which doesn't have an associated fare" do
+      assert full_name(nil) == "Shuttle"
+    end
+
+    test "gives the name and duration for all other fares" do
+      assert full_name(%Fare{name: :commuter_ferry, duration: :month}) ==
+               ["Hingham/Hull Ferry", " ", "Monthly Pass"]
+    end
+  end
+
   test "duration/1" do
     assert duration(%Fare{duration: :single_trip}) == "One-Way"
     assert duration(%Fare{duration: :round_trip}) == "Round Trip"


### PR DESCRIPTION
Add some tests for the full_name function while I'm in there.

No Asana ticket, we discussed this quick change during grooming this morning.

![Screen Shot 2020-06-02 at 11 31 49](https://user-images.githubusercontent.com/42339/83539444-06ee1400-a4c5-11ea-98bd-b243007a6e62.png)


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
