### PR TITLE
⏱️ Commuter Rail Schedules | Some "via Fairmount" trips missing from Franklin Line 

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -112,13 +112,13 @@ defmodule SiteWeb.ScheduleController.TimetableController do
   end
 
   def trip_messages(%Routes.Route{id: "CR-Franklin"}, 1) do
-    ["740", "746", "748", "750", "754", "726", "758"]
+    ["740", "746", "748", "750", "754", "726", "758", "7742", "7744", "7722"]
     |> Enum.flat_map(&franklin_via_fairmount(&1, 1))
     |> Enum.into(%{})
   end
 
   def trip_messages(%Routes.Route{id: "CR-Franklin"}, 0) do
-    ["741", "743", "747", "749", "755", "757", "759"]
+    ["741", "743", "747", "749", "755", "757", "759", "7703", "7751", "7753", "7755"]
     |> Enum.flat_map(&franklin_via_fairmount(&1, 0))
     |> Enum.into(%{})
   end

--- a/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
@@ -103,9 +103,9 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
                "750",
                "754",
                "758",
+               "7722",
                "7742",
                "7744",
-               "7722"
              ] =
                %Routes.Route{id: "CR-Franklin"}
                |> trip_messages(1)

--- a/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
@@ -102,7 +102,10 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
                "748",
                "750",
                "754",
-               "758"
+               "758",
+               "7742",
+               "7744",
+               "7722"
              ] =
                %Routes.Route{id: "CR-Franklin"}
                |> trip_messages(1)
@@ -118,7 +121,11 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
                "749",
                "755",
                "757",
-               "759"
+               "759",
+               "7703",
+               "7751",
+               "7753",
+               "7755"
              ] ==
                %Routes.Route{id: "CR-Franklin"}
                |> trip_messages(0)

--- a/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
@@ -105,7 +105,7 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
                "758",
                "7722",
                "7742",
-               "7744",
+               "7744"
              ] =
                %Routes.Route{id: "CR-Franklin"}
                |> trip_messages(1)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱️ Commuter Rail Schedules | Some "via Fairmount" trips missing from Franklin Line ](https://app.asana.com/0/385363666817452/1188018759297667/f)

Added a few missing trips so the timetable display matches the PDF.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
