### PR TITLE
Update time duration formatting in trip planner output

### DIFF
--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -67,6 +67,10 @@
     margin-right: $base-spacing / 2;
   }
 
+  &-length-duration {
+    white-space: nowrap;
+  }
+
   &-length-distance {
     margin-left: $space-12;
     white-space: nowrap;

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_tab.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_tab.html.eex
@@ -8,7 +8,7 @@
   <span class="m-trip-plan-results__itinerary-length-time">
     <%= Timex.format!(@itinerary.start, "{h12}:{m} {AM}") %> - <%= Timex.format!(@itinerary.stop, "{h12}:{m} {AM}") %>
   </span>
-  <span>
+  <span class="m-trip-plan-results__itinerary-length-duration">
     <%= Timex.diff(@itinerary.stop, @itinerary.start, :minutes) |> format_minutes_duration %>
   </span>
 </div>

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -365,7 +365,7 @@ defmodule SiteWeb.TripPlanView do
   def format_minutes_duration(duration) do
     case duration do
       duration when duration >= 60 ->
-        "#{div(duration, 60)} h #{rem(duration, 60)} min"
+        "#{div(duration, 60)} hr #{rem(duration, 60)} min"
 
       _ ->
         "#{duration} min"

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -604,7 +604,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
 
   describe "format_minutes_duration/1" do
     test "for at least an hour" do
-      assert format_minutes_duration(66) === "1 h 6 min"
+      assert format_minutes_duration(66) === "1 hr 6 min"
     end
 
     test "for less than an hour" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🎫 Fare Calculator | Polish | Update Hrs/Mins](https://app.asana.com/0/385363666817452/1179323146835849/f)

Updates the abbreviation of hour and adds styling to force it to wrap rather than break the text.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
