### PR TITLE
Redirect routes 62 and 76 to the combined 627 pages

### DIFF
--- a/apps/site/lib/site_web/plugs/rewrite_urls.ex
+++ b/apps/site/lib/site_web/plugs/rewrite_urls.ex
@@ -28,6 +28,14 @@ defmodule SiteWeb.Plugs.RewriteUrls do
     String.replace(conn.request_path, "Boat-F3", "Boat-F1")
   end
 
+  defp rewrite_url(%{path_info: ["schedules", "62" | _]} = conn) do
+    String.replace(conn.request_path, "62", "627")
+  end
+
+  defp rewrite_url(%{path_info: ["schedules", "76" | _]} = conn) do
+    String.replace(conn.request_path, "76", "627")
+  end
+
   defp rewrite_url(_conn) do
     nil
   end

--- a/apps/site/test/site_web/plugs/rewrite_urls_test.exs
+++ b/apps/site/test/site_web/plugs/rewrite_urls_test.exs
@@ -19,7 +19,7 @@ defmodule SiteWeb.Plugs.RewriteUrlsTest do
       assert conn.halted
     end
 
-    test "temporarily redirects route 76 to the combined 627 pages, for service adjustments in Fall 200",
+    test "temporarily redirects route 76 to the combined 627 pages, for service adjustments in Fall 2020",
          %{conn: conn} do
       conn = %{conn | path_info: ["schedules", "76", "line"], request_path: "/schedules/76/line"}
       conn = call(conn, [])

--- a/apps/site/test/site_web/plugs/rewrite_urls_test.exs
+++ b/apps/site/test/site_web/plugs/rewrite_urls_test.exs
@@ -11,6 +11,22 @@ defmodule SiteWeb.Plugs.RewriteUrlsTest do
       assert conn.halted
     end
 
+    test "temporarily redirects route 62 to the combined 627 pages, for service adjustments in Fall 200",
+         %{conn: conn} do
+      conn = %{conn | path_info: ["schedules", "62", "line"], request_path: "/schedules/62/line"}
+      conn = call(conn, [])
+      assert redirected_to(conn, 302) == "/schedules/627/line"
+      assert conn.halted
+    end
+
+    test "temporarily redirects route 76 to the combined 627 pages, for service adjustments in Fall 200",
+         %{conn: conn} do
+      conn = %{conn | path_info: ["schedules", "76", "line"], request_path: "/schedules/76/line"}
+      conn = call(conn, [])
+      assert redirected_to(conn, 302) == "/schedules/627/line"
+      assert conn.halted
+    end
+
     test "includes a query string if present", %{conn: conn} do
       conn = %{
         conn

--- a/apps/site/test/site_web/plugs/rewrite_urls_test.exs
+++ b/apps/site/test/site_web/plugs/rewrite_urls_test.exs
@@ -11,7 +11,7 @@ defmodule SiteWeb.Plugs.RewriteUrlsTest do
       assert conn.halted
     end
 
-    test "temporarily redirects route 62 to the combined 627 pages, for service adjustments in Fall 200",
+    test "temporarily redirects route 62 to the combined 627 pages, for service adjustments in Fall 2020",
          %{conn: conn} do
       conn = %{conn | path_info: ["schedules", "62", "line"], request_path: "/schedules/62/line"}
       conn = call(conn, [])


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Show 62/76 combined service page](https://app.asana.com/0/555089885850811/1187743350599921)

Redirect routes 62 and 76 to the combined 627 pages

Use a temporarily redirect. This is because all trips are now scheduled
on the combined Route 62/76, and will continue to be as such for the
entirety of the fall 2020 rating.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
