### PR TITLE
Display monthly commuter pass for trip plans

### DIFF
--- a/apps/fares/lib/fare.ex
+++ b/apps/fares/lib/fare.ex
@@ -1,8 +1,6 @@
 defmodule Fares.Fare do
-  @typedoc """
-
+  @moduledoc """
   Represents a method of paying for transit on the MBTA.
-
   """
 
   alias Routes.Route

--- a/apps/fares/lib/fare.ex
+++ b/apps/fares/lib/fare.ex
@@ -4,6 +4,9 @@ defmodule Fares.Fare do
   Represents a method of paying for transit on the MBTA.
 
   """
+
+  alias Routes.Route
+
   @type fare_name :: {atom, String.t()} | atom
   @type media ::
           :charlie_card
@@ -18,13 +21,13 @@ defmodule Fares.Fare do
   @type reduced :: nil | :student | :senior_disabled | :any
   @type duration :: :single_trip | :round_trip | :day | :week | :weekend | :month | :invalid
   @type t :: %__MODULE__{
-          mode: Routes.Route.route_type(),
+          mode: Route.route_type(),
           name: fare_name,
           media: [media],
           reduced: reduced,
           duration: duration,
           cents: non_neg_integer,
-          additional_valid_modes: [Routes.Route.route_type()],
+          additional_valid_modes: [Route.route_type()],
           price_label: String.t() | nil
         }
 
@@ -36,4 +39,10 @@ defmodule Fares.Fare do
             cents: 0,
             additional_valid_modes: [],
             price_label: nil
+
+  @spec valid_modes(t() | nil) :: [Route.route_type()]
+  def valid_modes(nil), do: []
+
+  def valid_modes(%__MODULE__{mode: mode, additional_valid_modes: additional_valid_modes}),
+    do: [mode] ++ additional_valid_modes
 end

--- a/apps/fares/test/fare_test.exs
+++ b/apps/fares/test/fare_test.exs
@@ -1,0 +1,26 @@
+defmodule Fares.FareTest do
+  use ExUnit.Case, async: true
+
+  alias Fares.Fare
+
+  describe "valid_modes/1" do
+    test "returns a list containing the primary mode and all other valid modes" do
+      fare = %Fare{
+        additional_valid_modes: [:bus],
+        cents: 9_000,
+        duration: :month,
+        media: [:charlie_card, :charlie_ticket],
+        mode: :subway,
+        name: :subway,
+        price_label: nil,
+        reduced: nil
+      }
+
+      assert Fare.valid_modes(fare) == [:subway, :bus]
+    end
+
+    test "returns an empty list when given nil" do
+      assert Fare.valid_modes(nil) == []
+    end
+  end
+end

--- a/apps/fares/test/month_test.exs
+++ b/apps/fares/test/month_test.exs
@@ -14,6 +14,40 @@ defmodule Fares.MonthTest do
     end
   end
 
+  describe "reduced_pass" do
+    @reduced_fares [
+      %Fares.Fare{
+        additional_valid_modes: [:bus],
+        cents: 3_000,
+        duration: :month,
+        media: [:senior_card, :student_card],
+        mode: :subway,
+        name: :subway,
+        price_label: nil,
+        reduced: :any
+      }
+    ]
+
+    test "returns a reduced month pass" do
+      fare_fn = fn [reduced: :any, duration: :month, mode: :subway] -> @reduced_fares end
+
+      assert %Fare{cents: 3_000} = Month.reduced_pass(%Route{type: 0}, nil, nil, nil, fare_fn)
+    end
+
+    test "accepts a Route ID" do
+      fare_fn = fn [reduced: :any, duration: :month, mode: :subway] -> @reduced_fares end
+
+      assert %Fare{cents: 3_000} = Month.reduced_pass("Red", nil, nil, nil, fare_fn)
+    end
+
+    test "accepts a Trip ID" do
+      route = %Route{type: 2, id: "CR-Franklin"}
+      trip_id = "CR-Weekday-Fall-19-751"
+
+      assert Month.reduced_pass(route, trip_id, "place-sstat", "place-FS-0049") == nil
+    end
+  end
+
   describe "subway" do
     @subway_route %Route{type: 0}
 
@@ -35,25 +69,6 @@ defmodule Fares.MonthTest do
 
       assert %Fare{cents: 9_000} = Month.recommended_pass(@subway_route, nil, nil, nil, fare_fn)
       assert %Fare{cents: 9_000} = Month.base_pass(@subway_route, nil, nil, nil, fare_fn)
-    end
-
-    test "returns a reduced month pass" do
-      fare_fn = fn [reduced: :any, duration: :month, mode: :subway] ->
-        [
-          %Fares.Fare{
-            additional_valid_modes: [:bus],
-            cents: 3_000,
-            duration: :month,
-            media: [:senior_card, :student_card],
-            mode: :subway,
-            name: :subway,
-            price_label: nil,
-            reduced: :any
-          }
-        ]
-      end
-
-      assert %Fare{cents: 3_000} = Month.reduced_pass(@subway_route, nil, nil, nil, fare_fn)
     end
 
     test "accepts a Route ID" do

--- a/apps/fares/test/month_test.exs
+++ b/apps/fares/test/month_test.exs
@@ -37,6 +37,25 @@ defmodule Fares.MonthTest do
       assert %Fare{cents: 9_000} = Month.base_pass(@subway_route, nil, nil, nil, fare_fn)
     end
 
