### PR TITLE
Run message body through profanity sanitizer

### DIFF
--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import Filter from "bad-words";
 
 export default function($ = window.jQuery) {
   document.addEventListener(
@@ -461,9 +462,13 @@ export function handleSubmitClick($, toUpload) {
     }
     deactivateSubmitButton($);
     const formData = new FormData();
+    const filter = new Filter();
     $("#support-form")
       .serializeArray()
       .forEach(({ name: name, value: value }) => {
+        if (name === "support[comments]") {
+          value = filter.clean(value);
+        }
         formData.append(name, value);
       });
     toUpload.forEach(photo => {

--- a/apps/site/assets/js/test/support-form_test.js
+++ b/apps/site/assets/js/test/support-form_test.js
@@ -3,6 +3,7 @@ import jsdom from "mocha-jsdom";
 import { File } from "file-api";
 import "custom-event-autopolyfill";
 import sinon from "sinon";
+import { cloneDeep } from "lodash";
 import {
   clearFallbacks,
   handleUploadedPhoto,
@@ -520,6 +521,33 @@ describe("support form", () => {
       // getAll returns [ "[object Object]", "[object Object]" ]
       // not sure how to recover actual values
       assert.equal(photos.length, toUpload.length);
+    });
+
+    it("passes comment thru profanity filter", () => {
+      const Filter = require("bad-words");
+      const f = new Filter();
+      f.addWords("redsox");
+      const fakeCleanFn = f.clean.bind(cloneDeep(f)); // need to copy it so it's not stubbed by sinon
+      const profanityStub = sinon
+        .stub(Filter.prototype, "clean")
+        .callsFake(fakeCleanFn);
+
+      $('[name="support[service]"][value="Commendation"]').attr(
+        "checked",
+        true
+      );
+      $("#comments").val("the redsox win");
+      $("#no_request_response").attr("checked", true);
+      $("#g-recaptcha-response").val("response");
+      $("#support-submit").click();
+      const censoredComments = spy.firstCall.args[0].data.getAll(
+        "support[comments]"
+      )[0];
+
+      assert.equal(profanityStub.callCount, 1);
+      assert.equal(censoredComments, "the ****** win");
+
+      profanityStub.restore();
     });
   });
 

--- a/apps/site/assets/package-lock.json
+++ b/apps/site/assets/package-lock.json
@@ -7890,6 +7890,19 @@
         }
       }
     },
+    "bad-words": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.3.tgz",
+      "integrity": "sha512-To+nGz+U8SpEQieZ2kSadY/1hVO88UXAslCJuTgLjDOuGrs/tNW2BYwl0fctxcRLooe0nzYN1pGzgvRIrd0BeA==",
+      "requires": {
+        "badwords-list": "^1.0.0"
+      }
+    },
+    "badwords-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
+      "integrity": "sha1-XphW2/E0gqKVw7CzBK+51M/FxXk="
+    },
     "bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",

--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -6,6 +6,7 @@
     "@types/dot-prop-immutable": "^1.5.0",
     "algoliasearch": "^3.25.1",
     "autocomplete.js": "git+https://github.com/mbta/autocomplete.js.git#ad94896",
+    "bad-words": "^3.0.3",
     "bootstrap": "4.0.0-alpha.2",
     "core-js": "^2.6.5",
     "dot-prop-immutable": "^1.5.0",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [☎️ Profanity sanitizer](https://app.asana.com/0/385363666817452/1188547161220113/f)

Uses the `bad-words` package to filter the text in the comments field before sending to the backend.
I didn't have the heart to put curse words in our codebase, so the test that I wrote for it modifies the library's behavior a bit to add a fake curse word... hopefully you get the idea 😅 