### PR TITLE
Support for mode, route and vehicle number

### DIFF
--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -24,11 +24,11 @@ defmodule Feedback.Mailer do
       <CATEGORY>#{message.subject}</CATEGORY>
       <TOPIC>#{topic(message)}</TOPIC>
       <SUBTOPIC></SUBTOPIC>
-      <MODE></MODE>
-      <LINE></LINE>
+      <MODE>#{message.mode}</MODE>
+      <LINE>#{message.line}</LINE>
       <STATION></STATION>
       <INCIDENTDATE>#{formatted_utc_timestamp(message.incident_date_time)}</INCIDENTDATE>
-      <VEHICLE></VEHICLE>
+      <VEHICLE>#{message.vehicle}</VEHICLE>
       <FIRSTNAME>#{first_name}</FIRSTNAME>
       <LASTNAME>#{last_name}</LASTNAME>
       <FULLNAME>#{full_name}</FULLNAME>

--- a/apps/feedback/lib/message.ex
+++ b/apps/feedback/lib/message.ex
@@ -75,7 +75,10 @@ defmodule Feedback.Message do
     :incident_date_time,
     :no_request_response,
     :photos,
-    :ticket_number
+    :ticket_number,
+    :mode,
+    :line,
+    :vehicle
   ]
 
   @type t :: %__MODULE__{
@@ -89,7 +92,10 @@ defmodule Feedback.Message do
           no_request_response: boolean,
           incident_date_time: DateTime.t(),
           photos: [Plug.Upload.t()] | nil,
-          ticket_number: String.t() | nil
+          ticket_number: String.t() | nil,
+          mode: String.t() | nil,
+          line: String.t() | nil,
+          vehicle: String.t() | nil
         }
 
   @spec service_options() :: [service_option_with_subjects()]

--- a/apps/site/assets/css/_customer-support.scss
+++ b/apps/site/assets/css/_customer-support.scss
@@ -229,6 +229,19 @@ a:first-of-type > h3 {
   }
 }
 
-#support-date{
+#support-date {
   width: 55%;
+}
+
+#support_vehicle {
+  margin-right: $base-spacing-sm;
+}
+
+.c-mode-selector {
+  margin-right: $base-spacing;
+  width: 40%;
+}
+
+.c-route-selector {
+  width: 100%;
 }

--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -19,7 +19,68 @@ export default function($ = window.jQuery) {
         setupValidation($);
 
         handleSubmitClick($, toUpload);
+
+        handleModeChangeSelection($);
       });
+    },
+    { passive: true }
+  );
+}
+
+export function handleModeChangeSelection($) {
+  const modeOptionsEl = document.getElementById("js-routes-by-mode");
+  const modeOptions = JSON.parse(modeOptionsEl.innerHTML);
+
+  const vehicleLabels = {
+    bus: "Bus",
+    commuter_rail: "Train",
+    subway: "Vehicle",
+    ferry: "Boat"
+  };
+
+  // initially hide the choices for route and vehicle
+  $("#routeAndVehicle").hide();
+
+  const modeSelect = document.getElementById("support_mode");
+  modeSelect.addEventListener(
+    "change",
+    ev => {
+      // empty contents of the select first:
+      $("#support_route").empty();
+
+      const routeSelect = document.getElementById("support_route");
+
+      // Get the text property of the <option> selected
+      // and build key in order to access the 'modeOptions' object
+      const selectedText = ev.target.selectedOptions[0].text;
+
+      const key = selectedText
+        .split(" ")
+        .map(el => el.toLowerCase())
+        .join("_");
+
+      const opts = modeOptions[`${key}_options`];
+
+      if (!!opts) {
+        $("#routeAndVehicle").show();
+        // update label:
+        $("#vehicleLabel").text(`${vehicleLabels[key]} number`);
+
+        // Create options for the select (prepending an extra one for 'Select'):
+        const option = document.createElement("option");
+        option.text = "Select";
+        option.value = " ";
+        routeSelect.appendChild(option);
+
+        opts.forEach(element => {
+          const opt = document.createElement("option");
+          opt.text = element;
+          opt.value = element;
+          routeSelect.appendChild(opt);
+        });
+      } else {
+        $("#routeAndVehicle").hide();
+      }
     },
     { passive: true }
   );

--- a/apps/site/assets/js/test/support-form_test.js
+++ b/apps/site/assets/js/test/support-form_test.js
@@ -8,9 +8,10 @@ import {
   handleUploadedPhoto,
   setupTextArea,
   handleSubmitClick,
-  rescale
+  rescale,
+  handleModeChangeSelection
 } from "../support-form";
-import testConfig from "./../../ts/jest.config";
+import testConfig from "../../ts/jest.config";
 
 const { testURL } = testConfig;
 
@@ -47,22 +48,22 @@ describe("support form", () => {
     });
   });
 
