### PR TITLE
Include the shape ID when requesting map data

### DIFF
--- a/apps/site/assets/ts/models/__tests__/routeTest.ts
+++ b/apps/site/assets/ts/models/__tests__/routeTest.ts
@@ -1,0 +1,32 @@
+import { Route } from "../../__v3api";
+import { isABusRoute, isAGreenLineRoute } from "../route";
+
+describe("isABusRoute", () => {
+  test("returns whether or not this is a bus route", () => {
+    const busRoutue: Route = {
+      id: "1",
+      type: 3
+    } as Route;
+    const subwayRoute: Route = {
+      id: "Red",
+      type: 1
+    } as Route;
+
+    expect(isABusRoute(busRoutue)).toBeTruthy();
+    expect(isABusRoute(subwayRoute)).toBeFalsy();
+  });
+});
+
+describe("isAGreenLineRoute", () => {
+  test("returns whether or not this is a Green Line route", () => {
+    const greenLineRoute: Route = {
+      id: "Green-E"
+    } as Route;
+    const redLineRoute: Route = {
+      id: "Red"
+    } as Route;
+
+    expect(isAGreenLineRoute(greenLineRoute)).toBeTruthy();
+    expect(isAGreenLineRoute(redLineRoute)).toBeFalsy();
+  });
+});

--- a/apps/site/assets/ts/models/route.ts
+++ b/apps/site/assets/ts/models/route.ts
@@ -1,0 +1,6 @@
+import { Route } from "../__v3api";
+
+export const isABusRoute = ({ type }: Route): boolean => type === 3;
+
+export const isAGreenLineRoute = ({ id }: Route): boolean =>
+  id.startsWith("Green");

--- a/apps/site/assets/ts/schedule/__tests__/BusMenuTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/BusMenuTest.tsx
@@ -2,9 +2,13 @@ import React, { Dispatch } from "react";
 import renderer from "react-test-renderer";
 import { mount } from "enzyme";
 import { EnhancedRoutePattern } from "../components/__schedule";
-import { BusMenuSelect } from "../components/direction/BusMenu";
+import {
+  BusMenuSelect,
+  ExpandedBusMenu
+} from "../components/direction/BusMenu";
 import {
   MenuAction,
+  setRoutePatternAction,
   toggleRoutePatternMenuAction
 } from "../components/direction/reducer";
 
