### PR TITLE
Sidebar with static information

### DIFF
--- a/apps/site/assets/css/_accordion-ui.scss
+++ b/apps/site/assets/css/_accordion-ui.scss
@@ -97,21 +97,15 @@
 }
 
 .c-expandable-block__header-caret--black {
-  color: $black;
-  float: right;
-  font-family: FontAwesome;
+  @include caret($color: $black);
 }
 
 .c-expandable-block__header-caret {
-  color: $brand-primary;
-  float: right;
-  font-family: FontAwesome;
+  @include caret($color: $brand-primary);
 }
 
 .c-expandable-block__header-caret--white {
-  color: $white;
-  float: right;
-  font-family: FontAwesome;
+  @include caret($color: $white);
 }
 
 .c-expandable-block__panel {

--- a/apps/site/assets/css/_customer-support.scss
+++ b/apps/site/assets/css/_customer-support.scss
@@ -169,3 +169,40 @@ button .waiting {
   top: -$base-spacing / 2;
   width: $base-spacing;
 }
+
+.c-expandable-block__link {
+  color: inherit;
+  text-decoration: none;
+  &:hover {
+    text-decoration: inherit;
+  }
+  &:link {
+    text-decoration: inherit;
+  }
+}
+
+
+a:first-of-type > h3 {
+  margin-top: 0;
+}
+
+.c-expandable-block__header-container {
+  display: flex;
+  justify-content: space-between;
+}
+
+.c-expandable-block-caret {
+  @include caret($color: $brand-primary);
+  align-items: flex-end;
+  display: flex;
+
+  [aria-expanded='false'] &::after {
+    content: $fa-var-angle-down;
+    display: flex;
+  }
+
+  [aria-expanded='true'] &::after {
+    content: $fa-var-angle-up;
+    display: flex;
+  }
+}

--- a/apps/site/assets/css/_mixins.scss
+++ b/apps/site/assets/css/_mixins.scss
@@ -369,3 +369,10 @@
     }
   }
 }
+
+// Caret used in some expandable/collapsable blocks in the application
+@mixin caret($color) {
+  color: $color;
+  float: right;
+  font-family: FontAwesome;
+}

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -5,6 +5,44 @@ defmodule SiteWeb.CustomerSupportController do
 
   @allowed_attachment_types ~w(image/bmp image/gif image/jpeg image/png image/tiff image/webp)
 
+  @content_blocks [
+    %{
+      header: %{text: "Call Us", iconSvgText: nil},
+      id: "call_us",
+      initially_expanded: true
+    },
+    %{
+      header: %{text: "Lost and Found", iconSvgText: nil},
+      id: "lost_and_found",
+      initially_expanded: true
+    },
+    %{
+      header: %{text: "Get Service Updates", iconSvgText: nil},
+      id: "service_updates",
+      initially_expanded: true
+    },
+    %{
+      header: %{text: "Transit Police", iconSvgText: nil},
+      id: "transit_police",
+      initially_expanded: false
+    },
+    %{
+      header: %{text: "Request Public Records", iconSvgText: nil},
+      id: "request_public_records",
+      initially_expanded: false
+    },
+    %{
+      header: %{text: "Write to Us", iconSvgText: nil},
+      id: "write_to_us",
+      initially_expanded: false
+    },
+    %{
+      header: %{text: "Report Fraud, Waste, or Abuse", iconSvgText: nil},
+      id: "report",
+      initially_expanded: false
+    }
+  ]
+
   plug(Turbolinks.Plug.NoCache)
   plug(:set_service_options)
   plug(:assign_ip)
@@ -39,6 +77,29 @@ defmodule SiteWeb.CustomerSupportController do
         |> put_status(400)
         |> render_form(%{errors: errors, comments: Map.get(params, "comments")})
     end
+  end
+
+  @spec render_expandable_blocks(Plug.Conn.t(), list) :: [Phoenix.HTML.safe()]
+  def render_expandable_blocks(assigns, content_blocks \\ @content_blocks) do
+    content_blocks
+    |> Enum.map(fn block ->
+      view_template = "_#{block.id}.html"
+
+      try do
+        SiteWeb.PartialView.render(
+          "_expandable_block.html",
+          Map.merge(assigns, %{
+            header: block.header,
+            id: block.id,
+            initially_expanded: block.initially_expanded,
+            view_template: view_template
+          })
+        )
+      rescue
+        # We still want to render the page, so we just return empty content:
+        _ -> ""
+      end
+    end)
   end
 
   @spec do_submit(Plug.Conn.t(), map) :: Plug.Conn.t()

