### PR TITLE
Drop subway predictions in the past

### DIFF
--- a/apps/schedules/lib/repo.ex
+++ b/apps/schedules/lib/repo.ex
@@ -238,11 +238,7 @@ defmodule Schedules.Repo do
                                 _stop_sequence,
                                 _pickup_type
                               } ->
-      case DateTime.compare(schedule_time, min_time) do
-        :gt -> true
-        :eq -> true
-        :lt -> false
-      end
+      Util.time_is_greater_or_equal?(schedule_time, min_time)
     end)
   end
 

--- a/apps/schedules/lib/repo_condensed.ex
+++ b/apps/schedules/lib/repo_condensed.ex
@@ -112,11 +112,7 @@ defmodule Schedules.RepoCondensed do
 
   defp filter_by_min_time(schedules, %DateTime{} = min_time) do
     Enum.filter(schedules, fn schedule ->
-      case DateTime.compare(schedule.time, min_time) do
-        :gt -> true
-        :eq -> true
-        :lt -> false
-      end
+      Util.time_is_greater_or_equal?(schedule.time, min_time)
     end)
   end
 

--- a/apps/site/lib/vehicle_helpers/vehicle_tooltip.ex
+++ b/apps/site/lib/vehicle_helpers/vehicle_tooltip.ex
@@ -1,6 +1,6 @@
 defmodule VehicleTooltip do
   @moduledoc """
-  Represents a vehicle with it's associated status information, used to render tooltips on schedule and
+  Represents a vehicle with its associated status information, used to render tooltips on schedule and
   line representations
   """
   alias Vehicles.Vehicle

--- a/apps/util/lib/util.ex
+++ b/apps/util/lib/util.ex
@@ -1,4 +1,6 @@
 defmodule Util do
+  @moduledoc "Utilities module"
+
   require Logger
   use Timex
 
@@ -23,6 +25,15 @@ defmodule Util do
   @doc "Today's date in the America/New_York timezone."
   def today do
     now() |> Timex.to_date()
+  end
+
+  @spec time_is_greater_or_equal?(DateTime.t(), DateTime.t()) :: boolean
+  def time_is_greater_or_equal?(time, ref_time) do
+    case DateTime.compare(time, ref_time) do
+      :gt -> true
+      :eq -> true
+      :lt -> false
+    end
   end
 
   @doc "Gives the date for tomorrow based on the provided date"

--- a/apps/util/test/util_test.exs
+++ b/apps/util/test/util_test.exs
@@ -448,4 +448,13 @@ defmodule UtilTest do
       assert log =~ "duration="
     end
   end
+
+  describe "time_is_greater_or_equal?/2" do
+    test "properly determines if date is before reference date" do
+      day = Util.to_local_time(~N[2020-07-13T00:00:00])
+      ten_days_later = Util.to_local_time(~N[2020-07-23T00:00:00])
+      assert time_is_greater_or_equal?(ten_days_later, day) == true
+      assert time_is_greater_or_equal?(day, ten_days_later) == false
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [RTR Subway Predictions | Drop subway predictions in the past](https://app.asana.com/0/555089885850811/1184691535835665)

Drop subway predictions from the prediction repo if the predicted time is earlier than the current time. This will only affect subway predictions—we want to continue showing commuter rail trains that have recently departed.

