### PR TITLE
Account for empty route patterns

### DIFF
--- a/apps/site/assets/ts/schedule/components/__tests__/ScheduleLoaderTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/ScheduleLoaderTest.tsx
@@ -16,6 +16,7 @@ import ScheduleFinder from "../ScheduleFinder";
 import ScheduleFinderModal from "../schedule-finder/ScheduleFinderModal";
 import ScheduleNote from "../ScheduleNote";
 import * as scheduleStoreModule from "../../store/ScheduleStore";
+import * as scheduleLoader from "../../schedule-loader";
 import * as routePatternsByDirectionData from "./test-data/routePatternsByDirectionData.json";
 
 jest.mock("../../../helpers/use-fetch", () => ({
@@ -941,5 +942,31 @@ describe("ScheduleLoader", () => {
 
     changeDirectionStub.mockRestore();
     wrapper.unmount();
+  });
+
+  it("Does not render schedule page nor line diagram because route information is empty", () => {
+    const schedulePageData = {
+      route_patterns: {}
+    };
+
+    document.body.innerHTML = `<div id="react-root">
+  <script id="js-schedule-page-data" type="text/plain">${JSON.stringify(
+    schedulePageData
+  )}</script>
+  </div>`;
+
+    const renderSchedulePageStub = jest.spyOn(
+      scheduleLoader,
+      "renderSchedulePage"
+    );
+    const renderDirectionOrMapPageStub = jest.spyOn(
+      scheduleLoader,
+      "renderDirectionOrMap"
+    );
+
+    scheduleLoader.default(); //onLoad
+
+    expect(renderSchedulePageStub).not.toHaveBeenCalled();
+    expect(renderDirectionOrMapPageStub).not.toHaveBeenCalled();
   });
 });

--- a/apps/site/assets/ts/schedule/schedule-loader.tsx
+++ b/apps/site/assets/ts/schedule/schedule-loader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
+import { isEmpty } from "lodash";
 import { updateInLocation } from "use-query-params";
 import Map from "./components/Map";
 import { SchedulePageData, SelectedOrigin } from "./components/__schedule";
@@ -50,7 +51,9 @@ const updateURL = (origin: SelectedOrigin, direction?: DirectionId): void => {
   }
 };
 
-const renderSchedulePage = (schedulePageData: SchedulePageData): void => {
+export const renderSchedulePage = (
+  schedulePageData: SchedulePageData
+): void => {
   const { schedule_note: scheduleNote } = schedulePageData;
 
   ReactDOM.render(
@@ -114,7 +117,9 @@ const renderDirectionAndMap = (
   }
 };
 
-const renderDirectionOrMap = (schedulePageData: SchedulePageData): void => {
+export const renderDirectionOrMap = (
+  schedulePageData: SchedulePageData
+): void => {
   const root = document.getElementById("react-schedule-direction-root");
   if (!root) {
     renderMap(schedulePageData);
@@ -129,10 +134,16 @@ const render = (): void => {
   const schedulePageData = JSON.parse(
     schedulePageDataEl.innerHTML
   ) as SchedulePageData;
-  const { direction_id: directionId } = schedulePageData;
+  const {
+    direction_id: directionId,
+    route_patterns: routePatterns
+  } = schedulePageData;
   createScheduleStore(directionId);
-  renderSchedulePage(schedulePageData);
-  renderDirectionOrMap(schedulePageData);
+
+  if (!isEmpty(routePatterns)) {
+    renderSchedulePage(schedulePageData);
+    renderDirectionOrMap(schedulePageData);
+  }
 };
 
 const onLoad = (): void => {


### PR DESCRIPTION
#### Summary of changes
Related to [🔥 Schedules | Fix right rail on suspended routes](https://app.asana.com/0/555089885850811/1187736907832137)

I noticed that there was a bug even though the "pinning on the right" was still working. This fix will avoid unnecessary renders of specific components.
