### PR TITLE
Skip Heath test instead of Cleveland Circle

### DIFF
--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -208,21 +208,22 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
       |> json_response(200)
     end
 
-    # "Skipping this test temporarily. In Summer 2020 the Green Line E branch is undergoing improvements"
-    # test "handles green line trips from the generic Green page", %{conn: conn} do
-    #   params = %{
-    #     id: "Green",
-    #     direction: "0",
-    #     stop: "place-north"
-    #   }
+    @tag skip:
+           "Skipping this test temporarily. In Summer 2020 the Green Line E branch is undergoing improvements"
+    test "handles green line trips from the generic Green page", %{conn: conn} do
+      params = %{
+        id: "Green",
+        direction: "0",
+        stop: "place-north"
+      }
 
-    #   params_for_trip = get_valid_trip_params(params, conn)
-    #   trip_path = finder_api_path(conn, :trip, params_for_trip)
+      params_for_trip = get_valid_trip_params(params, conn)
+      trip_path = finder_api_path(conn, :trip, params_for_trip)
 
-    #   conn
-    #   |> get(trip_path)
-    #   |> json_response(200)
-    # end
+      conn
+      |> get(trip_path)
+      |> json_response(200)
+    end
 
     test "only shows times starting at selected origin onward - outbound", %{conn: conn} do
       origin_stop = "place-sstat"

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -208,20 +208,21 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
       |> json_response(200)
     end
 
-    test "handles green line trips from the generic Green page", %{conn: conn} do
-      params = %{
-        id: "Green",
-        direction: "0",
-        stop: "place-north"
-      }
+    # "Skipping this test temporarily. In Summer 2020 the Green Line E branch is undergoing improvements"
+    # test "handles green line trips from the generic Green page", %{conn: conn} do
+    #   params = %{
+    #     id: "Green",
+    #     direction: "0",
+    #     stop: "place-north"
+    #   }
 
-      params_for_trip = get_valid_trip_params(params, conn)
-      trip_path = finder_api_path(conn, :trip, params_for_trip)
+    #   params_for_trip = get_valid_trip_params(params, conn)
+    #   trip_path = finder_api_path(conn, :trip, params_for_trip)
 
-      conn
-      |> get(trip_path)
-      |> json_response(200)
-    end
+    #   conn
+    #   |> get(trip_path)
+    #   |> json_response(200)
+    # end
 
     test "only shows times starting at selected origin onward - outbound", %{conn: conn} do
       origin_stop = "place-sstat"

--- a/apps/site/test/site_web/controllers/schedule/green_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/green_test.exs
@@ -91,17 +91,18 @@ defmodule SiteWeb.ScheduleController.GreenTest do
     assert conn.assigns.meta_description
   end
 
-  # "Skipping the check for Cleveland Circle in this test temporarily. In Summer 2020 the Green Line C branch is undergoing improvements"
+  # "Skipping the check for Heath Street in this test temporarily. In Summer 2020 the Green Line E branch is undergoing improvements"
   test "trip view :all_stops is a list of %Stop{} for all stops on all branches", %{conn: conn} do
     conn = get(conn, green_path(conn, :trip_view, %{schedule_direction: %{direction_id: 0}}))
 
     assert [%Stops.Stop{} | all_stops] = conn.assigns.all_stops
 
     all_stops = Enum.map(all_stops, & &1.id)
+
     assert "place-lake" in all_stops
-    # assert "place-clmnl" in all_stops
+    assert "place-clmnl" in all_stops
     assert "place-river" in all_stops
-    assert "place-hsmnl" in all_stops
+    # assert "place-hsmnl" in all_stops
   end
 
   test "line tab :all_stops is a list of {bubble_info, %RouteStops{}} for all stops on all branches",
@@ -285,7 +286,7 @@ defmodule SiteWeb.ScheduleController.GreenTest do
         "Green",
         schedule_direction: %{
           origin: "place-pktrm",
-          destination: "place-bckhl",
+          destination: "place-coecl",
           direction_id: 1
         }
       )


### PR DESCRIPTION
No ticket, tests are failing in CI.

Skip Heath test instead of Cleveland Circle

Construction projects have moved on to the E line.

Use a non-E line stop for another test.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
