### PR TITLE
Display shuttle fares properly

### DIFF
--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -94,7 +94,8 @@ defmodule Fares.Format do
   def name({:zone, zone}), do: "Zone #{zone}"
   def name({:interzone, zone}), do: "Interzone #{zone}"
   def name(:foxboro), do: "Foxboro Special Event"
-  def name(:free_fare), do: "Free Fare for SL1 Trips from Airport Stops"
+  # A free fare might be an SL1 trip from airport stops or shuttle bus service
+  def name(:free_fare), do: "Free Fare"
   def name(:ada_ride), do: "ADA Ride"
   def name(:premium_ride), do: "Premium Ride"
   def name(:invalid), do: "Invalid Fare"

--- a/apps/fares/test/format_test.exs
+++ b/apps/fares/test/format_test.exs
@@ -73,6 +73,10 @@ defmodule Fares.FormatTest do
       assert name(%Fare{name: :ferry_cross_harbor}) == "Cross Harbor Ferry"
       assert name(%Fare{name: :commuter_ferry}) == "Hingham/Hull Ferry"
     end
+
+    test "gives a descriptive name for free fares" do
+      assert name(%Fare{name: :free_fare}), do: "Free Fare"
+    end
   end
 
   describe "full_name/1" do

--- a/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
@@ -20,11 +20,17 @@
       <span class="m-trip-plan-farecalc__label">Recommended: </span>
       <% recommended = fare_values|>SiteWeb.TripPlanView.get_fare_by_type(:lowest_one_way_fare) %>
       <% media = recommended |> SiteWeb.TripPlanView.filter_media() %>
-      <%= recommended |> fare_cents()|>Format.price() %> <%= SiteWeb.TripPlanView.format_media(media) %>
+      <%=
+        cents = recommended |> fare_cents()
+        if cents == 0, do: "None", else: "#{Format.price(cents)} #{format_media(media)}"
+      %>
     </div>
     <div role="cell" class="m-trip-plan-farecalc__table-cell">
       <span class="m-trip-plan-farecalc__label">Reduced: </span>
-      <%= fare_values|>SiteWeb.TripPlanView.get_fare_by_type(:reduced_one_way_fare)|> fare_cents()|>Format.price() %>
+      <%=
+        cents = fare_values|> SiteWeb.TripPlanView.get_fare_by_type(:reduced_one_way_fare) |> fare_cents()
+        if cents == 0, do: "None", else: Format.price(cents)
+      %>
     </div>
 
   <% end %>

--- a/apps/site/lib/site_web/templates/trip_plan/_monthly_pass_row.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_monthly_pass_row.html.eex
@@ -4,12 +4,15 @@
 
 <div class="m-trip-plan-farecalc__table-cell">
   <span class="m-trip-plan-farecalc__label">Base: </span>
-  <%= Format.price(@pass) %>
+  <%=
+    price = Format.price(@pass)
+    if price != "", do: price, else: "None"
+  %>
 </div>
 
 <div class="m-trip-plan-farecalc__table-cell">
   <span class="m-trip-plan-farecalc__label">Reduced: </span>
-  <%= if @reduced, do: Format.price(@reduced), else: "n/a" %>
+  <%= if @reduced, do: Format.price(@reduced), else: "None" %>
 </div>
 
 <div class="m-trip-plan-farecalc__table-cell">

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -684,7 +684,7 @@ defmodule SiteWeb.TripPlanView do
   defp fare_cents(%Fare{cents: cents}), do: cents
 
   @spec monthly_pass(Fare.t() | nil) :: String.t()
-  def monthly_pass(nil), do: Format.full_name(nil)
+  def monthly_pass(nil), do: "#{Format.full_name(nil)}: None"
 
   def monthly_pass(fare) do
     "#{cr_prefix(fare)}#{Format.concise_full_name(fare)}: #{Format.price(fare)}"
