### PR TITLE
Use route patterns to get branch route stops

### DIFF
--- a/apps/route_patterns/lib/repo.ex
+++ b/apps/route_patterns/lib/repo.ex
@@ -3,9 +3,36 @@ defmodule RoutePatterns.Repo do
   use RepoCache, ttl: :timer.hours(1)
 
   alias RoutePatterns.RoutePattern
+  alias Routes.Route
   alias V3Api.RoutePatterns, as: RoutePatternsApi
 
-  def by_route_id(route_id, opts \\ []) do
+  @doc """
+  Returns a single route pattern by ID
+  """
+  @spec get(RoutePattern.id_t()) :: RoutePattern.t() | nil
+  @spec get(RoutePattern.id_t(), keyword()) :: RoutePattern.t() | nil
+  def get(id, opts \\ []) when is_binary(id) do
+    case cache({id, opts}, fn {id, opts} ->
+           with %{data: [route_pattern]} <- RoutePatternsApi.get(id, opts) do
+             {:ok, RoutePattern.new(route_pattern)}
+           end
+         end) do
+      {:ok, route_pattern} -> route_pattern
+      {:error, _} -> nil
+    end
+  end
+
+  @spec by_route_id(Route.id_t()) :: RoutePattern.t()
+  @spec by_route_id(Route.id_t(), keyword()) :: RoutePattern.t()
+  def by_route_id(route_id, opts \\ [])
+
+  def by_route_id("Green", opts) do
+    ~w(Green-B Green-C Green-D Green-E)s
+    |> Enum.join(",")
+    |> by_route_id(opts)
+  end
+
+  def by_route_id(route_id, opts) do
     opts
     |> Keyword.get(:direction_id)
     |> case do

--- a/apps/route_patterns/test/repo_test.exs
+++ b/apps/route_patterns/test/repo_test.exs
@@ -2,12 +2,33 @@ defmodule RoutePatterns.RepoTest do
   use ExUnit.Case, async: true
   alias RoutePatterns.{Repo, RoutePattern}
 
+  describe "get" do
+    test "returns a single route pattern" do
+      assert %RoutePattern{id: "111-5-0"} = Repo.get("111-5-0")
+    end
+
+    test "returns nil for an unknown route pattern" do
+      refute Repo.get("unknown_route_pattern")
+    end
+  end
+
   describe "by_route_id" do
     test "returns route patterns for a route" do
       assert [%RoutePattern{} | _] = Repo.by_route_id("Red")
     end
 
+    test "returns route patterns for all Green line branches" do
+      assert [%RoutePattern{} | _] = Repo.by_route_id("Green")
+    end
+
     test "takes a direction_id param" do
+      all_patterns = Repo.by_route_id("Red")
+      assert all_patterns |> Enum.map(& &1.direction_id) |> Enum.uniq() == [0, 1]
+      alewife_patterns = Repo.by_route_id("Red", direction_id: 1)
+      assert alewife_patterns |> Enum.map(& &1.direction_id) |> Enum.uniq() == [1]
+    end
+
+    test "takes a route_pattern_id param" do
       all_patterns = Repo.by_route_id("Red")
       assert all_patterns |> Enum.map(& &1.direction_id) |> Enum.uniq() == [0, 1]
       alewife_patterns = Repo.by_route_id("Red", direction_id: 1)

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -15,6 +15,7 @@ import { menuReducer, FetchAction } from "./direction/reducer";
 import { MapData, StaticMapData } from "../../leaflet/components/__mapdata";
 import Map from "../components/Map";
 import LineDiagram from "../components/line-diagram/LineDiagram";
