### PR TITLE
☎️ Add support for CharlieCard or Ticket number

### DIFF
--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -37,7 +37,7 @@ defmodule Feedback.Mailer do
       <ZIPCODE></ZIPCODE>
       <EMAILID>#{format_email(message.email)}</EMAILID>
       <PHONE>#{message.phone}</PHONE>
-      <DESCRIPTION>#{message.comments}</DESCRIPTION>
+      <DESCRIPTION>#{ticket_number(message)}#{message.comments}</DESCRIPTION>
       <CUSTREQUIRERESP>#{no_request_response}</CUSTREQUIRERESP>
       <MBTASOURCE>Auto Ticket 2</MBTASOURCE>
     </INCIDENT>
@@ -113,4 +113,16 @@ defmodule Feedback.Mailer do
     date
     |> Timex.format!("{0M}/{0D}/{YYYY} {h24}:{m}")
   end
+
+  defp ticket_number(%Message{
+         service: "Complaint",
+         subject: "CharlieCards & Tickets",
+         ticket_number: ticket_number
+       }),
+       do: """
+       CharlieCard or Ticket number: #{ticket_number}
+
+       """
+
+  defp ticket_number(_), do: nil
 end

--- a/apps/feedback/lib/message.ex
+++ b/apps/feedback/lib/message.ex
@@ -74,7 +74,8 @@ defmodule Feedback.Message do
     :subject,
     :incident_date_time,
     :no_request_response,
-    :photos
+    :photos,
+    :ticket_number
   ]
 
   @type t :: %__MODULE__{
@@ -87,7 +88,8 @@ defmodule Feedback.Message do
           subject: String.t(),
           no_request_response: boolean,
           incident_date_time: DateTime.t(),
-          photos: [Plug.Upload.t()] | nil
+          photos: [Plug.Upload.t()] | nil,
+          ticket_number: String.t() | nil
         }
 
   @spec service_options() :: [service_option_with_subjects()]

--- a/apps/feedback/test/mailer_test.exs
+++ b/apps/feedback/test/mailer_test.exs
@@ -208,5 +208,48 @@ defmodule Feedback.MailerTest do
                Mailer.send_heat_ticket(message, nil)
              end) =~ "disgruntled@user.com"
     end
+
+    test "prepends ticket number to the description for charliecard/ticket complaints" do
+      Mailer.send_heat_ticket(
+        %{
+          @base_message
+          | service: "Complaint",
+            subject: "CharlieCards & Tickets",
+            ticket_number: "123abc"
+        },
+        nil
+      )
+
+      assert Test.latest_message()["text"]
+             |> String.contains?("CharlieCard or Ticket number: 123abc")
+    end
+
+    test "does not add ticket number for non-complaints" do
+      Mailer.send_heat_ticket(
+        %{
+          @base_message
+          | service: "Question",
+            subject: "CharlieCards & Tickets",
+            ticket_number: "123abc"
+        },
+        nil
+      )
+
+      refute Test.latest_message()["text"]
+             |> String.contains?("CharlieCard or Ticket number: 123abc")
+    end
+
+    test "does not add ticket number for other subjects" do
+      Mailer.send_heat_ticket(
+        %{
+          @base_message
+          | ticket_number: "123abc"
+        },
+        nil
+      )
+
+      refute Test.latest_message()["text"]
+             |> String.contains?("123abc")
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [☎️ Add support for CharlieCard or Ticket number](https://app.asana.com/0/385363666817452/1188535657153277/f)

Adds backend support for a new ticket_number field that will be submitted along with the comments.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