--- a/apps/site/lib/site_web/templates/customer_support/_call_us.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_call_us.html.eex
@@ -1,0 +1,14 @@
+<p>
+  Monday - Friday: 6:30 AM - 8 PM<br>
+  Saturday - Sunday: 8 AM - 4 PM
+</p>
+
+<p>
+  <strong>Main Hotline:</strong> <%= tel_link "617-222-3200" %><br>
+  <strong>Toll Free:</strong> <%= tel_link "800-392-6100" %><br>
+  <strong>TTY:</strong> <%= tel_link "617-222-5146" %>
+</p>
+
+<p>
+  <strong>Elevator/Escalator Hotline:</strong> <%= tel_link "617-222-2828" %><br>
+</p>

--- a/apps/site/lib/site_web/templates/customer_support/_lost_and_found.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_lost_and_found.html.eex
@@ -1,0 +1,8 @@
+<p>
+  Follow the link below to find the number associated with the mode or route where you lost your item.
+</p>
+<p>
+  <%= link to: cms_static_page_path(@conn, "/customer-support/lost-and-found"), class: "c-call-to-action" do %>
+    View phone numbers
+  <% end %>
+</p>

--- a/apps/site/lib/site_web/templates/customer_support/_report.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_report.html.eex
@@ -1,0 +1,4 @@
+<%= content_tag(:p, "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs.") %>
+
+<%= content_tag(:p, [
+  content_tag(:a, "Report suspected fraud, waste, or abuse", href: "https://www.mass.gov/service-details/massdot-fraud-waste-and-abuse", class: "c-call-to-action", target: "_blank", class: "c-call-to-action")]) %>

--- a/apps/site/lib/site_web/templates/customer_support/_request_public_records.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_request_public_records.html.eex
@@ -1,0 +1,7 @@
+<p>Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request.</p>
+<p>
+  <%= link to: "https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&COID=64D93B66", target: "_blank", class: "c-call-to-action" do %>
+    Submit a public records request to the MBTA
+  <% end %>
+</p>
+<p>You can also email <a href="mailto:mbta.rao@mbta.com">mbta.rao@mbta.com</a> with your request.</p>

--- a/apps/site/lib/site_web/templates/customer_support/_service_updates.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_service_updates.html.eex
@@ -1,0 +1,4 @@
+<p>Receive notifications of MBTA service alerts by email or text.</p>
+<p><a class="c-call-to-action" href="https://alerts.mbta.com" target="_blank">Sign up for T-Alerts</a></p>
+<p><a class="c-call-to-action" href="https://twitter.com/MBTA" target="_blank">Follow @MBTA on Twitter</a></p>
+<p><a class="c-call-to-action" href="https://twitter.com/MBTA_CR" target="_blank">Follow @MBTA_CR on Twitter</a></p>

--- a/apps/site/lib/site_web/templates/customer_support/_transit_police.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_transit_police.html.eex
@@ -1,0 +1,14 @@
+<p>
+  <strong>Emergency:</strong> <%= tel_link "617-222-1212" %><br>
+  <strong>TTY:</strong> <%= tel_link "617-222-1200" %>
+</p>
+<p>
+<%= link to: cms_static_page_path(@conn, "/transit-police"), class: "c-call-to-action" do %>
+  Contact the Transit Police
+<% end %>
+</p>
+<p>
+<%= link to: cms_static_page_path(@conn, "/transit-police/see-something-say-something"), class: "c-call-to-action" do %>
+  See Something, Say Something
+<% end %>
+</p>

--- a/apps/site/lib/site_web/templates/customer_support/_write_to_us.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_write_to_us.html.eex
@@ -1,0 +1,6 @@
+<p>
+  MBTA<br />
+  10 Park Plaza<br />
+  Suite 5610<br />
+  Boston, MA 02116
+</p>

--- a/apps/site/lib/site_web/templates/customer_support/index.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/index.html.eex
@@ -1,125 +1,32 @@
 <div class="container">
   <div class="page-section">
     <h1>Contact Us</h1>
-    <div class="row">
-      <div class="col-xs-12 support-thank-you <%= if @show_form, do: "hidden-xs-up" %>" tabindex="-1">
-        <div class="support-success" id="<%= if !show_error_message(@conn), do: "support-result" %>">
-          <%= fa "check-circle" %>
-          Thank you for your feedback.
+
+    <div class="col-xs-12 col-md-8">
+
+      <div class="row">
+        <div class="col-xs-12 support-thank-you <%= if @show_form, do: "hidden-xs-up" %>" tabindex="-1">
+          <div class="support-success" id="<%= if !show_error_message(@conn), do: "support-result" %>">
+            <%= fa "check-circle" %>
+            Thank you for your feedback.
+          </div>
+          <p>Your comments have been sent to our Customer Support team.</p>
         </div>
