### PR TITLE
Set bypass to handle all requests being made

### DIFF
--- a/apps/predictions/test/repo_test.exs
+++ b/apps/predictions/test/repo_test.exs
@@ -72,9 +72,10 @@ defmodule Predictions.RepoTest do
 
       Application.put_env(:v3_api, :base_url, "http://localhost:#{bypass.port}")
 
-      Bypass.expect(bypass, fn %{request_path: "/predictions/"} = conn ->
-        # return a Prediction with a valid stop, and one with an invalid stop
-        Conn.resp(conn, 200, ~s(
+      Bypass.expect(bypass, fn %{request_path: request_path} = conn ->
+        if request_path == "/predictions/" do
+          # return a Prediction with a valid stop, and one with an invalid stop
+          Conn.resp(conn, 200, ~s(
               {
                 "included": [
                   {"type": "route", "id": "Red", "attributes": {"type": 1, "long_name": "Red Line", "direction_names": ["South", "North"], "description": "Rapid Transit"}, "relationships": {}},
@@ -108,6 +109,10 @@ defmodule Predictions.RepoTest do
                   }
                 ]
               }))
+        else
+          # Don't worry about requests for /routes or other.
+          Conn.resp(conn, 200, "")
+        end
       end)
 
       refute Repo.all(route: "Red", trip: "made_up_trip") == []


### PR DESCRIPTION
Set bypass to handle all requests being made

Fix test that breaks locally.

No ticket

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
