### PR TITLE
Stops | Shuttle Alert should be restricted to affected stations

### DIFF
--- a/apps/site/assets/css/_transit-near-me.scss
+++ b/apps/site/assets/css/_transit-near-me.scss
@@ -249,12 +249,6 @@ $xxl-map-height: map-get($container-max-widths, xxl) * (9 / 16);
   }
 }
 
-.m-tnm-sidebar__route-alert-effect {
-  background: $white;
-  box-shadow: 0 $space-2 $space-4 $drop-shadow-color;
-  margin-bottom: $base-spacing / 2;
-}
-
 .m-tnm-sidebar__route-alert {
   display: block;
   height: $base-spacing * 1.25;

--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -220,6 +220,15 @@ export interface InformedEntity {
   direction_id: DirectionId | null;
   activities: Activity[];
 }
+export interface InformedEntitySet {
+  route: string[] | null;
+  route_type: string[] | null;
+  stop: string[] | null;
+  trip: string[] | null;
+  direction_id: DirectionId[] | null;
+  activities: Activity[];
+  entities: InformedEntity[];
+}
 
 export type TimePeriodPairs = [string, string];
 
@@ -227,7 +236,7 @@ export interface Alert {
   id: string;
   active_period: TimePeriodPairs[];
   header: string;
-  informed_entity: InformedEntity[];
+  informed_entity: InformedEntitySet;
   effect: string;
   severity: number;
   lifecycle: Lifecycle;

--- a/apps/site/assets/ts/components/StopCard.tsx
+++ b/apps/site/assets/ts/components/StopCard.tsx
@@ -4,8 +4,10 @@ import { clickStopCardAction, Dispatch } from "../tnm/state";
 import Direction from "./Direction";
 import renderSvg from "../helpers/render-svg";
 import { useSMDown } from "../helpers/media-breakpoints";
-import { accessibleIcon } from "../helpers/icon";
+import { accessibleIcon, alertIcon } from "../helpers/icon";
 import stationSymbol from "../../static/images/icon-circle-t-small.svg";
+import { effectNameForAlert } from "./Alerts";
+import { isDiversion, alertsByStop } from "../models/alert";
 
 interface Props {
   stop: Stop;
@@ -80,6 +82,18 @@ export const StopCard = ({
         </a>
         <div className="m-tnm-sidebar__stop-distance">{distance}</div>
       </div>
+      {alertsByStop(route.alerts.filter(isDiversion), stop.id)
+        .map(alert => (
+          <div key={alert.id} className="m-tnm-sidebar__route-alert-effect">
+            <a
+              className="m-stop-page__departures-alert"
+              href={`/schedules/${route.id}/alerts`}
+            >
+              {alertIcon("c-svg__icon-alerts-triangle")}
+              {effectNameForAlert(alert)}
+            </a>
+          </div>
+        ))}
       {directions.map(direction => (
         <Direction
           key={`${key}-${direction.direction_id}`}

--- a/apps/site/assets/ts/components/StopCard.tsx
+++ b/apps/site/assets/ts/components/StopCard.tsx
@@ -7,7 +7,7 @@ import { useSMDown } from "../helpers/media-breakpoints";
 import { accessibleIcon, alertIcon } from "../helpers/icon";
 import stationSymbol from "../../static/images/icon-circle-t-small.svg";
 import { effectNameForAlert } from "./Alerts";
-import { isDiversion, alertsByStop } from "../models/alert";
+import { isDiversion, alertsByStop, uniqueByEffect } from "../models/alert";
 
 interface Props {
   stop: Stop;
@@ -83,6 +83,7 @@ export const StopCard = ({
         <div className="m-tnm-sidebar__stop-distance">{distance}</div>
       </div>
       {alertsByStop(route.alerts.filter(isDiversion), stop.id)
+        .filter(uniqueByEffect)
         .map(alert => (
           <div key={alert.id} className="m-tnm-sidebar__route-alert-effect">
             <a

--- a/apps/site/assets/ts/components/__tests__/AlertsTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/AlertsTest.tsx
@@ -7,7 +7,7 @@ import Alerts, {
   humanLabelForAlert
 } from "../Alerts";
 import { enzymeToJsonWithoutProps } from "../../app/helpers/testUtils";
-import { Alert } from "../../__v3api";
+import { Alert, InformedEntitySet } from "../../__v3api";
 
 /* eslint-disable @typescript-eslint/camelcase */
 const body = '<div id="react-root"></div>';
@@ -18,7 +18,7 @@ const highAlert: Alert = {
   priority: "high",
   lifecycle: "new",
   active_period: [],
-  informed_entity: [],
+  informed_entity: {} as InformedEntitySet,
   id: "304666",
   header:
     'Route 170 will be rerouted at certain times during the Marathon on Monday, April 15. More: <a href="https://mbta.com/marathon">mbta.com/marathon</a>',
@@ -34,7 +34,7 @@ const lowAlert: Alert = {
   priority: "low",
   lifecycle: "upcoming",
   active_period: [],
-  informed_entity: [],
+  informed_entity: {} as InformedEntitySet,
   id: "00005",
   header: "There is construction at this station.",
   effect: "other",

--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -2,7 +2,8 @@ import { Alert, InformedEntitySet } from "../../__v3api";
 import {
   isHighSeverityOrHighPriority,
   isCurrentAlert,
-  alertsByStop
+  alertsByStop,
+  uniqueByEffect
 } from "../alert";
 
 const testDate = new Date("2020-09-10T09:00");
@@ -82,4 +83,20 @@ test("alertsByStop finds alerts affecting a certain stop", () => {
   ];
   const alertsForStop = alertsByStop(alerts, "place-sstat");
   expect(alertsForStop).toEqual([alert_two, alert_three]);
+});
+
+test("uniqueByEffect enables filtering to unique effects", () => {
+  const alerts = [
+    { effect: "shuttle" } as Alert,
+    { effect: "detour" } as Alert,
+    { effect: "detour" } as Alert,
+    { effect: "shuttle" } as Alert,
+    { effect: "unknown" } as Alert
+  ];
+  expect(alerts.filter(uniqueByEffect)).toHaveLength(3);
+  expect(alerts.filter(uniqueByEffect).map(a => a.effect)).toEqual([
+    "shuttle",
+    "detour",
+    "unknown"
+  ]);
 });

--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -1,8 +1,8 @@
-import { Alert } from "../../__v3api";
+import { Alert, InformedEntitySet } from "../../__v3api";
 import {
   isHighSeverityOrHighPriority,
-  isDiversion,
-  isCurrentAlert
+  isCurrentAlert,
+  alertsByStop
 } from "../alert";
 
 const testDate = new Date("2020-09-10T09:00");
@@ -48,7 +48,7 @@ test.each`
   }
 );
 
-test.only.each`
+test.each`
   alert     | isCurrent
   ${alert1} | ${true}
   ${alert2} | ${true}
@@ -64,3 +64,22 @@ test.only.each`
     }
   }
 );
+
+test("alertsByStop finds alerts affecting a certain stop", () => {
+  const alert_two = {
+    ...alert2,
+    informed_entity: { stop: ["place-sstat"] } as InformedEntitySet
+  };
+  const alert_three = {
+    ...alert3,
+    informed_entity: { stop: ["place-sstat"] } as InformedEntitySet
+  };
+  const alerts = [
+    { ...alert1, informed_entity: { stop: null } as InformedEntitySet },
+    alert_two,
+    alert_three,
+    { ...alert4, informed_entity: { stop: null } as InformedEntitySet }
+  ];
+  const alertsForStop = alertsByStop(alerts, "place-sstat");
+  expect(alertsForStop).toEqual([alert_two, alert_three]);
+});

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -17,6 +17,12 @@ export const alertsByStop = (alerts: Alert[], stopId: string): Alert[] =>
       !!entities.stop && entities.stop!.some((id: string) => id === stopId)
   );
 
+export const uniqueByEffect = (
+  alert: Alert,
+  index: number,
+  alerts: Alert[]
+): boolean => alerts.findIndex(a => a.effect === alert.effect) === index;
+
 const withLeadingZero = (n: string): string => `0${n}`.slice(-2);
 
 const activePeriodToDates = (

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -11,6 +11,12 @@ export const isDiversion = ({ effect }: Alert): boolean =>
   effect === "station_closure" ||
   effect === "detour";
 
+export const alertsByStop = (alerts: Alert[], stopId: string): Alert[] =>
+  alerts.filter(
+    ({ informed_entity: entities }: Alert): boolean =>
+      !!entities.stop && entities.stop!.some((id: string) => id === stopId)
+  );
+
 const withLeadingZero = (n: string): string => `0${n}`.slice(-2);
 
 const activePeriodToDates = (

--- a/apps/site/assets/ts/stop/__tests__/AlertsTabTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/AlertsTabTest.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { mount } from "enzyme";
-import { Alert } from "../../__v3api";
+import { Alert, InformedEntitySet } from "../../__v3api";
 import { AlertsTab as AlertsTabType } from "../components/__stop";
 import AlertsTab from "../components/AlertsTab";
 
@@ -12,7 +12,7 @@ const highAlert: Alert = {
   priority: "high",
   lifecycle: "new",
   active_period: [],
-  informed_entity: [],
+  informed_entity: {} as InformedEntitySet,
   id: "304666",
   header:
     "Route 170 will be rerouted at certain times during the Marathon on Monday, April 15.",
@@ -28,7 +28,7 @@ const lowAlert: Alert = {
   priority: "low",
   lifecycle: "upcoming",
   active_period: [],
-  informed_entity: [],
+  informed_entity: {} as InformedEntitySet,
   id: "00005",
   header: "There is construction at this station.",
   effect: "other",

--- a/apps/site/assets/ts/stop/__tests__/RouteCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/RouteCardTest.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 import stopData from "./stopData.json";
 import { StopPageData, RouteWithDirections } from "../components/__stop";
 import { createReactRoot } from "../../app/helpers/testUtils";
@@ -236,10 +236,18 @@ it("renders effect for diversion-related alerts if present", () => {
   } as EnhancedRoute;
 
   const alerts = [
-    { id: "1", effect: "detour" } as Alert,
-    { id: "2", effect: "dock_issue" } as Alert,
-    { id: "3", effect: "snow_route" } as Alert,
-    { id: "4", effect: "track_change" } as Alert
+    {
+      id: "1",
+      effect: "detour",
+      informed_entity: { stop: [data.stop.id] }
+    } as Alert,
+    {
+      id: "2",
+      effect: "dock_issue",
+      informed_entity: { stop: [data.stop.id] }
+    } as Alert,
+    { id: "3", effect: "snow_route", informed_entity: {} } as Alert,
+    { id: "4", effect: "track_change", informed_entity: {} } as Alert
   ];
   const wrapper = mount(
     <RouteCard route={route} directions={[]} stop={data.stop} alerts={alerts} />

--- a/apps/site/assets/ts/stop/__tests__/RouteCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/RouteCardTest.tsx
@@ -211,7 +211,7 @@ it.each`
     name: "Bus"
   } as EnhancedRoute;
 
-  const alert = { severity: severity } as Alert;
+  const alert = { severity: severity, informed_entity: {} } as Alert;
   const wrapper = mount(
     <RouteCard
       route={route}

--- a/apps/site/assets/ts/stop/__tests__/StopPageTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageTest.tsx
@@ -3,7 +3,7 @@ import renderer from "react-test-renderer";
 import { mount } from "enzyme";
 import StopPage, { fetchData } from "../components/StopPage";
 import stopData from "./stopData.json";
-import { Alert } from "../../__v3api";
+import { Alert, InformedEntitySet } from "../../__v3api";
 import { StopPageData, AlertsTab, StopMapData } from "../components/__stop";
 import { MapData } from "../../leaflet/components/__mapdata";
 import { createReactRoot } from "../../app/helpers/testUtils";
@@ -42,7 +42,7 @@ const lowAlert: Alert = {
   priority: "low",
   lifecycle: "upcoming",
   active_period: [],
-  informed_entity: [],
+  informed_entity: {} as InformedEntitySet,
   id: "00005",
   header: "There is construction at this station.",
   effect: "other",

--- a/apps/site/assets/ts/stop/components/RouteCard.tsx
+++ b/apps/site/assets/ts/stop/components/RouteCard.tsx
@@ -12,7 +12,8 @@ import { effectNameForAlert } from "../../components/Alerts";
 import {
   isHighSeverityOrHighPriority,
   isDiversion,
-  alertsByStop
+  alertsByStop,
+  uniqueByEffect
 } from "../../models/alert";
 
 interface Props {
@@ -36,6 +37,7 @@ const RouteCard = ({
       }
     />
     {alertsByStop(alerts.filter(isDiversion), stop.id)
+      .filter(uniqueByEffect)
       .map(alert => (
         <a
           key={alert.id}

--- a/apps/site/assets/ts/stop/components/RouteCard.tsx
+++ b/apps/site/assets/ts/stop/components/RouteCard.tsx
@@ -9,7 +9,11 @@ import Direction from "../../components/Direction";
 import RouteCardHeader from "../../components/RouteCardHeader";
 import { alertIcon } from "../../helpers/icon";
 import { effectNameForAlert } from "../../components/Alerts";
-import { isHighSeverityOrHighPriority, isDiversion } from "../../models/alert";
+import {
+  isHighSeverityOrHighPriority,
+  isDiversion,
+  alertsByStop
+} from "../../models/alert";
 
 interface Props {
   route: EnhancedRoute;
@@ -31,16 +35,17 @@ const RouteCard = ({
         alerts && alerts.filter(isHighSeverityOrHighPriority).length > 0
       }
     />
-    {alerts.filter(isDiversion).map(alert => (
-      <a
-        key={alert.id}
-        className="m-stop-page__departures-alert"
-        href={`/schedules/${route.id}/alerts`}
-      >
-        {alertIcon("c-svg__icon-alerts-triangle")}
-        {effectNameForAlert(alert)}
-      </a>
-    ))}
+    {alertsByStop(alerts.filter(isDiversion), stop.id)
+      .map(alert => (
+        <a
+          key={alert.id}
+          className="m-stop-page__departures-alert"
+          href={`/schedules/${route.id}/alerts`}
+        >
+          {alertIcon("c-svg__icon-alerts-triangle")}
+          {effectNameForAlert(alert)}
+        </a>
+      ))}
     {directions.length === 0 && (
       <div className="m-stop-page__no-departures">
         <div>No departures within 24 hours</div>

--- a/apps/site/assets/ts/tnm/components/RouteCard.tsx
+++ b/apps/site/assets/ts/tnm/components/RouteCard.tsx
@@ -11,9 +11,6 @@ import { directionIsEmpty } from "../../components/Direction";
 import { modeByV3ModeType } from "../../components/ModeFilter";
 import RouteCardHeader from "../../components/RouteCardHeader";
 import { isABusRoute } from "../../models/route";
-import { isDiversion } from "../../models/alert";
-import { alertIcon } from "../../helpers/icon";
-import { effectNameForAlert } from "../../components/Alerts";
 
 interface Props {
   route: RouteWithStopsWithDirections;
@@ -52,18 +49,6 @@ const RouteCard = ({
   return (
     <div className="m-tnm-sidebar__route" data-mode={mode}>
       <RouteCardHeader route={route.route} hasAlert={hasAlert} />
-      {route.route.alerts.filter(isDiversion).map(alert => (
-        <div className="m-tnm-sidebar__route-alert-effect">
-          <a
-            key={alert.id}
-            className="m-stop-page__departures-alert"
-            href={`/schedules/${route.route.id}/alerts`}
-          >
-            {alertIcon("c-svg__icon-alerts-triangle")}
-            {effectNameForAlert(alert)}
-          </a>
-        </div>
-      ))}
       {filterStops(route).map(
         stopWithDirections =>
           !everyDirectionIsEmpty(stopWithDirections.directions) && (


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Stops | Shuttle Alert should be restricted to affected stations](https://app.asana.com/0/385363666817452/1190590218814913/f)

In Transit Near Me and on the Stop pages, route cards show an alert icon and effect text when there is a diversion anywhere on the route. This update refines the logic and restricts showing this unless the relevant _stop_ is also affected.

Also includes a bugfix to remove duplicate texts.

Without changes, Boylston (not affected by shuttle) vs Copley (affected by shuttle):

![image](https://user-images.githubusercontent.com/2136286/95359709-72435a80-0898-11eb-9086-b4c1884caa47.png)


With changes, Boylston vs. Copley:

![image](https://user-images.githubusercontent.com/2136286/95359436-255f8400-0898-11eb-8945-4bc165e3a056.png)


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
