### PR TITLE
Fare Calculator | Trip Planner (top-level summary)

### DIFF
--- a/apps/fares/lib/fares.ex
+++ b/apps/fares/lib/fares.ex
@@ -1,4 +1,10 @@
 defmodule Fares do
+  @moduledoc """
+
+  Handling logic around fares.
+
+  """
+
   alias Routes.Route
   alias Schedules.Trip
   alias Stops.Stop
@@ -139,4 +145,28 @@ defmodule Fares do
   def inner_express, do: @inner_express_routes
 
   def outer_express, do: @outer_express_routes
+
+  @type fare_atom :: Route.gtfs_route_type() | :inner_express_bus | :outer_express_bus
+
+  @spec to_fare_atom(fare_atom | Route.id_t() | Route.t()) :: fare_atom
+  def to_fare_atom(route_or_atom) do
+    case route_or_atom do
+      %Route{type: 3, id: id} ->
+        cond do
+          silver_line_rapid_transit?(id) -> :subway
+          inner_express?(id) -> :inner_express_bus
+          outer_express?(id) -> :outer_express_bus
+          true -> :bus
+        end
+
+      %Route{} ->
+        Route.type_atom(route_or_atom)
+
+      <<id::binary>> ->
+        Routes.Repo.get(id) |> to_fare_atom
+
+      _ ->
+        route_or_atom
+    end
+  end
 end

--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -100,7 +100,7 @@ defmodule Fares.Format do
   def name(:invalid), do: "Invalid Fare"
 
   @spec full_name(Fare.t() | nil) :: String.t() | iolist
-  def full_name(nil), do: "Free"
+  def full_name(nil), do: "Shuttle"
   def full_name(%Fare{mode: :subway, duration: :month}), do: "Monthly LinkPass"
   def full_name(%Fare{mode: :commuter_rail, duration: :weekend}), do: "Weekend Pass"
   def full_name(%Fare{duration: :week}), do: "7-Day Pass"

--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -1,4 +1,7 @@
 defmodule Fares.Format do
+  @moduledoc """
+  Formatting functions for fare data.
+  """
   alias Fares.{Fare, Summary}
 
   @type mode_type :: :bus_subway | :commuter_rail | :ferry
@@ -96,7 +99,8 @@ defmodule Fares.Format do
   def name(:premium_ride), do: "Premium Ride"
   def name(:invalid), do: "Invalid Fare"
 
-  @spec full_name(Fare.t()) :: String.t() | iolist
+  @spec full_name(Fare.t() | nil) :: String.t() | iolist
+  def full_name(nil), do: "Free"
   def full_name(%Fare{mode: :subway, duration: :month}), do: "Monthly LinkPass"
   def full_name(%Fare{mode: :commuter_rail, duration: :weekend}), do: "Weekend Pass"
   def full_name(%Fare{duration: :week}), do: "7-Day Pass"

--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -112,6 +112,15 @@ defmodule Fares.Format do
     [name(fare), " ", duration(fare)]
   end
 
+  @spec concise_full_name(Fare.t()) :: String.t() | iolist()
+  def concise_full_name(%Fare{mode: :commuter_rail} = fare), do: name(fare)
+
+  def concise_full_name(%Fare{mode: :bus, name: name} = fare)
+      when name in [:inner_express_bus, :outer_express_bus],
+      do: name(fare)
+
+  def concise_full_name(fare), do: full_name(fare)
+
   @spec summarize([Fare.t()], mode_type | [mode_type], String.t() | nil) :: [Summary.t()]
   def summarize(fares, mode, url \\ nil)
 

--- a/apps/fares/lib/month.ex
+++ b/apps/fares/lib/month.ex
@@ -1,0 +1,121 @@
+defmodule Fares.Month do
+  @moduledoc """
+  Calculates the lowest and highest monthly pass fare for a particular trip.
+  """
+
+  alias Fares.{Fare, Repo}
+  alias Routes.Route
+  alias Schedules.Trip
+  alias Stops.Stop
+
+  @type fare_fn :: (Keyword.t() -> [Fare.t()])
+
+  @spec recommended_pass(
+          Route.t() | Route.id_t(),
+          Trip.t() | Trip.id_t() | nil,
+          Stop.id_t(),
+          Stop.id_t(),
+          fare_fn()
+        ) ::
+          Fare.t() | nil
+  def recommended_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def recommended_pass(nil, _, _, _, _), do: nil
+
+  def recommended_pass(route_id, trip, origin_id, destination_id, fare_fn)
+      when is_binary(route_id) do
+    route = Routes.Repo.get(route_id)
+    recommended_pass(route, trip, origin_id, destination_id, fare_fn)
+  end
+
+  def recommended_pass(route, trip_id, origin_id, destination_id, fare_fn)
+      when is_binary(trip_id) do
+    trip = Schedules.Repo.trip(trip_id)
+    recommended_pass(route, trip, origin_id, destination_id, fare_fn)
+  end
+
+  def recommended_pass(route, trip, origin_id, destination_id, fare_fn) do
+    route
+    |> get_fares(trip, origin_id, destination_id, fare_fn)
+    |> Enum.min_by(& &1.cents, fn -> nil end)
+  end
+
+  @spec base_pass(
+          Route.t() | Route.id_t(),
+          Trip.t() | Trip.id_t() | nil,
+          Stop.id_t(),
+          Stop.id_t(),
+          fare_fn()
+        ) ::
+          Fare.t() | nil
+  def base_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def base_pass(nil, _, _, _, _), do: nil
+
+  def base_pass(route_id, trip, origin_id, destination_id, fare_fn) when is_binary(route_id) do
+    route = Routes.Repo.get(route_id)
+    base_pass(route, trip, origin_id, destination_id, fare_fn)
+  end
+
+  def base_pass(route, trip_id, origin_id, destination_id, fare_fn) when is_binary(trip_id) do
+    trip = Schedules.Repo.trip(trip_id)
+    base_pass(route, trip, origin_id, destination_id, fare_fn)
+  end
+
+  def base_pass(route, trip, origin_id, destination_id, fare_fn) do
+    route
+    |> get_fares(trip, origin_id, destination_id, fare_fn)
+    |> Enum.max_by(& &1.cents, fn -> nil end)
+  end
+
+  @spec get_fares(Route.t(), Trip.t() | nil, Stop.id_t(), Stop.id_t(), fare_fn()) :: [Fare.t()]
+  defp get_fares(route, trip, origin_id, destination_id, fare_fn) do
+    route_filters =
+      route.type
+      |> Route.type_atom()
+      |> name_or_mode_filter(route, origin_id, destination_id, trip)
+
+    [reduced: nil, duration: :month]
+    |> Keyword.merge(route_filters)
+    |> fare_fn.()
+  end
+
+  @spec name_or_mode_filter(atom(), Route.t(), Stop.id_t(), Stop.id_t(), Trip.t() | nil) ::
+          Keyword.t()
+  defp name_or_mode_filter(:subway, _route, _origin_id, _destination_id, _trip) do
+    [mode: :subway]
+  end
+
+  defp name_or_mode_filter(_, %{description: :rail_replacement_bus}, _, _, _) do
+    [name: :free_fare]
+  end
+
+  defp name_or_mode_filter(_, %{id: "CR-Foxboro"}, _, _, _) do
+    [name: :foxboro]
+  end
+
+  defp name_or_mode_filter(:bus, %{id: route_id}, origin_id, _destination_id, _trip) do
+    name =
+      cond do
+        Fares.inner_express?(route_id) -> :inner_express_bus
+        Fares.outer_express?(route_id) -> :outer_express_bus
+        Fares.silver_line_airport_stop?(route_id, origin_id) -> :free_fare
+        Fares.silver_line_rapid_transit?(route_id) -> :subway
+        true -> :local_bus
+      end
+
+    [name: name]
+  end
+
+  defp name_or_mode_filter(:commuter_rail, _, origin_id, destination_id, trip) do
+    case Fares.fare_for_stops(:commuter_rail, origin_id, destination_id, trip) do
+      {:ok, name} ->
+        [name: name]
+
+      :error ->
+        [mode: :commuter_rail]
+    end
+  end
+
+  defp name_or_mode_filter(:ferry, _, origin_id, destination_id, _) do
+    [name: :ferry |> Fares.fare_for_stops(origin_id, destination_id) |> elem(1)]
+  end
+end

--- a/apps/fares/lib/one_way.ex
+++ b/apps/fares/lib/one_way.ex
@@ -1,4 +1,4 @@
-defmodule Fares.HighestLowestFare do
+defmodule Fares.OneWay do
   @moduledoc """
   Calculates the lowest and highest fare for a particular trip i.e. a regular priced, non-discounted, one-way fare for the given mode.
   Commuter rail and ferry fares distinguish between the possible sets of stops.
@@ -15,49 +15,49 @@ defmodule Fares.HighestLowestFare do
 
   @default_trip %Trip{name: "", id: ""}
 
-  @spec lowest_fare(
+  @spec recommended_fare(
           Route.t() | map,
           Trip.t() | map,
           Stops.Stop.id_t(),
           Stops.Stop.id_t(),
           (Keyword.t() -> [Fare.t()])
         ) ::
-          String.t() | nil
-  def lowest_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
-  def lowest_fare(nil, _, _, _, _), do: nil
+          Fare.t() | nil
+  def recommended_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def recommended_fare(nil, _, _, _, _), do: nil
 
-  def lowest_fare(route, nil, origin_id, destination_id, fare_fn) do
-    lowest_fare(route, @default_trip, origin_id, destination_id, fare_fn)
+  def recommended_fare(route, nil, origin_id, destination_id, fare_fn) do
+    recommended_fare(route, @default_trip, origin_id, destination_id, fare_fn)
   end
 
-  def lowest_fare(route, trip, origin_id, destination_id, fare_fn) do
+  def recommended_fare(route, trip, origin_id, destination_id, fare_fn) do
     route
     |> get_fares(trip, origin_id, destination_id, fare_fn)
     |> Enum.min_by(& &1.cents, fn -> nil end)
   end
 
-  @spec highest_fare(
+  @spec base_fare(
           Route.t() | map,
           Trip.t() | map,
           Stops.Stop.id_t(),
           Stops.Stop.id_t(),
           (Keyword.t() -> [Fare.t()])
         ) ::
-          String.t() | nil
-  def highest_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
-  def highest_fare(nil, _, _, _, _), do: nil
+          Fare.t() | nil
+  def base_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def base_fare(nil, _, _, _, _), do: nil
 
-  def highest_fare(route, nil, origin_id, destination_id, fare_fn) do
-    highest_fare(route, @default_trip, origin_id, destination_id, fare_fn)
+  def base_fare(route, nil, origin_id, destination_id, fare_fn) do
+    base_fare(route, @default_trip, origin_id, destination_id, fare_fn)
   end
 
-  def highest_fare(route, trip, origin_id, destination_id, fare_fn) do
+  def base_fare(route, trip, origin_id, destination_id, fare_fn) do
     route
     |> get_fares(trip, origin_id, destination_id, fare_fn)
     |> Enum.max_by(& &1.cents, fn -> nil end)
   end
 
-  def get_fares(route, trip, origin_id, destination_id, fare_fn) do
+  defp get_fares(route, trip, origin_id, destination_id, fare_fn) do
     route_filters =
       route.type
       |> Route.type_atom()

--- a/apps/fares/lib/one_way.ex
+++ b/apps/fares/lib/one_way.ex
@@ -1,6 +1,6 @@
 defmodule Fares.OneWay do
   @moduledoc """
-  Calculates the lowest and highest fare for a particular trip i.e. a regular priced, non-discounted, one-way fare for the given mode.
+  Calculates the lowest, highest and reduced one-way fares for a particular trip for the given mode.
   Commuter rail and ferry fares distinguish between the possible sets of stops.
   Bus fares for express buses do not distinguish between the local and express portions;
   the express fare is always returned.
