### PR TITLE
Reverse the "I would like a response" default

### DIFF
--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -8,7 +8,7 @@ defmodule Feedback.Mailer do
     no_request_response = if message.no_request_response, do: "No", else: "Yes"
 
     _ =
-      if message.no_request_response do
+      unless message.no_request_response do
         Logger.info("HEAT Ticket submitted by #{format_email(message.email)}")
       end
 

--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -5,10 +5,10 @@ defmodule Feedback.Mailer do
 
   @spec send_heat_ticket(Feedback.Message.t(), [map()]) :: {:ok, any} | {:error, any}
   def send_heat_ticket(message, photo_info) do
-    request_response = if message.request_response, do: "Yes", else: "No"
+    no_request_response = if message.no_request_response, do: "No", else: "Yes"
 
     _ =
-      if message.request_response do
+      if message.no_request_response do
         Logger.info("HEAT Ticket submitted by #{format_email(message.email)}")
       end
 
@@ -36,7 +36,7 @@ defmodule Feedback.Mailer do
       <EMAILID>#{format_email(message.email)}</EMAILID>
       <PHONE>#{message.phone}</PHONE>
       <DESCRIPTION>#{message.comments}</DESCRIPTION>
-      <CUSTREQUIRERESP>#{request_response}</CUSTREQUIRERESP>
+      <CUSTREQUIRERESP>#{no_request_response}</CUSTREQUIRERESP>
       <MBTASOURCE>Auto Ticket 2</MBTASOURCE>
     </INCIDENT>
     """

--- a/apps/feedback/lib/message.ex
+++ b/apps/feedback/lib/message.ex
@@ -13,7 +13,7 @@ defmodule Feedback.Message do
     {"Compliment", "Commendation"}
   ]
 
-  @enforce_keys [:comments, :service, :request_response]
+  @enforce_keys [:comments, :service, :no_request_response]
   defstruct [
     :email,
     :phone,
@@ -21,7 +21,7 @@ defmodule Feedback.Message do
     :last_name,
     :comments,
     :service,
-    :request_response,
+    :no_request_response,
     :photos
   ]
 
@@ -32,7 +32,7 @@ defmodule Feedback.Message do
           last_name: String.t(),
           comments: String.t(),
           service: String.t(),
-          request_response: boolean,
+          no_request_response: boolean,
           photos: [Plug.Upload.t()] | nil
         }
 

--- a/apps/feedback/test/mailer_test.exs
+++ b/apps/feedback/test/mailer_test.exs
@@ -7,13 +7,13 @@ defmodule Feedback.MailerTest do
   @base_message %Message{
     comments: "",
     service: "Inquiry",
-    request_response: false
+    no_request_response: false
   }
 
   describe "send_heat_ticket/2" do
     test "sends an email for heat 2" do
       Mailer.send_heat_ticket(
-        %Message{comments: "", service: "Complaint", request_response: false},
+        %Message{comments: "", service: "Complaint", no_request_response: false},
         nil
       )
 
@@ -22,7 +22,7 @@ defmodule Feedback.MailerTest do
 
     test "has the body format that heat 2 expects" do
       Mailer.send_heat_ticket(
-        %Message{comments: "", service: "Complaint", request_response: false},
+        %Message{comments: "", service: "Complaint", no_request_response: false},
         nil
       )
 
@@ -167,7 +167,7 @@ defmodule Feedback.MailerTest do
         phone: "1231231234",
         first_name: "Disgruntled",
         last_name: "User",
-        request_response: true,
+        no_request_response: true,
         service: "Complaint"
       }
 

--- a/apps/feedback/test/mailer_test.exs
+++ b/apps/feedback/test/mailer_test.exs
@@ -7,13 +7,13 @@ defmodule Feedback.MailerTest do
   @base_message %Message{
     comments: "",
     service: "Inquiry",
-    no_request_response: false
+    no_request_response: true
   }
 
   describe "send_heat_ticket/2" do
     test "sends an email for heat 2" do
       Mailer.send_heat_ticket(
-        %Message{comments: "", service: "Complaint", no_request_response: false},
+        %Message{comments: "", service: "Complaint", no_request_response: true},
         nil
       )
 
@@ -22,7 +22,7 @@ defmodule Feedback.MailerTest do
 
     test "has the body format that heat 2 expects" do
       Mailer.send_heat_ticket(
-        %Message{comments: "", service: "Complaint", no_request_response: false},
+        %Message{comments: "", service: "Complaint", no_request_response: true},
         nil
       )
 
@@ -167,7 +167,7 @@ defmodule Feedback.MailerTest do
         phone: "1231231234",
         first_name: "Disgruntled",
         last_name: "User",
-        no_request_response: true,
+        no_request_response: false,
         service: "Complaint"
       }
 

--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -209,8 +209,8 @@ function removeClass(node, className) {
 }
 
 export function setupRequestResponse($) {
-  $("#request_response").change(function() {
-    $("#contactInfoForm").toggle($(this).is(":checked"));
+  $("#no_request_response").change(function() {
+    $("#contactInfoForm").toggle(!$(this).is(":checked"));
   });
 }
 
@@ -250,7 +250,7 @@ const validators = {
 };
 
 function responseRequested($) {
-  return $("#request_response")[0].checked;
+  return !$("#no_request_response")[0].checked;
 }
 
 function setupValidation($) {

--- a/apps/site/assets/js/test/support-form_test.js
+++ b/apps/site/assets/js/test/support-form_test.js
@@ -243,7 +243,7 @@ describe("support form", () => {
             <div class="support-comments-error-container hidden-xs-up" tabindex="-1"><div class="support-comments-error"></div></div>
             <textarea name="support[comments]" id="comments"></textarea>
             <input name="support[photo]" id="photo" type="file" />
-            <input name="support[request_response]" id="request_response" type="checkbox" />
+            <input name="support[no_request_response]" id="no_request_response" type="checkbox" />
             <input name="support[name]" id="name" />
             <input name="support[phone]" id="phone" />
             <input name="support[email]" id="email" />
@@ -287,7 +287,6 @@ describe("support form", () => {
     });
 
     it("requires the privacy box to be checked if the customer wants a response", () => {
-      $("#request_response").click();
       $("#support-submit").click();
       assert.isFalse(
         $(".support-privacy-error-container").hasClass("hidden-xs-up")
@@ -295,6 +294,7 @@ describe("support form", () => {
     });
 
     it("does not require the privacy box to be checked if the customer does not want a response", () => {
+      $("#no_request_response").click();
       $("#support-submit").click();
       assert.isTrue(
         $(".support-privacy-error-container").hasClass("hidden-xs-up")
@@ -302,7 +302,6 @@ describe("support form", () => {
     });
 
     it("requires a name if the customer wants a response", () => {
-      $("#request_response").click();
       $("#support-submit").click();
       assert.isFalse(
         $(".support-name-error-container").hasClass("hidden-xs-up")
@@ -310,7 +309,6 @@ describe("support form", () => {
     });
 
     it("requires an email when the customer wants a response", () => {
-      $("#request_response").click();
       $("#support-submit").click();
       assert.isFalse(
         $(".support-email-error-container").hasClass("hidden-xs-up")
@@ -318,6 +316,7 @@ describe("support form", () => {
     });
 
     it("does not require a phone number or an email when the customer does not want a response", () => {
+      $("#no_request_response").click();
       $("#support-submit").click();
       assert.isTrue(
         $(".support-email-error-container").hasClass("hidden-xs-up")
@@ -325,7 +324,6 @@ describe("support form", () => {
     });
 
     it("requires a valid email", () => {
-      $("#request_response").click();
       $("#email").val("not an email");
       $("#support-submit").click();
       assert.isFalse(
@@ -339,7 +337,6 @@ describe("support form", () => {
     });
 
     it("focuses to the highest error message on the page", () => {
-      $("#request_response").click();
       $("#support-submit").click();
       assert.equal(
         document.activeElement,

--- a/apps/site/assets/js/test/support-form_test.js
+++ b/apps/site/assets/js/test/support-form_test.js
@@ -433,6 +433,7 @@ describe("support form", () => {
     });
 
     it("sends multiple files down to the server", () => {
+      $("#no_request_response").click();
       let file_1 = new File({
         name: "test-file",
         buffer: new Buffer("this is a 24 byte string"),

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -154,7 +154,7 @@ defmodule SiteWeb.CustomerSupportController do
   @spec do_validation(map) :: [String.t()]
   defp do_validation(params) do
     validators =
-      if params["request_response"] == "on" do
+      if params["no_request_response"] == "off" do
         [
           &validate_comments/1,
           &validate_service/1,
@@ -246,7 +246,7 @@ defmodule SiteWeb.CustomerSupportController do
       last_name: params["last_name"],
       comments: params["comments"],
       service: params["service"],
-      request_response: params["request_response"] == "on"
+      no_request_response: params["no_request_response"] == "on"
     })
   end
 

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -41,14 +41,14 @@
     <div class="form-group">
       <%= SiteWeb.PartialView.render("_checkbox.html", %{
         form: f,
-        field: :request_response,
-        id: "request_response",
+        field: :no_request_response,
+        id: "no_request_response",
         checked: false,
-        label_text: "I would like a response from the Customer Support team."
+        label_text: "I do not want a response from the Customer Support Team."
       })
       %>
     </div>
-    <div id="contactInfoForm" style="display: none;">
+    <div id="contactInfoForm">
       <h3>Contact Info</h3>
       <div class="form-group <%= class_for_error("name", @errors, "has-danger", "has-success") %>">
         <%= label f, :name, "Full Name*", [for: "name", class: "form-control-label"] %>

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -49,7 +49,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
           "privacy" => "on",
           "phone" => "",
           "name" => "tom brady",
-          "request_response" => "on",
+          "no_request_response" => "off",
           "service" => "Inquiry"
         },
         "g-recaptcha-response" => "valid_response"
@@ -60,7 +60,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
       %{
         "support" => %{
           "comments" => "comments",
-          "request_response" => "off",
+          "no_request_response" => "on",
           "service" => "Inquiry"
         },
         "g-recaptcha-response" => "valid_response"

--- a/apps/site/test/site_web/integration/support_form_test.exs
+++ b/apps/site/test/site_web/integration/support_form_test.exs
@@ -28,9 +28,9 @@ defmodule CustomerSupportTest do
     } do
       session
       |> visit("/customer-support")
-      |> click(css("#request_response_label"))
+      |> click(css("#no_request_response_label"))
 
-      assert selected?(session, css("#request_response", visible: false))
+      assert selected?(session, css("#no_request_response", visible: false))
     end
 
     @tag :wallaby
@@ -39,7 +39,7 @@ defmodule CustomerSupportTest do
     } do
       session
       |> visit("/customer-support")
-      |> click(css("#request_response_label"))
+      |> click(css("#no_request_response_label"))
       |> assert_has(css("#name"))
       |> assert_has(css("#email"))
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [☎️ Reverse the "I would like a response" default](https://app.asana.com/0/385363666817452/1188535657153270/f)

Changes the copy on the frontend, shows the response form on the front end by default, and aligns the logic on the `CUSTREQUIRERESP` field.

Also decided to change the _name_ of the relevant variable from request_response to no_request_response such that a "positive" response (checked) means "No" (it's less confusing for my brain, at least).

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
