### PR TITLE
Hide monthly pass sections for free Logan trips

### DIFF
--- a/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
@@ -66,7 +66,7 @@
 </div>
 
 
-<%= if @show_monthly_passes? do %>
+<%= if show_monthly_passes?(@itinerary) do %>
   <div class="m-trip-plan-farecalc__table">
     <div class="m-trip-plan-farecalc__table-cell m-trip-plan-farecalc__subheader">
       Monthly Passes

--- a/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
@@ -66,25 +66,27 @@
 </div>
 
 
-<div class="m-trip-plan-farecalc__table">
-  <div class="m-trip-plan-farecalc__table-cell m-trip-plan-farecalc__subheader">
-    Monthly Passes
-  </div>
-  <div class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">
-    Base
-  </div>
-  <div class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">
-    Reduced
-  </div>
-  <div class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">
-    Valid On
-  </div>
+<%= if @show_monthly_passes? do %>
+  <div class="m-trip-plan-farecalc__table">
+    <div class="m-trip-plan-farecalc__table-cell m-trip-plan-farecalc__subheader">
+      Monthly Passes
+    </div>
+    <div class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">
+      Base
+    </div>
+    <div class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">
+      Reduced
+    </div>
+    <div class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">
+      Valid On
+    </div>
 
-  <%= for pass <- Enum.uniq([@itinerary.passes.base_month_pass, @itinerary.passes.recommended_month_pass]) do %>
-    <%= render "_monthly_pass_row.html", pass: pass, reduced: @itinerary.passes.reduced_month_pass %>
-  <% end %>
+    <%= for pass <- Enum.uniq([@itinerary.passes.base_month_pass, @itinerary.passes.recommended_month_pass]) do %>
+      <%= render "_monthly_pass_row.html", pass: pass, reduced: @itinerary.passes.reduced_month_pass %>
+    <% end %>
+  </div>
+<% end %>
 
-</div>
 <div class="m-trip-plan-farecalc__notes-block">
   <span class="m-trip-plan-farecalc__title">Reduced fares:</span> Some riders are eligible for <%= link "reduced fares", to: fare_path(@conn, :show, "reduced") %>. Military personnel and children 11 and under ride for free.
 </div>

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
@@ -2,5 +2,8 @@
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--one-way"><%= @one_way_total %> one way</div>
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--round-trip"><%= @round_trip_total %> round trip</div>
 <div class="m-trip-plan-results__itinerary-note"><%= transfer_note(@itinerary) %></div>
-<div class="m-trip-plan-results__itinerary-fare-title">Monthly Pass</div>
-<div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--month"><%= monthly_pass(@itinerary.passes.base_month_pass) %></div>
+
+<%= if @show_monthly_passes? do %>
+  <div class="m-trip-plan-results__itinerary-fare-title">Monthly Pass</div>
+  <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--month"><%= monthly_pass(@itinerary.passes.base_month_pass) %></div>
+<% end %>

--- a/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_itinerary_fares.html.eex
@@ -3,7 +3,7 @@
 <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--round-trip"><%= @round_trip_total %> round trip</div>
 <div class="m-trip-plan-results__itinerary-note"><%= transfer_note(@itinerary) %></div>
 
-<%= if @show_monthly_passes? do %>
+<%= if show_monthly_passes?(@itinerary) do %>
   <div class="m-trip-plan-results__itinerary-fare-title">Monthly Pass</div>
   <div class="m-trip-plan-results__itinerary-fare m-trip-plan-results__itinerary-fare--month"><%= monthly_pass(@itinerary.passes.base_month_pass) %></div>
 <% end %>

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -599,15 +599,12 @@ defmodule SiteWeb.TripPlanView do
 
       one_way_total_fare = get_one_way_total_by_type(i, :highest_one_way_fare)
 
-      show_monthly_passes? = show_monthly_passes?(i)
-
       fares_estimate_html =
         "_itinerary_fares.html"
         |> render_to_string(
           itinerary: i,
           one_way_total: Format.price(one_way_total_fare),
-          round_trip_total: Format.price(one_way_total_fare * 2),
-          show_monthly_passes?: show_monthly_passes?
+          round_trip_total: Format.price(one_way_total_fare * 2)
         )
 
       fares = get_calculated_fares(i)
@@ -617,8 +614,7 @@ defmodule SiteWeb.TripPlanView do
         |> render_to_string(
           itinerary: i,
           fares: fares,
-          conn: conn,
-          show_monthly_passes?: show_monthly_passes?
+          conn: conn
         )
 
       html =
@@ -797,7 +793,6 @@ defmodule SiteWeb.TripPlanView do
   end
 
   # Hide monthly pass sections in the case of a Silver Line trip with no transfers from Logain Airport.
-  # Public solely for testing.
   @spec show_monthly_passes?(Itinerary.t()) :: boolean()
   def show_monthly_passes?(itinerary), do: !sl_only_trip_from_airport?(itinerary)
 

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -803,11 +803,20 @@ defmodule SiteWeb.TripPlanView do
 
   @spec sl_only_trip_from_airport?(Itinerary.t()) :: boolean()
   defp sl_only_trip_from_airport?(itinerary) do
-    transit_legs = Itinerary.transit_legs(itinerary)
-    first_leg = List.first(transit_legs)
-    route_id = first_leg.mode.route_id
-    from_stop_id = first_leg.from.stop_id
-
-    length(transit_legs) == 1 && Fares.silver_line_airport_stop?(route_id, from_stop_id)
+    itinerary
+    |> Itinerary.transit_legs()
+    |> sl_only_legs_from_airport?()
   end
