### PR TITLE
Avoid redirect for trips

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/trip_info.ex
+++ b/apps/site/lib/site_web/controllers/schedule/trip_info.ex
@@ -7,9 +7,7 @@ defmodule SiteWeb.ScheduleController.TripInfo do
   """
   @behaviour Plug
   alias Plug.Conn
-  import Plug.Conn, only: [assign: 3, halt: 1]
-  import Phoenix.Controller, only: [redirect: 2]
-  import UrlHelpers, only: [update_url: 2]
+  import Plug.Conn, only: [assign: 3]
 
   require Routes.Route
   alias Routes.Route
@@ -84,23 +82,11 @@ defmodule SiteWeb.ScheduleController.TripInfo do
   defp handle_trip(conn, selected_trip_id, opts) do
     case build_info(selected_trip_id, conn, opts) do
       {:error, _} ->
-        possibly_remove_trip_query(conn)
+        assign(conn, :trip_info, nil)
 
       info ->
         assign(conn, :trip_info, info)
     end
-  end
-
-  defp possibly_remove_trip_query(%{query_params: %{"trip" => _}} = conn) do
-    url = update_url(conn, trip: nil)
-
-    conn
-    |> redirect(to: url)
-    |> halt
-  end
-
-  defp possibly_remove_trip_query(conn) do
-    assign(conn, :trip_info, nil)
   end
 
   defp build_info(trip_id, conn, opts) do

--- a/apps/site/test/site_web/controllers/schedule/trip_info_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/trip_info_test.exs
@@ -285,7 +285,7 @@ defmodule SiteWeb.ScheduleController.TripInfoTest do
     assert conn.assigns.trip_info == nil
   end
 
-  test "redirects if we can't generate a trip info", %{conn: conn} do
+  test "returns nil if we can't generate a trip info", %{conn: conn} do
     conn =
       conn_builder(
         conn,
@@ -296,11 +296,7 @@ defmodule SiteWeb.ScheduleController.TripInfoTest do
         param: "param"
       )
 
-    expected_path =
-      schedule_path(conn, :show, "1", destination: "fake", origin: "fake", param: "param")
-
-    assert conn.halted
-    assert redirected_to(conn) == expected_path
+    assert conn.assigns.trip_info == nil
   end
 
   test "does not redirect if we didn't have a trip already", %{conn: conn} do
@@ -615,7 +611,7 @@ defmodule SiteWeb.ScheduleController.TripInfoTest do
     assert conn.assigns.trip_info == nil
   end
 
-  test "removes the trip from the query string if the API returns an error", %{conn: conn} do
+  test "returns a nil trip if the API returns an error", %{conn: conn} do
     init = init(trip_fn: &trip_fn/2, vehicle_fn: &vehicle_fn/1)
 
     conn =
@@ -630,7 +626,7 @@ defmodule SiteWeb.ScheduleController.TripInfoTest do
       |> assign(:vehicle_locations, %{})
       |> call(init)
 
-    assert redirected_to(conn) == schedule_path(conn, :show, "Red")
+    assert conn.assigns.trip_info == nil
   end
 
   describe "show_trips?/4" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Elixir.Phoenix.ActionClauseError: no function clause matching in SiteWeb.ScheduleController.FinderApi.trip/2](https://app.asana.com/0/555089885850811/1180647194087413)

Scenario: obtain trip information for a trip e.g. for ferry `https://www.mbta.com/schedules/finder_api/trip?id=Boat-F1-1000-Long-Sunday&route=Boat-F1&date=2020-08-23&direction=0&stop=Boat-Hingham`

When there is no trip information, a redirection is made with a new URL containing parameter `origin` (e.g. `https://www.mbta.com/schedules/finder_api/trip?origin=Boat-Hingham`). The `trip` function doesn't expect such parameter so it is sending errors to Sentry. This is a possible solution to just return an empty trip instead.