### PR TITLE
Document the current API version for the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The new face of https://www.mbta.com/
 
 1. Request a V3 API key at https://dev.api.mbtace.com/, and request an increased
 rate limit for it (someone with access will need to approve this). Note that, at
-any given time, the site may not be compatible with the very latest API version - the site is currently using API version `2019-07-01`.
+any given time, the site may not be compatible with the very latest API version - as of Aug 2020 the site is using API version `2019-07-01`.
 
 1. Install [Homebrew](https://docs.brew.sh/Installation.html):
     ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The new face of https://www.mbta.com/
 
 1. Request a V3 API key at https://dev.api.mbtace.com/, and request an increased
 rate limit for it (someone with access will need to approve this). Note that, at
-any given time, the site may not be compatible with the very latest API version.
+any given time, the site may not be compatible with the very latest API version - the site is currently using API version `2019-07-01`.
 
 1. Install [Homebrew](https://docs.brew.sh/Installation.html):
     ```


### PR DESCRIPTION
No ticket. This is something I ran into. My key was set to the wrong API version and it was causing tests to fail for me that pass on CI.

Document the current API version for the site

Developers should set their key to the same version to avoid
discrepancies in the data they see.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