+    test "returns a reduced month pass" do
+      fare_fn = fn [reduced: :any, duration: :month, mode: :subway] ->
+        [
+          %Fares.Fare{
+            additional_valid_modes: [:bus],
+            cents: 3_000,
+            duration: :month,
+            media: [:senior_card, :student_card],
+            mode: :subway,
+            name: :subway,
+            price_label: nil,
+            reduced: :any
+          }
+        ]
+      end
+
+      assert %Fare{cents: 3_000} = Month.reduced_pass(@subway_route, nil, nil, nil, fare_fn)
+    end
+
     test "accepts a Route ID" do
       fare_fn = fn @default_filters ++ [mode: :subway] -> @subway_fares end
 

--- a/apps/site/assets/css/_trip-plan-fare-calculator.scss
+++ b/apps/site/assets/css/_trip-plan-fare-calculator.scss
@@ -34,6 +34,12 @@
     @include media-breakpoint-down(xs) {
       margin-left: 20px;
     }
+
+    [class*='c-svg__icon'] {
+      height: $icon-size-sm;
+      margin-right: 0.3rem;
+      width: $icon-size-sm;
+    }
   }
 
   &__label {

--- a/apps/site/assets/css/_trip-plan-fare-calculator.scss
+++ b/apps/site/assets/css/_trip-plan-fare-calculator.scss
@@ -72,6 +72,7 @@
   &__transfer-note {
     @include media-breakpoint-down(xs) {
       font-weight: bold;
+      margin-left: 0;
     }
   }
 }

--- a/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
@@ -58,3 +58,24 @@
    </span>
   </div>
 </div>
+
+
+<div class="m-trip-plan-farecalc__table">
+  <div class="m-trip-plan-farecalc__table-cell m-trip-plan-farecalc__subheader">
+    Monthly Commuter Passes
+  </div>
+  <div class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">
+    Base
+  </div>
+  <div class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">
+    Reduced
+  </div>
+  <div class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">
+    Valid On
+  </div>
+
+  <%= for pass <- Enum.uniq([@itinerary.passes.base_month_pass, @itinerary.passes.recommended_month_pass]) do %>
+    <%= render "_monthly_pass_row.html", pass: pass, reduced: @itinerary.passes.reduced_month_pass %>
+  <% end %>
+
+</div>

--- a/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
@@ -62,7 +62,7 @@
 
 <div class="m-trip-plan-farecalc__table">
   <div class="m-trip-plan-farecalc__table-cell m-trip-plan-farecalc__subheader">
-    Monthly Commuter Passes
+    Monthly Passes
   </div>
   <div class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">
     Base

--- a/apps/site/lib/site_web/templates/trip_plan/_monthly_pass_row.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_monthly_pass_row.html.eex
@@ -1,0 +1,18 @@
+<div class="m-trip-plan-farecalc__table-cell m-trip-plan-farecalc__mode-name">
+  <%= Format.full_name(@pass) %>
+</div>
+
+<div class="m-trip-plan-farecalc__table-cell">
+  <span class="m-trip-plan-farecalc__label">Base: </span>
+  <%= Format.price(@pass) %>
+</div>
+
+<div class="m-trip-plan-farecalc__table-cell">
+  <span class="m-trip-plan-farecalc__label">Reduced: </span>
+  <%= if @reduced, do: Format.price(@reduced), else: "n/a" %>
+</div>
+
+<div class="m-trip-plan-farecalc__table-cell">
+  <span class="m-trip-plan-farecalc__label">Valid on: </span>
+  <%= @pass |> Fares.Fare.valid_modes() |> icon_for_routes() %>
+</div>

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -338,6 +338,9 @@ defmodule SiteWeb.TripPlanView do
     )
   end
 
+  @spec icon_for_routes([Route.t()]) :: [Phoenix.HTML.Safe.t()]
+  def icon_for_routes(routes), do: Enum.map(routes, &icon_for_route/1)
+
   @spec icon_for_route(Route.t()) :: Phoenix.HTML.Safe.t()
   def icon_for_route(%Route{description: :rail_replacement_bus}) do
     svg_icon_with_circle(%SvgIconWithCircle{icon: :bus})

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -387,10 +387,32 @@ closest arrival to 12:00 AM, Thursday, January 1st."
     end
   end
 
+  describe "icon_for_routes/1" do
+    test "returns a list of icons for the given routes" do
+      routes = [
+        %Route{
+          id: "Red",
+          type: 1
+        },
+        %Route{
+          id: "Green",
+          type: 0
+        }
+      ]
+
+      assert icons = icon_for_routes(routes)
+      assert length(icons) == 2
+
+      [rl_icon | [gl_icon | _]] = icons
+      assert safe_to_string(rl_icon) =~ "red-line"
+      assert safe_to_string(gl_icon) =~ "green-line"
+    end
+  end
+
   describe "icon_for_route/1" do
     test "non-subway transit legs" do
       for {gtfs_type, expected_icon_class} <- [{2, "commuter-rail"}, {3, "bus"}, {4, "ferry"}] do
-        route = %Routes.Route{
+        route = %Route{
           id: "id",
           type: gtfs_type
         }
@@ -408,7 +430,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
             {"Blue", 1, "blue-line"},
             {"Green", 0, "green-line"}
           ] do
-        route = %Routes.Route{
+        route = %Route{
           id: id,
           type: type
         }

--- a/apps/trip_plan/lib/trip_plan/itinerary.ex
+++ b/apps/trip_plan/lib/trip_plan/itinerary.ex
@@ -28,7 +28,8 @@ defmodule TripPlan.Itinerary do
 
   @type passes :: %{
           base_month_pass: Fare.t(),
-          recommended_month_pass: Fare.t()
+          recommended_month_pass: Fare.t(),
+          reduced_month_pass: Fare.t()
         }
 
   alias TripPlan.NamedPosition


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fare Calculator Accordion | Recommended Passes](https://app.asana.com/0/555089885850811/1169236529454075)

Display monthly commuter pass for trip plans.

Include reduced pass where applicable.

Depends on https://github.com/mbta/dotcom/pull/499

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
