### PR TITLE
Cross out skipped/cancelled stops for CR predictions

### DIFF
--- a/apps/predictions/lib/prediction.ex
+++ b/apps/predictions/lib/prediction.ex
@@ -1,4 +1,10 @@
 defmodule Predictions.Prediction do
+  @moduledoc """
+  A prediction of when a vehicle will arrive at a stop.
+  """
+
+  @derive Jason.Encoder
+
   defstruct id: nil,
             trip: nil,
             stop: nil,

--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -3,6 +3,8 @@ defmodule Routes.Route do
 
   alias Routes.Repo
 
+  @derive Jason.Encoder
+
   defstruct id: "",
             type: 0,
             name: "",

--- a/apps/schedules/lib/schedule.ex
+++ b/apps/schedules/lib/schedule.ex
@@ -1,4 +1,10 @@
 defmodule Schedules.Schedule do
+  @moduledoc """
+  Representation of GTFS schedules.
+  """
+
+  @derive Jason.Encoder
+
   defstruct route: nil,
             trip: nil,
             stop: nil,
@@ -26,9 +32,7 @@ end
 
 defmodule Schedules.ScheduleCondensed do
   @moduledoc """
-
   Light weight alternate to Schedule.t()
-
   """
   defstruct stop_id: nil,
             time: nil,
@@ -50,6 +54,12 @@ defmodule Schedules.ScheduleCondensed do
 end
 
 defmodule Schedules.Trip do
