### PR TITLE
Add fare calculator widget to fares CMS pages: the prequel

### DIFF
--- a/apps/cms/lib/partial/paragraph.ex
+++ b/apps/cms/lib/partial/paragraph.ex
@@ -37,6 +37,7 @@ defmodule CMS.Partial.Paragraph do
     PeopleGrid,
     PhotoGallery,
     TitleCardSet,
+    TripPlanWidget,
     Unknown
   }
 
@@ -57,6 +58,7 @@ defmodule CMS.Partial.Paragraph do
     PeopleGrid,
     PhotoGallery,
     TitleCardSet,
+    TripPlanWidget,
     Unknown
   ]
 
@@ -77,6 +79,7 @@ defmodule CMS.Partial.Paragraph do
           | PeopleGrid.t()
           | PhotoGallery.t()
           | TitleCardSet.t()
+          | TripPlanWidget.t()
           | Unknown.t()
 
   @type name ::
@@ -96,6 +99,7 @@ defmodule CMS.Partial.Paragraph do
           | PeopleGrid
           | PhotoGallery
           | TitleCardSet
+          | TripPlanWidget
           | Unknown
 
   @spec from_api(map, Keyword.t()) :: t
@@ -163,6 +167,10 @@ defmodule CMS.Partial.Paragraph do
 
   def from_api(%{"type" => [%{"target_id" => "title_card_set"}]} = para, _preview_opts) do
     TitleCardSet.from_api(para)
+  end
+
+  def from_api(%{"type" => [%{"target_id" => "trip_plan_widget"}]} = para, _preview_opts) do
+    TripPlanWidget.from_api(para)
   end
 
   @doc "This ¶ type has a single paragraph reference within. Get the nested paragraph."

--- a/apps/cms/lib/partial/paragraph/trip_plan_widget.ex
+++ b/apps/cms/lib/partial/paragraph/trip_plan_widget.ex
@@ -1,0 +1,32 @@
+defmodule CMS.Partial.Paragraph.TripPlanWidget do
+  @moduledoc """
+  Represents a widget on the page leading to the Trip Planner.
+  Is also used for the Fare Calculator widget.
+  """
+  import CMS.Helpers,
+    only: [
+      field_value: 2
+    ]
+
+  @type t :: %__MODULE__{
+          title: String.t() | nil,
+          text: String.t() | nil,
+          button_text: String.t() | nil,
+          right_rail: boolean
+        }
+
+  defstruct title: "Plan a trip",
+            text: nil,
+            button_text: "Get trip suggestions",
+            right_rail: true
+
+  @spec from_api(map, Keyword.t()) :: t
+  def from_api(data, _preview_opts \\ []) do
+    %__MODULE__{
+      title: field_value(data, "field_widget_title"),
+      text: field_value(data, "field_widget_text"),
+      button_text: field_value(data, "field_widget_submit_text"),
+      right_rail: field_value(data, "field_right_rail")
+    }
+  end
+end

--- a/apps/cms/test/paragraph_test.exs
+++ b/apps/cms/test/paragraph_test.exs
@@ -24,6 +24,7 @@ defmodule CMS.ParagraphTest do
     PeopleGrid,
     PhotoGallery,
     TitleCardSet,
+    TripPlanWidget,
     Unknown
   }
 
@@ -262,6 +263,14 @@ defmodule CMS.ParagraphTest do
 
       assert %CustomHTML{body: body} = from_api(api_data)
       assert safe_to_string(body) =~ "<p>library item</p>"
+    end
+
+    test "parses a trip plan widget" do
+      api_data = %{
+        "type" => [%{"target_id" => "trip_plan_widget"}]
+      }
+
+      assert %TripPlanWidget{} = from_api(api_data)
     end
 
     test "parses an unknown paragraph type" do

--- a/apps/site/assets/css/_trip-plan-widget.scss
+++ b/apps/site/assets/css/_trip-plan-widget.scss
@@ -4,6 +4,44 @@
   padding: 0 $base-spacing $base-spacing;
 }
 
