### PR TITLE
Fix trip details for the generic Green line page

### DIFF
--- a/apps/site/assets/ts/helpers/css.ts
+++ b/apps/site/assets/ts/helpers/css.ts
@@ -1,7 +1,8 @@
 import {
-  isASilverLineRoute,
   isABusRoute,
-  isAGreenLineRoute
+  isACommuterRailRoute,
+  isAGreenLineRoute,
+  isASilverLineRoute
 } from "../models/route";
 import { Route } from "../__v3api";
 
@@ -12,7 +13,7 @@ export const busClass = (route: Route): string =>
   isABusRoute(route) && !isASilverLineRoute(route) ? "bus-route-sign" : "";
 
 export const routeToModeName = (route: Route): string => {
-  if (route.type === 2) return "commuter-rail";
+  if (isACommuterRailRoute(route)) return "commuter-rail";
   if (route.type === 4) return "ferry";
   if (route.id === "Red" || route.id === "Mattapan") return "red-line";
   if (route.id === "Orange") return "orange-line";

--- a/apps/site/assets/ts/models/__tests__/route-test.ts
+++ b/apps/site/assets/ts/models/__tests__/route-test.ts
@@ -1,5 +1,10 @@
 import { Route } from "../../__v3api";
-import { isABusRoute, isAGreenLineRoute, isASilverLineRoute } from "../route";
+import {
+  isABusRoute,
+  isACommuterRailRoute,
+  isAGreenLineRoute,
+  isASilverLineRoute
+} from "../route";
 
 describe("isABusRoute", () => {
   test("returns whether or not this is a bus route", () => {
@@ -14,6 +19,22 @@ describe("isABusRoute", () => {
 
     expect(isABusRoute(busRoute)).toBeTruthy();
     expect(isABusRoute(subwayRoute)).toBeFalsy();
+  });
+});
+
+describe("isACommuterRailRoute", () => {
+  test("returns whether or not this is a commuter rail route", () => {
+    const crRoutue: Route = {
+      id: "CR-Haverhill",
+      type: 2
+    } as Route;
+    const subwayRoute: Route = {
+      id: "Red",
+      type: 1
+    } as Route;
+
+    expect(isACommuterRailRoute(crRoutue)).toBeTruthy();
+    expect(isACommuterRailRoute(subwayRoute)).toBeFalsy();
   });
 });
 

--- a/apps/site/assets/ts/models/route.ts
+++ b/apps/site/assets/ts/models/route.ts
@@ -2,6 +2,8 @@ import { Route } from "../__v3api";
 
 export const isABusRoute = ({ type }: Route): boolean => type === 3;
 
+export const isACommuterRailRoute = ({ type }: Route): boolean => type === 2;
+
 export const isAGreenLineRoute = ({ id }: Route): boolean =>
   id.startsWith("Green");
 

--- a/apps/site/assets/ts/schedule/__tests__/TableRowTest.tsx
+++ b/apps/site/assets/ts/schedule/__tests__/TableRowTest.tsx
@@ -98,78 +98,78 @@ describe("TableRow", () => {
 
     expect(wrapper.find("td.schedule-table__cell").length).toBe(4);
   });
+});
 
-  describe("fetchJourney", () => {
-    it("fetches the selected journey", async () => {
-      window.fetch = jest.fn().mockImplementation(
-        () =>
-          new Promise((resolve: Function) =>
-            resolve({
-              json: () => ({
-                vehicle_stop_name: "",
-                vehicle: null,
-                times: [],
-                stop_count: 1,
-                status: "",
-                origin_id: "",
-                fare: {},
-                duration: 1,
-                destination_id: ""
-              }),
-              ok: true,
-              status: 200,
-              statusText: "OK"
-            })
-          )
-      );
+describe("fetchJourney", () => {
+  it("fetches the selected journey", async () => {
+    window.fetch = jest.fn().mockImplementation(
+      () =>
+        new Promise((resolve: Function) =>
+          resolve({
+            json: () => ({
+              vehicle_stop_name: "",
+              vehicle: null,
+              times: [],
+              stop_count: 1,
+              status: "",
+              origin_id: "",
+              fare: {},
+              duration: 1,
+              destination_id: ""
+            }),
+            ok: true,
+            status: 200,
+            statusText: "OK"
+          })
+        )
+    );
 
-      const dispatchSpy = jest.fn();
+    const dispatchSpy = jest.fn();
 
-      await await fetchJourney(journey.trip.id, input, dispatchSpy);
+    await await fetchJourney(journey.trip.id, input, dispatchSpy);
 
-      expect(window.fetch).toHaveBeenCalledWith(
-        "/schedules/finder_api/trip?id=CR-Weekday-Fall-19-801&route=CR-Providence&date=2019-11-26&direction=0&stop=place-sstat"
-      );
+    expect(window.fetch).toHaveBeenCalledWith(
+      "/schedules/finder_api/trip?id=CR-Weekday-Fall-19-801&route=CR-Providence&date=2019-11-26&direction=0&stop=place-sstat"
+    );
 
-      expect(dispatchSpy).toHaveBeenCalledTimes(2);
-      expect(dispatchSpy).toHaveBeenCalledWith({
-        type: "FETCH_STARTED"
-      });
-      expect(dispatchSpy).toHaveBeenCalledWith({
-        payload: {
-          destination_id: "",
-          duration: 1,
-          fare: {},
-          origin_id: "",
-          status: "",
-          stop_count: 1,
-          times: [],
-          vehicle: null,
-          vehicle_stop_name: ""
-        },
-        type: "FETCH_COMPLETE"
-      });
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: "FETCH_STARTED"
     });
-
-    it("throws an error if the fetch fails", async () => {
-      window.fetch = jest.fn().mockImplementation(
-        () =>
-          new Promise((resolve: Function) =>
-            resolve({
-              ok: false,
-              status: 500,
-              statusText: "you broke it"
-            })
-          )
-      );
-
-      const dispatchSpy = jest.fn();
-
-      await await fetchJourney(journey.trip.id, input, dispatchSpy);
-
-      expect(dispatchSpy).toHaveBeenCalledTimes(2);
-      expect(dispatchSpy).toHaveBeenCalledWith({ type: "FETCH_STARTED" });
-      expect(dispatchSpy).toHaveBeenCalledWith({ type: "FETCH_ERROR" });
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      payload: {
+        destination_id: "",
+        duration: 1,
+        fare: {},
+        origin_id: "",
+        status: "",
+        stop_count: 1,
+        times: [],
+        vehicle: null,
+        vehicle_stop_name: ""
+      },
+      type: "FETCH_COMPLETE"
     });
+  });
+
+  it("throws an error if the fetch fails", async () => {
+    window.fetch = jest.fn().mockImplementation(
+      () =>
+        new Promise((resolve: Function) =>
+          resolve({
+            ok: false,
+            status: 500,
+            statusText: "you broke it"
+          })
+        )
+    );
+
+    const dispatchSpy = jest.fn();
+
+    await await fetchJourney(journey.trip.id, input, dispatchSpy);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchSpy).toHaveBeenCalledWith({ type: "FETCH_STARTED" });
+    expect(dispatchSpy).toHaveBeenCalledWith({ type: "FETCH_ERROR" });
   });
 });

--- a/apps/site/assets/ts/schedule/components/line-diagram/SingleStop.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/SingleStop.tsx
@@ -7,7 +7,11 @@ import {
   parkingIcon,
   accessibleIcon
 } from "../../../helpers/icon";
-import { isABusRoute, isAGreenLineRoute } from "../../../models/route";
+import {
+  isABusRoute,
+  isACommuterRailRoute,
+  isAGreenLineRoute
+} from "../../../models/route";
 import { Alert, Route } from "../../../__v3api";
 import { LiveData } from "./LineDiagram";
 import StopPredictions from "./StopPredictions";
@@ -126,11 +130,13 @@ const StopFeatures = (routeStop: RouteStop): JSX.Element => (
         )}
       </TooltipWrapper>
     ) : null}