+  @moduledoc """
+  Representation of GTFS trips.
+  """
+
+  @derive Jason.Encoder
+
   defstruct [
     :id,
     :name,
@@ -74,6 +84,10 @@ defmodule Schedules.Trip do
 end
 
 defmodule Schedules.Frequency do
+  @moduledoc """
+  Schedule headways.
+  """
+
   defstruct time_block: nil,
             min_headway: :infinity,
             max_headway: :infinity

--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -1,4 +1,5 @@
 import { CrowdingType } from "./schedule/components/__schedule";
+import { Prediction as TripsPrediction } from "./schedule/components/__trips";
 
 export interface Direction {
   direction_id: DirectionId;
@@ -28,6 +29,12 @@ export interface HeadsignWithCrowding {
 export interface PredictedOrScheduledTimeWithCrowding {
   time_data: PredictedOrScheduledTime;
   crowding: CrowdingType;
+  predicted_schedule: PredictedSchedule;
+}
+
+export interface PredictedSchedule {
+  schedule: Schedule;
+  prediction: TripsPrediction;
 }
 
 export type Mode = "commuter_rail" | "subway" | "bus" | "ferry";

--- a/apps/site/assets/ts/models/__tests__/prediction-test.ts
+++ b/apps/site/assets/ts/models/__tests__/prediction-test.ts
@@ -1,0 +1,34 @@
+import { Prediction } from "../../schedule/components/__trips";
+import { isSkippedOrCancelled } from "../prediction";
+
+describe("isABusRoute", () => {
+  test("returns true if the schedule_relationship is skipped or cancelled", () => {
+    const skippedPrediction = {
+      schedule_relationship: "skipped"
+    } as Prediction;
+    const cancelledPrediction = {
+      schedule_relationship: "cancelled"
+    } as Prediction;
+
+    expect(isSkippedOrCancelled(skippedPrediction)).toBeTruthy();
+    expect(isSkippedOrCancelled(cancelledPrediction)).toBeTruthy();
+  });
+
+  test("returns false if the schedule_relationship is anything other than skipped or cancelled", () => {
+    const addedPrediction = { schedule_relationship: "added" } as Prediction;
+    const unscheduledPrediction = {
+      schedule_relationship: "unscheduled"
+    } as Prediction;
+    const noDataPrediction = { schedule_relationship: "no_data" } as Prediction;
+    const nullPrediction = { schedule_relationship: null } as Prediction;
+
+    expect(isSkippedOrCancelled(addedPrediction)).toBeFalsy();
+    expect(isSkippedOrCancelled(unscheduledPrediction)).toBeFalsy();
+    expect(isSkippedOrCancelled(noDataPrediction)).toBeFalsy();
+    expect(isSkippedOrCancelled(nullPrediction)).toBeFalsy();
+  });
+
+  test("returns false when given null", () => {
+    expect(isSkippedOrCancelled(null)).toBeFalsy();
+  });
+});

--- a/apps/site/assets/ts/models/prediction.ts
+++ b/apps/site/assets/ts/models/prediction.ts
@@ -1,0 +1,8 @@
+import { Prediction } from "../schedule/components/__trips";
+
+// eslint-disable-next-line import/prefer-default-export
+export const isSkippedOrCancelled = (prediction: Prediction | null): boolean =>
+  prediction
+    ? prediction.schedule_relationship === "skipped" ||
+      prediction.schedule_relationship === "cancelled"
+    : false;

--- a/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/LineDiagramTest.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
+import { mount, ReactWrapper } from "enzyme";
 import { cloneDeep, merge } from "lodash";
 import LineDiagram from "../components/line-diagram/LineDiagram";
 import { EnhancedRoute, RouteType } from "../../__v3api";

--- a/apps/site/assets/ts/schedule/__tests__/SingleStopTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/SingleStopTest.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { mount } from "enzyme";
 import { cloneDeep, merge } from "lodash";
+import { Schedule } from "../../__v3api";
 import SingleStop from "../components/line-diagram/SingleStop";
 import { LiveData } from "../components/line-diagram/LineDiagram";
 import { LineDiagramStop, RouteStopRoute } from "../components/__schedule";
+import { Prediction } from "../components/__trips";
 
 const basicStop: LineDiagramStop = {
   alerts: [],
@@ -58,6 +60,9 @@ const crStop: LineDiagramStop = merge(cloneDeep(basicStop), {
   route_stop: { route: crRouteStub }
 });
 
+const mockPrediction = {} as Prediction & { headsign: string };
+const mockSchedule = {} as Schedule & { headsign: string };
+
 const liveData: LiveData = {
   headsigns: [
     {
@@ -73,7 +78,11 @@ const liveData: LiveData = {
             },
             scheduled_time: null
           },
-          crowding: null
+          crowding: null,
+          predicted_schedule: {
+            prediction: mockPrediction,
+            schedule: mockSchedule
+          }
         }
       ],
       train_number: null
@@ -91,7 +100,11 @@ const liveData: LiveData = {
             },
             scheduled_time: null
           },
-          crowding: null
+          crowding: null,
+          predicted_schedule: {
+            prediction: mockPrediction,
+            schedule: mockSchedule
+          }
         }
       ],
       train_number: null
@@ -130,7 +143,11 @@ const crLiveData: LiveData = {
             },
             scheduled_time: ["5:00", " ", "PM"]
           },
-          crowding: null
+          crowding: null,
+          predicted_schedule: {
+            prediction: mockPrediction,
+            schedule: mockSchedule
+          }
         }
       ],
       train_number: "404"
@@ -144,7 +161,11 @@ const crLiveData: LiveData = {
             prediction: null,
             scheduled_time: ["5:30", " ", "PM"]
           },
-          crowding: null
+          crowding: null,
+          predicted_schedule: {
+            prediction: mockPrediction,
+            schedule: mockSchedule
+          }
         }
       ],
       train_number: "504"

