### PR TITLE
(revision) 💈 special line diagram styling for stops diversion-related alerts

### DIFF
--- a/apps/alerts/lib/alert.ex
+++ b/apps/alerts/lib/alert.ex
@@ -103,8 +103,7 @@ defmodule Alerts.Alert do
     :shuttle,
     :stop_closure,
     :station_closure,
-    :detour,
-    :suspension
+    :detour
   ]
 
   @spec new(Keyword.t()) :: t()

--- a/apps/alerts/lib/alert.ex
+++ b/apps/alerts/lib/alert.ex
@@ -99,6 +99,14 @@ defmodule Alerts.Alert do
     :unknown | @ongoing_effects
   ]
 
+  @diversion_effects [
+    :shuttle,
+    :stop_closure,
+    :station_closure,
+    :detour,
+    :suspension
+  ]
+
   @spec new(Keyword.t()) :: t()
   def new(keywords \\ [])
 
@@ -243,4 +251,8 @@ defmodule Alerts.Alert do
     do: true
 
   def is_high_severity_or_high_priority(_), do: false
+
+  @spec is_diversion(t) :: boolean()
+  def is_diversion(%{effect: effect}),
+    do: effect in @diversion_effects
 end

--- a/apps/alerts/test/alerts_test.exs
+++ b/apps/alerts/test/alerts_test.exs
@@ -142,4 +142,37 @@ defmodule AlertsTest do
       refute is_high_severity_or_high_priority(%Alert{severity: 3, priority: :low})
     end
   end
+
+  describe "is_diversion/1" do
+    test "returns true for certain effects" do
+      assert is_diversion(%Alert{effect: :shuttle})
+      assert is_diversion(%Alert{effect: :stop_closure})
+      assert is_diversion(%Alert{effect: :station_closure})
+      assert is_diversion(%Alert{effect: :detour})
+    end
+
+    test "returns false for other effects" do
+      refute is_diversion(%Alert{effect: :access_issue})
+      refute is_diversion(%Alert{effect: :amber_alert})
+      refute is_diversion(%Alert{effect: :delay})
+      refute is_diversion(%Alert{effect: :dock_closure})
+      refute is_diversion(%Alert{effect: :dock_issue})
+      refute is_diversion(%Alert{effect: :extra_service})
+      refute is_diversion(%Alert{effect: :elevator_closure})
+      refute is_diversion(%Alert{effect: :escalator_closure})
+      refute is_diversion(%Alert{effect: :policy_change})
+      refute is_diversion(%Alert{effect: :schedule_change})
+      refute is_diversion(%Alert{effect: :station_issue})
+      refute is_diversion(%Alert{effect: :stop_moved})
+      refute is_diversion(%Alert{effect: :summary})
+      refute is_diversion(%Alert{effect: :suspension})
+      refute is_diversion(%Alert{effect: :track_change})
+      refute is_diversion(%Alert{effect: :unknown})
+      refute is_diversion(%Alert{effect: :cancellation})
+      refute is_diversion(%Alert{effect: :no_service})
+      refute is_diversion(%Alert{effect: :service_change})
+      refute is_diversion(%Alert{effect: :snow_route})
+      refute is_diversion(%Alert{effect: :stop_shoveling})
+    end
+  end
 end

--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -39,6 +39,9 @@
   &__merge {
     path {
       fill: none;
+    }
+
+    path:not([stroke]) {
       stroke: currentColor;
     }
   }

--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -127,14 +127,9 @@
 
 // Diversions may be shown in lieu of predictions
 .m-schedule-diagram__alert {
-  @include icon-size-inline($base-spacing);
   flex-grow: 1;
   font-weight: bold;
   text-align: right;
-
-  .c-svg__icon-alerts-triangle {
-    margin-right: $base-spacing * .35;
-  }
 }
 
 // 'View schedules' link

--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -125,6 +125,18 @@
   }
 }
 
