### PR TITLE
Add a mock version of ExAws.Operation.perform for dev

### DIFF
--- a/apps/feedback/config/dev.exs
+++ b/apps/feedback/config/dev.exs
@@ -1,1 +1,5 @@
 use Mix.Config
+
+config :feedback,
+  exaws_config_fn: &Feedback.MockAws.config/1,
+  exaws_perform_fn: &Feedback.MockAws.perform/2

--- a/apps/feedback/lib/mock_aws.ex
+++ b/apps/feedback/lib/mock_aws.ex
@@ -1,0 +1,35 @@
+defmodule Feedback.MockAws do
+  @moduledoc """
+  Mock ExAws functions so that we aren't dependent on AWS in development.
+  """
+  require Logger
+
+  def config(:ses) do
+    :ok
+  end
+
+  def perform(%{params: %{"RawMessage.Data" => raw_message}}, _config) do
+    _ =
+      raw_message
+      |> Base.decode64!()
+      |> Mail.Parsers.RFC2822.parse()
+      |> log_email()
+
+    {:ok, :status_info_that_gets_ignored_by_caller}
+  end
+
+  defp log_email(%Mail.Message{headers: %{"to" => to}, body: body}) do
+    Logger.info(fn ->
+      """
+
+      MOCK EMAIL
+
+      To: #{to}
+
+      Body:
+      #{body}
+
+      """
+    end)
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔧 Mock version of ExAws.Operation.perform for dev](https://app.asana.com/0/555089885850811/1193042951805049)

Add a mock version of ExAws.Operation.perform for dev

NB to use, set the `LOGGER_LEVEL` env var: `LOGGER_LEVEL=info`.

<img width="715" alt="Screen Shot 2020-09-09 at 15 19 52" src="https://user-images.githubusercontent.com/42339/92655157-f832ac80-f2be-11ea-95ec-6cbfa802f51f.png">


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
