### PR TITLE
Flesh out time_data_for_route_by_stop test a little

### DIFF
--- a/apps/site/test/site/transit_near_me_test.exs
+++ b/apps/site/test/site/transit_near_me_test.exs
@@ -237,7 +237,7 @@ defmodule Site.TransitNearMeTest do
     end
   end
 
-  describe "filter_predicted_schedules/3" do
+  describe "filter_predicted_schedules/4" do
     test "does not remove schedules without predictions for commuter rail, bus, or ferry" do
       now = DateTime.from_naive!(~N[2019-02-27T12:00:00], "Etc/UTC")
 


### PR DESCRIPTION
No ticket, preliminary work for realtime crowding data.

Flesh out time_data_for_route_by_stop test a little.

Fix the function arity in a test description.

There's room for a lot more improvement, but this is at least an initial test that passes in master while failing in my branch and it better describes the desired behavior. 

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
