### PR TITLE
Use configuration settings for test expectations

### DIFF
--- a/apps/feedback/test/mailer_test.exs
+++ b/apps/feedback/test/mailer_test.exs
@@ -17,7 +17,9 @@ defmodule Feedback.MailerTest do
         nil
       )
 
-      assert Test.latest_message()["to"] == ["test@test.com"]
+      assert Test.latest_message()["to"] == [
+               Application.get_env(:feedback, :support_ticket_to_email)
+             ]
     end
 
     test "has the body format that heat 2 expects" do
@@ -44,7 +46,7 @@ defmodule Feedback.MailerTest do
                  <CITY></CITY>
                  <STATE></STATE>
                  <ZIPCODE></ZIPCODE>
-                 <EMAILID>reply@test.com</EMAILID>
+                 <EMAILID>#{Application.get_env(:feedback, :support_ticket_reply_email)}</EMAILID>
                  <PHONE></PHONE>
                  <DESCRIPTION></DESCRIPTION>
                  <CUSTREQUIRERESP>No</CUSTREQUIRERESP>
@@ -73,14 +75,18 @@ defmodule Feedback.MailerTest do
       assert Test.latest_message()["text"] =~ "<EMAILID>disgruntled@user.com</EMAILID>"
     end
 
-    test "when the user does not set an email, the email is reply@test.com" do
+    test "when the user does not set an email, the SUPPORT_TICKET_REPLY_EMAIL configuration email is used" do
       Mailer.send_heat_ticket(@base_message, nil)
-      assert Test.latest_message()["text"] =~ "<EMAILID>reply@test.com</EMAILID>"
+
+      assert Test.latest_message()["text"] =~
+               "<EMAILID>#{Application.get_env(:feedback, :support_ticket_reply_email)}</EMAILID>"
     end
 
-    test "when the user sets an empty string, the email is reply@test.com" do
+    test "when the user sets an empty string, the SUPPORT_TICKET_REPLY_EMAIL configuration email is used" do
       Mailer.send_heat_ticket(%{@base_message | email: ""}, nil)
-      assert Test.latest_message()["text"] =~ "<EMAILID>reply@test.com</EMAILID>"
+
+      assert Test.latest_message()["text"] =~
+               "<EMAILID>#{Application.get_env(:feedback, :support_ticket_reply_email)}</EMAILID>"
     end
 
     test "the email does not have leading or trailing spaces" do


### PR DESCRIPTION
Use configuration settings for test expectations

If you've changed these values in your `.env` file the tests would fail
for you.

No ticket, just fixes a problem I've been experiencing.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
