### PR TITLE
Remove deprecated route description parsers

### DIFF
--- a/apps/cms/priv/cms/teasers_project.json
+++ b/apps/cms/priv/cms/teasers_project.json
@@ -523,7 +523,6 @@
             "branch": null,
             "custom": [
               "local_bus",
-              "limited_service",
               "misc"
             ]
           }
@@ -544,7 +543,6 @@
             "branch": null,
             "custom": [
               "local_bus",
-              "limited_service",
               "misc"
             ]
           }
@@ -565,7 +563,6 @@
             "branch": null,
             "custom": [
               "local_bus",
-              "limited_service",
               "misc"
             ]
           }

--- a/apps/cms/test/helpers_test.exs
+++ b/apps/cms/test/helpers_test.exs
@@ -507,7 +507,7 @@ defmodule CMS.HelpersTest do
       tags = [
         %{
           "data" => %{
-            "gtfs_id" => "limited_service",
+            "gtfs_id" => "supplemental_bus",
             "gtfs_group" => "custom",
             "gtfs_ancestry" => %{
               "mode" => nil,
@@ -517,7 +517,7 @@ defmodule CMS.HelpersTest do
         }
       ]
 
-      assert [%{id: "limited_service", mode: nil, group: "custom"}] = routes(tags)
+      assert [%{id: "supplemental_bus", mode: nil, group: "custom"}] = routes(tags)
     end
   end
 

--- a/apps/routes/lib/parser.ex
+++ b/apps/routes/lib/parser.ex
@@ -75,9 +75,6 @@ defmodule Routes.Parser do
   defp parse_gtfs_desc("Supplemental Bus"), do: :supplemental_bus
   defp parse_gtfs_desc("Commuter Bus"), do: :commuter_bus
   defp parse_gtfs_desc("Community Bus"), do: :community_bus
-  defp parse_gtfs_desc("Limited Service"), do: :limited_service
-  defp parse_gtfs_desc("Express Bus"), do: :express_bus
-  defp parse_gtfs_desc("Key Bus Route (Frequent Service)"), do: :key_bus_route
   defp parse_gtfs_desc(_), do: :unknown
 
   @spec parse_shape(Item.t()) :: [Shape.t()]

--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -40,8 +40,6 @@ defmodule Routes.Route do
           | :supplemental_bus
           | :commuter_bus
           | :community_bus
-          | :limited_service
-          | :express_bus
           | :unknown
   @type route_type :: gtfs_route_type | :the_ride
   @type type_int :: 0..4

--- a/apps/routes/test/parser_test.exs
+++ b/apps/routes/test/parser_test.exs
@@ -29,7 +29,7 @@ defmodule Routes.ParserTest do
           "type" => 3,
           "short_name" => "short",
           "long_name" => "long",
-          "description" => "Key Bus Route (Frequent Service)",
+          "description" => "Key Bus",
           "direction_names" => ["zero", "one"],
           "direction_destinations" => ["Destination 1", "Destination 2"]
         }

--- a/apps/site/lib/site_web/controllers/schedule/cms.ex
+++ b/apps/site/lib/site_web/controllers/schedule/cms.ex
@@ -96,8 +96,7 @@ defmodule SiteWeb.ScheduleController.CMS do
              :commuter_bus,
              :supplemental_bus,
              :rail_replacement_bus,
-             :community_bus,
-             :express_bus
+             :community_bus
            ] ->
         "bus"
 

--- a/apps/site/test/site_web/controllers/transit_near_me_controller_test.exs
+++ b/apps/site/test/site_web/controllers/transit_near_me_controller_test.exs
@@ -44,7 +44,7 @@ defmodule SiteWeb.TransitNearMeControllerTest do
   }
   @bus_10 %{id: "10", description: :local_bus, name: "10", type: 3, href: "/bus-10"}
   @bus_39 %{id: "39", description: :key_bus_route, name: "39", type: 3, href: "/bus-39"}
-  @bus_170 %{id: "170", description: :limited_service, name: "170", type: 3, href: "/bus-170"}
+  @bus_170 %{id: "170", description: :supplemental_bus, name: "170", type: 3, href: "/bus-170"}
 
   @back_bay %Stop{
     accessibility: ["accessible", "elevator", "tty_phone", "escalator_up"],
@@ -304,7 +304,7 @@ defmodule SiteWeb.TransitNearMeControllerTest do
                 },
                 %{
                   custom_route?: false,
-                  description: :limited_service,
+                  description: :supplemental_bus,
                   direction_destinations: :unknown,
                   direction_names: %{"0" => "Outbound", "1" => "Inbound"},
                   id: "170",

--- a/apps/site/test/site_web/views/partial/location_card_test.exs
+++ b/apps/site/test/site_web/views/partial/location_card_test.exs
@@ -64,7 +64,7 @@ defmodule SiteWeb.LocationCardTest do
       routes: [
         %{id: "10", description: :local_bus, name: "10", type: 3, href: "/10"},
         %{id: "39", description: :key_bus_route, name: "39", type: 3, href: "/39"},
-        %{id: "170", description: :limited_service, name: "170", type: 3, href: "/170"}
+        %{id: "170", description: :supplemental_bus, name: "170", type: 3, href: "/170"}
       ]
     }
   ]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔧 Remove deprecated route description parsers](https://app.asana.com/0/555089885850811/931777477470570)

Remove deprecated route description parsers

These were removed from GTFS in:
https://app.asana.com/0/727048923819421/829424034455337

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
