### PR TITLE
Remove "Monthly Pass" from CR & express bus pass names

### DIFF
--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -112,6 +112,15 @@ defmodule Fares.Format do
     [name(fare), " ", duration(fare)]
   end
 
+  @spec concise_full_name(Fare.t()) :: String.t() | iolist()
+  def concise_full_name(%Fare{mode: :commuter_rail} = fare), do: name(fare)
+
+  def concise_full_name(%Fare{mode: :bus, name: name} = fare)
+      when name in [:inner_express_bus, :outer_express_bus],
+      do: name(fare)
+
+  def concise_full_name(fare), do: full_name(fare)
+
   @spec summarize([Fare.t()], mode_type | [mode_type], String.t() | nil) :: [Summary.t()]
   def summarize(fares, mode, url \\ nil)
 

--- a/apps/fares/test/format_test.exs
+++ b/apps/fares/test/format_test.exs
@@ -104,6 +104,38 @@ defmodule Fares.FormatTest do
     end
   end
 
+  describe "concise_full_name/1" do
+    test "returns the full name excluding 'Monthly Pass' for commuter rail and express buses" do
+      cr_fare = %Fare{
+        mode: :commuter_rail,
+        media: [:commuter_ticket],
+        duration: :month,
+        name: {:zone, "7"}
+      }
+
+      inner_express_fare = %Fare{
+        name: :inner_express_bus,
+        mode: :bus,
+        duration: :month
+      }
+
+      outer_express_fare = %Fare{
+        name: :outer_express_bus,
+        mode: :bus,
+        duration: :month
+      }
+
+      assert concise_full_name(cr_fare) == "Zone 7"
+      assert concise_full_name(inner_express_fare) == "Inner Express Bus"
+      assert concise_full_name(outer_express_fare) == "Outer Express Bus"
+    end
+
+    test "returns the full_name for other fares" do
+      assert concise_full_name(%Fare{mode: :subway, duration: :month}) == "Monthly LinkPass"
+      assert full_name(%Fare{duration: :day}) == "1-Day Pass"
+    end
+  end
+
   test "duration/1" do
     assert duration(%Fare{duration: :single_trip}) == "One-Way"
     assert duration(%Fare{duration: :round_trip}) == "Round Trip"

--- a/apps/fares/test/format_test.exs
+++ b/apps/fares/test/format_test.exs
@@ -132,7 +132,7 @@ defmodule Fares.FormatTest do
 
     test "returns the full_name for other fares" do
       assert concise_full_name(%Fare{mode: :subway, duration: :month}) == "Monthly LinkPass"
-      assert full_name(%Fare{duration: :day}) == "1-Day Pass"
+      assert concise_full_name(%Fare{duration: :day}) == "1-Day Pass"
     end
   end
 

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -675,7 +675,7 @@ defmodule SiteWeb.TripPlanView do
   def monthly_pass(nil), do: Format.full_name(nil)
 
   def monthly_pass(fare) do
-    "#{cr_prefix(fare)}#{Format.full_name(fare)}: #{Format.price(fare)}"
+    "#{cr_prefix(fare)}#{Format.concise_full_name(fare)}: #{Format.price(fare)}"
   end
 
   @spec cr_prefix(Fare.t()) :: String.t()

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -968,7 +968,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         reduced: nil
       }
 
-      assert monthly_pass(fare) == "Commuter Rail Zone 7 Monthly Pass: $360.00"
+      assert monthly_pass(fare) == "Commuter Rail Zone 7: $360.00"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fare Calculator | Polish | Remove "Monthly Pass" from Commuter Rail and Inner and Outer Express bus pass names](https://app.asana.com/0/555089885850811/1179944684136548)

Remove "Monthly Pass" from CR & express bus pass names

![Screen Shot 2020-06-11 at 14 14 22](https://user-images.githubusercontent.com/42339/84424577-4bc52980-abee-11ea-8b36-628f1b30fbb7.png)

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
