### PR TITLE
Move Lynn and River Works to zone 1A-1

### DIFF
--- a/apps/zones/priv/crzones.csv
+++ b/apps/zones/priv/crzones.csv
@@ -274,7 +274,7 @@ place-ER-0312,7
 place-NEC-2173,2
 place-NB-0064,1
 place-GB-0353,8
-place-ER-0099,2
+place-ER-0099,1
 place-DB-0095,2
 place-WR-0120,2
 place-NEC-1851,8
@@ -305,7 +305,7 @@ place-NHRML-0116,2
 place-WR-0067,1
 place-WR-0075,1
 place-NEC-2040,6
-place-ER-0115,2
+place-ER-0115,1
 place-NHRML-0254,6
 place-FR-0301,7
 place-FR-0167,4


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trip Planner Fares | Lynn/Riverworks Zone 1A](https://app.asana.com/0/555089885850811/1179825855722420)

Move Lynn and River Works to zone 1A-1

The official zone is `CR-zone-1A-1`, but based on the equivalent
situation at Quincy Center (place-qnctr) we apparently represent that
currently just as `1`.

This change updates the information on the station page. The zone data for the trip planner and associated fares comes from OTP so we'll pick up that change when it comes through.

Lynn:
![Screen Shot 2020-06-29 at 18 21 00](https://user-images.githubusercontent.com/42339/86146918-c7681700-bac6-11ea-9b7c-0cb88b468f9d.png)

River Works:
![Screen Shot 2020-06-29 at 18 21 06](https://user-images.githubusercontent.com/42339/86146945-cf27bb80-bac6-11ea-9d51-c8bbfb9ed038.png)

Compared with Quincy Center:
![Screen Shot 2020-06-29 at 18 21 14](https://user-images.githubusercontent.com/42339/86146969-d6e76000-bac6-11ea-9a20-f15df2da4f32.png)


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
