### PR TITLE
Add back-end support for a new Subject field

### DIFF
--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -3,7 +3,9 @@ defmodule Feedback.Mailer do
 
   require Logger
 
-  @spec send_heat_ticket(Feedback.Message.t(), [map()]) :: {:ok, any} | {:error, any}
+  alias Feedback.Message
+
+  @spec send_heat_ticket(Message.t(), [map()]) :: {:ok, any} | {:error, any}
   def send_heat_ticket(message, photo_info) do
     no_request_response = if message.no_request_response, do: "No", else: "Yes"
 
@@ -19,8 +21,8 @@ defmodule Feedback.Mailer do
     body = """
     <INCIDENT>
       <SERVICE>#{message.service}</SERVICE>
-      <CATEGORY>Other</CATEGORY>
-      <TOPIC></TOPIC>
+      <CATEGORY>#{message.subject}</CATEGORY>
+      <TOPIC>#{topic(message)}</TOPIC>
       <SUBTOPIC></SUBTOPIC>
       <MODE></MODE>
       <LINE></LINE>
@@ -70,6 +72,19 @@ defmodule Feedback.Mailer do
       |> ExAws.SES.send_raw_email()
       |> exaws_perform_fn.(exaws_config_fn.(:ses))
   end
+
+  @spec topic(Message.t()) :: String.t()
+  defp topic(%Message{service: "Complaint", subject: "Bus Stop"}), do: "Other"
+  defp topic(%Message{service: "Complaint", subject: "CharlieCards & Tickets"}), do: "Other"
+  defp topic(%Message{service: "Complaint", subject: "Employee Complaint"}), do: "Other"
+  defp topic(%Message{service: "Complaint", subject: "Fare Evasion"}), do: "Other"
+  defp topic(%Message{service: "Complaint", subject: "Maintenance Complaint"}), do: "Other"
+  defp topic(%Message{service: "Complaint", subject: "Parking"}), do: "Other"
+  defp topic(%Message{service: "Complaint", subject: "Service Complaint"}), do: "Other"
+  defp topic(%Message{service: "Complaint", subject: "T-Alerts/Apps/Countdown"}), do: "Other"
+  defp topic(%Message{service: "Inquiry", subject: "Disability ID Cards"}), do: "Other"
+  defp topic(%Message{service: "Inquiry", subject: "Senior ID Cards"}), do: "Other"
+  defp topic(_), do: ""
 
   @spec format_name(String.t() | nil, String.t()) :: String.t()
   defp format_name(nil, default) do

--- a/apps/feedback/lib/message.ex
+++ b/apps/feedback/lib/message.ex
@@ -4,13 +4,63 @@ defmodule Feedback.Message do
   """
 
   # The integration with HEAT only accepts certain values for the message type
-  # Only "Complaint", "Suggestion", "Inquiry" and "Commendation" are supported.
+  # and subject. Only "Complaint", "Suggestion", "Inquiry" and "Commendation"
+  # are supported service options, and each has a list of allowed subjects.
   # Other values will cause HEAT to throw an error and reject the ticket
-  @service_options [
-    {"Complaint", "Complaint"},
-    {"Comment", "Suggestion"},
-    {"Question", "Inquiry"},
-    {"Compliment", "Commendation"}
+  @type service_name :: String.t()
+  @type service_value :: String.t()
+  @type subject_value :: String.t()
+  @type service_option_with_subjects :: {service_name(), service_value(), [subject_value()]}
+  @service_options_with_subjects [
+    {"Complaint", "Complaint",
+     [
+       "Bus Stop",
+       "CharlieCards & Tickets",
+       "Employee Complaint",
+       "Fare Evasion",
+       "Maintenance Complaint",
+       "Mobile Ticketing",
+       "Parking",
+       "Service Complaint",
+       "TAlerts/Countdowns/Apps",
+       "Other"
+     ]},
+    {"Comment", "Suggestion",
+     [
+       "Bus Stop",
+       "CharlieCards & Tickets",
+       "Fare Policy",
+       "Maintenance",
+       "MBTA Projects/Programs",
+       "Parking",
+       "Schedules",
+       "Service Inquiry",
+       "Website",
+       "Other"
+     ]},
+    {"Question", "Inquiry",
+     [
+       "CharlieCards & Tickets",
+       "Disability ID Cards",
+       "Fare Policy",
+       "Maintenance",
+       "Mobile Ticketing",
+       "Parking",
+       "Schedules",
+       "Senior ID Cards",
+       "Service Inquiry",
+       "Trip Planner",
+       "Website",
+       "Other"
+     ]},
+    {"Compliment", "Commendation",
+     [
+       "Employee",
+       "Maintenance",
+       "MBTA Projects/Programs",
+       "Service",
+       "Other"
+     ]}
   ]
 
   @enforce_keys [:comments, :service, :no_request_response]
@@ -21,6 +71,7 @@ defmodule Feedback.Message do
     :last_name,
     :comments,
     :service,
+    :subject,
     :no_request_response,
     :photos
   ]