+import { isABusRoute } from "../../models/route";
 
 export interface Props {
   route: EnhancedRoute;
@@ -34,16 +35,19 @@ export interface Props {
 export const fetchMapData = (
   routeId: string,
   directionId: DirectionId,
-  shapeId: string,
+  currentRoutePatternIdForData: string | undefined,
   dispatch: Dispatch<FetchAction>
 ): Promise<void> => {
   dispatch({ type: "FETCH_STARTED" });
+  const baseURL = `/schedules/map_api?id=${routeId}&direction_id=${directionId}`;
+  const url = currentRoutePatternIdForData
+    ? `${baseURL}&shape_id=${currentRoutePatternIdForData}`
+    : baseURL;
+
   return (
     window.fetch &&
     window
-      .fetch(
-        `/schedules/map_api?id=${routeId}&direction_id=${directionId}&shape_id=${shapeId}`
-      )
+      .fetch(url)
       .then(response => {
         if (response.ok) return response.json();
         throw new Error(response.statusText);
@@ -57,16 +61,20 @@ export const fetchMapData = (
 export const fetchLineData = (
   routeId: string,
   directionId: DirectionId,
-  shapeId: string,
+  currentRoutePatternIdForData: string | undefined,
   dispatch: Dispatch<FetchAction>
 ): Promise<void> => {
   dispatch({ type: "FETCH_STARTED" });
+
+  const baseURL = `/schedules/line_api?id=${routeId}&direction_id=${directionId}`;
+  const url = currentRoutePatternIdForData
+    ? `${baseURL}&route_pattern=${currentRoutePatternIdForData}`
+    : baseURL;
+
   return (
     window.fetch &&
     window
-      .fetch(
-        `/schedules/line_api?id=${routeId}&direction_id=${directionId}&variant=${shapeId}`
-      )
+      .fetch(url)
       .then(response => {
         if (response.ok) return response.json();
         throw new Error(response.statusText);
@@ -123,6 +131,10 @@ const ScheduleDirection = ({
   const shapeIds = state.routePatternsByDirection[state.directionId].map(
     routePattern => routePattern.shape_id
   );
+  const currentRoutePatternIdForData =
+    isABusRoute(route) && routePatternsInCurrentDirection.length > 1
+      ? state.routePattern.id
+      : undefined;
 
   useEffect(
     () => {
@@ -130,7 +142,7 @@ const ScheduleDirection = ({
         fetchMapData(
           route.id,
           state.directionId,
-          currentShapeId,
+          currentRoutePatternIdForData,
           dispatchMapData
         );
       }
@@ -150,11 +162,11 @@ const ScheduleDirection = ({
       fetchLineData(
         route.id,
         state.directionId,
-        currentShapeId,
+        currentRoutePatternIdForData,
         dispatchLineData
       );
     },
-    [route, state.directionId, currentShapeId]
+    [route, state.directionId, currentShapeId, currentRoutePatternIdForData]
   );
 
   return (

--- a/apps/site/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
@@ -495,7 +495,7 @@ describe("fetchLineData", () => {
 
     return fetchLineData("Orange", 1, "1", spy).then(() => {
       expect(window.fetch).toHaveBeenCalledWith(
-        "/schedules/line_api?id=Orange&direction_id=1&variant=1"
+        "/schedules/line_api?id=Orange&direction_id=1&route_pattern=1"
       );
       expect(spy).toHaveBeenCalledWith({
         type: "FETCH_STARTED"
@@ -523,7 +523,7 @@ describe("fetchLineData", () => {
 
     return fetchLineData("Red", 0, "1", spy).then(() => {
       expect(window.fetch).toHaveBeenCalledWith(
-        "/schedules/line_api?id=Red&direction_id=0&variant=1"
+        "/schedules/line_api?id=Red&direction_id=0&route_pattern=1"
       );
       expect(spy).toHaveBeenCalledWith({
         type: "FETCH_STARTED"

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -80,7 +80,7 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
   defp do_get_branch_route_stops(route, direction_id, route_pattern_id) do
     route.id
     |> get_route_patterns(direction_id, route_pattern_id)
-    |> Enum.filter(&(&1.typicality == 1))
+    |> Enum.filter(&by_typicality(&1, route_pattern_id))
     |> Enum.map(&stops_for_route_pattern/1)
   end
 
@@ -263,6 +263,10 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
         []
     end
   end
+
+  @spec by_typicality(RoutePattern.t(), RoutePattern.id_t() | nil) :: boolean()
+  def by_typicality(%RoutePattern{typicality: typicality}, nil), do: typicality == 1
+  def by_typicality(_, _), do: true
 
   @spec nil_out_shared_stop_branches([[RouteStop.t()]]) :: [[RouteStop.t()]]
   defp nil_out_shared_stop_branches(route_stop_groups) do

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -60,7 +60,7 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
     |> Enum.map(fn route ->
       route
       |> do_get_branch_route_stops(direction_id, route_pattern_id)
-      |> RouteStop.list_from_route_patterns(route, direction_id)
+      |> RouteStop.list_from_route_patterns(route, direction_id, true)
     end)
     |> nil_out_shared_stop_branches()
     |> RouteStops.from_route_stop_groups()

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -295,14 +295,9 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
         |> MapSet.new()
       end)
 
-    [
-      [0, 1],
-      [0, 2],
-      [0, 3],
-      [1, 2],
-      [1, 3],
-      [2, 3]
-    ]
+    stop_id_sets
+    |> length()
+    |> combination_pairs()
     |> Enum.map(&intersection(&1, stop_id_sets))
     |> Enum.reduce(MapSet.new(), fn set, acc -> MapSet.union(set, acc) end)
   end
@@ -310,4 +305,27 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
   @spec intersection([non_neg_integer()], [MapSet.t()]) :: MapSet.t()
   defp intersection(indices, map_sets),
     do: apply(MapSet, :intersection, Enum.map(indices, &Enum.at(map_sets, &1)))
+
+  @doc """
+  Generates every combination of pairs for the given number of possibilities.
+
+  Public solely for testing.
+
+  iex> SiteWeb.ScheduleController.Line.Helpers.combination_pairs(4)
+  [
+    [0, 1],
+    [0, 2],
+    [0, 3],
+    [1, 2],
+    [1, 3],
+    [2, 3]
+  ]
+  """
+  @spec combination_pairs(non_neg_integer()) :: [[non_neg_integer()]]
+  def combination_pairs(count) do
+    for i <- 0..(count - 2),
+        j <- (i + 1)..(count - 1) do
+      [i, j]
+    end
+  end
 end

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -12,11 +12,23 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
   @type direction_id :: 0 | 1
   @typep stops_by_route :: %{String.t() => [Stop.t()]}
 
-  def get_route("Green") do
+  @spec get_route(String.t()) :: {:ok, Route.t()} | :not_found
+  def get_route(route_id) do
+    route = do_get_route(route_id)
+
+    if route != nil do
+      {:ok, route}
+    else
+      :not_found
+    end
+  end
+
+  @spec do_get_route(String.t()) :: Route.t() | nil
+  defp do_get_route("Green") do
     RoutesRepo.green_line()
   end
 
-  def get_route(route_id) do
+  defp do_get_route(route_id) do
     RoutesRepo.get(route_id)
   end
 

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -32,6 +32,21 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
     RoutesRepo.get(route_id)
   end
 
+  @doc """
+  Gets a list of RouteStops representing all of the branches on the route. Routes without branches will always be a
+  list with a single RouteStops struct.
+  """
+  @spec get_branch_route_stops(Route.t(), direction_id(), Route.branch_name()) :: [RouteStops.t()]
+  def get_branch_route_stops(route, direction_id, variant) do
+    route_shapes = get_route_shapes(route.id, direction_id)
+    route_stops = get_route_stops(route.id, direction_id, &StopsRepo.by_route/3)
+    active_shapes = get_active_shapes(route_shapes, route, variant)
+
+    route_shapes
+    |> filter_route_shapes(active_shapes, route)
+    |> get_branches(route_stops, route, direction_id)
+  end
+
   # Gathers all of the shapes for the route. Green Line has to make a call for each branch separately, because of course
   @spec get_route_shapes(Route.id_t(), direction_id | nil) :: [Shape.t()]
   def get_route_shapes(route_id, direction_id \\ nil, filter_by_priority \\ true)

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -105,13 +105,9 @@ defmodule SiteWeb.ScheduleController.LineApi do
   @spec get_line_data(Route.t(), LineHelpers.direction_id(), Route.branch_name()) ::
           [DiagramHelpers.stop_with_bubble_info()]
   defp get_line_data(route, direction_id, variant) do
-    route_shapes = LineHelpers.get_route_shapes(route.id, direction_id)
-    route_stops = LineHelpers.get_route_stops(route.id, direction_id, &StopsRepo.by_route/3)
-    active_shapes = LineHelpers.get_active_shapes(route_shapes, route, variant)
-    filtered_shapes = LineHelpers.filter_route_shapes(route_shapes, active_shapes, route)
-    branches = LineHelpers.get_branches(filtered_shapes, route_stops, route, direction_id)
-
-    DiagramHelpers.build_stop_list(branches, direction_id)
+    route
+    |> LineHelpers.get_branch_route_stops(direction_id, variant)
+    |> DiagramHelpers.build_stop_list(direction_id)
   end
 
   @spec update_route_stop_data({any, RouteStop.t()}, any, DateTime.t()) :: map()

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -3,6 +3,7 @@ defmodule SiteWeb.ScheduleController.LineApi do
   use SiteWeb, :controller
 
   alias Alerts.Stop, as: AlertsStop
+  alias RoutePatterns.RoutePattern
   alias Routes.Route
   alias Schedules.Repo, as: SchedulesRepo
   alias Site.TransitNearMe
@@ -34,7 +35,11 @@ defmodule SiteWeb.ScheduleController.LineApi do
           |> assign_alerts(filter_by_direction?: true)
 
         line_data =
-          get_line_data(route, String.to_integer(direction_id), conn.query_params["variant"])
+          get_line_data(
+            route,
+            String.to_integer(direction_id),
+            conn.query_params["route_pattern"]
+          )
 
         json(
           conn,
@@ -102,11 +107,12 @@ defmodule SiteWeb.ScheduleController.LineApi do
   defp expand_route_id("Green"), do: GreenLine.branch_ids()
   defp expand_route_id(route_id), do: [route_id]
 
-  @spec get_line_data(Route.t(), LineHelpers.direction_id(), Route.branch_name()) ::
-          [DiagramHelpers.stop_with_bubble_info()]
-  defp get_line_data(route, direction_id, variant) do
+  @spec get_line_data(Route.t(), LineHelpers.direction_id(), RoutePattern.id_t() | nil) :: [
+          DiagramHelpers.stop_with_bubble_info()
+        ]
+  defp get_line_data(route, direction_id, route_pattern_id) do
     route
-    |> LineHelpers.get_branch_route_stops(direction_id, variant)
+    |> LineHelpers.get_branch_route_stops(direction_id, route_pattern_id)
     |> DiagramHelpers.build_stop_list(direction_id)
   end
 

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -25,21 +25,27 @@ defmodule SiteWeb.ScheduleController.LineApi do
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, %{"id" => route_id, "direction_id" => direction_id}) do
-    line_data =
-      get_line_data(route_id, String.to_integer(direction_id), conn.query_params["variant"])
+    case LineHelpers.get_route(route_id) do
+      {:ok, route} ->
+        conn =
+          conn
+          |> assign(:route, route)
+          |> assign(:direction_id, direction_id)
+          |> assign_alerts(filter_by_direction?: true)
 
-    conn =
-      conn
-      |> assign(:route, LineHelpers.get_route(route_id))
-      |> assign(:direction_id, direction_id)
-      |> assign_alerts(filter_by_direction?: true)
+        line_data =
+          get_line_data(route, String.to_integer(direction_id), conn.query_params["variant"])
 
-    json(
-      conn,
-      Enum.map(line_data, fn stop ->
-        update_route_stop_data(stop, conn.assigns.alerts, conn.assigns.date)
-      end)
-    )
+        json(
+          conn,
+          Enum.map(line_data, fn stop ->
+            update_route_stop_data(stop, conn.assigns.alerts, conn.assigns.date)
+          end)
+        )
+
+      :not_found ->
+        return_invalid_arguments_error(conn)
+    end
   end
 
   @doc """
@@ -92,23 +98,13 @@ defmodule SiteWeb.ScheduleController.LineApi do
     Jason.encode!(combined_data_by_stop)
   end
 
-  @spec update_route_stop_data({any, RouteStop.t()}, any, DateTime.t()) :: map()
-  def update_route_stop_data({data, %RouteStop{id: stop_id} = map}, alerts, date) do
-    %{
-      alerts: alerts |> AlertsStop.match(stop_id) |> json_safe_alerts(date),
-      route_stop: RouteStop.to_json_safe(map),
-      stop_data: Enum.map(data, fn {key, value} -> %{branch: key, type: value} end)
-    }
-  end
-
   @spec expand_route_id(Route.id_t()) :: [Route.id_t()]
   defp expand_route_id("Green"), do: GreenLine.branch_ids()
   defp expand_route_id(route_id), do: [route_id]
 
-  @spec get_line_data(Route.id_t(), LineHelpers.direction_id(), Route.branch_name()) ::
+  @spec get_line_data(Route.t(), LineHelpers.direction_id(), Route.branch_name()) ::
           [DiagramHelpers.stop_with_bubble_info()]
-  defp get_line_data(route_id, direction_id, variant) do
-    route = LineHelpers.get_route(route_id)
+  defp get_line_data(route, direction_id, variant) do
     route_shapes = LineHelpers.get_route_shapes(route.id, direction_id)
     route_stops = LineHelpers.get_route_stops(route.id, direction_id, &StopsRepo.by_route/3)
     active_shapes = LineHelpers.get_active_shapes(route_shapes, route, variant)
@@ -116,6 +112,15 @@ defmodule SiteWeb.ScheduleController.LineApi do
     branches = LineHelpers.get_branches(filtered_shapes, route_stops, route, direction_id)
 
     DiagramHelpers.build_stop_list(branches, direction_id)
+  end
+
+  @spec update_route_stop_data({any, RouteStop.t()}, any, DateTime.t()) :: map()
+  def update_route_stop_data({data, %RouteStop{id: stop_id} = map}, alerts, date) do
+    %{
+      alerts: alerts |> AlertsStop.match(stop_id) |> json_safe_alerts(date),
+      route_stop: RouteStop.to_json_safe(map),
+      stop_data: Enum.map(data, fn {key, value} -> %{branch: key, type: value} end)
+    }
   end
 
   @spec simple_vehicle_map(Vehicle.t()) :: simple_vehicle

--- a/apps/site/lib/site_web/controllers/schedule/map_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/map_api.ex
@@ -9,7 +9,6 @@ defmodule SiteWeb.ScheduleController.MapApi do
   alias SiteWeb.ControllerHelpers
   alias SiteWeb.ScheduleController.Line.Helpers, as: LineHelpers
   alias SiteWeb.ScheduleController.Line.Maps
-  alias Stops.Repo, as: StopsRepo
 
   @type direction_id :: 0 | 1
 
@@ -37,10 +36,8 @@ defmodule SiteWeb.ScheduleController.MapApi do
   @spec get_map_data(Route.t(), direction_id(), Route.branch_name()) :: MapData.t()
   defp get_map_data(route, direction_id, shape_id) do
     route_shapes = LineHelpers.get_route_shapes(route.id, direction_id)
-    route_stops = LineHelpers.get_route_stops(route.id, direction_id, &StopsRepo.by_route/3)
     active_shapes = LineHelpers.get_active_shapes(route_shapes, route, shape_id)
-    filtered_shapes = LineHelpers.filter_route_shapes(route_shapes, active_shapes, route)
-    branches = LineHelpers.get_branches(filtered_shapes, route_stops, route, direction_id)
+    branches = LineHelpers.get_branch_route_stops(route, direction_id, shape_id)
     map_stops = Maps.map_stops(branches, {route_shapes, active_shapes}, route.id)
 
     {_map_img_src, dynamic_map_data} = Maps.map_data(route, map_stops, [], [])

--- a/apps/site/test/site_web/controllers/line_api_test.exs
+++ b/apps/site/test/site_web/controllers/line_api_test.exs
@@ -7,6 +7,14 @@ defmodule SiteWeb.LineApiTest do
 
       assert json_response(conn, 200)
     end
+
+    test "bad route", %{conn: conn} do
+      conn = get(conn, line_api_path(conn, :show, %{"id" => "Puce", "direction_id" => "1"}))
+
+      assert conn.status == 400
+      body = json_response(conn, 400)
+      assert body["error"] == "Invalid arguments"
+    end
   end
 
   describe "realtime" do

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
@@ -1,0 +1,1003 @@
+defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias Routes.Route
+  alias SiteWeb.ScheduleController.Line.DiagramHelpers
+  alias Stops.{RouteStop, RouteStops}
+
+  @route_red %Route{
+    id: "Red",
+    name: "Red Line",
+    type: 1
+  }
+  @route_1 %Route{
+    id: "1",
+    name: "1",
+    type: 3
+  }
+  @route_green_b %Route{
+    id: "Green-B",
+    name: "",
+    type: 0
+  }
+  @route_green_c %Route{
+    id: "Green-C",
+    name: "",
+    type: 0
+  }
+  @route_green_d %Route{
+    id: "Green-D",
+    name: "",
+    type: 0
+  }
+  @route_green_e %Route{
+    id: "Green-E",
+    name: "",
+    type: 0
+  }
+
+  describe "build_stop_list/2" do
+    test "builds a list of stops with bubble info for Red line (2 branches), direction 0" do
+      branches = [
+        %RouteStops{
+          branch: nil,
+          stops: [
+            %RouteStop{
+              branch: nil,
+              id: "place-alfcl",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "Alewife",
+              route: @route_red
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-jfk",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "JFK/UMass",
+              route: @route_red
+            }
+          ]
+        },
+        %RouteStops{
+          branch: "Alewife - Braintree",
+          stops: [
+            %RouteStop{
+              branch: "Alewife - Braintree",
+              id: "place-nqncy",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "North Quincy",
+              route: @route_red
+            },
+            %RouteStop{
+              branch: "Alewife - Braintree",
+              id: "place-brntn",
+              is_beginning?: false,
+              is_terminus?: true,
+              name: "Braintree",
+              route: @route_red
+            }
+          ]
+        },
+        %RouteStops{
+          branch: "Alewife - Ashmont",
+          stops: [
+            %RouteStop{
+              branch: "Alewife - Ashmont",
+              id: "place-shmnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Savin Hill",
+              route: @route_red
+            },
+            %RouteStop{
+              branch: "Alewife - Ashmont",
+              id: "place-asmnl",
+              is_beginning?: false,
+              is_terminus?: true,
+              name: "Ashmont",
+              route: @route_red
+            }
+          ]
+        }
+      ]
+
+      assert [
+               {
+                 [nil: :terminus],
+                 %RouteStop{id: "place-alfcl"}
+               },
+               {
+                 [{"Alewife - Ashmont", :merge}, {"Alewife - Braintree", :merge}],
+                 %RouteStop{id: "place-jfk"}
+               },
+               {
+                 [{"Alewife - Ashmont", :line}, {"Alewife - Braintree", :stop}],
+                 %RouteStop{id: "place-nqncy"}
+               },
+               {
+                 [{"Alewife - Ashmont", :line}, {"Alewife - Braintree", :terminus}],
+                 %RouteStop{id: "place-brntn"}
+               },
+               {
+                 [{"Alewife - Ashmont", :stop}],
+                 %RouteStop{id: "place-shmnl"}
+               },
+               {
+                 [{"Alewife - Ashmont", :terminus}],
+                 %RouteStop{id: "place-asmnl"}
+               }
+             ] = DiagramHelpers.build_stop_list(branches, 0)
+    end
+
+    test "builds a list of stops with bubble info for Red line (2 branches), direction 1" do
+      branches = [
+        %RouteStops{
+          branch: "Ashmont - Alewife",
+          stops: [
+            %RouteStop{
+              branch: "Ashmont - Alewife",
+              id: "place-asmnl",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "Ashmont",
+              route: @route_red
+            },
+            %RouteStop{
+              branch: "Ashmont - Alewife",
+              id: "place-shmnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Savin Hill",
+              route: @route_red
+            }
+          ]
+        },
+        %RouteStops{
+          branch: "Braintree - Alewife",
+          stops: [
+            %RouteStop{
+              branch: "Braintree - Alewife",
+              id: "place-brntn",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "Braintree",
+              route: @route_red
+            },
+            %RouteStop{
+              branch: "Braintree - Alewife",
+              id: "place-nqncy",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "North Quincy",
+              route: @route_red
+            }
+          ]
+        },
+        %RouteStops{
+          branch: nil,
+          stops: [
+            %RouteStop{
+              branch: nil,
+              id: "place-jfk",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "JFK/UMass",
+              route: @route_red
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-alfcl",
+              is_beginning?: false,
+              is_terminus?: true,
+              name: "Alewife",
+              route: @route_red
+            }
+          ]
+        }
+      ]
+
+      assert [
+               {
+                 [{"Ashmont - Alewife", :terminus}],
+                 %RouteStop{id: "place-asmnl"}
+               },
+               {
+                 [{"Ashmont - Alewife", :stop}],
+                 %RouteStop{id: "place-shmnl"}
+               },
+               {
+                 [{"Ashmont - Alewife", :line}, {"Braintree - Alewife", :terminus}],
+                 %RouteStop{id: "place-brntn"}
+               },
+               {
+                 [{"Ashmont - Alewife", :line}, {"Braintree - Alewife", :stop}],
+                 %RouteStop{id: "place-nqncy"}
+               },
+               {
+                 [{"Ashmont - Alewife", :merge}, {"Braintree - Alewife", :merge}],
+                 %RouteStop{id: "place-jfk"}
+               },
+               {
+                 [nil: :terminus],
+                 %RouteStop{id: "place-alfcl"}
+               }
+             ] = DiagramHelpers.build_stop_list(branches, 1)
+    end
+
+    test "builds a list of stops with bubble info for route 1 (1 branch, direction is ignored)" do
+      branches = [
+        %RouteStops{
+          branch: "Harvard Square - Nubian Station",
+          stops: [
+            %RouteStop{
+              branch: "Harvard Square - Nubian Station",
+              id: "110",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "Massachusetts Ave @ Holyoke St",
+              route: @route_1
+            },
+            %RouteStop{
+              branch: "Harvard Square - Nubian Station",
+              id: "66",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Mt Auburn St @ DeWolfe St",
+              route: @route_1
+            },
+            %RouteStop{
+              branch: "Harvard Square - Nubian Station",
+              id: "place-dudly",
+              is_beginning?: false,
+              is_terminus?: true,
+              name: "Nubian",
+              route: @route_1
+            }
+          ]
+        }
+      ]
+
+      assert [
+               {
+                 [nil: :terminus],
+                 %RouteStop{id: "110"}
+               },
+               {
+                 [nil: :stop],
+                 %RouteStop{id: "66"}
+               },
+               {
+                 [nil: :terminus],
+                 %RouteStop{id: "place-dudly"}
+               }
+             ] = DiagramHelpers.build_stop_list(branches, 0)
+    end
+
+    test "builds a list of stops with bubble info for Green line (4 branches), direction 0" do
+      branches = [
+        %RouteStops{
+          branch: "Green-E",
+          stops: [
+            %RouteStop{
+              branch: nil,
+              id: "place-north",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "North Station",
+              route: @route_green_e,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-haecl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Haymarket",
+              route: @route_green_e,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-gover",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Government Center",
+              route: @route_green_e,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-pktrm",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Park Street",
+              route: @route_green_e,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-boyls",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Boylston",
+              route: @route_green_e,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-armnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Arlington",
+              route: @route_green_e,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-coecl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Copley",
+              route: @route_green_e,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-E",
+              id: "place-prmnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Prudential",
+              route: @route_green_e,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-E",
+              id: "place-hsmnl",
+              is_beginning?: false,
+              is_terminus?: true,
+              name: "Heath Street",
+              route: @route_green_e,
+              connections: []
+            }
+          ]
+        },
+        %RouteStops{
+          branch: "Green-D",
+          stops: [
+            %RouteStop{
+              branch: nil,
+              id: "place-gover",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "Government Center",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-pktrm",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Park Street",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-boyls",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Boylston",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-armnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Arlington",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-coecl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Copley",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-hymnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Hynes Convention Center",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-kencl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Kenmore",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-D",
+              id: "place-fenwy",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Fenway",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-D",
+              id: "place-river",
+              is_beginning?: false,
+              is_terminus?: true,
+              name: "Riverside",
+              route: @route_green_d,
+              connections: []
+            }
+          ]
+        },
+        %RouteStops{
+          branch: "Green-C",
+          stops: [
+            %RouteStop{
+              branch: nil,
+              id: "place-north",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "North Station",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-haecl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Haymarket",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-gover",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Government Center",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-pktrm",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Park Street",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-boyls",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Boylston",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-armnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Arlington",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-coecl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Copley",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-hymnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Hynes Convention Center",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-kencl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Kenmore",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-C",
+              id: "place-smary",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Saint Marys Street",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-C",
+              id: "place-clmnl",
+              is_beginning?: false,
+              is_terminus?: true,
+              name: "Cleveland Circle",
+              route: @route_green_c,
+              connections: []
+            }
+          ]
+        },
+        %RouteStops{
+          branch: "Green-B",
+          stops: [
+            %RouteStop{
+              branch: nil,
+              id: "place-pktrm",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "Park Street",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-boyls",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Boylston",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-armnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Arlington",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-coecl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Copley",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-hymnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Hynes Convention Center",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-kencl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Kenmore",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-B",
+              id: "place-bland",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Blandford Street",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-B",
+              id: "place-lake",
+              is_beginning?: false,
+              is_terminus?: true,
+              name: "Boston College",
+              route: @route_green_b,
+              connections: []
+            }
+          ]
+        }
+      ]
+
+      assert [
+               {
+                 [nil: :terminus],
+                 %RouteStop{id: "place-north"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-haecl"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-gover"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-pktrm"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-boyls"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-armnl"}
+               },
+               {
+                 [{nil, :merge}, {"Green-E", :merge}],
+                 %Stops.RouteStop{id: "place-coecl"}
+               },
+               {
+                 [{nil, :line}, {"Green-E", :stop}],
+                 %Stops.RouteStop{id: "place-prmnl"}
+               },
+               {
+                 [{nil, :line}, {"Green-E", :terminus}],
+                 %Stops.RouteStop{id: "place-hsmnl"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-hymnl"}
+               },
+               {
+                 [{"Green-B", :merge}, {"Green-C", :merge}, {"Green-D", :merge}],
+                 %Stops.RouteStop{id: "place-kencl"}
+               },
+               {
+                 [{"Green-B", :line}, {"Green-C", :line}, {"Green-D", :stop}],
+                 %Stops.RouteStop{id: "place-fenwy"}
+               },
+               {
+                 [{"Green-B", :line}, {"Green-C", :line}, {"Green-D", :terminus}],
+                 %Stops.RouteStop{id: "place-river"}
+               },
+               {
+                 [{"Green-B", :line}, {"Green-C", :stop}],
+                 %Stops.RouteStop{id: "place-smary"}
+               },
+               {
+                 [{"Green-B", :line}, {"Green-C", :terminus}],
+                 %Stops.RouteStop{id: "place-clmnl"}
+               },
+               {
+                 [{"Green-B", :stop}],
+                 %Stops.RouteStop{id: "place-bland"}
+               },
+               {
+                 [{"Green-B", :terminus}],
+                 %Stops.RouteStop{id: "place-lake"}
+               }
+             ] = DiagramHelpers.build_stop_list(branches, 0)
+    end
+
+    test "builds a list of stops with bubble info for Green line (4 branches), direction 1" do
+      branches = [
+        %RouteStops{
+          branch: "Green-E",
+          stops: [
+            %RouteStop{
+              branch: "Green-E",
+              id: "place-hsmnl",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "Heath Street",
+              route: @route_green_e,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-E",
+              id: "place-prmnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Prudential",
+              route: @route_green_e,
+              connections: []
+            }
+          ]
+        },
+        %RouteStops{
+          branch: "Green-D",
+          stops: [
+            %RouteStop{
+              branch: "Green-D",
+              id: "place-river",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "Riverside",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-D",
+              id: "place-fenwy",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Fenway",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-kencl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Kenmore",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-hymnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Hynes Convention Center",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-coecl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Copley",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-armnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Arlington",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-boyls",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Boylston",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-pktrm",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Park Street",
+              route: @route_green_d,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-gover",
+              is_beginning?: false,
+              is_terminus?: true,
+              name: "Government Center",
+              route: @route_green_d,
+              connections: []
+            }
+          ]
+        },
+        %RouteStops{
+          branch: "Green-C",
+          stops: [
+            %RouteStop{
+              branch: "Green-C",
+              id: "place-clmnl",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "Cleveland Circle",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-C",
+              id: "place-smary",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Saint Marys Street",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-kencl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Kenmore",
+              route: @route_green_c,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-hymnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Hynes Convention Center",
+              route: @route_green_c,
+              connections: []
+            }
+          ]
+        },
+        %RouteStops{
+          branch: "Green-B",
+          stops: [
+            %RouteStop{
+              branch: "Green-B",
+              id: "place-lake",
+              is_beginning?: true,
+              is_terminus?: true,
+              name: "Boston College",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: "Green-B",
+              id: "place-bland",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Blandford Street",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-kencl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Kenmore",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-hymnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Hynes Convention Center",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-coecl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Copley",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-armnl",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Arlington",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-boyls",
+              is_beginning?: false,
+              is_terminus?: false,
+              name: "Boylston",
+              route: @route_green_b,
+              connections: []
+            },
+            %RouteStop{
+              branch: nil,
+              id: "place-pktrm",
+              is_beginning?: false,
+              is_terminus?: true,
+              name: "Park Street",
+              route: @route_green_b,
+              connections: []
+            }
+          ]
+        }
+      ]
+
+      assert [
+               {
+                 [{"Green-B", :terminus}],
+                 %Stops.RouteStop{id: "place-lake"}
+               },
+               {
+                 [{"Green-B", :stop}],
+                 %Stops.RouteStop{id: "place-bland"}
+               },
+               {
+                 [{"Green-B", :line}, {"Green-C", :terminus}],
+                 %Stops.RouteStop{id: "place-clmnl"}
+               },
+               {
+                 [{"Green-B", :line}, {"Green-C", :stop}],
+                 %Stops.RouteStop{id: "place-smary"}
+               },
+               {
+                 [{"Green-B", :line}, {"Green-C", :line}, {"Green-D", :terminus}],
+                 %Stops.RouteStop{id: "place-river"}
+               },
+               {
+                 [{"Green-B", :line}, {"Green-C", :line}, {"Green-D", :stop}],
+                 %Stops.RouteStop{id: "place-fenwy"}
+               },
+               {
+                 [{"Green-B", :merge}, {"Green-C", :merge}, {"Green-D", :merge}],
+                 %Stops.RouteStop{id: "place-kencl"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-hymnl"}
+               },
+               {
+                 [{nil, :line}, {"Green-E", :terminus}],
+                 %Stops.RouteStop{id: "place-hsmnl"}
+               },
+               {
+                 [{nil, :line}, {"Green-E", :stop}],
+                 %Stops.RouteStop{id: "place-prmnl"}
+               },
+               {
+                 [{nil, :merge}, {"Green-E", :merge}],
+                 %Stops.RouteStop{id: "place-coecl"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-armnl"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-boyls"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-pktrm"}
+               },
+               {
+                 [nil: :stop],
+                 %Stops.RouteStop{id: "place-gover"}
+               }
+             ] = DiagramHelpers.build_stop_list(branches, 1)
+    end
+  end
+end

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -2,6 +2,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
   use ExUnit.Case, async: true
 
   alias Routes.{Route, Shape}
+  alias RoutePatterns.RoutePattern
   alias SiteWeb.ScheduleController.Line.Helpers
   alias Stops.{RouteStops, Stop}
 
@@ -692,6 +693,18 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
       shapes = Routes.Repo.get_shapes("Red", direction_id: 0)
 
       assert Helpers.get_branches(shapes, stops, %Route{id: "Red"}, 0) == []
+    end
+  end
+
+  describe "by_typicality/2" do
+    test "without a selected route pattern, allows (returns true) only RoutePattern with a typicality of 1 through the filter" do
+      assert Helpers.by_typicality(%RoutePattern{typicality: 1}, nil)
+      refute Helpers.by_typicality(%RoutePattern{typicality: 2}, nil)
+    end
+
+    test "with a selected route pattern, allows (returns true) all RoutePatterns through the filter" do
+      assert Helpers.by_typicality(%RoutePattern{typicality: 1}, "123")
+      assert Helpers.by_typicality(%RoutePattern{typicality: 2}, "123")
     end
   end
 

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -42,7 +42,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                %RouteStops{branch: nil, stops: trunk_route_stops},
                %RouteStops{branch: "Alewife - Braintree", stops: braintree_route_stops},
                %RouteStops{branch: "Alewife - Ashmont", stops: ashmont_route_stops}
-             ] = Helpers.get_branch_route_stops(%Route{id: "Red"}, 0, "931_0009")
+             ] = Helpers.get_branch_route_stops(%Route{id: "Red"}, 0)
 
       assert Enum.all?(trunk_route_stops, &(&1.branch == nil))
 
@@ -103,7 +103,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                %Stops.RouteStops{branch: "Green-D", stops: d_stops},
                %Stops.RouteStops{branch: "Green-C", stops: c_stops},
                %Stops.RouteStops{branch: "Green-B", stops: b_stops}
-             ] = Helpers.get_branch_route_stops(%Route{id: "Green"}, 0, "123")
+             ] = Helpers.get_branch_route_stops(%Route{id: "Green"}, 0, nil)
 
       assert Enum.map(e_stops, & &1.branch) ==
                [

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -39,10 +39,62 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
   describe "get_branch_route_stops/3" do
     test "returns a list of RouteStops, one for each branch of the line" do
       assert [
-               %RouteStops{branch: nil},
-               %RouteStops{branch: "Alewife - Braintree"},
-               %RouteStops{branch: "Alewife - Ashmont"}
+               %RouteStops{branch: nil, stops: trunk_route_stops},
+               %RouteStops{branch: "Alewife - Braintree", stops: braintree_route_stops},
+               %RouteStops{branch: "Alewife - Ashmont", stops: ashmont_route_stops}
              ] = Helpers.get_branch_route_stops(%Route{id: "Red"}, 0, "931_0009")
+
+      assert Enum.all?(trunk_route_stops, &(&1.branch == nil))
+
+      assert Enum.map(trunk_route_stops, & &1.is_terminus?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
+
+      assert Enum.map(trunk_route_stops, & &1.is_beginning?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
+
+      assert Enum.all?(braintree_route_stops, &(&1.branch == "Alewife - Braintree"))
+
+      assert Enum.map(braintree_route_stops, & &1.is_terminus?) ==
+               [false, false, false, false, true]
+
+      assert Enum.map(braintree_route_stops, & &1.is_beginning?) ==
+               [false, false, false, false, false]
+
+      assert Enum.all?(ashmont_route_stops, &(&1.branch == "Alewife - Ashmont"))
+
+      assert Enum.map(ashmont_route_stops, & &1.is_terminus?) ==
+               [false, false, false, true]
+
+      assert Enum.map(ashmont_route_stops, & &1.is_beginning?) ==
+               [false, false, false, false]
     end
 
     test "handles the combined Green line" do
@@ -52,6 +104,28 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                %Stops.RouteStops{branch: "Green-C", stops: c_stops},
                %Stops.RouteStops{branch: "Green-B", stops: b_stops}
              ] = Helpers.get_branch_route_stops(%Route{id: "Green"}, 0, "123")
+
+      assert Enum.map(e_stops, & &1.branch) ==
+               [
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 "Green-E",
+                 "Green-E",
+                 "Green-E",
+                 "Green-E",
+                 "Green-E",
+                 "Green-E",
+                 "Green-E",
+                 "Green-E",
+                 "Green-E",
+                 "Green-E",
+                 "Green-E"
+               ]
 
       assert_stop_ids(e_stops, [
         "place-north",
@@ -73,6 +147,74 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
         "place-bckhl",
         "place-hsmnl"
       ])
+
+      assert Enum.map(e_stops, & &1.is_terminus?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 true
+               ]
+
+      assert Enum.map(e_stops, & &1.is_beginning?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
+
+      assert Enum.map(d_stops, & &1.branch) ==
+               [
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 "Green-D",
+                 "Green-D",
+                 "Green-D",
+                 "Green-D",
+                 "Green-D",
+                 "Green-D",
+                 "Green-D",
+                 "Green-D",
+                 "Green-D",
+                 "Green-D",
+                 "Green-D",
+                 "Green-D",
+                 "Green-D"
+               ]
 
       assert_stop_ids(d_stops, [
         "place-gover",
@@ -96,6 +238,80 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
         "place-woodl",
         "place-river"
       ])
+
+      assert Enum.map(d_stops, & &1.is_terminus?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 true
+               ]
+
+      assert Enum.map(d_stops, & &1.is_beginning?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
+
+      assert Enum.map(c_stops, & &1.branch) ==
+               [
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 "Green-C",
+                 "Green-C",
+                 "Green-C",
+                 "Green-C",
+                 "Green-C",
+                 "Green-C",
+                 "Green-C",
+                 "Green-C",
+                 "Green-C",
+                 "Green-C",
+                 "Green-C",
+                 "Green-C",
+                 "Green-C"
+               ]
 
       assert_stop_ids(c_stops, [
         "place-north",
@@ -121,6 +337,86 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
         "place-engav",
         "place-clmnl"
       ])
+
+      assert Enum.map(c_stops, & &1.is_terminus?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 true
+               ]
+
+      assert Enum.map(c_stops, & &1.is_beginning?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
+
+      assert Enum.map(b_stops, & &1.branch) ==
+               [
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 nil,
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B",
+                 "Green-B"
+               ]
 
       assert_stop_ids(b_stops, [
         "place-pktrm",
@@ -148,6 +444,62 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
         "place-sougr",
         "place-lake"
       ])
+
+      assert Enum.map(b_stops, & &1.is_terminus?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 true
+               ]
+
+      assert Enum.map(b_stops, & &1.is_beginning?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
     end
   end
 

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -44,6 +44,111 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                %RouteStops{branch: "Alewife - Ashmont"}
              ] = Helpers.get_branch_route_stops(%Route{id: "Red"}, 0, "931_0009")
     end
+
+    test "handles the combined Green line" do
+      assert [
+               %Stops.RouteStops{branch: "Green-E", stops: e_stops},
+               %Stops.RouteStops{branch: "Green-D", stops: d_stops},
+               %Stops.RouteStops{branch: "Green-C", stops: c_stops},
+               %Stops.RouteStops{branch: "Green-B", stops: b_stops}
+             ] = Helpers.get_branch_route_stops(%Route{id: "Green"}, 0, "123")
+
+      assert_stop_ids(e_stops, [
+        "place-north",
+        "place-haecl",
+        "place-gover",
+        "place-pktrm",
+        "place-boyls",
+        "place-armnl",
+        "place-coecl",
+        "place-prmnl",
+        "place-symcl",
+        "place-nuniv",
+        "place-mfa",
+        "place-lngmd",
+        "place-brmnl",
+        "place-fenwd",
+        "place-mispk",
+        "place-rvrwy",
+        "place-bckhl",
+        "place-hsmnl"
+      ])
+
+      assert_stop_ids(d_stops, [
+        "place-gover",
+        "place-pktrm",
+        "place-boyls",
+        "place-armnl",
+        "place-coecl",
+        "place-hymnl",
+        "place-kencl",
+        "place-fenwy",
+        "place-longw",
+        "place-bvmnl",
+        "place-brkhl",
+        "place-bcnfd",
+        "place-rsmnl",
+        "place-chhil",
+        "place-newto",
+        "place-newtn",
+        "place-eliot",
+        "place-waban",
+        "place-woodl",
+        "place-river"
+      ])
+
+      assert_stop_ids(c_stops, [
+        "place-north",
+        "place-haecl",
+        "place-gover",
+        "place-pktrm",
+        "place-boyls",
+        "place-armnl",
+        "place-coecl",
+        "place-hymnl",
+        "place-kencl",
+        "place-smary",
+        "place-hwsst",
+        "place-kntst",
+        "place-stpul",
+        "place-cool",
+        "place-sumav",
+        "place-bndhl",
+        "place-fbkst",
+        "place-bcnwa",
+        "place-tapst",
+        "place-denrd",
+        "place-engav",
+        "place-clmnl"
+      ])
+
+      assert_stop_ids(b_stops, [
+        "place-pktrm",
+        "place-boyls",
+        "place-armnl",
+        "place-coecl",
+        "place-hymnl",
+        "place-kencl",
+        "place-bland",
+        "place-buest",
+        "place-bucen",
+        "place-buwst",
+        "place-stplb",
+        "place-plsgr",
+        "place-babck",
+        "place-brico",
+        "place-harvd",
+        "place-grigg",
+        "place-alsgr",
+        "place-wrnst",
+        "place-wascm",
+        "place-sthld",
+        "place-chswk",
+        "place-chill",
+        "place-sougr",
+        "place-lake"
+      ])
+    end
   end
 
   describe "get_route_shapes" do
@@ -170,5 +275,9 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
       assert Helpers.get_branches(shapes, stops, %Route{id: "Red"}, 0) == []
     end
+  end
+
+  def assert_stop_ids(actual, stop_ids) do
+    assert Enum.map(actual, & &1.id) == stop_ids
   end
 end

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -1,0 +1,20 @@
+defmodule SiteWeb.ScheduleController.Line.HelpersTest do
+  use ExUnit.Case, async: true
+
+  alias Routes.Route
+  alias SiteWeb.ScheduleController.Line.Helpers
+
+  describe "get_route/1" do
+    test "gets a route given its ID" do
+      assert {:ok, %Route{id: "1", name: "1"}} = Helpers.get_route("1")
+    end
+
+    test "gets a custom response for 'Green'" do
+      assert {:ok, %Route{id: "Green", name: "Green Line"}} = Helpers.get_route("Green")
+    end
+
+    test "returns :not_found if given a bad route ID" do
+      assert Helpers.get_route("Puce") == :not_found
+    end
+  end
+end

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -1,8 +1,26 @@
 defmodule SiteWeb.ScheduleController.Line.HelpersTest do
   use ExUnit.Case, async: true
 
-  alias Routes.Route
+  alias Routes.{Route, Shape}
   alias SiteWeb.ScheduleController.Line.Helpers
+  alias Stops.{RouteStops, Stop}
+
+  @shape %Shape{
+    direction_id: 1,
+    id: "SHAPE_ID",
+    name: "Nubian Station",
+    polyline: "POLYLINE",
+    priority: 3,
+    stop_ids: ["110", "66", "place-dudly"]
+  }
+
+  @stop %Stop{
+    id: "110",
+    name: "Massachusetts Ave @ Holyoke St",
+    type: :stop
+  }
+
+  @route_stops %{"1" => [@stop]}
 
   describe "get_route/1" do
     test "gets a route given its ID" do
@@ -15,6 +33,142 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
     test "returns :not_found if given a bad route ID" do
       assert Helpers.get_route("Puce") == :not_found
+    end
+  end
+
+  describe "get_branch_route_stops/3" do
+    test "returns a list of RouteStops, one for each branch of the line" do
+      assert [
+               %RouteStops{branch: nil},
+               %RouteStops{branch: "Alewife - Braintree"},
+               %RouteStops{branch: "Alewife - Ashmont"}
+             ] = Helpers.get_branch_route_stops(%Route{id: "Red"}, 0, "931_0009")
+    end
+  end
+
+  describe "get_route_shapes" do
+    test "gets shapes for both directions of the given route" do
+      get_shapes_fn = fn route_id, _shapes_opts, _filter_by_priority? ->
+        if route_id == "1", do: [@shape], else: []
+      end
+
+      assert Helpers.get_route_shapes("1", nil, true, get_shapes_fn: get_shapes_fn) == [@shape]
+    end
+
+    test "gets shapes a single directions of the given route" do
+      get_shapes_fn = fn route_id, shapes_opts, _filter_by_priority? ->
+        if route_id == "1" and shapes_opts == [direction_id: 0], do: [@shape], else: []
+      end
+
+      assert Helpers.get_route_shapes("1", 0, true, get_shapes_fn: get_shapes_fn) == [@shape]
+    end
+
+    test "optionally does not filter out shapes with a negative priority" do
+      get_shapes_fn = fn route_id, _shapes_opts, filter_by_priority? ->
+        if route_id == "1" and filter_by_priority? == false, do: [@shape], else: []
+      end
+
+      assert Helpers.get_route_shapes("1", nil, false, get_shapes_fn: get_shapes_fn) == [@shape]
+    end
+
+    test "gets shapes for all Green lines" do
+      get_shapes_fn = fn route_id, _shapes_opts, _filter_by_priority? ->
+        if route_id == "Green-B,Green-C,Green-D,Green-E", do: [@shape], else: []
+      end
+
+      assert Helpers.get_route_shapes("Green", nil, true, get_shapes_fn: get_shapes_fn) == [
+               @shape
+             ]
+    end
+  end
+
+  describe "get_route_stops" do
+    test "gets stops by route for a given route" do
+      stops_by_route_fn = fn route_id, direction_id, _opts ->
+        if route_id == "1" and direction_id == 0, do: [@stop], else: []
+      end
+
+      assert Helpers.get_route_stops("1", 0, stops_by_route_fn) == @route_stops
+    end
+
+    test "handles an error response from the stops_by_route_fn" do
+      stops_by_route_fn = fn _, _, _ -> {:error, "Error"} end
+
+      assert Helpers.get_route_stops("1", 0, stops_by_route_fn) == %{}
+    end
+
+    test "gets stops for all Green lines" do
+      stops_by_route_fn = fn _, _, _ -> [@stop] end
+
+      assert Helpers.get_route_stops("Green", 0, stops_by_route_fn) == %{
+               "Green-B" => [@stop],
+               "Green-C" => [@stop],
+               "Green-D" => [@stop],
+               "Green-E" => [@stop]
+             }
+    end
+  end
+
+  describe "get_active_shapes/3" do
+    test "for bus routes, returns the requested shape" do
+      assert Helpers.get_active_shapes([@shape], %Route{type: 3, id: "1"}, "SHAPE_ID") == [
+               @shape
+             ]
+    end
+
+    test "for bus routes, returns the first shape if the requested shape wasn't found" do
+      assert Helpers.get_active_shapes([@shape], %Route{type: 3, id: "1"}, "OTHER_SHAPE_ID") == [
+               @shape
+             ]
+    end
+
+    test "for bus routes, returns an empty list if given an empty list of shapes" do
+      assert Helpers.get_active_shapes([], %Route{type: 3, id: "1"}, "SHAPE_ID") == []
+    end
+
+    test "returns an empty list for the generic Green line" do
+      assert Helpers.get_active_shapes([@shape], %Route{id: "Green"}, "SHAPE_ID") == []
+    end
+
+    test "returns the passed in shapes for non-bus routes" do
+      assert Helpers.get_active_shapes([@shape], %Route{type: 1, id: "Blue"}, "SHAPE_ID") == [
+               @shape
+             ]
+    end
+  end
+
+  describe "filter_route_shapes/3" do
+    test "returns the active shapes list for bus routes" do
+      assert Helpers.filter_route_shapes([], [@shape], %Route{type: 3}) == [@shape]
+    end
+
+    test "returns the all shapes list for non-bus routes" do
+      assert Helpers.filter_route_shapes([@shape], [], %Route{type: 1}) == [@shape]
+    end
+  end
+
+  describe "get_branches/4" do
+    test "returns a list of RouteStops, one for each branch of the line" do
+      stops = Helpers.get_route_stops("Red", 0, &Stops.Repo.by_route/3)
+      shapes = Routes.Repo.get_shapes("Red", direction_id: 0)
+
+      assert [%RouteStops{}, %RouteStops{}, %RouteStops{}] =
+               Helpers.get_branches(shapes, stops, %Route{id: "Red"}, 0)
+    end
+
+    test "returns RouteStops for all Green line branches" do
+      stops = Helpers.get_route_stops("Green", 0, &Stops.Repo.by_route/3)
+      shapes = Helpers.get_route_shapes("Green", 0)
+
+      assert [%RouteStops{}, %RouteStops{}, %RouteStops{}, %RouteStops{}] =
+               Helpers.get_branches(shapes, stops, %Route{id: "Green"}, 0)
+    end
+
+    test "returns an empty list when given no stops" do
+      stops = %{}
+      shapes = Routes.Repo.get_shapes("Red", direction_id: 0)
+
+      assert Helpers.get_branches(shapes, stops, %Route{id: "Red"}, 0) == []
     end
   end
 end

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -501,6 +501,70 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                  false
                ]
     end
+
+    test "handles a single Green line" do
+      assert [
+               %RouteStops{branch: "Park Street - Boston College", stops: stops}
+             ] = Helpers.get_branch_route_stops(%Route{id: "Green-B"}, 0, "123")
+
+      assert Enum.all?(stops, &(&1.branch == "Park Street - Boston College"))
+
+      assert Enum.map(stops, & &1.is_terminus?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 true
+               ]
+
+      assert Enum.map(stops, & &1.is_beginning?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
+    end
   end
 
   describe "get_route_shapes" do

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -5,6 +5,8 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
   alias SiteWeb.ScheduleController.Line.Helpers
   alias Stops.{RouteStops, Stop}
 
+  doctest Helpers
+
   @shape %Shape{
     direction_id: 1,
     id: "SHAPE_ID",

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -105,7 +105,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                %Stops.RouteStops{branch: "Green-D", stops: d_stops},
                %Stops.RouteStops{branch: "Green-C", stops: c_stops},
                %Stops.RouteStops{branch: "Green-B", stops: b_stops}
-             ] = Helpers.get_branch_route_stops(%Route{id: "Green"}, 0, nil)
+             ] = Helpers.get_branch_route_stops(%Route{id: "Green"}, 0)
 
       assert Enum.map(e_stops, & &1.branch) ==
                [
@@ -507,7 +507,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
     test "handles a single Green line" do
       assert [
                %RouteStops{branch: "Park Street - Boston College", stops: stops}
-             ] = Helpers.get_branch_route_stops(%Route{id: "Green-B"}, 0, "123")
+             ] = Helpers.get_branch_route_stops(%Route{id: "Green-B"}, 0)
 
       assert Enum.all?(stops, &(&1.branch == "Park Street - Boston College"))
 

--- a/apps/site/test/site_web/controllers/schedule/map_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/map_api_test.exs
@@ -37,6 +37,14 @@ defmodule SiteWeb.ScheduleController.MapApiTest do
              } = response
     end
 
+    test "returns 400 if given a bad route", %{conn: conn} do
+      conn = get(conn, map_api_path(conn, :show, id: "Puce"))
+
+      assert response = json_response(conn, 400)
+
+      assert response == %{"error" => "Invalid arguments"}
+    end
+
     test "doesn't 500 if given bad params", %{conn: conn} do
       conn = get(conn, map_api_path(conn, :show, id: "66"))
 

--- a/apps/stops/lib/route_stop.ex
+++ b/apps/stops/lib/route_stop.ex
@@ -71,7 +71,7 @@ defmodule Stops.RouteStop do
   def list_from_route_patterns([], _route, _direction_id), do: []
 
   def list_from_route_patterns([route_pattern_with_stops], route, _direction_id) do
-    # If there is only one route pattern, we know that we won't need to deal with merging branches so we just return whatever the list of stops is without calling &breanch_branch_list/2.
+    # If there is only one route pattern, we know that we won't need to deal with merging branches so we just return whatever the list of stops is without calling &merge_branch_list/2.
     do_list_from_route_pattern(route_pattern_with_stops, route)
   end
 

--- a/apps/stops/lib/route_stop.ex
+++ b/apps/stops/lib/route_stop.ex
@@ -8,9 +8,9 @@ defmodule Stops.RouteStop do
       id: "place-sstat",                                  # The id that the stop is typically identified by (i.e. the parent stop's id)
       name: "South Station"                               # Stop's display name
       zone: "1A"                                          # Commuter rail zone (will be nil if stop doesn't have CR routes)
-      route: %Routes.Route{id: "Red"...}                  # The full Routes.Route for the parent route
+      route: %Route{id: "Red"...}                         # The full Route for the parent route
       branch: nil                                         # Name of the branch that this stop is on for this route. will be nil unless the stop is actually on a branch.
-      station_info: %Stops.Stop{id: "place-sstat"...}     # Full Stops.Stop struct for the parent stop.
+      station_info: %Stop{id: "place-sstat"...}           # Full Stops.Stop struct for the parent stop.
 
       stop_features: [:commuter_rail, :bus, :accessible]  # List of atoms representing the icons that should be displayed for this stop.
       is_terminus?: false                                 # Whether this is either the first or last stop on the route.
@@ -18,22 +18,25 @@ defmodule Stops.RouteStop do
   ```
 
   """
-  alias Routes.{Route}
+  alias Routes.{Route, Shape}
+  alias RoutePatterns.RoutePattern
+  alias Stops.Stop
+
   @type branch_name_t :: String.t() | nil
   @type direction_id_t :: 0 | 1
 
   @type t :: %__MODULE__{
-          id: Stops.Stop.id_t(),
+          id: Stop.id_t(),
           name: String.t(),
           zone: String.t() | {:error, :not_fetched},
           branch: branch_name_t,
-          station_info: Stops.Stop.t(),
-          route: Routes.Route.t() | nil,
-          connections: [Routes.Route.t()] | {:error, :not_fetched},
+          station_info: Stop.t(),
+          route: Route.t() | nil,
+          connections: [Route.t()] | {:error, :not_fetched},
           stop_features: [Stops.Repo.stop_feature()] | {:error, :not_fetched},
           is_terminus?: boolean,
           is_beginning?: boolean,
-          closed_stop_info: Stops.Stop.ClosedStopInfo.t() | nil
+          closed_stop_info: Stop.ClosedStopInfo.t() | nil
         }
 
   defstruct [
@@ -61,15 +64,65 @@ defmodule Stops.RouteStop do
   end
 
   @doc """
+  Given a list of route patterns with stops and a route, generates a list of RouteStops representing all stops on that route. If the route has branches, the branched stops appear grouped together in order as part of the list.
+  """
+  @spec list_from_route_patterns([{RoutePattern.t(), [Stop.t()]}], Route.t(), direction_id_t()) ::
+          [t()]
+  def list_from_route_patterns([], _route, _direction_id), do: []
+
+  def list_from_route_patterns([route_pattern_with_stops], route, _direction_id) do
+    # If there is only one route pattern, we know that we won't need to deal with merging branches so we just return whatever the list of stops is without calling &breanch_branch_list/2.
+    do_list_from_route_pattern(route_pattern_with_stops, route)
+  end
+
+  def list_from_route_patterns(route_patterns_with_stops, route, direction_id) do
+    route_patterns_with_stops
+    |> Enum.map(&do_list_from_route_pattern(&1, route))
+    |> merge_branch_list(direction_id)
+  end
+
+  @spec do_list_from_route_pattern({RoutePattern.t(), [Stop.t()]}, Route.t()) :: [t()]
+  def do_list_from_route_pattern({route_pattern, stops}, route) do
+    if String.starts_with?(route.id, "Green") and !String.starts_with?(route_pattern.id, "Green") do
+      # Hide the Lechemere shuttle for the moment
+      []
+    else
+      stops
+      |> Util.EnumHelpers.with_first_last()
+      |> Enum.with_index()
+      |> Enum.map(fn {{stop, first_or_last?}, idx} ->
+        branch = branch_name(route_pattern)
+        first? = idx == 0
+        last? = first_or_last? and idx > 0
+
+        stop
+        |> build_route_stop(route, branch: branch, first?: first?, last?: last?)
+        |> fetch_zone()
+        |> fetch_connections()
+        |> fetch_stop_features()
+      end)
+    end
+  end
+
+  @spec branch_name(RoutePattern.t()) :: String.t()
+  defp branch_name(%RoutePattern{name: name, route_id: route_id}) do
+    if String.starts_with?(route_id, "Green") do
+      route_id
+    else
+      name
+    end
+  end
+
+  @doc """
   Given a route and a list of that route's shapes, generates a list of RouteStops representing all stops on that route. If the route has branches,
   the branched stops appear grouped together in order as part of the list.
   """
-  @spec list_from_shapes([Routes.Shape.t()], [Stops.Stop.t()], Routes.Route.t(), direction_id_t) ::
+  @spec list_from_shapes([Shape.t()], [Stop.t()], Route.t(), direction_id_t) ::
           [RouteStop.t()]
   # Can't build route stops if there are no stops or shapes
   def list_from_shapes([], [], _route, _direction_id), do: []
 
-  def list_from_shapes([], [%Stops.Stop{} | _] = stops, route, _direction_id) do
+  def list_from_shapes([], [%Stop{} | _] = stops, route, _direction_id) do
     # if the repo doesn't have any shapes, just fake one since we only need the name and stop_ids.
 
     stops
@@ -79,8 +132,8 @@ defmodule Stops.RouteStop do
   end
 
   def list_from_shapes(
-        [%Routes.Shape{} = shape],
-        [%Stops.Stop{} | _] = stops,
+        [%Shape{} = shape],
+        [%Stop{} | _] = stops,
         route,
         _direction_id
       ) do
@@ -90,9 +143,9 @@ defmodule Stops.RouteStop do
   end
 
   def list_from_shapes(
-        [%Routes.Shape{} = shape | _],
+        [%Shape{} = shape | _],
         stops,
-        %Routes.Route{type: 4} = route,
+        %Route{type: 4} = route,
         _direction_id
       ) do
     # for the ferry, for now, just return a single branch
@@ -157,9 +210,9 @@ defmodule Stops.RouteStop do
     |> merge_branch_list(direction_id)
   end
 
-  @spec do_list_from_shapes(String.t(), [Stops.Stop.id_t()], [Stops.Stop.t()], Routes.Route.t()) ::
+  @spec do_list_from_shapes(String.t(), [Stop.id_t()], [Stop.t()], Route.t()) ::
           [RouteStop.t()]
-  defp do_list_from_shapes(shape_name, stop_ids, [%Stops.Stop{} | _] = stops, route) do
+  defp do_list_from_shapes(shape_name, stop_ids, [%Stop{} | _] = stops, route) do
     stops = Map.new(stops, &{&1.id, &1})
 
     stop_ids
@@ -190,8 +243,8 @@ defmodule Stops.RouteStop do
   @doc """
   Builds a RouteStop from information about a stop.
   """
-  @spec build_route_stop(Stops.Stop.t(), Routes.Route.t(), Keyword.t()) :: RouteStop.t()
-  def build_route_stop(%Stops.Stop{} = stop, route, opts \\ []) do
+  @spec build_route_stop(Stop.t(), Route.t(), Keyword.t()) :: RouteStop.t()
+  def build_route_stop(%Stop{} = stop, route, opts \\ []) do
     branch = Keyword.get(opts, :branch)
     first? = Keyword.get(opts, :first?) == true
     last? = Keyword.get(opts, :last?) == true
@@ -219,7 +272,7 @@ defmodule Stops.RouteStop do
   end
 
   def fetch_connections(
-        %__MODULE__{route: %Routes.Route{}, connections: {:error, :not_fetched}} = route_stop
+        %__MODULE__{route: %Route{}, connections: {:error, :not_fetched}} = route_stop
       ) do
     connections =
       route_stop.id
@@ -230,7 +283,7 @@ defmodule Stops.RouteStop do
   end
 
   @spec route_stop_features(t) :: [Stops.Repo.stop_feature()]
-  defp route_stop_features(%__MODULE__{station_info: %Stops.Stop{}} = route_stop) do
+  defp route_stop_features(%__MODULE__{station_info: %Stop{}} = route_stop) do
     Stops.Repo.stop_features(route_stop.station_info, connections: route_stop.connections)
   end
 

--- a/apps/stops/lib/route_stop.ex
+++ b/apps/stops/lib/route_stop.ex
@@ -82,7 +82,7 @@ defmodule Stops.RouteStop do
   end
 
   @spec do_list_from_route_pattern({RoutePattern.t(), [Stop.t()]}, Route.t()) :: [t()]
-  def do_list_from_route_pattern({route_pattern, stops}, route) do
+  defp do_list_from_route_pattern({route_pattern, stops}, route) do
     if String.starts_with?(route.id, "Green") and !String.starts_with?(route_pattern.id, "Green") do
       # Hide the Lechemere shuttle for the moment
       []

--- a/apps/stops/lib/route_stops.ex
+++ b/apps/stops/lib/route_stops.ex
@@ -1,21 +1,33 @@
 defmodule Stops.RouteStops do
+  @moduledoc """
+  Helpers for assembling a list of RouteStops.
+  """
+
+  alias Routes.{Route, Shape}
+  alias Stops.{RouteStop, Stop}
+
   defstruct [:branch, :stops]
 
   @type t :: %__MODULE__{
-          branch: String.t(),
-          stops: [Stops.RouteStop.t()]
+          branch: RouteStop.branch_name_t(),
+          stops: [RouteStop.t()]
         }
   @type direction_id_t :: 0 | 1
 
-  alias Stops.RouteStop
+  @spec from_route_stop_groups([[RouteStop.t()]]) :: [
+          t()
+        ]
+  def from_route_stop_groups(route_stop_groups) do
+    Enum.map(route_stop_groups, &from_list/1)
+  end
 
   @doc """
   Builds a list of all stops (as %RouteStop{}) on a route in a single direction.
   """
-  @spec by_direction([Stops.Stop.t()], [Routes.Shape.t()], Routes.Route.t(), direction_id_t) :: [
-          t
+  @spec by_direction([Stop.t()], [Shape.t()], Route.t(), direction_id_t) :: [
+          t()
         ]
-  def by_direction(stops, shapes, %Routes.Route{} = route, direction_id)
+  def by_direction(stops, shapes, %Route{} = route, direction_id)
       when is_integer(direction_id) do
     shapes
     |> RouteStop.list_from_shapes(stops, route, direction_id)
@@ -33,11 +45,24 @@ defmodule Stops.RouteStops do
     |> Enum.map(&from_list/1)
   end
 
-  @spec from_list([RouteStop.t()]) :: t
-  defp from_list([%RouteStop{branch: branch} | _] = stops) do
+  @spec from_list([RouteStop.t()]) :: t()
+  def from_list(stops) do
     %__MODULE__{
-      branch: branch,
+      branch: branch(stops),
       stops: stops
     }
   end
+
+  @spec branch([RouteStop.t()]) :: RouteStop.branch_name_t()
+  defp branch([first | _] = route_stops) do
+    route_stops
+    |> Enum.find(first, &green_branch?/1)
+    |> Map.get(:branch)
+  end
+
+  @spec green_branch?(RouteStop.t()) :: boolean()
+  defp green_branch?(%RouteStop{branch: branch}) when is_binary(branch),
+    do: String.starts_with?(branch, "Green")
+
+  defp green_branch?(_), do: false
 end

--- a/apps/stops/test/route_stop_test.exs
+++ b/apps/stops/test/route_stop_test.exs
@@ -148,9 +148,9 @@ defmodule Stops.RouteStopTest do
       assert_stop_ids(actual, ~w(place-pktrm place-bucen place-lake)s)
 
       assert_branch_names(actual, [
-        "Green-B",
-        "Green-B",
-        "Green-B"
+        "Park Street - Boston College",
+        "Park Street - Boston College",
+        "Park Street - Boston College"
       ])
     end
 
@@ -173,9 +173,9 @@ defmodule Stops.RouteStopTest do
       assert_stop_ids(actual, ~w(place-lake place-bucen place-pktrm)s)
 
       assert_branch_names(actual, [
-        "Green-B",
-        "Green-B",
-        "Green-B"
+        "Boston College - Park Street",
+        "Boston College - Park Street",
+        "Boston College - Park Street"
       ])
     end
 
@@ -249,7 +249,7 @@ defmodule Stops.RouteStopTest do
         {lechmere_shuttle_route_pattern, lechmere_shuttle_stops}
       ]
 
-      actual = list_from_route_patterns(route_patterns_with_stops, @green_route, 0)
+      actual = list_from_route_patterns(route_patterns_with_stops, @green_route, 0, true)
 
       assert_stop_ids(
         actual,
@@ -307,6 +307,52 @@ defmodule Stops.RouteStopTest do
 
     test "handles an empty list of route patterns" do
       assert list_from_route_patterns([], @red_route, 0) == []
+    end
+
+    test "optionally uses the route ID for the branch name" do
+      route_pattern_0 = %RoutePattern{
+        direction_id: 0,
+        id: "Green-B-3-0",
+        name: "Park Street - Boston College",
+        representative_trip_id: "45809685",
+        route_id: "Green-B",
+        typicality: 1
+      }
+
+      stops_0 = make_stops(~w(place-pktrm place-bucen place-lake)s)
+
+      route_pattern_with_stops_0 = [{route_pattern_0, stops_0}]
+
+      route_pattern_1 = %RoutePattern{
+        direction_id: 0,
+        id: "Green-B-3-1",
+        name: "Boston College - Park Street",
+        representative_trip_id: "45809684",
+        route_id: "Green-B",
+        typicality: 1
+      }
+
+      stops_1 = make_stops(~w(place-lake place-bucen place-pktrm)s)
+
+      route_pattern_with_stops_1 = [{route_pattern_1, stops_1}]
+
+      assert_branch_names(
+        list_from_route_patterns(route_pattern_with_stops_0, @green_b_route, 0, true),
+        [
+          "Green-B",
+          "Green-B",
+          "Green-B"
+        ]
+      )
+
+      assert_branch_names(
+        list_from_route_patterns(route_pattern_with_stops_1, @green_b_route, 1, true),
+        [
+          "Green-B",
+          "Green-B",
+          "Green-B"
+        ]
+      )
     end
   end
 

--- a/apps/stops/test/route_stop_test.exs
+++ b/apps/stops/test/route_stop_test.exs
@@ -2,12 +2,313 @@ defmodule Stops.RouteStopTest do
   use ExUnit.Case, async: true
 
   import Stops.RouteStop
-  alias Stops.RouteStop
-  alias Stops.Stop
   alias Routes.{Route, Shape}
+  alias RoutePatterns.RoutePattern
+  alias Stops.{RouteStop, Stop}
 
   @stop %Stop{name: "Braintree", id: "place-brntn"}
-  @route %Routes.Route{id: "Red", type: 1}
+  @green_route %Route{id: "Green", type: 0}
+  @green_b_route %Route{id: "Green-B", type: 1}
+  @orange_route %Route{id: "Orange", type: 1}
+  @red_route %Route{id: "Red", type: 1}
+
+  describe "list_from_route_patterns/2" do
+    test "Orange line (1 branch), direction 0" do
+      route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "Orange-3-0",
+        name: "Oak Grove - Forest Hills",
+        representative_trip_id: "44080481",
+        route_id: "Orange",
+        typicality: 1
+      }
+
+      stops = make_stops(~w(place-ogmnl place-dwnxg place-forhl)s)
+
+      route_pattern_with_stops = [{route_pattern, stops}]
+
+      actual = list_from_route_patterns(route_pattern_with_stops, @orange_route, 0)
+
+      assert_stop_ids(actual, ~w(place-ogmnl place-dwnxg place-forhl)s)
+
+      assert_branch_names(actual, [
+        "Oak Grove - Forest Hills",
+        "Oak Grove - Forest Hills",
+        "Oak Grove - Forest Hills"
+      ])
+    end
+
+    test "Orange line (1 branch), direction 1" do
+      route_pattern = %RoutePattern{
+        direction_id: 1,
+        id: "Orange-3-1",
+        name: "Forest Hills - Oak Grove",
+        representative_trip_id: "44080614",
+        route_id: "Orange",
+        typicality: 1
+      }
+
+      stops = make_stops(~w(place-forhl place-dwnxg place-ogmnl)s)
+
+      route_pattern_with_stops = [{route_pattern, stops}]
+
+      actual = list_from_route_patterns(route_pattern_with_stops, @orange_route, 1)
+
+      assert_stop_ids(actual, ~w(place-forhl place-dwnxg place-ogmnl)s)
+
+      assert_branch_names(actual, [
+        "Forest Hills - Oak Grove",
+        "Forest Hills - Oak Grove",
+        "Forest Hills - Oak Grove"
+      ])
+    end
+
+    test "Red line (2 branches), direction 0" do
+      ashmont_route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "Red-1-0",
+        name: "Alewife - Ashmont",
+        representative_trip_id: "44079437",
+        route_id: "Red",
+        typicality: 1
+      }
+
+      braintree_route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "Red-3-0",
+        name: "Alewife - Braintree",
+        representative_trip_id: "44079593",
+        route_id: "Red",
+        typicality: 1
+      }
+
+      ashmont_stops = make_stops(~w(place-alfcl place-pktrm place-asmnl)s)
+      braintree_stops = make_stops(~w(place-alfcl place-pktrm place-brntn)s)
+
+      route_patterns_with_stops = [
+        {ashmont_route_pattern, ashmont_stops},
+        {braintree_route_pattern, braintree_stops}
+      ]
+
+      actual = list_from_route_patterns(route_patterns_with_stops, @red_route, 0)
+
+      assert_stop_ids(actual, ~w(place-alfcl place-pktrm place-brntn place-asmnl)s)
+      assert_branch_names(actual, [nil, nil, "Alewife - Braintree", "Alewife - Ashmont"])
+    end
+
+    test "Red line (2 branches), direction 1" do
+      ashmont_route_pattern = %RoutePattern{
+        direction_id: 1,
+        id: "Red-1-1",
+        name: "Ashmont - Alewife",
+        representative_trip_id: "44079438",
+        route_id: "Red",
+        typicality: 1
+      }
+
+      braintree_route_pattern = %RoutePattern{
+        direction_id: 1,
+        id: "Red-3-1",
+        name: "Braintree - Alewife",
+        representative_trip_id: "44079573",
+        route_id: "Red",
+        typicality: 1
+      }
+
+      ashmont_stops = make_stops(~w(place-asmnl place-pktrm place-alfcl)s)
+      braintree_stops = make_stops(~w(place-brntn place-pktrm place-alfcl)s)
+
+      route_patterns_with_stops = [
+        {ashmont_route_pattern, ashmont_stops},
+        {braintree_route_pattern, braintree_stops}
+      ]
+
+      actual = list_from_route_patterns(route_patterns_with_stops, @red_route, 1)
+
+      assert_stop_ids(actual, ~w(place-asmnl place-brntn place-pktrm place-alfcl))
+      assert_branch_names(actual, ["Ashmont - Alewife", "Braintree - Alewife", nil, nil])
+    end
+
+    test "Green-B, direction 0" do
+      route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "Green-B-3-0",
+        name: "Park Street - Boston College",
+        representative_trip_id: "45809685",
+        route_id: "Green-B",
+        typicality: 1
+      }
+
+      stops = make_stops(~w(place-pktrm place-bucen place-lake)s)
+
+      route_pattern_with_stops = [{route_pattern, stops}]
+
+      actual = list_from_route_patterns(route_pattern_with_stops, @green_b_route, 0)
+
+      assert_stop_ids(actual, ~w(place-pktrm place-bucen place-lake)s)
+
+      assert_branch_names(actual, [
+        "Green-B",
+        "Green-B",
+        "Green-B"
+      ])
+    end
+
+    test "Green-B, direction 1" do
+      route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "Green-B-3-1",
+        name: "Boston College - Park Street",
+        representative_trip_id: "45809684",
+        route_id: "Green-B",
+        typicality: 1
+      }
+
+      stops = make_stops(~w(place-lake place-bucen place-pktrm)s)
+
+      route_pattern_with_stops = [{route_pattern, stops}]
+
+      actual = list_from_route_patterns(route_pattern_with_stops, @green_b_route, 1)
+
+      assert_stop_ids(actual, ~w(place-lake place-bucen place-pktrm)s)
+
+      assert_branch_names(actual, [
+        "Green-B",
+        "Green-B",
+        "Green-B"
+      ])
+    end
+
+    test "Green, direction 0" do
+      b_route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "Green-B-3-0",
+        name: "Park Street - Boston College",
+        representative_trip_id: "45809685",
+        route_id: "Green-B",
+        typicality: 1
+      }
+
+      b_stops = make_stops(~w(place-pktrm place-coecl place-kencl place-bland place-lake)s)
+
+      c_route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "Green-C-1-0",
+        name: "North Station - Cleveland Circle",
+        representative_trip_id: "45809669",
+        route_id: "Green-C",
+        typicality: 1
+      }
+
+      c_stops =
+        make_stops(
+          ~w(place-north place-gover place-pktrm place-coecl place-kencl place-smary place-clmnl)s
+        )
+
+      d_route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "Green-D-2-0",
+        name: "Government Center - Riverside",
+        representative_trip_id: "45809766",
+        route_id: "Green-D",
+        typicality: 1
+      }
+
+      d_stops =
+        make_stops(~w(place-gover place-pktrm place-coecl place-kencl place-fenwy place-river)s)
+
+      e_route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "Green-E-1-0",
+        name: "North Station - Heath Street",
+        representative_trip_id: "45809752",
+        route_id: "Green-E",
+        typicality: 1
+      }
+
+      e_stops =
+        make_stops(~w(place-north place-gover place-pktrm place-coecl place-prmnl place-hsmnl)s)
+
+      lechmere_shuttle_route_pattern = %RoutePatterns.RoutePattern{
+        direction_id: 0,
+        id: "602-1-0",
+        name: "Lechmere - Nashua St @ North Station",
+        representative_trip_id: "45171678",
+        route_id: "602",
+        time_desc: nil,
+        typicality: 1
+      }
+
+      lechmere_shuttle_stops = make_stops(~w(place-lech 14159 21458)s)
+
+      route_patterns_with_stops = [
+        {b_route_pattern, b_stops},
+        {c_route_pattern, c_stops},
+        {d_route_pattern, d_stops},
+        {e_route_pattern, e_stops},
+        {lechmere_shuttle_route_pattern, lechmere_shuttle_stops}
+      ]
+
+      actual = list_from_route_patterns(route_patterns_with_stops, @green_route, 0)
+
+      assert_stop_ids(
+        actual,
+        ~w(place-north place-gover place-pktrm place-coecl place-prmnl place-hsmnl place-gover place-pktrm place-coecl place-kencl place-fenwy place-river place-north place-gover place-pktrm place-coecl place-kencl place-smary place-clmnl place-pktrm place-coecl place-kencl place-bland place-lake)s
+      )
+
+      assert_branch_names(actual, [
+        "Green-E",
+        "Green-E",
+        "Green-E",
+        "Green-E",
+        "Green-E",
+        "Green-E",
+        "Green-D",
+        "Green-D",
+        "Green-D",
+        "Green-D",
+        "Green-D",
+        "Green-D",
+        "Green-C",
+        "Green-C",
+        "Green-C",
+        "Green-C",
+        "Green-C",
+        "Green-C",
+        "Green-C",
+        "Green-B",
+        "Green-B",
+        "Green-B",
+        "Green-B",
+        "Green-B"
+      ])
+    end
+
+    test "Hingham/Hull Ferry, direction 0" do
+      route_patterns_with_stops = [
+        {%RoutePatterns.RoutePattern{
+           direction_id: 0,
+           id: "Boat-F1-1-0",
+           name: "Rowes Wharf - Hingham",
+           representative_trip_id: "Boat-F1-0650-Rowes-WeekdayLimited",
+           route_id: "Boat-F1",
+           time_desc: "Weekdays only",
+           typicality: 1
+         }, make_stops(~w(Boat-Rowes Boat-Hingham)s)}
+      ]
+
+      route = %Route{id: "Boat-F1", type: 4}
+
+      actual = list_from_route_patterns(route_patterns_with_stops, route, 1)
+
+      assert_stop_ids(actual, ~w(Boat-Rowes Boat-Hingham))
+      assert_branch_names(actual, ["Rowes Wharf - Hingham", "Rowes Wharf - Hingham"])
+    end
+
+    test "handles an empty list of route patterns" do
+      assert list_from_route_patterns([], @red_route, 0) == []
+    end
+  end
 
   describe "list_from_shapes/4" do
     test "handles Red line when Ashmont/Braintree are first" do
@@ -24,8 +325,7 @@ defmodule Stops.RouteStopTest do
       }
 
       stops = make_stops(~w(place-brntn place-asmnl place-pktrm place-alfcl)s)
-      route = %Route{id: "Red"}
-      actual = list_from_shapes([ashmont_shape, braintree_shape], stops, route, 0)
+      actual = list_from_shapes([ashmont_shape, braintree_shape], stops, @red_route, 0)
 
       assert_stop_ids(actual, ~w(place-alfcl place-pktrm place-brntn place-asmnl)s)
       assert_branch_names(actual, [nil, nil, "Braintree", "Ashmont"])
@@ -45,8 +345,7 @@ defmodule Stops.RouteStopTest do
       }
 
       stops = make_stops(~w(place-asmnl place-brntn place-pktrm place-alfcl)s)
-      route = %Route{id: "Red"}
-      actual = list_from_shapes([ashmont_shape, braintree_shape], stops, route, 1)
+      actual = list_from_shapes([ashmont_shape, braintree_shape], stops, @red_route, 1)
 
       assert_stop_ids(actual, ~w(place-asmnl place-brntn place-pktrm place-alfcl))
       assert_branch_names(actual, ["Ashmont", "Braintree", nil, nil])
@@ -166,7 +465,7 @@ defmodule Stops.RouteStopTest do
 
   describe "build_route_stop/3" do
     test "creates a RouteStop object with all expected attributes" do
-      result = build_route_stop(@stop, @route, first?: true, last?: true, branch: "Braintree")
+      result = build_route_stop(@stop, @red_route, first?: true, last?: true, branch: "Braintree")
       assert result.id == "place-brntn"
       assert result.name == "Braintree"
       assert result.station_info == @stop
@@ -182,7 +481,7 @@ defmodule Stops.RouteStopTest do
 
   describe "fetch_zone/1" do
     test "returns a RouteStop with the zone data" do
-      route_stop = build_route_stop(@stop, @route)
+      route_stop = build_route_stop(@stop, @red_route)
       fetched = fetch_zone(route_stop)
       refute fetched.zone == route_stop.zone
     end
@@ -190,7 +489,7 @@ defmodule Stops.RouteStopTest do
 
   describe "fetch_stop_features/1" do
     test "returns a RouteStop with the stop feature data" do
-      route_stop = build_route_stop(@stop, @route)
+      route_stop = build_route_stop(@stop, @red_route)
       fetched = fetch_stop_features(route_stop)
       refute fetched.stop_features == route_stop.stop_features
     end
@@ -198,7 +497,7 @@ defmodule Stops.RouteStopTest do
 
   describe "fetch_connections/1" do
     test "builds a list of connecting routes at a stop" do
-      route_stop = build_route_stop(@stop, @route)
+      route_stop = build_route_stop(@stop, @red_route)
       assert route_stop.connections == {:error, :not_fetched}
       fetched = fetch_connections(route_stop)
       assert [%Route{} | _] = fetched.connections
@@ -207,11 +506,11 @@ defmodule Stops.RouteStopTest do
   end
 
   describe "RouteStop implements Util.Position" do
-    @route_stop %RouteStop{station_info: %Stop{latitude: 100.0, longitude: 50.0}}
+    @red_route_stop %RouteStop{station_info: %Stop{latitude: 100.0, longitude: 50.0}}
 
     test "Position.Latitude" do
-      assert Util.Position.latitude(@route_stop) == 100.0
-      assert Util.Position.longitude(@route_stop) == 50.0
+      assert Util.Position.latitude(@red_route_stop) == 100.0
+      assert Util.Position.longitude(@red_route_stop) == 50.0
     end
   end
 

--- a/apps/v3_api/lib/route_patterns.ex
+++ b/apps/v3_api/lib/route_patterns.ex
@@ -1,8 +1,19 @@
 defmodule V3Api.RoutePatterns do
-  @moduledoc false
+  @moduledoc """
+  Responsible for fetching Route Pattern data from the V3 API.
+  """
 
-  @spec all(Keyword.t()) :: JsonApi.t() | {:error, any}
+  alias Routes.Route
+
+  @type api_response_t() :: JsonApi.t() | {:error, any}
+
+  @spec all(Keyword.t()) :: api_response_t()
   def all(params \\ []) do
     V3Api.get_json("/route_patterns/", params)
+  end
+
+  @spec get(Route.id_t(), keyword()) :: api_response_t()
+  def get(id, opts \\ []) do
+    V3Api.get_json("/route_patterns/#{id}", opts)
   end
 end

--- a/apps/v3_api/test/route_patterns_test.exs
+++ b/apps/v3_api/test/route_patterns_test.exs
@@ -10,4 +10,11 @@ defmodule V3Api.RoutePatternsTest do
       assert %JsonApi{data: [%JsonApi.Item{}]} = RoutePatterns.all(@opts)
     end
   end
+
+  describe "get/1" do
+    test "gets the route pattern by ID" do
+      %JsonApi{data: [%JsonApi.Item{} = route_pattern]} = RoutePatterns.get("111-5-0")
+      assert route_pattern.id == "111-5-0"
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Tech Debt | Line page: remove dependency on shape.stops](https://app.asana.com/0/555089885850811/1145443859488281)

Use route patterns to get branch route stops

Get data for a specific route pattern, where applicable, only for buses.

Only the final commit includes functional changes. Before that, I refactored a bit to remove duplicate functionality and added a bunch of tests to prove the behavior I needed to match with the route pattern change.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
