### PR TITLE
☎️ Add support for First and Last names (to replace Full Name)

### DIFF
--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -1,5 +1,5 @@
 defmodule Feedback.Mailer do
-  @moduledoc false
+  @moduledoc "Module to send a HEAT ticket and some previous pre-processing of the data received from the customer support form"
 
   require Logger
 
@@ -12,6 +12,10 @@ defmodule Feedback.Mailer do
         Logger.info("HEAT Ticket submitted by #{format_email(message.email)}")
       end
 
+    first_name = format_name(message.first_name, "Riding")
+    last_name = format_name(message.last_name, "Public")
+    full_name = "#{first_name} #{last_name}"
+
     body = """
     <INCIDENT>
       <SERVICE>#{message.service}</SERVICE>
@@ -23,9 +27,9 @@ defmodule Feedback.Mailer do
       <STATION></STATION>
       <INCIDENTDATE>#{formatted_utc_timestamp()}</INCIDENTDATE>
       <VEHICLE></VEHICLE>
-      <FIRSTNAME>#{format_first_name(message.name)}</FIRSTNAME>
-      <LASTNAME>#{format_last_name(message.name)}</LASTNAME>
-      <FULLNAME>#{format_name(message.name)}</FULLNAME>
+      <FIRSTNAME>#{first_name}</FIRSTNAME>
+      <LASTNAME>#{last_name}</LASTNAME>
+      <FULLNAME>#{full_name}</FULLNAME>
       <CITY></CITY>
       <STATE></STATE>
       <ZIPCODE></ZIPCODE>
@@ -67,36 +71,15 @@ defmodule Feedback.Mailer do
       |> exaws_perform_fn.(exaws_config_fn.(:ses))
   end
 
-  defp format_name(nil) do
-    "Riding Public"
+  @spec format_name(String.t() | nil, String.t()) :: String.t()
+  defp format_name(nil, default) do
+    default
   end
 
-  defp format_name(name) do
+  defp format_name(name, default) do
     case String.trim(name) do
-      "" -> "Riding Public"
+      "" -> default
       name -> name
-    end
-  end
-
-  defp format_first_name(nil) do
-    "Riding"
-  end
-
-  defp format_first_name(name) do
-    case String.trim(name) do
-      "" -> "Riding"
-      name -> name
-    end
-  end
-
-  defp format_last_name(nil) do
-    "Public"
-  end
-
-  defp format_last_name(name) do
-    case String.trim(name) do
-      "" -> "Public"
-      _name -> "-"
     end
   end
 

--- a/apps/feedback/lib/message.ex
+++ b/apps/feedback/lib/message.ex
@@ -9,7 +9,8 @@ defmodule Feedback.Message do
   @service_options [
     {"Complaint", "Complaint"},
     {"Comment", "Suggestion"},
-    {"Question", "Inquiry"}
+    {"Question", "Inquiry"},
+    {"Compliment", "Commendation"}
   ]
 
   @enforce_keys [:comments, :service, :request_response]

--- a/apps/feedback/lib/message.ex
+++ b/apps/feedback/lib/message.ex
@@ -4,7 +4,7 @@ defmodule Feedback.Message do
   """
 
   # The integration with HEAT only accepts certain values for the message type
-  # Only "Complaint", "Suggestion" and "Inquiry" are supported
+  # Only "Complaint", "Suggestion", "Inquiry" and "Commendation" are supported.
   # Other values will cause HEAT to throw an error and reject the ticket
   @service_options [
     {"Complaint", "Complaint"},
@@ -14,12 +14,22 @@ defmodule Feedback.Message do
   ]
 
   @enforce_keys [:comments, :service, :request_response]
-  defstruct [:email, :phone, :name, :comments, :service, :request_response, :photos]
+  defstruct [
+    :email,
+    :phone,
+    :first_name,
+    :last_name,
+    :comments,
+    :service,
+    :request_response,
+    :photos
+  ]
 
   @type t :: %__MODULE__{
           email: String.t() | nil,
           phone: String.t() | nil,
-          name: String.t() | nil,
+          first_name: String.t(),
+          last_name: String.t(),
           comments: String.t(),
           service: String.t(),
           request_response: boolean,

--- a/apps/feedback/test/mailer_test.exs
+++ b/apps/feedback/test/mailer_test.exs
@@ -93,23 +93,27 @@ defmodule Feedback.MailerTest do
     end
 
     test "gives the full name as the name the user provided" do
-      Mailer.send_heat_ticket(%{@base_message | name: "My Full Name"}, nil)
-      assert Test.latest_message()["text"] =~ "<FULLNAME>My Full Name</FULLNAME>"
+      Mailer.send_heat_ticket(%{@base_message | first_name: "Full", last_name: "Name"}, nil)
+      assert Test.latest_message()["text"] =~ "<FIRSTNAME>Full</FIRSTNAME>"
+      assert Test.latest_message()["text"] =~ "<LASTNAME>Name</LASTNAME>"
+      assert Test.latest_message()["text"] =~ "<FULLNAME>Full Name</FULLNAME>"
     end
 
-    test "also puts the full name in the first name field" do
-      Mailer.send_heat_ticket(%{@base_message | name: "My Full Name"}, nil)
-      assert Test.latest_message()["text"] =~ "<FIRSTNAME>My Full Name</FIRSTNAME>"
+    test "uses default first name if not provided" do
+      Mailer.send_heat_ticket(%{@base_message | first_name: "", last_name: "Smith"}, nil)
+      assert Test.latest_message()["text"] =~ "<FIRSTNAME>Riding</FIRSTNAME>"
+      assert Test.latest_message()["text"] =~ "<LASTNAME>Smith</LASTNAME>"
     end
 
-    test "if the user does not provide a name, sets the full name to riding public" do
-      Mailer.send_heat_ticket(%{@base_message | name: ""}, nil)
+    test "uses default last name if not provided" do
+      Mailer.send_heat_ticket(%{@base_message | first_name: "James", last_name: ""}, nil)
+      assert Test.latest_message()["text"] =~ "<FIRSTNAME>James</FIRSTNAME>"
+      assert Test.latest_message()["text"] =~ "<LASTNAME>Public</LASTNAME>"
+    end
+
+    test "if the user does not provide a name, sets the full name to 'Riding Public'" do
+      Mailer.send_heat_ticket(%{@base_message | first_name: "", last_name: ""}, nil)
       assert Test.latest_message()["text"] =~ "<FULLNAME>Riding Public</FULLNAME>"
-    end
-
-    test "if the user provides a name, sets the last name to -" do
-      Mailer.send_heat_ticket(%{@base_message | name: "My Full Name"}, nil)
-      assert Test.latest_message()["text"] =~ "<LASTNAME>-</LASTNAME>"
     end
 
     test "sets customer requests response to no" do
@@ -161,7 +165,8 @@ defmodule Feedback.MailerTest do
         comments: "major issue to report",
         email: "disgruntled@user.com",
         phone: "1231231234",
-        name: "Disgruntled User",
+        first_name: "Disgruntled",
+        last_name: "User",
         request_response: true,
         service: "Complaint"
       }

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -181,7 +181,8 @@ defmodule SiteWeb.CustomerSupportController do
       photos: params["photos"],
       email: params["email"],
       phone: params["phone"],
-      name: params["name"],
+      first_name: params["first_name"],
+      last_name: params["last_name"],
       comments: params["comments"],
       service: params["service"],
       request_response: params["request_response"] == "on"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [☎️ Add support for First and Last names (to replace Full Name)](https://app.asana.com/0/555089885850811/1188547161220115)

Update message and mailer logic (and adjust tests): account for first & last name instead of just one field for name.