### PR TITLE
Fix for accordions not expanding (when translating page)

### DIFF
--- a/apps/site/assets/css/_accordion-ui.scss
+++ b/apps/site/assets/css/_accordion-ui.scss
@@ -12,18 +12,18 @@
 
 .c-accordion-ui__trigger {
   @include icon-size-inline(1.5em);
+  background-color: transparent;
   border-bottom: solid $border-width $brand-primary-dark;
+  border-left: 0;
+  border-right: 0;
+  border-top: 0;
   color: $brand-primary;
   // Flexbox used to keep indicator icon right
   display: flex;
   justify-content: space-between;
+  text-align: left;
+  text-decoration: none;
   width: 100%;
-
-  &[role='button'] {
-    // <a> is higher spec. than single class,
-    // so bump up the spec by using an attr.
-    text-decoration: none;
-  }
 
   &:hover {
     background-color: $brand-primary-lightest;
@@ -32,7 +32,7 @@
 }
 
 .c-accordion-ui__indicator {
-  align-items: center;
+  align-self: center;
   display: flex;
   padding-left: $base-spacing * 2;
 }

--- a/apps/site/assets/css/_customer-support.scss
+++ b/apps/site/assets/css/_customer-support.scss
@@ -193,8 +193,15 @@ body {
 }
 
 .c-expandable-block__link {
+  background-color: transparent;
+  border: 0;
   color: inherit;
+  margin-top: 1.075em;
+  padding: 0;
+  text-align: left;
   text-decoration: none;
+  width: 100%;
+
   &:hover {
     text-decoration: inherit;
   }
@@ -203,8 +210,8 @@ body {
   }
 }
 
-
-a:first-of-type > h3 {
+.c-expandable-block__link > h3,
+.c-expandable-block__link:nth-of-type(1) {
   margin-top: 0;
 }
 

--- a/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
@@ -2,9 +2,8 @@
   <%= for section <- @sections do %>
     <div class="panel" role="heading">
       <div class="c-accordion-ui__heading<%= if assigns[:sticky] do %> fixedsticky sticky-top<% end %>">
-        <a class="c-accordion-ui__trigger collapsed"
-            href="#<%= section.prefix %>-section"
-            role="button"
+        <button class="c-accordion-ui__trigger collapsed"
+            data-target="#<%= section.prefix %>-section"
             aria-expanded="false"
             aria-controls="<%= section.prefix %>-section"
             data-toggle="collapse"
@@ -15,7 +14,7 @@
           <div class="c-accordion-ui__indicator">
             <span class="c-indicator__content c-indicator__content--angle"></span>
           </div>
-        </a>
+        </button>
       </div>
       <div class="c-accordion-ui__target collapse js-focus-on-expand"
           id="<%= section.prefix %>-section"

--- a/apps/site/lib/site_web/templates/partial/_expandable_block.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_expandable_block.html.eex
@@ -2,13 +2,12 @@
 <% header_id = "header-#{@id}" %>
 <% panel_id = "panel-#{@id}" %>
 
-<a class="c-expandable-block__link"
-  href="#<%= panel_id %>"
+<button class="c-expandable-block__link"
+  data-target="#<%= panel_id %>"
   tabIndex="0"
   id="<%= header_id %>"
   aria-expanded="<%= @initially_expanded %>"
   aria-controls="<%= panel_id %>"
-  role="button"
   data-toggle="collapse">
   <h3 class="c-expandable-block__header">
     <%= if @header.iconSvgText do %>
@@ -19,7 +18,7 @@
       <span class="c-expandable-block-caret"></span>
     </div>
   </h3>
-</a>
+</button>
 <div
   class="c-expandable-block__panel collapse<%= if @initially_expanded do %> in<% end %> js-focus-on-expand"
   tabIndex="0"

--- a/apps/site/test/site_web/views/paragraph_view_test.exs
+++ b/apps/site/test/site_web/views/paragraph_view_test.exs
@@ -663,8 +663,7 @@ defmodule SiteWeb.CMS.ParagraphViewTest do
         {_,
          [
            _,
-           {"href", href_1},
-           _,
+           {"data-target", href_1},
            _,
            {"aria-controls", aria_controls_1},
            _,
@@ -673,8 +672,7 @@ defmodule SiteWeb.CMS.ParagraphViewTest do
         {_,
          [
            _,
-           {"href", href_2},
-           _,
+           {"data-target", href_2},
            _,
            {"aria-controls", aria_controls_2},
            _,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Translation | Accordions do not open in Google Translate tool](https://app.asana.com/0/555089885850811/1191214531803714)

Google translate seems to translate the `href` content as well, so we are using buttons instead of anchors and making the necessary readjustments on the CSS side accordingly.

These changes actually shouldn't have any visual impact.