+
+  @spec sl_only_legs_from_airport?([Leg.t()]) :: boolean()
+  defp sl_only_legs_from_airport?([]), do: false
+
+  defp sl_only_legs_from_airport?([leg]) do
+    route_id = leg.mode.route_id
+    from_stop_id = leg.from.stop_id
+
+    Fares.silver_line_airport_stop?(route_id, from_stop_id)
+  end
+
+  defp sl_only_legs_from_airport?(_), do: false
 end

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -730,7 +730,8 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         }
       },
       one_way_total: "$2.90",
-      round_trip_total: "$5.80"
+      round_trip_total: "$5.80",
+      show_monthly_passes?: true
     }
 
     @itinerary %TripPlan.Itinerary{
@@ -1364,7 +1365,8 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         |> render_to_string(
           itinerary: @itinerary,
           fares: get_calculated_fares(@itinerary),
-          conn: conn
+          conn: conn,
+          show_monthly_passes?: true
         )
 
       fare_calc_tables = Floki.find(html, ".m-trip-plan-farecalc__table")
@@ -1386,7 +1388,8 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         |> render_to_string(
           itinerary: itinerary_with_transfers,
           fares: get_calculated_fares(@itinerary),
-          conn: conn
+          conn: conn,
+          show_monthly_passes?: true
         )
 
       titles = Floki.find(html_with_transfer_note, ".m-trip-plan-farecalc__title")
@@ -1433,6 +1436,112 @@ closest arrival to 12:00 AM, Thursday, January 1st."
 
     test "accepts nil" do
       assert monthly_pass(nil) == "Shuttle: None"
+    end
+  end
+
+  describe "show_monthly_passes?/1" do
+    test "returns false if the itinerary contains a single transit leg that's specifically a Silver Line trip from the airport" do
+      sl_from_logan_itinerary = %Itinerary{
+        accessible?: true,
+        legs: [
+          %Leg{
+            description: "WALK",
+            from: %NamedPosition{
+              latitude: 42.365396,
+              longitude: -71.017547,
+              name: "Boston Logan Airport"
+            },
+            mode: %TripPlan.PersonalDetail{
+              distance: 510.20700000000005,
+              steps: [
+                %TripPlan.PersonalDetail.Step{
+                  absolute_direction: :southwest,
+                  distance: 456.485,
+                  relative_direction: :depart,
+                  street_name: "footbridge"
+                },
+                %TripPlan.PersonalDetail.Step{
+                  absolute_direction: :west,
+                  distance: 44.900999999999996,
+                  relative_direction: :hard_left,
+                  street_name: "path"
+                },
+                %TripPlan.PersonalDetail.Step{
+                  absolute_direction: :south,
+                  distance: 8.821,
+                  relative_direction: :left,
+                  street_name: "service road"
+                }
+              ]
+            },
+            name: "",
+            to: %NamedPosition{
+              latitude: 42.366494,
+              longitude: -71.017289,
+              name: "Terminal C - Arrivals Level",
+              stop_id: "17094"
+            },
+            type: nil,
+            url: nil
+          },
+          %Leg{
+            description: "BUS",
+            from: %NamedPosition{
+              latitude: 42.366494,
+              longitude: -71.017289,
+              name: "Terminal C - Arrivals Level",
+              stop_id: "17094"
+            },
+            long_name: "Logan Airport Terminals - South Station",
+            mode: %TransitDetail{
+              fares: %{
+                highest_one_way_fare: %Fare{
+                  additional_valid_modes: [],
+                  cents: 0,
+                  duration: :single_trip,
+                  media: [],
+                  mode: :bus,
+                  name: :free_fare,
+                  price_label: nil,
+                  reduced: nil
+                },
+                lowest_one_way_fare: %Fare{
+                  additional_valid_modes: [],
+                  cents: 0,
+                  duration: :single_trip,
+                  media: [],
+                  mode: :bus,
+                  name: :free_fare,
+                  price_label: nil,
+                  reduced: nil
+                },
+                reduced_one_way_fare: nil
+              },
+              intermediate_stop_ids: ["17095", "17096", "74614", "74615", "74616"],
+              route_id: "741",
+              trip_id: "44812182"
+            },
+            name: "SL1",
+            to: %NamedPosition{
+              latitude: 42.352271,
+              longitude: -71.055242,
+              name: "South Station",
+              stop_id: "74617"
+            },
+            type: "1",
+            url: "http://www.mbta.com"
+          }
+        ],
+        passes: %{
+          base_month_pass: nil,
+          recommended_month_pass: nil,
+          reduced_month_pass: nil
+        },
+        start: DateTime.now!("Etc/UTC"),
+        stop: DateTime.now!("Etc/UTC")
+      }
+
+      refute show_monthly_passes?(sl_from_logan_itinerary)
     end
   end
 end

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -1439,101 +1439,30 @@ closest arrival to 12:00 AM, Thursday, January 1st."
   describe "show_monthly_passes?/1" do
     test "returns false if the itinerary contains a single transit leg that's specifically a Silver Line trip from the airport" do
       sl_from_logan_itinerary = %Itinerary{
-        accessible?: true,
         legs: [
           %Leg{
             description: "WALK",
-            from: %NamedPosition{
-              latitude: 42.365396,
-              longitude: -71.017547,
-              name: "Boston Logan Airport"
-            },
             mode: %TripPlan.PersonalDetail{
-              distance: 510.20700000000005,
-              steps: [
-                %TripPlan.PersonalDetail.Step{
-                  absolute_direction: :southwest,
-                  distance: 456.485,
-                  relative_direction: :depart,
-                  street_name: "footbridge"
-                },
-                %TripPlan.PersonalDetail.Step{
-                  absolute_direction: :west,
-                  distance: 44.900999999999996,
-                  relative_direction: :hard_left,
-                  street_name: "path"
-                },
-                %TripPlan.PersonalDetail.Step{
-                  absolute_direction: :south,
-                  distance: 8.821,
-                  relative_direction: :left,
-                  street_name: "service road"
-                }
-              ]
-            },
-            name: "",
-            to: %NamedPosition{
-              latitude: 42.366494,
-              longitude: -71.017289,
-              name: "Terminal C - Arrivals Level",
-              stop_id: "17094"
-            },
-            type: nil,
-            url: nil
+              distance: 510.2
+            }
           },
           %Leg{
             description: "BUS",
             from: %NamedPosition{
-              latitude: 42.366494,
-              longitude: -71.017289,
               name: "Terminal C - Arrivals Level",
               stop_id: "17094"
             },
-            long_name: "Logan Airport Terminals - South Station",
             mode: %TransitDetail{
-              fares: %{
-                highest_one_way_fare: %Fare{
-                  additional_valid_modes: [],
-                  cents: 0,
-                  duration: :single_trip,
-                  media: [],
-                  mode: :bus,
-                  name: :free_fare,
-                  price_label: nil,
-                  reduced: nil
-                },
-                lowest_one_way_fare: %Fare{
-                  additional_valid_modes: [],
-                  cents: 0,
-                  duration: :single_trip,
-                  media: [],
-                  mode: :bus,
-                  name: :free_fare,
-                  price_label: nil,
-                  reduced: nil
-                },
-                reduced_one_way_fare: nil
-              },
-              intermediate_stop_ids: ["17095", "17096", "74614", "74615", "74616"],
-              route_id: "741",
-              trip_id: "44812182"
+              route_id: "741"
             },
             name: "SL1",
             to: %NamedPosition{
-              latitude: 42.352271,
-              longitude: -71.055242,
               name: "South Station",
               stop_id: "74617"
             },
-            type: "1",
-            url: "http://www.mbta.com"
+            type: "1"
           }
         ],
-        passes: %{
-          base_month_pass: nil,
-          recommended_month_pass: nil,
-          reduced_month_pass: nil
-        },
         start: DateTime.from_unix!(0),
         stop: DateTime.from_unix!(0)
       }