+// Diversions may be shown in lieu of predictions
+.m-schedule-diagram__alert {
+  @include icon-size-inline($base-spacing);
+  flex-grow: 1;
+  font-weight: bold;
+  text-align: right;
+
+  .c-svg__icon-alerts-triangle {
+    margin-right: $base-spacing * .35;
+  }
+}
+
 // 'View schedules' link
 .m-schedule-diagram__footer {
   margin-top: $base-spacing / 2;

--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -1,21 +1,34 @@
 import { Alert } from "../../__v3api";
-import { isHighSeverityOrHighPriority } from "../alert";
+import {
+  isHighSeverityOrHighPriority,
+  isDiversion,
+  isCurrentAlert
+} from "../alert";
 
+const testDate = new Date("2020-09-10T09:00");
 const alert1: Alert = {
   severity: 7,
-  priority: "high"
+  priority: "high",
+  lifecycle: "new",
+  active_period: [["2020-09-10 08:00", "2020-09-10 20:00"]]
 } as Alert;
 const alert2: Alert = {
   severity: 3,
-  priority: "high"
+  priority: "high",
+  lifecycle: "ongoing",
+  active_period: [["2020-09-08 12:00", "2020-09-11 20:00"]]
 } as Alert;
 const alert3: Alert = {
   severity: 7,
-  priority: "low"
+  priority: "low",
+  lifecycle: "ongoing_upcoming",
+  active_period: [["2020-09-10 12:00", "2020-09-10 20:00"]]
 } as Alert;
 const alert4: Alert = {
   severity: 3,
-  priority: "low"
+  priority: "low",
+  lifecycle: "upcoming",
+  active_period: [["2020-09-10 12:00", "2020-09-10 20:00"]]
 } as Alert;
 
 test.each`
@@ -31,6 +44,23 @@ test.each`
       expect(isHighSeverityOrHighPriority(alert)).toBeTruthy();
     } else {
       expect(isHighSeverityOrHighPriority(alert)).toBeFalsy();
+    }
+  }
+);
+
+test.only.each`
+  alert     | isCurrent
+  ${alert1} | ${true}
+  ${alert2} | ${true}
+  ${alert3} | ${false}
+  ${alert4} | ${false}
+`(
+  "isCurrentAlert returns whether alert is current based on lifecycle and active period",
+  ({ alert, isCurrent }) => {
+    if (isCurrent) {
+      expect(isCurrentAlert(alert, testDate)).toBeTruthy();
+    } else {
+      expect(isCurrentAlert(alert, testDate)).toBeFalsy();
     }
   }
 );

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -45,12 +45,12 @@ export const isCurrentAlert = (
 ): boolean => {
   if (!alert.active_period) return false;
   const dateRanges = alert.active_period.map(ap => activePeriodToDates(ap));
-  const isInARange = dateRanges.find(
+  const isInARange = dateRanges.some(
     (range): boolean => {
       const [start, end] = range;
       if (!start) return false; // end might be null for ongoing alerts
       return currentDate >= start && (end ? currentDate <= end : true);
     }
   );
-  return isCurrentLifecycle(alert) && !!isInARange;
+  return isCurrentLifecycle(alert) && isInARange;
 };

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -9,5 +9,4 @@ export const isDiversion = ({ effect }: Alert): boolean =>
   effect === "shuttle" ||
   effect === "stop_closure" ||
   effect === "station_closure" ||
-  effect === "detour" ||
-  effect === "suspension";
+  effect === "detour";

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -6,10 +6,8 @@ export const isHighSeverityOrHighPriority = ({
 }: Alert): boolean => priority === "high" || severity >= 7;
 
 export const isDiversion = ({ effect }: Alert): boolean =>
-  [
-    "detour",
-    "shuttle",
-    "stop_closure",
-    "station_closure",
-    "suspension"
-  ].includes(effect);
+  effect === "shuttle" ||
+  effect === "stop_closure" ||
+  effect === "station_closure" ||
+  effect === "detour" ||
+  effect === "suspension";

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -1,4 +1,4 @@
-import { Alert } from "../__v3api";
+import { Alert, TimePeriodPairs } from "../__v3api";
 
 export const isHighSeverityOrHighPriority = ({
   priority,
@@ -10,3 +10,47 @@ export const isDiversion = ({ effect }: Alert): boolean =>
   effect === "stop_closure" ||
   effect === "station_closure" ||
   effect === "detour";
+
+const withLeadingZero = (n: string): string => `0${n}`.slice(-2);
+
+const activePeriodToDates = (
+  activePeriod: TimePeriodPairs
+): (Date | null)[] => {
+  const datePattern = /^(\d{4})-(\d{1,2})-(\d{1,2})\s(\d{1,2}):(\d{2})$/;
+
+  return activePeriod.map(
+    (d: string): Date | null => {
+      const match = datePattern.exec(d);
+      if (match) {
+        const [, year, rawMonth, rawDay, rawHour, min] = match;
+        return new Date(
+          `${year}-${withLeadingZero(rawMonth)}-${withLeadingZero(
+            rawDay
+          )}T${withLeadingZero(rawHour)}:${min}:00`
+        );
+      }
+      return null;
+    }
+  );
+};
+
+const isCurrentLifecycle = ({ lifecycle }: Alert): boolean =>
+  lifecycle === "new" ||
+  lifecycle === "ongoing" ||
+  lifecycle === "ongoing_upcoming";
+
+export const isCurrentAlert = (
+  alert: Alert,
+  currentDate: Date = new Date()
+): boolean => {
+  if (!alert.active_period) return false;
+  const dateRanges = alert.active_period.map(ap => activePeriodToDates(ap));
+  const isInARange = dateRanges.find(
+    (range): boolean => {
+      const [start, end] = range;
+      if (!start) return false; // end might be null for ongoing alerts
+      return currentDate >= start && (end ? currentDate <= end : true);
+    }
+  );
+  return isCurrentLifecycle(alert) && !!isInARange;
+};

--- a/apps/site/assets/ts/schedule/components/__schedule.d.ts
+++ b/apps/site/assets/ts/schedule/components/__schedule.d.ts
@@ -53,6 +53,7 @@ export interface SchedulePageData {
 interface StopData {
   branch: string | null;
   type: "line" | "merge" | "stop" | "terminus" | null;
+  "has_disruption?": boolean;
 }
 
 export interface LineDiagramStop {

--- a/apps/site/assets/ts/schedule/components/__tests__/test-data/lineDiagramData.json
+++ b/apps/site/assets/ts/schedule/components/__tests__/test-data/lineDiagramData.json
@@ -1,6 +1,6 @@
 [
   {
-    "stop_data": [{ "type": "terminus", "branch": null }],
+    "stop_data": [{ "type": "terminus", "branch": null, "has_disruption?": false }],
     "route_stop": {
       "zone": "1A",
       "stop_features": ["bus"],
@@ -60,7 +60,7 @@
     "alerts": []
   },
   {
-    "stop_data": [{ "type": "stop", "branch": "Lowell" }],
+    "stop_data": [{ "type": "stop", "branch": "Lowell", "has_disruption?": false }],
     "route_stop": {
       "zone": "",
       "stop_features": [],
@@ -95,7 +95,7 @@
     "alerts": []
   },
   {
-    "stop_data": [{ "type": "stop", "branch": "Lowell" }],
+    "stop_data": [{ "type": "stop", "branch": "Lowell", "has_disruption?": false }],
     "route_stop": {
       "zone": "1A",
       "stop_features": [
@@ -278,7 +278,7 @@
     "alerts": []
   },
   {
-    "stop_data": [{ "type": "terminus", "branch": null }],
+    "stop_data": [{ "type": "terminus", "branch": null, "has_disruption?": false }],
     "route_stop": {
       "zone": null,
       "stop_features": ["bus", "access", "parking_lot"],

--- a/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
@@ -30,7 +30,9 @@ const BranchToggle = (
             width={width}
             height="100%"
           >
-            <g transform={`translate(${BRANCH_LINE_WIDTH - 1}, -1)`}>
+            <g
+              transform={`translate(${maxBranches * BRANCH_LINE_WIDTH - 1}, 1)`}
+            >
               <rect width={CIRC_DIAMETER * 2} height="42" rx={CIRC_DIAMETER} />
               {times(3, i => (
                 <circle

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -93,7 +93,6 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
           {hasDiversion
             ? stopAlerts.filter(isDiversion).map(alert => (
                 <div key={alert.id} className="m-schedule-diagram__alert">
-                  {alertIcon("c-svg__icon-alerts-triangle")}
                   {effectNameForAlert(alert)}
                 </div>
               ))

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -6,11 +6,15 @@ import { isMergeStop, diagramWidth } from "./line-diagram-helpers";
 import StopConnections from "./StopConnections";
 import StopPredictions from "./StopPredictions";
 import { alertIcon } from "../../../helpers/icon";
-import { isHighSeverityOrHighPriority } from "../../../models/alert";
+import {
+  isHighSeverityOrHighPriority,
+  isDiversion
+} from "../../../models/alert";
 import { Alert, Route } from "../../../__v3api";
 import MatchHighlight from "../../../components/MatchHighlight";
 import StopFeatures from "./StopFeatures";
 import { StopRefContext } from "./LineDiagramWithStops";
+import { effectNameForAlert } from "../../../components/Alerts";
 
 interface StopCardProps {
   stop: LineDiagramStop;
@@ -60,6 +64,8 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
     : diagramWidth(stopData.length);
   const refs = useContext(StopRefContext)[0];
 
+  const hasDiversion = stopAlerts.some(isDiversion);
+
   return (
     <li
       className="m-schedule-diagram__stop"
@@ -84,14 +90,22 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
 
         <div className="m-schedule-diagram__stop-details">
           {StopConnections(routeStop.connections)}
-          {!isDestination && liveData && (
-            <StopPredictions
-              headsigns={liveData.headsigns}
-              isCommuterRail={
-                !!routeStop.route && isACommuterRailRoute(routeStop.route)
-              }
-            />
-          )}
+          {hasDiversion
+            ? stopAlerts.filter(isDiversion).map(alert => (
+                <div key={alert.id} className="m-schedule-diagram__alert">
+                  {alertIcon("c-svg__icon-alerts-triangle")}
+                  {effectNameForAlert(alert)}
+                </div>
+              ))
+            : !isDestination &&
+              liveData && (
+                <StopPredictions
+                  headsigns={liveData.headsigns}
+                  isCommuterRail={
+                    !!routeStop.route && isACommuterRailRoute(routeStop.route)
+                  }
+                />
+              )}
         </div>
 
         <footer className="m-schedule-diagram__footer">

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -9,7 +9,8 @@ import { hasPredictionTime } from "../../../models/prediction";
 import { alertIcon } from "../../../helpers/icon";
 import {
   isHighSeverityOrHighPriority,
-  isDiversion
+  isDiversion,
+  isCurrentAlert
 } from "../../../models/alert";
 import { Alert, Route } from "../../../__v3api";
 import MatchHighlight from "../../../components/MatchHighlight";
@@ -65,7 +66,16 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
     : diagramWidth(stopData.length);
   const refs = useContext(StopRefContext)[0];
 
-  const diversionAlert = stopAlerts.find(isDiversion);
+  const diversionAlert = stopAlerts.find(
+    alert => isDiversion(alert) && isCurrentAlert(alert)
+  );
+  const hasLivePredictions =
+    liveData &&
+    liveData.headsigns.length &&
+    liveData.headsigns.some(hasPredictionTime);
+  const showPrediction = hasLivePredictions && !isDestination;
+  const showDiversion =
+    diversionAlert && !(hasLivePredictions && isDestination);
 
   return (
     <li
@@ -91,23 +101,20 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
 
         <div className="m-schedule-diagram__stop-details">
           {StopConnections(routeStop.connections)}
-          {!isDestination &&
-          liveData &&
-          liveData.headsigns.length &&
-          liveData.headsigns.some(hasPredictionTime) ? (
+          {showPrediction ? (
             <StopPredictions
-              headsigns={liveData.headsigns}
+              headsigns={liveData!.headsigns}
               isCommuterRail={
                 !!routeStop.route && isACommuterRailRoute(routeStop.route)
               }
             />
           ) : (
-            diversionAlert && (
+            showDiversion && (
               <div
-                key={diversionAlert.id}
+                key={diversionAlert!.id}
                 className="m-schedule-diagram__alert"
               >
-                {effectNameForAlert(diversionAlert)}
+                {effectNameForAlert(diversionAlert!)}
               </div>
             )
           )}

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -5,6 +5,7 @@ import { LiveData } from "./__line-diagram";
 import { isMergeStop, diagramWidth } from "./line-diagram-helpers";
 import StopConnections from "./StopConnections";
 import StopPredictions from "./StopPredictions";
+import { hasPredictionTime } from "../../../models/prediction";
 import { alertIcon } from "../../../helpers/icon";
 import {
   isHighSeverityOrHighPriority,
@@ -90,7 +91,10 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
 
         <div className="m-schedule-diagram__stop-details">
           {StopConnections(routeStop.connections)}
-          {!isDestination && liveData && liveData.headsigns.length ? (
+          {!isDestination &&
+          liveData &&
+          liveData.headsigns.length &&
+          liveData.headsigns.some(hasPredictionTime) ? (
             <StopPredictions
               headsigns={liveData.headsigns}
               isCommuterRail={

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -64,7 +64,7 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
     : diagramWidth(stopData.length);
   const refs = useContext(StopRefContext)[0];
 
-  const hasDiversion = stopAlerts.some(isDiversion);
+  const diversionAlert = stopAlerts.find(isDiversion);
 
   return (
     <li
@@ -90,21 +90,23 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
 
         <div className="m-schedule-diagram__stop-details">
           {StopConnections(routeStop.connections)}
-          {hasDiversion
-            ? stopAlerts.filter(isDiversion).map(alert => (
-                <div key={alert.id} className="m-schedule-diagram__alert">
-                  {effectNameForAlert(alert)}
-                </div>
-              ))
-            : !isDestination &&
-              liveData && (
-                <StopPredictions
-                  headsigns={liveData.headsigns}
-                  isCommuterRail={
-                    !!routeStop.route && isACommuterRailRoute(routeStop.route)
-                  }
-                />
-              )}
+          {!isDestination && liveData && liveData.headsigns.length ? (
+            <StopPredictions
+              headsigns={liveData.headsigns}
+              isCommuterRail={
+                !!routeStop.route && isACommuterRailRoute(routeStop.route)
+              }
+            />
+          ) : (
+            diversionAlert && (
+              <div
+                key={diversionAlert.id}
+                className="m-schedule-diagram__alert"
+              >
+                {effectNameForAlert(diversionAlert)}
+              </div>
+            )
+          )}
         </div>
 
         <footer className="m-schedule-diagram__footer">

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/StopCardTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/StopCardTest.tsx
@@ -90,6 +90,13 @@ describe("StopCard", () => {
       expect(Object.entries(props)).toContainEqual(["data-toggle", "tooltip"]);
     });
   });
+
+  it("indicates detours, stop closures, etc", () => {
+    expect(wrapper.exists(".m-schedule-diagram__alert")).toBeTruthy();
+    expect(wrapper.find(".m-schedule-diagram__alert").text()).toContain(
+      "Detour"
+    );
+  });
 });
 
 it.each`

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/StopCardTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/StopCardTest.tsx
@@ -2,12 +2,19 @@ import React from "react";
 import * as redux from "react-redux";
 import { mount, ReactWrapper } from "enzyme";
 import { cloneDeep, merge } from "lodash";
-import { RouteType } from "../../../../__v3api";
+import {
+  RouteType,
+  HeadsignWithCrowding,
+  Schedule,
+  Prediction
+} from "../../../../__v3api";
 import { LineDiagramStop } from "../../__schedule";
 import simpleLineDiagram from "./lineDiagramData/simple.json"; // not a full line diagram
 import outwardLineDiagram from "./lineDiagramData/outward.json"; // not a full line diagram
 import { createLineDiagramCoordStore } from "../graphics/graphic-helpers";
 import StopCard from "../StopCard";
+import { TripPrediction } from "../../__trips";
+import StopPredictions from "../StopPredictions";
 
 const lineDiagram = (simpleLineDiagram as unknown) as LineDiagramStop[];
 let lineDiagramBranchingOut = (outwardLineDiagram as unknown) as LineDiagramStop[];
@@ -97,6 +104,54 @@ describe("StopCard", () => {
       "Detour"
     );
   });
+});
+
+const predictionHeadsign: HeadsignWithCrowding = {
+  name: "Somewhere",
+  time_data_with_crowding_list: [
+    {
+      time_data: {
+        delay: 0,
+        scheduled_time: ["4:30", " ", "PM"],
+        prediction: {
+          time: ["14", " ", "min"],
+          status: null,
+          track: null
+        } as Prediction
+      },
+      crowding: null,
+      predicted_schedule: {
+        schedule: {} as Schedule,
+        prediction: {} as TripPrediction
+      }
+    }
+  ],
+  train_number: null
+};
+const liveDataWithPrediction = {
+  headsigns: [predictionHeadsign],
+  vehicles: []
+};
+it.only("indicates predictions if available", () => {
+  const wrapper = mount(
+    <redux.Provider store={store}>
+      <StopCard
+        stop={lineDiagram[2]}
+        onClick={handleStopClick}
+        liveData={liveDataWithPrediction}
+      />
+    </redux.Provider>
+  );
+
+  expect(wrapper.exists(StopPredictions)).toBeTruthy();
+  const predictions = wrapper.find(StopPredictions);
+  expect(predictions.text()).toContain("Somewhere");
+  expect(
+    predictions.find(".m-schedule-diagram__prediction-time").text()
+  ).toContain("14");
+  expect(
+    predictions.find(".m-schedule-diagram__prediction-time").text()
+  ).toContain("min");
 });
 
 it.each`

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/DiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/DiagramTest.tsx.snap
@@ -84,7 +84,7 @@ exports[`Diagram with branches going inward renders and matches snapshot 1`] = `
             <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"290px\\" y2=\\"150px\\" />
           </Line>
           <path strokeWidth=\\"10px\\" d=\\"M10,250 v74 a-6,6 0 0 1 -6,6 h6\\" />
-          <path strokeWidth=\\"10px\\" d=\\"M10,190 v14 a-6,6 0 0 1 -6,6 h6\\" />
+          <path strokeWidth=\\"10px\\" d=\\"M10,170 v-6 a-6,6 0 0 1 -6,6 h6\\" />
         </g>
       </Merges>
       <Line from={{...}} to={{...}}>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/DiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/DiagramTest.tsx.snap
@@ -16,8 +16,13 @@ exports[`Diagram for simple lines renders and matches snapshot 1`] = `
       <desc id=\\"diagram-desc\\">
         4 stops going Outbound to Begin
       </desc>
+      <defs>
+        <pattern id=\\"diagonalHatch\\" width=\\"10\\" height=\\"10\\" patternTransform=\\"rotate(45 0 0)\\" patternUnits=\\"userSpaceOnUse\\">
+          <line className=\\"line-diagram-svg__line\\" y2={8} strokeWidth=\\"16px\\" />
+        </pattern>
+      </defs>
       <Line from={{...}} to={{...}}>
-        <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"30px\\" y2=\\"50px\\" />
+        <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"30px\\" y2=\\"50px\\" stroke=\\"url(#diagonalHatch)\\" />
       </Line>
       <Line from={{...}} to={{...}}>
         <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"50px\\" y2=\\"70px\\" />
@@ -68,6 +73,11 @@ exports[`Diagram with branches going inward renders and matches snapshot 1`] = `
         13 stops going Outbound to Begin
         Use Stop 1 to transfer to trains on TreeTrunk or TreeTwig or TreeBranch branches. 
       </desc>
+      <defs>
+        <pattern id=\\"diagonalHatch\\" width=\\"10\\" height=\\"10\\" patternTransform=\\"rotate(45 0 0)\\" patternUnits=\\"userSpaceOnUse\\">
+          <line className=\\"line-diagram-svg__line\\" y2={8} strokeWidth=\\"16px\\" />
+        </pattern>
+      </defs>
       <Merges lineDiagram={{...}}>
         <g className=\\"line-diagram-svg__merge\\">
           <Line from={{...}} to={{...}}>
@@ -189,6 +199,11 @@ exports[`Diagram with branches going outward renders and matches snapshot 1`] = 
         13 stops going Outbound to Begin
         Use Stop 1 to transfer to trains on TreeTrunk or TreeTwig or TreeBranch branches. 
       </desc>
+      <defs>
+        <pattern id=\\"diagonalHatch\\" width=\\"10\\" height=\\"10\\" patternTransform=\\"rotate(45 0 0)\\" patternUnits=\\"userSpaceOnUse\\">
+          <line className=\\"line-diagram-svg__line\\" y2={8} strokeWidth=\\"16px\\" />
+        </pattern>
+      </defs>
       <Merges lineDiagram={{...}}>
         <g className=\\"line-diagram-svg__merge\\">
           <Line from={{...}} to={{...}}>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/ExpandableBranchTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/ExpandableBranchTest.tsx.snap
@@ -10,7 +10,7 @@ exports[`ExpandableBranch renders and matches snapshot 1`] = `
             <div className=\\"m-schedule-diagram__expander-header\\">
               <div style={{...}}>
                 <svg className=\\"line-diagram-svg__toggle bus\\" width={38} height=\\"100%\\">
-                  <g transform=\\"translate(15, -1)\\">
+                  <g transform=\\"translate(15, 1)\\">
                     <rect width={16} height=\\"42\\" rx={8} />
                     <circle cx={8} cy={11} r={4} />
                     <circle cx={8} cy={21} r={4} />

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -60,8 +60,13 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
             <desc id=\\"diagram-desc\\">
               4 stops going Outbound to Begin
             </desc>
+            <defs>
+              <pattern id=\\"diagonalHatch\\" width=\\"10\\" height=\\"10\\" patternTransform=\\"rotate(45 0 0)\\" patternUnits=\\"userSpaceOnUse\\">
+                <line className=\\"line-diagram-svg__line\\" y2={8} strokeWidth=\\"16px\\" />
+              </pattern>
+            </defs>
             <Line from={{...}} to={{...}}>
-              <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"0px\\" y2=\\"0px\\" />
+              <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"0px\\" y2=\\"0px\\" stroke=\\"url(#diagonalHatch)\\" />
             </Line>
             <Line from={{...}} to={{...}}>
               <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"0px\\" y2=\\"0px\\" />
@@ -107,6 +112,9 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                 </header>
                 <div className=\\"m-schedule-diagram__stop-details\\">
                   <div className=\\"m-schedule-diagram__connections\\" />
+                  <div className=\\"m-schedule-diagram__alert\\">
+                    Detour
+                  </div>
                 </div>
                 <footer className=\\"m-schedule-diagram__footer\\">
                   <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -45,8 +45,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
           <desc id=\\"diagram-desc\\">
             4 stops going Outbound to Begin
           </desc>
+          <defs>
+            <pattern id=\\"diagonalHatch\\" width=\\"10\\" height=\\"10\\" patternTransform=\\"rotate(45 0 0)\\" patternUnits=\\"userSpaceOnUse\\">
+              <line className=\\"line-diagram-svg__line\\" y2={8} strokeWidth=\\"16px\\" />
+            </pattern>
+          </defs>
           <Line from={{...}} to={{...}}>
-            <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"30px\\" y2=\\"50px\\" />
+            <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"30px\\" y2=\\"50px\\" stroke=\\"url(#diagonalHatch)\\" />
           </Line>
           <Line from={{...}} to={{...}}>
             <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"50px\\" y2=\\"70px\\" />
@@ -92,6 +97,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
               </header>
               <div className=\\"m-schedule-diagram__stop-details\\">
                 <div className=\\"m-schedule-diagram__connections\\" />
+                <div className=\\"m-schedule-diagram__alert\\">
+                  Detour
+                </div>
               </div>
               <footer className=\\"m-schedule-diagram__footer\\">
                 <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineTest.tsx.snap
@@ -13,7 +13,7 @@ exports[`Line component between stops with branches renders and matches snapshot
 exports[`Line component renders and matches snapshot 1`] = `
 "<Provider store={{...}}>
   <Line from={{...}} to={{...}}>
-    <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"17px\\" y2=\\"24px\\" />
+    <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"17px\\" y2=\\"24px\\" stroke=\\"url(#diagonalHatch)\\" />
   </Line>
 </Provider>"
 `;

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineTest.tsx.snap
@@ -10,6 +10,14 @@ exports[`Line component between stops with branches renders and matches snapshot
 </Provider>"
 `;
 
+exports[`Line component between stops with disruptions renders and matches snapshot 1`] = `
+"<Provider store={{...}}>
+  <Line from={{...}} to={{...}}>
+    <line className=\\"line-diagram-svg__line\\" strokeWidth=\\"10px\\" x1=\\"11px\\" x2=\\"11px\\" y1=\\"17px\\" y2=\\"24px\\" stroke=\\"url(#diagonalHatch)\\" />
+  </Line>
+</Provider>"
+`;
+
 exports[`Line component renders and matches snapshot 1`] = `
 "<Provider store={{...}}>
   <Line from={{...}} to={{...}}>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
@@ -25,9 +25,10 @@ exports[`StopCard renders and matches snapshot 1`] = `
         </header>
         <div className=\\"m-schedule-diagram__stop-details\\">
           <div className=\\"m-schedule-diagram__connections\\" />
-          <StopPredictions headsigns={{...}} isCommuterRail={false}>
-            <div className=\\"m-schedule-diagram__predictions\\" />
-          </StopPredictions>
+          <div className=\\"m-schedule-diagram__alert\\">
+            <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+            Detour
+          </div>
         </div>
         <footer className=\\"m-schedule-diagram__footer\\">
           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
@@ -26,7 +26,6 @@ exports[`StopCard renders and matches snapshot 1`] = `
         <div className=\\"m-schedule-diagram__stop-details\\">
           <div className=\\"m-schedule-diagram__connections\\" />
           <div className=\\"m-schedule-diagram__alert\\">
-            <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
             Detour
           </div>
         </div>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopListWithBranchesTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopListWithBranchesTest.tsx.snap
@@ -211,7 +211,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
                     <div className=\\"m-schedule-diagram__expander-header\\">
                       <div style={{...}}>
                         <svg className=\\"line-diagram-svg__toggle commuter-rail\\" width={54} height=\\"100%\\">
-                          <g transform=\\"translate(15, -1)\\">
+                          <g transform=\\"translate(31, 1)\\">
                             <rect width={16} height=\\"42\\" rx={8} />
                             <circle cx={8} cy={11} r={4} />
                             <circle cx={8} cy={21} r={4} />

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/lineDiagramData/simple.json
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/lineDiagramData/simple.json
@@ -42,7 +42,11 @@
       {
         "id": "2",
         "severity": "3",
-        "effect": "detour"
+        "effect": "detour",
+        "lifecycle": "ongoing",
+        "active_period": [
+          ["2020-09-01 12:00", "2022-01-01 01:00"]
+        ]
       }
     ]
   },

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/lineDiagramData/simple.json
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/lineDiagramData/simple.json
@@ -1,6 +1,6 @@
 [
   {
-    "stop_data": [{ "type": "terminus", "branch": null }],
+    "stop_data": [{ "type": "terminus", "branch": null, "has_disruption?": true }],
     "route_stop": {
       "zone": null,
       "stop_features": ["parking_lot"],
@@ -47,7 +47,7 @@
     ]
   },
   {
-    "stop_data": [{ "type": "stop", "branch": null }],
+    "stop_data": [{ "type": "stop", "branch": null, "has_disruption?": false }],
     "route_stop": {
       "zone": null,
       "stop_features": [],
@@ -112,7 +112,7 @@
     ]
   },
   {
-    "stop_data": [{ "type": "stop", "branch": null }],
+    "stop_data": [{ "type": "stop", "branch": null, "has_disruption?": false }],
     "route_stop": {
       "zone": null,
       "stop_features": ["access"],
@@ -177,7 +177,7 @@
     ]
   },
   {
-    "stop_data": [{ "type": "terminus", "branch": null }],
+    "stop_data": [{ "type": "terminus", "branch": null, "has_disruption?": false }],
     "route_stop": {
       "zone": null,
       "stop_features": ["parking_lot", "access"],

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Diagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Diagram.tsx
@@ -17,7 +17,7 @@ import VehicleIcons from "../VehicleIcons";
 import { getCurrentState } from "../../../store/ScheduleStore";
 import { DirectionId } from "../../../../__v3api";
 import { isAGreenLineRoute } from "../../../../models/route";
-import { BASE_LINE_WIDTH } from "./graphic-helpers";
+import { BASE_LINE_WIDTH, DiagonalHatchPattern } from "./graphic-helpers";
 
 interface DiagramProps {
   lineDiagram: LineDiagramStop[];
@@ -114,6 +114,7 @@ const Diagram = (props: DiagramProps): ReactElement<HTMLElement> | null => {
           {hasBranchLines(lineDiagram) && branchingDescription(lineDiagram)}
         </desc>
 
+        <defs>{DiagonalHatchPattern}</defs>
         {/* If there are multiple branches, draw the lines and curves for those */
         hasBranchLines(lineDiagram) && <Merges lineDiagram={lineDiagram} />}
 

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Line.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Line.tsx
@@ -13,7 +13,6 @@ import {
   BASE_LINE_WIDTH,
   BRANCH_SPACING
 } from "./graphic-helpers";
-import { isDiversion } from "../../../../models/alert";
 
 interface PathGraphicsProps {
   from: LineDiagramStop;

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Line.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Line.tsx
@@ -13,6 +13,7 @@ import {
   BASE_LINE_WIDTH,
   BRANCH_SPACING
 } from "./graphic-helpers";
+import { isDiversion } from "../../../../models/alert";
 
 interface PathGraphicsProps {
   from: LineDiagramStop;
@@ -43,6 +44,9 @@ const Line = ({ from, to }: PathGraphicsProps): ReactElement | null => {
     lineProps.x2 = lineProps.x1;
     lineProps.y1 = `${y1}px`;
     lineProps.y2 = `${y2}px`;
+    if (from.alerts.some(isDiversion)) {
+      lineProps.stroke = "url(#diagonalHatch)";
+    }
     return <line className="line-diagram-svg__line" {...lineProps} />;
   }
 
@@ -69,6 +73,9 @@ const Line = ({ from, to }: PathGraphicsProps): ReactElement | null => {
         lineProps.x2 = lineProps.x1;
         lineProps.y1 = `${y1}px`;
         lineProps.y2 = `${y2}px`;
+        if (branchLine.type !== "line" && from.alerts.some(isDiversion)) {
+          lineProps.stroke = "url(#diagonalHatch)";
+        }
         return <line className="line-diagram-svg__line" {...lineProps} />;
       })}
     </>

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Line.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Line.tsx
@@ -44,7 +44,10 @@ const Line = ({ from, to }: PathGraphicsProps): ReactElement | null => {
     lineProps.x2 = lineProps.x1;
     lineProps.y1 = `${y1}px`;
     lineProps.y2 = `${y2}px`;
-    if (from.alerts.some(isDiversion)) {
+    if (
+      from.stop_data.some(sd => sd["has_disruption?"]) &&
+      to.stop_data.some(sd => sd["has_disruption?"])
+    ) {
       lineProps.stroke = "url(#diagonalHatch)";
     }
     return <line className="line-diagram-svg__line" {...lineProps} />;
@@ -73,7 +76,7 @@ const Line = ({ from, to }: PathGraphicsProps): ReactElement | null => {
         lineProps.x2 = lineProps.x1;
         lineProps.y1 = `${y1}px`;
         lineProps.y2 = `${y2}px`;
-        if (branchLine.type !== "line" && from.alerts.some(isDiversion)) {
+        if (branchLine["has_disruption?"]) {
           lineProps.stroke = "url(#diagonalHatch)";
         }
         return <line className="line-diagram-svg__line" {...lineProps} />;

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Merge.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Merge.tsx
@@ -56,7 +56,7 @@ const Merges = ({ lineDiagram }: MergeGraphicsProps): ReactElement | null => {
       // along the branch might be subsequent stops or prior stops
       const downBranch = (branchingOutward
         ? lineDiagram.slice(mergeStopIndex)
-        : lineDiagram.slice(0, mergeStopIndex - 1)
+        : lineDiagram.slice(0, mergeStopIndex)
       ).filter(stop => stop.route_stop.branch === branch);
       const nextStopOnBranch = branchingOutward
         ? first(downBranch)

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Merge.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Merge.tsx
@@ -85,14 +85,15 @@ const Merges = ({ lineDiagram }: MergeGraphicsProps): ReactElement | null => {
       const arc = branchingOutward
         ? `-${MERGE_RADIUS},-${MERGE_RADIUS} 0 0 0 -${MERGE_RADIUS},-${MERGE_RADIUS}`
         : `-${MERGE_RADIUS},${MERGE_RADIUS} 0 0 1 -${MERGE_RADIUS},${MERGE_RADIUS}`;
-      const d = `M${x},${y} v${dy} a${arc} h${dx}`;
-      return (
-        <path
-          key={`${mergeStop.route_stop.id}-${terminus!.route_stop.id}-merge`}
-          strokeWidth={`${BASE_LINE_WIDTH}px`}
-          d={d}
-        />
-      );
+      const pathProps: React.SVGProps<SVGPathElement> = {
+        key: `${mergeStop.route_stop.id}-${terminus!.route_stop.id}-merge`,
+        strokeWidth: `${BASE_LINE_WIDTH}px`,
+        d: `M${x},${y} v${dy} a${arc} h${dx}`
+      };
+      if (nextStop!.stop_data.some(sd => sd["has_disruption?"])) {
+        pathProps.stroke = "url(#diagonalHatch)";
+      }
+      return <path {...pathProps} />;
     });
   });
 

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/graphic-helpers.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/graphic-helpers.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { AnyAction, Reducer, Store, createStore } from "redux";
 import { LineDiagramStop } from "../../__schedule";
 
@@ -48,3 +49,19 @@ export const createLineDiagramCoordStore = (
 
   return store;
 };
+
+export const DiagonalHatchPattern = (
+  <pattern
+    id="diagonalHatch"
+    width="10"
+    height="10"
+    patternTransform="rotate(45 0 0)"
+    patternUnits="userSpaceOnUse"
+  >
+    <line
+      className="line-diagram-svg__line"
+      y2={CIRC_DIAMETER}
+      strokeWidth={`${BRANCH_LINE_WIDTH}px`}
+    />
+  </pattern>
+);

--- a/apps/site/lib/site/json_helpers.ex
+++ b/apps/site/lib/site/json_helpers.ex
@@ -40,7 +40,7 @@ defmodule Site.JsonHelpers do
   end
 
   defp format_time(t) do
-    case Timex.format(t, "{YYYY}-{M}-{D} {h12}:{m}") do
+    case Timex.format(t, "{YYYY}-{M}-{D} {h24}:{m}") do
       {:ok, formatted_time} -> formatted_time
       _ -> nil
     end

--- a/apps/site/lib/site_web/controllers/helpers.ex
+++ b/apps/site/lib/site_web/controllers/helpers.ex
@@ -145,14 +145,17 @@ defmodule SiteWeb.ControllerHelpers do
     Conn.put_resp_header(conn, "x-robots-tag", "noindex")
   end
 
-  @spec filter_alerts_by_direction([Alert.t()], boolean, map) :: [Alert.t()]
+  @spec filter_alerts_by_direction([Alert.t()], boolean, String.t() | number | nil) :: [Alert.t()]
   defp filter_alerts_by_direction(alerts, false, _), do: alerts
   defp filter_alerts_by_direction(alerts, true, nil), do: alerts
 
-  defp filter_alerts_by_direction(alerts, true, direction_id) do
+  defp filter_alerts_by_direction(alerts, true, direction_id) when is_bitstring(direction_id),
+    do: filter_alerts_by_direction(alerts, true, String.to_integer(direction_id))
+
+  defp filter_alerts_by_direction(alerts, true, direction_id) when is_number(direction_id) do
     Enum.filter(alerts, fn %{informed_entity: informed_entity} ->
       # direction matches if the direction of the alert is the same or nil
-      Enum.any?(informed_entity, &(&1.direction_id == direction_id or &1.direction_id == nil))
+      Enum.any?(informed_entity, &(&1.direction_id == direction_id or is_nil(&1.direction_id)))
     end)
   end
 

--- a/apps/site/lib/site_web/controllers/schedule/line/diagram_format.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/diagram_format.ex
@@ -44,9 +44,14 @@ defmodule SiteWeb.ScheduleController.Line.DiagramFormat do
 
   @spec stop_data_with_disruption([map()]) :: [map()]
   defp stop_data_with_disruption(stop_data) do
-    {stop_or_terminus, other_stop_data} = List.pop_at(stop_data, -1)
-    stop_or_terminus_with_disruption = %{stop_or_terminus | has_disruption?: true}
-    other_stop_data ++ [stop_or_terminus_with_disruption]
+    stop_data
+    |> Enum.map(fn %{type: type} = sd ->
+      if type != :line do
+        %{sd | has_disruption?: true}
+      else
+        sd
+      end
+    end)
   end
 
   @spec stop_has_diversion_now?(line_diagram_stop, DateTime.t()) :: boolean

--- a/apps/site/lib/site_web/controllers/schedule/line/diagram_format.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/diagram_format.ex
@@ -1,0 +1,121 @@
+defmodule SiteWeb.ScheduleController.Line.DiagramFormat do
+  @moduledoc """
+  Even more helpers for the line diagram, using the outputs from SiteWeb.ScheduleController.Line.DiagramHelpers
+  """
+  alias Alerts.{Alert, Match}
+  alias Stops.RouteStop
+
+  @type line_diagram_stop :: %{
+          alerts: [Alert.t()],
+          route_stop: RouteStop.t(),
+          stop_data: [map]
+        }
+
+  # For each set of disrupted stops, maybe make adjustment to the diagram based on
+  # the nature of the disruption.
+  #   * if there is a shuttle we don't style the final stop
+  #   * if there is a detour or stop/station
+  @spec shift_indices_by_effect([number], [Alerts.Alert.effect()]) :: [number]
+  defp shift_indices_by_effect(indices, [:shuttle | _]) do
+    List.delete_at(indices, -1)
+  end
+
+  defp shift_indices_by_effect(indices, [effect | _])
+       when effect in [:stop_closure, :station_closure, :detour]
+       when hd(indices) > 0 do
+    [hd(indices) - 1] ++ indices
+  end
+
+  defp shift_indices_by_effect(indices, [_ | effects]),
+    do: shift_indices_by_effect(indices, effects)
+
+  defp shift_indices_by_effect(indices, _), do: indices
+
+  @spec effects_for_stop(line_diagram_stop) :: [Alerts.Alert.effect()]
+  defp effects_for_stop(%{alerts: []}), do: []
+
+  defp effects_for_stop(%{alerts: alerts}) do
+    Enum.map(alerts, & &1.effect)
+  end
+
+  @spec stop_with_disruption({line_diagram_stop, number}, [number]) :: line_diagram_stop
+  defp stop_with_disruption({%{stop_data: stop_data} = stop, index}, disrupted_stop_indices) do
+    if index in disrupted_stop_indices do
+      %{stop | stop_data: stop_data_with_disruption(stop_data)}
+    else
+      stop
+    end
+  end
+
+  defp stop_with_disruption({stop, _}, _), do: stop
+
+  @spec stop_data_with_disruption([map()]) :: [map()]
+  defp stop_data_with_disruption(stop_data) do
+    {stop_or_terminus, other_stop_data} = List.pop_at(stop_data, -1)
+    stop_or_terminus_with_disruption = %{stop_or_terminus | has_disruption?: true}
+    other_stop_data ++ [stop_or_terminus_with_disruption]
+  end
+
+  @spec stop_has_diversion_now?(line_diagram_stop, DateTime.t()) :: boolean
+  defp stop_has_diversion_now?(%{alerts: alerts}, now) do
+    Enum.any?(alerts, &has_active_diversion?(&1, now))
+  end
+
+  @spec has_active_diversion?(Alert.t(), DateTime.t()) :: boolean
+  defp has_active_diversion?(%Alert{active_period: active_period} = alert, now) do
+    Match.any_period_match?(active_period, now) and Alert.is_diversion(alert)
+  end
+
+  defp has_active_diversion?(_, _), do: false
+
+  defp chunk_by_diversions({stop, index}, chunk, date) do
+    if stop_has_diversion_now?(stop, date) do
+      stop_effect = effects_for_stop(stop)
+
+      case chunk do
+        [] ->
+          {:cont, [{index, stop_effect}]}
+
+        [{_, last_effect} | _] ->
+          if stop_effect == last_effect do
+            {:cont, [{index, stop_effect} | chunk]}
+          else
+            {:cont, [{index, stop_effect}]}
+          end
+      end
+    else
+      {:cont, chunk}
+    end
+  end
+
+  @doc """
+  Identify sequences of disrupted stops and makes adjustments to the line
+  diagram stop data. Disruptions include diversions, such as shuttles, detours,
+  and stop closures.
+  """
+  @spec do_stops_list_with_disruptions([line_diagram_stop], DateTime.t()) :: [line_diagram_stop]
+  def do_stops_list_with_disruptions(_, nil), do: []
+
+  def do_stops_list_with_disruptions(stops_list, date) do
+    disrupted_stop_indices =
+      stops_list
+      |> Stream.with_index()
+      |> Stream.chunk_while(
+        [],
+        &chunk_by_diversions(&1, &2, date),
+        fn
+          [] -> {:cont, []}
+          chunk -> {:cont, Enum.reverse(chunk), []}
+        end
+      )
+      |> Stream.flat_map(fn chunked_stops ->
+        {indices, effects} = Enum.unzip(chunked_stops)
+        shift_indices_by_effect(indices, List.flatten(effects) |> Enum.uniq())
+      end)
+      |> Enum.uniq()
+
+    stops_list
+    |> Enum.with_index()
+    |> Enum.map(&stop_with_disruption(&1, disrupted_stop_indices))
+  end
+end

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -2,6 +2,7 @@ defmodule SiteWeb.ScheduleController.LineApi do
   @moduledoc "Provides JSON endpoints for retrieving line diagram data."
   use SiteWeb, :controller
 
+  alias Alerts.Match
   alias Alerts.Stop, as: AlertsStop
   alias RoutePatterns.RoutePattern
   alias Routes.Route
@@ -119,7 +120,11 @@ defmodule SiteWeb.ScheduleController.LineApi do
   @spec update_route_stop_data({any, RouteStop.t()}, any, DateTime.t()) :: map()
   def update_route_stop_data({data, %RouteStop{id: stop_id} = map}, alerts, date) do
     %{
-      alerts: alerts |> AlertsStop.match(stop_id) |> json_safe_alerts(date),
+      alerts:
+        alerts
+        |> Enum.filter(&Match.any_time_match?(&1, date))
+        |> AlertsStop.match(stop_id)
+        |> json_safe_alerts(date),
       route_stop: RouteStop.to_json_safe(map),
       stop_data: Enum.map(data, fn {key, value} -> %{branch: key, type: value} end)
     }

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -158,11 +158,11 @@ defmodule SiteWeb.ScheduleController.LineApi do
     effect_avoids_stop? = effects -- effects -- [:stop_closure, :station_closure, :detour]
 
     cond do
-      effect_avoids_stop? && List.first(indices) > 0 ->
-        [List.first(indices) - 1] ++ indices
-
       :shuttle in effects ->
         List.delete_at(indices, -1)
+
+      effect_avoids_stop? && List.first(indices) > 0 ->
+        [List.first(indices) - 1] ++ indices
 
       true ->
         indices

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -176,13 +176,14 @@ defmodule SiteWeb.ScheduleController.LineApi do
   # modify the stop preceding it but for shuttle we don't style the final stop
   @spec shift_indices_by_disruption_effect([number], [Alerts.Alert.effect()]) :: [number]
   defp shift_indices_by_disruption_effect(indices, effects) do
-    effects_avoiding_stop = effects -- effects -- [:stop_closure, :station_closure, :detour]
+    effect_avoids_stop? =
+      Enum.any?(effects, &Enum.member?([:stop_closure, :station_closure, :detour], &1))
 
     cond do
       :shuttle in effects ->
         List.delete_at(indices, -1)
 
-      Kernel.length(effects_avoiding_stop) > 0 && List.first(indices) > 0 ->
+      effect_avoids_stop? and List.first(indices) > 0 ->
         [List.first(indices) - 1] ++ indices
 
       true ->

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -49,7 +49,7 @@ defmodule SiteWeb.ScheduleController.LineApi do
 
         json(
           conn,
-          update_route_stop_data(line_data, conn.assigns.alerts, conn.assigns.date)
+          update_route_stop_data(line_data, conn.assigns.alerts, conn.assigns.date_time)
         )
 
       :not_found ->

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -158,7 +158,7 @@ defmodule SiteWeb.ScheduleController.LineApi do
     effect_avoids_stop? = effects -- effects -- [:stop_closure, :station_closure, :detour]
 
     cond do
-      effect_avoids_stop? and List.first(indices) > 0 ->
+      effect_avoids_stop? && List.first(indices) > 0 ->
         [List.first(indices) - 1] ++ indices
 
       :shuttle in effects ->
@@ -179,7 +179,7 @@ defmodule SiteWeb.ScheduleController.LineApi do
 
   defp add_disruption(stop) do
     Map.update(stop, :stop_data, [], fn stop_data ->
-      stop_or_terminus = List.last(stop_data)
+      stop_or_terminus = Kernel.length(stop_data) - 1
 
       stop_data
       |> List.update_at(stop_or_terminus, fn sd ->

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -124,9 +124,13 @@ defmodule SiteWeb.ScheduleController.LineApi do
     diagram itself - branch name, stop/line/terminus/merge, and whether it needs
     to show a disruption
   """
-  @spec update_route_stop_data([
-    DiagramHelpers.stop_with_bubble_info()
-  ], [Alerts.Alert.t()], DateTime.t()) :: [DiagramFormat.line_diagram_stop()]
+  @spec update_route_stop_data(
+          [
+            DiagramHelpers.stop_with_bubble_info()
+          ],
+          [Alerts.Alert.t()],
+          DateTime.t()
+        ) :: [DiagramFormat.line_diagram_stop()]
   def update_route_stop_data(all_stops, alerts, date) do
     Enum.map(all_stops, fn stop ->
       compose_route_stop_data(stop, alerts, date)

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -79,9 +79,7 @@ defmodule SiteWeb.ScheduleController.LineController do
         route_patterns: conn.assigns.route_patterns,
         shape_map: conn.assigns.shape_map,
         line_diagram:
-          Enum.map(conn.assigns.all_stops, fn stop ->
-            update_route_stop_data(stop, conn.assigns.alerts, conn.assigns.date)
-          end),
+          update_route_stop_data(conn.assigns.all_stops, conn.assigns.alerts, conn.assigns.date),
         today: conn.assigns.date_time |> DateTime.to_date() |> Date.to_iso8601(),
         variant: conn.assigns.variant
       }

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -79,7 +79,11 @@ defmodule SiteWeb.ScheduleController.LineController do
         route_patterns: conn.assigns.route_patterns,
         shape_map: conn.assigns.shape_map,
         line_diagram:
-          update_route_stop_data(conn.assigns.all_stops, conn.assigns.alerts, conn.assigns.date),
+          update_route_stop_data(
+            conn.assigns.all_stops,
+            conn.assigns.alerts,
+            conn.assigns.date_time
+          ),
         today: conn.assigns.date_time |> DateTime.to_date() |> Date.to_iso8601(),
         variant: conn.assigns.variant
       }

--- a/apps/site/test/site_web/controllers/line_api_test.exs
+++ b/apps/site/test/site_web/controllers/line_api_test.exs
@@ -1,6 +1,14 @@
 defmodule SiteWeb.LineApiTest do
   use SiteWeb.ConnCase
 
+  import SiteWeb.ScheduleController.LineApi
+  alias Alerts.Alert
+  alias Alerts.InformedEntity, as: IE
+  alias Alerts.Match
+  alias Alerts.Stop, as: AlertsStop
+  alias Routes.Route
+  alias Stops.RouteStop
+
   describe "show" do
     test "success response", %{conn: conn} do
       conn = get(conn, line_api_path(conn, :show, %{"id" => "Red", "direction_id" => "1"}))
@@ -26,6 +34,119 @@ defmodule SiteWeb.LineApiTest do
         )
 
       assert %{"place-brdwy" => %{"headsigns" => _, "vehicles" => _}} = json_response(conn, 200)
+    end
+  end
+
+  @now Timex.now()
+
+  @line_data [
+    {
+      [nil: :terminus],
+      %RouteStop{id: "place-alfcl", connections: [], route: %Route{id: "Red"}}
+    },
+    {
+      [{"Alewife - Ashmont", :merge}, {"Alewife - Braintree", :merge}],
+      %RouteStop{id: "place-jfk", connections: [], route: %Route{id: "Red"}}
+    },
+    {
+      [{"Alewife - Ashmont", :line}, {"Alewife - Braintree", :stop}],
+      %RouteStop{id: "place-nqncy", connections: [], route: %Route{id: "Red"}}
+    },
+    {
+      [{"Alewife - Ashmont", :line}, {"Alewife - Braintree", :terminus}],
+      %RouteStop{id: "place-brntn", connections: [], route: %Route{id: "Red"}}
+    },
+    {
+      [{"Alewife - Ashmont", :stop}],
+      %RouteStop{id: "place-shmnl", connections: [], route: %Route{id: "Red"}}
+    },
+    {
+      [{"Alewife - Ashmont", :terminus}],
+      %RouteStop{id: "place-asmnl", connections: [], route: %Route{id: "Red"}}
+    }
+  ]
+
+  @disruption_alert Alert.new(
+                      lifecycle: :ongoing,
+                      effect: :detour,
+                      informed_entity: [%IE{stop: "place-nqncy"}, %IE{stop: "place-brntn"}],
+                      active_period: [{Timex.shift(@now, days: -1), Timex.shift(@now, days: 1)}]
+                    )
+
+  @future_alert Alert.new(
+                  active_period: [{Timex.shift(@now, days: 2), Timex.shift(@now, days: 3)}],
+                  lifecycle: :upcoming,
+                  effect: :stop_closure,
+                  informed_entity: [%IE{stop: "place-alfcl"}]
+                )
+
+  @other_alert Alert.new(
+                 active_period: [{@now, nil}],
+                 priority: :high,
+                 lifecycle: :ongoing,
+                 effect: :stop_shoveling,
+                 informed_entity: [%IE{stop: "place-jfk"}]
+               )
+
+  @alerts [
+    @disruption_alert,
+    @future_alert,
+    @other_alert
+  ]
+
+  describe "update_route_stop_data/3" do
+    test "returns a list of line diagram stops" do
+      assert [%{alerts: alerts, route_stop: route_stop, stop_data: stop_data} | _] =
+               update_route_stop_data(@line_data, @alerts, @now)
+    end
+
+    test "includes expected alerts" do
+      filtered =
+        @alerts
+        |> Enum.filter(&Match.any_time_match?(&1, @now))
+
+      for stop_id <- Enum.map(@line_data, fn {_, %RouteStop{id: id}} -> id end) do
+        stop_alerts = AlertsStop.match(filtered, stop_id)
+        refute @future_alert in stop_alerts
+
+        case stop_id do
+          "place-nqncy" ->
+            refute @other_alert in stop_alerts
+            assert @disruption_alert in stop_alerts
+
+          "place-brntn" ->
+            refute @other_alert in stop_alerts
+            assert @disruption_alert in stop_alerts
+
+          "place-jfk" ->
+            assert @other_alert in stop_alerts
+            refute @disruption_alert in stop_alerts
+
+          "place-alfcl" ->
+            refute @other_alert in stop_alerts
+            refute @disruption_alert in stop_alerts
+
+          _ ->
+            assert [] == stop_alerts
+        end
+      end
+    end
+
+    test "includes disrupted stop_data where appropriate" do
+      line_diagram_data = update_route_stop_data(@line_data, @alerts, @now)
+
+      disruption = fn stop_data ->
+        %{has_disruption?: has_disruption} = List.last(stop_data)
+        has_disruption
+      end
+
+      %{stop_data: stop_data} = Enum.find(line_diagram_data, &(&1.route_stop.id == "place-nqncy"))
+      assert disruption.(stop_data)
+
+      %{stop_data: stop_data_no_disruption} =
+        Enum.find(line_diagram_data, &(&1.route_stop.id == "place-shmnl"))
+
+      refute disruption.(stop_data_no_disruption)
     end
   end
 end

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_format_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_format_test.exs
@@ -79,20 +79,23 @@ defmodule SiteWeb.ScheduleController.Line.DiagramFormatTest do
     }
   ]
 
-  def stops_with_diversion(effect, stop_ids) do
+  @doc "Creates a new alert and adds it to stops list"
+  def stops_with_effect(effect, stop_ids, base_list \\ @stops_list_base, alert_id \\ 1) do
     stop_list =
-      @stops_list_base
-      |> Enum.map(fn %{route_stop: %RouteStop{id: id}} = stop ->
+      base_list
+      |> Enum.map(fn %{route_stop: %RouteStop{id: id}, alerts: alerts} = stop ->
         if id in stop_ids do
           %{
             stop
             | alerts: [
                 Alert.new(
+                  id: alert_id,
                   lifecycle: :ongoing,
                   effect: effect,
                   informed_entity: Enum.map(stop_ids, &%IE{stop: &1}),
                   active_period: [{Timex.shift(@now, days: -1), Timex.shift(@now, days: 1)}]
                 )
+                | alerts
               ]
           }
         else
@@ -108,7 +111,7 @@ defmodule SiteWeb.ScheduleController.Line.DiagramFormatTest do
     has_disruption
   end
 
-  def route_ids(stops_list) do
+  def disrupted_stop_ids(stops_list) do
     stops_list
     |> Enum.filter(&disruption(&1.stop_data))
     |> Enum.map(& &1.route_stop.id)
@@ -116,24 +119,54 @@ defmodule SiteWeb.ScheduleController.Line.DiagramFormatTest do
 
   describe "do_stops_list_with_disruptions/2" do
     test "formats shuttle stops" do
-      stops = stops_with_diversion(:shuttle, ["place-nqncy", "place-brntn"])
+      stops = stops_with_effect(:shuttle, ["place-nqncy", "place-brntn"])
       adjusted_stops = do_stops_list_with_disruptions(stops, @now)
-      assert ["place-nqncy"] = adjusted_stops |> route_ids()
+      assert ["place-nqncy"] = adjusted_stops |> disrupted_stop_ids()
     end
 
     test "formats detour stops" do
-      stops = stops_with_diversion(:detour, ["place-nqncy", "place-brntn"])
+      stops = stops_with_effect(:detour, ["place-nqncy", "place-brntn"])
       adjusted_stops = do_stops_list_with_disruptions(stops, @now)
-      assert ["place-jfk", "place-nqncy", "place-brntn"] = adjusted_stops |> route_ids()
+      assert ["place-jfk", "place-nqncy", "place-brntn"] = adjusted_stops |> disrupted_stop_ids()
     end
 
     test "formats stop closure stops" do
-      stops = stops_with_diversion(:stop_closure, ["place-nqncy", "place-brntn"])
+      stops = stops_with_effect(:stop_closure, ["place-nqncy", "place-brntn"])
       adjusted_stops = do_stops_list_with_disruptions(stops, @now)
-      assert ["place-jfk", "place-nqncy", "place-brntn"] = adjusted_stops |> route_ids()
+      assert ["place-jfk", "place-nqncy", "place-brntn"] = adjusted_stops |> disrupted_stop_ids()
     end
 
-    test "handles no disruptions" do
+    test "formats stops list with first shuttle" do
+      stops = stops_with_effect(:shuttle, ["place-alfcl", "place-jfk"])
+
+      adjusted_stops = do_stops_list_with_disruptions(stops, @now)
+      assert ["place-alfcl"] = adjusted_stops |> disrupted_stop_ids()
+    end
+
+    test "formats stops list with second shuttle" do
+      stops = stops_with_effect(:shuttle, ["place-shmnl", "place-asmnl"])
+
+      adjusted_stops = do_stops_list_with_disruptions(stops, @now)
+      assert ["place-shmnl"] = adjusted_stops |> disrupted_stop_ids()
+    end
+
+    test "formats stops list with first and second shuttle" do
+      stops_with_first_shuttle = stops_with_effect(:shuttle, ["place-alfcl", "place-jfk"])
+
+      stops =
+        stops_with_effect(:shuttle, ["place-shmnl", "place-asmnl"], stops_with_first_shuttle, 2)
+
+      adjusted_stops = do_stops_list_with_disruptions(stops, @now)
+      assert ["place-alfcl", "place-shmnl"] = adjusted_stops |> disrupted_stop_ids()
+    end
+
+    test "formats stops for some other alert effect" do
+      stops = stops_with_effect(:unknown, ["place-nqncy", "place-brntn"])
+      adjusted_stops = do_stops_list_with_disruptions(stops, @now)
+      assert [] = adjusted_stops |> disrupted_stop_ids()
+    end
+
+    test "handles no alerts" do
       adjusted_stops = do_stops_list_with_disruptions(@stops_list_base, @now)
       refute Enum.any?(adjusted_stops, &disruption(&1.stop_data))
     end

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_format_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_format_test.exs
@@ -1,0 +1,141 @@
+defmodule SiteWeb.ScheduleController.Line.DiagramFormatTest do
+  use ExUnit.Case, async: true
+
+  import SiteWeb.ScheduleController.Line.DiagramFormat
+  alias Alerts.Alert
+  alias Alerts.InformedEntity, as: IE
+  alias Routes.Route
+  alias Stops.RouteStop
+
+  @now Timex.now()
+
+  @stops_list_base [
+    %{
+      alerts: [],
+      route_stop: %RouteStop{
+        connections: [],
+        id: "place-alfcl",
+        route: %Route{id: "Red"}
+      },
+      stop_data: [%{branch: nil, has_disruption?: false, type: :terminus}]
+    },
+    %{
+      alerts: [],
+      route_stop: %RouteStop{
+        connections: [],
+        id: "place-jfk",
+        route: %Route{id: "Red"}
+      },
+      stop_data: [
+        %{branch: "Alewife - Ashmont", has_disruption?: false, type: :merge},
+        %{branch: "Alewife - Braintree", has_disruption?: false, type: :merge}
+      ]
+    },
+    %{
+      alerts: [],
+      route_stop: %RouteStop{
+        connections: [],
+        id: "place-nqncy",
+        route: %Route{id: "Red"}
+      },
+      stop_data: [
+        %{branch: "Alewife - Ashmont", has_disruption?: false, type: :line},
+        %{branch: "Alewife - Braintree", has_disruption?: false, type: :stop}
+      ]
+    },
+    %{
+      alerts: [],
+      route_stop: %RouteStop{
+        connections: [],
+        id: "place-brntn",
+        route: %Route{id: "Red"}
+      },
+      stop_data: [
+        %{branch: "Alewife - Ashmont", has_disruption?: false, type: :line},
+        %{branch: "Alewife - Braintree", has_disruption?: false, type: :terminus}
+      ]
+    },
+    %{
+      alerts: [],
+      route_stop: %RouteStop{
+        connections: [],
+        id: "place-shmnl",
+        route: %Route{id: "Red"}
+      },
+      stop_data: [
+        %{branch: "Alewife - Ashmont", has_disruption?: false, type: :stop}
+      ]
+    },
+    %{
+      alerts: [],
+      route_stop: %RouteStop{
+        connections: [],
+        id: "place-asmnl",
+        route: %Route{id: "Red"}
+      },
+      stop_data: [
+        %{branch: "Alewife - Ashmont", has_disruption?: false, type: :terminus}
+      ]
+    }
+  ]
+
+  def stops_with_diversion(effect, stop_ids) do
+    stop_list =
+      @stops_list_base
+      |> Enum.map(fn %{route_stop: %RouteStop{id: id}} = stop ->
+        if id in stop_ids do
+          %{
+            stop
+            | alerts: [
+                Alert.new(
+                  lifecycle: :ongoing,
+                  effect: effect,
+                  informed_entity: Enum.map(stop_ids, &%IE{stop: &1}),
+                  active_period: [{Timex.shift(@now, days: -1), Timex.shift(@now, days: 1)}]
+                )
+              ]
+          }
+        else
+          stop
+        end
+      end)
+
+    stop_list
+  end
+
+  def disruption(stop_data) do
+    %{has_disruption?: has_disruption} = List.last(stop_data)
+    has_disruption
+  end
+
+  def route_ids(stops_list) do
+    stops_list
+    |> Enum.filter(&disruption(&1.stop_data))
+    |> Enum.map(& &1.route_stop.id)
+  end
+
+  describe "do_stops_list_with_disruptions/2" do
+    test "formats shuttle stops" do
+      stops = stops_with_diversion(:shuttle, ["place-nqncy", "place-brntn"])
+      adjusted_stops = do_stops_list_with_disruptions(stops, @now)
+      assert ["place-nqncy"] = adjusted_stops |> route_ids()
+    end
+
+    test "formats detour stops" do
+      stops = stops_with_diversion(:detour, ["place-nqncy", "place-brntn"])
+      adjusted_stops = do_stops_list_with_disruptions(stops, @now)
+      assert ["place-jfk", "place-nqncy", "place-brntn"] = adjusted_stops |> route_ids()
+    end
+
+    test "formats stop closure stops" do
+      stops = stops_with_diversion(:stop_closure, ["place-nqncy", "place-brntn"])
+      adjusted_stops = do_stops_list_with_disruptions(stops, @now)
+      assert ["place-jfk", "place-nqncy", "place-brntn"] = adjusted_stops |> route_ids()
+    end
+
+    test "handles no disruptions" do
+      adjusted_stops = do_stops_list_with_disruptions(@stops_list_base, @now)
+      refute Enum.any?(adjusted_stops, &disruption(&1.stop_data))
+    end
+  end
+end

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_format_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_format_test.exs
@@ -1,83 +1,19 @@
 defmodule SiteWeb.ScheduleController.Line.DiagramFormatTest do
   use ExUnit.Case, async: true
 
+  import SiteWeb.DiagramHelpers
   import SiteWeb.ScheduleController.Line.DiagramFormat
   alias Alerts.Alert
   alias Alerts.InformedEntity, as: IE
-  alias Routes.Route
-  alias Stops.RouteStop
 
   @now Timex.now()
 
-  @stops_list_base [
-    %{
-      alerts: [],
-      route_stop: %RouteStop{
-        connections: [],
-        id: "place-alfcl",
-        route: %Route{id: "Red"}
-      },
-      stop_data: [%{branch: nil, has_disruption?: false, type: :terminus}]
-    },
-    %{
-      alerts: [],
-      route_stop: %RouteStop{
-        connections: [],
-        id: "place-jfk",
-        route: %Route{id: "Red"}
-      },
-      stop_data: [
-        %{branch: "Alewife - Ashmont", has_disruption?: false, type: :merge},
-        %{branch: "Alewife - Braintree", has_disruption?: false, type: :merge}
-      ]
-    },
-    %{
-      alerts: [],
-      route_stop: %RouteStop{
-        connections: [],
-        id: "place-nqncy",
-        route: %Route{id: "Red"}
-      },
-      stop_data: [
-        %{branch: "Alewife - Ashmont", has_disruption?: false, type: :line},
-        %{branch: "Alewife - Braintree", has_disruption?: false, type: :stop}
-      ]
-    },
-    %{
-      alerts: [],
-      route_stop: %RouteStop{
-        connections: [],
-        id: "place-brntn",
-        route: %Route{id: "Red"}
-      },
-      stop_data: [
-        %{branch: "Alewife - Ashmont", has_disruption?: false, type: :line},
-        %{branch: "Alewife - Braintree", has_disruption?: false, type: :terminus}
-      ]
-    },
-    %{
-      alerts: [],
-      route_stop: %RouteStop{
-        connections: [],
-        id: "place-shmnl",
-        route: %Route{id: "Red"}
-      },
-      stop_data: [
-        %{branch: "Alewife - Ashmont", has_disruption?: false, type: :stop}
-      ]
-    },
-    %{
-      alerts: [],
-      route_stop: %RouteStop{
-        connections: [],
-        id: "place-asmnl",
-        route: %Route{id: "Red"}
-      },
-      stop_data: [
-        %{branch: "Alewife - Ashmont", has_disruption?: false, type: :terminus}
-      ]
-    }
-  ]
+  setup_all do
+    {:ok,
+     simple_line_diagram: setup_simple_line_diagram(),
+     outward_line_diagram: setup_outward_line_diagram(),
+     inward_line_diagram: setup_inward_line_diagram()}
+  end
 
   @doc "Creates a new alert and adds it to stops list"
   def stops_with_effect(effect, stop_ids, base_list \\ @stops_list_base, alert_id \\ 1) do
@@ -170,5 +106,41 @@ defmodule SiteWeb.ScheduleController.Line.DiagramFormatTest do
       adjusted_stops = do_stops_list_with_disruptions(@stops_list_base, @now)
       refute Enum.any?(adjusted_stops, &disruption(&1.stop_data))
     end
+  end
+
+  defp setup_simple_line_diagram do
+    [
+      {"place-alfcl", [stop: nil]},
+      {"place-jfk", [stop: nil]},
+      {"place-nqncy", [stop: nil]},
+      {"place-brntn", [stop: nil]},
+      {"place-shmnl", [stop: nil]},
+      {"place-asmnl", [stop: nil]}
+    ]
+    |> route_stops_to_line_diagram_stops()
+  end
+
+  defp setup_inward_line_diagram do
+    [
+      {"place-asmnl", [terminus: "Alewife - Ashmont"]},
+      {"place-shmnl", [stop: "Alewife - Ashmont"]},
+      {"place-brntn", [line: "Alewife - Ashmont", terminus: "Alewife - Braintree"]},
+      {"place-nqncy", [line: "Alewife - Ashmont", stop: "Alewife - Braintree"]},
+      {"place-jfk", [merge: "Alewife - Ashmont", merge: "Alewife - Braintree"]},
+      {"place-alfcl", [terminus: nil]}
+    ]
+    |> route_stops_to_line_diagram_stops()
+  end
+
+  defp setup_outward_line_diagram do
+    [
+      {"place-alfcl", [terminus: nil]},
+      {"place-jfk", [merge: "Alewife - Ashmont", merge: "Alewife - Braintree"]},
+      {"place-nqncy", [line: "Alewife - Ashmont", stop: "Alewife - Braintree"]},
+      {"place-brntn", [line: "Alewife - Ashmont", terminus: "Alewife - Braintree"]},
+      {"place-shmnl", [stop: "Alewife - Ashmont"]},
+      {"place-asmnl", [terminus: "Alewife - Ashmont"]}
+    ]
+    |> route_stops_to_line_diagram_stops()
   end
 end

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_format_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_format_test.exs
@@ -92,6 +92,11 @@ defmodule SiteWeb.ScheduleController.Line.DiagramFormatTest do
   end
 
   describe "do_stops_list_with_disruptions/2" do
+    test "handles no date input", %{simple_line_diagram: line_diagram} do
+      adjusted_stops = do_stops_list_with_disruptions(line_diagram, nil)
+      assert [] = adjusted_stops |> disrupted_stop_ids()
+    end
+
     test "formats shuttle stops", %{simple_line_diagram: line_diagram} do
       stops =
         stops_with_current_effect(

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_format_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_format_test.exs
@@ -3,8 +3,6 @@ defmodule SiteWeb.ScheduleController.Line.DiagramFormatTest do
 
   import SiteWeb.DiagramHelpers
   import SiteWeb.ScheduleController.Line.DiagramFormat
-  alias Alerts.Alert
-  alias Alerts.InformedEntity, as: IE
 
   @now Timex.now()
 
@@ -15,97 +13,119 @@ defmodule SiteWeb.ScheduleController.Line.DiagramFormatTest do
      inward_line_diagram: setup_inward_line_diagram()}
   end
 
-  @doc "Creates a new alert and adds it to stops list"
-  def stops_with_effect(effect, stop_ids, base_list \\ @stops_list_base, alert_id \\ 1) do
-    stop_list =
-      base_list
-      |> Enum.map(fn %{route_stop: %RouteStop{id: id}, alerts: alerts} = stop ->
-        if id in stop_ids do
-          %{
-            stop
-            | alerts: [
-                Alert.new(
-                  id: alert_id,
-                  lifecycle: :ongoing,
-                  effect: effect,
-                  informed_entity: Enum.map(stop_ids, &%IE{stop: &1}),
-                  active_period: [{Timex.shift(@now, days: -1), Timex.shift(@now, days: 1)}]
-                )
-                | alerts
-              ]
-          }
-        else
-          stop
-        end
-      end)
-
-    stop_list
-  end
-
-  def disruption(stop_data) do
-    %{has_disruption?: has_disruption} = List.last(stop_data)
-    has_disruption
-  end
-
-  def disrupted_stop_ids(stops_list) do
-    stops_list
-    |> Enum.filter(&disruption(&1.stop_data))
-    |> Enum.map(& &1.route_stop.id)
-  end
-
   describe "do_stops_list_with_disruptions/2" do
-    test "formats shuttle stops" do
-      stops = stops_with_effect(:shuttle, ["place-nqncy", "place-brntn"])
+    test "formats shuttle stops", %{outward_line_diagram: line_diagram} do
+      stops =
+        stops_with_current_effect(line_diagram, ["place-nqncy", "place-brntn"], :shuttle, @now)
+
       adjusted_stops = do_stops_list_with_disruptions(stops, @now)
       assert ["place-nqncy"] = adjusted_stops |> disrupted_stop_ids()
     end
 
-    test "formats detour stops" do
-      stops = stops_with_effect(:detour, ["place-nqncy", "place-brntn"])
+    test "formats detour stops", %{outward_line_diagram: line_diagram} do
+      stops =
+        stops_with_current_effect(line_diagram, ["place-nqncy", "place-brntn"], :detour, @now)
+
       adjusted_stops = do_stops_list_with_disruptions(stops, @now)
       assert ["place-jfk", "place-nqncy", "place-brntn"] = adjusted_stops |> disrupted_stop_ids()
     end
 
-    test "formats stop closure stops" do
-      stops = stops_with_effect(:stop_closure, ["place-nqncy", "place-brntn"])
+    test "formats stop closure stops", %{outward_line_diagram: line_diagram} do
+      stops =
+        stops_with_current_effect(
+          line_diagram,
+          ["place-nqncy", "place-brntn"],
+          :stop_closure,
+          @now
+        )
+
       adjusted_stops = do_stops_list_with_disruptions(stops, @now)
       assert ["place-jfk", "place-nqncy", "place-brntn"] = adjusted_stops |> disrupted_stop_ids()
     end
 
-    test "formats stops list with first shuttle" do
-      stops = stops_with_effect(:shuttle, ["place-alfcl", "place-jfk"])
+    test "formats stops list with first shuttle", %{outward_line_diagram: line_diagram} do
+      stops =
+        stops_with_current_effect(line_diagram, ["place-alfcl", "place-jfk"], :shuttle, @now)
 
       adjusted_stops = do_stops_list_with_disruptions(stops, @now)
       assert ["place-alfcl"] = adjusted_stops |> disrupted_stop_ids()
     end
 
-    test "formats stops list with second shuttle" do
-      stops = stops_with_effect(:shuttle, ["place-shmnl", "place-asmnl"])
+    test "formats stops list with second shuttle", %{outward_line_diagram: line_diagram} do
+      stops =
+        stops_with_current_effect(line_diagram, ["place-shmnl", "place-asmnl"], :shuttle, @now)
 
       adjusted_stops = do_stops_list_with_disruptions(stops, @now)
       assert ["place-shmnl"] = adjusted_stops |> disrupted_stop_ids()
     end
 
-    test "formats stops list with first and second shuttle" do
-      stops_with_first_shuttle = stops_with_effect(:shuttle, ["place-alfcl", "place-jfk"])
+    test "formats stops list with first and second shuttle", %{outward_line_diagram: line_diagram} do
+      adjusted_stops =
+        stops_with_current_effect(line_diagram, ["place-alfcl", "place-jfk"], :shuttle, @now)
+        |> stops_with_current_effect(["place-shmnl", "place-asmnl"], :shuttle, @now, 2)
+        |> do_stops_list_with_disruptions(@now)
 
-      stops =
-        stops_with_effect(:shuttle, ["place-shmnl", "place-asmnl"], stops_with_first_shuttle, 2)
-
-      adjusted_stops = do_stops_list_with_disruptions(stops, @now)
       assert ["place-alfcl", "place-shmnl"] = adjusted_stops |> disrupted_stop_ids()
     end
 
-    test "formats stops for some other alert effect" do
-      stops = stops_with_effect(:unknown, ["place-nqncy", "place-brntn"])
+    test "formats stops list with detour and shuttle", %{
+      outward_line_diagram: line_diagram
+    } do
+      adjusted_stops =
+        stops_with_current_effect(
+          line_diagram,
+          ["place-alfcl", "place-jfk"],
+          :detour,
+          @now
+        )
+        |> stops_with_current_effect(["place-shmnl", "place-asmnl"], :shuttle, @now, 2)
+        |> do_stops_list_with_disruptions(@now)
+
+      disrupted_stops = adjusted_stops |> disrupted_stop_ids()
+
+      assert ["place-alfcl", "place-jfk"] |> Enum.all?(&Enum.member?(disrupted_stops, &1)),
+             "detour disruption"
+
+      assert "place-shmnl" in disrupted_stops, "shuttle disruption (styled)"
+      refute "place-asmnl" in disrupted_stops, "shuttle disruption (unstyled)"
+    end
+
+    test "formats stops list through merge stop", %{outward_line_diagram: line_diagram} do
+      stops =
+        stops_with_current_effect(
+          line_diagram,
+          ["place-jfk", "place-shmnl", "place-asmnl"],
+          :shuttle,
+          @now
+        )
+
+      adjusted_stops = do_stops_list_with_disruptions(stops, @now)
+      assert ["place-jfk", "place-shmnl"] = adjusted_stops |> disrupted_stop_ids()
+    end
+
+    test "formats stops for some other alert effect", %{outward_line_diagram: line_diagram} do
+      stops =
+        stops_with_current_effect(line_diagram, ["place-nqncy", "place-brntn"], :unknown, @now)
+
       adjusted_stops = do_stops_list_with_disruptions(stops, @now)
       assert [] = adjusted_stops |> disrupted_stop_ids()
     end
 
-    test "handles no alerts" do
-      adjusted_stops = do_stops_list_with_disruptions(@stops_list_base, @now)
+    test "handles no alerts", %{outward_line_diagram: line_diagram} do
+      adjusted_stops = do_stops_list_with_disruptions(line_diagram, @now)
       refute Enum.any?(adjusted_stops, &disruption(&1.stop_data))
     end
+  end
+
+  defp disruption(stop_data) do
+    %{has_disruption?: has_disruption} = List.last(stop_data)
+    has_disruption
+  end
+
+  defp disrupted_stop_ids(stops_list) do
+    stops_list
+    |> Enum.filter(&disruption(&1.stop_data))
+    |> Enum.map(& &1.route_stop.id)
   end
 
   defp setup_simple_line_diagram do

--- a/apps/site/test/support/diagram_helpers.ex
+++ b/apps/site/test/support/diagram_helpers.ex
@@ -1,0 +1,49 @@
+defmodule SiteWeb.DiagramHelpers do
+  @moduledoc """
+  Helper functions for generating test data structures for `SiteWeb.ScheduleController.Line.DiagramFormatTest`.
+  """
+  alias Site.StopBubble
+  alias SiteWeb.ScheduleController.Line.DiagramFormat
+  alias Stops.RouteStop
+  alias Stops.Stop
+
+  @doc "Builds a list of line diagram stops from some route stop info"
+  @spec route_stops_to_line_diagram_stops([
+          {Stop.id_t(), [{StopBubble.bubble_class(), RouteStop.branch_name_t()}]}
+        ]) :: [DiagramFormat.line_diagram_stop()]
+  def route_stops_to_line_diagram_stops(stops) do
+    Enum.map(stops, fn {id, stop_info} -> route_stop_id_to_stop(id, stop_info) end)
+  end
+
+  @spec route_stop_id_to_stop(
+          Stop.id_t(),
+          [{StopBubble.bubble_class(), RouteStop.branch_name_t()}]
+        ) :: DiagramFormat.line_diagram_stop()
+  defp route_stop_id_to_stop(route_stop_id, stop_info) do
+    %{
+      alerts: [],
+      route_stop: %RouteStop{
+        connections: [],
+        id: route_stop_id,
+        branch: stop_info_to_branch(stop_info)
+      },
+      stop_data: stop_info_to_stop_data(stop_info)
+    }
+  end
+
+  @spec stop_info_to_stop_data([{StopBubble.bubble_class(), RouteStop.branch_name_t()}]) :: [
+          map()
+        ]
+  defp stop_info_to_stop_data(stop_info) do
+    stop_info
+    |> Enum.map(fn {type, branch} ->
+      %{type: type, branch: branch, has_disruption?: false}
+    end)
+  end
+
+  @spec stop_info_to_branch([{StopBubble.bubble_class(), RouteStop.branch_name_t()}]) ::
+          RouteStop.branch_name_t()
+  defp stop_info_to_branch(stop_info) do
+    Keyword.get(stop_info, :terminus, Keyword.get(stop_info, :stop))
+  end
+end


### PR DESCRIPTION
Replaces #596 as I wanted a chance to rebase on the latest master and clean up the changed commits list a bit. See #596 for prior review and progress.

Needs dev review from https://github.com/mbta/dotcom/commit/2f0e79952928b48f7952b1c6c6d704d5cc10aa0d onward.

Ongoing design review -- @ingridpierre, the `BadBooleanError` you cited last week should be fixed now.
