### PR TITLE
Make error response functions general helpers

### DIFF
--- a/apps/site/lib/site_web/controllers/helpers.ex
+++ b/apps/site/lib/site_web/controllers/helpers.ex
@@ -1,7 +1,7 @@
 defmodule SiteWeb.ControllerHelpers do
   @moduledoc false
 
-  import Plug.Conn, only: [put_status: 2, halt: 1]
+  import Plug.Conn, only: [halt: 1, put_resp_content_type: 2, put_status: 2]
   import Phoenix.Controller, only: [render: 3, put_view: 2]
 
   alias Alerts.{Alert, InformedEntity, Match, Repo}
@@ -36,6 +36,22 @@ defmodule SiteWeb.ControllerHelpers do
     |> put_view(SiteWeb.ErrorView)
     |> render("404.html", [])
     |> halt()
+  end
+
+  def return_internal_error(conn),
+    do: return_error(conn, :internal_server_error, "Internal error")
+
+  def return_invalid_arguments_error(conn),
+    do: return_error(conn, :bad_request, "Invalid arguments")
+
+  def return_zero_results_error(conn),
+    do: return_error(conn, :internal_server_error, "Zero results")
+
+  def return_error(conn, response_code, message) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> put_status(response_code)
+    |> Controller.json(%{error: message})
   end
 
   @spec filter_routes([{atom, [Route.t()]}], [atom]) :: [{atom, [Route.t()]}]

--- a/apps/site/lib/site_web/controllers/places_controller.ex
+++ b/apps/site/lib/site_web/controllers/places_controller.ex
@@ -5,6 +5,7 @@ defmodule SiteWeb.PlacesController do
   use SiteWeb, :controller
   alias GoogleMaps.{Geocode, Place, Place.AutocompleteQuery}
   alias Plug.Conn
+  alias SiteWeb.ControllerHelpers
 
   @spec autocomplete(Conn.t(), map) :: Conn.t()
   def autocomplete(conn, %{"input" => input, "hit_limit" => hit_limit_str, "token" => token}) do
@@ -20,10 +21,10 @@ defmodule SiteWeb.PlacesController do
       json(conn, %{predictions: Poison.encode!(predictions)})
     else
       {:error, :internal_error} ->
-        return_internal_error(conn)
+        ControllerHelpers.return_internal_error(conn)
 
       _ ->
-        return_invalid_arguments_error(conn)
+        ControllerHelpers.return_invalid_arguments_error(conn)
     end
   end
 
@@ -37,10 +38,10 @@ defmodule SiteWeb.PlacesController do
         json(conn, %{result: results |> List.first() |> Poison.encode!()})
 
       {:error, :internal_error} ->
-        return_internal_error(conn)
+        ControllerHelpers.return_internal_error(conn)
 
       {:error, :zero_results} ->
-        return_zero_results_error(conn)
+        ControllerHelpers.return_zero_results_error(conn)
     end
   end
 
@@ -53,13 +54,13 @@ defmodule SiteWeb.PlacesController do
       json(conn, %{results: Poison.encode!(results)})
     else
       :invalid_lat_lng ->
-        return_invalid_arguments_error(conn)
+        ControllerHelpers.return_invalid_arguments_error(conn)
 
       {:error, :internal_error} ->
-        return_internal_error(conn)
+        ControllerHelpers.return_internal_error(conn)
 
       {:error, :zero_results} ->
-        return_zero_results_error(conn)
+        ControllerHelpers.return_zero_results_error(conn)
     end
   end
 
@@ -71,20 +72,5 @@ defmodule SiteWeb.PlacesController do
       _ ->
         :invalid_lat_lng
     end
