### PR TITLE
Add Subject field to the customer support form

### DIFF
--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -16,6 +16,7 @@ export default function($ = window.jQuery) {
         setupPhotoPreviews($, toUpload);
         setupTextArea();
         setupRequestResponse($);
+        setupSubject($);
         setupValidation($);
 
         handleSubmitClick($, toUpload);
@@ -195,6 +196,26 @@ export function setupTextArea() {
     },
     { passive: true }
   );
+}
+
+export function setupSubject($) {
+  const support_service_opts = JSON.parse(
+    document.getElementById("js-subjects-by-service").innerHTML
+  );
+  // show the field once a category is selected
+  $("[name='support[service]']").change(function() {
+    // remove all <options> except the first
+    $("#support_subject option")
+      .nextAll()
+      .remove();
+    const selectedCategory = $("[name='support[service]']:checked").val();
+    const selectedOptions = support_service_opts[selectedCategory];
+    if (selectedOptions) {
+      $("#support_subject").append(
+        selectedOptions.map(opt => `<option value=${opt}>${opt}</option>`)
+      );
+    }
+  });
 }
 
 function findSiblingWithClass(node, className) {

--- a/apps/site/assets/js/test/support-form_test.js
+++ b/apps/site/assets/js/test/support-form_test.js
@@ -7,6 +7,7 @@ import {
   clearFallbacks,
   handleUploadedPhoto,
   setupTextArea,
+  setupSubject,
   handleSubmitClick,
   rescale
 } from "../support-form";
@@ -226,6 +227,49 @@ describe("support form", () => {
     });
   });
 
+  describe("setupSubject", () => {
+    beforeEach(() => {
+      $("#test").html(`
+        <script id="js-subjects-by-service" type="text/plain">
+          ${JSON.stringify({
+            Complaint: ["complaint 1", "complaint 2"],
+            Inquiry: ["inquiry 1", "inquiry 2", "inquiry 3"]
+          })}
+        </script>
+        <div class="form-group">
+          <input type="radio" name="support[service]" value="Complaint">Complaint</input>
+          <input type="radio" name="support[service]" value="Inquiry">Question</input>
+        </div>
+        <select class="form-control c-select" id="support_subject" name="support[subject]"><option value="">Please choose a subject</option></select>
+      `);
+
+      setupSubject($);
+    });
+
+    afterEach(() => {
+      $("#test").empty();
+    });
+
+    it("changes options based on selected service", () => {
+      const servicesChoices = document.querySelectorAll(
+        "[name='support[service]']"
+      );
+      $(servicesChoices)
+        .eq(0)
+        .prop("checked", true)
+        .trigger("change");
+      const options1 = [...document.querySelectorAll("option")];
+      assert.lengthOf(options1, 3);
+      $(servicesChoices)
+        .eq(1)
+        .prop("checked", true)
+        .trigger("change");
+      const options2 = [...document.querySelectorAll("option")];
+      assert.lengthOf(options2, 4);
+      assert.notEqual(options1, options2);
+    });
+  });
+
   describe("handleSubmitClick", () => {
     var spy;
     const toUpload = [];
@@ -240,7 +284,7 @@ describe("support form", () => {
             <input name="support[service]" value="Complaint">Complaint</input>
             <input name="support[service]" value="Suggestion">Comment</input>
             <input name="support[service]" value="Inquiry">Question</input>
-            <input name="support[service]" value="Inquiry">Request</input>
+            <input name="support[service]" value="Commendation">Request</input>
             <div class="support-comments-error-container hidden-xs-up" tabindex="-1"><div class="support-comments-error"></div></div>
             <textarea name="support[comments]" id="comments"></textarea>
             <input name="support[photo]" id="photo" type="file" />

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -1,4 +1,7 @@
 <% form_action = "#{customer_support_path(@conn, :submit)}#support-result" %>
+<script id="js-subjects-by-service" type="text/plain">
+<%= raw Poison.encode!(subject_map(@service_options)) %>
+</script>
 
 <%= form_for @conn, form_action, [as: :support, multipart: true, method: :post, id: "support-form", class: "support-form"], fn f -> %>
   <h2>Email Us</h2>
@@ -18,6 +21,10 @@
         <% end %>
       </div>
     </fieldset>
+    <div class="form-group <%= class_for_error("subject", @errors, "has-danger", "has-success") %>">
+      <%= label f, :subject, "Subject", [for: "support_subject", class: "form-control-label"] %>
+      <%= select f, :subject, [], prompt: "Please choose a subject", value: "", class: "form-control c-select" %>
+    </div>
     <div class="form-group <%= class_for_error("comments", @errors, "has-danger", "has-success") %>">
       <%= support_error_tag @errors, "comments" %>
       <%= label f, :comments, "Let us know how we can help*", [for: "comments", class: "form-control-label"] %>

--- a/apps/site/lib/site_web/views/customer_support_view.ex
+++ b/apps/site/lib/site_web/views/customer_support_view.ex
@@ -6,6 +6,8 @@ defmodule SiteWeb.CustomerSupportView do
 
   import Phoenix.HTML.Tag, only: [content_tag: 2, content_tag: 3]
 
+  alias Feedback.Message
+
   def photo_info(%{
         "photo" => %Plug.Upload{path: path, filename: filename, content_type: content_type}
       }) do
@@ -43,6 +45,13 @@ defmodule SiteWeb.CustomerSupportView do
         content_tag(:p, "All fields with an asterisk* are required.")
       ]
     )
+  end
+
+  @spec subject_map([Message.service_option_with_subjects()]) ::
+          {Message.service_value(), [Message.subject_value()]}
+  def subject_map(service_options) do
+    service_options
+    |> Enum.into(%{}, fn {_text, value, subjects} -> {value, subjects} end)
   end
 
   @spec placeholder_text(String.t()) :: String.t()

--- a/apps/site/lib/site_web/views/customer_support_view.ex
+++ b/apps/site/lib/site_web/views/customer_support_view.ex
@@ -48,7 +48,7 @@ defmodule SiteWeb.CustomerSupportView do
   end
 
   @spec subject_map([Message.service_option_with_subjects()]) ::
-          {Message.service_value(), [Message.subject_value()]}
+          %{Message.service_value() => [Message.subject_value()]}
   def subject_map(service_options) do
     service_options
     |> Enum.into(%{}, fn {_text, value, subjects} -> {value, subjects} end)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [☎️ Add Subject field to the customer support form](https://app.asana.com/0/385363666817452/1188535657153281/f)

Front end support for the (not yet required) subject field and its interaction with the value selected from the service category radio inputs.


---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [ ] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
