### PR TITLE
Remove realtime endpoint version checking

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -119,9 +119,7 @@ const LineDiagram = ({
   }, []);
 
   const { data: maybeLiveData } = useSWR(
-    `/schedules/line_api/realtime?id=${
-      route.id
-    }&direction_id=${directionId}&v=2`,
+    `/schedules/line_api/realtime?id=${route.id}&direction_id=${directionId}`,
     url => fetch(url).then(response => response.json()),
     { refreshInterval: 15000 }
   );

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -52,24 +52,17 @@ defmodule SiteWeb.ScheduleController.LineApi do
   The line diagram polls this endpoint for its real-time data.
   """
   @spec realtime(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def realtime(conn, %{"id" => route_id, "direction_id" => direction_id} = query_params) do
-    # We added this since we made some alterations to the corresponding
-    # frontend code, and we only want to service requests from the latest
-    # version of said code
-    if query_params["v"] == "2" do
-      cache_key = {route_id, direction_id, conn.assigns.date}
+  def realtime(conn, %{"id" => route_id, "direction_id" => direction_id}) do
+    cache_key = {route_id, direction_id, conn.assigns.date}
 
-      payload =
-        ConCache.get_or_store(:line_diagram_realtime_cache, cache_key, fn ->
-          do_realtime(route_id, direction_id, conn.assigns.date, conn.assigns.date_time)
-        end)
+    payload =
+      ConCache.get_or_store(:line_diagram_realtime_cache, cache_key, fn ->
+        do_realtime(route_id, direction_id, conn.assigns.date, conn.assigns.date_time)
+      end)
 
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(200, payload)
-    else
-      json(conn, %{})
-    end
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, payload)
   end
 
   defp do_realtime(route_id, direction_id, date, now) do


### PR DESCRIPTION
Reverts mbta/dotcom#416

No ticket. This check was added to ensure that there weren't problems with old versions of the client-side code calling the new version of the server-side code. I think we are well past the point of needing to worry about that.