-    {routeStop.zone && routeStop.route && routeStop.route.type === 2 && (
-      <span className="c-icon__cr-zone m-schedule-diagram__feature-icon">{`Zone ${
-        routeStop.zone
-      }`}</span>
-    )}
+    {routeStop.zone &&
+      routeStop.route &&
+      isACommuterRailRoute(routeStop.route) && (
+        <span className="c-icon__cr-zone m-schedule-diagram__feature-icon">{`Zone ${
+          routeStop.zone
+        }`}</span>
+      )}
   </div>
 );
 
@@ -140,7 +146,7 @@ const StopBranchLabel = (stop: RouteStop): JSX.Element | null =>
       {isAGreenLineRoute(stop.route)
         ? `Green Line ${stop.route.id.split("-")[1]}`
         : stop.name}
-      {stop.route.type === 2 ? " Line" : " Branch"}
+      {isACommuterRailRoute(stop.route) ? " Line" : " Branch"}
     </div>
   ) : null;
 
@@ -249,7 +255,9 @@ const SingleStop = ({
           {!isDestination && liveData && (
             <StopPredictions
               headsigns={liveData.headsigns}
-              isCommuterRail={!!routeStop.route && routeStop.route.type === 2}
+              isCommuterRail={
+                !!routeStop.route && isACommuterRailRoute(routeStop.route)
+              }
             />
           )}
         </div>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/AccordionRow.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/AccordionRow.tsx
@@ -1,8 +1,9 @@
 import React, { ReactElement } from "react";
 import { caret } from "../../../helpers/icon";
-import { State, TripDetails } from "./TripDetails";
 import { handleReactEnterKeyPress } from "../../../helpers/keyboard-events";
+import { isACommuterRailRoute } from "../../../models/route";
 import { Journey, EnhancedJourney } from "../__trips";
+import { State, TripDetails } from "./TripDetails";
 
 interface Props {
   state: State;
@@ -20,6 +21,7 @@ const AccordionRow = ({
   toggle
 }: Props): ReactElement<HTMLElement> => {
   const tripId = journey.trip.id;
+  const isCommuterRail = isACommuterRailRoute(journey.route);
 
   return (
     <>
@@ -44,10 +46,10 @@ const AccordionRow = ({
       {expanded && (
         <tr id={`trip-${tripId}-expanded`}>
           <td
-            colSpan={journey.route.type === 2 ? 4 : 3}
+            colSpan={isCommuterRail ? 4 : 3}
             className="schedule-table__cell schedule-table__cell--expanded"
           >
-            <TripDetails state={state} showFare={journey.route.type === 2} />
+            <TripDetails state={state} showFare={isCommuterRail} />
           </td>
         </tr>
       )}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleTable.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleTable.tsx
@@ -1,8 +1,9 @@
 import React, { ReactElement } from "react";
+import { isACommuterRailRoute } from "../../../models/route";
+import { UserInput } from "../../components/__schedule";
 import { EnhancedRoutePattern } from "../__schedule";
 import { Journey } from "../__trips";
 import TableRow from "./TableRow";
-import { UserInput } from "../../components/__schedule";
 
 interface Props {
   journeys: Journey[];
@@ -78,7 +79,7 @@ const ScheduleTable = ({
             <th scope="col" className="schedule-table__cell">
               Departs
             </th>
-            {firstTrip.route.type === 2 && (
+            {isACommuterRailRoute(firstTrip.route) && (
               <th scope="col" className="schedule-table__cell">
                 Train
               </th>

--- a/apps/site/assets/ts/tnm/__tests__/RoutesSidebarTest.tsx
+++ b/apps/site/assets/ts/tnm/__tests__/RoutesSidebarTest.tsx
@@ -5,7 +5,7 @@ import { createReactRoot } from "../../app/helpers/testUtils";
 import { importData, importRealtimeResponse } from "./helpers/testUtils";
 import { RouteWithStopsWithDirections } from "../../__v3api";
 import { transformRoutes } from "../helpers/process-realtime-data";
-import { isABusRoute } from "../../models/route";
+import { isABusRoute, isACommuterRailRoute } from "../../models/route";
 
 const realtimeData = importRealtimeResponse();
 const stopsWithDistances = importData();
@@ -219,8 +219,8 @@ describe("filterData", () => {
     );
     expect(filteredRailData).toHaveLength(1);
     expect(
-      filteredRailData.every(
-        (route: RouteWithStopsWithDirections) => route.route.type === 2
+      filteredRailData.every((route: RouteWithStopsWithDirections) =>
+        isACommuterRailRoute(route.route)
       )
     ).toEqual(true);
 

--- a/apps/site/lib/site_web/controllers/schedule/finder_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/finder_api.ex
@@ -100,7 +100,11 @@ defmodule SiteWeb.ScheduleController.FinderApi do
       }) do
     {service_end_date, direction_id, _} = convert_from_string(date: date, direction: direction)
 
-    route = Routes.Repo.get(route_id)
+    route =
+      route_id
+      |> get_route_id(trip_id)
+      |> Routes.Repo.get()
+
     opts = Map.get(conn.assigns, :trip_info_functions, [])
     params = %{"origin" => origin, "trip" => trip_id}
 
@@ -445,4 +449,16 @@ defmodule SiteWeb.ScheduleController.FinderApi do
   @spec maybe_remove_prediction_stop(map | nil) :: map | nil
   defp maybe_remove_prediction_stop(nil), do: nil
   defp maybe_remove_prediction_stop(p), do: Map.put(p, :stop, nil)
+
+  @spec get_route_id(Route.id_t(), Trip.id_t()) :: Route.id_t()
+  defp get_route_id("Green", trip_id) do
+    schedule =
+      trip_id
+      |> Schedules.Repo.schedule_for_trip()
+      |> List.first()
+
+    schedule.route.id
+  end
+
+  defp get_route_id(route_id, _trip_id), do: route_id
 end

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -208,6 +208,21 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
       |> json_response(200)
     end
 
+    test "handles green line trips from the generic Green page", %{conn: conn} do
+      params = %{
+        id: "Green",
+        direction: "0",
+        stop: "place-north"
+      }
+
+      params_for_trip = get_valid_trip_params(params, conn)
+      trip_path = finder_api_path(conn, :trip, params_for_trip)
+
+      conn
+      |> get(trip_path)
+      |> json_response(200)
+    end
+
     test "only shows times starting at selected origin onward - outbound", %{conn: conn} do
       origin_stop = "place-sstat"
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Error loading trip details on Green Line page](https://app.asana.com/0/555089885850811/1185053800103665)

Fix trip details for the generic Green line page

![Screen Shot 2020-07-17 at 11 52 57](https://user-images.githubusercontent.com/42339/87806471-f13e6f00-c824-11ea-9293-f7ef7454e0f2.png)

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