-  describe("rescale", function() {
-    it("returns the same dimensions if they are in the limit", function() {
+  describe("rescale", () => {
+    it("returns the same dimensions if they are in the limit", () => {
       let dim = { width: 900, height: 900 };
       dim = rescale(dim);
       assert.equal(dim.width, 900);
       assert.equal(dim.height, 900);
     });
 
-    it("returns a properly scaled dimension if the width is longer", function() {
+    it("returns a properly scaled dimension if the width is longer", () => {
       let dim = { width: 2000, height: 1000 };
       dim = rescale(dim);
       assert.equal(dim.width, 1000);
       assert.equal(dim.height, 500);
     });
 
-    it("returns a properly scaled dimension if the height is longer", function() {
+    it("returns a properly scaled dimension if the height is longer", () => {
       let dim = { width: 1000, height: 2000 };
       dim = rescale(dim);
       assert.equal(dim.width, 500);
@@ -71,7 +72,7 @@ describe("support form", () => {
   });
 
   describe("handleUploadedPhoto", () => {
-    var toUpload = [];
+    let toUpload = [];
 
     beforeEach(() => {
       toUpload = [];
@@ -141,9 +142,7 @@ describe("support form", () => {
 
       handleUploadedPhoto($, blob, $(".photo-preview-container"), toUpload);
 
-      let fileNames = toUpload.map(file => {
-        return file.name;
-      });
+      const fileNames = toUpload.map(file => file.name);
       assert.deepEqual(fileNames, ["test-file", "test-file-2"]);
     });
 
@@ -191,20 +190,12 @@ describe("support form", () => {
       const $second_photo = $preview.last();
       $first_photo.find(".clear-photo").trigger("click");
 
-      let fileNames = toUpload.map(file => {
-        return file.name;
-      });
+      const fileNames = toUpload.map(file => file.name);
       assert.notInclude(fileNames, "test-file");
     });
   });
 
   describe("setupTextArea", () => {
-    function enterComment(comment) {
-      const $textarea = $("#comments");
-      $textarea.val(comment);
-      $textarea.blur();
-    }
-
     beforeEach(() => {
       $("#test").html(`
         <div class="form-group">
@@ -227,7 +218,7 @@ describe("support form", () => {
   });
 
   describe("handleSubmitClick", () => {
-    var spy;
+    let spy;
     const toUpload = [];
 
     beforeEach(() => {
@@ -385,7 +376,7 @@ describe("support form", () => {
     });
 
     it("disables the submit button and shows the spinner on submit", () => {
-      var isWaiting = false;
+      let isWaiting = false;
 
       $("#support-submit").on("waiting:start", () => {
         assert.isTrue($("#support-submit").prop("disabled"));
@@ -460,12 +451,12 @@ describe("support form", () => {
 
     it("sends multiple files down to the server", () => {
       $("#no_request_response").click();
-      let file_1 = new File({
+      const file_1 = new File({
         name: "test-file",
         buffer: new Buffer("this is a 24 byte string"),
         type: "image/png"
       });
-      let file_2 = new File({
+      const file_2 = new File({
         name: "test-file-2",
         buffer: new Buffer("this is now a 28 byte string"),
         type: "image/png"
@@ -485,6 +476,58 @@ describe("support form", () => {
       // getAll returns [ "[object Object]", "[object Object]" ]
       // not sure how to recover actual values
       assert.equal(photos.length, toUpload.length);
+    });
+  });
+
+  describe("handleModeChangeSelection", () => {
+    beforeEach(() => {
+      const opts = { opt1_options: [1, 2, 3], opt2_options: [4, 5] };
+
+      $("#test").html(`
+      <script id="js-routes-by-mode" type="text/plain">
+        ${JSON.stringify(opts)}
+      </script>
+       <select class="c-select c-mode-selector" id="support_mode">
+         <option value=" ">Select</option>
+         <option value="opt1">opt1</option>
+         <option value="opt2">opt2</option>
+       </select>
+       <div id="routeAndVehicle">
+        <select class="c-select c-route-selector" id="support_route"></select>
+       </div>
+     `);
+      handleModeChangeSelection($);
+    });
+
+    afterEach(() => {
+      $("#test").remove();
+    });
+
+    it("detects a new selection and updates the options with dynamic values", () => {
+      // initEvent is deprecated and no longer recommended but the newer way of triggering events nor jQuery's .change() were triggering a change in the selection
+
+      const sortBySelect = document.querySelector("select.c-mode-selector");
+      sortBySelect.value = "opt2";
+      const event = document.createEvent("HTMLEvents");
+      event.initEvent("change", false, false);
+      sortBySelect.dispatchEvent(event);
+
+      assert.equal(
+        $("#support_route").html(),
+        `<option value=" ">Select</option><option value="4">4</option><option value="5">5</option>`
+      );
+    });
+
+    it("detects a new but invalid selection so it hides the container", () => {
+      // initEvent is deprecated and no longer recommended but the newer way of triggering events nor jQuery's .change() were triggering a change in the selection
+
+      const sortBySelect = document.querySelector("select.c-mode-selector");
+      sortBySelect.value = " ";
+      const event = document.createEvent("HTMLEvents");
+      event.initEvent("change", false, false);
+      sortBySelect.dispatchEvent(event);
+
+      assert.isFalse($("#routeAndVehicle").is(":visible"));
     });
   });
 });

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -1,3 +1,6 @@
+<script id="js-routes-by-mode" type="text/plain">
+  <%= raw Poison.encode!(@all_options_per_mode) %>
+</script>
 <% form_action = "#{customer_support_path(@conn, :submit)}#support-result" %>
 
 <%= form_for @conn, form_action, [as: :support, multipart: true, method: :post, id: "support-form", class: "support-form"], fn f -> %>
@@ -11,8 +14,7 @@
       <div id="service" class="service-radios">
         <%= for {text, value, _subjects} <- @service_options do %>
           <span class="form-check service-radio">
-            <%= radio_button f, :service, value, class: "support-form-control service c-radio",
-                                                id: "service-#{value}" %>
+            <%= radio_button f, :service, value, class: "support-form-control service c-radio", id: "service-#{value}" %>
             <%= label f, :service, text, [for: "service-#{value}", class: "c-radio__label"] %>
           </span>
         <% end %>
@@ -21,8 +23,7 @@
     <div class="form-group <%= class_for_error("comments", @errors, "has-danger", "has-success") %>">
       <%= support_error_tag @errors, "comments" %>
       <%= label f, :comments, "Let us know how we can help*", [for: "comments", class: "form-control-label"] %>
-      <%= textarea f, :comments, id: "comments", class: "support-form-text-input form-control #{class_for_error("comments", @errors, "form-control-danger", "form-control-success")}", "aria-describedby": "commentsHelp", maxlength: "3000",
-                                rows: "3", placeholder: placeholder_text("comments"), required: "required", value: assigns[:comments] %>
+      <%= textarea f, :comments, id: "comments", class: "support-form-text-input form-control #{class_for_error("comments", @errors, "form-control-danger", "form-control-success")}", "aria-describedby": "commentsHelp", maxlength: "3000", rows: "3", placeholder: placeholder_text("comments"), required: "required", value: assigns[:comments] %>
       <small id="commentsHelp" class="form-text">3000 characters maximum</small>
     </div>
     <div id="support-datepicker" class="m-trip-plan__departure-last">
@@ -34,7 +35,32 @@
     </div>
   </section>
   <section>
-    <%# <h3>Additional Details (optional)</h3> %>
+    <h3>Additional Details (optional)</h3>
+    <div>Adding more details helps us more effectively respond to your concerns.</div>
+    <div class="form-group">
+      <%= label f, "Mode", [for: "support_mode", class: "form-control-label"] %>
+      <div class="plan-time-select">
+        <%= select(f, :mode, get_all_modes(), class: "c-select c-mode-selector") %>
+      </div>
+    </div>
+    <div id="routeAndVehicle" class="form-group m-schedule-line__connection-line">
+      <div class="c-mode-selector">
+        <%= label f, "Route", [for: "support_route", class: "form-control-label"] %>
+        <div class="plan-time-select">
+          <%= select(f, :route, [], class: "c-select c-route-selector") %>
+        </div>
+      </div>
+      <div class="plan-time-select">
+        <%= label f, "Vehicle", [id: "vehicleLabel", for: "support_vehicle", class: "form-control-label"] %>
+        <div>
+          <%= text_input(f, :vehicle, placeholder: placeholder_text("vehicle"), class: "plan-date-input") %>
+          <span data-toggle="tooltip" data-placement="right" title="Vehicle numbers are usually displayed overhead at either end of the vehicle, and always displayed on the exterior.">
+            <span aria-hidden="true" class="c-search-result__content-icon fa fa-info">
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
     <div class="form-group <%= if @errors do class_for_error("upload", @errors, "has-danger", "has-success") end %>">
       <%= support_error_tag @errors, "upload" %>
       <span id="upload-photo-error"></span>
@@ -60,26 +86,22 @@
       <div class="form-group <%= class_for_error("first_name", @errors, "has-danger", "has-success") %>">
         <%= label f, :first_name, "First Name*", [for: "first_name", class: "form-control-label"] %>
         <%= support_error_tag @errors, "first_name" %>
-        <%= text_input f, :first_name, placeholder: placeholder_text("first_name"), class: "support-form-text-input support-form-text-input--small form-control #{class_for_error("first_name", @errors, "form-control-danger", "form-control-success")}",
-                                  autocomplete: "first_name", id: "first_name" %>
+        <%= text_input f, :first_name, placeholder: placeholder_text("first_name"), class: "support-form-text-input support-form-text-input--small form-control #{class_for_error("first_name", @errors, "form-control-danger", "form-control-success")}", autocomplete: "first_name", id: "first_name" %>
       </div>
       <div class="form-group <%= class_for_error("last_name", @errors, "has-danger", "has-success") %>">
         <%= label f, :name, "Last Name*", [for: "last_name", class: "form-control-label"] %>
         <%= support_error_tag @errors, "last_name" %>
-        <%= text_input f, :last_name, placeholder: placeholder_text("last_name"), class: "support-form-text-input support-form-text-input--small form-control #{class_for_error("last_name", @errors, "form-control-danger", "form-control-success")}",
-                                  autocomplete: "last_name", id: "last_name" %>
+        <%= text_input f, :last_name, placeholder: placeholder_text("last_name"), class: "support-form-text-input support-form-text-input--small form-control #{class_for_error("last_name", @errors, "form-control-danger", "form-control-success")}", autocomplete: "last_name", id: "last_name" %>
       </div>
       <div class="form-group <%= class_for_error("email", @errors, "has-danger", "has-success") %>">
         <%= label f, :email, "Email*", [for: "email", class: "form-control-label"] %>
         <%= support_error_tag @errors, "email" %>
-        <%= text_input f, :email, placeholder: placeholder_text("email"), class: "form-control support-form-text-input support-form-text-input--small #{class_for_error("email", @errors, "form-control-danger", "form-control-success")}",
-                                  autocomplete: "email", id: "email" %>
+        <%= text_input f, :email, placeholder: placeholder_text("email"), class: "form-control support-form-text-input support-form-text-input--small #{class_for_error("email", @errors, "form-control-danger", "form-control-success")}", autocomplete: "email", id: "email" %>
       </div>
       <div class="form-group">
         <%= help_text "phone" %>
         <%= label f, :phone, "Phone number", [for: "phone", class: "form-control-label"] %>
-        <%= telephone_input f, :phone, placeholder: placeholder_text("phone"), class: "support-form-text-input support-form-text-input--small form-control", "aria-describedby": "phoneHelp",
-                                        autocomplete: "tel", id: "phone" %>
+        <%= telephone_input f, :phone, placeholder: placeholder_text("phone"), class: "support-form-text-input support-form-text-input--small form-control", "aria-describedby": "phoneHelp", autocomplete: "tel", id: "phone" %>
       </div>
       <div class="form-group <%= class_for_error("privacy", @errors, "has-danger", "has-success") %> mb-0 mt-1">
         <%= support_error_tag @errors, "privacy" %>

--- a/apps/site/lib/site_web/views/customer_support_view.ex
+++ b/apps/site/lib/site_web/views/customer_support_view.ex
@@ -3,7 +3,7 @@ defmodule SiteWeb.CustomerSupportView do
   Helper functions for handling interaction with and submitting the customer support form
   """
   use SiteWeb, :view
-
+  alias Routes.Route
   import Phoenix.HTML.Tag, only: [content_tag: 2, content_tag: 3]
 
   def photo_info(%{
@@ -54,6 +54,7 @@ defmodule SiteWeb.CustomerSupportView do
   def placeholder_text("last_name"), do: "Smith"
   def placeholder_text("email"), do: "janesmith@email.com"
   def placeholder_text("phone"), do: "(555)-555-5555"
+  def placeholder_text("vehicle"), do: "e.g. 00001"
   def placeholder_text(_), do: ""
 
   def help_text("phone"),
@@ -84,6 +85,31 @@ defmodule SiteWeb.CustomerSupportView do
     else
       nil
     end
+  end
+
+  @spec get_all_modes() :: list
+  def get_all_modes() do
+    # get options for subway, bus, commuter rail and ferry:
+    subway_bus_cr_ferry_opts =
+      Enum.map(1..4, fn mode ->
+        mode_name = SiteWeb.ViewHelpers.mode_name(mode)
+
+        if mode == 3 do
+          [key: mode_name, value: "Bus Other"]
+        else
+          [key: mode_name, value: mode_name]
+        end
+      end)
+      |> List.insert_at(0, key: "Select", value: " ")
+
+    # append The RIDE:
+    the_ride = Route.type_name(:the_ride)
+
+    subway_bus_cr_ferry_opts
+    |> List.insert_at(Enum.count(subway_bus_cr_ferry_opts),
+      key: the_ride,
+      value: the_ride
+    )
   end
 
   defp error_msg("service"), do: "Please select the type of concern."

--- a/apps/site/lib/site_web/views/helpers.ex
+++ b/apps/site/lib/site_web/views/helpers.ex
@@ -14,6 +14,14 @@ defmodule SiteWeb.ViewHelpers do
 
   alias Routes.Route
 
+  @subway_lines [
+    :red_line,
+    :blue_line,
+    :orange_line,
+    :green_line,
+    :silver_line
+  ]
+
   # precompile the SVGs, rather than hitting the filesystem every time
   for path <-
         :site
@@ -37,6 +45,8 @@ defmodule SiteWeb.ViewHelpers do
       )
     end
   end
+
+  def subway_lines, do: @subway_lines
 
   def svg(unknown) do
     raise ArgumentError, message: "unknown SVG #{unknown}"
@@ -176,13 +186,7 @@ defmodule SiteWeb.ViewHelpers do
   def mode_name(:free_fare), do: "Free Service"
 
   def mode_name(mode_atom)
-      when mode_atom in [
-             :red_line,
-             :blue_line,
-             :orange_line,
-             :green_line,
-             :silver_line
-           ] do
+      when mode_atom in @subway_lines do
     mode_atom
     |> Atom.to_string()
     |> String.split("_")


### PR DESCRIPTION
#### Summary of changes
**Asana Tickets:**
[☎️ Additional Details: Mode, Route, and Vehicle number (frontend)](https://app.asana.com/0/555089885850811/1188547161220086)
[☎️ Additional Details: Mode, Route, and Vehicle number (backend)](https://app.asana.com/0/555089885850811/1188535657153279)

These three extra fields have been added to the Customer Support form:
<img width="652" alt="image" src="https://user-images.githubusercontent.com/61979382/95601343-50291400-0a21-11eb-8597-164a750916a8.png">

The routes and label for the vehicle field are both refreshed depending on the choice for mode.

