### PR TITLE
Logic for the Fare Calculator in the Trip Planner (2nd accordion)

### DIFF
--- a/apps/fares/test/one_way_test.exs
+++ b/apps/fares/test/one_way_test.exs
@@ -8,7 +8,7 @@ defmodule OneWayTest do
 
   @default_filters [duration: :single_trip]
 
-  test "returns nil if no route is provided" do
+  test "returns nil if no route is provided for all fare types" do
     refute recommended_fare(nil, nil, nil, nil)
     refute base_fare(nil, nil, nil, nil)
     refute reduced_fare(nil, nil, nil, nil)

--- a/apps/site/assets/css/_trip-plan-fare-calculator.scss
+++ b/apps/site/assets/css/_trip-plan-fare-calculator.scss
@@ -1,0 +1,71 @@
+.m-trip-plan-farecalc {
+  &__title {
+    margin-bottom: 0;
+  }
+
+  &__table {
+    display: flex;
+    flex-wrap: wrap;
+    @include media-breakpoint-down(xs) {
+      display: block;
+    }
+
+    > div:nth-of-type(odd) {
+      width: 35%;
+      @include media-breakpoint-down(xs) {
+        width: 100%;
+      }
+    }
+    > div:nth-of-type(even) {
+      width: 15%;
+      @include media-breakpoint-down(xs) {
+        width: 100%;
+      }
+    }
+
+  }
+
+  &__table-cell {
+    align-items: flex-start;
+    box-sizing: border-box;
+    display: flex;
+    padding: 1px;
+    width: 100%;
+    @include media-breakpoint-down(xs) {
+      margin-left: 20px;
+    }
+  }
+
+  &__label {
+    display: none;
+    white-space: pre;
+    @include media-breakpoint-down(xs) {
+      display: inline;
+    }
+  }
+
+  &__header {
+    margin-bottom: 10px;
+    margin-top: 24px;
+    @include media-breakpoint-down(xs) {
+      display: none;
+    }
+  }
+
+  &__subheader {
+    @include h4();
+    margin-bottom: 10px;
+    margin-top: 24px;
+    @include media-breakpoint-down(xs) {
+      @include h3();
+      margin-left: 0;
+    }
+  }
+
+  &__mode-name,
+  &__transfer-note {
+    @include media-breakpoint-down(xs) {
+      font-weight: bold;
+    }
+  }
+}

