### PR TITLE
Fix text overflow on itinerary summary

### DIFF
--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -20,21 +20,33 @@
     }
   }
 
+  /* stylelint-disable property-no-vendor-prefix */
   &-header {
     background-color: $brand-primary-lightest-contrast;
     border: 1px solid $brand-primary;
     border-bottom: 0;
-    display: flex;
-    font-size: $base-spacing;
-    justify-content: space-between;
+    display: -ms-grid;
+    display: grid;
+    -ms-grid-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr;
     line-height: 1.5;
     margin-top: 0;
     padding: $base-spacing;
+
+    .m-trip-plan-results__itinerary-header-content {
+      -ms-grid-column: 1;
+      grid-column: 1;
+    }
+    .m-trip-plan-results__itinerary-fares {
+      -ms-grid-column: 2;
+      grid-column: 2;
+    }
 
     @include media-breakpoint-down(sm) {
       display: block;
     }
   }
+  /* stylelint-enable property-no-vendor-prefix */
 
   &-accessible {
     @include icon-size-inline(1em);
@@ -91,7 +103,6 @@
   }
 
   &-fares {
-    min-width: 40%;
     padding-left: $base-spacing;
     padding-top: 0;
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fare Calculator | Polish | Overflow on blue summary](https://app.asana.com/0/385363666817452/1179862274019473/f)

Changed it from using flexbox to using CSS grid. It even works in IE! Bonus: the two sides should stay the same width now too.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