-  end
-
-  defp return_internal_error(conn),
-    do: return_error(conn, :internal_server_error, "Internal error")
-
-  defp return_invalid_arguments_error(conn),
-    do: return_error(conn, :bad_request, "Invalid arguments")
-
-  defp return_zero_results_error(conn),
-    do: return_error(conn, :internal_server_error, "Zero results")
-
-  defp return_error(conn, response_code, message) do
-    conn
-    |> Conn.put_status(response_code)
-    |> json(%{error: message})
   end
 end

--- a/apps/site/lib/site_web/controllers/schedule/finder_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/finder_api.ex
@@ -11,6 +11,7 @@ defmodule SiteWeb.ScheduleController.FinderApi do
   alias Routes.Route
   alias Schedules.{Schedule, Trip}
   alias Site.TransitNearMe
+  alias SiteWeb.ControllerHelpers
   alias SiteWeb.ScheduleController.TripInfo, as: Trips
   alias SiteWeb.ScheduleController.VehicleLocations, as: Vehicles
 
@@ -139,10 +140,7 @@ defmodule SiteWeb.ScheduleController.FinderApi do
   end
 
   def trip(conn, _) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> put_status(:bad_request)
-    |> json(%{error: "Invalid arguments"})
+    ControllerHelpers.return_invalid_arguments_error(conn)
   end
 
   # Use internal API to generate list of relevant schedules and predictions

--- a/apps/site/test/site_web/controllers/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/helpers_test.exs
@@ -11,7 +11,18 @@ defmodule SiteWeb.ControllerHelpersTest do
       put_private: 3
     ]
 
-  describe "filter_modes/2" do
+  describe "render_404/1" do
+    test "renders the 404 bus" do
+      rendered =
+        build_conn()
+        |> render_404()
+        |> html_response(404)
+
+      assert rendered =~ "Your stop cannot be found."
+    end
+  end
+
+  describe "filter_routes/2" do
     test "filters the key routes of all modes that are passed" do
       routes = [
         {:subway,
@@ -291,17 +302,6 @@ defmodule SiteWeb.ControllerHelpersTest do
       assert [_wkday, _day, _month, _year, _time, _tz] = String.split(date, " ")
       # we don't pass content-length cuz it causes problems with gzip
       assert get_resp_header(response, "content-length") == []
-    end
-  end
-
-  describe "render_404/1" do
-    test "renders the 404 bus" do
-      rendered =
-        build_conn()
-        |> render_404()
-        |> html_response(404)
-
-      assert rendered =~ "Your stop cannot be found."
     end
   end
 

--- a/apps/site/test/site_web/controllers/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/helpers_test.exs
@@ -22,6 +22,50 @@ defmodule SiteWeb.ControllerHelpersTest do
     end
   end
 
+  describe "return_internal_error/1" do
+    test "renders an 'Internal error' 500 json response" do
+      response =
+        build_conn()
+        |> return_internal_error()
+        |> json_response(500)
+
+      assert response == %{"error" => "Internal error"}
+    end
+  end
+
+  describe "return_invalid_arguments_error/1" do
+    test "renders a 400 json response" do
+      response =
+        build_conn()
+        |> return_invalid_arguments_error()
+        |> json_response(400)
+
+      assert response == %{"error" => "Invalid arguments"}
+    end
+  end
+
+  describe "return_zero_results_error/1" do
+    test "renders a 'Zero results' 500 json response" do
+      response =
+        build_conn()
+        |> return_zero_results_error()
+        |> json_response(500)
+
+      assert response == %{"error" => "Zero results"}
+    end
+  end
+
+  describe "return_error/3" do
+    test "renders a generic error code and message" do
+      response =
+        build_conn()
+        |> return_error(418, "I'm a teapot")
+        |> json_response(418)
+
+      assert response == %{"error" => "I'm a teapot"}
+    end
+  end
+
   describe "filter_routes/2" do
     test "filters the key routes of all modes that are passed" do
       routes = [


### PR DESCRIPTION
No ticket, follow-up to https://github.com/mbta/dotcom/pull/524

Make error response functions general helpers

Use in both PlacesController and FinderApi.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
