### PR TITLE
Skip a test failing because of schedule changes

### DIFF
--- a/apps/stops/test/repo_test.exs
+++ b/apps/stops/test/repo_test.exs
@@ -89,6 +89,8 @@ defmodule Stops.RepoTest do
       refute (response |> Enum.at(1)).id == "place-sull"
     end
 
+    @tag skip:
+           "Skipping this test temporarily. In Summer 2020 the Providence line isn't skipping stops on the weekend so this test is failing."
     test "can take additional fields" do
       today = Timex.today()
       weekday = today |> Timex.shift(days: 7) |> Timex.beginning_of_week(:fri)


### PR DESCRIPTION
No ticket, tests are failing in master.

Skip a test failing because of schedule changes.

The Providence line is not currently skipping stops on the weekend,
which is making this test fail.

If anyone knows a line that does skip stops on the weekend we can always restore this with that new route.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
