### PR TITLE
Remove "Recommended" column from Fare Calculator

### DIFF
--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -438,6 +438,11 @@ defmodule Fares.FareInfo do
     ]
   end
 
+  @spec charging_september_2020_fares?() :: boolean()
+  @spec charging_september_2020_fares?(integer()) :: boolean()
+  def charging_september_2020_fares?(now \\ System.system_time(:second)),
+    do: now >= @september_1_2020
+
   defp fare_data(filename) do
     :fares
     |> Application.app_dir()

--- a/apps/fares/test/fare_info_test.exs
+++ b/apps/fares/test/fare_info_test.exs
@@ -157,6 +157,13 @@ defmodule Fares.FareInfoTest do
     end
   end
 
+  describe "charging_september_2020_fares?/1" do
+    test "returns whether we are post the 9/1/20 fare transition" do
+      assert charging_september_2020_fares?(1_598_932_801)
+      refute charging_september_2020_fares?(1_598_932_799)
+    end
+  end
+
   describe "mticket_price/1" do
     test "subtracts 10 dollars from the monthly price" do
       assert mticket_price(2000) == 1000

--- a/apps/site/assets/css/_trip-plan-fare-calculator.scss
+++ b/apps/site/assets/css/_trip-plan-fare-calculator.scss
@@ -22,7 +22,6 @@
         width: 100%;
       }
     }
-
   }
 
   &__table-cell {

--- a/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
@@ -1,11 +1,15 @@
-
 <div class="h2 m-trip-plan-farecalc__main-title">Fare Calculator</div>
 
 <div role="table" aria-label="A summary of the different fares by media for each itinerary" class="m-trip-plan-farecalc__table">
   <div role="columnheader" class="m-trip-plan-farecalc__table-cell m-trip-plan-farecalc__subheader">One-Way Fare</div>
   <div role="columnheader" class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">Base</div>
-  <div role="columnheader" class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">Recommended</div>
+  <%= unless Fares.FareInfo.charging_september_2020_fares? do %>
+    <div role="columnheader" class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">Recommended</div>
+  <% end %>
   <div role="columnheader" class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header">Reduced</div>
+  <%= if Fares.FareInfo.charging_september_2020_fares? do %>
+    <div role="columnheader" class="m-trip-plan-farecalc__table-cell m-trip-plan-results__itinerary-fare-title m-trip-plan-farecalc__header"></div>
+  <% end %>
 
   <%= for {_mode_key, fare_values} <- @fares do %>
 
@@ -16,15 +20,17 @@
       <span class="m-trip-plan-farecalc__label">Base: </span>
       <%= fare_values|>Fares.get_fare_by_type(:highest_one_way_fare)|> fare_cents()|>Format.price() %>
     </div>
-    <div role="cell" class="m-trip-plan-farecalc__table-cell">
-      <span class="m-trip-plan-farecalc__label">Recommended: </span>
-      <% recommended = fare_values|>Fares.get_fare_by_type(:lowest_one_way_fare) %>
-      <% media = recommended |> SiteWeb.TripPlanView.filter_media() %>
-      <%=
-        cents = recommended |> fare_cents()
-        if cents == 0, do: "None", else: "#{Format.price(cents)} #{format_media(media)}"
-      %>
-    </div>
+    <%= unless Fares.FareInfo.charging_september_2020_fares? do %>
+      <div role="cell" class="m-trip-plan-farecalc__table-cell">
+        <span class="m-trip-plan-farecalc__label">Recommended: </span>
+        <% recommended = fare_values|>Fares.get_fare_by_type(:lowest_one_way_fare) %>
+        <% media = recommended |> SiteWeb.TripPlanView.filter_media() %>
+        <%=
+          cents = recommended |> fare_cents()
+          if cents == 0, do: "None", else: "#{Format.price(cents)} #{format_media(media)}"
+        %>
+      </div>
+    <% end %>
     <div role="cell" class="m-trip-plan-farecalc__table-cell">
       <span class="m-trip-plan-farecalc__label">Reduced: </span>
       <%=
@@ -32,6 +38,9 @@
         if cents == 0, do: "None", else: Format.price(cents)
       %>
     </div>
+    <%= if Fares.FareInfo.charging_september_2020_fares? do %>
+      <div role="cell" class="m-trip-plan-farecalc__table-cell"></div>
+    <% end %>
 
   <% end %>
 
@@ -53,7 +62,9 @@
        %></strong>
    </span>
  </div>
-  <div role="cell" class="m-trip-plan-farecalc__table-cell"></div>
+  <%= unless Fares.FareInfo.charging_september_2020_fares? do %>
+    <div role="cell" class="m-trip-plan-farecalc__table-cell"></div>
+  <% end %>
   <div role="cell" class="m-trip-plan-farecalc__table-cell">
     <span class="m-trip-plan-farecalc__label">Reduced: </span>
     <span>
@@ -63,6 +74,9 @@
        %></strong>
    </span>
   </div>
+  <%= if Fares.FareInfo.charging_september_2020_fares? do %>
+    <div role="cell" class="m-trip-plan-farecalc__table-cell"></div>
+  <% end %>
 </div>
 
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🎫 Trip Planner | Eliminate CharlieCard - CharlieTicket/Cash differential](https://app.asana.com/0/555089885850811/1187029333962715)

Remove "Recommended" column from Fare Calculator after the fare transition on 9/1.

~~Depends on https://github.com/mbta/dotcom/pull/602~~

![Screen Shot 2020-08-28 at 11 09 23](https://user-images.githubusercontent.com/42339/91589870-7343ac80-e928-11ea-9a08-e5599cb619d9.png)


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
