### PR TITLE
Do not show crowding if none of the Upcoming Departures for buses has that info

### DIFF
--- a/apps/site/assets/ts/schedule/__tests__/UpcomingDeparturesTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/UpcomingDeparturesTest.tsx
@@ -237,16 +237,26 @@ describe("UpcomingDepartures", () => {
 
     const tripId = enhancedBusJourneys[0].trip.id;
 
-    wrapper = mount(<>{crowdingInformation(journey, tripId)}</>);
+    wrapper = mount(<>{crowdingInformation(journey, tripId, true)}</>);
 
     expect(wrapper.find(".c-icon__crowding--some_crowding").length).toBe(1);
+  });
+
+  it("should not display crowding information for buses if it doesn't exist", () => {
+    const journey = enhancedBusJourneys[0];
+
+    const tripId = enhancedBusJourneys[0].trip.id;
+
+    wrapper = mount(<>{crowdingInformation(journey, tripId, false)}</>);
+
+    expect(wrapper.find(".c-icon__crowding--some_crowding").length).toBe(0);
   });
 
   it("should not display crowding information for CR", () => {
     act(() => {
       const journey: EnhancedJourney = enhancedCRjourneysResponse[0];
 
-      wrapper = mount(<>{crowdingInformation(journey, "")}</>);
+      wrapper = mount(<>{crowdingInformation(journey, "", false)}</>);
 
       expect(wrapper).toEqual({});
     });


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👩‍👩‍👧‍👦 Crowding | Hide crowding column if no vehicles have crowding data](https://app.asana.com/0/555089885850811/1181994766435225)

The column containing the crowding information will not be shown if there's not at least one vehicle with those values:

With crowding:
<img width="748" alt="image" src="https://user-images.githubusercontent.com/61979382/87594260-b15b7880-c6ba-11ea-820b-41c7ae954b3a.png">

Without crowding:
<img width="754" alt="image" src="https://user-images.githubusercontent.com/61979382/87594285-bae4e080-c6ba-11ea-91ba-638460cca680.png">


