### PR TITLE
Do not discard predicted schedules if they are less than 24 hours away

### DIFF
--- a/apps/site/test/predicted_schedule_test.exs
+++ b/apps/site/test/predicted_schedule_test.exs
@@ -161,6 +161,11 @@ defmodule PredictedScheduleTest do
                %{schedule: %{trip: %{id: "Trip 3"}}, prediction: %{trip: %{id: "Trip 3"}}}
              ] = predicted_schedules
     end
+
+    test "returns a list of predicted schedules, including ones that are within the next 24 hours" do
+      predicted_schedules = get("15", 1, direction_id: 1, now: Util.now())
+      refute Enum.empty?(predicted_schedules)
+    end
   end
 
   describe "group/2" do

--- a/apps/util/lib/util.ex
+++ b/apps/util/lib/util.ex
@@ -287,4 +287,11 @@ defmodule Util do
 
     result
   end
+
+  @spec is_within_24_hours?(DateTime.t(), DateTime.t()) :: boolean
+  def is_within_24_hours?(time, ref_time) do
+    # diff returns seconds by default
+    diff_in_hours = DateTime.diff(time, ref_time) / (60 * 60)
+    abs(diff_in_hours) <= 24
+  end
 end

--- a/apps/util/test/util_test.exs
+++ b/apps/util/test/util_test.exs
@@ -449,12 +449,20 @@ defmodule UtilTest do
     end
   end
 
-  describe "time_is_greater_or_equal?/2" do
+  describe "Comparing dates" do
     test "properly determines if date is before reference date" do
       day = Util.to_local_time(~N[2020-07-13T00:00:00])
       ten_days_later = Util.to_local_time(~N[2020-07-23T00:00:00])
       assert time_is_greater_or_equal?(ten_days_later, day) == true
       assert time_is_greater_or_equal?(day, ten_days_later) == false
+    end
+
+    test "24-hour difference check" do
+      ref_day = Util.to_local_time(~N[2020-09-01T00:00:00])
+      less_than_24hrs_later = Util.to_local_time(~N[2020-09-01T00:30:00])
+      two_days_later = Util.to_local_time(~N[2020-09-03T00:00:00])
+      assert is_within_24_hours?(less_than_24hrs_later, ref_day) == true
+      assert is_within_24_hours?(two_days_later, ref_day) == false
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Stations/Stops/TNM | False "No departures within 24 hours" language](https://app.asana.com/0/555089885850811/1188548382586302)

Added a fix to compare the dates of the predicted schedules so there's no "no departures within 24 hours" message.

Before:
![image](https://user-images.githubusercontent.com/61979382/93496316-0d21c800-f8dd-11ea-8620-d8faa80fb454.png)


After:
<img width="396" alt="image" src="https://user-images.githubusercontent.com/61979382/93496340-1448d600-f8dd-11ea-8446-3bc90f6a0512.png">
