### PR TITLE
Ensure that the map api doesn't 500 if given bad params

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/map_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/map_api.ex
@@ -6,6 +6,7 @@ defmodule SiteWeb.ScheduleController.MapApi do
 
   alias Leaflet.MapData
   alias Routes.Route
+  alias SiteWeb.ControllerHelpers
   alias SiteWeb.ScheduleController.Line.Helpers, as: LineHelpers
   alias SiteWeb.ScheduleController.Line.Maps
   alias Stops.Repo, as: StopsRepo
@@ -22,6 +23,10 @@ defmodule SiteWeb.ScheduleController.MapApi do
       get_map_data(conn, route_id, String.to_integer(direction_id), &StopsRepo.by_route/3)
 
     json(conn, map_data)
+  end
+
+  def show(conn, _) do
+    ControllerHelpers.return_invalid_arguments_error(conn)
   end
 
   @type stops_by_route_fn :: (Route.id_t(), 0 | 1, Keyword.t() -> [Stop.t()] | {:error, any})

--- a/apps/site/test/site_web/controllers/schedule/map_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/map_api_test.exs
@@ -36,5 +36,13 @@ defmodule SiteWeb.ScheduleController.MapApiTest do
                "zoom" => _
              } = response
     end
+
+    test "doesn't 500 if given bad params", %{conn: conn} do
+      conn = get(conn, map_api_path(conn, :show, id: "66"))
+
+      assert response = json_response(conn, 400)
+
+      assert response == %{"error" => "Invalid arguments"}
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Elixir.Phoenix.ActionClauseError: no function clause matching in SiteWeb.ScheduleController.MapApi.show/2](https://app.asana.com/0/555089885850811/1181695474176953)

Ensure that the map api doesn't 500 if given bad params

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