--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -8,6 +8,10 @@
 
   .c-accordion-ui {
     margin: 0;
+
+    &:nth-child(n + 3) {
+      border-top: 0;
+    }
   }
 
   .c-accordion-ui__trigger {

--- a/apps/site/assets/css/app.scss
+++ b/apps/site/assets/css/app.scss
@@ -132,6 +132,7 @@
 @import 'project-page';
 @import 'schedule-page';
 @import 'trip-plan-results';
+@import 'trip-plan-fare-calculator';
 @import 'schedule-direction';
 @import 'schedule-page-line-diagram';
 

--- a/apps/site/assets/ts/components/Accordion.tsx
+++ b/apps/site/assets/ts/components/Accordion.tsx
@@ -4,7 +4,10 @@ import React, { ReactElement, useState } from "react";
 // This attempts to mimic the usage of <ExpandableBlock />, where the contents rerender with expanded state
 interface Props {
   id: string;
-  title: string;
+  title: {
+    collapsed: string;
+    expanded: string;
+  };
   children: ReactElement<HTMLElement>;
 }
 
@@ -24,7 +27,7 @@ const Accordion = (props: Props): ReactElement<HTMLElement> => {
             type="button"
           >
             <span className="c-accordion-ui__title" id={`${id}-title`}>
-              {title}
+              {isExpanded ? title.expanded : title.collapsed}
             </span>
             <div className="c-accordion-ui__indicator">
               <span className="c-indicator__content c-indicator__content--angle" />

--- a/apps/site/assets/ts/components/__tests__/AccordionTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/AccordionTest.tsx
@@ -9,7 +9,13 @@ describe("Accordion component", () => {
     createReactRoot();
     const tree = renderer
       .create(
-        <Accordion id="test-accordion" title="Open me for a surprise">
+        <Accordion
+          id="test-accordion"
+          title={{
+            collapsed: "Open me for a surprise",
+            expanded: "Close me, surprise seen"
+          }}
+        >
           <p>The surprise</p>
         </Accordion>
       )
@@ -19,7 +25,13 @@ describe("Accordion component", () => {
 
   it("shows title in heading and children in content", () => {
     const wrapper = shallow(
-      <Accordion id="test-accordion" title="Open me for a surprise">
+      <Accordion
+        id="test-accordion"
+        title={{
+          collapsed: "Open me for a surprise",
+          expanded: "Close me, surprise seen"
+        }}
+      >
         <p>The surprise</p>
       </Accordion>
     );

--- a/apps/site/assets/ts/trip-plan-results/__tests__/TripPlannerResultsTest.tsx
+++ b/apps/site/assets/ts/trip-plan-results/__tests__/TripPlannerResultsTest.tsx
@@ -7,7 +7,8 @@ import { TileServerUrl } from "../../leaflet/components/__mapdata";
 const html = "<div>Lots of content about the itinerary</div>";
 const tab_html = "<div>HTML for the accordion button</div>";
 const access_html = "<div>Accessible</div>";
-const fares_html = "<div>HTML content for fares</div>";
+const fares_estimate_html = "<div>HTML content for fares</div>";
+const fare_calculator_html = "<div>HTML content for fare calculator</div>";
 const tile_server_url: TileServerUrl = "";
 
 const positions: [number, number][] = [
@@ -36,12 +37,32 @@ it("it renders", () => {
   createReactRoot();
   const tree = renderer.create(
     <TripPlannerResults
-      itineraryData={[{ html, access_html, fares_html, tab_html, id: 1, map }]}
+      itineraryData={[
+        {
+          html,
+          access_html,
+          fares_estimate_html,
+          tab_html,
+          fare_calculator_html,
+          id: 1,
+          map
+        }
+      ]}
     />
   );
   tree.update(
     <TripPlannerResults
-      itineraryData={[{ html, access_html, fares_html, tab_html, id: 1, map }]}
+      itineraryData={[
+        {
+          html,
+          access_html,
+          fares_estimate_html,
+          tab_html,
+          fare_calculator_html,
+          id: 1,
+          map
+        }
+      ]}
     />
   );
   expect(tree.toJSON()).toMatchSnapshot();

--- a/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
+++ b/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
@@ -76,5 +76,45 @@ exports[`it renders 1`] = `
       />
     </div>
   </div>
+  <div
+    className="c-accordion-ui"
+  >
+    <div
+      className="panel"
+      role="heading"
+    >
+      <div
+        className="c-accordion-ui__heading"
+      >
+        <button
+          aria-controls="itinerary-1-fare-calculator-section"
+          aria-expanded={false}
+          className="c-accordion-ui__trigger collapsed"
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            className="c-accordion-ui__title"
+            id="itinerary-1-fare-calculator-title"
+          >
+            Show fare calculator
+          </span>
+          <div
+            className="c-accordion-ui__indicator"
+          >
+            <span
+              className="c-indicator__content c-indicator__content--angle"
+            />
+          </div>
+        </button>
+      </div>
+      <div
+        aria-labelledby="itinerary-1-fare-calculator-title"
+        className="c-accordion-ui__target js-focus-on-expand"
+        id="itinerary-1-fare-calculator-section"
+        role="region"
+      />
+    </div>
+  </div>
 </div>
 `;

--- a/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
+++ b/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
@@ -87,14 +87,28 @@ const ItineraryAccordion = ({
       </div>
       <div
         className="m-trip-plan-results__itinerary-fares"
-        dangerouslySetInnerHTML={{ __html: itinerary.fares_html }} // eslint-disable-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: itinerary.fares_estimate_html }} // eslint-disable-line react/no-danger
       />
     </div>
     <Accordion
       id={`itinerary-${itinerary.id}`}
-      title="Show map and trip details"
+      title={{
+        collapsed: "Show map and trip details",
+        expanded: "Hide map and trip details"
+      }}
     >
       <ItineraryBody {...itinerary} />
+    </Accordion>
+    <Accordion
+      id={`itinerary-${itinerary.id}-fare-calculator`}
+      title={{
+        collapsed: "Show fare calculator",
+        expanded: "Hide fare calculator"
+      }}
+    >
+      <div
+        dangerouslySetInnerHTML={{ __html: itinerary.fare_calculator_html }} // eslint-disable-line react/no-danger
+      />
     </Accordion>
   </div>
 );

--- a/apps/site/assets/ts/trip-plan-results/components/TripPlannerResults.tsx
+++ b/apps/site/assets/ts/trip-plan-results/components/TripPlannerResults.tsx
@@ -9,7 +9,8 @@ export interface Itinerary {
   map: MapData;
   tab_html: string;
   access_html: string;
-  fares_html: string;
+  fares_estimate_html: string;
+  fare_calculator_html: string;
 }
 
 interface Props {

--- a/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
@@ -1,0 +1,60 @@
+
+<div class="h2 m-trip-plan-farecalc__title">Fare Calculator</div>
+
+<div role="table" aria-label="A summary of the different fares by media for each itinerary" class="m-trip-plan-farecalc__table">
+  <div role="columnheader" class="m-trip-plan-farecalc__table-cell m-trip-plan-farecalc__subheader">One-Way Fare</div>
+  <div role="columnheader" class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">Base</div>
+  <div role="columnheader" class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">Recommended</div>
+  <div role="columnheader" class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">Reduced</div>
+
+  <%= for {_mode_key, fare_values} <- @fares do %>
+
+    <div role="cell" class="m-trip-plan-farecalc__table-cell m-trip-plan-farecalc__mode-name">
+      <%= SiteWeb.TripPlanView.format_mode(fare_values.mode) %>
+    </div>
+    <div role="cell" class="m-trip-plan-farecalc__table-cell">
+      <span class="m-trip-plan-farecalc__label">Base: </span>
+      <%= fare_values|>SiteWeb.TripPlanView.get_fare_by_type(:highest_one_way_fare)|> fare_cents()|>Format.price() %>
+    </div>
+    <div role="cell" class="m-trip-plan-farecalc__table-cell">
+      <span class="m-trip-plan-farecalc__label">Recommended: </span>
+      <% recommended = fare_values|>SiteWeb.TripPlanView.get_fare_by_type(:lowest_one_way_fare) %>
+      <% media = recommended |> SiteWeb.TripPlanView.filter_media() %>
+      <%= recommended |> fare_cents()|>Format.price() %> <%= SiteWeb.TripPlanView.format_media(media) %>
+    </div>
+    <div role="cell" class="m-trip-plan-farecalc__table-cell">
+      <span class="m-trip-plan-farecalc__label">Reduced: </span>
+      <%= fare_values|>SiteWeb.TripPlanView.get_fare_by_type(:reduced_one_way_fare)|> fare_cents()|>Format.price() %>
+    </div>
+
+  <% end %>
+
+  <div role="cell" class="m-trip-plan-farecalc__table-cell m-trip-plan-farecalc__transfer-note">
+    <% transfer_note = transfer_note(@itinerary) %>
+    <%= if transfer_note == nil do %>
+      Total
+    <% else %>
+      <%= transfer_note %>
+    <% end %>
+  </div>
+
+  <div role="cell" class="m-trip-plan-farecalc__table-cell">
+    <span class="m-trip-plan-farecalc__label">Base: </span>
+    <span>
+      <strong><%=
+        SiteWeb.TripPlanView.get_one_way_total_by_type(@itinerary, :highest_one_way_fare)
+        |>Format.price()
+       %></strong>
+   </span>
+ </div>
+  <div role="cell" class="m-trip-plan-farecalc__table-cell"></div>
+  <div role="cell" class="m-trip-plan-farecalc__table-cell">
+    <span class="m-trip-plan-farecalc__label">Reduced: </span>
+    <span>
+      <strong><%=
+      SiteWeb.TripPlanView.get_one_way_total_by_type(@itinerary, :reduced_one_way_fare)
+      |>Format.price()
+       %></strong>
+   </span>
+  </div>
+</div>

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -672,6 +672,106 @@ closest arrival to 12:00 AM, Thursday, January 1st."
       round_trip_total: "$5.80"
     }
 
+    @highest_one_way_fare %Fares.Fare{
+      additional_valid_modes: [:bus],
+      cents: 290,
+      duration: :single_trip,
+      media: [:charlie_ticket, :cash],
+      mode: :subway,
+      name: :subway,
+      price_label: nil,
+      reduced: nil
+    }
+
+    @lowest_one_way_fare %Fares.Fare{
+      additional_valid_modes: [:bus],
+      cents: 240,
+      duration: :single_trip,
+      media: [:charlie_card],
+      mode: :subway,
+      name: :subway,
+      price_label: nil,
+      reduced: nil
+    }
+
+    @reduced_one_way_fare %Fares.Fare{
+      additional_valid_modes: [],
+      cents: 110,
+      duration: :single_trip,
+      media: [:senior_card],
+      mode: :subway,
+      name: :subway,
+      price_label: nil,
+      reduced: :senior_disabled
+    }
+
+    @itinerary %TripPlan.Itinerary{
+      start: nil,
+      stop: nil,
+      legs: [
+        %TripPlan.Leg{
+          description: "WALK",
+          from: %TripPlan.NamedPosition{
+            latitude: 42.365486,
+            longitude: -71.103802,
+            name: "Central",
+            stop_id: nil
+          },
+          long_name: nil,
+          mode: %TripPlan.PersonalDetail{
+            distance: 24.274,
+            steps: [
+              %TripPlan.PersonalDetail.Step{
+                absolute_direction: :southeast,
+                distance: 24.274,
+                relative_direction: :depart,
+                street_name: "Massachusetts Avenue"
+              }
+            ]
+          },
+          name: "",
+          polyline: "eoqaGzm~pLTe@BE@A",
+          to: %TripPlan.NamedPosition{
+            latitude: 42.365304,
+            longitude: -71.103621,
+            name: "Central",
+            stop_id: "70069"
+          },
+          type: nil,
+          url: nil
+        },
+        %TripPlan.Leg{
+          description: "SUBWAY",
+          from: %TripPlan.NamedPosition{
+            latitude: 42.365304,
+            longitude: -71.103621,
+            name: "Central",
+            stop_id: "70069"
+          },
+          long_name: "Red Line",
+          mode: %TripPlan.TransitDetail{
+            fares: %{
+              highest_one_way_fare: @highest_one_way_fare,
+              lowest_one_way_fare: @lowest_one_way_fare,
+              reduced_one_way_fare: @reduced_one_way_fare
+            },
+            intermediate_stop_ids: ["70071", "70073"],
+            route_id: "Red",
+            trip_id: "43870769C0"
+          },
+          name: "Red Line",
+          to: %TripPlan.NamedPosition{
+            latitude: 42.356395,
+            longitude: -71.062424,
+            name: "Park Street",
+            stop_id: "70075"
+          },
+          type: "1",
+          url: "http://www.mbta.com"
+        }
+      ]
+    }
+
     test "renders fare information", %{conn: conn} do
       html =
         "_itinerary_fares.html"
@@ -688,6 +788,47 @@ closest arrival to 12:00 AM, Thursday, January 1st."
     end
 
     test "gets the highest one-way fare" do
+      assert get_one_way_total_by_type(@itinerary, :highest_one_way_fare) == 290
+    end
+
+    test "gets the total for a reduced one-way fare" do
+      assert get_one_way_total_by_type(@itinerary, :reduced_one_way_fare) == 110
+    end
+
+    test "gets calculated fares" do
+      bus_fares = %{
+        highest_one_way_fare: %Fares.Fare{
+          additional_valid_modes: [],
+          cents: 200,
+          duration: :single_trip,
+          media: [:charlie_ticket, :cash],
+          mode: :bus,
+          name: :local_bus,
+          price_label: nil,
+          reduced: nil
+        },
+        lowest_one_way_fare: %Fares.Fare{
+          additional_valid_modes: [],
+          cents: 170,
+          duration: :single_trip,
+          media: [:charlie_card],
+          mode: :bus,
+          name: :local_bus,
+          price_label: nil,
+          reduced: nil
+        },
+        reduced_one_way_fare: %Fares.Fare{
+          additional_valid_modes: [],
+          cents: 85,
+          duration: :single_trip,
+          media: [:senior_card],
+          mode: :bus,
+          name: :local_bus,
+          price_label: nil,
+          reduced: :senior_disabled
+        }
+      }
+
       itinerary = %TripPlan.Itinerary{
         start: nil,
         stop: nil,
@@ -734,26 +875,63 @@ closest arrival to 12:00 AM, Thursday, January 1st."
             long_name: "Red Line",
             mode: %TripPlan.TransitDetail{
               fares: %{
-                highest_one_way_fare: %Fares.Fare{
-                  additional_valid_modes: [:bus],
-                  cents: 290,
-                  duration: :single_trip,
-                  media: [:charlie_ticket, :cash],
-                  mode: :subway,
-                  name: :subway,
-                  price_label: nil,
-                  reduced: nil
-                },
-                lowest_one_way_fare: %Fares.Fare{
-                  additional_valid_modes: [:bus],
-                  cents: 240,
-                  duration: :single_trip,
-                  media: [:charlie_card],
-                  mode: :subway,
-                  name: :subway,
-                  price_label: nil,
-                  reduced: nil
-                }
+                highest_one_way_fare: @highest_one_way_fare,
+                lowest_one_way_fare: @lowest_one_way_fare,
+                reduced_one_way_fare: @reduced_one_way_fare
+              },
+              intermediate_stop_ids: ["70071", "70073"],
+              route_id: "Red",
+              trip_id: "43870769C0"
+            },
+            name: "Red Line",
+            to: %TripPlan.NamedPosition{
+              latitude: 42.356395,
+              longitude: -71.062424,
+              name: "Park Street",
+              stop_id: "70075"
+            },
+            type: "1",
+            url: "http://www.mbta.com"
+          },
+          %TripPlan.Leg{
+            description: "BUS",
+            from: %TripPlan.NamedPosition{
+              latitude: 42.362804,
+              longitude: -71.099509,
+              name: "Massachusetts Ave @ Sidney St",
+              stop_id: "73"
+            },
+            long_name: "Harvard Square - Dudley Station",
+            mode: %TripPlan.TransitDetail{
+              fares: bus_fares,
+              intermediate_stop_ids: ["74", "75", "77", "79", "80"],
+              route_id: "1",
+              trip_id: "44170977"
+            },
+            name: "1",
+            to: %TripPlan.NamedPosition{
+              latitude: 42.342478,
+              longitude: -71.084701,
+              name: "Massachusetts Ave @ Huntington Ave",
+              stop_id: "82"
+            },
+            type: "1",
+            url: "http://www.mbta.com"
+          },
+          %TripPlan.Leg{
+            description: "SUBWAY",
+            from: %TripPlan.NamedPosition{
+              latitude: 42.365304,
+              longitude: -71.103621,
+              name: "Central",
+              stop_id: "70069"
+            },
+            long_name: "Red Line",
+            mode: %TripPlan.TransitDetail{
+              fares: %{
+                highest_one_way_fare: @highest_one_way_fare,
+                lowest_one_way_fare: @lowest_one_way_fare,
+                reduced_one_way_fare: @reduced_one_way_fare
               },
               intermediate_stop_ids: ["70071", "70073"],
               route_id: "Red",
@@ -772,7 +950,83 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         ]
       }
 
-      assert get_highest_one_way_fare(itinerary) == 290
+      calculated_fares = %{
+        subway: %{
+          mode: %{
+            fares: %{
+              highest_one_way_fare: @highest_one_way_fare,
+              lowest_one_way_fare: @lowest_one_way_fare,
+              reduced_one_way_fare: @reduced_one_way_fare
+            },
+            mode_name: "Subway",
+            name: "Subway",
+            mode: :subway
+          }
+        },
+        bus: %{
+          mode: %{
+            fares: bus_fares,
+            mode_name: "Bus",
+            name: "Local Bus",
+            mode: :bus
+          }
+        }
+      }
+
+      assert get_calculated_fares(itinerary) == calculated_fares
+    end
+
+    test "gets fare by type" do
+      non_transit_leg = @itinerary.legs |> List.first()
+      assert get_fare_by_type(non_transit_leg, :highest_one_way_fare) == nil
+      assert get_fare_by_type(non_transit_leg, :lowest_one_way_fare) == nil
+      assert get_fare_by_type(non_transit_leg, :reduced_one_way_fare) == nil
+
+      transit_leg = @itinerary.legs |> List.last()
+      assert get_fare_by_type(transit_leg, :highest_one_way_fare) == @highest_one_way_fare
+      assert get_fare_by_type(transit_leg, :lowest_one_way_fare) == @lowest_one_way_fare
+      assert get_fare_by_type(transit_leg, :reduced_one_way_fare) == @reduced_one_way_fare
+    end
+
+    test "removes cash from payment options for Commuter Rail" do
+      cr_fare = %Fare{
+        media: [:commuter_ticket, :cash, :mticket],
+        mode: :commuter_rail
+      }
+
+      subway_fare = %Fare{
+        media: [:commuter_ticket, :cash],
+        mode: :subway
+      }
+
+      assert cr_fare |> filter_media() == [
+               :commuter_ticket,
+               :mticket
+             ]
+
+      assert subway_fare |> filter_media() == subway_fare.media
+    end
+
+    test "formats mode properly" do
+      cr = %{
+        mode_name: "Commuter Rail",
+        name: "Zone 8",
+        mode: :commuter_rail
+      }
+
+      bus = %{
+        name: "Bus",
+        mode: :bus
+      }
+
+      subway = %{
+        mode_name: "Subway",
+        mode: :subway
+      }
+
+      assert format_mode(cr) == "Commuter Rail Zone 8"
+      assert format_mode(bus) == "Bus"
+      assert format_mode(subway) == "Subway"
     end
 
     test "gets the highest one-way fare correctly with subway -> subway xfer" do
@@ -827,7 +1081,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         legs: [red_leg, orange_leg]
       }
 
-      assert get_highest_one_way_fare(itinerary) == 290
+      assert get_one_way_total_by_type(itinerary, :highest_one_way_fare) == 290
     end
 
     test "returns 0 when there is no highest one-way fare" do
@@ -897,7 +1151,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         ]
       }
 
-      assert get_highest_one_way_fare(itinerary) == 0
+      assert get_one_way_total_by_type(itinerary, :highest_one_way_fare) == 0
     end
 
     test "shows a transfer note", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fare Calculator Accordion | One-Way/Round Trip fares](https://app.asana.com/0/555089885850811/1162903717356813)

This second accordion in the Trip Planner will contain all the calculated fares for the specific itineraries. Said fares will be presented in a table with the information broken down by mode and also by fare type:

**General view**:<br/>
<img width="589" alt="image" src="https://user-images.githubusercontent.com/61979382/83982687-9006b000-a8f6-11ea-933b-3bf856e3fd19.png">

**Small screen**:<br/>
<img width="392" alt="image" src="https://user-images.githubusercontent.com/61979382/83982689-9432cd80-a8f6-11ea-9d83-7a247034b19e.png">




