### PR TITLE
Cross out skipped/cancelled stops (all modes)

### DIFF
--- a/apps/site/assets/css/_helpers.scss
+++ b/apps/site/assets/css/_helpers.scss
@@ -17,7 +17,7 @@
 }
 
 .strikethrough {
-  color: $gray-lighter;
+  color: $gray;
   text-decoration: line-through;
 }
 

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -362,6 +362,11 @@
   th[scope='row'] {
     font-weight: normal;
   }
+
+  [class*='c-svg__icon'] path[fill] {
+    fill: currentColor;
+  }
+
   &__title {
     margin-right: $base-spacing;
   }

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -359,6 +359,9 @@
     border-top: $border;
   }
 
+  th[scope='row'] {
+    font-weight: normal;
+  }
   &__title {
     margin-right: $base-spacing;
   }

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -360,11 +360,16 @@
   }
 
   th[scope='row'] {
+    @include icon-size-inline($base-spacing * .85, .05em);
     font-weight: normal;
   }
 
   [class*='c-svg__icon'] path[fill] {
     fill: currentColor;
+  }
+
+  .c-svg__icon-alerts-triangle {
+    margin-right: $base-spacing * .35;
   }
 
   &__title {

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
@@ -56,15 +56,16 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
   </thead>
   <tbody>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-bbsta"
         >
           Back Bay
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -80,15 +81,16 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-rugg"
         >
           Ruggles
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -100,15 +102,16 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-2108"
         >
           Sharon
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -124,15 +127,16 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-2040"
         >
           Mansfield
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -144,15 +148,16 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-1969"
         >
           Attleboro
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -168,15 +173,16 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-1919"
         >
           South Attleboro
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -188,15 +194,16 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-1851"
         >
           Providence
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -285,15 +292,16 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
   </thead>
   <tbody>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-sstat"
         >
           South Station
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -310,15 +318,16 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-bbsta"
         >
           Back Bay
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -335,15 +344,16 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-rugg"
         >
           Ruggles
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -360,15 +370,16 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-2173"
         >
           Route 128
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -385,15 +396,16 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-2139"
         >
           Canton Junction
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -410,15 +422,16 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-2108"
         >
           Sharon
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -435,15 +448,16 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-2040"
         >
           Mansfield
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -460,15 +474,16 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-1969"
         >
           Attleboro
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -485,15 +500,16 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-1919"
         >
           South Attleboro
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -510,15 +526,16 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-NEC-1851"
         >
           Providence
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -594,15 +611,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
   </thead>
   <tbody>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-sstat"
         >
           South Station
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -614,15 +632,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-crtst"
         >
           Courthouse
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -634,15 +653,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-wtcst"
         >
           World Trade Center
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -654,15 +674,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-conrd"
         >
           Silver Line Way
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -674,15 +695,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/247"
         >
           Northern Ave @ Harbor St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -694,15 +716,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/30249"
         >
           Northern Ave @ Tide St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -714,15 +737,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/30250"
         >
           23 Drydock Ave
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -734,15 +758,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/30251"
         >
           27 Drydock Ave
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -754,15 +779,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/31259"
         >
           Drydock Ave @ Black Falcon Ave
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -774,15 +800,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/31258"
         >
           88 Black Falcon
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -794,15 +821,16 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/31255"
         >
           Drydock Ave @ Design Center Place
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -873,15 +901,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
   </thead>
   <tbody>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/place-forhl"
         >
           Forest Hills
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -893,15 +922,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/596"
         >
           3867 Washington St opp Tollgate Way
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -913,15 +943,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/597"
         >
           Washington St @ Lochdale Rd
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -933,15 +964,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/598"
         >
           Washington St @ Archdale Rd
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -953,15 +985,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/599"
         >
           Washington St @ Mosgrove Ave
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -973,15 +1006,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/600"
         >
           Washington St opp Granfield Ave
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -993,15 +1027,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/601"
         >
           Washington St @ South St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1013,15 +1048,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/602"
         >
           South St @ Taft Hill Terr
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1033,15 +1069,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/797"
         >
           Belgrade Ave @ Robert St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1053,15 +1090,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/798"
         >
           Belgrade Ave opp Pinehurst St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1073,15 +1111,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/799"
         >
           Belgrade Ave opp Penfield St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1093,15 +1132,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/800"
         >
           Belgrade Ave @ Walworth St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1113,15 +1153,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/801"
         >
           Belgrade Ave opp Aldrich St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1133,15 +1174,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/802"
         >
           277 Belgrade Ave opp Rexhame St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1153,15 +1195,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/803"
         >
           Belgrade Ave @ McCraw St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1173,15 +1216,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/804"
         >
           Belgrade Ave @ West Roxbury Pkwy
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1193,15 +1237,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/805"
         >
           Belgrade Ave @ Centre St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1213,15 +1258,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/806"
         >
           Centre St @ Willow St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1233,15 +1279,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/807"
         >
           Centre St @ Corey St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1253,15 +1300,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/808"
         >
           Centre St opp Bellevue st
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1273,15 +1321,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/810"
         >
           Opp 2000 Centre St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1293,15 +1342,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/821"
         >
           Centre St @ Lorette St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1313,15 +1363,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/811"
         >
           Centre St @ Spring St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1333,15 +1384,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/822"
         >
           Centre St @ Autumn St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1353,15 +1405,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/823"
         >
           Centre St @ Cass St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1373,15 +1426,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/824"
         >
           Centre St @ Bronx Rd
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1393,15 +1447,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/825"
         >
           Centre St opp Wedgemere Rd
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1413,15 +1468,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/826"
         >
           Centre St @ Glenhaven Rd
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1433,15 +1489,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/10768"
         >
           Centre St @ Grove St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1453,15 +1510,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/827"
         >
           Centre St @ Northdale Rd
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1473,15 +1531,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/828"
         >
           Centre St @ Fairlane Rd
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1493,15 +1552,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/829"
         >
           2519 Centre St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1513,15 +1573,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/830"
         >
           Stimson St @ Centre St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1533,15 +1594,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/831"
         >
           80 Stimson St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1553,15 +1615,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/832"
         >
           Stimson St @ Washington St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1573,15 +1636,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/618"
         >
           Washington St opp Meshaka St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1593,15 +1657,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/10618"
         >
           Washington St @ Sumner St
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1613,15 +1678,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/10835"
         >
           Dedham Mall @ South Side
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
@@ -1633,15 +1699,16 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       </td>
     </tr>
     <tr>
-      <td
+      <th
         className="schedule-table__cell"
+        scope="row"
       >
         <a
           href="/stops/10833"
         >
           Dedham Mall @ Stop & Shop
         </a>
-      </td>
+      </th>
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
@@ -92,7 +92,11 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:04 PM
+        <span
+          className=""
+        >
+          04:04 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -132,7 +136,11 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:30 PM
+        <span
+          className=""
+        >
+          04:30 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -172,7 +180,11 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:48 PM
+        <span
+          className=""
+        >
+          04:48 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -290,7 +302,11 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        02:30 PM
+        <span
+          className=""
+        >
+          02:30 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -311,7 +327,11 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        02:35 PM
+        <span
+          className=""
+        >
+          02:35 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -332,7 +352,11 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        02:38 PM
+        <span
+          className=""
+        >
+          02:38 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -353,7 +377,11 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        02:51 PM
+        <span
+          className=""
+        >
+          02:51 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -374,7 +402,11 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        02:57 PM
+        <span
+          className=""
+        >
+          02:57 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -395,7 +427,11 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        03:03 PM
+        <span
+          className=""
+        >
+          03:03 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -416,7 +452,11 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        03:11 PM
+        <span
+          className=""
+        >
+          03:11 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -437,7 +477,11 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        03:19 PM
+        <span
+          className=""
+        >
+          03:19 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -458,7 +502,11 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        03:29 PM
+        <span
+          className=""
+        >
+          03:29 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -479,7 +527,11 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        03:39 PM
+        <span
+          className=""
+        >
+          03:39 PM
+        </span>
       </td>
     </tr>
   </tbody>
@@ -554,7 +606,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:46 AM
+        <span
+          className=""
+        >
+          05:46 AM
+        </span>
       </td>
     </tr>
     <tr>
@@ -570,7 +626,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:48 AM
+        <span
+          className=""
+        >
+          05:48 AM
+        </span>
       </td>
     </tr>
     <tr>
@@ -586,7 +646,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:50 AM
+        <span
+          className=""
+        >
+          05:50 AM
+        </span>
       </td>
     </tr>
     <tr>
@@ -602,7 +666,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:53 AM
+        <span
+          className=""
+        >
+          05:53 AM
+        </span>
       </td>
     </tr>
     <tr>
@@ -618,7 +686,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:54 AM
+        <span
+          className=""
+        >
+          05:54 AM
+        </span>
       </td>
     </tr>
     <tr>
@@ -634,7 +706,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:55 AM
+        <span
+          className=""
+        >
+          05:55 AM
+        </span>
       </td>
     </tr>
     <tr>
@@ -650,7 +726,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:56 AM
+        <span
+          className=""
+        >
+          05:56 AM
+        </span>
       </td>
     </tr>
     <tr>
@@ -666,7 +746,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:56 AM
+        <span
+          className=""
+        >
+          05:56 AM
+        </span>
       </td>
     </tr>
     <tr>
@@ -682,7 +766,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:56 AM
+        <span
+          className=""
+        >
+          05:56 AM
+        </span>
       </td>
     </tr>
     <tr>
@@ -698,7 +786,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:57 AM
+        <span
+          className=""
+        >
+          05:57 AM
+        </span>
       </td>
     </tr>
     <tr>
@@ -714,7 +806,11 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        06:00 AM
+        <span
+          className=""
+        >
+          06:00 AM
+        </span>
       </td>
     </tr>
   </tbody>
@@ -789,7 +885,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:39 PM
+        <span
+          className=""
+        >
+          04:39 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -805,7 +905,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:42 PM
+        <span
+          className=""
+        >
+          04:42 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -821,7 +925,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:42 PM
+        <span
+          className=""
+        >
+          04:42 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -837,7 +945,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:43 PM
+        <span
+          className=""
+        >
+          04:43 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -853,7 +965,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:43 PM
+        <span
+          className=""
+        >
+          04:43 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -869,7 +985,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:44 PM
+        <span
+          className=""
+        >
+          04:44 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -885,7 +1005,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:45 PM
+        <span
+          className=""
+        >
+          04:45 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -901,7 +1025,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:46 PM
+        <span
+          className=""
+        >
+          04:46 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -917,7 +1045,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:47 PM
+        <span
+          className=""
+        >
+          04:47 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -933,7 +1065,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:47 PM
+        <span
+          className=""
+        >
+          04:47 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -949,7 +1085,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:47 PM
+        <span
+          className=""
+        >
+          04:47 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -965,7 +1105,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:48 PM
+        <span
+          className=""
+        >
+          04:48 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -981,7 +1125,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:48 PM
+        <span
+          className=""
+        >
+          04:48 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -997,7 +1145,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:49 PM
+        <span
+          className=""
+        >
+          04:49 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1013,7 +1165,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:49 PM
+        <span
+          className=""
+        >
+          04:49 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1029,7 +1185,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:50 PM
+        <span
+          className=""
+        >
+          04:50 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1045,7 +1205,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:51 PM
+        <span
+          className=""
+        >
+          04:51 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1061,7 +1225,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:53 PM
+        <span
+          className=""
+        >
+          04:53 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1077,7 +1245,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:54 PM
+        <span
+          className=""
+        >
+          04:54 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1093,7 +1265,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:55 PM
+        <span
+          className=""
+        >
+          04:55 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1109,7 +1285,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:56 PM
+        <span
+          className=""
+        >
+          04:56 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1125,7 +1305,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:58 PM
+        <span
+          className=""
+        >
+          04:58 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1141,7 +1325,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:58 PM
+        <span
+          className=""
+        >
+          04:58 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1157,7 +1345,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        04:59 PM
+        <span
+          className=""
+        >
+          04:59 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1173,7 +1365,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:00 PM
+        <span
+          className=""
+        >
+          05:00 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1189,7 +1385,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:00 PM
+        <span
+          className=""
+        >
+          05:00 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1205,7 +1405,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:00 PM
+        <span
+          className=""
+        >
+          05:00 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1221,7 +1425,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:01 PM
+        <span
+          className=""
+        >
+          05:01 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1237,7 +1445,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:01 PM
+        <span
+          className=""
+        >
+          05:01 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1253,7 +1465,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:01 PM
+        <span
+          className=""
+        >
+          05:01 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1269,7 +1485,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:02 PM
+        <span
+          className=""
+        >
+          05:02 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1285,7 +1505,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:02 PM
+        <span
+          className=""
+        >
+          05:02 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1301,7 +1525,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:02 PM
+        <span
+          className=""
+        >
+          05:02 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1317,7 +1545,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:03 PM
+        <span
+          className=""
+        >
+          05:03 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1333,7 +1565,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:03 PM
+        <span
+          className=""
+        >
+          05:03 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1349,7 +1585,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:05 PM
+        <span
+          className=""
+        >
+          05:05 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1365,7 +1605,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:05 PM
+        <span
+          className=""
+        >
+          05:05 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1381,7 +1625,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:09 PM
+        <span
+          className=""
+        >
+          05:09 PM
+        </span>
       </td>
     </tr>
     <tr>
@@ -1397,7 +1645,11 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        05:11 PM
+        <span
+          className=""
+        >
+          05:11 PM
+        </span>
       </td>
     </tr>
   </tbody>

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
@@ -61,6 +61,7 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-bbsta"
         >
           Back Bay
@@ -86,6 +87,7 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-rugg"
         >
           Ruggles
@@ -94,11 +96,7 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:04 PM
-        </span>
+        04:04 PM
       </td>
     </tr>
     <tr>
@@ -107,6 +105,7 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-2108"
         >
           Sharon
@@ -132,6 +131,7 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-2040"
         >
           Mansfield
@@ -140,11 +140,7 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:30 PM
-        </span>
+        04:30 PM
       </td>
     </tr>
     <tr>
@@ -153,6 +149,7 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-1969"
         >
           Attleboro
@@ -178,6 +175,7 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-1919"
         >
           South Attleboro
@@ -186,11 +184,7 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:48 PM
-        </span>
+        04:48 PM
       </td>
     </tr>
     <tr>
@@ -199,6 +193,7 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-1851"
         >
           Providence
@@ -297,6 +292,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-sstat"
         >
           South Station
@@ -310,11 +306,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          02:30 PM
-        </span>
+        02:30 PM
       </td>
     </tr>
     <tr>
@@ -323,6 +315,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-bbsta"
         >
           Back Bay
@@ -336,11 +329,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          02:35 PM
-        </span>
+        02:35 PM
       </td>
     </tr>
     <tr>
@@ -349,6 +338,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-rugg"
         >
           Ruggles
@@ -362,11 +352,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          02:38 PM
-        </span>
+        02:38 PM
       </td>
     </tr>
     <tr>
@@ -375,6 +361,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-2173"
         >
           Route 128
@@ -388,11 +375,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          02:51 PM
-        </span>
+        02:51 PM
       </td>
     </tr>
     <tr>
@@ -401,6 +384,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-2139"
         >
           Canton Junction
@@ -414,11 +398,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          02:57 PM
-        </span>
+        02:57 PM
       </td>
     </tr>
     <tr>
@@ -427,6 +407,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-2108"
         >
           Sharon
@@ -440,11 +421,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          03:03 PM
-        </span>
+        03:03 PM
       </td>
     </tr>
     <tr>
@@ -453,6 +430,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-2040"
         >
           Mansfield
@@ -466,11 +444,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          03:11 PM
-        </span>
+        03:11 PM
       </td>
     </tr>
     <tr>
@@ -479,6 +453,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-1969"
         >
           Attleboro
@@ -492,11 +467,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          03:19 PM
-        </span>
+        03:19 PM
       </td>
     </tr>
     <tr>
@@ -505,6 +476,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-1919"
         >
           South Attleboro
@@ -518,11 +490,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          03:29 PM
-        </span>
+        03:29 PM
       </td>
     </tr>
     <tr>
@@ -531,6 +499,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-NEC-1851"
         >
           Providence
@@ -544,11 +513,7 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          03:39 PM
-        </span>
+        03:39 PM
       </td>
     </tr>
   </tbody>
@@ -616,6 +581,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-sstat"
         >
           South Station
@@ -624,11 +590,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:46 AM
-        </span>
+        05:46 AM
       </td>
     </tr>
     <tr>
@@ -637,6 +599,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-crtst"
         >
           Courthouse
@@ -645,11 +608,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:48 AM
-        </span>
+        05:48 AM
       </td>
     </tr>
     <tr>
@@ -658,6 +617,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-wtcst"
         >
           World Trade Center
@@ -666,11 +626,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:50 AM
-        </span>
+        05:50 AM
       </td>
     </tr>
     <tr>
@@ -679,6 +635,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-conrd"
         >
           Silver Line Way
@@ -687,11 +644,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:53 AM
-        </span>
+        05:53 AM
       </td>
     </tr>
     <tr>
@@ -700,6 +653,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/247"
         >
           Northern Ave @ Harbor St
@@ -708,11 +662,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:54 AM
-        </span>
+        05:54 AM
       </td>
     </tr>
     <tr>
@@ -721,6 +671,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/30249"
         >
           Northern Ave @ Tide St
@@ -729,11 +680,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:55 AM
-        </span>
+        05:55 AM
       </td>
     </tr>
     <tr>
@@ -742,6 +689,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/30250"
         >
           23 Drydock Ave
@@ -750,11 +698,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:56 AM
-        </span>
+        05:56 AM
       </td>
     </tr>
     <tr>
@@ -763,6 +707,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/30251"
         >
           27 Drydock Ave
@@ -771,11 +716,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:56 AM
-        </span>
+        05:56 AM
       </td>
     </tr>
     <tr>
@@ -784,6 +725,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/31259"
         >
           Drydock Ave @ Black Falcon Ave
@@ -792,11 +734,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:56 AM
-        </span>
+        05:56 AM
       </td>
     </tr>
     <tr>
@@ -805,6 +743,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/31258"
         >
           88 Black Falcon
@@ -813,11 +752,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:57 AM
-        </span>
+        05:57 AM
       </td>
     </tr>
     <tr>
@@ -826,6 +761,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
         scope="row"
       >
         <a
+          className=""
           href="/stops/31255"
         >
           Drydock Ave @ Design Center Place
@@ -834,11 +770,7 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          06:00 AM
-        </span>
+        06:00 AM
       </td>
     </tr>
   </tbody>
@@ -906,6 +838,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/place-forhl"
         >
           Forest Hills
@@ -914,11 +847,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:39 PM
-        </span>
+        04:39 PM
       </td>
     </tr>
     <tr>
@@ -927,6 +856,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/596"
         >
           3867 Washington St opp Tollgate Way
@@ -935,11 +865,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:42 PM
-        </span>
+        04:42 PM
       </td>
     </tr>
     <tr>
@@ -948,6 +874,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/597"
         >
           Washington St @ Lochdale Rd
@@ -956,11 +883,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:42 PM
-        </span>
+        04:42 PM
       </td>
     </tr>
     <tr>
@@ -969,6 +892,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/598"
         >
           Washington St @ Archdale Rd
@@ -977,11 +901,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:43 PM
-        </span>
+        04:43 PM
       </td>
     </tr>
     <tr>
@@ -990,6 +910,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/599"
         >
           Washington St @ Mosgrove Ave
@@ -998,11 +919,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:43 PM
-        </span>
+        04:43 PM
       </td>
     </tr>
     <tr>
@@ -1011,6 +928,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/600"
         >
           Washington St opp Granfield Ave
@@ -1019,11 +937,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:44 PM
-        </span>
+        04:44 PM
       </td>
     </tr>
     <tr>
@@ -1032,6 +946,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/601"
         >
           Washington St @ South St
@@ -1040,11 +955,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:45 PM
-        </span>
+        04:45 PM
       </td>
     </tr>
     <tr>
@@ -1053,6 +964,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/602"
         >
           South St @ Taft Hill Terr
@@ -1061,11 +973,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:46 PM
-        </span>
+        04:46 PM
       </td>
     </tr>
     <tr>
@@ -1074,6 +982,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/797"
         >
           Belgrade Ave @ Robert St
@@ -1082,11 +991,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:47 PM
-        </span>
+        04:47 PM
       </td>
     </tr>
     <tr>
@@ -1095,6 +1000,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/798"
         >
           Belgrade Ave opp Pinehurst St
@@ -1103,11 +1009,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:47 PM
-        </span>
+        04:47 PM
       </td>
     </tr>
     <tr>
@@ -1116,6 +1018,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/799"
         >
           Belgrade Ave opp Penfield St
@@ -1124,11 +1027,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:47 PM
-        </span>
+        04:47 PM
       </td>
     </tr>
     <tr>
@@ -1137,6 +1036,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/800"
         >
           Belgrade Ave @ Walworth St
@@ -1145,11 +1045,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:48 PM
-        </span>
+        04:48 PM
       </td>
     </tr>
     <tr>
@@ -1158,6 +1054,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/801"
         >
           Belgrade Ave opp Aldrich St
@@ -1166,11 +1063,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:48 PM
-        </span>
+        04:48 PM
       </td>
     </tr>
     <tr>
@@ -1179,6 +1072,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/802"
         >
           277 Belgrade Ave opp Rexhame St
@@ -1187,11 +1081,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:49 PM
-        </span>
+        04:49 PM
       </td>
     </tr>
     <tr>
@@ -1200,6 +1090,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/803"
         >
           Belgrade Ave @ McCraw St
@@ -1208,11 +1099,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:49 PM
-        </span>
+        04:49 PM
       </td>
     </tr>
     <tr>
@@ -1221,6 +1108,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/804"
         >
           Belgrade Ave @ West Roxbury Pkwy
@@ -1229,11 +1117,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:50 PM
-        </span>
+        04:50 PM
       </td>
     </tr>
     <tr>
@@ -1242,6 +1126,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/805"
         >
           Belgrade Ave @ Centre St
@@ -1250,11 +1135,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:51 PM
-        </span>
+        04:51 PM
       </td>
     </tr>
     <tr>
@@ -1263,6 +1144,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/806"
         >
           Centre St @ Willow St
@@ -1271,11 +1153,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:53 PM
-        </span>
+        04:53 PM
       </td>
     </tr>
     <tr>
@@ -1284,6 +1162,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/807"
         >
           Centre St @ Corey St
@@ -1292,11 +1171,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:54 PM
-        </span>
+        04:54 PM
       </td>
     </tr>
     <tr>
@@ -1305,6 +1180,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/808"
         >
           Centre St opp Bellevue st
@@ -1313,11 +1189,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:55 PM
-        </span>
+        04:55 PM
       </td>
     </tr>
     <tr>
@@ -1326,6 +1198,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/810"
         >
           Opp 2000 Centre St
@@ -1334,11 +1207,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:56 PM
-        </span>
+        04:56 PM
       </td>
     </tr>
     <tr>
@@ -1347,6 +1216,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/821"
         >
           Centre St @ Lorette St
@@ -1355,11 +1225,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:58 PM
-        </span>
+        04:58 PM
       </td>
     </tr>
     <tr>
@@ -1368,6 +1234,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/811"
         >
           Centre St @ Spring St
@@ -1376,11 +1243,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:58 PM
-        </span>
+        04:58 PM
       </td>
     </tr>
     <tr>
@@ -1389,6 +1252,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/822"
         >
           Centre St @ Autumn St
@@ -1397,11 +1261,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          04:59 PM
-        </span>
+        04:59 PM
       </td>
     </tr>
     <tr>
@@ -1410,6 +1270,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/823"
         >
           Centre St @ Cass St
@@ -1418,11 +1279,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:00 PM
-        </span>
+        05:00 PM
       </td>
     </tr>
     <tr>
@@ -1431,6 +1288,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/824"
         >
           Centre St @ Bronx Rd
@@ -1439,11 +1297,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:00 PM
-        </span>
+        05:00 PM
       </td>
     </tr>
     <tr>
@@ -1452,6 +1306,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/825"
         >
           Centre St opp Wedgemere Rd
@@ -1460,11 +1315,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:00 PM
-        </span>
+        05:00 PM
       </td>
     </tr>
     <tr>
@@ -1473,6 +1324,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/826"
         >
           Centre St @ Glenhaven Rd
@@ -1481,11 +1333,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:01 PM
-        </span>
+        05:01 PM
       </td>
     </tr>
     <tr>
@@ -1494,6 +1342,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/10768"
         >
           Centre St @ Grove St
@@ -1502,11 +1351,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:01 PM
-        </span>
+        05:01 PM
       </td>
     </tr>
     <tr>
@@ -1515,6 +1360,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/827"
         >
           Centre St @ Northdale Rd
@@ -1523,11 +1369,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:01 PM
-        </span>
+        05:01 PM
       </td>
     </tr>
     <tr>
@@ -1536,6 +1378,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/828"
         >
           Centre St @ Fairlane Rd
@@ -1544,11 +1387,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:02 PM
-        </span>
+        05:02 PM
       </td>
     </tr>
     <tr>
@@ -1557,6 +1396,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/829"
         >
           2519 Centre St
@@ -1565,11 +1405,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:02 PM
-        </span>
+        05:02 PM
       </td>
     </tr>
     <tr>
@@ -1578,6 +1414,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/830"
         >
           Stimson St @ Centre St
@@ -1586,11 +1423,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:02 PM
-        </span>
+        05:02 PM
       </td>
     </tr>
     <tr>
@@ -1599,6 +1432,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/831"
         >
           80 Stimson St
@@ -1607,11 +1441,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:03 PM
-        </span>
+        05:03 PM
       </td>
     </tr>
     <tr>
@@ -1620,6 +1450,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/832"
         >
           Stimson St @ Washington St
@@ -1628,11 +1459,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:03 PM
-        </span>
+        05:03 PM
       </td>
     </tr>
     <tr>
@@ -1641,6 +1468,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/618"
         >
           Washington St opp Meshaka St
@@ -1649,11 +1477,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:05 PM
-        </span>
+        05:05 PM
       </td>
     </tr>
     <tr>
@@ -1662,6 +1486,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/10618"
         >
           Washington St @ Sumner St
@@ -1670,11 +1495,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:05 PM
-        </span>
+        05:05 PM
       </td>
     </tr>
     <tr>
@@ -1683,6 +1504,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/10835"
         >
           Dedham Mall @ South Side
@@ -1691,11 +1513,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:09 PM
-        </span>
+        05:09 PM
       </td>
     </tr>
     <tr>
@@ -1704,6 +1522,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
         scope="row"
       >
         <a
+          className=""
           href="/stops/10833"
         >
           Dedham Mall @ Stop & Shop
@@ -1712,11 +1531,7 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
       <td
         className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums"
       >
-        <span
-          className=""
-        >
-          05:11 PM
-        </span>
+        05:11 PM
       </td>
     </tr>
   </tbody>

--- a/apps/site/assets/ts/schedule/components/__trips.d.ts
+++ b/apps/site/assets/ts/schedule/components/__trips.d.ts
@@ -33,7 +33,16 @@ export interface TripInfo {
   route_type: number;
 }
 
+type ScheduleRelationship =
+  | "added"
+  | "unscheduled"
+  | "cancelled"
+  | "skipped"
+  | "no_data"
+  | null;
+
 export interface Prediction {
+  schedule_relationship: ScheduleRelationship;
   delay: number;
   status: string | null;
   track: string | null;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
@@ -10,7 +10,7 @@ interface Props {
   routeType: number;
 }
 
-const skippedOrCancelled = (prediction: Prediction | null) =>
+const skippedOrCancelled = (prediction: Prediction | null): boolean | null =>
   prediction
     ? prediction.schedule_relationship === "skipped" ||
       prediction.schedule_relationship === "cancelled"
@@ -62,7 +62,7 @@ const TripStop = ({
         >
           {skippedOrCancelled(departure.prediction) && (
             <>
-              {alertIcon("c-svg__icon-alerts-triangle")}&nbsp;
+              {alertIcon("c-svg__icon-alerts-triangle")}
               <span className="sr-only">This trip skips this stop at</span>
             </>
           )}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
@@ -62,11 +62,11 @@ const TripStop = ({
 
   return (
     <tr key={`${schedule.stop.id}`}>
-      <td className="schedule-table__cell">
+      <th className="schedule-table__cell" scope="row">
         <a href={`/stops/${schedule.stop.id}`}>
           {breakTextAtSlash(schedule.stop.name)}
         </a>
-      </td>
+      </th>
       {showFare && (
         <td className="schedule-table__cell schedule-table__cell--right-adjusted u-tabular-nums">
           {index === 0 ? "" : schedule.fare.price}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
@@ -41,6 +41,9 @@ const formattedDepartureTimes = (
 
   return (
     <span className={skippedOrCancelled ? "strikethrough" : ""}>
+      {skippedOrCancelled && (
+        <span className="sr-only">This trip skips {schedule.stop.name}.</span>
+      )}
       {routeType === 2 ? schedule.time : predictionOrScheduleTime}
     </span>
   );

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
@@ -14,24 +14,36 @@ const formattedDepartureTimes = (
   routeType: number
 ): ReactElement<HTMLElement> => {
   const { schedule, prediction, delay } = departure;
+  const skippedOrCancelled = prediction
+    ? prediction.schedule_relationship === "skipped" ||
+      prediction.schedule_relationship === "cancelled"
+    : null;
+  const predictionOrScheduleTime =
+    prediction && prediction.time ? prediction.time : schedule.time;
 
-  if (routeType === 2) {
-    if (delay && delay >= 300 && prediction && prediction.time) {
-      return (
-        <>
-          <span className="schedule-table__times--delayed schedule-table__times--delayed-future_stop">
-            {schedule.time}
-          </span>
-          <br className="hidden-sm-up" />
-          {prediction.time}
-        </>
-      );
-    }
-
-    return <>{schedule.time}</>;
+  if (
+    routeType === 2 &&
+    delay &&
+    delay >= 300 &&
+    prediction &&
+    prediction.time
+  ) {
+    return (
+      <>
+        <span className="schedule-table__times--delayed schedule-table__times--delayed-future_stop">
+          {schedule.time}
+        </span>
+        <br className="hidden-sm-up" />
+        {prediction.time}
+      </>
+    );
   }
 
-  return <>{prediction && prediction.time ? prediction.time : schedule.time}</>;
+  return (
+    <span className={skippedOrCancelled ? "strikethrough" : ""}>
+      {routeType === 2 ? schedule.time : predictionOrScheduleTime}
+    </span>
+  );
 };
 
 const TripStop = ({


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🚍Schedule Finder | Cross out skipped/cancelled stops (all modes)](https://app.asana.com/0/385363666817452/1173665781696615/f)

Uses the existing but neglected `schedule_relationship` field on the prediction to identify skipped or cancelled stops. Also adds a short message for screen reader users: `This trip skips {schedule.stop.name}.`

I'm having trouble testing it on other modes, but the example below is from the 201 bus:

<img width="627" alt="image" src="https://user-images.githubusercontent.com/2136286/85467056-b1170400-b578-11ea-8762-3817fa9b0b87.png">



---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
