### PR TITLE
Revert "Move Lynn and River Works to zone 1A-1"

### DIFF
--- a/apps/zones/priv/crzones.csv
+++ b/apps/zones/priv/crzones.csv
@@ -274,7 +274,7 @@ place-ER-0312,7
 place-NEC-2173,2
 place-NB-0064,1
 place-GB-0353,8
-place-ER-0099,1
+place-ER-0099,2
 place-DB-0095,2
 place-WR-0120,2
 place-NEC-1851,8
@@ -305,7 +305,7 @@ place-NHRML-0116,2
 place-WR-0067,1
 place-WR-0075,1
 place-NEC-2040,6
-place-ER-0115,1
+place-ER-0115,2
 place-NHRML-0254,6
 place-FR-0301,7
 place-FR-0167,4


### PR DESCRIPTION
Reverts mbta/dotcom#551

Based on clarifications from Paul: https://github.com/mbta/dotcom/pull/551#issuecomment-651983191