@@ -89,5 +93,45 @@ describe("BusMenuSelect", () => {
 
     wrapper.find(".m-schedule-direction__route-pattern").simulate("click");
     expect(mockDisptach).toHaveBeenCalledWith(toggleRoutePatternMenuAction());
+  });
+});
+
+describe("ExpandedBusMenu", () => {
+  it("renders a menu", () => {
+    const tree = renderer
+      .create(
+        <ExpandedBusMenu
+          routePatterns={routePatterns}
+          selectedRoutePatternId="66-6-0"
+          showAllRoutePatterns={false}
+          itemFocus={"first"}
+          dispatch={mockDisptach}
+        />
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("selects a new route pattern when an item is clicked on", () => {
+    const wrapper = mount(
+      <ExpandedBusMenu
+        routePatterns={routePatterns}
+        selectedRoutePatternId="66-6-0"
+        showAllRoutePatterns={true}
+        itemFocus={"first"}
+        dispatch={mockDisptach}
+      />
+    );
+
+    expect(wrapper.find(".m-schedule-direction__menu-item")).toHaveLength(2);
+
+    const routePattern = routePatterns[1];
+    expect(wrapper.find(`#route-pattern_${routePattern.id}`)).toHaveLength(1);
+    wrapper.find(`#route-pattern_${routePattern.id}`).simulate("click");
+
+    expect(mockDisptach).toHaveBeenCalledWith(
+      setRoutePatternAction(routePattern)
+    );
   });
 });

--- a/apps/site/assets/ts/schedule/__tests__/BusMenuTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/BusMenuTest.tsx
@@ -1,0 +1,90 @@
+import React, { Dispatch } from "react";
+import renderer from "react-test-renderer";
+import { mount } from "enzyme";
+import { EnhancedRoutePattern } from "../components/__schedule";
+import { BusMenuSelect } from "../components/direction/BusMenu";
+import { MenuAction } from "../components/direction/reducer";
+
+const mockDisptach: Dispatch<MenuAction> = jest.fn();
+
+const routePatterns: EnhancedRoutePattern[] = [
+  {
+    direction_id: 0,
+    headsign: "Harvard via Allston",
+    id: "66-6-0",
+    name: "Dudley Station - Harvard Square",
+    representative_trip_id: "44172015",
+    route_id: "66",
+    shape_id: "660140",
+    time_desc: null,
+    typicality: 1
+  },
+  {
+    typicality: 3,
+    time_desc: "School days only",
+    shape_id: "660141-2",
+    route_id: "66",
+    representative_trip_id: "43773700_2",
+    name: "Dudley Station - Union Square, Boston",
+    id: "66-B-0",
+    headsign: "Watertown Yard via Union Square Allston",
+    direction_id: 0
+  }
+];
+const singleRoutePattern = routePatterns.slice(0, 1);
+
+describe("BusMenuSelect", () => {
+  it("renders a menu with a single route pattern", () => {
+    const tree = renderer
+      .create(
+        <BusMenuSelect
+          routePatterns={singleRoutePattern}
+          selectedRoutePatternId="66-6-0"
+          dispatch={mockDisptach}
+        />
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders a menu with multiple route patterns", () => {
+    const tree = renderer
+      .create(
+        <BusMenuSelect
+          routePatterns={routePatterns}
+          selectedRoutePatternId="66-6-0"
+          dispatch={mockDisptach}
+        />
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("it does nothing when clicked if there is only one route pattern", () => {
+    const wrapper = mount(
+      <BusMenuSelect
+        routePatterns={singleRoutePattern}
+        selectedRoutePatternId="66-6-0"
+        dispatch={mockDisptach}
+      />
+    );
+
+    wrapper.find(".m-schedule-direction__route-pattern").simulate("click");
+    expect(mockDisptach).not.toHaveBeenCalled();
+  });
+
+  it("it opens the route pattern menu when clicked if there are multiple route patterns", () => {
+    const wrapper = mount(
+      <BusMenuSelect
+        routePatterns={routePatterns}
+        selectedRoutePatternId="66-6-0"
+        dispatch={mockDisptach}
+      />
+    );
+
+    wrapper.find(".m-schedule-direction__route-pattern").simulate("click");
+    expect(mockDisptach).toHaveBeenCalledWith({ type: "toggleRoutePatternMenu", payload: {} })
+  });
+});

--- a/apps/site/assets/ts/schedule/__tests__/BusMenuTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/BusMenuTest.tsx
@@ -3,7 +3,10 @@ import renderer from "react-test-renderer";
 import { mount } from "enzyme";
 import { EnhancedRoutePattern } from "../components/__schedule";
 import { BusMenuSelect } from "../components/direction/BusMenu";
-import { MenuAction } from "../components/direction/reducer";
+import {
+  MenuAction,
+  toggleRoutePatternMenuAction
+} from "../components/direction/reducer";
 
 const mockDisptach: Dispatch<MenuAction> = jest.fn();
 
@@ -85,6 +88,6 @@ describe("BusMenuSelect", () => {
     );
 
     wrapper.find(".m-schedule-direction__route-pattern").simulate("click");
-    expect(mockDisptach).toHaveBeenCalledWith({ type: "toggleRoutePatternMenu", payload: {} })
+    expect(mockDisptach).toHaveBeenCalledWith(toggleRoutePatternMenuAction());
   });
 });

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -436,9 +436,9 @@ describe("fetchMapData", () => {
         )
     );
 
-    return fetchMapData("1", 0, ["2"], spy).then(() => {
+    return fetchMapData("1", 0, "2", spy).then(() => {
       expect(window.fetch).toHaveBeenCalledWith(
-        "/schedules/map_api?id=1&direction_id=0"
+        "/schedules/map_api?id=1&direction_id=0&shape_id=2"
       );
       expect(spy).toHaveBeenCalledWith({
         type: "FETCH_STARTED"
@@ -464,9 +464,9 @@ describe("fetchMapData", () => {
         )
     );
 
-    return fetchMapData("1", 0, ["2"], spy).then(() => {
+    return fetchMapData("1", 0, "2", spy).then(() => {
       expect(window.fetch).toHaveBeenCalledWith(
-        "/schedules/map_api?id=1&direction_id=0"
+        "/schedules/map_api?id=1&direction_id=0&shape_id=2"
       );
       expect(spy).toHaveBeenCalledWith({
         type: "FETCH_STARTED"

--- a/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/ScheduleDirectionTest.tsx
@@ -5,9 +5,11 @@ import {
 } from "../../app/helpers/testUtils";
 import { mount } from "enzyme";
 import {
+  closeRoutePatternMenuAction,
+  MenuAction as Action,
   menuReducer as reducer,
-  State,
-  MenuAction as Action
+  showAllRoutePatternsAction,
+  State
 } from "../components/direction/reducer";
 import ScheduleDirection, {
   fetchMapData,
@@ -406,9 +408,7 @@ it("can change route pattern for bus mode (accessible)", () => {
 it("reducer can change state correctly for closeRoutePatternMenu", () => {
   const previousState = { ...state, routePatternMenuOpen: true } as State;
 
-  const action = { type: "closeRoutePatternMenu", payload: {} } as Action;
-
-  const nextState = reducer(previousState, action);
+  const nextState = reducer(previousState, closeRoutePatternMenuAction());
 
   expect(nextState.routePatternMenuOpen).toEqual(false);
 });
@@ -416,9 +416,7 @@ it("reducer can change state correctly for closeRoutePatternMenu", () => {
 it("reducer can change state correctly for showAllRoutePatterns", () => {
   const previousState = { ...state, routePatternMenuAll: false } as State;
 
-  const action = { type: "showAllRoutePatterns", payload: {} } as Action;
-
-  const nextState = reducer(previousState, action);
+  const nextState = reducer(previousState, showAllRoutePatternsAction());
 
   expect(nextState.routePatternMenuAll).toEqual(true);
 });

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/BusMenuTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/BusMenuTest.tsx.snap
@@ -32,3 +32,71 @@ exports[`BusMenuSelect renders a menu with multiple route patterns 1`] = `
   />
 </div>
 `;
+
+exports[`ExpandedBusMenu renders a menu 1`] = `
+<div
+  className="m-schedule-direction__menu"
+  role="menu"
+>
+  <div
+    aria-current="page"
+    className="m-schedule-direction__menu-item m-schedule-direction__menu--selected"
+    id="route-pattern_66-6-0"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    role="menuitem"
+    tabIndex={0}
+  >
+    <div
+      className="m-schedule-direction__menu-item-headsign"
+    >
+      <div
+        className="m-schedule-direction__checkmark"
+      >
+        <span
+          aria-hidden="true"
+          className="notranslate c-svg__icon"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      Harvard via Allston
+    </div>
+    <div
+      className="m-schedule-direction__menu-item-description"
+    >
+      typical route
+    </div>
+  </div>
+  <div
+    aria-label="click for additional routes"
+    className="m-schedule-direction__menu-item"
+    id="route-pattern_uncommon"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    role="menuitem"
+    tabIndex={0}
+  >
+    <div
+      className="m-schedule-direction__menu-item-more"
+    >
+      Uncommon destinations
+       
+      <span
+        aria-hidden="true"
+        className="notranslate c-svg__icon m-schedule-direction__route-pattern-arrow"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "SVG",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/BusMenuTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/BusMenuTest.tsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BusMenuSelect renders a menu with a single route pattern 1`] = `
+<div
+  className="m-schedule-direction__route-pattern"
+  onClick={[Function]}
+  onKeyUp={[Function]}
+>
+  Harvard via Allston
+   
+</div>
+`;
+
+exports[`BusMenuSelect renders a menu with multiple route patterns 1`] = `
+<div
+  className="m-schedule-direction__route-pattern m-schedule-direction__route-pattern--clickable"
+  onClick={[Function]}
+  onKeyUp={[Function]}
+  role="button"
+  tabIndex={0}
+>
+  Harvard via Allston
+   
+  <span
+    aria-hidden="true"
+    className="notranslate c-svg__icon m-schedule-direction__route-pattern-arrow"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "SVG",
+      }
+    }
+  />
+</div>
+`;

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -136,7 +136,7 @@ const ScheduleDirection = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [route, state.directionId, staticMapData]
+    [route, state.directionId, currentShapeId, staticMapData]
   );
 
   const [lineState, dispatchLineData] = useReducer(fetchReducer, {

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -34,13 +34,16 @@ export interface Props {
 export const fetchMapData = (
   routeId: string,
   directionId: DirectionId,
+  shapeId: string,
   dispatch: Dispatch<FetchAction>
 ): Promise<void> => {
   dispatch({ type: "FETCH_STARTED" });
   return (
     window.fetch &&
     window
-      .fetch(`/schedules/map_api?id=${routeId}&direction_id=${directionId}`)
+      .fetch(
+        `/schedules/map_api?id=${routeId}&direction_id=${directionId}&shape_id=${shapeId}`
+      )
       .then(response => {
         if (response.ok) return response.json();
         throw new Error(response.statusText);
@@ -124,7 +127,12 @@ const ScheduleDirection = ({
   useEffect(
     () => {
       if (!staticMapData) {
-        fetchMapData(route.id, state.directionId, dispatchMapData);
+        fetchMapData(
+          route.id,
+          state.directionId,
+          currentShapeId,
+          dispatchMapData
+        );
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -51,6 +51,7 @@ export const fetchMapData = (
       .catch(() => dispatch({ type: "FETCH_ERROR" }))
   );
 };
+
 export const fetchLineData = (
   routeId: string,
   directionId: DirectionId,
@@ -73,6 +74,7 @@ export const fetchLineData = (
       .catch(() => dispatch({ type: "FETCH_ERROR" }))
   );
 };
+
 const ScheduleDirection = ({
   route,
   directionId,

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -34,7 +34,6 @@ export interface Props {
 export const fetchMapData = (
   routeId: string,
   directionId: DirectionId,
-  shapeIds: string[],
   dispatch: Dispatch<FetchAction>
 ): Promise<void> => {
   dispatch({ type: "FETCH_STARTED" });
@@ -125,7 +124,7 @@ const ScheduleDirection = ({
   useEffect(
     () => {
       if (!staticMapData) {
-        fetchMapData(route.id, state.directionId, shapeIds, dispatchMapData);
+        fetchMapData(route.id, state.directionId, dispatchMapData);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/site/assets/ts/schedule/components/direction/BusMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/BusMenu.tsx
@@ -169,14 +169,17 @@ export const ExpandedBusMenu = ({
     showAllRoutePatterns ? true : routePattern.typicality < 3;
 
   const focusIndex = determineFocusIndex(itemFocus, routePatterns);
+
   const toggleButtonIds =
     hasMoreRoutePatterns(routePatterns) && showAllRoutePatterns === false
       ? ["uncommon"]
       : [];
+
   const routePatternIds = routePatterns
     .filter(filterRule)
     .map((routePattern: EnhancedRoutePattern) => routePattern.id)
     .concat(toggleButtonIds);
+
   return (
     <div className="m-schedule-direction__menu" role="menu">
       {routePatterns

--- a/apps/site/assets/ts/schedule/components/direction/BusMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/BusMenu.tsx
@@ -29,7 +29,6 @@ interface RoutePatternItem {
 }
 
 interface BusMenuSelectProps {
-  clickableMenu: boolean;
   routePatterns: EnhancedRoutePattern[];
   selectedRoutePatternId: string;
   dispatch: Dispatch<MenuAction>;
@@ -191,19 +190,20 @@ const routePatternNameById = (
   )!.headsign;
 
 export const BusMenuSelect = ({
-  clickableMenu,
   routePatterns,
   selectedRoutePatternId,
   dispatch
 }: BusMenuSelectProps): ReactElement<HTMLElement> => {
-  const handleClick = clickableMenu
+  const isMenuClickable = routePatterns.length > 1;
+
+  const handleClick = isMenuClickable
     ? () => {
         dispatch({ type: "toggleRoutePatternMenu", payload: {} });
       }
     : /* istanbul ignore next */
       () => {};
 
-  const linkClass = clickableMenu
+  const linkClass = isMenuClickable
     ? " m-schedule-direction__route-pattern--clickable"
     : "";
 
@@ -211,8 +211,8 @@ export const BusMenuSelect = ({
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      tabIndex={clickableMenu ? 0 : undefined}
-      role={clickableMenu ? "button" : undefined}
+      tabIndex={isMenuClickable ? 0 : undefined}
+      role={isMenuClickable ? "button" : undefined}
       className={`m-schedule-direction__route-pattern${linkClass}`}
       onClick={handleClick}
       onKeyUp={e =>
@@ -222,7 +222,7 @@ export const BusMenuSelect = ({
       }
     >
       {routePatternNameById(routePatterns, selectedRoutePatternId)}{" "}
-      {clickableMenu &&
+      {isMenuClickable &&
         renderSvg(
           "c-svg__icon m-schedule-direction__route-pattern-arrow",
           arrowIcon

--- a/apps/site/assets/ts/schedule/components/direction/BusMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/BusMenu.tsx
@@ -33,6 +33,11 @@ interface RoutePatternItem {
   dispatch: Dispatch<MenuAction>;
 }
 
+interface UncommonDestinationsItem {
+  routePatternIds: string[];
+  dispatch: Dispatch<MenuAction>;
+}
+
 interface BusMenuSelectProps {
   routePatterns: EnhancedRoutePattern[];
   selectedRoutePatternId: string;
@@ -54,12 +59,15 @@ const RoutePatternItem = ({
   dispatch
 }: RoutePatternItem): ReactElement<HTMLElement> => {
   const selectedClass = selected ? " m-schedule-direction__menu--selected" : "";
+
   const icon = selected ? (
     <div className="m-schedule-direction__checkmark">
       {renderSvg("c-svg__icon", checkIcon)}
     </div>
   ) : null;
+
   const handleClick = (): void => dispatch(setRoutePatternAction(routePattern));
+
   return (
     <div
       aria-current={selected ? "page" : undefined}
@@ -86,6 +94,40 @@ const RoutePatternItem = ({
         {duplicated && `from ${routePattern.name.split(" - ")[0]}, `}
         {routePattern.time_desc ||
           typicalityDefaultText(routePattern.typicality)}
+      </div>
+    </div>
+  );
+};
+
+const UncommonDestinationsItem = ({
+  routePatternIds,
+  dispatch
+}: UncommonDestinationsItem): ReactElement<HTMLElement> => {
+  const handleClick = (): void => dispatch(showAllRoutePatternsAction());
+
+  return (
+    <div
+      id="route-pattern_uncommon"
+      role="menuitem"
+      tabIndex={0}
+      aria-label="click for additional routes"
+      className="m-schedule-direction__menu-item"
+      onClick={handleClick}
+      onKeyUp={(e: ReactKeyboardEvent) =>
+        handleReactEnterKeyPress(e, () => {
+          handleClick();
+        })
+      }
+      onKeyDown={(e: ReactKeyboardEvent) => {
+        handleNavigation(e, routePatternIds);
+      }}
+    >
+      <div className="m-schedule-direction__menu-item-more">
+        Uncommon destinations{" "}
+        {renderSvg(
+          "c-svg__icon m-schedule-direction__route-pattern-arrow",
+          arrowIcon
+        )}
       </div>
     </div>
   );
@@ -126,8 +168,6 @@ export const ExpandedBusMenu = ({
   const filterRule = (routePattern: EnhancedRoutePattern): boolean =>
     showAllRoutePatterns ? true : routePattern.typicality < 3;
 
-  const handleClick = (): void => dispatch(showAllRoutePatternsAction());
-
   const focusIndex = determineFocusIndex(itemFocus, routePatterns);
   const toggleButtonIds =
     hasMoreRoutePatterns(routePatterns) && showAllRoutePatterns === false
@@ -152,32 +192,13 @@ export const ExpandedBusMenu = ({
             dispatch={dispatch}
           />
         ))}
-      {hasMoreRoutePatterns(routePatterns) && showAllRoutePatterns === false && (
-        <div
-          id="route-pattern_uncommon"
-          role="menuitem"
-          tabIndex={0}
-          aria-label="click for additional routes"
-          className="m-schedule-direction__menu-item"
-          onClick={handleClick}
-          onKeyUp={(e: ReactKeyboardEvent) =>
-            handleReactEnterKeyPress(e, () => {
-              handleClick();
-            })
-          }
-          onKeyDown={(e: ReactKeyboardEvent) => {
-            handleNavigation(e, routePatternIds);
-          }}
-        >
-          <div className="m-schedule-direction__menu-item-more">
-            Uncommon destinations{" "}
-            {renderSvg(
-              "c-svg__icon m-schedule-direction__route-pattern-arrow",
-              arrowIcon
-            )}
-          </div>
-        </div>
-      )}
+      {hasMoreRoutePatterns(routePatterns) &&
+        showAllRoutePatterns === false && (
+          <UncommonDestinationsItem
+            routePatternIds={routePatternIds}
+            dispatch={dispatch}
+          />
+        )}
     </div>
   );
 };

--- a/apps/site/assets/ts/schedule/components/direction/BusMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/BusMenu.tsx
@@ -3,7 +3,12 @@ import React, {
   Dispatch,
   KeyboardEvent as ReactKeyboardEvent
 } from "react";
-import { MenuAction } from "./reducer";
+import {
+  MenuAction,
+  setRoutePatternAction,
+  showAllRoutePatternsAction,
+  toggleRoutePatternMenuAction
+} from "./reducer";
 import { EnhancedRoutePattern } from "../__schedule";
 import handleNavigation from "./menu-helpers";
 import renderSvg from "../../../helpers/render-svg";
@@ -54,11 +59,7 @@ const RoutePatternItem = ({
       {renderSvg("c-svg__icon", checkIcon)}
     </div>
   ) : null;
-  const handleClick = (): void =>
-    dispatch({
-      type: "setRoutePattern",
-      payload: { routePattern }
-    });
+  const handleClick = (): void => dispatch(setRoutePatternAction(routePattern));
   return (
     <div
       aria-current={selected ? "page" : undefined}
@@ -124,8 +125,9 @@ export const ExpandedBusMenu = ({
 }: ExpandedBusMenuProps): ReactElement<HTMLElement> => {
   const filterRule = (routePattern: EnhancedRoutePattern): boolean =>
     showAllRoutePatterns ? true : routePattern.typicality < 3;
-  const handleClick = (): void =>
-    dispatch({ type: "showAllRoutePatterns", payload: {} });
+
+  const handleClick = (): void => dispatch(showAllRoutePatternsAction());
+
   const focusIndex = determineFocusIndex(itemFocus, routePatterns);
   const toggleButtonIds =
     hasMoreRoutePatterns(routePatterns) && showAllRoutePatterns === false
@@ -198,7 +200,7 @@ export const BusMenuSelect = ({
 
   const handleClick = isMenuClickable
     ? () => {
-        dispatch({ type: "toggleRoutePatternMenu", payload: {} });
+        dispatch(toggleRoutePatternMenuAction());
       }
     : /* istanbul ignore next */
       () => {};

--- a/apps/site/assets/ts/schedule/components/direction/GreenLineMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/GreenLineMenu.tsx
@@ -4,7 +4,7 @@ import React, {
   KeyboardEvent as ReactKeyboardEvent
 } from "react";
 import { DirectionId, EnhancedRoute } from "../../../__v3api";
-import { MenuAction } from "./reducer";
+import { MenuAction, toggleRoutePatternMenuAction } from "./reducer";
 import renderSvg from "../../../helpers/render-svg";
 import handleNavigation from "./menu-helpers";
 import arrowIcon from "../../../../static/images/icon-down-arrow.svg";
@@ -154,7 +154,7 @@ export const GreenLineSelect = ({
   directionId
 }: GreenLineSelectProps): ReactElement<HTMLElement> => {
   const handleClick = (): void => {
-    dispatch({ type: "toggleRoutePatternMenu", payload: {} });
+    dispatch(toggleRoutePatternMenuAction());
   };
 
   const route = greenRoutes.find(greenRoute => greenRoute.id === routeId)!;

--- a/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionButton.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionButton.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, Dispatch } from "react";
 import renderSVG from "../../../helpers/render-svg";
 import icon from "../../../../static/images/icon-change-direction.svg";
-import { MenuAction } from "./reducer";
+import { MenuAction, toggleDirectionAction } from "./reducer";
 
 interface Props {
   dispatch: Dispatch<MenuAction>;
@@ -14,7 +14,7 @@ const ScheduleDirectionButton = ({
     type="button"
     className="m-schedule-direction__button btn btn-primary"
     onClick={() => {
-      dispatch({ type: "toggleDirection" });
+      dispatch(toggleDirectionAction());
     }}
   >
     {renderSVG("m-schedule-direction__icon", icon)}Change Direction

--- a/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
@@ -50,8 +50,6 @@ const ScheduleDirectionMenu = ({
   itemFocus,
   dispatch
 }: Props): ReactElement<HTMLElement> => {
-  const clickableMenu = routePatternsByDirection[directionId].length > 1;
-
   const routePatterns = routePatternsByDirection[directionId];
 
   useEffect(() => {
@@ -64,7 +62,6 @@ const ScheduleDirectionMenu = ({
       {// bus mode
       route.type === 3 && (
         <BusMenuSelect
-          clickableMenu={clickableMenu}
           routePatterns={routePatternsByDirection[directionId]}
           selectedRoutePatternId={selectedRoutePatternId}
           dispatch={dispatch}

--- a/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
@@ -5,6 +5,7 @@ import { MenuAction, closeRoutePatternMenuAction } from "./reducer";
 import { GreenLineSelect, ExpandedGreenMenu } from "./GreenLineMenu";
 import { BusMenuSelect, ExpandedBusMenu } from "./BusMenu";
 import { handleNativeEscapeKeyPress } from "../../../helpers/keyboard-events";
+import { isABusRoute, isAGreenLineRoute } from "../../../models/route";
 
 interface Props {
   route: EnhancedRoute;
@@ -60,7 +61,7 @@ const ScheduleDirectionMenu = ({
   return (
     <div className="js-m-schedule-click-boundary">
       {// bus mode
-      route.type === 3 && (
+      isABusRoute(route) && (
         <BusMenuSelect
           routePatterns={routePatternsByDirection[directionId]}
           selectedRoutePatternId={selectedRoutePatternId}
@@ -68,7 +69,7 @@ const ScheduleDirectionMenu = ({
         />
       )}
       {// Green Line
-      route.id.startsWith("Green") && (
+      isAGreenLineRoute(route) && (
         <GreenLineSelect
           routeId={route.id}
           dispatch={dispatch}
@@ -87,7 +88,7 @@ const ScheduleDirectionMenu = ({
           {route.direction_destinations[directionId]}
         </div>
       )}
-      {menuOpen && route.type === 3 && (
+      {menuOpen && isABusRoute(route) && (
         <ExpandedBusMenu
           routePatterns={routePatterns}
           selectedRoutePatternId={selectedRoutePatternId}
@@ -96,7 +97,7 @@ const ScheduleDirectionMenu = ({
           dispatch={dispatch}
         />
       )}
-      {menuOpen && route.id.startsWith("Green") && (
+      {menuOpen && isAGreenLineRoute(route) && (
         <ExpandedGreenMenu directionId={directionId} route={route} />
       )}
     </div>

--- a/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, Dispatch, useEffect } from "react";
 import { DirectionId, EnhancedRoute } from "../../../__v3api";
 import { RoutePatternsByDirection } from "../__schedule";
-import { MenuAction } from "./reducer";
+import { MenuAction, closeRoutePatternMenuAction } from "./reducer";
 import { GreenLineSelect, ExpandedGreenMenu } from "./GreenLineMenu";
 import { BusMenuSelect, ExpandedBusMenu } from "./BusMenu";
 import { handleNativeEscapeKeyPress } from "../../../helpers/keyboard-events";
@@ -25,7 +25,7 @@ const externalCloseEvent = (dispatch: Dispatch<MenuAction>): void => {
       if (!event.target) return;
       const element = event.target as HTMLElement;
       if (element.closest(".js-m-schedule-click-boundary")) return;
-      dispatch({ type: "closeRoutePatternMenu", payload: {} });
+      dispatch(closeRoutePatternMenuAction());
     },
     true
   );
@@ -34,7 +34,7 @@ const externalCloseEvent = (dispatch: Dispatch<MenuAction>): void => {
     "keydown",
     (event: KeyboardEvent): void => {
       handleNativeEscapeKeyPress(event, () => {
-        dispatch({ type: "closeRoutePatternMenu", payload: {} });
+        dispatch(closeRoutePatternMenuAction());
       });
     }
   );

--- a/apps/site/assets/ts/schedule/components/direction/reducer.ts
+++ b/apps/site/assets/ts/schedule/components/direction/reducer.ts
@@ -22,6 +22,29 @@ export interface Payload {
   routePattern?: EnhancedRoutePattern;
 }
 
+export const toggleDirectionAction = (): MenuAction => ({
+  type: "toggleDirection"
+});
+
+export const setRoutePatternAction = (
+  routePattern: EnhancedRoutePattern
+): MenuAction => ({
+  type: "setRoutePattern",
+  payload: { routePattern }
+});
+
+export const toggleRoutePatternMenuAction = (): MenuAction => ({
+  type: "toggleRoutePatternMenu"
+});
+
+export const closeRoutePatternMenuAction = (): MenuAction => ({
+  type: "closeRoutePatternMenu"
+});
+
+export const showAllRoutePatternsAction = (): MenuAction => ({
+  type: "showAllRoutePatterns"
+});
+
 export interface MenuAction {
   type:
     | "toggleDirection"

--- a/apps/site/assets/ts/schedule/components/line-diagram/SingleStop.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/SingleStop.tsx
@@ -7,6 +7,7 @@ import {
   parkingIcon,
   accessibleIcon
 } from "../../../helpers/icon";
+import { isABusRoute, isAGreenLineRoute } from "../../../models/route";
 import { Alert, Route } from "../../../__v3api";
 import { LiveData } from "./LineDiagram";
 import StopPredictions from "./StopPredictions";
@@ -43,7 +44,7 @@ const busBackgroundClass = (connection: Route): string =>
   connection.name.startsWith("SL") ? "u-bg--silver-line" : "u-bg--bus";
 
 const connectionName = (connection: Route): string => {
-  if (connection.type === 3) {
+  if (isABusRoute(connection)) {
     return connection.name.startsWith("SL")
       ? `Silver Line ${connection.name}`
       : `Route ${connection.name}`;
@@ -68,7 +69,7 @@ const StopConnections = (connections: RouteStopRoute[]): JSX.Element => (
           animation: "false"
         }}
       >
-        {connectingRoute.type === 3 ? (
+        {isABusRoute(connectingRoute) ? (
           <span
             key={connectingRoute.id}
             className={`c-icon__bus-pill--small m-schedule-diagram__connection ${busBackgroundClass(
@@ -135,7 +136,7 @@ const StopFeatures = (routeStop: RouteStop): JSX.Element => (
 const StopBranchLabel = (stop: RouteStop): JSX.Element | null =>
   stop["is_terminus?"] && !!stop.branch && !!stop.route ? (
     <div className="u-bold u-small-caps">
-      {stop.route.id.startsWith("Green")
+      {isAGreenLineRoute(stop.route)
         ? `Green Line ${stop.route.id.split("-")[1]}`
         : stop.name}
       {stop.route.type === 2 ? " Line" : " Branch"}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/UpcomingDepartures.tsx
@@ -5,6 +5,7 @@ import {
   statusForCommuterRail
 } from "../../../helpers/prediction-helpers";
 import { modeIcon } from "../../../helpers/icon";
+import { isABusRoute } from "../../../models/route";
 import { modeBgClass } from "../../../stop/components/RoutePillList";
 import { Route } from "../../../__v3api";
 import { EnhancedJourney } from "../__trips";
@@ -61,7 +62,7 @@ const BusTableRow = ({
   return (
     <>
       <td className="schedule-table__cell schedule-table__cell--headsign">
-        {route.type === 3 ? (
+        {isABusRoute(route) ? (
           <RoutePillSmall route={route} />
         ) : (
           <span className="schedule-table__row-route-pill m-route-pills">

--- a/apps/site/assets/ts/stop/components/RouteCard.tsx
+++ b/apps/site/assets/ts/stop/components/RouteCard.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react";
 import { Direction as DirectionType, EnhancedRoute, Stop } from "../../__v3api";
 import Direction from "../../components/Direction";
 import { isSilverLine } from "../../helpers/silver-line";
+import { isABusRoute } from "../../models/route";
 
 interface Props {
   route: EnhancedRoute;
@@ -17,7 +18,7 @@ const routeBgColor = (route: EnhancedRoute): string => {
   if (route.id === "Blue") return "blue-line";
   if (route.id.startsWith("Green-")) return "green-line";
   if (isSilverLine(route.id)) return "silver-line";
-  if (route.type === 3) return "bus";
+  if (isABusRoute(route)) return "bus";
   return "unknown";
 };
 
@@ -25,7 +26,7 @@ const routeBgClass = (route: EnhancedRoute): string =>
   `u-bg--${routeBgColor(route)}`;
 
 const busClass = (route: EnhancedRoute): string =>
-  route.type === 3 && !isSilverLine(route.id) ? "bus-route-sign" : "";
+  isABusRoute(route) && !isSilverLine(route.id) ? "bus-route-sign" : "";
 
 const routeHeader = (route: EnhancedRoute): string =>
   isSilverLine(route.id) ? `Silver Line ${route.name}` : route.name;

--- a/apps/site/assets/ts/stop/components/StopCard.tsx
+++ b/apps/site/assets/ts/stop/components/StopCard.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react";
 import { Stop, EnhancedRoute, DirectionId } from "../../__v3api";
 import { RouteWithDirection } from "./__stop";
 import { modeIcon } from "../../helpers/icon";
+import { isABusRoute } from "../../models/route";
 import accessible from "./StopAccessibilityIcon";
 
 const formatMilesToFeet = (miles: number): number => Math.floor(miles * 5280.0);
@@ -72,7 +73,7 @@ const StopCard = ({
             className="c-stop-card__route"
             key={`suggestedTransferRoute${route.id}`}
           >
-            {route.type === 3 && !route.name.startsWith("SL") ? (
+            {isABusRoute(route) && !route.name.startsWith("SL") ? (
               <div className="c-stop-card__bus-pill u-bg--bus u-small-class">
                 {route.name}
               </div>

--- a/apps/site/assets/ts/tnm/__tests__/RoutesSidebarTest.tsx
+++ b/apps/site/assets/ts/tnm/__tests__/RoutesSidebarTest.tsx
@@ -5,6 +5,7 @@ import { createReactRoot } from "../../app/helpers/testUtils";
 import { importData, importRealtimeResponse } from "./helpers/testUtils";
 import { RouteWithStopsWithDirections } from "../../__v3api";
 import { transformRoutes } from "../helpers/process-realtime-data";
+import { isABusRoute } from "../../models/route";
 
 const realtimeData = importRealtimeResponse();
 const stopsWithDistances = importData();
@@ -205,8 +206,8 @@ describe("filterData", () => {
     );
     expect(filteredBusData).toHaveLength(13);
     expect(
-      filteredBusData.every(
-        (route: RouteWithStopsWithDirections) => route.route.type === 3
+      filteredBusData.every((route: RouteWithStopsWithDirections) =>
+        isABusRoute(route.route)
       )
     ).toEqual(true);
 

--- a/apps/site/assets/ts/tnm/components/RouteCard.tsx
+++ b/apps/site/assets/ts/tnm/components/RouteCard.tsx
@@ -10,6 +10,7 @@ import { Dispatch } from "../state";
 import { directionIsEmpty } from "../../components/Direction";
 import { modeByV3ModeType } from "../../components/ModeFilter";
 import { alertIcon } from "../../helpers/icon";
+import { isABusRoute } from "../../models/route";
 
 interface Props {
   route: RouteWithStopsWithDirections;
@@ -29,7 +30,7 @@ const filterStops = (
 ): StopWithDirections[] => {
   // show the closest two stops for bus, in order to display both inbound and outbound stops
 
-  const count = route.route.type === 3 ? 2 : 1;
+  const count = isABusRoute(route.route) ? 2 : 1;
   return route.stops_with_directions.slice(0, count);
 };
 
@@ -57,12 +58,12 @@ export const routeBgColor = (route: RouteWithStopsWithDirections): string => {
   if (route.route.id === "Blue") return "blue-line";
   if (route.route.id.startsWith("Green-")) return "green-line";
   if (isSilverLine(route)) return "silver-line";
-  if (route.route.type === 3) return "bus";
+  if (isABusRoute(route.route)) return "bus";
   return "unknown";
 };
 
 export const busClass = (route: RouteWithStopsWithDirections): string =>
-  route.route.type === 3 && !isSilverLine(route) ? "bus-route-sign" : "";
+  isABusRoute(route.route) && !isSilverLine(route) ? "bus-route-sign" : "";
 
 const RouteCard = ({
   route,

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -56,25 +56,25 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
     end
   end
 
-  @spec get_active_shapes([Shape.t()], Route.t(), Route.branch_name()) :: [
+  @spec get_active_shapes([Shape.t()], Route.t(), Shape.id_t()) :: [
           Shape.t()
         ]
-  def get_active_shapes(shapes, %Route{type: 3}, variant) do
+  def get_active_shapes(shapes, %Route{type: 3}, shape_id) do
     shapes
-    |> get_requested_shape(variant)
+    |> get_requested_shape(shape_id)
     |> get_default_shape(shapes)
   end
 
-  def get_active_shapes(_shapes, %Route{id: "Green"}, _variant) do
+  def get_active_shapes(_shapes, %Route{id: "Green"}, _shape_id) do
     # not used by the green line code
     []
   end
 
-  def get_active_shapes(shapes, _route, _variant), do: shapes
+  def get_active_shapes(shapes, _route, _shape_id), do: shapes
 
   @spec get_requested_shape([Shape.t()], query_param) :: Shape.t() | nil
   defp get_requested_shape(_shapes, nil), do: nil
-  defp get_requested_shape(shapes, variant), do: Enum.find(shapes, &(&1.id == variant))
+  defp get_requested_shape(shapes, shape_id), do: Enum.find(shapes, &(&1.id == shape_id))
 
   @spec get_default_shape(Shape.t() | nil, [Shape.t()]) :: [Shape.t()]
   defp get_default_shape(nil, [default | _]), do: [default]

--- a/apps/site/lib/site_web/controllers/schedule/line/maps.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/maps.ex
@@ -1,4 +1,8 @@
 defmodule SiteWeb.ScheduleController.Line.Maps do
+  @moduledoc """
+  Handles Map information for the line controller
+  """
+
   alias GoogleMaps.MapData, as: GoogleMapData
   alias GoogleMapData.Marker, as: GoogleMarker
   alias GoogleMapData.Path
@@ -7,111 +11,6 @@ defmodule SiteWeb.ScheduleController.Line.Maps do
   alias Routes.{Route, Shape}
   alias Site.MapHelpers
   alias Site.MapHelpers.Markers
-
-  @moduledoc """
-  Handles Map information for the line controller
-  """
-
-  @spec map_img_src({any, [Shape.t()]}, [Shape.t()], Route.t()) :: String.t()
-  def map_img_src(_, _, %Route{type: 4}) do
-    MapHelpers.image(:ferry)
-  end
-
-  def map_img_src({route_stops, _shapes}, polylines, %{color: route_color} = _route) do
-    markers = Enum.map(route_stops, &build_google_stop_marker/1)
-    paths = Enum.map(polylines, &Path.new(&1, color: route_color))
-
-    {600, 600}
-    |> GoogleMapData.new()
-    |> GoogleMapData.add_markers(markers)
-    |> GoogleMapData.add_paths(paths)
-    |> GoogleMaps.static_map_url()
-  end
-
-  @spec build_google_stop_marker(RouteStop.t()) :: GoogleMarker.t()
-  defp build_google_stop_marker(%RouteStop{id: id, is_terminus?: is_terminus?}) do
-    id
-    |> Repo.get()
-    |> Markers.stop(is_terminus?)
-  end
-
-  @spec build_stop_marker(RouteStop.t()) :: Marker.t()
-  defp build_stop_marker(%RouteStop{id: id}) do
-    id
-    |> Repo.get()
-    |> do_build_stop_marker()
-  end
-
-  @spec do_build_stop_marker(Stop.t()) :: Marker.t()
-  defp do_build_stop_marker(%Stop{id: id, latitude: lat, longitude: lng, name: name}) do
-    Marker.new(lat, lng, id: id, icon: "stop-circle-bordered-expanded", tooltip_text: name)
-  end
-
-  @spec dynamic_map_data(
-          String.t(),
-          [Shape.t()],
-          {[RouteStop.t()], any},
-          {[String.t()], VehicleHelpers.tooltip_index()} | {any, nil}
-        ) :: MapData.t()
-  def dynamic_map_data(
-        color,
-        map_shapes,
-        {route_stops, _shapes},
-        {_vehicle_polylines, vehicle_tooltips}
-      ) do
-    {stop_markers, all_markers} = dynamic_markers(route_stops, vehicle_tooltips)
-
-    paths = dynamic_paths("#" <> color, map_shapes, [])
-
-    {600, 600}
-    |> MapData.new(16)
-    |> MapData.add_markers(all_markers)
-    |> MapData.add_stop_markers(stop_markers)
-    |> MapData.add_polylines(paths)
-    |> Map.put(:tile_server_url, Application.fetch_env!(:site, :tile_server_url))
-  end
-
-  @spec dynamic_markers([RouteStop.t()], VehicleHelpers.tooltip_index() | nil) ::
-          {[Marker.t()], [Marker.t()]}
-  defp dynamic_markers(route_stops, nil) do
-    stop_markers = Enum.map(route_stops, &build_stop_marker/1)
-    {stop_markers, stop_markers}
-  end
-
-  defp dynamic_markers(route_stops, tooltip_index) do
-    vehicle_markers = build_vehicle_markers(tooltip_index)
-    stop_markers = Enum.map(route_stops, &build_stop_marker/1)
-    {stop_markers, stop_markers ++ vehicle_markers}
-  end
-
-  @spec build_vehicle_markers(VehicleHelpers.tooltip_index()) :: [Marker.t()]
-  defp build_vehicle_markers(tooltip_index) do
-    # the tooltip index uses two different key formats, so
-    # the Enum.reject call here is essentially just
-    # deduplicating the index
-    tooltip_index
-    |> Enum.reject(&match?({{_trip, _id}, _tooltip}, &1))
-    |> Enum.map(fn {_, vt} ->
-      Marker.new(
-        vt.vehicle.latitude,
-        vt.vehicle.longitude,
-        id: vt.vehicle.id,
-        icon: "vehicle-bordered-expanded",
-        rotation_angle: vt.vehicle.bearing,
-        tooltip_text:
-          vt
-          |> VehicleHelpers.tooltip()
-          |> Floki.text()
-      )
-    end)
-  end
-
-  @spec dynamic_paths(String.t(), [Shape.t()], [Shape.t()]) :: [Polyline.t()]
-  defp dynamic_paths(color, route_polylines, vehicle_polylines) do
-    route_paths = Enum.map(route_polylines, &Polyline.new(&1, color: color, weight: 4))
-    vehicle_paths = Enum.map(vehicle_polylines, &Polyline.new(&1, color: color, weight: 2))
-    route_paths ++ vehicle_paths
-  end
 
   @doc """
   Returns a tuple {String.t, MapData.t} where the first element
@@ -146,11 +45,6 @@ defmodule SiteWeb.ScheduleController.Line.Maps do
     {static_data, dynamic_data}
   end
 
-  @spec map_polylines({any, [Shape.t()]}, Route.t()) :: [Shape.t()]
-  defp map_polylines(_, %Route{type: 4}), do: []
-
-  defp map_polylines({_stops, shapes}, _), do: shapes
-
   @doc "Returns the stops that should be displayed on the map"
   @spec map_stops([RouteStops.t()], {[Shape.t()], [Shape.t()]}, Route.id_t()) ::
           {[Stops.Stop.t()], [Shape.t()]}
@@ -160,6 +54,112 @@ defmodule SiteWeb.ScheduleController.Line.Maps do
 
   def map_stops(branches, {_route_shapes, active_shapes}, _route_id) do
     {do_map_stops(branches), active_shapes}
+  end
+
+  @spec map_polylines({any, [Shape.t()]}, Route.t()) :: [Shape.t()]
+  defp map_polylines(_, %Route{type: 4}), do: []
+
+  defp map_polylines({_stops, shapes}, _), do: shapes
+
+  @spec map_img_src({any, [Shape.t()]}, [Shape.t()], Route.t()) :: String.t()
+  defp map_img_src(_, _, %Route{type: 4}) do
+    MapHelpers.image(:ferry)
+  end
+
+  defp map_img_src({route_stops, _shapes}, polylines, %{color: route_color} = _route) do
+    markers = Enum.map(route_stops, &build_google_stop_marker/1)
+    paths = Enum.map(polylines, &Path.new(&1, color: route_color))
+
+    {600, 600}
+    |> GoogleMapData.new()
+    |> GoogleMapData.add_markers(markers)
+    |> GoogleMapData.add_paths(paths)
+    |> GoogleMaps.static_map_url()
+  end
+
+  @spec build_google_stop_marker(RouteStop.t()) :: GoogleMarker.t()
+  defp build_google_stop_marker(%RouteStop{id: id, is_terminus?: is_terminus?}) do
+    id
+    |> Repo.get()
+    |> Markers.stop(is_terminus?)
+  end
+
+  @spec dynamic_map_data(
+          String.t(),
+          [Shape.t()],
+          {[RouteStop.t()], any},
+          {[String.t()], VehicleHelpers.tooltip_index()} | {any, nil}
+        ) :: MapData.t()
+  defp dynamic_map_data(
+         color,
+         map_shapes,
+         {route_stops, _shapes},
+         {_vehicle_polylines, vehicle_tooltips}
+       ) do
+    {stop_markers, all_markers} = dynamic_markers(route_stops, vehicle_tooltips)
+
+    paths = dynamic_paths("#" <> color, map_shapes, [])
+
+    {600, 600}
+    |> MapData.new(16)
+    |> MapData.add_markers(all_markers)
+    |> MapData.add_stop_markers(stop_markers)
+    |> MapData.add_polylines(paths)
+    |> Map.put(:tile_server_url, Application.fetch_env!(:site, :tile_server_url))
+  end
+
+  @spec dynamic_markers([RouteStop.t()], VehicleHelpers.tooltip_index() | nil) ::
+          {[Marker.t()], [Marker.t()]}
+  defp dynamic_markers(route_stops, nil) do
+    stop_markers = Enum.map(route_stops, &build_stop_marker/1)
+    {stop_markers, stop_markers}
+  end
+
+  defp dynamic_markers(route_stops, tooltip_index) do
+    vehicle_markers = build_vehicle_markers(tooltip_index)
+    stop_markers = Enum.map(route_stops, &build_stop_marker/1)
+    {stop_markers, stop_markers ++ vehicle_markers}
+  end
+
+  @spec build_stop_marker(RouteStop.t()) :: Marker.t()
+  defp build_stop_marker(%RouteStop{id: id}) do
+    id
+    |> Repo.get()
+    |> do_build_stop_marker()
+  end
+
+  @spec do_build_stop_marker(Stop.t()) :: Marker.t()
+  defp do_build_stop_marker(%Stop{id: id, latitude: lat, longitude: lng, name: name}) do
+    Marker.new(lat, lng, id: id, icon: "stop-circle-bordered-expanded", tooltip_text: name)
+  end
+
+  @spec build_vehicle_markers(VehicleHelpers.tooltip_index()) :: [Marker.t()]
+  defp build_vehicle_markers(tooltip_index) do
+    # the tooltip index uses two different key formats, so
+    # the Enum.reject call here is essentially just
+    # deduplicating the index
+    tooltip_index
+    |> Enum.reject(&match?({{_trip, _id}, _tooltip}, &1))
+    |> Enum.map(fn {_, vt} ->
+      Marker.new(
+        vt.vehicle.latitude,
+        vt.vehicle.longitude,
+        id: vt.vehicle.id,
+        icon: "vehicle-bordered-expanded",
+        rotation_angle: vt.vehicle.bearing,
+        tooltip_text:
+          vt
+          |> VehicleHelpers.tooltip()
+          |> Floki.text()
+      )
+    end)
+  end
+
+  @spec dynamic_paths(String.t(), [Shape.t()], [Shape.t()]) :: [Polyline.t()]
+  defp dynamic_paths(color, route_polylines, vehicle_polylines) do
+    route_paths = Enum.map(route_polylines, &Polyline.new(&1, color: color, weight: 4))
+    vehicle_paths = Enum.map(vehicle_polylines, &Polyline.new(&1, color: color, weight: 2))
+    route_paths ++ vehicle_paths
   end
 
   @spec do_map_stops([RouteStops.t()]) :: [RouteStop.t()]

--- a/apps/site/lib/site_web/controllers/schedule/line/maps.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/maps.ex
@@ -4,7 +4,7 @@ defmodule SiteWeb.ScheduleController.Line.Maps do
   alias GoogleMapData.Path
   alias Leaflet.{MapData, MapData.Marker, MapData.Polyline}
   alias Stops.{RouteStops, RouteStop, Repo, Stop}
-  alias Routes.{Shape, Route}
+  alias Routes.{Route, Shape}
   alias Site.MapHelpers
   alias Site.MapHelpers.Markers
 
@@ -12,7 +12,8 @@ defmodule SiteWeb.ScheduleController.Line.Maps do
   Handles Map information for the line controller
   """
 
-  def map_img_src(_, _, %Routes.Route{type: 4}) do
+  @spec map_img_src({any, [Shape.t()]}, [Shape.t()], Route.t()) :: String.t()
+  def map_img_src(_, _, %Route{type: 4}) do
     MapHelpers.image(:ferry)
   end
 
@@ -117,6 +118,12 @@ defmodule SiteWeb.ScheduleController.Line.Maps do
   is the url for the static map, and the second element is the MapData
   struct used to build the dynamic map
   """
+  @spec map_data(
+          Route.t(),
+          {any, [Shape.t()]},
+          [String.t()] | any,
+          VehicleHelpers.tooltip_index() | [] | nil
+        ) :: {String.t(), MapData.t()}
   def map_data(route, map_route_stops, [], []) do
     map_shapes = map_polylines(map_route_stops, route)
     static_data = map_img_src(map_route_stops, [], route)
@@ -139,8 +146,8 @@ defmodule SiteWeb.ScheduleController.Line.Maps do
     {static_data, dynamic_data}
   end
 
-  @spec map_polylines({any, [Routes.Shape.t()]}, Route.t()) :: [Shape.t()]
-  defp map_polylines(_, %Routes.Route{type: 4}), do: []
+  @spec map_polylines({any, [Shape.t()]}, Route.t()) :: [Shape.t()]
+  defp map_polylines(_, %Route{type: 4}), do: []
 
   defp map_polylines({_stops, shapes}, _), do: shapes
 

--- a/apps/site/lib/site_web/controllers/schedule/map_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/map_api.ex
@@ -29,10 +29,10 @@ defmodule SiteWeb.ScheduleController.MapApi do
           MapData.t()
   defp get_map_data(conn, route_id, direction_id, stops_by_route_fn) do
     route = LineHelpers.get_route(route_id)
-    variant = conn.query_params["variant"]
-    route_shapes = LineHelpers.get_route_shapes(route.id, direction_id)
+    shape_id = conn.query_params["shape_id"]
+    route_shapes = LineHelpers.get_route_shapes(route.id, direction_id, false)
     route_stops = LineHelpers.get_route_stops(route.id, direction_id, stops_by_route_fn)
-    active_shapes = LineHelpers.get_active_shapes(route_shapes, route, variant)
+    active_shapes = LineHelpers.get_active_shapes(route_shapes, route, shape_id)
     filtered_shapes = LineHelpers.filter_route_shapes(route_shapes, active_shapes, route)
     branches = LineHelpers.get_branches(filtered_shapes, route_stops, route, direction_id)
     map_stops = Maps.map_stops(branches, {route_shapes, active_shapes}, route.id)

--- a/apps/site/lib/site_web/controllers/schedule/map_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/map_api.ex
@@ -4,30 +4,34 @@ defmodule SiteWeb.ScheduleController.MapApi do
   """
   use SiteWeb, :controller
 
+  alias Leaflet.MapData
+  alias Routes.Route
   alias SiteWeb.ScheduleController.Line.Helpers, as: LineHelpers
   alias SiteWeb.ScheduleController.Line.Maps
   alias Stops.Repo, as: StopsRepo
+  alias Stops.Stop
 
-  @type query_param :: String.t() | nil
   @type direction_id :: 0 | 1
 
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, %{
         "id" => route_id,
         "direction_id" => direction_id
       }) do
     map_data =
-      get_map_data(conn, route_id, String.to_integer(direction_id), %{
-        stops_by_route_fn: &StopsRepo.by_route/3
-      })
+      get_map_data(conn, route_id, String.to_integer(direction_id), &StopsRepo.by_route/3)
 
     json(conn, map_data)
   end
 
-  def get_map_data(conn, route_id, direction_id, deps) do
+  @type stops_by_route_fn :: (Route.id_t(), 0 | 1, Keyword.t() -> [Stop.t()] | {:error, any})
+  @spec get_map_data(Plug.Conn.t(), Route.id_t(), direction_id(), stops_by_route_fn()) ::
+          MapData.t()
+  defp get_map_data(conn, route_id, direction_id, stops_by_route_fn) do
     route = LineHelpers.get_route(route_id)
     variant = conn.query_params["variant"]
     route_shapes = LineHelpers.get_route_shapes(route.id, direction_id)
-    route_stops = LineHelpers.get_route_stops(route.id, direction_id, deps.stops_by_route_fn)
+    route_stops = LineHelpers.get_route_stops(route.id, direction_id, stops_by_route_fn)
     active_shapes = LineHelpers.get_active_shapes(route_shapes, route, variant)
     filtered_shapes = LineHelpers.filter_route_shapes(route_shapes, active_shapes, route)
     branches = LineHelpers.get_branches(filtered_shapes, route_stops, route, direction_id)

--- a/apps/site/lib/site_web/controllers/schedule/map_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/map_api.ex
@@ -30,7 +30,7 @@ defmodule SiteWeb.ScheduleController.MapApi do
   defp get_map_data(conn, route_id, direction_id, stops_by_route_fn) do
     route = LineHelpers.get_route(route_id)
     shape_id = conn.query_params["shape_id"]
-    route_shapes = LineHelpers.get_route_shapes(route.id, direction_id, false)
+    route_shapes = LineHelpers.get_route_shapes(route.id, direction_id)
     route_stops = LineHelpers.get_route_stops(route.id, direction_id, stops_by_route_fn)
     active_shapes = LineHelpers.get_active_shapes(route_shapes, route, shape_id)
     filtered_shapes = LineHelpers.filter_route_shapes(route_shapes, active_shapes, route)

--- a/apps/site/test/site_web/controllers/schedule/map_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/map_api_test.exs
@@ -19,8 +19,9 @@ defmodule SiteWeb.ScheduleController.MapApiTest do
              } = response
     end
 
-    test "allows you to specify a variant", %{conn: conn} do
-      conn = get(conn, map_api_path(conn, :show, id: "66", direction_id: "0", variant: "66-B-0"))
+    test "allows you to specify a shape_id", %{conn: conn} do
+      conn =
+        get(conn, map_api_path(conn, :show, id: "66", direction_id: "0", shape_id: "660141-2"))
 
       assert response = json_response(conn, 200)
 

--- a/apps/site/test/site_web/controllers/schedule/map_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/map_api_test.exs
@@ -1,0 +1,39 @@
+defmodule SiteWeb.ScheduleController.MapApiTest do
+  use SiteWeb.ConnCase, async: true
+
+  describe "show/2" do
+    test "returns map data formatted as json", %{conn: conn} do
+      conn = get(conn, map_api_path(conn, :show, id: "66", direction_id: "0"))
+
+      assert response = json_response(conn, 200)
+
+      assert %{
+               "default_center" => %{"latitude" => _, "longitude" => _},
+               "height" => _,
+               "markers" => _,
+               "polylines" => _,
+               "stop_markers" => _,
+               "tile_server_url" => _,
+               "width" => _,
+               "zoom" => _
+             } = response
+    end
+
+    test "allows you to specify a variant", %{conn: conn} do
+      conn = get(conn, map_api_path(conn, :show, id: "66", direction_id: "0", variant: "66-B-0"))
+
+      assert response = json_response(conn, 200)
+
+      assert %{
+               "default_center" => %{"latitude" => _, "longitude" => _},
+               "height" => _,
+               "markers" => _,
+               "polylines" => _,
+               "stop_markers" => _,
+               "tile_server_url" => _,
+               "width" => _,
+               "zoom" => _
+             } = response
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Schedules | Variant Selector](https://app.asana.com/0/555089885850811/1178546719272801)

Include the shape ID when requesting map data.
Don't filter out shapes with negative priority.
Fix server functions that were incorrectly calling the piece of data "variant" when it was actually a Shape ID.

Just the last commit is the actual fix to the bug and the only functional change. Before that is a hodgepodge of refactoring and adding tests I did on my way to figuring out how everything works. I tried to keep commits distinct to hopefully aid in walking through them, but let me know if anything isn't clear.

Screenshots showing the maps are correctly different now:

![Screen Shot 2020-06-04 at 14 50 25](https://user-images.githubusercontent.com/42339/83799384-b537bc00-a673-11ea-8ff0-6fb13cf847ea.png)
![Screen Shot 2020-06-04 at 14 50 35](https://user-images.githubusercontent.com/42339/83799391-b7017f80-a673-11ea-8ef7-fe2975cef5df.png)

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