@@ -10,8 +10,8 @@ defmodule Fares.OneWay do
   alias Routes.Route
   alias Schedules.Trip
 
-  @default_filters [reduced: nil, duration: :single_trip]
-  @default_foxboro_filters [reduced: nil, duration: :round_trip]
+  @default_filters [duration: :single_trip]
+  @default_foxboro_filters [duration: :round_trip]
 
   @default_trip %Trip{name: "", id: ""}
 
@@ -33,6 +33,7 @@ defmodule Fares.OneWay do
   def recommended_fare(route, trip, origin_id, destination_id, fare_fn) do
     route
     |> get_fares(trip, origin_id, destination_id, fare_fn)
+    |> Enum.filter(fn fare -> fare.reduced == nil end)
     |> Enum.min_by(& &1.cents, fn -> nil end)
   end
 
@@ -54,9 +55,35 @@ defmodule Fares.OneWay do
   def base_fare(route, trip, origin_id, destination_id, fare_fn) do
     route
     |> get_fares(trip, origin_id, destination_id, fare_fn)
+    |> Enum.filter(fn fare -> fare.reduced == nil end)
     |> Enum.max_by(& &1.cents, fn -> nil end)
   end
 
+  @spec reduced_fare(
+          Route.t() | map,
+          Trip.t() | map,
+          Stops.Stop.id_t(),
+          Stops.Stop.id_t(),
+          (Keyword.t() -> [Fare.t()])
+        ) ::
+          Fare.t() | nil
+  def reduced_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1) do
+    # The reduced fare is always the same so we just return any element from the list
+
+    route
+    |> get_fares(trip, origin_id, destination_id, fare_fn)
+    |> Enum.filter(fn fare -> fare.reduced != nil end)
+    |> List.first()
+  end
+
+  @spec get_fares(
+          Route.t() | map,
+          Trip.t() | map,
+          Stops.Stop.id_t(),
+          Stops.Stop.id_t(),
+          (Keyword.t() -> [Fare.t()])
+        ) ::
+          [Fare.t() | nil]
   defp get_fares(route, trip, origin_id, destination_id, fare_fn) do
     route_filters =
       route.type

--- a/apps/fares/lib/one_way.ex
+++ b/apps/fares/lib/one_way.ex
@@ -67,9 +67,12 @@ defmodule Fares.OneWay do
           (Keyword.t() -> [Fare.t()])
         ) ::
           Fare.t() | nil
