### PR TITLE
Update test to handle both sides of the Nubian stop ID change

### DIFF
--- a/apps/site/test/site_web/controllers/schedule/origin_destination_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/origin_destination_test.exs
@@ -135,7 +135,10 @@ defmodule SiteWeb.ScheduleController.OriginDestinationTest do
       refute conn.assigns.origin == nil
       assert conn.assigns.origin.id == "place-hymnl"
       refute conn.assigns.destination == nil
-      assert conn.assigns.destination.id == "place-dudly"
+
+      # Temporary fix to cover the transition period from the stop ID "place-dudly" to the new "place-nubn". Once the "place-nubn" data change is live in production, we can revert to the simple equality check. -- MSS 20200914
+      # assert conn.assigns.destination.id == "place-dudly"
+      assert Enum.member?(["place-dudly", "place-nubn"], conn.assigns.destination.id)
       assert conn.assigns.direction_id == 1
     end
 


### PR DESCRIPTION
Update test to handle both sides of the Nubian stop ID change

This will pass against either the old or the new value. Once the
`place-nubn` data change is live in production, we can revert to the
simple equality check.

No ticket, just noticed the failure when investigating the new data on dev-green.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
