### PR TITLE
☎️ Organize the customer support form

### DIFF
--- a/apps/site/assets/css/_customer-support.scss
+++ b/apps/site/assets/css/_customer-support.scss
@@ -142,15 +142,6 @@ button .waiting {
   font-size: inherit;
 }
 
-.service-radios {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.service-radio {
-  margin: 0 $base-spacing 0 0;
-}
-
 .response-time-disclaimer {
   margin-top: $base-spacing / 2;
 }

--- a/apps/site/assets/css/_customer-support.scss
+++ b/apps/site/assets/css/_customer-support.scss
@@ -1,8 +1,58 @@
 @import 'variables';
 
 .support-form {
+  margin-bottom: $base-spacing;
+
+  h2,
+  h3 {
+    margin-top: 0;
+  }
+
+  section {
+    background-color: $gray-bordered-background;
+    margin-bottom: $base-spacing / 4;
+    padding: $base-spacing * .75;
+
+    > .form-group:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  #contactInfoForm {
+    margin-bottom: $base-spacing;
+  }
+
+  legend {
+    font-size: inherit;
+  }
+
+  .form-control-label {
+    font-weight: bold;
+    padding-left: 0;
+  }
+
+  .service-radio {
+    margin: 0 $base-spacing 0 0;
+
+    .c-radio {
+      border-color: $brand-primary;
+    }
+  }
+
   .error-container {
     margin: 0 0 .5em;
+  }
+
+  .submit-button {
+    margin-top: $base-spacing / 2;
+
+    .waiting {
+      margin: 5%;
+    }
+
+    @include media-breakpoint-down(xs) {
+      width: 100%;
+    }
   }
 }
 
@@ -83,14 +133,6 @@ body {
   }
 }
 
-.support-comment-success {
-  color: $brand-success;
-}
-
-.support-tel-number:nth-child(2) {
-  margin-left: 1rem;
-}
-
 .support-form-text-input {
   border: 2px solid $brand-primary;
   font-size: inherit; // Bootstrap override
@@ -106,10 +148,6 @@ body {
   }
 }
 
-.support-form-control {
-  border-color: $brand-primary;
-}
-
 .has-success .support-form-control + span::before {
   @include fa-icon();
   color: $brand-success;
@@ -118,35 +156,6 @@ body {
   left: -.5rem;
   position: relative;
   top: -1.75rem;
-}
-
-.submit-button {
-  margin-top: $base-spacing / 2;
-
-  @include media-breakpoint-down(xs) {
-    width: 100%;
-  }
-}
-
-button .waiting {
-  margin: 5%;
-}
-
-.contrast {
-  background-color: $gray-bordered-background;
-
-  &.form-group {
-    margin-bottom: $base-spacing / 8;
-    padding: $base-spacing * .75;
-  }
-}
-
-.service-legend {
-  font-size: inherit;
-}
-
-.response-time-disclaimer {
-  margin-top: $base-spacing / 2;
 }
 
 .clear-upload-container {

--- a/apps/site/assets/css/_customer-support.scss
+++ b/apps/site/assets/css/_customer-support.scss
@@ -54,10 +54,25 @@
       width: 100%;
     }
   }
-}
 
