### PR TITLE
Replace Wollaston main nav link with Building a Better T

### DIFF
--- a/apps/site/lib/site_web/templates/layout/_desktop_menu_more.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_desktop_menu_more.html.eex
@@ -75,6 +75,9 @@
     <div class="col-xs-12 p-a-0">
       <ul>
         <li>
+          <%= link "Building a Better T", to: cms_static_page_path(@conn, "/projects/building-better-t-2020"), class: "ga-nav-sublink" %>
+        </li>
+        <li>
           <%= link "Commuter Rail Positive Train Control", to: project_path(@conn, :show, "commuter-rail-positive-train-control-ptc"), class: "ga-nav-sublink" %>
         </li>
         <li>
@@ -82,9 +85,6 @@
         </li>
         <li>
           <%= link "Green Line Extension", to: "https://www.mass.gov/green-line-extension-project-glx", target: "_blank", class: "ga-nav-sublink" %>
-        </li>
-        <li>
-          <%= link "Wollaston Station", to: cms_static_page_path(@conn, "/wollaston"), class: "ga-nav-sublink" %>
         </li>
         <li>
           <%= link "See All Projects", to: project_path(@conn, :index), class: "ga-nav-sublink" %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔗 Main Nav | Swap "Wollaston" Link for "Building a Better T"](https://app.asana.com/0/555089885850811/1182865188439818)

Replace Wollaston main nav link with Building a Better T

Move it to the top of the list.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
