### PR TITLE
Turn off Algolia click tracking temporarily

### DIFF
--- a/apps/algolia/config/prod.exs
+++ b/apps/algolia/config/prod.exs
@@ -6,5 +6,5 @@ config :algolia, :keys,
   search: "${ALGOLIA_SEARCH_KEY}"
 
 config :algolia, :click_analytics_url, "https://insights.algolia.io"
-config :algolia, :track_clicks?, true
+config :algolia, :track_clicks?, false
 config :algolia, :track_analytics?, true


### PR DESCRIPTION

No ticket. Stop the [bleeding](https://sentry.io/organizations/mbtace/issues/1699282277/?project=194344&query=is%3Aunresolved+client+alert&statsPeriod=14d) while we figure out the solution to [🐞 Results on the search page can't be clicked](https://app.asana.com/0/555089885850811/1179421898312873).

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
