### PR TITLE
Remove filtering of bus routes for crowding purposes

### DIFF
--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -49,9 +49,6 @@ defmodule Routes.Route do
   @silver_line ~w(741 742 743 746 749 751)
   @silver_line_set MapSet.new(@silver_line)
 
-  @routes_with_occupancy ~w(1 15 16 21 22 23 31 32 57 66 70 71 73 86 104 109 110)
-  @routes_with_occupancy_set MapSet.new(@routes_with_occupancy)
-
   @spec type_atom(t | type_int | String.t()) :: gtfs_route_type
   def type_atom(%__MODULE__{type: type}), do: type_atom(type)
   def type_atom(0), do: :subway
@@ -202,9 +199,6 @@ defmodule Routes.Route do
   def silver_line?(%__MODULE__{id: id}), do: id in @silver_line_set
 
   def silver_line, do: @silver_line
-
-  @spec has_occupancy_data?(t()) :: boolean()
-  def has_occupancy_data?(%__MODULE__{id: id}), do: id in @routes_with_occupancy_set
 
   @spec to_json_safe(t) :: map
   def to_json_safe(%__MODULE__{

--- a/apps/routes/test/route_test.exs
+++ b/apps/routes/test/route_test.exs
@@ -170,13 +170,6 @@ defmodule Routes.RouteTest do
     end
   end
 
-  describe "has_occupancy_data?/1" do
-    test "returns true if vehicles on the route might have occupancy/crowding data" do
-      assert "1" |> Repo.get() |> has_occupancy_data?()
-      refute "7" |> Repo.get() |> has_occupancy_data?()
-    end
-  end
-
   describe "to_naive/1" do
     test "turns a green line branch into a generic green line route" do
       for branch <- ["B", "C", "D", "E"] do

--- a/apps/site/lib/site/transit_near_me.ex
+++ b/apps/site/lib/site/transit_near_me.ex
@@ -602,9 +602,8 @@ defmodule Site.TransitNearMe do
   @spec crowding_for_predicted_schedule(PredictedSchedule.t()) :: Vehicle.crowding() | nil
   defp crowding_for_predicted_schedule(predicted_schedule) do
     with %Trip{id: trip_id} <- PredictedSchedule.trip(predicted_schedule),
-         route <- PredictedSchedule.route(predicted_schedule),
          %Vehicle{crowding: crowding} <- Vehicles.Repo.trip(trip_id) do
-      if Route.has_occupancy_data?(route), do: crowding, else: nil
+      crowding
     else
       _ ->
         nil


### PR DESCRIPTION
#### Summary of changes
**Asana Tickets:**
[👩‍👩‍👧‍👦 Crowding | Hide crowding column if no vehicles have crowding data](https://app.asana.com/0/555089885850811/1181994766435225)
[👩‍👩‍👧‍👦 Crowding | Schedule Pages, Line Diagram](https://app.asana.com/0/555089885850811/1177064032714383)
[👩‍👩‍👧‍👦 Crowding | Upcoming Departures](https://app.asana.com/0/555089885850811/1180063111128636)

Get rid of the list of bus routes from a crowding standpoint.