-        <p>Your comments have been sent to our Customer Support team.</p>
-      </div>
-      <div class="col-xs-12 support-form-error <%= if !show_error_message(@conn), do: "hidden-xs-up" %>" tabindex="-1">
-        <div class="support-error" id="<%= if show_error_message(@conn), do: "support-result" %>">
-          <%= fa "exclamation-circle" %>
-          We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes.
+        <div class="col-xs-12 support-form-error <%= if !show_error_message(@conn), do: "hidden-xs-up" %>" tabindex="-1">
+          <div class="support-error" id="<%= if show_error_message(@conn), do: "support-result" %>">
+            <%= fa "exclamation-circle" %>
+            We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes.
+          </div>
         </div>
       </div>
+      <%= if @show_form do %>
+        <%= render "_form.html", forward_assigns(@conn) %>
+      <% end %>
+
     </div>
-    <%= if @show_form do %>
-      <%= render "_form.html", forward_assigns(@conn) %>
-    <% end %>
-    <div class="row">
-      <div class="col-xs-12">
-        <div class="row">
-          <div class="col-xs-12 col-sm-6">
-            <h2>Call Us</h2>
-            <p>
-              Monday &mdash; Friday: 6:30 AM &mdash; 8 PM<br>
-              Saturday &mdash; Sunday: 8 AM &mdash; 4 PM
-            </p>
 
-            <p>
-              <strong>Main Hotline:</strong> <%= tel_link "617-222-3200" %><br>
-              <strong>Toll Free:</strong> <%= tel_link "800-392-6100" %><br>
-              <strong>TTY:</strong> <%= tel_link "617-222-5146" %>
-            </p>
-          
-            <p>
-              <strong>Elevator/Escalator Hotline:</strong> <%= tel_link "617-222-2828" %><br>
-            </p>
-
-            <p>
-              <strong>Lost and Found:</strong>
-                <%= link to: cms_static_page_path(@conn, "/customer-support/lost-and-found") do %>
-                  View phone numbers
-                <% end %>
-            </p>
-          </div>
-          <div class="col-xs-12 col-sm-6">
-            <h2>Transit Police</h2>
-              <p>
-                <strong>Emergency:</strong> <%= tel_link "617-222-1212" %><br>
-                <strong>TTY:</strong> <%= tel_link "617-222-1200" %>
-              </p>
-            <p>
-              <%= link to: cms_static_page_path(@conn, "/transit-police"), class: "c-call-to-action" do %>
-                Contact the Transit Police
-              <% end %>
-            </p>
-            <p>
-              <%= link to: cms_static_page_path(@conn, "/transit-police/see-something-say-something"), class: "c-call-to-action" do %>
-                See Something, Say Something
-              <% end %>
-            </p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-xs-12 col-sm-6">
-            <h2>Get Service Updates</h2>
-            <p>Receive notifications of MBTA service alerts by email or text.</p>
-            <p><a class="c-call-to-action" href="https://alerts.mbta.com" target="_blank">Sign up for T-Alerts</a></p>
-            <p><a class="c-call-to-action" href="https://twitter.com/MBTA" target="_blank">Follow @MBTA on Twitter</a></p>
-            <p><a class="c-call-to-action" href=https://twitter.com/MBTA_CR" target="_blank">Follow @MBTA_CR on Twitter</a></p>
-          </div>
-          <div class="col-xs-12 col-sm-6">
-            <h2>Write to Us</h2>
-            <p>
-              MBTA<br />
-              10 Park Plaza<br />
-              Suite 5610<br />
-              Boston, MA 02116
-            </p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-xs-12 col-sm-6">
-            <h2>Request Public Records</h2>
-            <p>Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request.</p>
-            <p>
-              <%= link to: "https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&COID=64D93B66", target: "_blank", class: "c-call-to-action" do %>
-                Submit a public records request to the MBTA
-              <% end %>
-            </p>
-            <p>You can also email <a class="c-call-to-action" href="mailto:mbta.rao@mbta.com">mbta.rao@mbta.com</a> with your request.</p>
-          </div>
-          <div class="col-xs-12 col-sm-6">
-            <h2>Report Fraud, Waste, or Abuse</h2>
-            <p>The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs.</p>
-            <p>
-              <%= link to: "https://www.mass.gov/service-details/massdot-fraud-waste-and-abuse", target: "_blank", class: "c-call-to-action" do %>
-                Report suspected fraud, waste, or abuse
-              <% end %>
-            </p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-xs-12 col-sm-6">
-            <h2>Join Us</h2>
-            <p>Check out the exciting roles we're hiring for and find out how to start your career at the MBTA.</p>
-            <p>
-              <%= link to: "/careers", class: "c-call-to-action" do %>
-                Learn about MBTA career opportunities
-              <% end %>
-            </p>
-            <p>
-              <%= link to: "https://jobs.lever.co/mbta", target: "_blank", class: "c-call-to-action" do %>
-                View Customer Technology opportunities
-              <% end %>
-            </p>
-          </div>
-        </div>
-      </div>
+    <div class="col-xs-12 col-md-4">
+      <%= SiteWeb.CustomerSupportController.render_expandable_blocks(assigns) %>
     </div>
   </div>
 </div>