@@ -1543,219 +1472,53 @@ closest arrival to 12:00 AM, Thursday, January 1st."
 
     test "returns true for all other itineraries" do
       login_sl_plus_subway_itinerary = %TripPlan.Itinerary{
-        accessible?: false,
         legs: [
           %TripPlan.Leg{
             description: "WALK",
-            from: %TripPlan.NamedPosition{
-              latitude: 42.365396,
-              longitude: -71.017547,
-              name: "Boston Logan Airport",
-              stop_id: nil
-            },
-            long_name: nil,
             mode: %TripPlan.PersonalDetail{
-              distance: 385.75800000000004,
-              steps: [
-                %TripPlan.PersonalDetail.Step{
-                  absolute_direction: :southwest,
-                  distance: 382.50800000000004,
-                  relative_direction: :depart,
-                  street_name: "footbridge"
-                },
-                %TripPlan.PersonalDetail.Step{
-                  absolute_direction: :northwest,
-                  distance: 3.25,
-                  relative_direction: :left,
-                  street_name: "service road"
-                }
-              ]
-            },
-            name: "",
-            to: %TripPlan.NamedPosition{
-              latitude: 42.364612,
-              longitude: -71.020862,
-              name: "Terminal A",
-              stop_id: "17091"
-            },
-            type: nil,
-            url: nil
+              distance: 385.75800000000004
+            }
           },
           %TripPlan.Leg{
             description: "BUS",
             from: %TripPlan.NamedPosition{
-              latitude: 42.364612,
-              longitude: -71.020862,
               name: "Terminal A",
               stop_id: "17091"
             },
-            long_name: "Logan Airport Terminals - South Station",
             mode: %TripPlan.TransitDetail{
-              fares: %{
-                highest_one_way_fare: %Fares.Fare{
-                  additional_valid_modes: [],
-                  cents: 0,
-                  duration: :single_trip,
-                  media: [],
-                  mode: :bus,
-                  name: :free_fare,
-                  price_label: nil,
-                  reduced: nil
-                },
-                lowest_one_way_fare: %Fares.Fare{
-                  additional_valid_modes: [],
-                  cents: 0,
-                  duration: :single_trip,
-                  media: [],
-                  mode: :bus,
-                  name: :free_fare,
-                  price_label: nil,
-                  reduced: nil
-                },
-                reduced_one_way_fare: nil
-              },
-              intermediate_stop_ids: [
-                "27092",
-                "17093",
-                "17094",
-                "17095",
-                "17096",
-                "74614",
-                "74615",
-                "74616"
-              ],
-              route_id: "741",
-              trip_id: "44812260"
+              route_id: "741"
             },
             name: "SL1",
             to: %TripPlan.NamedPosition{
-              latitude: 42.352271,
-              longitude: -71.055242,
               name: "South Station",
               stop_id: "74617"
             },
-            type: "1",
-            url: "http://www.mbta.com"
+            type: "1"
           },
           %TripPlan.Leg{
             description: "WALK",
-            from: %TripPlan.NamedPosition{
-              latitude: 42.352271,
-              longitude: -71.055242,
-              name: "South Station",
-              stop_id: "74617"
-            },
-            long_name: nil,
             mode: %TripPlan.PersonalDetail{
-              distance: 0.0,
-              steps: [
-                %TripPlan.PersonalDetail.Step{
-                  absolute_direction: :south,
-                  distance: 0.0,
-                  relative_direction: :depart,
-                  street_name: "Transfer"
-                }
-              ]
+              distance: 0.0
             },
-            name: "",
-            to: %TripPlan.NamedPosition{
-              latitude: 42.352271,
-              longitude: -71.055242,
-              name: "South Station",
-              stop_id: "70080"
-            },
-            type: nil,
-            url: nil
+            name: ""
           },
           %TripPlan.Leg{
             description: "SUBWAY",
             from: %TripPlan.NamedPosition{
-              latitude: 42.352271,
-              longitude: -71.055242,
               name: "South Station",
               stop_id: "70080"
             },
-            long_name: "Red Line",
             mode: %TripPlan.TransitDetail{
-              fares: %{
-                highest_one_way_fare: %Fares.Fare{
-                  additional_valid_modes: [:bus],
-                  cents: 290,
-                  duration: :single_trip,
-                  media: [:charlie_ticket, :cash],
-                  mode: :subway,
-                  name: :subway,
-                  price_label: nil,
-                  reduced: nil
-                },
-                lowest_one_way_fare: %Fares.Fare{
-                  additional_valid_modes: [:bus],
-                  cents: 240,
-                  duration: :single_trip,
-                  media: [:charlie_card],
-                  mode: :subway,
-                  name: :subway,
-                  price_label: nil,
-                  reduced: nil
-                },
-                reduced_one_way_fare: %Fares.Fare{
-                  additional_valid_modes: [],
-                  cents: 110,
-                  duration: :single_trip,
-                  media: [:senior_card],
-                  mode: :subway,
-                  name: :subway,
-                  price_label: nil,
-                  reduced: :senior_disabled
-                }
-              },
-              intermediate_stop_ids: [],
-              route_id: "Red",
-              trip_id: "44080180-20:45-BraintreeQuincyCenterExtended"
+              route_id: "Red"
             },
             name: "Red Line",
             to: %TripPlan.NamedPosition{
-              latitude: 42.355518,
-              longitude: -71.060225,
               name: "Downtown Crossing",
               stop_id: "70078"
             },
-            type: "1",
-            url: "http://www.mbta.com"
+            type: "1"
           }
         ],