+// adjustments for when rendered as a paragraph from the CMS
+.c-paragraph--trip-plan-widget .c-trip-plan-widget {
+  background-color: initial;
+  border: 0;
+  padding: initial;
+
+  h2:first-child {
+    margin-top: 0;
+  }
+
+  .c-trip-plan-widget__reverse-control {
+    display: none;
+  }
+
+  .c-trip-plan-widget__submit-container {
+    justify-content: flex-start;
+  }
+
+  @include media-breakpoint-down(sm) {
+    padding-bottom: 1rem;
+    padding-top: 1rem;
+
+    h2:first-child {
+      margin-top: .5rem;
+    }
+  }
+
+  @include media-breakpoint-only(md) {
+    .c-trip-plan-widget__inputs {
+      flex-direction: column;
+
+      .c-trip-plan-widget__from {
+        margin-right: 0;
+      }
+    }
+  }
+}
+
 .c-trip-plan-widget__inputs {
   display: flex;
   flex-direction: column;

--- a/apps/site/lib/site_web/templates/cms/paragraph/_trip_plan_widget.html.eex
+++ b/apps/site/lib/site_web/templates/cms/paragraph/_trip_plan_widget.html.eex
@@ -1,0 +1,2 @@
+<%= SiteWeb.PartialView.render("_trip_planner_widget.html",
+  Map.merge(assigns, Map.from_struct(assigns.content))) %>

--- a/apps/site/lib/site_web/templates/partial/_trip_planner_widget.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_trip_planner_widget.html.eex
@@ -13,9 +13,12 @@
 
 %>
 <div class="c-trip-plan-widget">
-  <h2>Plan a trip</h2>
+  <h2><%= if assigns[:title], do: @title, else: "Plan a trip" %></h2>
+  <%= if assigns[:text] do %>
+    <p><%= @text %></p>
+  <% end %>
   <%= form_for @conn, "/trip-planner"<>"#plan_result_focus", form_options, fn _ -> %>
   <%= SiteWeb.TripPlanView.render("_to_from_inputs.html", Map.merge(assigns, %{ from_error: from_error, to_error: to_error, from_position: from_position, to_position: to_position })) %>
-  <%= SiteWeb.TripPlanView.render("_submit_button.html") %>
-  <% end %> 
+  <%= SiteWeb.TripPlanView.render("_submit_button.html", assigns) %>
+  <% end %>
 </div>

--- a/apps/site/lib/site_web/templates/trip_plan/_submit_button.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_submit_button.html.eex
@@ -1,3 +1,5 @@
 <div class="c-trip-plan-widget__submit-container">
-  <button id="trip-plan__submit" type="submit" class="btn btn-primary hidden-print c-trip-plan-widget__submit">Get trip suggestions</button>
+  <button id="trip-plan__submit" type="submit" class="btn btn-primary hidden-print c-trip-plan-widget__submit">
+  <%= if assigns[:button_text], do: @button_text, else: "Get trip suggestions" %>
+  </button>
 </div>

--- a/apps/site/test/site_web/views/paragraph_view_test.exs
+++ b/apps/site/test/site_web/views/paragraph_view_test.exs
@@ -23,6 +23,7 @@ defmodule SiteWeb.CMS.ParagraphViewTest do
     PeopleGrid,
     PhotoGallery,
     TitleCardSet,
+    TripPlanWidget,
     Unknown
   }
 
@@ -696,6 +697,35 @@ defmodule SiteWeb.CMS.ParagraphViewTest do
       assert parent_1 == parent_2
       assert Floki.raw_html(body_1, encode: false) =~ "First section's content"
       assert Floki.raw_html(body_2, encode: false) =~ "Second section's content"
+    end
+
+    test "renders a CMS.Partial.Paragraph.TripPlanWidget with default content", %{conn: conn} do
+      rendered =
+        %TripPlanWidget{}
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "<h2>Plan a trip</h2>"
+      refute rendered =~ "<p>"
+
+      assert rendered =~
+               "Get trip suggestions"
+    end
+
+    test "renders a CMS.Partial.Paragraph.TripPlanWidget with custom content", %{conn: conn} do
+      rendered =
+        %TripPlanWidget{
+          right_rail: true,
+          title: "Secret Trip Plan Tool",
+          text: "Find the newest travel tips for your origin and destination.",
+          button_text: "Go fast"
+        }
+        |> render_paragraph(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "<h2>Secret Trip Plan Tool</h2>"
+      assert rendered =~ "<p>Find the newest travel tips for your origin and destination.</p>"
+      assert rendered =~ "Go fast"
     end
 
     test "renders a Paragraph.Unknown", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🎫 Trip Planner | Add fare calculator widget to fares CMS pages](https://app.asana.com/0/385363666817452/1162903717356815/f)

This change, in tandem with [this change to the CMS](https://github.com/mbta/cms/pull/339), will enable content authors to add the existing trip planner widget to their pages, with the ability to customize text if desired. The initial use case is for adding a Fare Calculator to the sidebar of certain fares pages (example below):

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/2136286/85142490-79295d00-b216-11ea-9677-891997a4dcd2.png">

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/2136286/85142582-9c540c80-b216-11ea-9b16-8c6e938d69f5.png">

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