@@ -32,15 +83,37 @@ defmodule Feedback.Message do
           last_name: String.t(),
           comments: String.t(),
           service: String.t(),
+          subject: String.t(),
           no_request_response: boolean,
           photos: [Plug.Upload.t()] | nil
         }
 
+  @spec service_options() :: [service_option_with_subjects()]
   def service_options do
-    @service_options
+    @service_options_with_subjects
   end
 
+  @spec valid_service?(service_value()) :: boolean()
   def valid_service?(value) do
     value in Enum.map(service_options(), &elem(&1, 1))
   end
+
+  @spec valid_subject_for_service?(subject_value(), service_value()) :: boolean()
+  def valid_subject_for_service?(subject_value, service_value) do
+    case service(service_value) do
+      nil ->
+        false
+
+      service ->
+        subject_value in subjects(service)
+    end
+  end
+
+  @spec service(service_value()) :: service_option_with_subjects() | nil
+  defp service(value) do
+    Enum.find(service_options(), &(elem(&1, 1) == value))
+  end
+
+  @spec subjects(service_option_with_subjects()) :: [subject_value()]
+  defp subjects(service), do: elem(service, 2)
 end

--- a/apps/feedback/test/mailer_test.exs
+++ b/apps/feedback/test/mailer_test.exs
@@ -7,30 +7,33 @@ defmodule Feedback.MailerTest do
   @base_message %Message{
     comments: "",
     service: "Inquiry",
+    subject: "Website",
     no_request_response: true
   }
 
   describe "send_heat_ticket/2" do
     test "sends an email for heat 2" do
       Mailer.send_heat_ticket(
-        %Message{comments: "", service: "Complaint", no_request_response: true},
+        @base_message,
         nil
       )
 