-        passes: %{
-          base_month_pass: %Fares.Fare{
-            additional_valid_modes: [:bus],
-            cents: 9000,
-            duration: :month,
-            media: [:charlie_card, :charlie_ticket],
-            mode: :subway,
-            name: :subway,
-            price_label: nil,
-            reduced: nil
-          },
-          recommended_month_pass: %Fares.Fare{
-            additional_valid_modes: [:bus],
-            cents: 9000,
-            duration: :month,
-            media: [:charlie_card, :charlie_ticket],
-            mode: :subway,
-            name: :subway,
-            price_label: nil,
-            reduced: nil
-          },
-          reduced_month_pass: %Fares.Fare{
-            additional_valid_modes: [:bus],
-            cents: 3000,
-            duration: :month,
-            media: [:senior_card, :student_card],
-            mode: :subway,
-            name: :subway,
-            price_label: nil,
-            reduced: :any
-          }
-        },
         start: DateTime.from_unix!(0),
         stop: DateTime.from_unix!(0)
       }
@@ -1765,107 +1528,20 @@ closest arrival to 12:00 AM, Thursday, January 1st."
 
     test "returns true for an itinerary without any transit legs" do
       no_transit_legs_itinerary = %TripPlan.Itinerary{
-        accessible?: false,
         legs: [
           %TripPlan.Leg{
             description: "WALK",
-            from: %TripPlan.NamedPosition{
-              latitude: 42.365396,
-              longitude: -71.017547,
-              name: "Boston Logan Airport",
-              stop_id: nil
-            },
-            long_name: nil,
             mode: %TripPlan.PersonalDetail{
-              distance: 385.75800000000004,
-              steps: [
-                %TripPlan.PersonalDetail.Step{
-                  absolute_direction: :southwest,
-                  distance: 382.50800000000004,
-                  relative_direction: :depart,
-                  street_name: "footbridge"
-                },
-                %TripPlan.PersonalDetail.Step{
-                  absolute_direction: :northwest,
-                  distance: 3.25,
-                  relative_direction: :left,
-                  street_name: "service road"
-                }
-              ]
-            },
-            name: "",
-            to: %TripPlan.NamedPosition{
-              latitude: 42.364612,
-              longitude: -71.020862,
-              name: "Terminal A",
-              stop_id: "17091"
-            },
-            type: nil,
-            url: nil
+              distance: 385.75800000000004
+            }
           },
           %TripPlan.Leg{
             description: "WALK",
-            from: %TripPlan.NamedPosition{
-              latitude: 42.352271,
-              longitude: -71.055242,
-              name: "South Station",
-              stop_id: "74617"
-            },
-            long_name: nil,
             mode: %TripPlan.PersonalDetail{
-              distance: 0.0,
-              steps: [
-                %TripPlan.PersonalDetail.Step{
-                  absolute_direction: :south,
-                  distance: 0.0,
-                  relative_direction: :depart,
-                  street_name: "Transfer"
-                }
-              ]
-            },
-            name: "",
-            to: %TripPlan.NamedPosition{
-              latitude: 42.352271,
-              longitude: -71.055242,
-              name: "South Station",
-              stop_id: "70080"
-            },
-            type: nil,
-            url: nil
+              distance: 0.0
+            }
           }
         ],