--- a/apps/site/assets/ts/schedule/__tests__/StopPredictionsTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/StopPredictionsTest.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { mount } from "enzyme";
+import { HeadsignWithCrowding, Schedule } from "../../__v3api";
+import StopPredictions from "../components/line-diagram/StopPredictions";
+import { Prediction } from "../components/__trips";
+
+const mockPrediction = {} as Prediction & { headsign: string };
+const mockSchedule = {} as Schedule & { headsign: string };
+
+describe("StopPredictions", () => {
+  it("renders bus predictions", () => {
+    const headsigns: HeadsignWithCrowding[] = [
+      {
+        name: "Harvard",
+        time_data_with_crowding_list: [
+          {
+            crowding: null,
+            predicted_schedule: {
+              prediction: mockPrediction,
+              schedule: mockSchedule
+            },
+            time_data: {
+              delay: 0,
+              prediction: {
+                status: null,
+                time: ["6", " ", "min"],
+                track: null
+              },
+              scheduled_time: ["3:15", " ", "PM"]
+            }
+          }
+        ],
+        train_number: ""
+      }
+    ];
+
+    const tree = renderer
+      .create(<StopPredictions headsigns={headsigns} isCommuterRail={false} />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders commuter rail predictions", () => {
+    const headsigns: HeadsignWithCrowding[] = [
+      {
+        name: "Worcester",
+        time_data_with_crowding_list: [
+          {
+            crowding: null,
+            predicted_schedule: {
+              prediction: mockPrediction,
+              schedule: mockSchedule
+            },
+            time_data: {
+              delay: 0,
+              prediction: {
+                status: null,
+                time: ["6", " ", "min"],
+                track: null
+              },
+              scheduled_time: ["4:15", " ", "PM"]
+            }
+          }
+        ],
+        train_number: "7519"
+      }
+    ];
+
+    const tree = renderer
+      .create(<StopPredictions headsigns={headsigns} isCommuterRail={true} />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders commuter rail predictions with a skipped stop", () => {
+    const skippedPrediction = {
+      schedule_relationship: "skipped",
+      time: "1:23 pm",
+      headsign: ""
+    } as Prediction & { headsign: string };
+    const headsigns: HeadsignWithCrowding[] = [
+      {
+        name: "Worcester",
+        time_data_with_crowding_list: [
+          {
+            crowding: null,
+            predicted_schedule: {
+              prediction: skippedPrediction,
+              schedule: mockSchedule
+            },
+            time_data: {
+              delay: 0,
+              prediction: {
+                status: null,
+                time: ["6", " ", "min"],
+                track: null
+              },
+              scheduled_time: ["4:15", " ", "PM"]
+            }
+          }
+        ],
+        train_number: "7519"
+      }
+    ];
+
+    const wrapper = mount(
+      <StopPredictions headsigns={headsigns} isCommuterRail={true} />
+    );
+
+    expect(
+      wrapper
+        .find(".m-schedule-diagram__cr-prediction-time.strikethrough")
+        .exists()
+    ).toBeTruthy();
+  });
+});

--- a/apps/site/assets/ts/schedule/__tests__/__snapshots__/StopPredictionsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/__tests__/__snapshots__/StopPredictionsTest.tsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StopPredictions renders bus predictions 1`] = `
+<div
+  className="m-schedule-diagram__predictions"
+>
+  <div
+    className="m-schedule-diagram__prediction"
+  >
+    <div>
+      Harvard
+    </div>
+    <div
+      className="m-schedule-diagram__prediction-time"
+    >
+      6   min
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StopPredictions renders commuter rail predictions 1`] = `
+<div
+  className="m-schedule-diagram__predictions"
+>
+  <div>
+    <div
+      className="m-schedule-diagram__cr-prediction"
+    >
+      <div
+        className="m-schedule-diagram__cr-prediction-time"
+      >
+        6 min
+      </div>
+    </div>
+    <div
+      className="m-schedule-diagram__cr-prediction-details"
+    >
+      <span>
+        Worcester
+      </span>
+      <span>
+         · Train 7519
+      </span>
+      <span>
+        
+      </span>
+      <span>
+         · On time
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopPredictions.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopPredictions.tsx
@@ -4,6 +4,7 @@ import {
   timeForCommuterRail,
   statusForCommuterRail
 } from "../../../helpers/prediction-helpers";
+import { isSkippedOrCancelled } from "../../../models/prediction";
 
 interface Props {
   headsigns: HeadsignWithCrowding[];
@@ -25,17 +26,20 @@ const StopPredictions = ({ headsigns, isCommuterRail }: Props): JSX.Element => {
   if (isCommuterRail) {
     // Display at most 1 prediction for Commuter Rail
     predictions = liveHeadsigns.slice(0, 1).map(headsign => {
-      const time = headsign.time_data_with_crowding_list[0].time_data;
+      const enhancedTimeData = headsign.time_data_with_crowding_list[0];
+      const time = enhancedTimeData.time_data;
       const prediction = time.prediction!;
       const status = statusForCommuterRail(time);
+      const predictionTimeClass = isSkippedOrCancelled(
+        enhancedTimeData.predicted_schedule.prediction
+      )
+        ? "m-schedule-diagram__cr-prediction-time strikethrough"
+        : "m-schedule-diagram__cr-prediction-time";
 
       return (
         <div key={headsign.name}>
           <div className="m-schedule-diagram__cr-prediction">
-            {timeForCommuterRail(
-              time,
-              "m-schedule-diagram__cr-prediction-time"
-            )}
+            {timeForCommuterRail(time, predictionTimeClass)}
           </div>
           <div className="m-schedule-diagram__cr-prediction-details">
             <span>{`${headsign.name}`}</span>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/TripStop.tsx
@@ -1,7 +1,8 @@
 import React, { ReactElement } from "react";
-import { TripDeparture, Prediction } from "../__trips";
+import { TripDeparture } from "../__trips";
 import { breakTextAtSlash } from "../../../helpers/text";
 import { alertIcon } from "../../../helpers/icon";
+import { isSkippedOrCancelled } from "../../../models/prediction";
 
 interface Props {
   departure: TripDeparture;
@@ -9,12 +10,6 @@ interface Props {
   showFare: boolean;
   routeType: number;
 }
-
-const skippedOrCancelled = (prediction: Prediction | null): boolean | null =>
-  prediction
-    ? prediction.schedule_relationship === "skipped" ||
-      prediction.schedule_relationship === "cancelled"
-    : null;
 
 const formattedDepartureTimes = (
   departure: TripDeparture,
@@ -57,10 +52,10 @@ const TripStop = ({
         <a
           href={`/stops/${schedule.stop.id}`}
           className={
-            skippedOrCancelled(departure.prediction) ? "strikethrough" : ""
+            isSkippedOrCancelled(departure.prediction) ? "strikethrough" : ""
           }
         >
-          {skippedOrCancelled(departure.prediction) && (
+          {isSkippedOrCancelled(departure.prediction) && (
             <>
               {alertIcon("c-svg__icon-alerts-triangle")}
               <span className="sr-only">This trip skips this stop at</span>

--- a/apps/site/lib/predicted_schedule.ex
+++ b/apps/site/lib/predicted_schedule.ex
@@ -8,6 +8,8 @@ defmodule PredictedSchedule do
   alias Predictions.Prediction
   alias Schedules.{Schedule, ScheduleCondensed}
 
+  @derive Jason.Encoder
+
   defstruct schedule: nil,
             prediction: nil
 

--- a/apps/site/lib/site/transit_near_me.ex
+++ b/apps/site/lib/site/transit_near_me.ex
@@ -55,7 +55,8 @@ defmodule Site.TransitNearMe do
 
   @type time_data_with_crowding :: %{
           time_data: time_data(),
-          crowding: Vehicle.crowding() | nil
+          crowding: Vehicle.crowding() | nil,
+          predicted_schedule: PredictedSchedule
         }
 
   @type time_data :: %{
@@ -530,13 +531,10 @@ defmodule Site.TransitNearMe do
           |> Map.get(:predicted_schedule)
           |> PredictedSchedule.time()
 
-        time_data_with_crowding_list =
-          Enum.map(filtered_time_data_with_crowding_list, &Map.drop(&1, [:predicted_schedule]))
-
         {first_predicted_schedule_time,
          %{
            name: headsign && ViewHelpers.break_text_at_slash(headsign),
-           time_data_with_crowding_list: time_data_with_crowding_list,
+           time_data_with_crowding_list: filtered_time_data_with_crowding_list,
            train_number: trip && trip.name
          }}
       end)

--- a/apps/site/test/site/transit_near_me_test.exs
+++ b/apps/site/test/site/transit_near_me_test.exs
@@ -747,7 +747,11 @@ defmodule Site.TransitNearMeTest do
                   },
                   scheduled_time: nil
                 },
-                crowding: nil
+                crowding: nil,
+                predicted_schedule: %PredictedSchedule{
+                  prediction: @prediction1,
+                  schedule: nil
+                }
               }
             ],
             train_number: nil
@@ -766,7 +770,11 @@ defmodule Site.TransitNearMeTest do
                   scheduled_time: nil,
                   delay: 0
                 },
-                crowding: nil
+                crowding: nil,
+                predicted_schedule: %PredictedSchedule{
+                  prediction: @prediction2,
+                  schedule: nil
+                }
               }
             ],
             train_number: nil

--- a/apps/stops/lib/stop.ex
+++ b/apps/stops/lib/stop.ex
@@ -4,6 +4,8 @@ defmodule Stops.Stop do
   """
   alias Stops.{Api, Stop}
 
+  @derive {Jason.Encoder, except: [:bike_storage, :fare_facilities]}
+
   defstruct id: nil,
             parent_id: nil,
             child_ids: [],
@@ -82,6 +84,8 @@ defmodule Stops.Stop.ParkingLot do
   @moduledoc """
   A group of parking spots at a Stop.
   """
+  @derive Jason.Encoder
+
   defstruct [
     :name,
     :address,
@@ -115,6 +119,8 @@ defmodule Stops.Stop.ParkingLot.Payment do
   :mobile_app - {payment-app, payment-app-id, payment-app-url}
   :rate - {fee-daily, fee-monthly}
   """
+  @derive Jason.Encoder
+
   defstruct [:methods, :mobile_app, :daily_rate, :monthly_rate]
 
   @type t :: %__MODULE__{
@@ -143,6 +149,8 @@ defmodule Stops.Stop.ParkingLot.Payment.MobileApp do
   :id - payment-app-id
   :url - payment-app-url
   """
+  @derive Jason.Encoder
+
   defstruct [:name, :id, :url]
 
   @type t :: %__MODULE__{
@@ -170,6 +178,7 @@ defmodule Stops.Stop.ParkingLot.Capacity do
   :overnight - overnight-allowed
   :type - enclosed
   """
+  @derive Jason.Encoder
 
   defstruct [:total, :accessible, :overnight, :type]
 
@@ -218,6 +227,8 @@ defmodule Stops.Stop.ParkingLot.Manager do
   :phone - contact-phone
   :url - contact-url
   """
+  @derive Jason.Encoder
+
   defstruct [:name, :contact, :phone, :url]
 
   @type t :: %__MODULE__{
@@ -245,6 +256,8 @@ defmodule Stops.Stop.ParkingLot.Utilization do
   :arrive_before - weekday-arrive-before
   :typical: - weekday-typical-utilization
   """
+  @derive Jason.Encoder
+
   defstruct [:arrive_before, :typical]
 
   @type t :: %__MODULE__{
@@ -278,6 +291,8 @@ defmodule Stops.Stop.ClosedStopInfo do
   @moduledoc """
   Information about stations not in API data.
   """
+  @derive Jason.Encoder
+
   defstruct reason: "",
             info_link: ""
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🚍 Line Diagram | CR | Cross out skipped/cancelled stops](https://app.asana.com/0/555089885850811/1158407361173137)

Cross out skipped/canceled stops for CR predictions in the line diagram.

![Screen Shot 2020-07-13 at 15 00 26](https://user-images.githubusercontent.com/42339/87353691-47f92f80-c52b-11ea-90f9-f25d374803ee.png)


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
