### PR TITLE
Include URL in list of fields to parse

### DIFF
--- a/apps/alerts/lib/parser.ex
+++ b/apps/alerts/lib/parser.ex
@@ -1,5 +1,11 @@
 defmodule Alerts.Parser do
+  @moduledoc """
+  This is the logic for parsing the different alerts on the website.
+  """
   defmodule Alert do
+    @moduledoc """
+    This is the module to parse alerts
+    """
     @spec parse(JsonApi.Item.t()) :: Alerts.Alert.t()
     def parse(%JsonApi.Item{type: "alert", id: id, attributes: attributes}) do
       Alerts.Alert.new(
@@ -11,7 +17,8 @@ defmodule Alerts.Parser do
         severity: severity(attributes["severity"]),
         lifecycle: lifecycle(attributes["lifecycle"]),
         updated_at: parse_time(attributes["updated_at"]),
-        description: description(attributes["description"])
+        description: description(attributes["description"]),
+        url: description(attributes["url"])
       )
     end
 
@@ -176,6 +183,9 @@ defmodule Alerts.Parser do
   end
 
   defmodule Banner do
+    @moduledoc """
+    This is the module to parse the banner
+    """
     alias Alerts.{Banner, InformedEntitySet, Parser.Alert}
 
     @spec parse(JsonApi.Item.t()) :: [Banner.t()]

--- a/apps/alerts/test/parser_test.exs
+++ b/apps/alerts/test/parser_test.exs
@@ -34,7 +34,8 @@ defmodule Alerts.ParserTest do
                  "effect_name" => "Delay",
                  "updated_at" => "2016-06-20T16:09:29-04:00",
                  "description" => "Affected routes: 18",
-                 "banner" => "Test banner copy"
+                 "banner" => "Test banner copy",
+                 "url" => "www.mbta.com"
                }
              }) ==
                %Alerts.Alert{
@@ -64,7 +65,8 @@ defmodule Alerts.ParserTest do
                  effect: :delay,
                  updated_at: ~N[2016-06-20T16:09:29] |> Timex.to_datetime("Etc/GMT+4"),
                  description: "Affected routes: 18",
-                 priority: :high
+                 priority: :high,
+                 url: "www.mbta.com"
                }
     end
 

--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -234,7 +234,7 @@ export interface Alert {
   updated_at: string;
   description: string;
   priority: Priority;
-  url: string;
+  url: string | null;
 }
 
 interface DatesNotes {

--- a/apps/site/assets/ts/components/Alerts.tsx
+++ b/apps/site/assets/ts/components/Alerts.tsx
@@ -147,8 +147,11 @@ const alertDescription = (alert: AlertType): ReactElement<HTMLElement> => (
 const Alert = ({ alert }: { alert: AlertType }): ReactElement<HTMLElement> => {
   const [expanded, toggleExpanded] = useState(false);
   const onClick = (): void => toggleExpanded(!expanded);
+
+  const alertUrl = alert.url ? alert.url : "";
+
   // remove [http:// | https:// | www.] from alert URL:
-  let strippedAlertUrl = alert.url.replace(/(https?:\/\/)?(www\.)?/i, "");
+  let strippedAlertUrl = alertUrl.replace(/(https?:\/\/)?(www\.)?/i, "");
 
   // capitalize 'mbta' (special case):
   strippedAlertUrl = strippedAlertUrl.replace(/mbta/gi, "MBTA");

--- a/apps/site/assets/ts/components/__tests__/AlertsTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/AlertsTest.tsx
@@ -73,6 +73,26 @@ test("it renders", () => {
   expect(enzymeToJsonWithoutProps(wrapper)).toMatchSnapshot();
 });
 
+test("it includes the URL field when it exists", () => {
+  document.body.innerHTML = body;
+
+  const highAlertID = `#alert-${highAlert.id}`;
+
+  let wrapper = mount(<Alerts alerts={[highAlert]} />);
+
+  wrapper.find(highAlertID).simulate("click");
+  expect(wrapper.html()).toContain(
+    `<a href="https://www.mbta.com" target="_blank">MBTA.com</a>`
+  );
+
+  wrapper.unmount();
+
+  wrapper = mount(<Alerts alerts={[{ url: null, ...highAlert }]} />);
+
+  wrapper.find(highAlertID).simulate("click");
+  expect(wrapper.find("a")).toEqual({});
+});
+
 describe("iconForAlert", () => {
   test("renders no icon for low priority alerts", () => {
     expect(iconForAlert(lowAlert)).toBeNull();

--- a/apps/site/lib/site_web/plugs/banner.ex
+++ b/apps/site/lib/site_web/plugs/banner.ex
@@ -4,7 +4,7 @@ defmodule SiteWeb.Plugs.Banner do
   A module Plug to handle the banner at the top of every page.
 
   * If there's a banner alert, that should always be displayed with the alert styling.
-  * Otherwise, display the beta announcment banner if necessary.
+  * Otherwise, display the beta announcement banner if necessary.
   """
 
   @behaviour Plug


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Alerts | URL field still doesn't work](https://app.asana.com/0/555089885850811/1176599342634997)

Even though the alerts for dotcom included a URL for more information, it was not 'passed down' and hence not displayed.
Content team members had to manually include said URL in the description.

Also included here a fix to anticipate URLs being null.

Before:
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/61979382/88408475-9c10d900-cda1-11ea-85c7-79f5518f736f.png">

After:
<img width="1168" alt="image" src="https://user-images.githubusercontent.com/61979382/88408796-0b86c880-cda2-11ea-87ec-bcf733cfca2c.png">