-        passes: %{
-          base_month_pass: %Fares.Fare{
-            additional_valid_modes: [:bus],
-            cents: 9000,
-            duration: :month,
-            media: [:charlie_card, :charlie_ticket],
-            mode: :subway,
-            name: :subway,
-            price_label: nil,
-            reduced: nil
-          },
-          recommended_month_pass: %Fares.Fare{
-            additional_valid_modes: [:bus],
-            cents: 9000,
-            duration: :month,
-            media: [:charlie_card, :charlie_ticket],
-            mode: :subway,
-            name: :subway,
-            price_label: nil,
-            reduced: nil
-          },
-          reduced_month_pass: %Fares.Fare{
-            additional_valid_modes: [:bus],
-            cents: 3000,
-            duration: :month,
-            media: [:senior_card, :student_card],
-            mode: :subway,
-            name: :subway,
-            price_label: nil,
-            reduced: :any
-          }
-        },
         start: DateTime.from_unix!(0),
         stop: DateTime.from_unix!(0)
       }

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -1534,8 +1534,8 @@ closest arrival to 12:00 AM, Thursday, January 1st."
           recommended_month_pass: nil,
           reduced_month_pass: nil
         },
-        start: DateTime.now!("Etc/UTC"),
-        stop: DateTime.now!("Etc/UTC")
+        start: DateTime.from_unix!(0),
+        stop: DateTime.from_unix!(0)
       }
 
       refute show_monthly_passes?(sl_from_logan_itinerary)
@@ -1756,8 +1756,8 @@ closest arrival to 12:00 AM, Thursday, January 1st."
             reduced: :any
           }
         },
-        start: DateTime.now!("Etc/UTC"),
-        stop: DateTime.now!("Etc/UTC")
+        start: DateTime.from_unix!(0),
+        stop: DateTime.from_unix!(0)
       }
 
       assert show_monthly_passes?(login_sl_plus_subway_itinerary)
@@ -1866,8 +1866,8 @@ closest arrival to 12:00 AM, Thursday, January 1st."
             reduced: :any
           }
         },
-        start: DateTime.now!("Etc/UTC"),
-        stop: DateTime.now!("Etc/UTC")
+        start: DateTime.from_unix!(0),
+        stop: DateTime.from_unix!(0)
       }
 
       assert show_monthly_passes?(no_transit_legs_itinerary)

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -1543,5 +1543,337 @@ closest arrival to 12:00 AM, Thursday, January 1st."
 
       refute show_monthly_passes?(sl_from_logan_itinerary)
     end
