### PR TITLE
Update tests to reflect changes in the Green Line C branch

### DIFF
--- a/apps/site/test/site_web/controllers/schedule/green_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/green_test.exs
@@ -91,6 +91,7 @@ defmodule SiteWeb.ScheduleController.GreenTest do
     assert conn.assigns.meta_description
   end
 
+  # "Skipping the check for Cleveland Circle in this test temporarily. In Summer 2020 the Green Line C branch is undergoing improvements"
   test "trip view :all_stops is a list of %Stop{} for all stops on all branches", %{conn: conn} do
     conn = get(conn, green_path(conn, :trip_view, %{schedule_direction: %{direction_id: 0}}))
 
@@ -98,7 +99,7 @@ defmodule SiteWeb.ScheduleController.GreenTest do
 
     all_stops = Enum.map(all_stops, & &1.id)
     assert "place-lake" in all_stops
-    assert "place-clmnl" in all_stops
+    # assert "place-clmnl" in all_stops
     assert "place-river" in all_stops
     assert "place-hsmnl" in all_stops
   end

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -205,7 +205,7 @@ defmodule SiteWeb.ScheduleControllerTest do
     end
 
     test "assigns schedules, frequency table, and origin for green line", %{conn: conn} do
-      conn = get(conn, trip_view_path(conn, :show, "Green-C", origin: "place-pktrm"))
+      conn = get(conn, trip_view_path(conn, :show, "Green-D", origin: "place-pktrm"))
       assert conn.assigns.schedules
       assert conn.assigns.journeys.journeys
       assert conn.assigns.frequency_table


### PR DESCRIPTION
No ticket.

Update in tests to reflect changes in the Green Line C branch:
https://www.mbta.com/news/2020-07-02/reminder-building-better-t-green-line-c-branch-track-improvements-and-intersection