### PR TITLE
Skip Mattapan test temporarily while the shuttle is running

### DIFF
--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -237,6 +237,8 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert conn.assigns.destination
     end
 
+    @tag skip:
+           "Commenting out this test temporarily. As of Summer 2020 there is shuttle service on the Mattapan line."
     test "assigns trip info and journeys for mattapan line", %{conn: conn} do
       conn =
         get(


### PR DESCRIPTION
No ticket, the test started failing in CI.

Skip Mattapan test temporarily while the shuttle is running

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