+
+    test "returns true for all other itineraries" do
+      login_sl_plus_subway_itinerary = %TripPlan.Itinerary{
+        accessible?: false,
+        legs: [
+          %TripPlan.Leg{
+            description: "WALK",
+            from: %TripPlan.NamedPosition{
+              latitude: 42.365396,
+              longitude: -71.017547,
+              name: "Boston Logan Airport",
+              stop_id: nil
+            },
+            long_name: nil,
+            mode: %TripPlan.PersonalDetail{
+              distance: 385.75800000000004,
+              steps: [
+                %TripPlan.PersonalDetail.Step{
+                  absolute_direction: :southwest,
+                  distance: 382.50800000000004,
+                  relative_direction: :depart,
+                  street_name: "footbridge"
+                },
+                %TripPlan.PersonalDetail.Step{
+                  absolute_direction: :northwest,
+                  distance: 3.25,
+                  relative_direction: :left,
+                  street_name: "service road"
+                }
+              ]
+            },
+            name: "",
+            to: %TripPlan.NamedPosition{
+              latitude: 42.364612,
+              longitude: -71.020862,
+              name: "Terminal A",
+              stop_id: "17091"
+            },
+            type: nil,
+            url: nil
+          },
+          %TripPlan.Leg{
+            description: "BUS",
+            from: %TripPlan.NamedPosition{
+              latitude: 42.364612,
+              longitude: -71.020862,
+              name: "Terminal A",
+              stop_id: "17091"
+            },
+            long_name: "Logan Airport Terminals - South Station",
+            mode: %TripPlan.TransitDetail{
+              fares: %{
+                highest_one_way_fare: %Fares.Fare{
+                  additional_valid_modes: [],
+                  cents: 0,
+                  duration: :single_trip,
+                  media: [],
+                  mode: :bus,
+                  name: :free_fare,
+                  price_label: nil,
+                  reduced: nil
+                },
+                lowest_one_way_fare: %Fares.Fare{
+                  additional_valid_modes: [],
+                  cents: 0,
+                  duration: :single_trip,
+                  media: [],
+                  mode: :bus,
+                  name: :free_fare,
+                  price_label: nil,
+                  reduced: nil
+                },
+                reduced_one_way_fare: nil
+              },
+              intermediate_stop_ids: [
+                "27092",
+                "17093",
+                "17094",
+                "17095",
+                "17096",
+                "74614",
+                "74615",
+                "74616"
+              ],
+              route_id: "741",
+              trip_id: "44812260"
+            },
+            name: "SL1",
+            to: %TripPlan.NamedPosition{
+              latitude: 42.352271,
+              longitude: -71.055242,
+              name: "South Station",
+              stop_id: "74617"
+            },
+            type: "1",
+            url: "http://www.mbta.com"
+          },
+          %TripPlan.Leg{
+            description: "WALK",
+            from: %TripPlan.NamedPosition{
+              latitude: 42.352271,
+              longitude: -71.055242,
+              name: "South Station",
+              stop_id: "74617"
+            },
+            long_name: nil,
+            mode: %TripPlan.PersonalDetail{
+              distance: 0.0,
+              steps: [
+                %TripPlan.PersonalDetail.Step{
+                  absolute_direction: :south,
+                  distance: 0.0,
+                  relative_direction: :depart,
+                  street_name: "Transfer"
+                }
+              ]
+            },
+            name: "",
+            to: %TripPlan.NamedPosition{
+              latitude: 42.352271,
+              longitude: -71.055242,
+              name: "South Station",
+              stop_id: "70080"
+            },
+            type: nil,
+            url: nil
+          },
+          %TripPlan.Leg{
+            description: "SUBWAY",
+            from: %TripPlan.NamedPosition{
+              latitude: 42.352271,
+              longitude: -71.055242,
+              name: "South Station",
+              stop_id: "70080"
+            },
+            long_name: "Red Line",
+            mode: %TripPlan.TransitDetail{
+              fares: %{
+                highest_one_way_fare: %Fares.Fare{
+                  additional_valid_modes: [:bus],
+                  cents: 290,
+                  duration: :single_trip,
+                  media: [:charlie_ticket, :cash],
+                  mode: :subway,
+                  name: :subway,
+                  price_label: nil,
+                  reduced: nil
+                },
+                lowest_one_way_fare: %Fares.Fare{
+                  additional_valid_modes: [:bus],
+                  cents: 240,
+                  duration: :single_trip,
+                  media: [:charlie_card],
+                  mode: :subway,
+                  name: :subway,
+                  price_label: nil,
+                  reduced: nil
+                },
+                reduced_one_way_fare: %Fares.Fare{
+                  additional_valid_modes: [],
+                  cents: 110,
+                  duration: :single_trip,
+                  media: [:senior_card],
+                  mode: :subway,
+                  name: :subway,
+                  price_label: nil,
+                  reduced: :senior_disabled
+                }
+              },
+              intermediate_stop_ids: [],
+              route_id: "Red",
+              trip_id: "44080180-20:45-BraintreeQuincyCenterExtended"
+            },
+            name: "Red Line",
+            to: %TripPlan.NamedPosition{
+              latitude: 42.355518,
+              longitude: -71.060225,
+              name: "Downtown Crossing",
+              stop_id: "70078"
+            },
+            type: "1",
+            url: "http://www.mbta.com"
+          }
+        ],
+        passes: %{
+          base_month_pass: %Fares.Fare{
+            additional_valid_modes: [:bus],
+            cents: 9000,
+            duration: :month,
+            media: [:charlie_card, :charlie_ticket],
+            mode: :subway,
+            name: :subway,
+            price_label: nil,
+            reduced: nil
+          },
+          recommended_month_pass: %Fares.Fare{
+            additional_valid_modes: [:bus],
+            cents: 9000,
+            duration: :month,
+            media: [:charlie_card, :charlie_ticket],
+            mode: :subway,
+            name: :subway,
+            price_label: nil,
+            reduced: nil
+          },
+          reduced_month_pass: %Fares.Fare{
+            additional_valid_modes: [:bus],
+            cents: 3000,
+            duration: :month,
+            media: [:senior_card, :student_card],
+            mode: :subway,
+            name: :subway,
+            price_label: nil,
+            reduced: :any
+          }
+        },
+        start: DateTime.now!("Etc/UTC"),
+        stop: DateTime.now!("Etc/UTC")
+      }
+
+      assert show_monthly_passes?(login_sl_plus_subway_itinerary)
+    end
+
+    test "returns true for an itinerary without any transit legs" do
+      no_transit_legs_itinerary = %TripPlan.Itinerary{
+        accessible?: false,
+        legs: [
+          %TripPlan.Leg{
+            description: "WALK",
+            from: %TripPlan.NamedPosition{
+              latitude: 42.365396,
+              longitude: -71.017547,
+              name: "Boston Logan Airport",
+              stop_id: nil
+            },
+            long_name: nil,
+            mode: %TripPlan.PersonalDetail{
+              distance: 385.75800000000004,
+              steps: [
+                %TripPlan.PersonalDetail.Step{
+                  absolute_direction: :southwest,
+                  distance: 382.50800000000004,
+                  relative_direction: :depart,
+                  street_name: "footbridge"
+                },
+                %TripPlan.PersonalDetail.Step{
+                  absolute_direction: :northwest,
+                  distance: 3.25,
+                  relative_direction: :left,
+                  street_name: "service road"
+                }
+              ]
+            },
+            name: "",
+            to: %TripPlan.NamedPosition{
+              latitude: 42.364612,
+              longitude: -71.020862,
+              name: "Terminal A",
+              stop_id: "17091"
+            },
+            type: nil,
+            url: nil
+          },
+          %TripPlan.Leg{
+            description: "WALK",
+            from: %TripPlan.NamedPosition{
+              latitude: 42.352271,
+              longitude: -71.055242,
+              name: "South Station",
+              stop_id: "74617"
+            },
+            long_name: nil,
+            mode: %TripPlan.PersonalDetail{
+              distance: 0.0,
+              steps: [
+                %TripPlan.PersonalDetail.Step{
+                  absolute_direction: :south,
+                  distance: 0.0,
+                  relative_direction: :depart,
+                  street_name: "Transfer"
+                }
+              ]
+            },
+            name: "",
+            to: %TripPlan.NamedPosition{
+              latitude: 42.352271,
+              longitude: -71.055242,
+              name: "South Station",
+              stop_id: "70080"
+            },
+            type: nil,
+            url: nil
+          }
+        ],
+        passes: %{
+          base_month_pass: %Fares.Fare{
+            additional_valid_modes: [:bus],
+            cents: 9000,
+            duration: :month,
+            media: [:charlie_card, :charlie_ticket],
+            mode: :subway,
+            name: :subway,
+            price_label: nil,
+            reduced: nil
+          },
+          recommended_month_pass: %Fares.Fare{
+            additional_valid_modes: [:bus],
+            cents: 9000,
+            duration: :month,
+            media: [:charlie_card, :charlie_ticket],
+            mode: :subway,
+            name: :subway,
+            price_label: nil,
+            reduced: nil
+          },
+          reduced_month_pass: %Fares.Fare{
+            additional_valid_modes: [:bus],
+            cents: 3000,
+            duration: :month,
+            media: [:senior_card, :student_card],
+            mode: :subway,
+            name: :subway,
+            price_label: nil,
+            reduced: :any
+          }
+        },
+        start: DateTime.now!("Etc/UTC"),
+        stop: DateTime.now!("Etc/UTC")
+      }
+
+      assert show_monthly_passes?(no_transit_legs_itinerary)
+    end
   end
 end

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -730,8 +730,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         }
       },
       one_way_total: "$2.90",
