### PR TITLE
Combine CharlieCard and Ticket/Cash media prices after Sep. 1, 2020

### DIFF
--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -6,7 +6,7 @@ defmodule Fares.FareInfo do
   alias Fares.Fare
 
   @doc "Load fare info from a CSV file."
-  @september_1_2020 1_598_918_400
+  @september_1_2020 1_598_932_800
   @september_1_2020_modes ["subway", "local_bus", "inner_express_bus", "outer_express_bus"]
 
   @spec fare_info() :: [Fare.t()]

--- a/apps/fares/test/fare_info_test.exs
+++ b/apps/fares/test/fare_info_test.exs
@@ -170,4 +170,42 @@ defmodule Fares.FareInfoTest do
       assert Enum.all?(fares, fn %Fare{name: :ferry_george} -> true end)
     end
   end
+
+  describe "mapper/2" do
+    test "merges paper and plastic fares for subway and bus" do
+      fare_map_expected_modes = [
+        ["subway", "2.40", "2.40", "1.10", "30.00", "12.75", "22.50", "90.00", ""],
+        ["local_bus", "1.70", "1.70", "0.85", "30.00", "12.75", "22.50", "55.00", ""],
+        ["inner_express_bus", "4.25", "4.25", "2.10", "30.00", "12.75", "22.50", "136.00", ""],
+        ["outer_express_bus", "5.25", "5.25", "2.60", "30.00", "12.75", "22.50", "168.00", ""]
+      ]
+
+      assert Enum.count(
+               Enum.flat_map(fare_map_expected_modes, &mapper(&1, 1_598_918_400)),
+               &match?(%Fare{media: [:charlie_card, :charlie_ticket, :cash]}, &1)
+             ) == 4
+
+      refute Enum.any?(
+               Enum.flat_map(fare_map_expected_modes, &mapper(&1, 1_598_918_400)),
+               &match?(%Fare{media: [:charlie_card]}, &1)
+             )
+
+      refute Enum.any?(
+               Enum.flat_map(fare_map_expected_modes, &mapper(&1, 1_598_918_400)),
+               &match?(%Fare{media: [:charlie_ticket, :cash]}, &1)
+             )
+
+      fare_map_expected_unchanged_modes = [
+        ["commuter", "interzone_10", "7.25", "3.50", "257.00", "", "", "", ""],
+        ["foxboro", "20.00", "", "", "", "", "", "", ""],
+        ["ferry", "3.70", "90.00", "9.75", "9.75", "329.00", "9.75", "12.75", "22.50"],
+        ["the_ride", "3.35", "5.60", "", "", "", "", "", ""]
+      ]
+
+      refute Enum.any?(
+               Enum.flat_map(fare_map_expected_unchanged_modes, &mapper(&1, 1_598_918_400)),
+               &match?(%Fare{media: [:charlie_card, :charlie_ticket, :cash]}, &1)
+             )
+    end
+  end
 end

--- a/apps/fares/test/fare_info_test.exs
+++ b/apps/fares/test/fare_info_test.exs
@@ -181,17 +181,17 @@ defmodule Fares.FareInfoTest do
       ]
 
       assert Enum.count(
-               Enum.flat_map(fare_map_expected_modes, &mapper(&1, 1_598_918_400)),
+               Enum.flat_map(fare_map_expected_modes, &mapper(&1, 1_598_932_800)),
                &match?(%Fare{media: [:charlie_card, :charlie_ticket, :cash]}, &1)
              ) == 4
 
       refute Enum.any?(
-               Enum.flat_map(fare_map_expected_modes, &mapper(&1, 1_598_918_400)),
+               Enum.flat_map(fare_map_expected_modes, &mapper(&1, 1_598_932_800)),
                &match?(%Fare{media: [:charlie_card]}, &1)
              )
 
       refute Enum.any?(
-               Enum.flat_map(fare_map_expected_modes, &mapper(&1, 1_598_918_400)),
+               Enum.flat_map(fare_map_expected_modes, &mapper(&1, 1_598_932_800)),
                &match?(%Fare{media: [:charlie_ticket, :cash]}, &1)
              )
 
@@ -203,7 +203,7 @@ defmodule Fares.FareInfoTest do
       ]
 
       refute Enum.any?(
-               Enum.flat_map(fare_map_expected_unchanged_modes, &mapper(&1, 1_598_918_400)),
+               Enum.flat_map(fare_map_expected_unchanged_modes, &mapper(&1, 1_598_932_800)),
                &match?(%Fare{media: [:charlie_card, :charlie_ticket, :cash]}, &1)
              )
     end

--- a/apps/site/lib/site_web/templates/mode/index.html.eex
+++ b/apps/site/lib/site_web/templates/mode/index.html.eex
@@ -47,6 +47,9 @@
         <%= PartialView.paragraph("paragraphs/multi-column/schedules-page-fares-subway-and-bus", @conn) %>
         <%= PartialView.paragraph("paragraphs/multi-column/schedule-page-fares-commuter-rail-and-ferry", @conn) %>
 
+        <h2>Current time</h2>
+        <%= System.system_time(:second) %>
+
         <p>
           <%= link("View fares overview", to: cms_static_page_path(@conn, "/fares"), class: "c-call-to-action") %>
         </p>

--- a/apps/site/lib/site_web/templates/mode/index.html.eex
+++ b/apps/site/lib/site_web/templates/mode/index.html.eex
@@ -47,9 +47,6 @@
         <%= PartialView.paragraph("paragraphs/multi-column/schedules-page-fares-subway-and-bus", @conn) %>
         <%= PartialView.paragraph("paragraphs/multi-column/schedule-page-fares-commuter-rail-and-ferry", @conn) %>
 
-        <h2>Current time</h2>
-        <%= System.system_time(:second) %>
-
         <p>
           <%= link("View fares overview", to: cms_static_page_path(@conn, "/fares"), class: "c-call-to-action") %>
         </p>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fare Change | Fare cards updates for 9/1 transition](https://app.asana.com/0/399597520748778/1186724915893667)

After the changeover date, adjust fare matches so charlie_card, charlie_ticket, and cash all have equal prices on subway/bus single trips (one-way). This affects the descriptive output around the site, such as "with a CharlieCard, CharlieTicket, or Cash."

I tried to make this as small as possible, rather than creating branches for each modes' existing `mapper/1` fare mapping. I recommend yanking this and the other sep_1_2020 logic after the changeover date.

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [ ] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
