### PR TITLE
Update vehicle parser occupancy status handling

### DIFF
--- a/apps/vehicles/lib/parser.ex
+++ b/apps/vehicles/lib/parser.ex
@@ -51,12 +51,8 @@ defmodule Vehicles.Parser do
   end
 
   @spec crowding(String.t()) :: Vehicle.crowding()
-  defp crowding("EMPTY"), do: :not_crowded
   defp crowding("MANY_SEATS_AVAILABLE"), do: :not_crowded
   defp crowding("FEW_SEATS_AVAILABLE"), do: :some_crowding
-  defp crowding("STANDING_ROOM_ONLY"), do: :some_crowding
-  defp crowding("CRUSHED_STANDING_ROOM_ONLY"), do: :some_crowding
   defp crowding("FULL"), do: :crowded
-  defp crowding("NOT_ACCEPTING_PASSENGERS"), do: :crowded
   defp crowding(_), do: nil
 end

--- a/apps/vehicles/test/parser_test.exs
+++ b/apps/vehicles/test/parser_test.exs
@@ -141,7 +141,7 @@ defmodule Vehicles.ParserTest do
     end
 
     test "can handle occupancy status" do
-      item = put_in(@item.attributes["occupancy_status"], "CRUSHED_STANDING_ROOM_ONLY")
+      item = put_in(@item.attributes["occupancy_status"], "FEW_SEATS_AVAILABLE")
 
       expected = %Vehicle{
         id: "y1799",


### PR DESCRIPTION
No ticket. Updating this to use the [current values for vehicle occupancy status](https://api-v3.mbta.com/docs/swagger/index.html).