-      round_trip_total: "$5.80",
-      show_monthly_passes?: true
+      round_trip_total: "$5.80"
     }
 
     @itinerary %TripPlan.Itinerary{
@@ -1365,8 +1364,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         |> render_to_string(
           itinerary: @itinerary,
           fares: get_calculated_fares(@itinerary),
-          conn: conn,
-          show_monthly_passes?: true
+          conn: conn
         )
 
       fare_calc_tables = Floki.find(html, ".m-trip-plan-farecalc__table")
@@ -1388,8 +1386,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         |> render_to_string(
           itinerary: itinerary_with_transfers,
           fares: get_calculated_fares(@itinerary),
-          conn: conn,
-          show_monthly_passes?: true
+          conn: conn
         )
 
       titles = Floki.find(html_with_transfer_note, ".m-trip-plan-farecalc__title")

--- a/apps/trip_plan/lib/trip_plan/itinerary.ex
+++ b/apps/trip_plan/lib/trip_plan/itinerary.ex
@@ -8,6 +8,10 @@ defmodule TripPlan.Itinerary do
   """
 
   alias Fares.Fare
+  alias Routes.Route
+  alias Schedules.Trip
+  alias Stops.Stop
+  alias TripPlan.{Leg, NamedPosition, TransitDetail}
 
   @enforce_keys [:start, :stop]
   defstruct [
@@ -21,7 +25,7 @@ defmodule TripPlan.Itinerary do
   @type t :: %__MODULE__{
           start: DateTime.t(),
           stop: DateTime.t(),
-          legs: [TripPlan.Leg.t()],
+          legs: [Leg.t()],
           accessible?: boolean,
           passes: passes()
         }
@@ -32,39 +36,40 @@ defmodule TripPlan.Itinerary do
           reduced_month_pass: Fare.t()
         }
 
-  alias TripPlan.NamedPosition
-
   @spec destination(t) :: NamedPosition.t()
   def destination(%__MODULE__{legs: legs}) do
     List.last(legs).to
   end
 
+  @spec transit_legs(t()) :: [Leg.t()]
+  def transit_legs(%__MODULE__{legs: legs}), do: Enum.filter(legs, &Leg.transit?/1)
+
   @doc "Return a list of all the route IDs used for this Itinerary"
-  @spec route_ids(t) :: [Routes.Route.id_t()]
+  @spec route_ids(t) :: [Route.id_t()]
   def route_ids(%__MODULE__{legs: legs}) do
-    flat_map_over_legs(legs, &TripPlan.Leg.route_id/1)
+    flat_map_over_legs(legs, &Leg.route_id/1)
   end
 
   @doc "Return a list of all the trip IDs used for this Itinerary"
-  @spec trip_ids(t) :: [Schedules.Trip.id_t()]
+  @spec trip_ids(t) :: [Trip.id_t()]
   def trip_ids(%__MODULE__{legs: legs}) do
-    flat_map_over_legs(legs, &TripPlan.Leg.trip_id/1)
+    flat_map_over_legs(legs, &Leg.trip_id/1)
   end
 
   @doc "Return a list of {route ID, trip ID} pairs for this Itinerary"
-  @spec route_trip_ids(t) :: [{Routes.Route.id_t(), Schedules.Trip.id_t()}]
+  @spec route_trip_ids(t) :: [{Route.id_t(), Trip.id_t()}]
   def route_trip_ids(%__MODULE__{legs: legs}) do
-    flat_map_over_legs(legs, &TripPlan.Leg.route_trip_ids/1)
+    flat_map_over_legs(legs, &Leg.route_trip_ids/1)
   end
 
   @doc "Returns a list of all the named positions for this Itinerary"
-  @spec positions(t) :: [TripPlan.NamedPosition.t()]
+  @spec positions(t) :: [NamedPosition.t()]
   def positions(%__MODULE__{legs: legs}) do
     Enum.flat_map(legs, &[&1.from, &1.to])
   end
 
   @doc "Return a list of all the stop IDs used for this Itinerary"
-  @spec stop_ids(t) :: [Schedules.Trip.id_t()]
+  @spec stop_ids(t) :: [Trip.id_t()]
   def stop_ids(%__MODULE__{} = itinerary) do
     itinerary
     |> positions
@@ -76,7 +81,7 @@ defmodule TripPlan.Itinerary do
   @spec walking_distance(t) :: float
   def walking_distance(itinerary) do
     itinerary
-    |> Enum.map(&TripPlan.Leg.walking_distance/1)
+    |> Enum.map(&Leg.walking_distance/1)
     |> Enum.sum()
   end
 
@@ -88,7 +93,7 @@ defmodule TripPlan.Itinerary do
   end
 
   @doc "Return a lost of all of the "
-  @spec intermediate_stop_ids(t) :: [Stops.Stop.id_t()]
+  @spec intermediate_stop_ids(t) :: [Stop.id_t()]
   def intermediate_stop_ids(itinerary) do
     itinerary
     |> Enum.flat_map(&leg_intermediate/1)
@@ -104,10 +109,10 @@ defmodule TripPlan.Itinerary do
   @spec same_legs?(t, t) :: boolean
   defp same_legs?(%__MODULE__{legs: legs_1}, %__MODULE__{legs: legs_2}) do
     Enum.count(legs_1) == Enum.count(legs_2) &&
-      legs_1 |> Enum.zip(legs_2) |> Enum.all?(fn {l1, l2} -> TripPlan.Leg.same_leg?(l1, l2) end)
+      legs_1 |> Enum.zip(legs_2) |> Enum.all?(fn {l1, l2} -> Leg.same_leg?(l1, l2) end)
   end
 
-  defp leg_intermediate(%TripPlan.Leg{mode: %TripPlan.TransitDetail{intermediate_stop_ids: ids}}) do
+  defp leg_intermediate(%Leg{mode: %TransitDetail{intermediate_stop_ids: ids}}) do
     ids
   end
 
@@ -117,11 +122,13 @@ defmodule TripPlan.Itinerary do
 end
 
 defimpl Enumerable, for: TripPlan.Itinerary do
+  alias TripPlan.Leg
+
   def count(_itinerary) do
     {:error, __MODULE__}
   end
 
-  def member?(_itinerary, %TripPlan.Leg{}) do
+  def member?(_itinerary, %Leg{}) do
     {:error, __MODULE__}
   end
 

--- a/apps/trip_plan/lib/trip_plan/itinerary.ex
+++ b/apps/trip_plan/lib/trip_plan/itinerary.ex
@@ -80,23 +80,11 @@ defmodule TripPlan.Itinerary do
     |> Enum.sum()
   end
 
-  defp flat_map_over_legs(legs, mapper) do
-    for leg <- legs, {:ok, value} <- leg |> mapper.() |> List.wrap() do
-      value
-    end
-  end
-
   @doc "Determines if two itineraries represent the same sequence of legs at the same time"
   @spec same_itinerary?(t, t) :: boolean
   def same_itinerary?(itinerary_1, itinerary_2) do
     itinerary_1.start == itinerary_2.start && itinerary_1.stop == itinerary_2.stop &&
       same_legs?(itinerary_2, itinerary_2)
-  end
-
-  @spec same_legs?(t, t) :: boolean
-  defp same_legs?(%__MODULE__{legs: legs_1}, %__MODULE__{legs: legs_2}) do
-    Enum.count(legs_1) == Enum.count(legs_2) &&
-      legs_1 |> Enum.zip(legs_2) |> Enum.all?(fn {l1, l2} -> TripPlan.Leg.same_leg?(l1, l2) end)
   end
 
   @doc "Return a lost of all of the "
@@ -105,6 +93,18 @@ defmodule TripPlan.Itinerary do
     itinerary
     |> Enum.flat_map(&leg_intermediate/1)
     |> Enum.uniq()
+  end
+
+  defp flat_map_over_legs(legs, mapper) do
+    for leg <- legs, {:ok, value} <- leg |> mapper.() |> List.wrap() do
+      value
+    end
+  end
+
+  @spec same_legs?(t, t) :: boolean
+  defp same_legs?(%__MODULE__{legs: legs_1}, %__MODULE__{legs: legs_2}) do
+    Enum.count(legs_1) == Enum.count(legs_2) &&
+      legs_1 |> Enum.zip(legs_2) |> Enum.all?(fn {l1, l2} -> TripPlan.Leg.same_leg?(l1, l2) end)
   end
 
   defp leg_intermediate(%TripPlan.Leg{mode: %TripPlan.TransitDetail{intermediate_stop_ids: ids}}) do

--- a/apps/trip_plan/test/itinerary_test.exs
+++ b/apps/trip_plan/test/itinerary_test.exs
@@ -13,6 +13,14 @@ defmodule TripPlan.ItineraryTest do
     end
   end
 
+  describe "transit_legs/1" do
+    test "returns all transit legs excluding personal legs" do
+      {:ok, [itinerary]} = MockPlanner.plan(@from, @to, [])
+
+      assert Enum.all?(transit_legs(itinerary), &Leg.transit?/1)
+    end
+  end
+
   describe "route_ids/1" do
     test "returns all the route IDs from the itinerary" do
       {:ok, [itinerary]} = MockPlanner.plan(@from, @to, [])

--- a/apps/trip_plan/test/itinerary_test.exs
+++ b/apps/trip_plan/test/itinerary_test.exs
@@ -6,6 +6,13 @@ defmodule TripPlan.ItineraryTest do
   @from MockPlanner.random_stop()
   @to MockPlanner.random_stop()
 
+  describe "destination/1" do
+    test "returns the final destination of the itinerary" do
+      {:ok, [itinerary]} = MockPlanner.plan(@from, @to, [])
+      assert destination(itinerary) == @to
+    end
+  end
+
   describe "route_ids/1" do
     test "returns all the route IDs from the itinerary" do
       {:ok, [itinerary]} = MockPlanner.plan(@from, @to, [])
@@ -60,13 +67,6 @@ defmodule TripPlan.ItineraryTest do
       [first, second] = itinerary.legs
       expected = [first.from, first.to, second.from, second.to]
       assert positions(itinerary) == expected
-    end
-  end
-
-  describe "destination/1" do
-    test "returns the final destination of the itinerary" do
-      {:ok, [itinerary]} = MockPlanner.plan(@from, @to, [])
-      assert destination(itinerary) == @to
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trip Planner | SL Trips from Airport to South Station - Monthly Pass Fare](https://app.asana.com/0/555089885850811/1183525584398249)

Hide monthly pass sections for free Logan trips

This is specifically just for Silver Line only (no transfers) trips
starting at one of the Logan terminals.

![Screen Shot 2020-07-21 at 11 40 37](https://user-images.githubusercontent.com/42339/88094119-0424ac80-cb61-11ea-80d9-ecc0c440e414.png)


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
