### PR TITLE
Trip Plan Language | Transfer

### DIFF
--- a/apps/site/lib/site/trip_plan/itinerary_row_list.ex
+++ b/apps/site/lib/site/trip_plan/itinerary_row_list.ex
@@ -49,9 +49,9 @@ defmodule Site.TripPlan.ItineraryRowList do
         ]
   defp get_rows(itinerary, deps, opts, alerts) do
     rows =
-      for leg <- itinerary do
+      for {leg, index} <- Enum.with_index(itinerary.legs) do
         leg
-        |> ItineraryRow.from_leg(deps)
+        |> ItineraryRow.from_leg(deps, Enum.at(itinerary.legs, index + 1))
         |> ItineraryRow.fetch_alerts(alerts)
       end
 

--- a/apps/site/test/site/trip_plan/itinerary_row_test.exs
+++ b/apps/site/test/site/trip_plan/itinerary_row_test.exs
@@ -5,7 +5,7 @@ defmodule TripPlan.ItineraryRowTest do
   alias Site.TripPlan.ItineraryRow
   alias Routes.Route
   alias Alerts.{Alert, InformedEntity}
-  alias TripPlan.NamedPosition
+  alias TripPlan.{Api.MockPlanner, NamedPosition}
 
   describe "route_id/1" do
     test "returns the route id when a route is present" do
@@ -307,6 +307,16 @@ defmodule TripPlan.ItineraryRowTest do
 
       assert {^name, nil} =
                name_from_position(%NamedPosition{stop_id: stop_id, name: name}, mapper)
+    end
+  end
+
+  describe "from_leg/2" do
+    @deps %ItineraryRow.Dependencies{stop_mapper: &Stops.Repo.get_parent/1}
+    @leg MockPlanner.personal_leg(MockPlanner.random_stop(), MockPlanner.random_stop(), nil, nil)
+
+    test "returns an itinerary row from a Leg" do
+      row = from_leg(@leg, @deps)
+      assert %ItineraryRow{} = row
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trip Plan Language | Transfer](https://app.asana.com/0/385363666817452/1179317340719423/f)

Changes "Depart onto Transfer" to either "Transfer" or "Depart" depending on whether the subsequent leg is transit or not, respectively.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
