### PR TITLE
Prevent text of button from overflowing

### DIFF
--- a/apps/site/assets/css/_buttons.scss
+++ b/apps/site/assets/css/_buttons.scss
@@ -147,6 +147,7 @@
 
   .btn {
     margin: 1em $half-gutter / 2 0;
+    white-space: normal;
 
     @include media-breakpoint-down(sm) {
       white-space: normal;


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Button text should wrap](https://app.asana.com/0/385363666817452/1186495960085451)

Small fix to this bug.

Before:
<img width="257" alt="image" src="https://user-images.githubusercontent.com/61979382/96756521-2a492b00-13a2-11eb-8b60-9a9548db540e.png">

After:
<img width="257" alt="image" src="https://user-images.githubusercontent.com/61979382/96756554-37feb080-13a2-11eb-8196-acdde169217f.png">