-      assert Test.latest_message()["to"] == ["test@test.com"]
+      assert Test.latest_message()["to"] == [
+               Application.get_env(:feedback, :support_ticket_to_email)
+             ]
     end
 
     test "has the body format that heat 2 expects" do
       Mailer.send_heat_ticket(
-        %Message{comments: "", service: "Complaint", no_request_response: true},
+        @base_message,
         nil
       )
 
       assert Test.latest_message()["text"] ==
                """
                <INCIDENT>
-                 <SERVICE>Complaint</SERVICE>
-                 <CATEGORY>Other</CATEGORY>
+                 <SERVICE>Inquiry</SERVICE>
+                 <CATEGORY>Website</CATEGORY>
                  <TOPIC></TOPIC>
                  <SUBTOPIC></SUBTOPIC>
                  <MODE></MODE>
@@ -44,7 +47,7 @@ defmodule Feedback.MailerTest do
                  <CITY></CITY>
                  <STATE></STATE>
                  <ZIPCODE></ZIPCODE>
-                 <EMAILID>reply@test.com</EMAILID>
+                 <EMAILID>#{Application.get_env(:feedback, :support_ticket_reply_email)}</EMAILID>
                  <PHONE></PHONE>
                  <DESCRIPTION></DESCRIPTION>
                  <CUSTREQUIRERESP>No</CUSTREQUIRERESP>
@@ -63,6 +66,29 @@ defmodule Feedback.MailerTest do
                "<DESCRIPTION>major issue to report</DESCRIPTION>"
     end
 
+    test "generates the topic based on the service and subject" do
+      Mailer.send_heat_ticket(
+        %{@base_message | service: "Complaint", subject: "Bus Stop"},
+        nil
+      )
+
+      assert Test.latest_message()["text"] =~ "<TOPIC>Other</TOPIC>"
+
+      Mailer.send_heat_ticket(
+        %{@base_message | service: "Inquiry", subject: "Disability ID Cards"},
+        nil
+      )
+
+      assert Test.latest_message()["text"] =~ "<TOPIC>Other</TOPIC>"
+
+      Mailer.send_heat_ticket(
+        %{@base_message | service: "Inquiry", subject: "Other"},
+        nil
+      )
+
+      assert Test.latest_message()["text"] =~ "<TOPIC></TOPIC>"
+    end
+
     test "uses the phone from the message in the phone field" do
       Mailer.send_heat_ticket(%{@base_message | phone: "617-123-4567"}, nil)
       assert Test.latest_message()["text"] =~ "<PHONE>617-123-4567</PHONE>"
@@ -73,14 +99,18 @@ defmodule Feedback.MailerTest do
       assert Test.latest_message()["text"] =~ "<EMAILID>disgruntled@user.com</EMAILID>"
     end
 
-    test "when the user does not set an email, the email is reply@test.com" do
+    test "when the user does not set an email, the SUPPORT_TICKET_REPLY_EMAIL configuration email is used" do
       Mailer.send_heat_ticket(@base_message, nil)
-      assert Test.latest_message()["text"] =~ "<EMAILID>reply@test.com</EMAILID>"
+
+      assert Test.latest_message()["text"] =~
+               "<EMAILID>#{Application.get_env(:feedback, :support_ticket_reply_email)}</EMAILID>"
     end
 
-    test "when the user sets an empty string, the email is reply@test.com" do
+    test "when the user sets an empty string, the SUPPORT_TICKET_REPLY_EMAIL configuration email is used" do
       Mailer.send_heat_ticket(%{@base_message | email: ""}, nil)
-      assert Test.latest_message()["text"] =~ "<EMAILID>reply@test.com</EMAILID>"
+
+      assert Test.latest_message()["text"] =~
+               "<EMAILID>#{Application.get_env(:feedback, :support_ticket_reply_email)}</EMAILID>"
     end
 
     test "the email does not have leading or trailing spaces" do

--- a/apps/feedback/test/message_test.exs
+++ b/apps/feedback/test/message_test.exs
@@ -17,4 +17,27 @@ defmodule MessageTest do
       refute valid_service?("nonsense")
     end
   end
+
+  describe "valid_subject_for_service?/2" do
+    test "is true when the subject is in the allowed subject values for the given service option" do
+      assert valid_subject_for_service?("Bus Stop", "Complaint")
+      assert valid_subject_for_service?("Other", "Complaint")
+      assert valid_subject_for_service?("MBTA Projects/Programs", "Suggestion")
+      assert valid_subject_for_service?("Other", "Suggestion")
+      assert valid_subject_for_service?("CharlieCards & Tickets", "Inquiry")
+      assert valid_subject_for_service?("Other", "Inquiry")
+      assert valid_subject_for_service?("Employee", "Commendation")
+      assert valid_subject_for_service?("Other", "Commendation")
+    end
+
+    test "is false when the subject is not in the allowed subject values for the given service option" do
+      refute valid_subject_for_service?("", "Complaint")
+      refute valid_subject_for_service?(nil, "Complaint")
+      refute valid_subject_for_service?(nil, "Complaint")
+      refute valid_subject_for_service?("Fare Policy", "Complaint")
+      refute valid_subject_for_service?("TAlerts/Countdowns/Apps", "Suggestion")
+      refute valid_subject_for_service?("TAlerts/Countdowns/Apps", "Inquiry")
+      refute valid_subject_for_service?("CTD", "Commendation")
+    end
+  end
 end

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -158,6 +158,7 @@ defmodule SiteWeb.CustomerSupportController do
         [
           &validate_comments/1,
           &validate_service/1,
+          &validate_subject/1,
           &validate_photos/1,
           &validate_name/1,
           &validate_email/1,
@@ -185,6 +186,17 @@ defmodule SiteWeb.CustomerSupportController do
   end
 
   defp validate_service(_), do: "service"
+
+  @spec validate_subject(map) :: :ok | String.t()
+  defp validate_subject(%{"subject" => subject, "service" => service}) do
+    if Feedback.Message.valid_subject_for_service?(subject, service) do
+      :ok
+    else
+      "subject"
+    end
+  end
+
+  defp validate_subject(_), do: "subject"
 
   @spec validate_name(map) :: :ok | String.t()
   defp validate_name(%{"name" => ""}), do: "name"
@@ -246,6 +258,7 @@ defmodule SiteWeb.CustomerSupportController do
       last_name: params["last_name"],
       comments: params["comments"],
       service: params["service"],
+      subject: params["subject"],
       no_request_response: params["no_request_response"] == "on"
     })
   end

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -9,7 +9,7 @@
     <fieldset class="form-group <%= class_for_error("service", @errors, "has-danger", "has-success") %>">
       <legend class="form-control-label">Category*</legend>
       <div id="service" class="service-radios">
-        <%= for {text, value} <- @service_options do %>
+        <%= for {text, value, _subjects} <- @service_options do %>
           <span class="form-check service-radio">
             <%= radio_button f, :service, value, class: "support-form-control service c-radio",
                                                 id: "service-#{value}" %>

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -50,7 +50,8 @@ defmodule SiteWeb.CustomerSupportControllerTest do
           "phone" => "",
           "name" => "tom brady",
           "no_request_response" => "off",
-          "service" => "Inquiry"
+          "service" => "Inquiry",
+          "subject" => "Website"
         },
         "g-recaptcha-response" => "valid_response"
       }
@@ -125,6 +126,17 @@ defmodule SiteWeb.CustomerSupportControllerTest do
         )
 
       assert "service" in conn.assigns.errors
+    end
+
+    test "validates that the subject is one of the allowed values for the service", %{conn: conn} do
+      conn =
+        post(
+          conn,
+          customer_support_path(conn, :submit),
+          put_in(valid_request_response_data(), ["support", "subject"], "Bad")
+        )
+
+      assert "subject" in conn.assigns.errors
     end
 
     test "requires name if customer does want a response", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [☎️ Add support for a new Subject field](https://app.asana.com/0/555089885850811/1188535657153274)

Add back-end support for a new Subject field

Submit subject to Heat in `CATEGORY` field.

Generate Heat `TOPIC` based on the service and subject.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
