### PR TITLE
🐞 Regression/Bug | Crowding column not collapsed properly on routes w/o crowding

### DIFF
--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -255,7 +255,12 @@
 
 .m-schedule-diagram__prediction-crowding {
   @include icon-size-inline(1.125em, .125em);
+  display: inline-block;
   margin-left: .5rem;
+
+  .u-no-crowding-data & {
+    display: none;
+  }
 }
 
 // live vehicle located along line diagram

--- a/apps/site/assets/ts/models/prediction.ts
+++ b/apps/site/assets/ts/models/prediction.ts
@@ -1,4 +1,5 @@
 import { TripPrediction } from "../schedule/components/__trips";
+import { HeadsignWithCrowding } from "../__v3api";
 
 // eslint-disable-next-line import/prefer-default-export
 export const isSkippedOrCancelled = (
@@ -8,3 +9,14 @@ export const isSkippedOrCancelled = (
     ? prediction.schedule_relationship === "skipped" ||
       prediction.schedule_relationship === "cancelled"
     : false;
+
+export const hasPredictionTime = ({
+  time_data_with_crowding_list: timeDataList
+}: HeadsignWithCrowding): boolean =>
+  !!(
+    timeDataList &&
+    timeDataList[0] &&
+    timeDataList[0].time_data &&
+    timeDataList[0].time_data.prediction &&
+    timeDataList[0].time_data.prediction.time
+  );

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
@@ -5,6 +5,7 @@ import StopListWithBranches from "./StopListWithBranches";
 import { CommonLineDiagramProps } from "./__line-diagram";
 import useStopPositions, { RefList } from "./graphics/useStopPositions";
 import StopCard from "./StopCard";
+import { hasPredictionTime } from "../../../models/prediction";
 
 export const StopRefContext = React.createContext<[RefList, () => void]>([
   {},
@@ -19,9 +20,25 @@ const LineDiagramWithStops = (
   // create a ref for each stop - we will use this to track the location of the stop so we can place the line diagram bubbles
   const [stopRefsMap, updateAllStopCoords] = useStopPositions(stops);
 
+  const anyCrowding = Object.values(liveData).some(
+    ({ headsigns }): boolean =>
+      headsigns
+        ? headsigns
+            .filter(hasPredictionTime)
+            .some(
+              ({ time_data_with_crowding_list: timeData }): boolean =>
+                !!timeData[0].crowding
+            )
+        : false
+  );
+
   return (
     <StopRefContext.Provider value={[stopRefsMap, updateAllStopCoords]}>
-      <div className="m-schedule-diagram">
+      <div
+        className={`m-schedule-diagram ${
+          !anyCrowding ? "u-no-crowding-data" : ""
+        }`}
+      >
         <Diagram lineDiagram={stops} liveData={liveData} />
         {hasBranchLines(stops) ? (
           <StopListWithBranches {...props} />

--- a/apps/site/assets/ts/schedule/components/line-diagram/LiveCrowdingIcon.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LiveCrowdingIcon.tsx
@@ -8,7 +8,7 @@ interface LiveCrowdingIconProps {
 }
 
 const LiveCrowdingIcon = ({ crowding }: LiveCrowdingIconProps): JSX.Element => (
-  <div className="m-schedule-diagram__prediction-crowding m-schedule-table-crowding">
+  <div className="m-schedule-diagram__prediction-crowding">
     {crowding ? (
       <TooltipWrapper
         tooltipText={`Currently <strong>${crowdingDescriptions(

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopPredictions.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopPredictions.tsx
@@ -77,11 +77,14 @@ const StopPredictions = ({
       );
     });
   } else {
-    predictions = liveHeadsigns.map(headsign => {
+    predictions = liveHeadsigns.map((headsign, index) => {
       const { crowding } = headsign.time_data_with_crowding_list[0];
       return (
-        /* eslint-disable-next-line react/no-array-index-key */
-        <div key={headsign.name} className="m-schedule-diagram__prediction">
+        <div
+          // eslint-disable-next-line react/no-array-index-key
+          key={`headsign.name-${index}`}
+          className="m-schedule-diagram__prediction"
+        >
           <div>{headsign.name}</div>
           <div className="m-schedule-diagram__prediction-time">
             {capitalize(

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopPredictions.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopPredictions.tsx
@@ -5,24 +5,16 @@ import {
   timeForCommuterRail,
   statusForCommuterRail
 } from "../../../helpers/prediction-helpers";
-import { isSkippedOrCancelled } from "../../../models/prediction";
+import {
+  isSkippedOrCancelled,
+  hasPredictionTime
+} from "../../../models/prediction";
 import LiveCrowdingIcon from "./LiveCrowdingIcon";
 
 interface StopPredictions {
   headsigns: HeadsignWithCrowding[];
   isCommuterRail: boolean;
 }
-
-const hasPredictionTime = ({
-  time_data_with_crowding_list: timeDataList
-}: HeadsignWithCrowding): boolean =>
-  !!(
-    timeDataList &&
-    timeDataList[0] &&
-    timeDataList[0].time_data &&
-    timeDataList[0].time_data.prediction &&
-    timeDataList[0].time_data.prediction.time
-  );
 
 const predictionTexts = (headsign: HeadsignWithCrowding): string[] => {
   const texts = [headsign.name];

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
@@ -54,8 +54,10 @@ lineDiagramBranchingIn.forEach(({ route_stop }) => {
 });
 
 const handleStopClick = () => {};
-const liveData = {};
-const liveDataWithCrowding = cloneDeep(simpleLiveData) as unknown as LiveDataByStop;
+const liveData = (simpleLiveData as unknown) as LiveDataByStop;
+const liveDataWithCrowding = (cloneDeep(
+  simpleLiveData
+) as unknown) as LiveDataByStop;
 (liveDataWithCrowding["line-stop2"].headsigns[0].time_data_with_crowding_list[0]
   .crowding as CrowdingType) = "not_crowded";
 const store = createLineDiagramCoordStore(lineDiagram);

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
@@ -3,13 +3,15 @@ import * as redux from "react-redux";
 import { mount, ReactWrapper } from "enzyme";
 import { cloneDeep, merge } from "lodash";
 import { RouteType } from "../../../../__v3api";
-import { LineDiagramStop } from "../../__schedule";
+import { LineDiagramStop, CrowdingType } from "../../__schedule";
 import simpleLineDiagram from "./lineDiagramData/simple.json"; // not a full line diagram
 import outwardLineDiagram from "./lineDiagramData/outward.json"; // not a full line diagram
 import LineDiagramWithStops from "../LineDiagramWithStops";
 import { createLineDiagramCoordStore } from "../graphics/graphic-helpers";
 import StopListWithBranches from "../StopListWithBranches";
 import * as UseStopPositions from "../graphics/useStopPositions";
+import * as simpleLiveData from "./lineDiagramData/live-data.json";
+import { LiveDataByStop } from "../__line-diagram";
 
 const lineDiagram = (simpleLineDiagram as unknown) as LineDiagramStop[];
 let lineDiagramBranchingOut = (outwardLineDiagram as unknown) as LineDiagramStop[];
@@ -53,6 +55,9 @@ lineDiagramBranchingIn.forEach(({ route_stop }) => {
 
 const handleStopClick = () => {};
 const liveData = {};
+const liveDataWithCrowding = cloneDeep(simpleLiveData) as unknown as LiveDataByStop;
+(liveDataWithCrowding["line-stop2"].headsigns[0].time_data_with_crowding_list[0]
+  .crowding as CrowdingType) = "not_crowded";
 const store = createLineDiagramCoordStore(lineDiagram);
 const spy = jest.spyOn(UseStopPositions, "default");
 
@@ -107,5 +112,19 @@ describe("LineDiagramWithStops", () => {
       </redux.Provider>
     );
     expect(wrapperWithBranches.find(StopListWithBranches)).toHaveLength(1);
+  });
+
+  it("toggles u-no-crowding-data class if crowding present", () => {
+    expect(wrapper.exists(".u-no-crowding-data")).toBeTruthy();
+    const wrapperWithCrowding = mount(
+      <redux.Provider store={store}>
+        <LineDiagramWithStops
+          stops={lineDiagram}
+          handleStopClick={handleStopClick}
+          liveData={liveDataWithCrowding}
+        />
+      </redux.Provider>
+    );
+    expect(wrapperWithCrowding.exists(".u-no-crowding-data")).toBeFalsy();
   });
 });

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -18,7 +18,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
   </SearchBox>
   <Provider store={{...}}>
     <LineDiagramWithStops stops={{...}} handleStopClick={[Function]} liveData={{...}}>
-      <div className=\\"m-schedule-diagram\\">
+      <div className=\\"m-schedule-diagram u-no-crowding-data\\">
         <Diagram lineDiagram={{...}} liveData={{...}}>
           <LiveVehicleIconSet stop={{...}} liveData={{...}} />
           <LiveVehicleIconSet stop={{...}} liveData={{...}}>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -163,7 +163,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                           2   min
                         </div>
                         <LiveCrowdingIcon crowding={{...}}>
-                          <div className=\\"m-schedule-diagram__prediction-crowding m-schedule-table-crowding\\">
+                          <div className=\\"m-schedule-diagram__prediction-crowding\\">
                             <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowding_unavailable\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
                           </div>
                         </LiveCrowdingIcon>
@@ -176,7 +176,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                           5   min
                         </div>
                         <LiveCrowdingIcon crowding={{...}}>
-                          <div className=\\"m-schedule-diagram__prediction-crowding m-schedule-table-crowding\\">
+                          <div className=\\"m-schedule-diagram__prediction-crowding\\">
                             <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowding_unavailable\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
                           </div>
                         </LiveCrowdingIcon>
@@ -245,7 +245,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                           7   min
                         </div>
                         <LiveCrowdingIcon crowding={{...}}>
-                          <div className=\\"m-schedule-diagram__prediction-crowding m-schedule-table-crowding\\">
+                          <div className=\\"m-schedule-diagram__prediction-crowding\\">
                             <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowding_unavailable\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
                           </div>
                         </LiveCrowdingIcon>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -3,7 +3,7 @@
 exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
 "<Provider store={{...}}>
   <LineDiagramWithStops stops={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-    <div className=\\"m-schedule-diagram\\">
+    <div className=\\"m-schedule-diagram u-no-crowding-data\\">
       <Diagram lineDiagram={{...}} liveData={{...}}>
         <LiveVehicleIconSet stop={{...}} liveData={{...}} />
         <LiveVehicleIconSet stop={{...}} liveData={{...}} />

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -6,8 +6,35 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
     <div className=\\"m-schedule-diagram u-no-crowding-data\\">
       <Diagram lineDiagram={{...}} liveData={{...}}>
         <LiveVehicleIconSet stop={{...}} liveData={{...}} />
-        <LiveVehicleIconSet stop={{...}} liveData={{...}} />
-        <LiveVehicleIconSet stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet stop={{...}} liveData={{...}}>
+          <VehicleIcons stop={{...}} vehicles={{...}}>
+            <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
+              <Component tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest1 bus is arriving at Stop 1</div>\\" tooltipOptions={{...}}>
+                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest1 bus is arriving at Stop 1</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest1 bus is arriving at Stop 1</div>\\">
+                  <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                </span>
+              </Component>
+            </div>
+            <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
+              <Component tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Bus is on the way to Stop 1</div>\\" tooltipOptions={{...}}>
+                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Bus is on the way to Stop 1</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Bus is on the way to Stop 1</div>\\">
+                  <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                </span>
+              </Component>
+            </div>
+          </VehicleIcons>
+        </LiveVehicleIconSet>
+        <LiveVehicleIconSet stop={{...}} liveData={{...}}>
+          <VehicleIcons stop={{...}} vehicles={{...}}>
+            <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
+              <Component tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest2 bus is on the way to Stop 2</div>\\" tooltipOptions={{...}}>
+                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest2 bus is on the way to Stop 2</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest2 bus is on the way to Stop 2</div>\\">
+                  <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                </span>
+              </Component>
+            </div>
+          </VehicleIcons>
+        </LiveVehicleIconSet>
         <LiveVehicleIconSet stop={{...}} liveData={{...}} />
         <svg xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" aria-labelledby=\\"diagram-title diagram-desc\\" className=\\"line-diagram-svg bus\\" width=\\"40px\\" height=\\"100%\\" style={{...}}>
           <title id=\\"diagram-title\\">
@@ -74,7 +101,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
             </section>
           </li>
         </StopCard>
-        <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+        <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={{...}}>
           <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
             <section className=\\"m-schedule-diagram__content\\">
               <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -111,6 +138,36 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                     </a>
                   </Component>
                 </div>
+                <StopPredictions headsigns={{...}} isCommuterRail={false}>
+                  <div className=\\"m-schedule-diagram__predictions\\">
+                    <div className=\\"m-schedule-diagram__prediction\\">
+                      <div>
+                        Dest1
+                      </div>
+                      <div className=\\"m-schedule-diagram__prediction-time\\">
+                        2   min
+                      </div>
+                      <LiveCrowdingIcon crowding={{...}}>
+                        <div className=\\"m-schedule-diagram__prediction-crowding\\">
+                          <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowding_unavailable\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+                        </div>
+                      </LiveCrowdingIcon>
+                    </div>
+                    <div className=\\"m-schedule-diagram__prediction\\">
+                      <div>
+                        Dest2
+                      </div>
+                      <div className=\\"m-schedule-diagram__prediction-time\\">
+                        5   min
+                      </div>
+                      <LiveCrowdingIcon crowding={{...}}>
+                        <div className=\\"m-schedule-diagram__prediction-crowding\\">
+                          <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowding_unavailable\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+                        </div>
+                      </LiveCrowdingIcon>
+                    </div>
+                  </div>
+                </StopPredictions>
               </div>
               <footer className=\\"m-schedule-diagram__footer\\">
                 <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -120,7 +177,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
             </section>
           </li>
         </StopCard>
-        <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+        <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={{...}}>
           <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
             <section className=\\"m-schedule-diagram__content\\">
               <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -163,6 +220,23 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                     </a>
                   </Component>
                 </div>
+                <StopPredictions headsigns={{...}} isCommuterRail={false}>
+                  <div className=\\"m-schedule-diagram__predictions\\">
+                    <div className=\\"m-schedule-diagram__prediction\\">
+                      <div>
+                        Dest2
+                      </div>
+                      <div className=\\"m-schedule-diagram__prediction-time\\">
+                        7   min
+                      </div>
+                      <LiveCrowdingIcon crowding={{...}}>
+                        <div className=\\"m-schedule-diagram__prediction-crowding\\">
+                          <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowding_unavailable\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+                        </div>
+                      </LiveCrowdingIcon>
+                    </div>
+                  </div>
+                </StopPredictions>
               </div>
               <footer className=\\"m-schedule-diagram__footer\\">
                 <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LiveCrowdingIconTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LiveCrowdingIconTest.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`LiveCrowdingIcon with crowded renders and matches snapshot 1`] = `
 "<LiveCrowdingIcon crowding=\\"crowded\\">
-  <div className=\\"m-schedule-diagram__prediction-crowding m-schedule-table-crowding\\">
+  <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <Component tooltipText=\\"Currently <strong>crowded</strong>\\" tooltipOptions={{...}}>
       <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>crowded</strong>\\" title=\\"Currently <strong>crowded</strong>\\">
         <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowded\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
@@ -14,7 +14,7 @@ exports[`LiveCrowdingIcon with crowded renders and matches snapshot 1`] = `
 
 exports[`LiveCrowdingIcon with not_crowded renders and matches snapshot 1`] = `
 "<LiveCrowdingIcon crowding=\\"not_crowded\\">
-  <div className=\\"m-schedule-diagram__prediction-crowding m-schedule-table-crowding\\">
+  <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <Component tooltipText=\\"Currently <strong>not crowded</strong>\\" tooltipOptions={{...}}>
       <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>not crowded</strong>\\" title=\\"Currently <strong>not crowded</strong>\\">
         <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--not_crowded\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
@@ -26,7 +26,7 @@ exports[`LiveCrowdingIcon with not_crowded renders and matches snapshot 1`] = `
 
 exports[`LiveCrowdingIcon with some_crowding renders and matches snapshot 1`] = `
 "<LiveCrowdingIcon crowding=\\"some_crowding\\">
-  <div className=\\"m-schedule-diagram__prediction-crowding m-schedule-table-crowding\\">
+  <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <Component tooltipText=\\"Currently <strong>some crowding</strong>\\" tooltipOptions={{...}}>
       <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>some crowding</strong>\\" title=\\"Currently <strong>some crowding</strong>\\">
         <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--some_crowding\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopPredictionsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopPredictionsTest.tsx.snap
@@ -16,7 +16,7 @@ exports[`StopPredictions renders bus predictions 1`] = `
       6   min
     </div>
     <div
-      className="m-schedule-diagram__prediction-crowding m-schedule-table-crowding"
+      className="m-schedule-diagram__prediction-crowding"
     >
       <span
         aria-hidden="true"

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/lineDiagramData/live-data.json
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/lineDiagramData/live-data.json
@@ -43,13 +43,15 @@
         "id": "veh1",
         "headsign": "Dest1",
         "status": "incoming",
-        "trip_name": ""
+        "trip_name": "",
+        "crowding": null
       },
       {
         "id": "veh2",
         "headsign": null,
         "status": "in_transit",
-        "trip_name": ""
+        "trip_name": "",
+        "crowding": null
       }
     ]
   },
@@ -79,7 +81,8 @@
         "id": "veh3",
         "headsign": "Dest2",
         "status": "in_transit",
-        "trip_name": ""
+        "trip_name": "",
+        "crowding": null
       }
     ]
   }

--- a/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/UpcomingDepartures.tsx
@@ -3,7 +3,7 @@ import { get, isEmpty } from "lodash";
 import { Route } from "../../../../__v3api";
 import Loading from "../../../../components/Loading";
 import { reducer } from "../../../../helpers/fetch";
-import { modeIcon, crowdingIcon } from "../../../../helpers/icon";
+import { modeIcon } from "../../../../helpers/icon";
 import {
   timeForCommuterRail,
   trackForCommuterRail,
@@ -16,6 +16,7 @@ import { modeBgClass } from "../../../../stop/components/RoutePillList";
 import { UserInput } from "../../__schedule";
 import { EnhancedJourney } from "../../__trips";
 import LazyAccordion, { AccordionRow } from "./LazyAccordion";
+import LiveCrowdingIcon from "../../line-diagram/LiveCrowdingIcon";
 
 interface State {
   data: EnhancedJourney[] | null;
@@ -70,13 +71,9 @@ export const crowdingInformation = (
       tripInfo.vehicle.trip_id === tripId;
 
     return (
-      <span className="m-schedule-diagram__prediction-crowding">
-        {crowdingIcon(
-          `c-icon__crowding--${
-            showCrowding ? tripInfo!.vehicle!.crowding! : "crowding_unavailable"
-          }`
-        )}
-      </span>
+      <LiveCrowdingIcon
+        crowding={showCrowding ? tripInfo!.vehicle!.crowding! : null}
+      />
     );
   }
 

--- a/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/UpcomingDepartures.tsx
@@ -59,11 +59,10 @@ const RoutePillSmall = ({
 
 export const crowdingInformation = (
   journey: EnhancedJourney,
-  tripId: string,
-  someCrowdingInfoExists: boolean
+  tripId: string
 ): ReactElement<HTMLElement> | null => {
   const { tripInfo } = journey;
-  if (tripInfo && someCrowdingInfoExists) {
+  if (tripInfo) {
     // Only display the crowding information if the trip ID of the vehicle matches the trip ID of the prediction being displayed.
     const showCrowding =
       !!tripInfo.vehicle &&
@@ -81,11 +80,9 @@ export const crowdingInformation = (
 };
 
 export const BusTableRow = ({
-  journey,
-  someCrowdingInfoExists
+  journey
 }: {
   journey: EnhancedJourney;
-  someCrowdingInfoExists: boolean;
 }): ReactElement<HTMLElement> | null => {
   const { trip, route, realtime } = journey;
 
@@ -103,7 +100,7 @@ export const BusTableRow = ({
       </td>
       <td className="schedule-table__cell schedule-table__cell--time u-nowrap u-bold text-right">
         {realtime.prediction!.time}
-        {crowdingInformation(journey, trip.id, someCrowdingInfoExists)}
+        {crowdingInformation(journey, trip.id)}
       </td>
     </>
   );
@@ -148,13 +145,11 @@ export const CrTableRow = ({
 const TableRow = ({
   state,
   input,
-  journey,
-  someCrowdingInfoExists
+  journey
 }: {
   state: State;
   input: UserInput;
   journey: EnhancedJourney;
-  someCrowdingInfoExists: boolean;
 }): ReactElement<HTMLElement> | null => {
   const { realtime } = journey;
 
@@ -162,12 +157,7 @@ const TableRow = ({
 
   const contentComponent =
     journey.route.type !== 2
-      ? () => (
-          <BusTableRow
-            journey={journey}
-            someCrowdingInfoExists={someCrowdingInfoExists}
-          />
-        )
+      ? () => <BusTableRow journey={journey} />
       : () => <CrTableRow journey={journey} />;
 
   if (isABusRoute(journey.route)) {
@@ -285,7 +275,11 @@ export const upcomingDeparturesTable = (
     <>
       {UpcomingDeparturesHeader}
       {journeysWithTripInfo !== null && hasPredictions(journeysWithTripInfo) ? (
-        <table className="schedule-table schedule-table--upcoming">
+        <table
+          className={`schedule-table schedule-table--upcoming ${
+            !someCrowdingInfoExists ? "u-no-crowding-data" : ""
+          }`}
+        >
           <thead className="schedule-table__header">
             <tr className="schedule-table__row-header">
               <th scope="col" className="schedule-table__cell">
@@ -311,7 +305,6 @@ export const upcomingDeparturesTable = (
                   journey={journey}
                   // eslint-disable-next-line react/no-array-index-key
                   key={idx}
-                  someCrowdingInfoExists={someCrowdingInfoExists}
                 />
               )
             )}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/UpcomingDeparturesTest.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/UpcomingDeparturesTest.tsx
@@ -14,6 +14,7 @@ import UpcomingDepartures, {
 import crDeparturesResponse from "./test-data/crDepartures.json";
 import enhancedBusJourneysResponse from "./test-data/enhancedBusJourneys.json";
 import enhancedCRjourneysResponse from "./test-data/enhancedCRjourneys.json";
+import LiveCrowdingIcon from "../../../line-diagram/LiveCrowdingIcon";
 
 const busDepartures = (departuresResponse as unknown) as EnhancedJourney[];
 const crDepartures = (crDeparturesResponse as unknown) as EnhancedJourney[];
@@ -235,30 +236,20 @@ describe("UpcomingDepartures", () => {
   it("should display crowding information for buses", () => {
     const journey = enhancedBusJourneys[0];
 
-    const tripId = enhancedBusJourneys[0].trip.id;
+    wrapper = mount(<>{crowdingInformation(journey, journey.trip.id)}</>);
 
-    wrapper = mount(<>{crowdingInformation(journey, tripId, true)}</>);
-
-    expect(wrapper.find(".c-icon__crowding--some_crowding").length).toBe(1);
-  });
-
-  it("should not display crowding information for buses if it doesn't exist", () => {
-    const journey = enhancedBusJourneys[0];
-
-    const tripId = enhancedBusJourneys[0].trip.id;
-
-    wrapper = mount(<>{crowdingInformation(journey, tripId, false)}</>);
-
-    expect(wrapper.find(".c-icon__crowding--some_crowding").length).toBe(0);
+    expect(wrapper.exists(LiveCrowdingIcon)).toBeTruthy();
+    expect(wrapper.find(LiveCrowdingIcon).prop("crowding")).toBe(
+      "some_crowding"
+    );
   });
 
   it("should not display crowding information for CR", () => {
     act(() => {
       const journey: EnhancedJourney = enhancedCRjourneysResponse[0];
 
-      wrapper = mount(<>{crowdingInformation(journey, "", false)}</>);
-
-      expect(wrapper).toEqual({});
+      wrapper = mount(<>{crowdingInformation(journey, journey.trip.id)}</>);
+      expect(wrapper.find(LiveCrowdingIcon).prop("crowding")).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Regression/Bug | Crowding column not collapsed properly on routes w/o crowding](https://app.asana.com/0/385363666817452/1190437676035289/f)

Introduced a CSS class to add to the parent element to handle hiding all the crowding icons when needed.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
