### PR TITLE
Define route_patterns before stops for dependencies

### DIFF
--- a/apps/site/mix.exs
+++ b/apps/site/mix.exs
@@ -29,6 +29,7 @@ defmodule Site.Mixfile do
       :phoenix_html,
       :plug_cowboy,
       :gettext,
+      :route_patterns,
       :stops,
       :routes,
       :alerts,
@@ -57,7 +58,6 @@ defmodule Site.Mixfile do
       :util,
       :trip_plan,
       :services,
-      :route_patterns,
       :con_cache,
       :recaptcha
     ]
@@ -116,6 +116,7 @@ defmodule Site.Mixfile do
       # Required to mock challenge failures. Upgrade once a version > 3.0.0 is released.
       {:recaptcha,
        github: "samueljseay/recaptcha", ref: "8ea13f63990ca18725ac006d30e55d42c3a58457"},
+      {:route_patterns, in_umbrella: true},
       {:stops, in_umbrella: true},
       {:routes, in_umbrella: true},
       {:alerts, in_umbrella: true},
@@ -132,7 +133,6 @@ defmodule Site.Mixfile do
       {:predictions, in_umbrella: true},
       {:trip_plan, in_umbrella: true},
       {:services, in_umbrella: true},
-      {:route_patterns, in_umbrella: true},
       {:repo_cache, in_umbrella: true},
       {:exvcr_helpers, in_umbrella: true, only: :test}
     ]

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -396,7 +396,7 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
     route_id
     |> ServicesRepo.by_route_id()
     |> Enum.filter(&(&1.type == :weekday))
-    |> Enum.sort_by(& &1.end_date, Date)
+    |> Enum.sort_by(&{&1.end_date.year, &1.end_date.month, &1.end_date.day})
     |> List.last()
     |> Map.get(:end_date)
     |> Date.to_iso8601()

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -396,7 +396,7 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
     route_id
     |> ServicesRepo.by_route_id()
     |> Enum.filter(&(&1.type == :weekday))
-    |> Enum.sort_by(& &1.end_date)
+    |> Enum.sort_by(& &1.end_date, Date)
     |> List.last()
     |> Map.get(:end_date)
     |> Date.to_iso8601()


### PR DESCRIPTION
Define route_patterns before stops for dependencies

No ticket, dev builds have been failing since https://github.com/mbta/dotcom/pull/599

Depends on https://github.com/mbta/dotcom/pull/606

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
