### PR TITLE
🚍 Stops/Station/TNM | CR | Cross out skipped/cancelled stops

### DIFF
--- a/apps/site/assets/css/_colors.scss
+++ b/apps/site/assets/css/_colors.scss
@@ -96,6 +96,7 @@ $holiday-color: #dcd3e8;
 $weekend-color: $gray-bordered-background;
 $today-color: $brand-primary;
 $drop-shadow-color: rgba(0, 0, 0, .2);
+$text-muted: $gray;
 
 $transparent-white: transparentize($white, .4);
 $transparent-gray: transparentize($gray-lighter, .5);

--- a/apps/site/assets/css/_transit-near-me.scss
+++ b/apps/site/assets/css/_transit-near-me.scss
@@ -345,7 +345,7 @@ $xxl-map-height: map-get($container-max-widths, xxl) * (9 / 16);
   }
 
   &--schedule {
-    color: $gray-light;
+    color: $gray;
 
     // double-selector required to override .m-tnm-sidebar__schedule:first-of-type selector
     .m-tnm-sidebar__time-number.m-tnm-sidebar__time-number,

--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -101,6 +101,7 @@ export interface Prediction {
   time: string[];
   status: string | null;
   track: string | null;
+  schedule_relationship: ScheduleRelationship;
 }
 
 export interface Route {

--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -89,6 +89,14 @@ export interface PredictedOrScheduledTime {
   prediction: Prediction | null;
 }
 
+export type ScheduleRelationship =
+  | "added"
+  | "unscheduled"
+  | "cancelled"
+  | "skipped"
+  | "no_data"
+  | null;
+
 export interface Prediction {
   time: string[];
   status: string | null;

--- a/apps/site/assets/ts/components/Headsign.tsx
+++ b/apps/site/assets/ts/components/Headsign.tsx
@@ -118,9 +118,10 @@ const HeadsignComponent = (props: Props): ReactElement<HTMLElement> => {
         {routeType === 2 && renderTrainName(`Train ${headsign.train_number}`)}
       </div>
       <div className="m-tnm-sidebar__schedules">
-        {headsign.times.map((time, idx) =>
-          renderTime(time, headsign.name, routeType, idx)
-        )}
+        {headsign.times.map((time, idx) => {
+          if (routeType === 2 && idx > 0) return null; // limit to 1 headsign
+          return renderTime(time, headsign.name, routeType, idx);
+        })}
       </div>
     </div>
   );

--- a/apps/site/assets/ts/components/Headsign.tsx
+++ b/apps/site/assets/ts/components/Headsign.tsx
@@ -58,9 +58,9 @@ const renderTimeCommuterRail = (
     >
       {timeForCommuterRail(
         data,
-        `m-tnm-sidebar__time-number ${
+        `${
           status === "Canceled" ? "strikethrough" : ""
-        }`
+        } m-tnm-sidebar__time-number`
       )}
       <div className="m-tnm-sidebar__status">
         {`${status}${trackForCommuterRail(data)}`}

--- a/apps/site/assets/ts/components/Headsign.tsx
+++ b/apps/site/assets/ts/components/Headsign.tsx
@@ -45,22 +45,29 @@ const renderTrainName = (trainName: string): ReactElement<HTMLElement> => (
   <div className="m-tnm-sidebar__headsign-train">{trainName}</div>
 );
 
-const crTime = (data: PredictedOrScheduledTime): ReactElement<HTMLElement> =>
-  timeForCommuterRail(data, "m-tnm-sidebar__time-number");
-
 const renderTimeCommuterRail = (
   data: PredictedOrScheduledTime,
   modifier: string
-): ReactElement<HTMLElement> => (
-  <div
-    className={`m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail ${modifier}`}
-  >
-    {crTime(data)}
-    <div className="m-tnm-sidebar__status">
-      {`${statusForCommuterRail(data) || ""}${trackForCommuterRail(data)}`}
+): ReactElement<HTMLElement> => {
+  const status = statusForCommuterRail(data) || "";
+  return (
+    <div
+      className={`m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail ${modifier} ${
+        status === "Scheduled" ? "text-muted" : ""
+      }`}
+    >
+      {timeForCommuterRail(
+        data,
+        `m-tnm-sidebar__time-number ${
+          status === "Canceled" ? "strikethrough" : ""
+        }`
+      )}
+      <div className="m-tnm-sidebar__status">
+        {`${status}${trackForCommuterRail(data)}`}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 const renderTimeDefault = (
   time: string[],

--- a/apps/site/assets/ts/components/__tests__/HeadsignTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/HeadsignTest.tsx
@@ -3,6 +3,7 @@ import renderer from "react-test-renderer";
 import HeadsignComponent from "../Headsign";
 import { createReactRoot } from "../../app/helpers/testUtils";
 import { Headsign } from "../../__v3api";
+import { shallow } from "enzyme";
 
 /* eslint-disable @typescript-eslint/camelcase */
 
@@ -224,4 +225,29 @@ it("it displays delayed status for CR", () => {
     )
     .toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+it("it displays cancelled status for CR", () => {
+  const headsign: Headsign = {
+    name: "Cancelled Train",
+    headsign: "Cancelled Train",
+    train_number: "404",
+    times: [
+      {
+        delay: 5,
+        scheduled_time: ["7:00", " ", "PM"],
+        prediction: {
+          schedule_relationship: "cancelled",
+          time: ["7:03", " ", "PM"],
+          status: null,
+          track: null
+        }
+      }
+    ]
+  };
+  const wrapper = shallow(
+    <HeadsignComponent headsign={headsign} condensed={false} routeType={2} />
+  );
+
+  expect(wrapper.find(".m-tnm-sidebar__time-number.strikethrough").exists()).toBeTruthy()
 });

--- a/apps/site/assets/ts/components/__tests__/HeadsignTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/HeadsignTest.tsx
@@ -15,6 +15,7 @@ it("it renders 2 predictions", () => {
         delay: 0,
         scheduled_time: ["4:30", " ", "PM"],
         prediction: {
+          schedule_relationship: null,
           time: ["14", " ", "min"],
           status: null,
           track: null
@@ -24,6 +25,7 @@ it("it renders 2 predictions", () => {
         delay: 0,
         scheduled_time: ["5:00", " ", "PM"],
         prediction: {
+          schedule_relationship: null,
           time: ["44", " ", "min"],
           status: null,
           track: null
@@ -74,6 +76,7 @@ it("it splits the headsign name when it contains 'via' ", () => {
         delay: 0,
         scheduled_time: ["4:30", " ", "PM"],
         prediction: {
+          schedule_relationship: null,
           time: ["14", " ", "min"],
           status: null,
           track: null
@@ -83,6 +86,7 @@ it("it splits the headsign name when it contains 'via' ", () => {
         delay: 0,
         scheduled_time: ["5:00", " ", "PM"],
         prediction: {
+          schedule_relationship: null,
           time: ["44", " ", "min"],
           status: null,
           track: null
@@ -110,6 +114,7 @@ it("it renders a status and train name for Commuter Rail", () => {
         delay: 0,
         scheduled_time: ["4:30", " ", "PM"],
         prediction: {
+          schedule_relationship: null,
           time: ["4:30", " ", "PM"],
           status: "On time",
           track: null
@@ -137,6 +142,7 @@ it("it renders a status and train name for Commuter Rail with track number if av
         delay: 0,
         scheduled_time: ["4:30", " ", "PM"],
         prediction: {
+          schedule_relationship: null,
           time: ["4:30", " ", "PM"],
           status: "Now boarding",
           track: "1"
@@ -164,6 +170,7 @@ it("it renders uncondensed bus headsign name as --small", () => {
         delay: 0,
         scheduled_time: ["7:00", " ", "PM"],
         prediction: {
+          schedule_relationship: null,
           time: ["14", " ", "min"],
           status: null,
           track: null
@@ -173,6 +180,7 @@ it("it renders uncondensed bus headsign name as --small", () => {
         delay: 0,
         scheduled_time: ["7:10", " ", "PM"],
         prediction: {
+          schedule_relationship: null,
           time: ["44", " ", "min"],
           status: null,
           track: null
@@ -201,6 +209,7 @@ it("it displays delayed status for CR", () => {
         delay: 5,
         scheduled_time: ["7:00", " ", "PM"],
         prediction: {
+          schedule_relationship: null,
           time: ["7:03", " ", "PM"],
           status: null,
           track: null

--- a/apps/site/assets/ts/components/__tests__/HeadsignTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/HeadsignTest.tsx
@@ -45,6 +45,42 @@ it("it renders 2 predictions", () => {
   expect(tree).toMatchSnapshot();
 });
 
+it("it renders 1 prediction for CR", () => {
+  const headsign: Headsign = {
+    name: "Watertown",
+    headsign: "Watertown",
+    times: [
+      {
+        delay: 0,
+        scheduled_time: ["4:30", " ", "PM"],
+        prediction: {
+          schedule_relationship: null,
+          time: ["14", " ", "min"],
+          status: null,
+          track: null
+        }
+      },
+      {
+        delay: 0,
+        scheduled_time: ["5:00", " ", "PM"],
+        prediction: {
+          schedule_relationship: null,
+          time: ["44", " ", "min"],
+          status: null,
+          track: null
+        }
+      }
+    ],
+    train_number: null
+  };
+
+  const wrapper = shallow(
+    <HeadsignComponent headsign={headsign} condensed={false} routeType={2} />
+  );
+
+  expect(wrapper.find(".m-tnm-sidebar__schedule")).toHaveLength(1);
+});
+
 it("it renders scheduled time when prediction is null", () => {
   const headsign: Headsign = {
     name: "Watertown",
@@ -249,5 +285,7 @@ it("it displays cancelled status for CR", () => {
     <HeadsignComponent headsign={headsign} condensed={false} routeType={2} />
   );
 
-  expect(wrapper.find(".m-tnm-sidebar__time-number.strikethrough").exists()).toBeTruthy()
+  expect(
+    wrapper.find(".m-tnm-sidebar__time-number.strikethrough").exists()
+  ).toBeTruthy();
 });

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/DirectionTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/DirectionTest.tsx.snap
@@ -87,17 +87,17 @@ exports[`it does not display the route direction for commuter rail 1`] = `
           className="m-tnm-sidebar__schedule"
         >
           <div
-            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
           >
             <div
-              className="m-tnm-sidebar__time-number"
+              className="m-tnm-sidebar__time-number "
             >
               4:30 PM
             </div>
             <div
               className="m-tnm-sidebar__status"
             >
-              On time
+              Scheduled
             </div>
           </div>
         </div>
@@ -127,17 +127,17 @@ exports[`it does not display the route direction for commuter rail 1`] = `
           className="m-tnm-sidebar__schedule"
         >
           <div
-            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
           >
             <div
-              className="m-tnm-sidebar__time-number"
+              className="m-tnm-sidebar__time-number "
             >
               4:30 PM
             </div>
             <div
               className="m-tnm-sidebar__status"
             >
-              On time
+              Scheduled
             </div>
           </div>
         </div>

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/DirectionTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/DirectionTest.tsx.snap
@@ -90,7 +90,7 @@ exports[`it does not display the route direction for commuter rail 1`] = `
             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
           >
             <div
-              className="m-tnm-sidebar__time-number "
+              className=" m-tnm-sidebar__time-number"
             >
               4:30 PM
             </div>
@@ -130,7 +130,7 @@ exports[`it does not display the route direction for commuter rail 1`] = `
             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
           >
             <div
-              className="m-tnm-sidebar__time-number "
+              className=" m-tnm-sidebar__time-number"
             >
               4:30 PM
             </div>

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/HeadsignTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/HeadsignTest.tsx.snap
@@ -28,12 +28,12 @@ exports[`it displays delayed status for CR 1`] = `
         className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
       >
         <div
-          className="m-tnm-sidebar__time-number --delayed"
+          className=" m-tnm-sidebar__time-number--delayed"
         >
           7:00 PM
         </div>
         <div
-          className="m-tnm-sidebar__time-number "
+          className=" m-tnm-sidebar__time-number"
         >
           7:03 PM
         </div>
@@ -132,7 +132,7 @@ exports[`it renders a status and train name for Commuter Rail 1`] = `
         className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
       >
         <div
-          className="m-tnm-sidebar__time-number "
+          className=" m-tnm-sidebar__time-number"
         >
           4:30 PM
         </div>
@@ -175,7 +175,7 @@ exports[`it renders a status and train name for Commuter Rail with track number 
         className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
       >
         <div
-          className="m-tnm-sidebar__time-number "
+          className=" m-tnm-sidebar__time-number"
         >
           4:30 PM
         </div>

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/HeadsignTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/HeadsignTest.tsx.snap
@@ -25,15 +25,15 @@ exports[`it displays delayed status for CR 1`] = `
       className="m-tnm-sidebar__schedule"
     >
       <div
-        className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+        className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
       >
         <div
-          className="m-tnm-sidebar__time-number--delayed"
+          className="m-tnm-sidebar__time-number --delayed"
         >
           7:00 PM
         </div>
         <div
-          className="m-tnm-sidebar__time-number"
+          className="m-tnm-sidebar__time-number "
         >
           7:03 PM
         </div>
@@ -129,10 +129,10 @@ exports[`it renders a status and train name for Commuter Rail 1`] = `
       className="m-tnm-sidebar__schedule"
     >
       <div
-        className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+        className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
       >
         <div
-          className="m-tnm-sidebar__time-number"
+          className="m-tnm-sidebar__time-number "
         >
           4:30 PM
         </div>
@@ -172,10 +172,10 @@ exports[`it renders a status and train name for Commuter Rail with track number 
       className="m-tnm-sidebar__schedule"
     >
       <div
-        className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+        className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
       >
         <div
-          className="m-tnm-sidebar__time-number"
+          className="m-tnm-sidebar__time-number "
         >
           4:30 PM
         </div>

--- a/apps/site/assets/ts/helpers/__tests__/prediction-helpers-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/prediction-helpers-test.ts
@@ -9,7 +9,8 @@ describe("statusForCommuterRail", () => {
       prediction: {
         status: "Held for reasons",
         time: ["11:11", " ", "AM"],
-        track: null
+        track: null,
+        schedule_relationship: null
       }
     };
 
@@ -20,12 +21,22 @@ describe("statusForCommuterRail", () => {
     const onTime: PredictedOrScheduledTime = {
       delay: 4,
       scheduled_time: ["11:00", " ", "AM"],
-      prediction: { status: null, time: ["11:04", " ", "AM"], track: null }
+      prediction: {
+        status: null,
+        time: ["11:04", " ", "AM"],
+        track: null,
+        schedule_relationship: null
+      }
     };
     const delayed: PredictedOrScheduledTime = {
       delay: 5,
       scheduled_time: ["11:00", " ", "AM"],
-      prediction: { status: null, time: ["11:05", " ", "AM"], track: null }
+      prediction: {
+        status: null,
+        time: ["11:05", " ", "AM"],
+        track: null,
+        schedule_relationship: null
+      }
     };
 
     expect(statusForCommuterRail(onTime)).toEqual("On time");
@@ -46,7 +57,12 @@ describe("statusForCommuterRail", () => {
     const data: PredictedOrScheduledTime = {
       delay: 4,
       scheduled_time: null,
-      prediction: { status: null, time: ["11:11", " ", "AM"], track: null }
+      prediction: {
+        status: null,
+        time: ["11:11", " ", "AM"],
+        track: null,
+        schedule_relationship: null
+      }
     };
 
     expect(statusForCommuterRail(data)).toBeNull();

--- a/apps/site/assets/ts/helpers/__tests__/prediction-helpers-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/prediction-helpers-test.ts
@@ -43,14 +43,55 @@ describe("statusForCommuterRail", () => {
     expect(statusForCommuterRail(delayed)).toEqual("Delayed 5 min");
   });
 
-  test("indicates 'on time' as long as there is a scheduled time", () => {
+  test("indicates if stop is skipped or trip is canceled", () => {
+    const skipped: PredictedOrScheduledTime = {
+      delay: 0,
+      scheduled_time: ["11:00", " ", "AM"],
+      prediction: {
+        status: null,
+        time: ["11:00", " ", "AM"],
+        track: null,
+        schedule_relationship: "skipped"
+      }
+    };
+    const canceled: PredictedOrScheduledTime = {
+      delay: 0,
+      scheduled_time: ["11:00", " ", "AM"],
+      prediction: {
+        status: null,
+        time: ["11:00", " ", "AM"],
+        track: null,
+        schedule_relationship: "cancelled"
+      }
+    };
+
+    expect(statusForCommuterRail(skipped)).toEqual("Canceled");
+    expect(statusForCommuterRail(canceled)).toEqual("Canceled");
+  });
+
+  test("indicates 'on time' for other predictions", () => {
+    const data: PredictedOrScheduledTime = {
+      delay: 0,
+      scheduled_time: ["11:00", " ", "AM"],
+      prediction: {
+        status: null,
+        time: ["11:00", " ", "AM"],
+        track: null,
+        schedule_relationship: null
+      }
+    };
+
+    expect(statusForCommuterRail(data)).toEqual("On time");
+  });
+
+  test("indicates 'scheduled' as long as there is a scheduled time", () => {
     const data: PredictedOrScheduledTime = {
       delay: 4,
       scheduled_time: ["11:00", " ", "AM"],
       prediction: null
     };
 
-    expect(statusForCommuterRail(data)).toEqual("On time");
+    expect(statusForCommuterRail(data)).toEqual("Scheduled");
   });
 
   test("returns null if there is no scheduled time to compare to", () => {

--- a/apps/site/assets/ts/helpers/prediction-helpers.tsx
+++ b/apps/site/assets/ts/helpers/prediction-helpers.tsx
@@ -1,5 +1,7 @@
 import React, { ReactElement } from "react";
 import { PredictedOrScheduledTime } from "../__v3api";
+import { isSkippedOrCancelled } from "../models/prediction";
+import { Prediction } from "../schedule/components/__trips";
 
 const delayForCommuterRail = (
   data: PredictedOrScheduledTime,
@@ -38,12 +40,17 @@ export const statusForCommuterRail = ({
   // If there is a human-entered status string, prioritize that
   if (prediction && prediction.status) return prediction.status;
 
+  if (isSkippedOrCancelled((prediction as unknown) as Prediction))
+    return "Canceled";
+
   // Indicate "Delayed" if train is delayed 5+ minutes
   if (delay >= 5) return `Delayed ${delay} min`;
 
-  // Indicate "On time" if train is not "Delayed" and we have a scheduled time
+  // Indicate "On time" if train otherwise has a prediction
+  // Indicate "Scheduled" if train is not "Delayed" and we have a scheduled time
   // (even if there is no real-time prediction)
-  if (scheduledTime) return "On time";
+  if (scheduledTime && prediction) return "On time";
+  if (scheduledTime) return "Scheduled";
 
   // We have just a prediction with no scheduled time, so we can't say whether
   // the train is on time, delayed, etc.

--- a/apps/site/assets/ts/schedule/__tests__/SingleStopTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/SingleStopTest.tsx
@@ -72,6 +72,7 @@ const liveData: LiveData = {
           time_data: {
             delay: 0,
             prediction: {
+              schedule_relationship: null,
               status: null,
               time: ["arriving"],
               track: null
@@ -94,6 +95,7 @@ const liveData: LiveData = {
           time_data: {
             delay: 0,
             prediction: {
+              schedule_relationship: null,
               status: null,
               time: ["2", " ", "min"],
               track: null
@@ -137,6 +139,7 @@ const crLiveData: LiveData = {
           time_data: {
             delay: 5,
             prediction: {
+              schedule_relationship: null,
               status: null,
               time: ["5:05", " ", "PM"],
               track: "3"

--- a/apps/site/assets/ts/schedule/__tests__/StopPredictionsTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/StopPredictionsTest.tsx
@@ -23,6 +23,7 @@ describe("StopPredictions", () => {
             time_data: {
               delay: 0,
               prediction: {
+                schedule_relationship: null,
                 status: null,
                 time: ["6", " ", "min"],
                 track: null
@@ -56,6 +57,7 @@ describe("StopPredictions", () => {
             time_data: {
               delay: 0,
               prediction: {
+                schedule_relationship: null,
                 status: null,
                 time: ["6", " ", "min"],
                 track: null
@@ -94,6 +96,7 @@ describe("StopPredictions", () => {
             time_data: {
               delay: 0,
               prediction: {
+                schedule_relationship: null,
                 status: null,
                 time: ["6", " ", "min"],
                 track: null

--- a/apps/site/assets/ts/schedule/components/__trips.d.ts
+++ b/apps/site/assets/ts/schedule/components/__trips.d.ts
@@ -1,4 +1,10 @@
-import { Route, Trip, Stop, PredictedOrScheduledTime } from "../../__v3api";
+import {
+  Route,
+  Trip,
+  Stop,
+  PredictedOrScheduledTime,
+  ScheduleRelationship
+} from "../../__v3api";
 import { CrowdingType } from "./__schedule";
 
 export interface Journey {
@@ -34,14 +40,6 @@ export interface TripInfo {
   fare: Fare;
   route_type: number;
 }
-
-type ScheduleRelationship =
-  | "added"
-  | "unscheduled"
-  | "cancelled"
-  | "skipped"
-  | "no_data"
-  | null;
 
 export interface Prediction {
   schedule_relationship: ScheduleRelationship;

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/DeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/DeparturesTest.tsx.snap
@@ -843,7 +843,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     4:55 AM
                   </div>
@@ -896,7 +896,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     6:24 AM
                   </div>
@@ -976,7 +976,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     4:40 AM
                   </div>
@@ -1016,7 +1016,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     5:30 AM
                   </div>
@@ -1056,7 +1056,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     7:30 AM
                   </div>
@@ -1109,7 +1109,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     4:45 AM
                   </div>
@@ -1189,7 +1189,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     3:50 AM
                   </div>
@@ -1229,7 +1229,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     6:40 AM
                   </div>
@@ -1269,7 +1269,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     4:15 PM
                   </div>
@@ -1322,7 +1322,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     4:55 AM
                   </div>
@@ -1402,7 +1402,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     5:40 AM
                   </div>
@@ -1455,7 +1455,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     6:54 AM
                   </div>
@@ -1535,7 +1535,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     5:30 AM
                   </div>
@@ -1588,7 +1588,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     7:11 AM
                   </div>
@@ -1628,7 +1628,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     10:50 AM
                   </div>
@@ -1708,7 +1708,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     5:20 AM
                   </div>
@@ -1761,7 +1761,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     6:35 AM
                   </div>
@@ -1841,7 +1841,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     6:05 AM
                   </div>
@@ -1894,7 +1894,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     7:05 AM
                   </div>
@@ -1974,7 +1974,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     4:45 AM
                   </div>
@@ -2027,7 +2027,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     4:58 AM
                   </div>
@@ -2067,7 +2067,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     6:31 AM
                   </div>
@@ -2107,7 +2107,7 @@ exports[`it renders 1`] = `
                   className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number "
+                    className=" m-tnm-sidebar__time-number"
                   >
                     6:57 AM
                   </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/DeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/DeparturesTest.tsx.snap
@@ -840,17 +840,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     4:55 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -893,17 +893,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     6:24 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -973,17 +973,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     4:40 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1013,17 +1013,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     5:30 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1053,17 +1053,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     7:30 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1106,17 +1106,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     4:45 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1186,17 +1186,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     3:50 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1226,17 +1226,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     6:40 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1266,10 +1266,10 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     4:15 PM
                   </div>
@@ -1319,17 +1319,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     4:55 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1399,17 +1399,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     5:40 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1452,17 +1452,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     6:54 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1532,17 +1532,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     5:30 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1585,17 +1585,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     7:11 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1625,17 +1625,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     10:50 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1705,17 +1705,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     5:20 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1758,17 +1758,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     6:35 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1838,17 +1838,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     6:05 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1891,17 +1891,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     7:05 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -1971,17 +1971,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     4:45 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -2024,17 +2024,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     4:58 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -2064,17 +2064,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     6:31 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>
@@ -2104,17 +2104,17 @@ exports[`it renders 1`] = `
                 className="m-tnm-sidebar__schedule"
               >
                 <div
-                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                  className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                 >
                   <div
-                    className="m-tnm-sidebar__time-number"
+                    className="m-tnm-sidebar__time-number "
                   >
                     6:57 AM
                   </div>
                   <div
                     className="m-tnm-sidebar__status"
                   >
-                    On time
+                    Scheduled
                   </div>
                 </div>
               </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
@@ -1359,17 +1359,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               4:55 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -1412,17 +1412,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               6:24 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -1492,17 +1492,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               4:40 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -1532,17 +1532,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               5:30 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -1572,17 +1572,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               7:30 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -1625,17 +1625,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               4:45 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -1705,17 +1705,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               3:50 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -1745,17 +1745,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               6:40 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -1785,10 +1785,10 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               4:15 PM
                             </div>
@@ -1838,17 +1838,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               4:55 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -1918,17 +1918,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               5:40 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -1971,17 +1971,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               6:54 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2051,17 +2051,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               5:30 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2104,17 +2104,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               7:11 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2144,17 +2144,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               10:50 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2224,17 +2224,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               5:20 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2277,17 +2277,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               6:35 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2357,17 +2357,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               6:05 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2410,17 +2410,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               7:05 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2490,17 +2490,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               4:45 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2543,17 +2543,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               4:58 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2583,17 +2583,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               6:31 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>
@@ -2623,17 +2623,17 @@ Array [
                           className="m-tnm-sidebar__schedule"
                         >
                           <div
-                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                            className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number"
+                              className="m-tnm-sidebar__time-number "
                             >
                               6:57 AM
                             </div>
                             <div
                               className="m-tnm-sidebar__status"
                             >
-                              On time
+                              Scheduled
                             </div>
                           </div>
                         </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
@@ -1362,7 +1362,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               4:55 AM
                             </div>
@@ -1415,7 +1415,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               6:24 AM
                             </div>
@@ -1495,7 +1495,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               4:40 AM
                             </div>
@@ -1535,7 +1535,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               5:30 AM
                             </div>
@@ -1575,7 +1575,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               7:30 AM
                             </div>
@@ -1628,7 +1628,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               4:45 AM
                             </div>
@@ -1708,7 +1708,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               3:50 AM
                             </div>
@@ -1748,7 +1748,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               6:40 AM
                             </div>
@@ -1788,7 +1788,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               4:15 PM
                             </div>
@@ -1841,7 +1841,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               4:55 AM
                             </div>
@@ -1921,7 +1921,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               5:40 AM
                             </div>
@@ -1974,7 +1974,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               6:54 AM
                             </div>
@@ -2054,7 +2054,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               5:30 AM
                             </div>
@@ -2107,7 +2107,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               7:11 AM
                             </div>
@@ -2147,7 +2147,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               10:50 AM
                             </div>
@@ -2227,7 +2227,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               5:20 AM
                             </div>
@@ -2280,7 +2280,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               6:35 AM
                             </div>
@@ -2360,7 +2360,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               6:05 AM
                             </div>
@@ -2413,7 +2413,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               7:05 AM
                             </div>
@@ -2493,7 +2493,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               4:45 AM
                             </div>
@@ -2546,7 +2546,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               4:58 AM
                             </div>
@@ -2586,7 +2586,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               6:31 AM
                             </div>
@@ -2626,7 +2626,7 @@ Array [
                             className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                           >
                             <div
-                              className="m-tnm-sidebar__time-number "
+                              className=" m-tnm-sidebar__time-number"
                             >
                               6:57 AM
                             </div>

--- a/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
+++ b/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
@@ -417,7 +417,7 @@ exports[`render it renders 1`] = `
                       className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
                     >
                       <div
-                        className="m-tnm-sidebar__time-number "
+                        className=" m-tnm-sidebar__time-number"
                       >
                         5:26 PM
                       </div>
@@ -470,7 +470,7 @@ exports[`render it renders 1`] = `
                       className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
                     >
                       <div
-                        className="m-tnm-sidebar__time-number "
+                        className=" m-tnm-sidebar__time-number"
                       >
                         5:53 PM
                       </div>

--- a/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
+++ b/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
@@ -414,10 +414,10 @@ exports[`render it renders 1`] = `
                     className="m-tnm-sidebar__schedule"
                   >
                     <div
-                      className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                      className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
                     >
                       <div
-                        className="m-tnm-sidebar__time-number"
+                        className="m-tnm-sidebar__time-number "
                       >
                         5:26 PM
                       </div>
@@ -432,10 +432,10 @@ exports[`render it renders 1`] = `
                     className="m-tnm-sidebar__schedule"
                   >
                     <div
-                      className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                      className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
                     >
                       <div
-                        className="m-tnm-sidebar__time-number"
+                        className="m-tnm-sidebar__time-number "
                       >
                         5:46 PM
                       </div>
@@ -485,10 +485,10 @@ exports[`render it renders 1`] = `
                     className="m-tnm-sidebar__schedule"
                   >
                     <div
-                      className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                      className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
                     >
                       <div
-                        className="m-tnm-sidebar__time-number"
+                        className="m-tnm-sidebar__time-number "
                       >
                         5:53 PM
                       </div>
@@ -503,17 +503,17 @@ exports[`render it renders 1`] = `
                     className="m-tnm-sidebar__schedule"
                   >
                     <div
-                      className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail "
+                      className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
                     >
                       <div
-                        className="m-tnm-sidebar__time-number"
+                        className="m-tnm-sidebar__time-number "
                       >
                         7:11 PM
                       </div>
                       <div
                         className="m-tnm-sidebar__status"
                       >
-                        On time
+                        Scheduled
                       </div>
                     </div>
                   </div>

--- a/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
+++ b/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
@@ -428,24 +428,6 @@ exports[`render it renders 1`] = `
                       </div>
                     </div>
                   </div>
-                  <div
-                    className="m-tnm-sidebar__schedule"
-                  >
-                    <div
-                      className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
-                    >
-                      <div
-                        className="m-tnm-sidebar__time-number "
-                      >
-                        5:46 PM
-                      </div>
-                      <div
-                        className="m-tnm-sidebar__status"
-                      >
-                        On time
-                      </div>
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>
@@ -496,24 +478,6 @@ exports[`render it renders 1`] = `
                         className="m-tnm-sidebar__status"
                       >
                         On time
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="m-tnm-sidebar__schedule"
-                  >
-                    <div
-                      className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  text-muted"
-                    >
-                      <div
-                        className="m-tnm-sidebar__time-number "
-                      >
-                        7:11 PM
-                      </div>
-                      <div
-                        className="m-tnm-sidebar__status"
-                      >
-                        Scheduled
                       </div>
                     </div>
                   </div>

--- a/apps/site/assets/ts/tnm/__tests__/state.json
+++ b/apps/site/assets/ts/tnm/__tests__/state.json
@@ -521,7 +521,8 @@
                   "headsign": "Forest Hills",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["1", " ", "min"],
                         "status": null
@@ -530,7 +531,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["14", " ", "min"],
                         "status": null
@@ -551,7 +553,8 @@
                   "headsign": "Oak Grove",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["5", " ", "min"],
                         "status": null
@@ -560,7 +563,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["26", " ", "min"],
                         "status": null
@@ -613,7 +617,8 @@
                   "headsign": "Haverhill",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["5:26", " ", "PM"],
                         "status": null
@@ -622,7 +627,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["5:46", " ", "PM"],
                         "status": null
@@ -643,7 +649,8 @@
                   "headsign": "North Station",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["5:53", " ", "PM"],
                         "status": null
@@ -701,7 +708,8 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["10", " ", "min"],
                         "status": null
@@ -710,7 +718,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["50", " ", "min"],
                         "status": null
@@ -731,7 +740,8 @@
                   "headsign": "Wellington",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["12", " ", "min"],
                         "status": null
@@ -740,7 +750,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["52", " ", "min"],
                         "status": null
@@ -796,7 +807,8 @@
                   "headsign": "Woodland Rd",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["3", " ", "min"],
                         "status": null
@@ -805,7 +817,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["39", " ", "min"],
                         "status": null
@@ -826,7 +839,8 @@
                   "headsign": "Wellington",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["27", " ", "min"],
                         "status": null
@@ -835,7 +849,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["71", " ", "min"],
                         "status": null
@@ -888,7 +903,8 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["7", " ", "min"],
                         "status": null
@@ -897,7 +913,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["8", " ", "min"],
                         "status": null
@@ -918,7 +935,8 @@
                   "headsign": "Sullivan",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["arriving"],
                         "status": null
@@ -927,7 +945,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["9", " ", "min"],
                         "status": null
@@ -980,7 +999,8 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["15", " ", "min"],
                         "status": null
@@ -989,7 +1009,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["45", " ", "min"],
                         "status": null
@@ -1010,7 +1031,8 @@
                   "headsign": "Sullivan",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["16", " ", "min"],
                         "status": null
@@ -1019,7 +1041,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["46", " ", "min"],
                         "status": null
@@ -1072,7 +1095,8 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["17", " ", "min"],
                         "status": null
@@ -1081,7 +1105,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["35", " ", "min"],
                         "status": null
@@ -1102,7 +1127,8 @@
                   "headsign": "Sullivan",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["18", " ", "min"],
                         "status": null
@@ -1111,7 +1137,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["36", " ", "min"],
                         "status": null
@@ -1167,7 +1194,8 @@
                   "headsign": "Lebanon Loop",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["16", " ", "min"],
                         "status": null
@@ -1176,7 +1204,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["29", " ", "min"],
                         "status": null
@@ -1209,7 +1238,8 @@
                   "headsign": "Wellington",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["15", " ", "min"],
                         "status": null
@@ -1218,7 +1248,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["31", " ", "min"],
                         "status": null
@@ -1234,7 +1265,8 @@
                   "headsign": "Wellington",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["70", " ", "min"],
                         "status": null
@@ -1243,7 +1275,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["92", " ", "min"],
                         "status": null
@@ -1296,7 +1329,8 @@
                   "headsign": "Linden Square",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["2", " ", "min"],
                         "status": null
@@ -1305,7 +1339,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["23", " ", "min"],
                         "status": null
@@ -1326,7 +1361,8 @@
                   "headsign": "Wellington",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["4", " ", "min"],
                         "status": null
@@ -1335,7 +1371,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["23", " ", "min"],
                         "status": null
@@ -1449,7 +1486,8 @@
                   "headsign": "Redstone",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["2", " ", "min"],
                         "status": null
@@ -1458,7 +1496,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["34", " ", "min"],
                         "status": null
@@ -1479,7 +1518,8 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["25", " ", "min"],
                         "status": null
@@ -1488,7 +1528,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": null,
                         "time": ["61", " ", "min"],
                         "status": null
@@ -1544,7 +1585,8 @@
                   "headsign": "Reading Depot",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["72", " ", "min"],
                         "status": null
@@ -1565,7 +1607,8 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["44", " ", "min"],
                         "status": null
@@ -1574,7 +1617,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["77", " ", "min"],
                         "status": null
@@ -1630,7 +1674,8 @@
                   "headsign": "Reading Depot",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["47", " ", "min"],
                         "status": null
@@ -1639,7 +1684,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["107", " ", "min"],
                         "status": null
@@ -1660,7 +1706,8 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["8", " ", "min"],
                         "status": null
@@ -1669,7 +1716,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "2",
                         "time": ["102", " ", "min"],
                         "status": null
@@ -1725,7 +1773,8 @@
                   "headsign": "Kennedy Dr",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["24", " ", "min"],
                         "status": null
@@ -1734,7 +1783,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["69", " ", "min"],
                         "status": null
@@ -1755,7 +1805,8 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["62", " ", "min"],
                         "status": null
@@ -1764,7 +1815,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["107", " ", "min"],
                         "status": null
@@ -1780,7 +1832,8 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["1", " ", "min"],
                         "status": null
@@ -1789,7 +1842,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["68", " ", "min"],
                         "status": null
@@ -1862,7 +1916,8 @@
                   "headsign": "Saugus Center via Square One Mall",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["8", " ", "min"],
                         "status": null
@@ -1871,7 +1926,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["66", " ", "min"],
                         "status": null
@@ -1909,7 +1965,8 @@
                   "headsign": "Malden via Square One Mall",
                   "times": [
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["62", " ", "min"],
                         "status": null
@@ -1918,7 +1975,8 @@
                       "delay": 0
                     },
                     {
-                      "prediction": {
+                      "prediction": { 
+                        "schedule_relationship": null,
                         "track": "1",
                         "time": ["arriving"],
                         "status": null

--- a/apps/site/assets/ts/tnm/helpers/process-realtime-data.ts
+++ b/apps/site/assets/ts/tnm/helpers/process-realtime-data.ts
@@ -121,7 +121,9 @@ const buildHeadsign = (
           ? {
               track: prediction.track,
               time: prediction.time,
-              status: null
+              status: null,
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              schedule_relationship: prediction.schedule_relationship
             }
           : null;
         const scheduledTime = schedule ? schedule.time : null;

--- a/apps/site/lib/site/transit_near_me.ex
+++ b/apps/site/lib/site/transit_near_me.ex
@@ -69,7 +69,8 @@ defmodule Site.TransitNearMe do
           required(:seconds) => integer,
           required(:time) => [String.t()],
           required(:status) => String.t() | nil,
-          required(:track) => String.t() | nil
+          required(:track) => String.t() | nil,
+          required(:schedule_relationship) => Prediction.schedule_relationship()
         }
 
   @default_opts [
@@ -633,7 +634,7 @@ defmodule Site.TransitNearMe do
     seconds = DateTime.diff(prediction.time, now)
 
     prediction
-    |> Map.take([:status, :track])
+    |> Map.take([:status, :track, :schedule_relationship])
     |> Map.put(:time, format_prediction_time(prediction.time, now, route_type, seconds))
     |> Map.put(:seconds, seconds)
   end

--- a/apps/site/test/site/transit_near_me_test.exs
+++ b/apps/site/test/site/transit_near_me_test.exs
@@ -743,7 +743,8 @@ defmodule Site.TransitNearMeTest do
                     seconds: 300,
                     status: nil,
                     time: ["5", " ", "min"],
-                    track: "2"
+                    track: "2",
+                    schedule_relationship: nil
                   },
                   scheduled_time: nil
                 },
@@ -765,7 +766,8 @@ defmodule Site.TransitNearMeTest do
                     seconds: 900,
                     status: nil,
                     time: ["15", " ", "min"],
-                    track: "2"
+                    track: "2",
+                    schedule_relationship: nil
                   },
                   scheduled_time: nil,
                   delay: 0


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🚍 Stops/Station/TNM | CR | Cross out skipped/cancelled stops](https://app.asana.com/0/385363666817452/1175248604991146/f)

* Adds `schedule_relationship` to the predictions used on stop pages and transit near me
* Shows predictions with `schedule_relationship` of skipped or canceled as "Canceled" with strikethrough
* Shows the absence of a prediction as "Scheduled" instead of "On time". 
* Adjusts the `$text-muted` color to use a darker gray to ensure good contrast.

Stops

![image](https://user-images.githubusercontent.com/2136286/87698058-f508bd80-c760-11ea-9840-43fae1128ea0.png)


Transit Near Me

![image](https://user-images.githubusercontent.com/2136286/87697996-e1f5ed80-c760-11ea-8490-d7a6d2a92763.png)


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
