### PR TITLE
Fix for no fetching journeys when selecting a different service

### DIFF
--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/DailySchedule.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/DailySchedule.tsx
@@ -136,23 +136,22 @@ export const DailySchedule = ({
     defaultSelectedService
   );
 
+  const getJourneysForSelectedService = (service: Service): void => {
+    fetch({
+      fetcher: fetchJourneys(routeId, stopId, service, directionId, false),
+      parser: parseResults
+    });
+  };
+
   useEffect(
     () => {
       /* istanbul ignore next */
       if (selectedService && isNotStarted(fetchState)) {
-        fetch({
-          fetcher: fetchJourneys(
-            routeId,
-            stopId,
-            selectedService,
-            directionId,
-            false
-          ),
-          parser: parseResults
-        });
+        getJourneysForSelectedService(selectedService);
       }
     },
-    [services, routeId, directionId, stopId, selectedService, fetch, fetchState]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   );
 
   if (services.length <= 0) return null;
@@ -169,6 +168,7 @@ export const DailySchedule = ({
         onSelectService={chosenService => {
           if (chosenService) {
             setSelectedService(chosenService);
+            getJourneysForSelectedService(chosenService);
           }
         }}
       />

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/__snapshots__/DailyScheduleTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/__snapshots__/DailyScheduleTest.tsx.snap
@@ -78,5 +78,86 @@ Array [
       />
     </div>
   </div>,
+  <div
+    className="schedule-finder__first-last-trip"
+  >
+    <div
+      className="u-small-caps u-bold"
+    >
+      First Trip
+    </div>
+    04:45 AM
+  </div>,
+  <table
+    className="schedule-table"
+  >
+    <thead
+      className="schedule-table__header"
+    >
+      <tr>
+        <th
+          className="schedule-table__cell"
+          scope="col"
+        >
+          Departs
+        </th>
+        <th
+          className="schedule-table__cell"
+          colSpan={2}
+          scope="col"
+        >
+          <span
+            className="pull-left"
+          >
+            Destination
+          </span>
+          Trip Details
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        aria-controls="trip-45030860"
+        aria-expanded={false}
+        className="schedule-table__row"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        <td
+          className="schedule-table__cell schedule-table__cell--time u-nowrap u-tabular-nums"
+        >
+          04:45 AM
+        </td>
+        <td
+          className="schedule-table__cell schedule-table__cell--headsign"
+        >
+          <span
+            className="schedule-table__route-pill m-route-pills"
+          >
+            <span
+              className="c-icon__bus-pill--small u-bg--bus"
+            >
+              1
+            </span>
+          </span>
+          Harvard
+        </td>
+        <td
+          className="schedule-table__cell schedule-table__cell--tiny"
+        >
+          <span
+            className="c-expandable-block__header-caret"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "&#xF107;",
+              }
+            }
+          />
+        </td>
+      </tr>
+    </tbody>
+  </table>,
 ]
 `;


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Schedule Finder | Service Picker doesn't update schedule](https://app.asana.com/0/555089885850811/1187746923806232)

Riders may be falsely led to believe that all days have the same schedule because the schedules were not refreshing properly.