--- a/apps/site/lib/site_web/templates/partial/_expandable_block.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_expandable_block.html.eex
@@ -1,0 +1,31 @@
+
+<% header_id = "header-#{@id}" %>
+<% panel_id = "panel-#{@id}" %>
+
+<a class="c-expandable-block__link"
+  href="#<%= panel_id %>"
+  tabIndex="0"
+  id="<%= header_id %>"
+  aria-expanded="<%= @initially_expanded %>"
+  aria-controls="<%= panel_id %>"
+  role="button"
+  data-toggle="collapse">
+  <h3 class="c-expandable-block__header">
+    <%= if @header.iconSvgText do %>
+      <%= content_tag(:span, svg(@header.iconSvgText), class: "notranslate c-expandable-block__header-icon", aria: [hidden: "true"]) %>
+    <% end %>
+    <div class="c-expandable-block__header-container">
+      <%= @header.text %>
+      <span class="c-expandable-block-caret"></span>
+    </div>
+  </h3>
+</a>
+<div
+  class="c-expandable-block__panel collapse<%= if @initially_expanded do %> in<% end %> js-focus-on-expand"
+  tabIndex="0"
+  role="region"
+  id="<%= panel_id %>"
+  aria-labelledby="<%= header_id %>"
+>
+<%= render @view_module, @view_template, assigns %>
+</div>

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule SiteWeb.CustomerSupportControllerTest do
   use SiteWeb.ConnCase
 
+  import Phoenix.HTML, only: [safe_to_string: 1, html_escape: 1]
+
   setup do
     conn =
       default_conn()
@@ -245,6 +247,51 @@ defmodule SiteWeb.CustomerSupportControllerTest do
         )
 
       assert "recaptcha" in conn.assigns.errors
+    end
+  end
+
+  describe "Expandable blocks" do
+    test "renders an expandable block", %{conn: conn} do
+      block = [
+        %{
+          header: %{text: "Call Us", iconSvgText: nil},
+          id: "call_us",
+          initially_expanded: true
+        }
+      ]
+
+      conn = assign(conn, :view_module, SiteWeb.CustomerSupportView)
+
+      rendered =
+        safe_to_string(
+          html_escape(
+            SiteWeb.CustomerSupportController.render_expandable_blocks(conn.assigns, block)
+          )
+        )
+
+      anchor = Floki.find(rendered, ".c-expandable-block__link")
+      assert Enum.count(anchor) == 1
+    end
+
+    test "fails gracefully if template does not exist", %{conn: conn} do
+      block = [
+        %{
+          header: %{text: "Does not exist", iconSvgText: nil},
+          id: "nonexistent",
+          initially_expanded: true
+        }
+      ]
+
+      conn = assign(conn, :view_module, SiteWeb.CustomerSupportView)
+
+      rendered =
+        safe_to_string(
+          html_escape(
+            SiteWeb.CustomerSupportController.render_expandable_blocks(conn.assigns, block)
+          )
+        )
+
+      assert rendered == ""
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [☎️ Make a new sidebar for static information](https://app.asana.com/0/555089885850811/1188535657153252)

The page has been rearranged. Content is now displayed on the right side and there is a flag that can be set to initially set the blocks as expanded when loading the page.

Before:
<img width="448" alt="image" src="https://user-images.githubusercontent.com/61979382/92505207-bd9f1600-f1d1-11ea-8a14-65939f49e70b.png">



After:
<img width="448" alt="image" src="https://user-images.githubusercontent.com/61979382/92505234-ca236e80-f1d1-11ea-835a-0848109e1d00.png">