@@ -699,8 +699,7 @@ defmodule SiteWeb.TripPlanView do
     itinerary.legs
     |> Enum.filter(fn leg -> Leg.transit?(leg) end)
     |> Enum.filter(fn leg ->
-      get_fare_by_type(leg, :highest_one_way_fare) != nil &&
-        get_fare_by_type(leg, :reduced_one_way_fare) != nil
+      get_fare_by_type(leg, :highest_one_way_fare) != nil
     end)
     |> Enum.reduce(%{}, fn leg, acc ->
       highest_fare =
@@ -722,11 +721,16 @@ defmodule SiteWeb.TripPlanView do
       if Map.has_key?(acc, mode_key) do
         acc
       else
+        name =
+          if leg.name && leg.name =~ "Shuttle",
+            do: "Shuttle",
+            else: Format.name(highest_fare.name)
+
         Map.put(acc, mode_key, %{
           mode: %{
             mode: mode,
             mode_name: mode_name(mode),
-            name: Format.name(highest_fare.name),
+            name: name,
             fares: %{
               highest_one_way_fare: highest_fare,
               lowest_one_way_fare:

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -1020,6 +1020,116 @@ closest arrival to 12:00 AM, Thursday, January 1st."
       assert get_calculated_fares(itinerary) == calculated_fares
     end
 
+    test "includes a shuttle fare" do
+      shuttle_fares = %{
+        highest_one_way_fare: %Fare{
+          additional_valid_modes: [],
+          cents: 0,
+          duration: :single_trip,
+          media: [],
+          mode: :bus,
+          name: :free_fare,
+          price_label: nil,
+          reduced: nil
+        },
+        lowest_one_way_fare: %Fare{
+          additional_valid_modes: [],
+          cents: 0,
+          duration: :single_trip,
+          media: [],
+          mode: :bus,
+          name: :free_fare,
+          price_label: nil,
+          reduced: nil
+        },
+        reduced_one_way_fare: nil
+      }
+
+      itinerary = %Itinerary{
+        legs: [
+          %Leg{
+            description: "BUS",
+            from: %NamedPosition{
+              latitude: 42.370864,
+              longitude: -71.077534,
+              name: "Lechmere",
+              stop_id: "9070092"
+            },
+            long_name: "Green Line Shuttle",
+            mode: %TransitDetail{
+              fares: shuttle_fares,
+              intermediate_stop_ids: ["9070093"],
+              route_id: "Shuttle-LechmereNorthStation",
+              trip_id: "43831675C0-LechmereNorthStation1"
+            },
+            name: "Green Line Shuttle",
+            to: %NamedPosition{
+              latitude: 42.36573,
+              longitude: -71.063989,
+              name: "North Station",
+              stop_id: "9070090"
+            },
+            type: "1"
+          },
+          %Leg{
+            description: "TRAM",
+            from: %NamedPosition{
+              latitude: 42.365577,
+              longitude: -71.06129,
+              name: "North Station",
+              stop_id: "70206"
+            },
+            long_name: "Green Line C",
+            mode: %TransitDetail{
+              fares: %{
+                highest_one_way_fare: @highest_one_way_fare,
+                lowest_one_way_fare: @lowest_one_way_fare,
+                reduced_one_way_fare: @reduced_one_way_fare
+              },
+              intermediate_stop_ids: ["70204", "70202", "70197", "70159", "70157"],
+              route_id: "Green-C",
+              trip_id: "43829886C0-LechmereNorthStation"
+            },
+            name: "C",
+            to: %NamedPosition{
+              latitude: 42.350126,
+              longitude: -71.077376,
+              name: "Copley",
+              stop_id: "70155"
+            },
+            type: "1"
+          }
+        ],
+        start: nil,
+        stop: nil
+      }
+
+      expected_fares = %{
+        bus: %{
+          mode: %{
+            fares: shuttle_fares,
+            mode_name: "Bus",
+            name: "Shuttle",
+            mode: :bus
+          }
+        },
+        subway: %{
+          mode: %{
+            fares: %{
+              highest_one_way_fare: @highest_one_way_fare,
+              lowest_one_way_fare: @lowest_one_way_fare,
+              reduced_one_way_fare: @reduced_one_way_fare
+            },
+            mode_name: "Subway",
+            name: "Subway",
+            mode: :subway
+          }
+        }
+      }
+
+      assert get_calculated_fares(itinerary) == expected_fares
+    end
+
     test "gets fare by type" do
       non_transit_leg = @itinerary.legs |> List.first()
       assert get_fare_by_type(non_transit_leg, :highest_one_way_fare) == nil

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -1430,5 +1430,9 @@ closest arrival to 12:00 AM, Thursday, January 1st."
 
       assert monthly_pass(fare) == "Commuter Rail Zone 7: $360.00"
     end
+
+    test "accepts nil" do
+      assert monthly_pass(nil) == "Shuttle: None"
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fare Calculator Accordion | Shuttle Fare (free)](https://app.asana.com/0/555089885850811/1178333054166489)

Display shuttle fares properly

In the summary, the Monthly Pass is called "Shuttle: None".

Include a row for the shuttle fare in the accordion section.

Use "None" in recommended and reduced columns.

Display fare name as "Shuttle".

![Screen Shot 2020-06-15 at 12 26 28](https://user-images.githubusercontent.com/42339/84690818-1e8bba80-af11-11ea-93bb-746922d20b9d.png)

![Screen Shot 2020-06-15 at 12 26 51](https://user-images.githubusercontent.com/42339/84690825-20557e00-af11-11ea-9bc2-c6d4e2dbfa1d.png)


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