-  def reduced_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1) do
-    # The reduced fare is always the same so we just return any element from the list
+  def reduced_fare(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
 
+  def reduced_fare(nil, _, _, _, _), do: nil
+
+  def reduced_fare(route, trip, origin_id, destination_id, fare_fn) do
+    # The reduced fare is always the same so we just return any element from the list
     route
     |> get_fares(trip, origin_id, destination_id, fare_fn)
     |> Enum.filter(fn fare -> fare.reduced != nil end)

--- a/apps/fares/test/fares_test.exs
+++ b/apps/fares/test/fares_test.exs
@@ -1,6 +1,7 @@
 defmodule FaresTest do
   use ExUnit.Case, async: true
   doctest Fares
+  alias Routes.Route
 
   describe "calculate_commuter_rail/2" do
     test "when the origin is zone 6, finds the zone 6 fares" do
@@ -106,6 +107,44 @@ defmodule FaresTest do
 
     test "origin_id can be nil" do
       refute Fares.silver_line_airport_stop?("741", nil)
+    end
+  end
+
+  describe "to_fare_atom/1" do
+    test "silver line rapid transit returns subway" do
+      assert Fares.to_fare_atom(%Route{type: 3, id: "741"}) == :subway
+    end
+
+    test "silver line returns bus" do
+      assert Fares.to_fare_atom(%Route{type: 3, id: "751"}) == :bus
+    end
+
+    test "inner express bus returns :inner_express_bus" do
+      assert Fares.to_fare_atom(%Route{type: 3, id: "170"}) == :inner_express_bus
+    end
+
+    test "outer express bus returns :outer_express_bus" do
+      assert Fares.to_fare_atom(%Route{type: 3, id: "352"}) == :outer_express_bus
+    end
+
+    test "other types of routes return specific atoms" do
+      assert Fares.to_fare_atom(%Route{type: 0, id: "Green-B"}) == :subway
+      assert Fares.to_fare_atom(%Route{type: 1, id: "Red"}) == :subway
+      assert Fares.to_fare_atom(%Route{type: 2, id: "CR-Fitchburg"}) == :commuter_rail
+      assert Fares.to_fare_atom(%Route{type: 3, id: "1"}) == :bus
+    end
+
+    test "also works with route IDs" do
+      assert Fares.to_fare_atom("Green-B") == :subway
+      assert Fares.to_fare_atom("Red") == :subway
+      assert Fares.to_fare_atom("CR-Fitchburg") == :commuter_rail
+      assert Fares.to_fare_atom("1") == :bus
+    end
+
+    test "handles fare atoms" do
+      assert Fares.to_fare_atom(:subway) == :subway
+      assert Fares.to_fare_atom(:commuter_rail) == :commuter_rail
+      assert Fares.to_fare_atom(:bus) == :bus
     end
   end
 end

--- a/apps/fares/test/format_test.exs
+++ b/apps/fares/test/format_test.exs
@@ -104,6 +104,38 @@ defmodule Fares.FormatTest do
     end
   end
 
+  describe "concise_full_name/1" do
+    test "returns the full name excluding 'Monthly Pass' for commuter rail and express buses" do
+      cr_fare = %Fare{
+        mode: :commuter_rail,
+        media: [:commuter_ticket],
+        duration: :month,
+        name: {:zone, "7"}
+      }
+
+      inner_express_fare = %Fare{
+        name: :inner_express_bus,
+        mode: :bus,
+        duration: :month
+      }
+
+      outer_express_fare = %Fare{
+        name: :outer_express_bus,
+        mode: :bus,
+        duration: :month
+      }
+
+      assert concise_full_name(cr_fare) == "Zone 7"
+      assert concise_full_name(inner_express_fare) == "Inner Express Bus"
+      assert concise_full_name(outer_express_fare) == "Outer Express Bus"
+    end
+
+    test "returns the full_name for other fares" do
+      assert concise_full_name(%Fare{mode: :subway, duration: :month}) == "Monthly LinkPass"
+      assert concise_full_name(%Fare{duration: :day}) == "1-Day Pass"
+    end
+  end
+
   test "duration/1" do
     assert duration(%Fare{duration: :single_trip}) == "One-Way"
     assert duration(%Fare{duration: :round_trip}) == "Round Trip"

--- a/apps/fares/test/format_test.exs
+++ b/apps/fares/test/format_test.exs
@@ -75,6 +75,35 @@ defmodule Fares.FormatTest do
     end
   end
 
+  describe "full_name/1" do
+    test "gives a name for monthly Subway passes" do
+      assert full_name(%Fare{mode: :subway, duration: :month}) == "Monthly LinkPass"
+    end
+
+    test "gives a name for weekend CR passes" do
+      assert full_name(%Fare{mode: :commuter_rail, duration: :weekend}) == "Weekend Pass"
+    end
+
+    test "gives a name for week and day passes" do
+      assert full_name(%Fare{duration: :week}) == "7-Day Pass"
+      assert full_name(%Fare{duration: :day}) == "1-Day Pass"
+    end
+
+    test "gives a name for ADA and premium rides" do
+      assert full_name(%Fare{name: :ada_ride}) == "ADA Ride Fare"
+      assert full_name(%Fare{name: :premium_ride}) == "Premium Ride Fare"
+    end
+
+    test "gives a name for a Shuttle which doesn't have an associated fare" do
+      assert full_name(nil) == "Shuttle"
+    end
+
+    test "gives the name and duration for all other fares" do
+      assert full_name(%Fare{name: :commuter_ferry, duration: :month}) ==
+               ["Hingham/Hull Ferry", " ", "Monthly Pass"]
+    end
+  end
+
   test "duration/1" do
     assert duration(%Fare{duration: :single_trip}) == "One-Way"
     assert duration(%Fare{duration: :round_trip}) == "Round Trip"

--- a/apps/fares/test/month_test.exs
+++ b/apps/fares/test/month_test.exs
@@ -1,0 +1,334 @@
+defmodule Fares.MonthTest do
+  use ExUnit.Case, async: true
+
+  alias Fares.{Fare, Month}
+  alias Routes.Route
+  alias Schedules.Trip
+
+  @default_filters [reduced: nil, duration: :month]
+
+  describe "nil route" do
+    test "returns nil if no route is provided" do
+      assert Month.recommended_pass(nil, nil, nil, nil) == nil
+      assert Month.base_pass(nil, nil, nil, nil) == nil
+    end
+  end
+
+  describe "subway" do
+    @subway_route %Route{type: 0}
+
+    @subway_fares [
+      %Fare{
+        additional_valid_modes: [:bus],
+        cents: 9_000,
+        duration: :month,
+        media: [:charlie_card, :charlie_ticket],
+        mode: :subway,
+        name: :subway,
+        price_label: nil,
+        reduced: nil
+      }
+    ]
+
+    test "returns the lowest and highest month pass fares that are not discounted" do
+      fare_fn = fn @default_filters ++ [mode: :subway] -> @subway_fares end
+
+      assert %Fare{cents: 9_000} = Month.recommended_pass(@subway_route, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass(@subway_route, nil, nil, nil, fare_fn)
+    end
+
+    test "accepts a Route ID" do
+      fare_fn = fn @default_filters ++ [mode: :subway] -> @subway_fares end
+
+      assert %Fare{cents: 9_000} = Month.recommended_pass("Red", nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass("Red", nil, nil, nil, fare_fn)
+    end
+  end
+
+  describe "bus" do
+    @bus_fares [
+      %Fare{
+        additional_valid_modes: [],
+        cents: 5_500,
+        duration: :month,
+        media: [:charlie_card, :charlie_ticket],
+        mode: :bus,
+        name: :local_bus,
+        price_label: nil,
+        reduced: nil
+      },
+      %Fare{
+        additional_valid_modes: [],
+        cents: 13_600,
+        duration: :month,
+        media: [:charlie_card, :charlie_ticket],
+        mode: :bus,
+        name: :inner_express_bus,
+        price_label: nil,
+        reduced: nil
+      },
+      %Fare{
+        additional_valid_modes: [],
+        cents: 16_800,
+        duration: :month,
+        media: [:charlie_card, :charlie_ticket],
+        mode: :bus,
+        name: :outer_express_bus,
+        price_label: nil,
+        reduced: nil
+      }
+    ]
+
+    test "returns the lowest and highest month pass fares that are not discounted for the local bus" do
+      local_route = %Route{type: 3, id: "1"}
+
+      fare_fn = fn @default_filters ++ [name: :local_bus] ->
+        Enum.filter(@bus_fares, &(&1.name == :local_bus))
+      end
+
+      assert %Fare{cents: 5_500} = Month.recommended_pass(local_route, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.base_pass(local_route, nil, nil, nil, fare_fn)
+    end
+
+    test "returns the lowest and highest month pass fares that are not discounted for the inner express bus" do
+      inner_express_route = %Route{type: 3, id: "170"}
+
+      fare_fn = fn @default_filters ++ [name: :inner_express_bus] ->
+        Enum.filter(@bus_fares, &(&1.name == :inner_express_bus))
+      end
+
+      assert %Fare{cents: 13_600} =
+               Month.recommended_pass(inner_express_route, nil, nil, nil, fare_fn)
+
+      assert %Fare{cents: 13_600} = Month.base_pass(inner_express_route, nil, nil, nil, fare_fn)
+    end
+
+    test "returns the lowest and highest month pass fares that are not discounted for the outer express bus" do
+      outer_express_route = %Route{type: 3, id: "352"}
+
+      fare_fn = fn @default_filters ++ [name: :outer_express_bus] ->
+        Enum.filter(@bus_fares, &(&1.name == :outer_express_bus))
+      end
+
+      assert %Fare{cents: 16_800} =
+               Month.recommended_pass(outer_express_route, nil, nil, nil, fare_fn)
+
+      assert %Fare{cents: 16_800} = Month.base_pass(outer_express_route, nil, nil, nil, fare_fn)
+    end
+
+    test "returns the lowest and highest subway pass fares for the SL1, SL2, and SL3 routes" do
+      sl1 = %Route{type: 3, id: "741"}
+      sl2 = %Route{type: 3, id: "742"}
+      sl3 = %Route{type: 3, id: "743"}
+
+      fare_fn = fn @default_filters ++ [name: :subway] ->
+        Enum.filter(@subway_fares, &(&1.name == :subway))
+      end
+
+      assert %Fare{cents: 9_000} = Month.recommended_pass(sl1, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass(sl1, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.recommended_pass(sl2, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass(sl2, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.recommended_pass(sl3, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 9_000} = Month.base_pass(sl3, nil, nil, nil, fare_fn)
+    end
+
+    test "returns the lowest and highest bus pass fares for the SL4 and SL5 routes" do
+      sl4 = %Route{type: 3, id: "751"}
+      sl5 = %Route{type: 3, id: "749"}
+
+      fare_fn = fn @default_filters ++ [name: :local_bus] ->
+        Enum.filter(@bus_fares, &(&1.name == :local_bus))
+      end
+
+      assert %Fare{cents: 5_500} = Month.recommended_pass(sl4, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.base_pass(sl4, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.recommended_pass(sl5, nil, nil, nil, fare_fn)
+      assert %Fare{cents: 5_500} = Month.base_pass(sl5, nil, nil, nil, fare_fn)
+    end
+  end
+
+  describe "commuter rail" do
+    test "returns the lowest and highest one-way fares that are not discounted for a trip originating in Zone 1A" do
+      route = %Route{type: 2}
+      origin_id = "place-north"
+      destination_id = "Haverhill"
+
+      fare_fn = fn @default_filters ++ [name: {:zone, "7"}] ->
+        [
+          %Fare{
+            additional_valid_modes: [:subway, :bus, :ferry],
+            cents: 36_000,
+            duration: :month,
+            media: [:commuter_ticket],
+            mode: :commuter_rail,
+            name: {:zone, "7"},
+            price_label: nil,
+            reduced: nil
+          },
+          %Fare{
+            additional_valid_modes: [],
+            cents: 35_000,
+            duration: :month,
+            media: [:mticket],
+            mode: :commuter_rail,
+            name: {:zone, "7"},
+            price_label: nil,
+            reduced: nil
+          }
+        ]
+      end
+
+      assert %Fare{cents: 35_000} =
+               Month.recommended_pass(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fare{cents: 36_000} =
+               Month.base_pass(route, nil, origin_id, destination_id, fare_fn)
+    end
+
+    test "returns the lowest and highest one-way fares that are not discounted for a trip terminating in Zone 1A" do
+      route = %Route{type: 2}
+      origin_id = "Ballardvale"
+      destination_id = "place-north"
+
+      fare_fn = fn @default_filters ++ [name: {:zone, "4"}] ->
+        [
+          %Fare{
+            additional_valid_modes: [:subway, :bus, :ferry],
+            cents: 28_100,
+            duration: :month,
+            media: [:commuter_ticket],
+            mode: :commuter_rail,
+            name: {:zone, "4"},
+            price_label: nil,
+            reduced: nil
+          },
+          %Fare{
+            additional_valid_modes: [],
+            cents: 27_100,
+            duration: :month,
+            media: [:mticket],
+            mode: :commuter_rail,
+            name: {:zone, "4"},
+            price_label: nil,
+            reduced: nil
+          }
+        ]
+      end
+
+      assert %Fare{cents: 27_100} =
+               Month.recommended_pass(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fare{cents: 28_100} =
+               Month.base_pass(route, nil, origin_id, destination_id, fare_fn)
+    end
+
+    test "returns an interzone fares that are not discounted for a trip that does not originate/terminate in Zone 1A" do
+      route = %Route{type: 2}
+      origin_id = "Ballardvale"
+      destination_id = "Haverhill"
+
+      fare_fn = fn @default_filters ++ [name: {:interzone, "4"}] ->
+        [
+          %Fare{
+            additional_valid_modes: [:bus],
+            cents: 13_900,
+            duration: :month,
+            media: [:commuter_ticket],
+            mode: :commuter_rail,
+            name: {:interzone, "4"},
+            price_label: nil,
+            reduced: nil
+          },
+          %Fare{
+            additional_valid_modes: [],
+            cents: 12_900,
+            duration: :month,
+            media: [:mticket],
+            mode: :commuter_rail,
+            name: {:interzone, "4"},
+            price_label: nil,
+            reduced: nil
+          }
+        ]
+      end
+
+      assert %Fare{cents: 12_900} =
+               Month.recommended_pass(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fare{cents: 13_900} =
+               Month.base_pass(route, nil, origin_id, destination_id, fare_fn)
+    end
+
+    test "returns zone-based fares for standard trips on Foxboro pilot" do
+      route = %Route{type: 2, id: "CR-Franklin"}
+      trip_1 = %Trip{name: "751", id: "CR-Weekday-Fall-19-751"}
+      trip_2 = %Trip{name: "759", id: "CR-Weekday-Fall-19-759"}
+
+      assert %Fare{name: {:zone, "4"}} =
+               Month.recommended_pass(route, trip_1, "place-sstat", "place-FS-0049")
+
+      assert %Fare{name: {:interzone, "3"}} =
+               Month.recommended_pass(route, trip_2, "place-FB-0118", "place-FS-0049")
+    end
+
+    test "accepts a Trip ID" do
+      route = %Route{type: 2, id: "CR-Franklin"}
+      trip_id = "CR-Weekday-Fall-19-751"
+
+      assert %Fare{name: {:zone, "4"}} =
+               Month.recommended_pass(route, trip_id, "place-sstat", "place-FS-0049")
+
+      assert %Fare{name: {:zone, "4"}} =
+               Month.base_pass(route, trip_id, "place-sstat", "place-FS-0049")
+    end
+
+    test "returns nil if no matching fares found" do
+      route = %Route{type: 2, id: "CapeFlyer"}
+      origin_id = "place-sstat"
+      destination_id = "Hyannis"
+
+      fare_fn = fn _ -> [] end
+
+      assert Month.recommended_pass(route, nil, origin_id, destination_id, fare_fn) == nil
+    end
+  end
+
+  describe "ferry" do
+    test "returns the fares that are not discounted for the correct ferry trip" do
+      route = %Route{type: 4}
+      origin_id = "Boat-Charlestown"
+      destination_id = "Boat-Long-South"
+
+      fare_fn = fn @default_filters ++ [name: :ferry_inner_harbor] ->
+        [
+          %Fare{
+            additional_valid_modes: [:subway, :bus, :commuter_rail],
+            cents: 9_000,
+            duration: :month,
+            media: [:charlie_ticket],
+            mode: :ferry,
+            name: :ferry_inner_harbor,
+            price_label: nil,
+            reduced: nil
+          },
+          %Fare{
+            additional_valid_modes: [],
+            cents: 8_000,
+            duration: :month,
+            media: [:mticket],
+            mode: :ferry,
+            name: :ferry_inner_harbor,
+            price_label: nil,
+            reduced: nil
+          }
+        ]
+      end
+
+      assert %Fare{cents: 8_000} =
+               Month.recommended_pass(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fare{cents: 9_000} = Month.base_pass(route, nil, origin_id, destination_id, fare_fn)
+    end
+  end
+end

--- a/apps/fares/test/one_way_test.exs
+++ b/apps/fares/test/one_way_test.exs
@@ -11,6 +11,7 @@ defmodule OneWayTest do
   test "returns nil if no route is provided" do
     refute recommended_fare(nil, nil, nil, nil)
     refute base_fare(nil, nil, nil, nil)
+    refute reduced_fare(nil, nil, nil, nil)
   end
 
   describe "subway" do

--- a/apps/fares/test/one_way_test.exs
+++ b/apps/fares/test/one_way_test.exs
@@ -1,28 +1,16 @@
-defmodule HighestLowestFareTest do
+defmodule OneWayTest do
   use ExUnit.Case, async: true
 
   alias Routes.Route
   alias Schedules.Trip
 
-  import Fares.HighestLowestFare
+  import Fares.OneWay
 
   @default_filters [reduced: nil, duration: :single_trip]
 
-  test "returns an empty string if no route is provided" do
-    refute lowest_fare(nil, nil, nil, nil)
-    refute highest_fare(nil, nil, nil, nil)
-  end
-
-  test "excludes weekend commuter rail rates" do
-    route = %Route{type: 2}
-    origin_id = "place-north"
-    destination_id = "Haverhill"
-
-    assert %Fares.Fare{cents: 1100, duration: :single_trip} =
-             lowest_fare(route, nil, origin_id, destination_id)
-
-    assert %Fares.Fare{cents: 1100, duration: :single_trip} =
-             highest_fare(route, nil, origin_id, destination_id)
+  test "returns nil if no route is provided" do
+    refute recommended_fare(nil, nil, nil, nil)
+    refute base_fare(nil, nil, nil, nil)
   end
 
   describe "subway" do
@@ -52,8 +40,8 @@ defmodule HighestLowestFareTest do
         @subway_fares
       end
 
-      assert %Fares.Fare{cents: 225} = lowest_fare(@route, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 275} = highest_fare(@route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = recommended_fare(@route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 275} = base_fare(@route, nil, nil, nil, fare_fn)
     end
   end
 
@@ -116,8 +104,8 @@ defmodule HighestLowestFareTest do
         Enum.filter(@bus_fares, &(&1.name == :local_bus))
       end
 
-      assert %Fares.Fare{cents: 170} = lowest_fare(local_route, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 200} = highest_fare(local_route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 170} = recommended_fare(local_route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 200} = base_fare(local_route, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest one-way trip fare that is not discounted for the inner express bus" do
@@ -127,8 +115,10 @@ defmodule HighestLowestFareTest do
         Enum.filter(@bus_fares, &(&1.name == :inner_express_bus))
       end
 
-      assert %Fares.Fare{cents: 400} = lowest_fare(inner_express_route, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 500} = highest_fare(inner_express_route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 400} =
+               recommended_fare(inner_express_route, nil, nil, nil, fare_fn)
+
+      assert %Fares.Fare{cents: 500} = base_fare(inner_express_route, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest one-way trip fare that is not discounted for the outer express bus" do
@@ -138,8 +128,10 @@ defmodule HighestLowestFareTest do
         Enum.filter(@bus_fares, &(&1.name == :outer_express_bus))
       end
 
-      assert %Fares.Fare{cents: 525} = lowest_fare(outer_express_route, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 700} = highest_fare(outer_express_route, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 525} =
+               recommended_fare(outer_express_route, nil, nil, nil, fare_fn)
+
+      assert %Fares.Fare{cents: 700} = base_fare(outer_express_route, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest subway fare for for SL1 route (id=741)" do
@@ -149,8 +141,8 @@ defmodule HighestLowestFareTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = lowest_fare(sl1, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 275} = highest_fare(sl1, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = recommended_fare(sl1, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 275} = base_fare(sl1, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest subway fare for for SL2 route (id=742)" do
@@ -160,8 +152,8 @@ defmodule HighestLowestFareTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = lowest_fare(sl2, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 275} = highest_fare(sl2, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = recommended_fare(sl2, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 275} = base_fare(sl2, nil, nil, nil, fare_fn)
     end
 
     test "returns lowest and highest the subway fare for for SL3 route (id=743)" do
@@ -171,8 +163,8 @@ defmodule HighestLowestFareTest do
         Enum.filter(@subway_fares, &(&1.name == :subway))
       end
 
-      assert %Fares.Fare{cents: 225} = lowest_fare(sl3, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 275} = highest_fare(sl3, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 225} = recommended_fare(sl3, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 275} = base_fare(sl3, nil, nil, nil, fare_fn)
     end
 
     test "returns the lowest and highest bus fare for for SL4 route (id=751)" do
@@ -182,8 +174,8 @@ defmodule HighestLowestFareTest do
         Enum.filter(@bus_fares, &(&1.name == :local_bus))
       end
 
-      assert %Fares.Fare{cents: 170} = lowest_fare(sl4, nil, nil, nil, fare_fn)
-      assert %Fares.Fare{cents: 200} = highest_fare(sl4, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 170} = recommended_fare(sl4, nil, nil, nil, fare_fn)
+      assert %Fares.Fare{cents: 200} = base_fare(sl4, nil, nil, nil, fare_fn)
     end
   end
 
@@ -207,10 +199,9 @@ defmodule HighestLowestFareTest do
       end
 
       assert %Fares.Fare{cents: 1050} =
-               lowest_fare(route, nil, origin_id, destination_id, fare_fn)
+               recommended_fare(route, nil, origin_id, destination_id, fare_fn)
 
-      assert %Fares.Fare{cents: 1050} =
-               highest_fare(route, nil, origin_id, destination_id, fare_fn)
+      assert %Fares.Fare{cents: 1050} = base_fare(route, nil, origin_id, destination_id, fare_fn)
     end
 
     test "returns the lowest and highest one-way fare that is not discounted for a trip terminating in Zone 1A" do
@@ -231,10 +222,10 @@ defmodule HighestLowestFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 825} = lowest_fare(route, nil, origin_id, destination_id, fare_fn)
-
       assert %Fares.Fare{cents: 825} =
-               highest_fare(route, nil, origin_id, destination_id, fare_fn)
+               recommended_fare(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fares.Fare{cents: 825} = base_fare(route, nil, origin_id, destination_id, fare_fn)
     end
 
     test "returns an interzone fare that is not discounted for a trip that does not originate/terminate in Zone 1A" do
@@ -255,10 +246,22 @@ defmodule HighestLowestFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 401} = lowest_fare(route, nil, origin_id, destination_id, fare_fn)
-
       assert %Fares.Fare{cents: 401} =
-               highest_fare(route, nil, origin_id, destination_id, fare_fn)
+               recommended_fare(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fares.Fare{cents: 401} = base_fare(route, nil, origin_id, destination_id, fare_fn)
+    end
+
+    test "excludes weekend commuter rail rates" do
+      route = %Route{type: 2}
+      origin_id = "place-north"
+      destination_id = "Haverhill"
+
+      assert %Fares.Fare{cents: 1100, duration: :single_trip} =
+               recommended_fare(route, nil, origin_id, destination_id)
+
+      assert %Fares.Fare{cents: 1100, duration: :single_trip} =
+               base_fare(route, nil, origin_id, destination_id)
     end
 
     test "returns the appropriate fare for Foxboro Special Events" do
@@ -268,16 +271,16 @@ defmodule HighestLowestFareTest do
       foxboro_id = "place-FS-0049"
 
       assert %Fares.Fare{cents: 2000, duration: :round_trip} =
-               lowest_fare(route, trip, south_station_id, foxboro_id)
+               recommended_fare(route, trip, south_station_id, foxboro_id)
 
       assert %Fares.Fare{cents: 2000, duration: :round_trip} =
-               highest_fare(route, trip, south_station_id, foxboro_id)
+               base_fare(route, trip, south_station_id, foxboro_id)
 
       assert %Fares.Fare{cents: 2000, duration: :round_trip} =
-               lowest_fare(route, trip, foxboro_id, south_station_id)
+               recommended_fare(route, trip, foxboro_id, south_station_id)
 
       assert %Fares.Fare{cents: 2000, duration: :round_trip} =
-               highest_fare(route, trip, foxboro_id, south_station_id)
+               base_fare(route, trip, foxboro_id, south_station_id)
     end
 
     test "returns zone-based fares for standard trips on Foxboro pilot" do
@@ -286,10 +289,10 @@ defmodule HighestLowestFareTest do
       trip_2 = %Trip{name: "759", id: "CR-Weekday-Fall-19-759"}
 
       assert %Fares.Fare{name: {:zone, "4"}} =
-               lowest_fare(route, trip_1, "place-sstat", "place-FS-0049")
+               recommended_fare(route, trip_1, "place-sstat", "place-FS-0049")
 
       assert %Fares.Fare{name: {:interzone, "3"}} =
-               lowest_fare(route, trip_2, "place-FB-0118", "place-FS-0049")
+               recommended_fare(route, trip_2, "place-FB-0118", "place-FS-0049")
     end
 
     test "Zone 1A to 1A reverse commute trips on Foxboro pilot retain original pricing" do
@@ -297,7 +300,7 @@ defmodule HighestLowestFareTest do
       trip = %Trip{name: "741", id: "CR-Weekday-Fall-19-741"}
 
       assert %Fares.Fare{name: {:zone, "1A"}} =
-               lowest_fare(route, trip, "origin=place-DB-2240", "place-DB-2222")
+               recommended_fare(route, trip, "origin=place-DB-2240", "place-DB-2222")
     end
 
     test "does not apply pilot/discounted fare for reverse commutes until Fall 2019" do
@@ -305,7 +308,7 @@ defmodule HighestLowestFareTest do
       trip = %Trip{name: "743", id: "CR-Weekday-Spring-19-743"}
 
       assert %Fares.Fare{name: {:zone, "3"}} =
-               lowest_fare(route, trip, "place-sstat", "place-FB-0148")
+               recommended_fare(route, trip, "place-sstat", "place-FB-0148")
     end
 
     test "returns interzone fare for reverse commute trips to and from Foxboro" do
@@ -317,10 +320,10 @@ defmodule HighestLowestFareTest do
       foxboro_id = "place-FS-0049"
 
       assert %Fares.Fare{name: {:interzone, "4"}} =
-               lowest_fare(route, inbound_trip, foxboro_id, south_station_id)
+               recommended_fare(route, inbound_trip, foxboro_id, south_station_id)
 
       assert %Fares.Fare{name: {:interzone, "4"}} =
-               lowest_fare(route, outbound_trip, south_station_id, foxboro_id)
+               recommended_fare(route, outbound_trip, south_station_id, foxboro_id)
     end
 
     test "returns nil if no matching fares found" do
@@ -330,7 +333,7 @@ defmodule HighestLowestFareTest do
 
       fare_fn = fn _ -> [] end
 
-      assert lowest_fare(route, nil, origin_id, destination_id, fare_fn) == nil
+      assert recommended_fare(route, nil, origin_id, destination_id, fare_fn) == nil
     end
 
     test "returns a free fare for any bus shuttle rail replacements" do
@@ -345,10 +348,10 @@ defmodule HighestLowestFareTest do
       destination_id = "place-WR-0099"
 
       assert %Fares.Fare{cents: 0, name: :free_fare} =
-               lowest_fare(route, nil, origin_id, destination_id)
+               recommended_fare(route, nil, origin_id, destination_id)
 
       assert %Fares.Fare{cents: 0, name: :free_fare} =
-               highest_fare(route, nil, origin_id, destination_id)
+               base_fare(route, nil, origin_id, destination_id)
     end
   end
 
@@ -371,10 +374,10 @@ defmodule HighestLowestFareTest do
         ]
       end
 
-      assert %Fares.Fare{cents: 350} = lowest_fare(route, nil, origin_id, destination_id, fare_fn)
-
       assert %Fares.Fare{cents: 350} =
-               highest_fare(route, nil, origin_id, destination_id, fare_fn)
+               recommended_fare(route, nil, origin_id, destination_id, fare_fn)
+
+      assert %Fares.Fare{cents: 350} = base_fare(route, nil, origin_id, destination_id, fare_fn)
     end
   end
 end

--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -79,6 +79,10 @@
     margin-right: $base-spacing / 2;
   }
 
+  &-length-duration {
+    white-space: nowrap;
+  }
+
   &-length-distance {
     margin-left: $space-12;
     white-space: nowrap;

--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -57,6 +57,8 @@
 
     .c-icon__bus-pill {
       font-size: .9em;
+      max-height: initial;
+      white-space: nowrap;
     }
   }
 

--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -20,21 +20,33 @@
     }
   }
 
+  /* stylelint-disable property-no-vendor-prefix */
   &-header {
     background-color: $brand-primary-lightest-contrast;
     border: 1px solid $brand-primary;
     border-bottom: 0;
-    display: flex;
-    font-size: $base-spacing;
-    justify-content: space-between;
+    display: -ms-grid;
+    display: grid;
+    -ms-grid-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr;
     line-height: 1.5;
     margin-top: 0;
     padding: $base-spacing;
+
+    .m-trip-plan-results__itinerary-header-content {
+      -ms-grid-column: 1;
+      grid-column: 1;
+    }
+    .m-trip-plan-results__itinerary-fares {
+      -ms-grid-column: 2;
+      grid-column: 2;
+    }
 
     @include media-breakpoint-down(sm) {
       display: block;
     }
   }
+  /* stylelint-enable property-no-vendor-prefix */
 
   &-accessible {
     @include icon-size-inline(1em);
@@ -91,7 +103,6 @@
   }
 
   &-fares {
-    min-width: 40%;
     padding-left: $base-spacing;
     padding-top: 0;
 

--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -24,10 +24,16 @@
     background-color: $brand-primary-lightest-contrast;
     border: 1px solid $brand-primary;
     border-bottom: 0;
+    display: flex;
     font-size: $base-spacing;
+    justify-content: space-between;
     line-height: 1.5;
     margin-top: 0;
     padding: $base-spacing;
+
+    @include media-breakpoint-down(sm) {
+      display: block;
+    }
   }
 
   &-accessible {
@@ -80,5 +86,25 @@
     background-color: $gray-lightest;
     margin-bottom: $base-spacing;
     padding: $base-spacing;
+  }
+
+  &-fares {
+    min-width: 40%;
+    padding-left: $base-spacing;
+    padding-top: 0;
+
+    @include media-breakpoint-down(sm) {
+      padding-left: 0;
+      padding-top: $base-spacing;
+    }
+  }
+
+  &-fare-title {
+    font-size: $font-size-h5;
+    font-weight: bold;
+  }
+
+  &-fare {
+    padding-left: $base-spacing;
   }
 }

--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -104,7 +104,8 @@
     font-weight: bold;
   }
 
-  &-fare {
+  &-fare,
+  &-note {
     padding-left: $base-spacing;
   }
 

--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -107,4 +107,8 @@
   &-fare {
     padding-left: $base-spacing;
   }
+
+  &-fare + &-fare-title {
+    margin-top: 1rem;
+  }
 }

--- a/apps/site/assets/ts/trip-plan-results/__tests__/TripPlannerResultsTest.tsx
+++ b/apps/site/assets/ts/trip-plan-results/__tests__/TripPlannerResultsTest.tsx
@@ -7,6 +7,7 @@ import { TileServerUrl } from "../../leaflet/components/__mapdata";
 const html = "<div>Lots of content about the itinerary</div>";
 const tab_html = "<div>HTML for the accordion button</div>";
 const access_html = "<div>Accessible</div>";
+const fares_html = "<div>HTML content for fares</div>";
 const tile_server_url: TileServerUrl = "";
 
 const positions: [number, number][] = [
@@ -35,12 +36,12 @@ it("it renders", () => {
   createReactRoot();
   const tree = renderer.create(
     <TripPlannerResults
-      itineraryData={[{ html, access_html, tab_html, id: 1, map }]}
+      itineraryData={[{ html, access_html, fares_html, tab_html, id: 1, map }]}
     />
   );
   tree.update(
     <TripPlannerResults
-      itineraryData={[{ html, access_html, tab_html, id: 1, map }]}
+      itineraryData={[{ html, access_html, fares_html, tab_html, id: 1, map }]}
     />
   );
   expect(tree.toJSON()).toMatchSnapshot();

--- a/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
+++ b/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
@@ -8,18 +8,30 @@ exports[`it renders 1`] = `
     className="m-trip-plan-results__itinerary-header"
   >
     <div
-      className="m-trip-plan-results__itinerary-summary"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "<div>HTML for the accordion button</div>",
+      className="m-trip-plan-results__itinerary-header-content"
+    >
+      <div
+        className="m-trip-plan-results__itinerary-summary"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<div>HTML for the accordion button</div>",
+          }
         }
-      }
-    />
+      />
+      <div
+        className="m-trip-plan-results__itinerary-accessible"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<div>Accessible</div>",
+          }
+        }
+      />
+    </div>
     <div
-      className="m-trip-plan-results__itinerary-accessible"
+      className="m-trip-plan-results__itinerary-fares"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<div>Accessible</div>",
+          "__html": "<div>HTML content for fares</div>",
         }
       }
     />

--- a/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
+++ b/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
@@ -11,7 +11,7 @@ import {
 The following ignored functions are vanilla JS event handlers
 that are for HTML that gets injected into itinerary rows.
 Ideally, all the HTML of this component would be built in React
-which would make it easy to test in this file. Since that HTML is 
+which would make it easy to test in this file. Since that HTML is
 server rendered and injected, it is difficult to test from jest.
 It is being ignored now to prevent a codecov ding.
 */
@@ -75,13 +75,19 @@ const ItineraryAccordion = ({
 }: Props): ReactElement<HTMLElement> => (
   <div className="m-trip-plan-results__itinerary">
     <div className="m-trip-plan-results__itinerary-header">
+      <div className="m-trip-plan-results__itinerary-header-content">
+        <div
+          className="m-trip-plan-results__itinerary-summary"
+          dangerouslySetInnerHTML={{ __html: itinerary.tab_html }} // eslint-disable-line react/no-danger
+        />
+        <div
+          className="m-trip-plan-results__itinerary-accessible"
+          dangerouslySetInnerHTML={{ __html: itinerary.access_html }} // eslint-disable-line react/no-danger
+        />
+      </div>
       <div
-        className="m-trip-plan-results__itinerary-summary"
-        dangerouslySetInnerHTML={{ __html: itinerary.tab_html }} // eslint-disable-line react/no-danger
-      />
-      <div
-        className="m-trip-plan-results__itinerary-accessible"
-        dangerouslySetInnerHTML={{ __html: itinerary.access_html }} // eslint-disable-line react/no-danger
+        className="m-trip-plan-results__itinerary-fares"
+        dangerouslySetInnerHTML={{ __html: itinerary.fares_html }} // eslint-disable-line react/no-danger
       />
     </div>
     <Accordion

--- a/apps/site/assets/ts/trip-plan-results/components/TripPlannerResults.tsx
+++ b/apps/site/assets/ts/trip-plan-results/components/TripPlannerResults.tsx
@@ -9,6 +9,7 @@ export interface Itinerary {
   map: MapData;
   tab_html: string;
   access_html: string;
+  fares_html: string;
 }
 
 interface Props {

--- a/apps/site/lib/site/trip_plan/itinerary_row.ex
+++ b/apps/site/lib/site/trip_plan/itinerary_row.ex
@@ -1,13 +1,17 @@
 defmodule Site.TripPlan.ItineraryRow do
-  alias TripPlan.{PersonalDetail, TransitDetail, NamedPosition, Leg}
-  alias TripPlan.PersonalDetail.Step
-  alias Site.TripPlan.IntermediateStop
+  @moduledoc false
+
   alias Routes.Route
+  alias Site.TripPlan.IntermediateStop
+  alias TripPlan.{Leg, NamedPosition, PersonalDetail, TransitDetail}
+  alias TripPlan.PersonalDetail.Step
 
   @typep name_and_id :: {String.t(), String.t() | nil}
   @typep step :: String.t()
 
   defmodule Dependencies do
+    @moduledoc false
+
     @type stop_mapper :: (Stops.Stop.id_t() -> Stops.Stop.t() | nil)
     @type route_mapper :: (Routes.Route.id_t() -> Routes.Route.t() | nil)
     @type trip_mapper :: (Schedules.Trip.id_t() -> Schedules.Trip.t() | nil)

--- a/apps/site/lib/site/trip_plan/related_link.ex
+++ b/apps/site/lib/site/trip_plan/related_link.ex
@@ -76,9 +76,11 @@ defmodule Site.TripPlan.RelatedLink do
 
   defp route_links(itinerary, opts) do
     route_by_id = Keyword.get(opts, :route_by_id)
+    not_shuttle? = fn route -> route.description !== :rail_replacement_bus end
 
     for {route_id, trip_id} <- Itinerary.route_trip_ids(itinerary),
-        %Route{} = route <- [route_by_id.(route_id)] do
+        %Route{} = route <- [route_by_id.(route_id)],
+        not_shuttle?.(route) do
       route_link(route, trip_id, itinerary)
     end
   end

--- a/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/schedule_api.ex
@@ -7,7 +7,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
   alias Fares.Format
   alias Routes.Route
   alias Schedules.Repo
-  alias Fares.{HighestLowestFare}
+  alias Fares.{OneWay}
   import SiteWeb.ViewHelpers, only: [cms_static_page_path: 2]
 
   def show(conn, %{
@@ -151,7 +151,7 @@ defmodule SiteWeb.ScheduleController.ScheduleApi do
   @spec fares_for_service(map, map, String.t(), String.t()) :: map
   def fares_for_service(route, trip, origin, destination) do
     %{
-      price: route |> HighestLowestFare.lowest_fare(trip, origin, destination) |> Format.price(),
+      price: route |> OneWay.recommended_fare(trip, origin, destination) |> Format.price(),
       fare_link:
         fare_link(
           Route.type_atom(route.type),

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -92,10 +92,12 @@ defmodule SiteWeb.TripPlanController do
     destination_id = leg.to.stop_id
     recommended_fare = OneWay.recommended_fare(route, trip, origin_id, destination_id)
     base_fare = OneWay.base_fare(route, trip, origin_id, destination_id)
+    reduced_fare = OneWay.reduced_fare(route, trip, origin_id, destination_id)
 
     fares = %{
       highest_one_way_fare: base_fare,
-      lowest_one_way_fare: recommended_fare
+      lowest_one_way_fare: recommended_fare,
+      reduced_one_way_fare: reduced_fare
     }
 
     mode_with_fares = %TransitDetail{leg.mode | fares: fares}

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -4,10 +4,11 @@ defmodule SiteWeb.TripPlanController do
   """
 
   use SiteWeb, :controller
+  alias Fares.{Fare, Month, OneWay}
   alias Routes.Route
   alias Site.TripPlan.{Query, RelatedLink, ItineraryRow, ItineraryRowList}
   alias Site.TripPlan.Map, as: TripPlanMap
-  alias TripPlan.{Itinerary, Leg, PersonalDetail, TransitDetail}
+  alias TripPlan.{Itinerary, Leg, NamedPosition, PersonalDetail, TransitDetail}
 
   plug(:require_google_maps)
   plug(:assign_initial_map)
@@ -41,7 +42,7 @@ defmodule SiteWeb.TripPlanController do
     itineraries =
       query
       |> Query.get_itineraries()
-      |> with_fares()
+      |> with_fares_and_passes()
 
     route_map = routes_for_query(itineraries)
     route_mapper = &Map.get(route_map, &1)
@@ -65,12 +66,17 @@ defmodule SiteWeb.TripPlanController do
     assign(conn, :requires_google_maps?, true)
   end
 
-  @spec with_fares([Itinerary.t()]) :: [Itinerary.t()]
-  defp with_fares(itineraries) do
+  @spec with_fares_and_passes([Itinerary.t()]) :: [Itinerary.t()]
+  defp with_fares_and_passes(itineraries) do
     Enum.map(itineraries, fn itinerary ->
       legs_with_fares = itinerary.legs |> Enum.map(&leg_with_fares/1)
 
-      %{itinerary | legs: legs_with_fares}
+      passes = %{
+        base_month_pass: base_month_pass_for_itinerary(itinerary),
+        recommended_month_pass: recommended_month_pass_for_itinerary(itinerary)
+      }
+
+      %{itinerary | legs: legs_with_fares, passes: passes}
     end)
   end
 
@@ -84,17 +90,60 @@ defmodule SiteWeb.TripPlanController do
     trip = Schedules.Repo.trip(leg.mode.trip_id)
     origin_id = leg.from.stop_id
     destination_id = leg.to.stop_id
-    lowest_fare = Fares.HighestLowestFare.lowest_fare(route, trip, origin_id, destination_id)
-    highest_fare = Fares.HighestLowestFare.highest_fare(route, trip, origin_id, destination_id)
+    recommended_fare = OneWay.recommended_fare(route, trip, origin_id, destination_id)
+    base_fare = OneWay.base_fare(route, trip, origin_id, destination_id)
 
     fares = %{
-      highest_one_way_fare: highest_fare,
-      lowest_one_way_fare: lowest_fare
+      highest_one_way_fare: base_fare,
+      lowest_one_way_fare: recommended_fare
     }
 
     mode_with_fares = %TransitDetail{leg.mode | fares: fares}
     %{leg | mode: mode_with_fares}
   end
+
+  @spec base_month_pass_for_itinerary(Itinerary.t()) :: Fare.t() | nil
+  defp base_month_pass_for_itinerary(%Itinerary{legs: legs}) do
+    legs
+    |> Enum.map(&highest_month_pass/1)
+    |> max_by_cents()
+  end
+
+  @spec recommended_month_pass_for_itinerary(Itinerary.t()) :: Fare.t() | nil
+  defp recommended_month_pass_for_itinerary(%Itinerary{legs: legs}) do
+    legs
+    |> Enum.map(&lowest_month_pass/1)
+    |> max_by_cents()
+  end
+
+  @spec highest_month_pass(Leg.t()) :: Fare.t() | nil
+  defp highest_month_pass(%Leg{mode: %PersonalDetail{}}), do: nil
+
+  defp highest_month_pass(%Leg{
+         mode: %TransitDetail{route_id: route_id, trip_id: trip_id},
+         from: %NamedPosition{stop_id: origin_id},
+         to: %NamedPosition{stop_id: destination_id}
+       }) do
+    Month.base_pass(route_id, trip_id, origin_id, destination_id)
+  end
+
+  @spec lowest_month_pass(Leg.t()) :: Fare.t() | nil
+  defp lowest_month_pass(%Leg{mode: %PersonalDetail{}}), do: nil
+
+  defp lowest_month_pass(%Leg{
+         mode: %TransitDetail{route_id: route_id, trip_id: trip_id},
+         from: %NamedPosition{stop_id: origin_id},
+         to: %NamedPosition{stop_id: destination_id}
+       }) do
+    Month.recommended_pass(route_id, trip_id, origin_id, destination_id)
+  end
+
+  @spec max_by_cents([Fare.t() | nil]) :: Fare.t() | nil
+  defp max_by_cents(fares), do: Enum.max_by(fares, &cents_for_max/1, fn -> nil end)
+
+  @spec cents_for_max(Fare.t() | nil) :: non_neg_integer
+  defp cents_for_max(nil), do: 0
+  defp cents_for_max(%Fare{cents: cents}), do: cents
 
   @spec itinerary_row_lists([Itinerary.t()], route_mapper, map) :: [ItineraryRowList.t()]
   defp itinerary_row_lists(itineraries, route_mapper, plan) do

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
@@ -1,6 +1,6 @@
 <div class="m-trip-plan-results__itinerary-fare-title">Base Fare Estimate</div>
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--one-way"><%= @one_way_total %> one way</div>
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--round-trip"><%= @round_trip_total %> round trip</div>
-
+<div class="m-trip-plan-results__itinerary-note"><%= transfer_note(@itinerary) %></div>
 <div class="m-trip-plan-results__itinerary-fare-title">Monthly Pass Fare</div>
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--month"><%= monthly_pass(@itinerary.passes.base_month_pass) %></div>

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
@@ -2,5 +2,5 @@
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--one-way"><%= @one_way_total %> one way</div>
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--round-trip"><%= @round_trip_total %> round trip</div>
 <div class="m-trip-plan-results__itinerary-note"><%= transfer_note(@itinerary) %></div>
-<div class="m-trip-plan-results__itinerary-fare-title">Monthly Pass Fare</div>
+<div class="m-trip-plan-results__itinerary-fare-title">Monthly Pass</div>
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--month"><%= monthly_pass(@itinerary.passes.base_month_pass) %></div>

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
@@ -1,3 +1,6 @@
 <div class="m-trip-plan-results__itinerary-fare-title">Base Fare Estimate</div>
-<div class="m-trip-plan-results__itinerary-fare"><%= @one_way_total %> one way</div>
-<div class="m-trip-plan-results__itinerary-fare"><%= @round_trip_total %> round trip</div>
+<div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--one-way"><%= @one_way_total %> one way</div>
+<div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--round-trip"><%= @round_trip_total %> round trip</div>
+
+<div class="m-trip-plan-results__itinerary-fare-title">Monthly Pass Fare</div>
+<div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--month"><%= monthly_pass(@itinerary.passes.base_month_pass) %></div>

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
@@ -1,0 +1,3 @@
+<div class="m-trip-plan-results__itinerary-fare-title">Base Fare Estimate</div>
+<div class="m-trip-plan-results__itinerary-fare"><%= @one_way_total %> one way</div>
+<div class="m-trip-plan-results__itinerary-fare"><%= @round_trip_total %> round trip</div>

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_tab.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_tab.html.eex
@@ -8,7 +8,7 @@
   <span class="m-trip-plan-results__itinerary-length-time">
     <%= Timex.format!(@itinerary.start, "{h12}:{m} {AM}") %> - <%= Timex.format!(@itinerary.stop, "{h12}:{m} {AM}") %>
   </span>
-  <span>
+  <span class="m-trip-plan-results__itinerary-length-duration">
     <%= Timex.diff(@itinerary.stop, @itinerary.start, :minutes) |> format_minutes_duration %>
   </span>
 </div>

--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -430,15 +430,15 @@ defmodule SiteWeb.ScheduleView do
   def single_trip_fares(route) do
     summary =
       route
-      |> to_fare_atom()
+      |> to_fare_summary_atom()
       |> mode_summaries()
       |> Enum.find(fn summary -> summary.duration == :single_trip end)
 
     summary.fares
   end
 
-  @spec to_fare_atom(Route.t()) :: atom
-  def to_fare_atom(%Route{type: 3, id: id}) do
+  @spec to_fare_summary_atom(Route.t()) :: atom
+  def to_fare_summary_atom(%Route{type: 3, id: id}) do
     cond do
       Fares.silver_line_rapid_transit?(id) -> :subway
       Fares.inner_express?(id) -> :inner_express_bus
@@ -447,7 +447,7 @@ defmodule SiteWeb.ScheduleView do
     end
   end
 
-  def to_fare_atom(route), do: Route.type_atom(route)
+  def to_fare_summary_atom(route), do: Route.type_atom(route)
 
   @spec sort_connections([Route.t()]) :: [Route.t()]
   def sort_connections(routes) do

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -675,7 +675,7 @@ defmodule SiteWeb.TripPlanView do
   def monthly_pass(nil), do: Format.full_name(nil)
 
   def monthly_pass(fare) do
-    "#{cr_prefix(fare)}#{Format.full_name(fare)}: #{Format.price(fare)}"
+    "#{cr_prefix(fare)}#{Format.concise_full_name(fare)}: #{Format.price(fare)}"
   end
 
   @spec cr_prefix(Fare.t()) :: String.t()

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -327,6 +327,10 @@ defmodule SiteWeb.TripPlanView do
   end
 
   @spec icon_for_route(Route.t()) :: Phoenix.HTML.Safe.t()
+  def icon_for_route(%Route{description: :rail_replacement_bus}) do
+    svg_icon_with_circle(%SvgIconWithCircle{icon: :bus})
+  end
+
   def icon_for_route(%Route{type: 3} = route) do
     SiteWeb.ViewHelpers.bus_icon_pill(route)
   end

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -8,7 +8,7 @@ defmodule SiteWeb.TripPlanView do
   alias Routes.Route
   alias Phoenix.{HTML, HTML.Form}
   alias SiteWeb.PartialView.SvgIconWithCircle
-  alias Fares.{Format}
+  alias Fares.{Fare, Format}
 
   import Schedules.Repo, only: [end_of_rating: 0]
 
@@ -559,6 +559,7 @@ defmodule SiteWeb.TripPlanView do
       fares_html =
         "_itinerary_fares.html"
         |> render_to_string(
+          itinerary: i,
           one_way_total: Format.price(fare),
           round_trip_total: Format.price(fare * 2)
         )
@@ -620,4 +621,15 @@ defmodule SiteWeb.TripPlanView do
       highest_one_way_fare + acc
     end)
   end
+
+  @spec monthly_pass(Fare.t() | nil) :: String.t()
+  def monthly_pass(nil), do: Format.full_name(nil)
+
+  def monthly_pass(fare) do
+    "#{cr_prefix(fare)}#{Format.full_name(fare)}: #{Format.price(fare)}"
+  end
+
+  @spec cr_prefix(Fare.t()) :: String.t()
+  defp cr_prefix(%Fare{mode: :commuter_rail}), do: "Commuter Rail "
+  defp cr_prefix(_), do: ""
 end

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -2,10 +2,10 @@ defmodule SiteWeb.TripPlanView do
   @moduledoc "Contains the logic for the Trip Planner"
   use SiteWeb, :view
   require Routes.Route
-  alias Site.React
-  alias Site.TripPlan.{Query, ItineraryRow}
-  alias TripPlan.{Leg, Itinerary}
   alias Routes.Route
+  alias Site.React
+  alias Site.TripPlan.{ItineraryRow, Query}
+  alias TripPlan.{Itinerary, Leg, Transfer}
   alias Phoenix.{HTML, HTML.Form}
   alias SiteWeb.PartialView.SvgIconWithCircle
   alias Fares.{Fare, Format}
@@ -523,33 +523,15 @@ defmodule SiteWeb.TripPlanView do
     SiteWeb.ViewHelpers.mode_name(type)
   end
 
+  @doc "Add a transfer note to the trip plan view when the itinerary might have valid transit transfers (determined by Transfer.is_maybe_transfer?) that are not already accounted for in the fare calculation. Right now the only transfer accounted for in the calculated fare is subway-subway (via Transfer.is_subway_transfer?)"
   @spec transfer_note(Itinerary.t()) :: String.t() | nil
   def transfer_note(itinerary) do
-    itinerary
-    |> Itinerary.route_ids()
-    |> Enum.chunk_every(2, 1, :discard)
-    |> Enum.find(&satisfies_transfer_note_conditions?(&1))
+    itinerary.legs
+    |> Stream.filter(&Leg.transit?/1)
+    |> Stream.chunk_every(2, 1)
+    |> Enum.reject(&Transfer.is_subway_transfer?/1)
+    |> Enum.find(&Transfer.is_maybe_transfer?/1)
     |> transfer_note_text
-  end
-
-  @spec satisfies_transfer_note_conditions?([Route.id_t()]) :: boolean
-  defp satisfies_transfer_note_conditions?(route_id_pair) do
-    route_atom_pair =
-      route_id_pair
-      |> Enum.map(&Routes.Repo.get(&1))
-      |> Enum.map(&SiteWeb.ScheduleView.to_fare_atom(&1))
-
-    route_atom_pair in [
-      # remove [:subway, :subway], when we reduce base fare for this transfer
-      [:subway, :subway],
-      [:subway, :bus],
-      [:bus, :subway],
-      [:bus, :bus],
-      [:inner_express_bus, :subway],
-      [:outer_express_bus, :subway],
-      [:inner_express_bus, :bus],
-      [:outer_express_bus, :bus]
-    ]
   end
 
   defp transfer_note_text(nil), do: nil
@@ -645,21 +627,39 @@ defmodule SiteWeb.TripPlanView do
     )
   end
 
-  @spec get_highest_one_way_fare(TripPlan.Itinerary.t()) :: integer
-  def get_highest_one_way_fare(itinerary) do
-    itinerary.legs
-    |> Enum.filter(fn leg -> Leg.transit?(leg) end)
-    |> Enum.reduce(0, fn leg, acc ->
-      highest_one_way_fare =
-        leg
-        |> Kernel.get_in([
-          Access.key(:mode, %{}),
-          Access.key(:fares, %{}),
-          Access.key(:highest_one_way_fare, %{}),
-          Access.key(:cents, 0)
-        ])
+  @spec get_highest_one_way_fare_for_leg(Leg.t()) :: non_neg_integer
+  def get_highest_one_way_fare_for_leg(leg) do
+    leg
+    |> Kernel.get_in([
+      Access.key(:mode, %{}),
+      Access.key(:fares, %{}),
+      Access.key(:highest_one_way_fare, %{}),
+      Access.key(:cents, 0)
+    ])
+  end
 
-      highest_one_way_fare + acc
+  @spec get_highest_one_way_fare(TripPlan.Itinerary.t()) :: non_neg_integer
+  def get_highest_one_way_fare(itinerary) do
+    transit_legs =
+      itinerary.legs
+      |> Stream.filter(&Leg.transit?/1)
+
+    transit_legs
+    |> Stream.with_index()
+    |> Enum.reduce(0, fn {leg, leg_index}, acc ->
+      if leg_index < 1 do
+        acc + get_highest_one_way_fare_for_leg(leg)
+      else
+        # Look at this transit leg and previous transit leg
+        legs = transit_legs |> Enum.slice(leg_index - 1, 2)
+
+        # If this is part of a free transfer, don't add fare
+        if Transfer.is_subway_transfer?(legs) do
+          acc
+        else
+          acc + get_highest_one_way_fare_for_leg(leg)
+        end
+      end
     end)
   end
 

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -627,17 +627,6 @@ defmodule SiteWeb.TripPlanView do
     )
   end
 
-  @spec get_highest_one_way_fare_for_leg(Leg.t()) :: non_neg_integer
-  def get_highest_one_way_fare_for_leg(leg) do
-    leg
-    |> Kernel.get_in([
-      Access.key(:mode, %{}),
-      Access.key(:fares, %{}),
-      Access.key(:highest_one_way_fare, %{}),
-      Access.key(:cents, 0)
-    ])
-  end
-
   @spec get_highest_one_way_fare(TripPlan.Itinerary.t()) :: non_neg_integer
   def get_highest_one_way_fare(itinerary) do
     transit_legs =
@@ -662,6 +651,21 @@ defmodule SiteWeb.TripPlanView do
       end
     end)
   end
+
+  @spec get_highest_one_way_fare_for_leg(Leg.t()) :: non_neg_integer
+  defp get_highest_one_way_fare_for_leg(leg) do
+    leg
+    |> Kernel.get_in([
+      Access.key(:mode, %{}),
+      Access.key(:fares, %{}),
+      Access.key(:highest_one_way_fare, %{})
+    ])
+    |> fare_cents()
+  end
+
+  @spec fare_cents(Fare.t() | nil) :: non_neg_integer()
+  defp fare_cents(nil), do: 0
+  defp fare_cents(%Fare{cents: cents}), do: cents
 
   @spec monthly_pass(Fare.t() | nil) :: String.t()
   def monthly_pass(nil), do: Format.full_name(nil)

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -365,7 +365,7 @@ defmodule SiteWeb.TripPlanView do
   def format_minutes_duration(duration) do
     case duration do
       duration when duration >= 60 ->
-        "#{div(duration, 60)} h #{rem(duration, 60)} min"
+        "#{div(duration, 60)} hr #{rem(duration, 60)} min"
 
       _ ->
         "#{duration} min"

--- a/apps/site/lib/trip_info.ex
+++ b/apps/site/lib/trip_info.ex
@@ -1,7 +1,7 @@
 defmodule TripInfo do
   require Routes.Route
   alias Routes.Route
-  alias Fares.HighestLowestFare
+  alias Fares.OneWay
 
   @moduledoc """
   Wraps the important information about a trip.
@@ -113,7 +113,7 @@ defmodule TripInfo do
     trip = PredictedSchedule.trip(time)
     duration = duration(times, origin_id)
     stop_count = Enum.count(times)
-    base_fare = HighestLowestFare.lowest_fare(route, trip, origin_id, destination_id)
+    base_fare = OneWay.recommended_fare(route, trip, origin_id, destination_id)
 
     %TripInfo{
       route: route,

--- a/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
+++ b/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
@@ -1,8 +1,9 @@
 defmodule SiteWeb.TripPlanControllerTest do
   use SiteWeb.ConnCase
+  alias Fares.Fare
   alias Site.TripPlan.Query
   alias SiteWeb.TripPlanController
-  alias TripPlan.{Api.MockPlanner}
+  alias TripPlan.{Api.MockPlanner, Itinerary, PersonalDetail, TransitDetail}
   import Phoenix.HTML, only: [html_escape: 1, safe_to_string: 1]
   doctest SiteWeb.TripPlanController
 
@@ -288,9 +289,9 @@ defmodule SiteWeb.TripPlanControllerTest do
 
       assert Enum.all?(conn.assigns.itineraries, fn itinerary ->
                Enum.all?(itinerary.legs, fn leg ->
-                 match?(%TripPlan.PersonalDetail{}, leg.mode) ||
+                 match?(%PersonalDetail{}, leg.mode) ||
                    match?(
-                     %TripPlan.TransitDetail{
+                     %TransitDetail{
                        fares: %{
                          highest_one_way_fare: %Fares.Fare{},
                          lowest_one_way_fare: %Fares.Fare{}
@@ -299,6 +300,15 @@ defmodule SiteWeb.TripPlanControllerTest do
                      leg.mode
                    )
                end)
+             end)
+    end
+
+    test "adds monthly pass data to each itinerary", %{conn: conn} do
+      conn = get(conn, trip_plan_path(conn, :index, @good_params))
+
+      assert Enum.all?(conn.assigns.itineraries, fn itinerary ->
+               %Itinerary{passes: %{base_month_pass: %Fare{}, recommended_month_pass: %Fare{}}} =
+                 itinerary
              end)
     end
 

--- a/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
+++ b/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
@@ -294,7 +294,8 @@ defmodule SiteWeb.TripPlanControllerTest do
                      %TransitDetail{
                        fares: %{
                          highest_one_way_fare: %Fares.Fare{},
-                         lowest_one_way_fare: %Fares.Fare{}
+                         lowest_one_way_fare: %Fares.Fare{},
+                         reduced_one_way_fare: %Fares.Fare{}
                        }
                      },
                      leg.mode

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -905,24 +905,25 @@ defmodule SiteWeb.ScheduleViewTest do
     end
   end
 
-  describe "to_fare_atom/1" do
+  describe "to_fare_summary_atom/1" do
     test "silver line returns subway" do
-      assert to_fare_atom(%Route{type: 3, id: "741"}) == :subway
+      assert to_fare_summary_atom(%Route{type: 3, id: "741"}) == :subway
     end
 
     test "inner express bus returns :inner_express_bus" do
-      assert to_fare_atom(%Route{type: 3, id: "170"}) == :inner_express_bus
+      assert to_fare_summary_atom(%Route{type: 3, id: "170"}) == :inner_express_bus
     end
 
     test "outer express bus returns :inner_express_bus" do
-      assert to_fare_atom(%Route{type: 3, id: "352"}) == :outer_express_bus
+      assert to_fare_summary_atom(%Route{type: 3, id: "352"}) == :outer_express_bus
     end
 
     test "other types of routes return specific atoms" do
-      assert to_fare_atom(%Route{type: 0, id: "Green-B"}) == :subway
-      assert to_fare_atom(%Route{type: 1, id: "Red"}) == :subway
-      assert to_fare_atom(%Route{type: 2, id: "CR-Fitchbury"}) == :commuter_rail
-      assert to_fare_atom(%Route{type: 3, id: "1"}) == :bus
+      assert to_fare_summary_atom(%Route{type: 0, id: "Green-B"}) == :subway
+      assert to_fare_summary_atom(%Route{type: 1, id: "Red"}) == :subway
+      assert to_fare_summary_atom(%Route{type: 2, id: "CR-Fitchburg"}) == :commuter_rail
+      assert to_fare_summary_atom("commuter_rail") == :commuter_rail
+      assert to_fare_summary_atom(%Route{type: 3, id: "1"}) == :bus
     end
   end
 

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -968,7 +968,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         reduced: nil
       }
 
-      assert monthly_pass(fare) == "Commuter Rail Zone 7 Monthly Pass: $360.00"
+      assert monthly_pass(fare) == "Commuter Rail Zone 7: $360.00"
     end
   end
 end

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -820,6 +820,76 @@ closest arrival to 12:00 AM, Thursday, January 1st."
       assert get_highest_one_way_fare(itinerary) == 290
     end
 
+    test "returns 0 when there is no highest one-way fare" do
+      itinerary = %TripPlan.Itinerary{
+        start: nil,
+        stop: nil,
+        legs: [
+          %TripPlan.Leg{
+            description: "WALK",
+            from: %TripPlan.NamedPosition{
+              latitude: 42.365486,
+              longitude: -71.103802,
+              name: "Central",
+              stop_id: nil
+            },
+            long_name: nil,
+            mode: %TripPlan.PersonalDetail{
+              distance: 24.274,
+              steps: [
+                %TripPlan.PersonalDetail.Step{
+                  absolute_direction: :southeast,
+                  distance: 24.274,
+                  relative_direction: :depart,
+                  street_name: "Massachusetts Avenue"
+                }
+              ]
+            },
+            name: "",
+            polyline: "eoqaGzm~pLTe@BE@A",
+            to: %TripPlan.NamedPosition{
+              latitude: 42.365304,
+              longitude: -71.103621,
+              name: "Central",
+              stop_id: "70069"
+            },
+            type: nil,
+            url: nil
+          },
+          %TripPlan.Leg{
+            description: "SUBWAY",
+            from: %TripPlan.NamedPosition{
+              latitude: 42.365304,
+              longitude: -71.103621,
+              name: "Central",
+              stop_id: "70069"
+            },
+            long_name: "Red Line",
+            mode: %TripPlan.TransitDetail{
+              fares: %{
+                highest_one_way_fare: nil,
+                lowest_one_way_fare: nil
+              },
+              intermediate_stop_ids: ["70071", "70073"],
+              route_id: "Red",
+              trip_id: "43870769C0"
+            },
+            name: "Red Line",
+            to: %TripPlan.NamedPosition{
+              latitude: 42.356395,
+              longitude: -71.062424,
+              name: "Park Street",
+              stop_id: "70075"
+            },
+            type: "1",
+            url: "http://www.mbta.com"
+          }
+        ]
+      }
+
+      assert get_highest_one_way_fare(itinerary) == 0
+    end
+
     test "shows a transfer note", %{conn: conn} do
       fares_with_transfer =
         Map.put(@fares_assigns, :itinerary, %{

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -417,6 +417,16 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         assert safe_to_string(icon) =~ expected_icon_class
       end
     end
+
+    test "rail replacement buses" do
+      route = %Routes.Route{
+        description: :rail_replacement_bus,
+        type: 3
+      }
+
+      icon = icon_for_route(route)
+      assert safe_to_string(icon) =~ "bus"
+    end
   end
 
   describe "transfer_route_name/1" do

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -604,7 +604,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
 
   describe "format_minutes_duration/1" do
     test "for at least an hour" do
-      assert format_minutes_duration(66) === "1 h 6 min"
+      assert format_minutes_duration(66) === "1 hr 6 min"
     end
 
     test "for less than an hour" do

--- a/apps/trip_plan/lib/trip_plan/itinerary.ex
+++ b/apps/trip_plan/lib/trip_plan/itinerary.ex
@@ -6,10 +6,14 @@ defmodule TripPlan.Itinerary do
   travel. Itineraries are separate even if they use the same modes but happen
   at different times of day.
   """
+
+  alias Fares.Fare
+
   @enforce_keys [:start, :stop]
   defstruct [
     :start,
     :stop,
+    :passes,
     legs: [],
     accessible?: false
   ]
@@ -18,8 +22,15 @@ defmodule TripPlan.Itinerary do
           start: DateTime.t(),
           stop: DateTime.t(),
           legs: [TripPlan.Leg.t()],
-          accessible?: boolean
+          accessible?: boolean,
+          passes: passes()
         }
+
+  @type passes :: %{
+          base_month_pass: Fare.t(),
+          recommended_month_pass: Fare.t()
+        }
+
   alias TripPlan.NamedPosition
 
   @spec destination(t) :: NamedPosition.t()

--- a/apps/trip_plan/lib/trip_plan/named_position.ex
+++ b/apps/trip_plan/lib/trip_plan/named_position.ex
@@ -1,4 +1,6 @@
 defmodule TripPlan.NamedPosition do
+  @moduledoc "Defines a position for a trip plan as a stop and/or lat/lon"
+
   defstruct name: "",
             stop_id: nil,
             latitude: nil,

--- a/apps/trip_plan/lib/trip_plan/transfer.ex
+++ b/apps/trip_plan/lib/trip_plan/transfer.ex
@@ -1,0 +1,81 @@
+defmodule TripPlan.Transfer do
+  @moduledoc """
+    Tools for handling logic around transfers between transit legs and modes.
+    The MBTA allows transfers between services depending on the fare media used
+    and the amount paid.
+
+    This logic may be superseded by the upcoming fares work.
+  """
+  alias TripPlan.{Leg, NamedPosition, TransitDetail}
+
+  # Paying a single-ride fare for the first may get you a transfer to the second
+  # (can't be certain, as it depends on media used)!
+  @single_ride_transfers %{
+    :bus => [:subway, :bus],
+    :subway => [:subway, :bus],
+    :inner_express_bus => [:subway, :bus],
+    :outer_express_bus => [:subway, :bus]
+  }
+
+  @doc "Searches a list of legs for evidence of an in-station subway transfer."
+  @spec is_subway_transfer?([Leg.t()]) :: boolean
+  def is_subway_transfer?([
+        %Leg{to: %NamedPosition{stop_id: to_stop}, mode: %TransitDetail{route_id: route_to}},
+        %Leg{
+          from: %NamedPosition{stop_id: from_stop},
+          mode: %TransitDetail{route_id: route_from}
+        }
+        | _
+      ]) do
+    same_station?(from_stop, to_stop) and is_subway?(route_to) and is_subway?(route_from)
+  end
+
+  def is_subway_transfer?([_ | legs]), do: is_subway_transfer?(legs)
+
+  def is_subway_transfer?(_), do: false
+
+  @doc "Takes a pair of legs and returns true if there might be a transfer between the two, based on the list in @single_ride_transfers. Exception: no transfers from bus route to same bus route."
+  @spec is_maybe_transfer?([Leg.t()]) :: boolean
+  def is_maybe_transfer?([
+        %Leg{mode: %TransitDetail{route_id: from_route}},
+        %Leg{mode: %TransitDetail{route_id: to_route}}
+      ]) do
+    if from_route === to_route and
+         Enum.all?([from_route, to_route], &is_bus?/1) do
+      false
+    else
+      Map.get(@single_ride_transfers, Fares.to_fare_atom(from_route), [])
+      |> Enum.member?(Fares.to_fare_atom(to_route))
+    end
+  end
+
+  def is_maybe_transfer?(_), do: false
+
+  defp same_station?(from_stop, to_stop) do
+    to_parent_stop = Stops.Repo.get_parent(to_stop)
+    from_parent_stop = Stops.Repo.get_parent(from_stop)
+
+    cond do
+      is_nil(to_parent_stop) or is_nil(from_parent_stop) ->
+        false
+
+      to_parent_stop == from_parent_stop ->
+        true
+
+      true ->
+        # Check whether this is DTX <-> Park St via. the Winter St. Concourse
+        uses_concourse?(to_parent_stop, from_parent_stop)
+    end
+  end
+
+  defp is_bus?(route), do: Fares.to_fare_atom(route) == :bus
+  defp is_subway?(route), do: Fares.to_fare_atom(route) == :subway
+
+  defp uses_concourse?(%Stops.Stop{id: "place-pktrm"}, %Stops.Stop{id: "place-dwnxg"}),
+    do: true
+
+  defp uses_concourse?(%Stops.Stop{id: "place-dwnxg"}, %Stops.Stop{id: "place-pktrm"}),
+    do: true
+
+  defp uses_concourse?(_, _), do: false
+end

--- a/apps/trip_plan/lib/trip_plan/transit_detail.ex
+++ b/apps/trip_plan/lib/trip_plan/transit_detail.ex
@@ -16,6 +16,7 @@ defmodule TripPlan.TransitDetail do
 
   @type fares :: %{
           highest_one_way_fare: Fare.t(),
-          lowest_one_way_fare: Fare.t()
+          lowest_one_way_fare: Fare.t(),
+          reduced_one_way_fare: Fare.t()
         }
 end

--- a/apps/trip_plan/lib/trip_plan/transit_detail.ex
+++ b/apps/trip_plan/lib/trip_plan/transit_detail.ex
@@ -15,8 +15,8 @@ defmodule TripPlan.TransitDetail do
         }
 
   @type fares :: %{
-          highest_one_way_fare: Fare.t(),
-          lowest_one_way_fare: Fare.t(),
-          reduced_one_way_fare: Fare.t()
+          highest_one_way_fare: Fare.t() | nil,
+          lowest_one_way_fare: Fare.t() | nil,
+          reduced_one_way_fare: Fare.t() | nil
         }
 end

--- a/apps/trip_plan/test/transfer_test.exs
+++ b/apps/trip_plan/test/transfer_test.exs
@@ -158,5 +158,27 @@ defmodule TransferTest do
       assert is_subway_transfer?(legs_with_transfer)
       refute is_subway_transfer?(legs_without_transfer)
     end
+
+    test "handles transfers within the Winter St. Concourse" do
+      leg_to_park = %Leg{
+        mode: %TransitDetail{
+          route_id: "Green-C"
+        },
+        to: %NamedPosition{
+          stop_id: "71199"
+        }
+      }
+
+      leg_from_dtx = %Leg{
+        mode: %TransitDetail{
+          route_id: "Orange"
+        },
+        from: %NamedPosition{
+          stop_id: "70020"
+        }
+      }
+
+      assert is_subway_transfer?([leg_to_park, leg_from_dtx])
+    end
   end
 end

--- a/apps/trip_plan/test/transfer_test.exs
+++ b/apps/trip_plan/test/transfer_test.exs
@@ -1,0 +1,162 @@
+defmodule TransferTest do
+  @moduledoc false
+  use ExUnit.Case
+
+  import TripPlan.Transfer
+  alias TripPlan.{Leg, NamedPosition, PersonalDetail, TransitDetail}
+
+  describe "is_maybe_transfer?/1 correctly identifies the potential presence of a transfer [assumes single ride media]" do
+    leg_for_route = fn id -> %Leg{mode: %TransitDetail{route_id: id}} end
+    @bus_leg leg_for_route.("77")
+    @other_bus_leg leg_for_route.("28")
+    @subway_leg leg_for_route.("Red")
+    @other_subway_leg leg_for_route.("Orange")
+    @cr_leg leg_for_route.("CR-Lowell")
+    @ferry_leg leg_for_route.("Boat-F4")
+    @innerxp_leg leg_for_route.("326")
+    @other_innerxp_leg leg_for_route.("351")
+    @outerxp_leg leg_for_route.("505")
+    @other_outerxp_leg leg_for_route.("352")
+    @sl_rapid_leg leg_for_route.("741")
+    @sl_bus_leg leg_for_route.("751")
+
+    test "if from or to is nil" do
+      refute [nil, nil] |> is_maybe_transfer?
+      refute [@subway_leg, nil] |> is_maybe_transfer?
+      refute [nil, @bus_leg] |> is_maybe_transfer?
+    end
+
+    test "subway -> subway" do
+      assert [@subway_leg, @other_subway_leg] |> is_maybe_transfer?
+    end
+
+    test "subway -> local bus" do
+      assert [@subway_leg, @bus_leg] |> is_maybe_transfer?
+    end
+
+    test "local bus -> subway" do
+      assert [@bus_leg, @subway_leg] |> is_maybe_transfer?
+    end
+
+    test "local bus -> local bus" do
+      assert [@bus_leg, @other_bus_leg] |> is_maybe_transfer?
+    end
+
+    test "inner express bus -> subway" do
+      assert [@innerxp_leg, @subway_leg] |> is_maybe_transfer?
+    end
+
+    test "outer express bus -> subway" do
+      assert [@outerxp_leg, @subway_leg] |> is_maybe_transfer?
+    end
+
+    test "inner express bus -> local bus" do
+      assert [@innerxp_leg, @bus_leg] |> is_maybe_transfer?
+    end
+
+    test "outer express bus -> local bus" do
+      assert [@outerxp_leg, @bus_leg] |> is_maybe_transfer?
+    end
+
+    test "SL4 -> local bus" do
+      assert [@sl_bus_leg, @bus_leg] |> is_maybe_transfer?
+    end
+
+    test "SL1 -> local bus" do
+      assert [@sl_rapid_leg, @bus_leg] |> is_maybe_transfer?
+    end
+
+    test "local bus -> the same local bus" do
+      refute [@bus_leg, @bus_leg] |> is_maybe_transfer?
+    end
+
+    test "inner express bus -> inner express bus" do
+      refute [@innerxp_leg, @other_innerxp_leg] |> is_maybe_transfer?
+    end
+
+    test "outer express bus -> outer express bus" do
+      refute [@outerxp_leg, @other_outerxp_leg] |> is_maybe_transfer?
+    end
+
+    test "commuter rail -> any other mode" do
+      refute [@cr_leg, @cr_leg] |> is_maybe_transfer?
+      refute [@cr_leg, @subway_leg] |> is_maybe_transfer?
+      refute [@cr_leg, @bus_leg] |> is_maybe_transfer?
+      refute [@cr_leg, @innerxp_leg] |> is_maybe_transfer?
+      refute [@cr_leg, @outerxp_leg] |> is_maybe_transfer?
+      refute [@cr_leg, @sl_bus_leg] |> is_maybe_transfer?
+      refute [@cr_leg, @sl_rapid_leg] |> is_maybe_transfer?
+    end
+
+    test "ferry -> any other mode" do
+      refute [@ferry_leg, @ferry_leg] |> is_maybe_transfer?
+      refute [@ferry_leg, @subway_leg] |> is_maybe_transfer?
+      refute [@ferry_leg, @bus_leg] |> is_maybe_transfer?
+      refute [@ferry_leg, @innerxp_leg] |> is_maybe_transfer?
+      refute [@ferry_leg, @outerxp_leg] |> is_maybe_transfer?
+      refute [@ferry_leg, @sl_bus_leg] |> is_maybe_transfer?
+      refute [@ferry_leg, @sl_rapid_leg] |> is_maybe_transfer?
+    end
+  end
+
+  describe "is_subway_transfer?/1" do
+    test "picks a transit-transit sequence" do
+      legs_with_transfer = [
+        %Leg{
+          mode: %PersonalDetail{
+            steps: [
+              %PersonalDetail.Step{
+                street_name: "Path"
+              }
+            ]
+          }
+        },
+        %Leg{
+          mode: %TransitDetail{
+            route_id: "Green-C"
+          },
+          to: %NamedPosition{
+            stop_id: "70202"
+          }
+        },
+        %Leg{
+          mode: %TransitDetail{
+            route_id: "Blue"
+          },
+          from: %NamedPosition{
+            stop_id: "70040"
+          }
+        }
+      ]
+
+      legs_without_transfer = [
+        %Leg{
+          mode: %TransitDetail{
+            route_id: "Green-C"
+          },
+          to: %NamedPosition{
+            stop_id: "70202"
+          }
+        },
+        %Leg{
+          mode: %PersonalDetail{
+            steps: [
+              %PersonalDetail.Step{
+                street_name: "Path"
+              }
+            ]
+          },
+          from: %NamedPosition{
+            stop_id: "70202"
+          },
+          to: %NamedPosition{
+            stop_id: "70040"
+          }
+        }
+      ]
+
+      assert is_subway_transfer?(legs_with_transfer)
+      refute is_subway_transfer?(legs_without_transfer)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes

Slightly redesigned trip planner output! This is the first chunk of work on our fare calculator. This is our chance to check this group of changes are good to go to deploy!

<img width="812" alt="image" src="https://user-images.githubusercontent.com/2136286/84215628-d3972080-aa94-11ea-8878-6fa932e0c5e9.png">

Covering a few tickets:

* [Base Fares | One-way/base fare trips and total price](https://app.asana.com/0/385363666817452/1162903717356809/f)
* [Base Fares | Add transfers note (not subway)](https://app.asana.com/0/385363666817452/1169236529454061/f)
* [Base Fares | Add transfers logic (subway)](https://app.asana.com/0/385363666817452/1169236529454063/f)
* [Base Fares | Recommend Monthly Passes](https://app.asana.com/0/385363666817452/1162903717356811/f)
* [Fare Calculator | Polish | "Monthly Pass" header](https://app.asana.com/0/555089885850811/1179944684136545)
* [Fare Calculator | Polish | Remove "Monthly Pass" from Commuter Rail and Inner and Outer Express bus pass names](https://app.asana.com/0/555089885850811/1179944684136548)

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [ ] Are interactive elements accessible to screen readers?
* [ ] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [ ] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