-.support-success {
-  background-color: $form-success-message;
+  // Form validation styling
+  .has-danger {
+    .c-radio__label::before,
+    .c-checkbox__label::before, {
+      border-color: $brand-danger;
+    }
+  }
+
+  .has-success {
+    .c-radio__label::after {
+      background-color: $brand-success;
+    }
+
+    .c-radio__label::before,
+    .c-checkbox__label::before, {
+      border-color: $brand-success;
+    }
+  }
 }
 
 .support-confirmation {

--- a/apps/site/assets/css/_customer-support.scss
+++ b/apps/site/assets/css/_customer-support.scss
@@ -1,11 +1,5 @@
 @import 'variables';
 
-.support-success,
-.support-error {
-  margin-top: .5em;
-  padding: .5em;
-}
-
 .support-form {
   .error-container {
     margin: 0 0 .5em;
@@ -16,9 +10,18 @@
   background-color: $form-success-message;
 }
 
-.support-error {
-  background-color: $form-error-message;
-  color: $error-text;
+.support-confirmation {
+  margin-bottom: .5em;
+  padding: .5em;
+
+  &--success {
+    background-color: $form-success-message;
+  }
+
+  &--error {
+    background-color: $form-error-message;
+    color: $error-text;
+  }
 }
 
 .photo-preview-container {

--- a/apps/site/assets/css/_customer-support.scss
+++ b/apps/site/assets/css/_customer-support.scss
@@ -31,6 +31,10 @@
     padding-left: 0;
   }
 
+  .help-text {
+    margin-bottom: 0;
+  }
+
   .service-radio {
     margin: 0 $base-spacing 0 0;
 

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -182,3 +182,22 @@
 .u-tabular-nums {
   font-variant-numeric: tabular-nums;
 }
+
+// quick margin utilities loosely based off Bootstrap v4
+/* stylelint-disable declaration-no-important */
+.mb-0 {
+  margin-bottom: 0 !important;
+}
+
+.mb-1 {
+  margin-bottom: $base-spacing !important;
+}
+
+.mt-0 {
+  margin-top: 0 !important;
+}
+
+.mt-1 {
+  margin-top: $base-spacing !important;
+}
+/* stylelint-enable declaration-no-important */

--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -209,12 +209,8 @@ function removeClass(node, className) {
 }
 
 export function setupRequestResponse($) {
-  $("#request_response").click(function() {
-    if ($(this).is(":checked")) {
-      showExpandedForm($);
-    } else {
-      hideExpandedForm($);
-    }
+  $("#request_response").change(function() {
+    $("#contactInfoForm").toggle($(this).is(":checked"));
   });
 }
 
@@ -398,12 +394,4 @@ export function handleSubmitClick($, toUpload) {
       }
     });
   });
-}
-
-function showExpandedForm($) {
-  $(".support-form-expanded").show();
-}
-
-function hideExpandedForm($) {
-  $(".support-form-expanded").hide();
 }

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -1,121 +1,94 @@
 <% form_action = "#{customer_support_path(@conn, :submit)}#support-result" %>
-<div class="row">
-  <div class="col-xs-12">
-      <%= form_for @conn, form_action, [as: :support, multipart: true, method: :post, id: "support-form",
-                                        class: "support-form"], fn f -> %>
-        <div class="form-group contrast <%= class_for_error("service", @errors, "has-danger", "") %>">
-          <div class="error-container support-service-error-container hidden-xs-up">
-            <span role="alert" class="support-service-error">Please select the type of concern</span>
-          </div>
-          <fieldset>
-            <legend class="service-legend">What kind of concern do you have? (Required)</legend>
-            <div id="service" class="service-radios">
-              <%= for {text, value} <- @service_options do %>
-                <span class="form-check service-radio">
-                  <%= radio_button f, :service, value, class: "support-form-control service c-radio",
-                                                      id: "service-#{value}" %>
-                  <%= label f, :service, text, [for: "service-#{value}", class: "c-radio__label"] %>
-                </span>
-              <% end %>
-            </div>
-          </fieldset>
-        </div>
-        <div class="form-group contrast <%= class_for_error("comments", @errors, "has-danger", "") %>">
-          <div class="error-container support-comments-error-container <%= class_for_error("comments", @errors, "", "hidden-xs-up") %>" tabindex="-1">
-            <span role="alert" class="support-comments-error">Please enter a comment to continue.</span>
-          </div>
-          <div>
-            <p>Let us know how we can help</p>
-          </div>
-          <% comments_placeholder = "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number." %>
-          <%= textarea f, :comments, id: "comments", class: "support-form-text-input form-control", maxlength: "3000",
-                                     rows: "3", placeholder: comments_placeholder, required: "required", value: assigns[:comments] %>
 
-          <span></span>
-          <small class="form-text">3000 characters maximum</small>
-        </div>
-        <div class="form-group contrast">
-          <div id="support-upload-error-container" class="support-upload-error-container error-container <%= class_for_error("upload", @errors, "", "hidden-xs-up") %>" tabindex="-1">
-            <span id="upload-photo-error" class="upload-photo-error support-comments-error">Sorry. We had trouble uploading your image. Please try again.</span>
-          </div>
-          <div class="photo-preview-container contrast <%= unless Map.has_key?(f.params, "photo"), do: "hidden-xs-up" %>" tabindex="-1">
-          </div>
-          <a id="upload-photo-link" class="upload-photo-link" tabindex="-1"><%= fa "camera" %>Upload Photo</a>
-          <%= file_input f, :photo, accept: "image/*", id: "photo" %>
-        </div>
-        <div class="form-group support-check-container contrast">
-          <%= SiteWeb.PartialView.render("_checkbox.html", %{
-            form: f,
-            field: :request_response,
-            id: "request_response",
-            label_text: "I would like a response from the Customer Support team."
+<%= form_for @conn, form_action, [as: :support, multipart: true, method: :post, id: "support-form", class: "support-form"], fn f -> %>
+  <h2>Email Us</h2>
+  <%= preamble_text() %>
+  <section>
+    <h3>Message</h3>
+    <fieldset class="form-group <%= class_for_error("service", @errors, "has-danger", "") %>">
+      <legend class="form-control-label">Category*</legend>
+      <div id="service" class="service-radios">
+        <%= for {text, value} <- @service_options do %>
+          <span class="form-check service-radio">
+            <%= radio_button f, :service, value, class: "support-form-control service c-radio",
+                                                id: "service-#{value}" %>
+            <%= label f, :service, text, [for: "service-#{value}", class: "c-radio__label"] %>
+          </span>
+        <% end %>
+      </div>
+    </fieldset>
+    <div class="form-group <%= class_for_error("comments", @errors, "has-danger", "") %>">
+      <%= label f, :comments, "Let us know how we can help*", [for: "comments", class: "form-control-label"] %>
+      <%= textarea f, :comments, id: "comments", class: "support-form-text-input form-control #{class_for_error("comments", @errors, "form-control-danger", "form-control-success")}", "aria-describedby": "commentsHelp", maxlength: "3000",
+                                rows: "3", placeholder: "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number.", required: "required", value: assigns[:comments] %>
+      <small id="commentsHelp" class="form-text">3000 characters maximum</small>
+    </div>
+  </section>
+  <section>
+    <%# <h3>Additional Details (optional)</h3> %>
+    <div class="form-group <%= if @errors do class_for_error("upload", @errors, "has-danger", "") end %>">
+      <span id="upload-photo-error"></span>
+      <div class="photo-preview-container <%= unless Map.has_key?(f.params, "photo"), do: "hidden-xs-up" %>" tabindex="-1">
+      </div>
+      <a id="upload-photo-link" class="upload-photo-link" tabindex="-1"><%= fa "camera" %>Upload Photo</a>
+      <%= file_input f, :photo, accept: "image/*", id: "photo" %>
+    </div>
+  </section>
+  <section>
+    <div class="form-group">
+      <%= SiteWeb.PartialView.render("_checkbox.html", %{
+        form: f,
+        field: :request_response,
+        id: "request_response",
+        checked: false,
+        label_text: "I would like a response from the Customer Support team."
+      })
+      %>
+    </div>
+    <div id="contactInfoForm" style="display: none;">
+      <h3>Contact Info</h3>
+      <div class="form-group <%= class_for_error("name", @errors, "has-danger", "") %>">
+        <%= label f, :name, "Full Name*", [for: "name", class: "form-control-label"] %>
+        <%= text_input f, :name, placeholder: "Jane Smith", class: "support-form-text-input support-form-text-input--small form-control #{class_for_error("name", @errors, "form-control-danger", "form-control-success")}",
+                                  autocomplete: "name", id: "name" %>
+      </div>
+      <div class="form-group <%= class_for_error("email", @errors, "has-danger", "") %>">
+        <%= label f, :email, "Email*", [for: "email", class: "form-control-label"] %>
+        <%= text_input f, :email, placeholder: "janesmith@email.com", class: "form-control support-form-text-input support-form-text-input--small #{class_for_error("email", @errors, "form-control-danger", "form-control-success")}",
+                                  autocomplete: "email", id: "email" %>
+      </div>
+      <div class="form-group">
+        <%= label f, :phone, "Phone number", [for: "phone", class: "form-control-label"] %>
+        <%= telephone_input f, :phone, placeholder: "(555)-555-5555", class: "support-form-text-input support-form-text-input--small form-control", "aria-describedby": "phoneHelp",
+                                        autocomplete: "tel", id: "phone" %>
+      </div>
+      <div class="form-group <%= class_for_error("privacy", @errors, "has-danger", "") %>">
+        <%= SiteWeb.PartialView.render("_checkbox.html", %{
+          form: f,
+          field: :privacy,
+          id: "privacy",
+          required: "required",
+          label_text: ["I have read and agree to the ", link("Privacy Policy", target: "_blank", to: cms_static_page_path(@conn, "/policies/privacy-policy"))]
+        })
+        %>
+      </div>
+      <div class="form-group">
+        <%= SiteWeb.PartialView.render("_checkbox.html", %{
+          form: f,
+          field: :promotions,
+          id: "promotions",
+          required: false,
+          label_text: "I would like to receive email updates on new MBTA services and promotions"
           })
-          %>
-        </div>
-        <div class="support-form-expanded form-group contrast">
-          <div class="form-group">
-            <label for="name" class="col-form-label"><strong>Full Name</strong> (Required)</label>
-            <div class="error-container support-name-error-container <%= class_for_error("name", @errors, "", "hidden-xs-up") %>" tabindex="-1">
-              <span role="alert" class="support-name-error">Please enter your full name to continue.</span>
-            </div>
-            <%= text_input f, :name, placeholder: "Jane Smith", class: "support-form-text-input support-form-text-input--small form-control",
-                                      autocomplete: "name", id: "name" %>
-          </div>
-          <div class="form-group <%= class_for_error("email", @errors, "has-danger", "") %>">
-            <label for="email"><strong>Email</strong> (Required)</label>
-            <div class="error-container support-email-error-container <%= class_for_error("email", @errors, "", "hidden-xs-up") %>" tabindex="-1">
-              <span role="alert" class="support-email-error">Please enter a valid email.</span>
-            </div>
-            <%= text_input f, :email, placeholder: "janesmith@email.com", class: "support-form-text-input support-form-text-input--small form-control",
-                                      autocomplete: "email", id: "email" %>
-          </div>
-          <p class="phone-description">
-            If you'd like us to give you a call, please give us the best number where we can reach you.
-          </p>
-          <div class="form-group">
-            <label for="phone"><strong>Phone number</strong></label>
-            <%= telephone_input f, :phone, placeholder: "(555)-555-5555", class: "support-form-text-input support-form-text-input--small form-control",
-                                            autocomplete: "tel", id: "phone" %>
-          </div>
-          <div class="support-check-container">
-            <div class="error-container support-privacy-error-container <%= class_for_error("privacy", @errors, "", "hidden-xs-up") %>" tabindex="-1">
-              <span role="alert" class="support-privacy-error">You must agree to our Privacy Policy before submitting your feedback.</span>
-            </div>
-          <%= SiteWeb.PartialView.render("_checkbox.html", %{
-            form: f,
-            field: :privacy,
-            id: "privacy",
-            required: "required",
-            label_text: ["I have read and agree to the ", link("Privacy Policy", target: "_blank", to: cms_static_page_path(@conn, "/policies/privacy-policy"))]
-          })
-          %>
-          </div>
-          <div class="support-check-container">
-            <%= SiteWeb.PartialView.render("_checkbox.html", %{
-              form: f,
-              field: :promotions,
-              id: "promotions",
-              required: "required",
-              label_text: "I would like to receive email updates on new MBTA services and promotions"
-              })
-            %>
-          </div>
-        </div>
-        <div class="form-group contrast">
-          <div class="error-container support-g-recaptcha-response-error-container <%= class_for_error("recaptcha", @errors, "", "hidden-xs-up") %>" tabindex="-1">
-            <span role="alert" class="support-g-recaptcha-response-error">You must complete the reCAPTCHA before submitting your feedback.</span>
-          </div>
-          <%= raw Recaptcha.Template.display(noscript: true) %>
-        </div>
-        <div class="response-time-disclaimer">
-          Responses may take up to 5 business days. If this is an emergency, please <%= link("contact the Transit Police", to: "/transit-police") %>.
-        </div>
-        <div class="form-group">
-          <button class="btn btn-primary submit-button" type="submit" id="support-submit">
-            Send comments
-            <span class="waiting" hidden><%= fa "refresh fa-spin" %></span>
-          </button>
-        </div>
-      <% end %>
-  </div>
-</div>
+        %>
+      </div>
+    </div> <!-- End contact info section -->
+    <div class="form-group <%= class_for_error("recaptcha", @errors, "has-danger", "") %>">
+      <%= raw Recaptcha.Template.display(noscript: true) %>
+      <button class="btn btn-primary submit-button" type="submit" id="support-submit">
+        Submit
+        <span class="waiting" hidden><%= fa "refresh fa-spin" %></span>
+      </button>
+    </div>
+  </section>
+<% end %>

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -63,6 +63,7 @@
                                   autocomplete: "email", id: "email" %>
       </div>
       <div class="form-group">
+        <%= help_text "phone" %>
         <%= label f, :phone, "Phone number", [for: "phone", class: "form-control-label"] %>
         <%= telephone_input f, :phone, placeholder: placeholder_text("phone"), class: "support-form-text-input support-form-text-input--small form-control", "aria-describedby": "phoneHelp",
                                         autocomplete: "tel", id: "phone" %>

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -5,7 +5,8 @@
   <%= preamble_text() %>
   <section>
     <h3>Message</h3>
-    <fieldset class="form-group <%= class_for_error("service", @errors, "has-danger", "") %>">
+    <%= support_error_tag @errors, "service" %>
+    <fieldset class="form-group <%= class_for_error("service", @errors, "has-danger", "has-success") %>">
       <legend class="form-control-label">Category*</legend>
       <div id="service" class="service-radios">
         <%= for {text, value} <- @service_options do %>
@@ -17,7 +18,8 @@
         <% end %>
       </div>
     </fieldset>
-    <div class="form-group <%= class_for_error("comments", @errors, "has-danger", "") %>">
+    <div class="form-group <%= class_for_error("comments", @errors, "has-danger", "has-success") %>">
+      <%= support_error_tag @errors, "comments" %>
       <%= label f, :comments, "Let us know how we can help*", [for: "comments", class: "form-control-label"] %>
       <%= textarea f, :comments, id: "comments", class: "support-form-text-input form-control #{class_for_error("comments", @errors, "form-control-danger", "form-control-success")}", "aria-describedby": "commentsHelp", maxlength: "3000",
                                 rows: "3", placeholder: "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number.", required: "required", value: assigns[:comments] %>
@@ -26,7 +28,8 @@
   </section>
   <section>
     <%# <h3>Additional Details (optional)</h3> %>
-    <div class="form-group <%= if @errors do class_for_error("upload", @errors, "has-danger", "") end %>">
+    <div class="form-group <%= if @errors do class_for_error("upload", @errors, "has-danger", "has-success") end %>">
+      <%= support_error_tag @errors, "upload" %>
       <span id="upload-photo-error"></span>
       <div class="photo-preview-container <%= unless Map.has_key?(f.params, "photo"), do: "hidden-xs-up" %>" tabindex="-1">
       </div>
@@ -47,13 +50,15 @@
     </div>
     <div id="contactInfoForm" style="display: none;">
       <h3>Contact Info</h3>
-      <div class="form-group <%= class_for_error("name", @errors, "has-danger", "") %>">
+      <div class="form-group <%= class_for_error("name", @errors, "has-danger", "has-success") %>">
         <%= label f, :name, "Full Name*", [for: "name", class: "form-control-label"] %>
+        <%= support_error_tag @errors, "name" %>
         <%= text_input f, :name, placeholder: "Jane Smith", class: "support-form-text-input support-form-text-input--small form-control #{class_for_error("name", @errors, "form-control-danger", "form-control-success")}",
                                   autocomplete: "name", id: "name" %>
       </div>
-      <div class="form-group <%= class_for_error("email", @errors, "has-danger", "") %>">
+      <div class="form-group <%= class_for_error("email", @errors, "has-danger", "has-success") %>">
         <%= label f, :email, "Email*", [for: "email", class: "form-control-label"] %>
+        <%= support_error_tag @errors, "email" %>
         <%= text_input f, :email, placeholder: "janesmith@email.com", class: "form-control support-form-text-input support-form-text-input--small #{class_for_error("email", @errors, "form-control-danger", "form-control-success")}",
                                   autocomplete: "email", id: "email" %>
       </div>
@@ -62,7 +67,8 @@
         <%= telephone_input f, :phone, placeholder: "(555)-555-5555", class: "support-form-text-input support-form-text-input--small form-control", "aria-describedby": "phoneHelp",
                                         autocomplete: "tel", id: "phone" %>
       </div>
-      <div class="form-group <%= class_for_error("privacy", @errors, "has-danger", "") %>">
+      <div class="form-group <%= class_for_error("privacy", @errors, "has-danger", "has-success") %>">
+        <%= support_error_tag @errors, "privacy" %>
         <%= SiteWeb.PartialView.render("_checkbox.html", %{
           form: f,
           field: :privacy,
@@ -83,7 +89,8 @@
         %>
       </div>
     </div> <!-- End contact info section -->
-    <div class="form-group <%= class_for_error("recaptcha", @errors, "has-danger", "") %>">
+    <div class="form-group <%= class_for_error("recaptcha", @errors, "has-danger", "has-success") %>">
+      <%= support_error_tag @errors, "recaptcha" %>
       <%= raw Recaptcha.Template.display(noscript: true) %>
       <button class="btn btn-primary submit-button" type="submit" id="support-submit">
         Submit

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -68,7 +68,7 @@
         <%= telephone_input f, :phone, placeholder: placeholder_text("phone"), class: "support-form-text-input support-form-text-input--small form-control", "aria-describedby": "phoneHelp",
                                         autocomplete: "tel", id: "phone" %>
       </div>
-      <div class="form-group <%= class_for_error("privacy", @errors, "has-danger", "has-success") %>">
+      <div class="form-group <%= class_for_error("privacy", @errors, "has-danger", "has-success") %> mb-0 mt-1">
         <%= support_error_tag @errors, "privacy" %>
         <%= SiteWeb.PartialView.render("_checkbox.html", %{
           form: f,

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -22,7 +22,7 @@
       <%= support_error_tag @errors, "comments" %>
       <%= label f, :comments, "Let us know how we can help*", [for: "comments", class: "form-control-label"] %>
       <%= textarea f, :comments, id: "comments", class: "support-form-text-input form-control #{class_for_error("comments", @errors, "form-control-danger", "form-control-success")}", "aria-describedby": "commentsHelp", maxlength: "3000",
-                                rows: "3", placeholder: "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number.", required: "required", value: assigns[:comments] %>
+                                rows: "3", placeholder: placeholder_text("comments"), required: "required", value: assigns[:comments] %>
       <small id="commentsHelp" class="form-text">3000 characters maximum</small>
     </div>
   </section>
@@ -53,18 +53,18 @@
       <div class="form-group <%= class_for_error("name", @errors, "has-danger", "has-success") %>">
         <%= label f, :name, "Full Name*", [for: "name", class: "form-control-label"] %>
         <%= support_error_tag @errors, "name" %>
-        <%= text_input f, :name, placeholder: "Jane Smith", class: "support-form-text-input support-form-text-input--small form-control #{class_for_error("name", @errors, "form-control-danger", "form-control-success")}",
+        <%= text_input f, :name, placeholder: placeholder_text("name"), class: "support-form-text-input support-form-text-input--small form-control #{class_for_error("name", @errors, "form-control-danger", "form-control-success")}",
                                   autocomplete: "name", id: "name" %>
       </div>
       <div class="form-group <%= class_for_error("email", @errors, "has-danger", "has-success") %>">
         <%= label f, :email, "Email*", [for: "email", class: "form-control-label"] %>
         <%= support_error_tag @errors, "email" %>
-        <%= text_input f, :email, placeholder: "janesmith@email.com", class: "form-control support-form-text-input support-form-text-input--small #{class_for_error("email", @errors, "form-control-danger", "form-control-success")}",
+        <%= text_input f, :email, placeholder: placeholder_text("email"), class: "form-control support-form-text-input support-form-text-input--small #{class_for_error("email", @errors, "form-control-danger", "form-control-success")}",
                                   autocomplete: "email", id: "email" %>
       </div>
       <div class="form-group">
         <%= label f, :phone, "Phone number", [for: "phone", class: "form-control-label"] %>
-        <%= telephone_input f, :phone, placeholder: "(555)-555-5555", class: "support-form-text-input support-form-text-input--small form-control", "aria-describedby": "phoneHelp",
+        <%= telephone_input f, :phone, placeholder: placeholder_text("phone"), class: "support-form-text-input support-form-text-input--small form-control", "aria-describedby": "phoneHelp",
                                         autocomplete: "tel", id: "phone" %>
       </div>
       <div class="form-group <%= class_for_error("privacy", @errors, "has-danger", "has-success") %>">

--- a/apps/site/lib/site_web/templates/customer_support/index.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/index.html.eex
@@ -1,32 +1,28 @@
 <div class="container">
   <div class="page-section">
-    <h1>Contact Us</h1>
-
-    <div class="col-xs-12 col-md-8">
-
-      <div class="row">
-        <div class="col-xs-12 support-thank-you <%= if @show_form, do: "hidden-xs-up" %>" tabindex="-1">
-          <div class="support-success" id="<%= if !show_error_message(@conn), do: "support-result" %>">
+    <h1>Customer Support</h1>
+    <div class="row">
+      <div class="col-md-8">
+        <div class="support-confirmation support-confirmation--success <%= if @show_form, do: "hidden-xs-up" %>" tabindex="-1">
+          <div id="<%= if !show_error_message(@conn), do: "support-result" %>">
             <%= fa "check-circle" %>
             Thank you for your feedback.
           </div>
           <p>Your comments have been sent to our Customer Support team.</p>
         </div>
-        <div class="col-xs-12 support-form-error <%= if !show_error_message(@conn), do: "hidden-xs-up" %>" tabindex="-1">
-          <div class="support-error" id="<%= if show_error_message(@conn), do: "support-result" %>">
+        <div class="support-confirmation support-confirmation--error <%= if !show_error_message(@conn), do: "hidden-xs-up" %>" tabindex="-1">
+          <div id="<%= if show_error_message(@conn), do: "support-result" %>">
             <%= fa "exclamation-circle" %>
             We had an issue submitting your feedback -- please call us at the Main Hotline below, or try again in a few minutes.
           </div>
         </div>
+        <%= if @show_form do %>
+          <%= render "_form.html", forward_assigns(@conn) %>
+        <% end %>
       </div>
-      <%= if @show_form do %>
-        <%= render "_form.html", forward_assigns(@conn) %>
-      <% end %>
-
-    </div>
-
-    <div class="col-xs-12 col-md-4">
-      <%= SiteWeb.CustomerSupportController.render_expandable_blocks(assigns) %>
+      <div class="col-md-4">
+        <%= SiteWeb.CustomerSupportController.render_expandable_blocks(assigns) %>
+      </div>
     </div>
   </div>
 </div>

--- a/apps/site/lib/site_web/views/customer_support_view.ex
+++ b/apps/site/lib/site_web/views/customer_support_view.ex
@@ -45,6 +45,16 @@ defmodule SiteWeb.CustomerSupportView do
     )
   end
 
+  @spec placeholder_text(String.t()) :: String.t()
+  def placeholder_text("comments"),
+    do:
+      "If applicable, please make sure to include the time and date of the incident, the route, and the vehicle number."
+
+  def placeholder_text("name"), do: "Jane Smith"
+  def placeholder_text("email"), do: "janesmith@email.com"
+  def placeholder_text("phone"), do: "(555)-555-5555"
+  def placeholder_text(_), do: ""
+
   @doc """
   Also see SiteWeb.ErrorHelpers.error_tag for a slightly different implementation of this functionality.
   """

--- a/apps/site/lib/site_web/views/customer_support_view.ex
+++ b/apps/site/lib/site_web/views/customer_support_view.ex
@@ -1,5 +1,10 @@
 defmodule SiteWeb.CustomerSupportView do
+  @moduledoc """
+  Helper functions for handling interaction with and submitting the customer support form
+  """
   use SiteWeb, :view
+
+  import Phoenix.HTML.Tag, only: [content_tag: 2, content_tag: 3]
 
   def photo_info(%{
         "photo" => %Plug.Upload{path: path, filename: filename, content_type: content_type}
@@ -23,5 +28,18 @@ defmodule SiteWeb.CustomerSupportView do
   @spec class_for_error(String.t(), [String.t()], String.t(), String.t()) :: String.t()
   def class_for_error(value, errors, on_class, off_class) do
     if Enum.member?(errors, value), do: on_class, else: off_class
+  end
+
+  def preamble_text do
+    content_tag(
+      :div,
+      [
+        content_tag(
+          :p,
+          "Responses may take up to 5 business days. Do not use this form to report emergencies."
+        ),
+        content_tag(:p, "All fields with an asterisk* are required.")
+      ]
+    )
   end
 end

--- a/apps/site/lib/site_web/views/customer_support_view.ex
+++ b/apps/site/lib/site_web/views/customer_support_view.ex
@@ -26,6 +26,8 @@ defmodule SiteWeb.CustomerSupportView do
   end
 
   @spec class_for_error(String.t(), [String.t()], String.t(), String.t()) :: String.t()
+  def class_for_error(_, [], _, _), do: ""
+
   def class_for_error(value, errors, on_class, off_class) do
     if Enum.member?(errors, value), do: on_class, else: off_class
   end
@@ -42,4 +44,37 @@ defmodule SiteWeb.CustomerSupportView do
       ]
     )
   end
+
+  @doc """
+  Also see SiteWeb.ErrorHelpers.error_tag for a slightly different implementation of this functionality.
+  """
+  def support_error_tag(errors, field) when is_list(errors) do
+    if Enum.member?(errors, field) do
+      content_tag(
+        :div,
+        content_tag(:span, error_msg(field),
+          role: "alert",
+          "aria-live": "assertive",
+          class: "support-#{field}-error"
+        ),
+        class: "error-container support-#{field}-error-container form-control-feedback"
+      )
+    else
+      nil
+    end
+  end
+
+  defp error_msg("service"), do: "Please select the type of concern."
+  defp error_msg("comments"), do: "Please enter a comment to continue."
+  defp error_msg("upload"), do: "Sorry. We had trouble uploading your image. Please try again."
+  defp error_msg("email"), do: "Please enter a valid email."
+  defp error_msg("name"), do: "Please enter your full name to continue."
+
+  defp error_msg("privacy"),
+    do: "You must agree to our Privacy Policy before submitting your feedback."
+
+  defp error_msg("recaptcha"),
+    do: "You must complete the reCAPTCHA before submitting your feedback."
+
+  defp error_msg(_), do: "Sorry. Something went wrong. Please try again."
 end

--- a/apps/site/lib/site_web/views/customer_support_view.ex
+++ b/apps/site/lib/site_web/views/customer_support_view.ex
@@ -55,6 +55,17 @@ defmodule SiteWeb.CustomerSupportView do
   def placeholder_text("phone"), do: "(555)-555-5555"
   def placeholder_text(_), do: ""
 
+  def help_text("phone"),
+    do:
+      content_tag(
+        :p,
+        "If you'd like us to give you a call, please give us the best number where we can reach you.",
+        id: "phoneHelp",
+        class: "help-text"
+      )
+
+  def help_text(_), do: ""
+
   @doc """
   Also see SiteWeb.ErrorHelpers.error_tag for a slightly different implementation of this functionality.
   """


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [☎️ Organize the customer support form](https://app.asana.com/0/385363666817452/1188535657153272/f)

Implements the intermediate customer support form design that will reign until we complete the epic.

* Adds reworded section headings
* Restructures the grey sections to match the mockup
* Arranges the category radio buttons vertically
* Moves and rephrases the "responses may take up to 5 days disclaimer"

There's a fair amount of code cleanup since I wanted to leave things in good shape for us to start adding new fields! Mostly I'm trying to reduce some duplication in the templates by moving a few key pieces over to functions in the Elixir view we can use to generate error messages, placeholder text, and help text. Tried to do all of this carefully as to not break any of the existing tests. :pray:

Merging into master since this change can go live before other changes to the customer support page.


---

Before getting review, please check the following:

* [x ] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
