### PR TITLE
Stitch together linked lists of stops on the back-end

### DIFF
--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -49,6 +49,22 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
       assert Enum.all?(trunk_route_stops, &(&1.branch == nil))
 
+      assert_stop_ids(trunk_route_stops, [
+        "place-alfcl",
+        "place-davis",
+        "place-portr",
+        "place-harsq",
+        "place-cntsq",
+        "place-knncl",
+        "place-chmnl",
+        "place-pktrm",
+        "place-dwnxg",
+        "place-sstat",
+        "place-brdwy",
+        "place-andrw",
+        "place-jfk"
+      ])
+
       assert Enum.map(trunk_route_stops, & &1.is_terminus?) ==
                [
                  true,
@@ -85,6 +101,14 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
       assert Enum.all?(braintree_route_stops, &(&1.branch == "Alewife - Braintree"))
 
+      assert_stop_ids(braintree_route_stops, [
+        "place-nqncy",
+        "place-wlsta",
+        "place-qnctr",
+        "place-qamnl",
+        "place-brntn"
+      ])
+
       assert Enum.map(braintree_route_stops, & &1.is_terminus?) ==
                [false, false, false, false, true]
 
@@ -92,6 +116,13 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                [false, false, false, false, false]
 
       assert Enum.all?(ashmont_route_stops, &(&1.branch == "Alewife - Ashmont"))
+
+      assert_stop_ids(ashmont_route_stops, [
+        "place-shmnl",
+        "place-fldcr",
+        "place-smmnl",
+        "place-asmnl"
+      ])
 
       assert Enum.map(ashmont_route_stops, & &1.is_terminus?) ==
                [false, false, false, true]
@@ -625,6 +656,112 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                  false,
                  false,
                  false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
+    end
+
+    test "stitches together connecting patterns due to a shuttle on a branching CR line" do
+      newburyport_route = %Route{id: "CR-Newburyport"}
+
+      assert [
+               %RouteStops{branch: nil, stops: trunk_route_stops},
+               %RouteStops{branch: "North Station - Rockport", stops: rockport_route_stops},
+               %RouteStops{branch: "North Station - Newburyport", stops: newburyport_route_stops}
+             ] = Helpers.get_branch_route_stops(newburyport_route, 0)
+
+      assert Enum.all?(trunk_route_stops, &(&1.branch == nil))
+
+      assert_stop_ids(trunk_route_stops, [
+        "place-north",
+        "place-ER-0046",
+        "place-ER-0099",
+        "place-ER-0115",
+        "place-ER-0128",
+        "place-ER-0168",
+        "place-ER-0183"
+      ])
+
+      assert Enum.map(trunk_route_stops, & &1.is_terminus?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
+
+      assert Enum.map(trunk_route_stops, & &1.is_beginning?) ==
+               [
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
+
+      assert Enum.all?(rockport_route_stops, &(&1.branch == "North Station - Rockport"))
+
+      assert_stop_ids(rockport_route_stops, [
+        "place-GB-0198",
+        "place-GB-0222",
+        "place-GB-0229",
+        "place-GB-0254",
+        "place-GB-0296",
+        "place-GB-0316",
+        "place-GB-0353"
+      ])
+
+      assert Enum.map(rockport_route_stops, & &1.is_terminus?) ==
+               [
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 true
+               ]
+
+      assert Enum.map(rockport_route_stops, & &1.is_beginning?) ==
+               [
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false
+               ]
+
+      assert Enum.all?(newburyport_route_stops, &(&1.branch == "North Station - Newburyport"))
+
+      assert_stop_ids(newburyport_route_stops, [
+        "place-ER-0208",
+        "place-ER-0227",
+        "place-ER-0276",
+        "place-ER-0312",
+        "place-ER-0362"
+      ])
+
+      assert Enum.map(newburyport_route_stops, & &1.is_terminus?) ==
+               [
+                 false,
+                 false,
+                 false,
+                 false,
+                 true
+               ]
+
+      assert Enum.map(newburyport_route_stops, & &1.is_beginning?) ==
+               [
                  false,
                  false,
                  false,

--- a/apps/stops/test/route_stop_test.exs
+++ b/apps/stops/test/route_stop_test.exs
@@ -705,6 +705,16 @@ defmodule Stops.RouteStopTest do
         typicality: 1
       }
 
+      shuttle_route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "Shuttle-RockportWestGloucester-0-0",
+        name: "West Gloucester - Rockport",
+        representative_trip_id: "CR-Weekday-Summer-20-103-RockportWestGloucester1",
+        route_id: "Shuttle-RockportWestGloucester",
+        time_desc: nil,
+        typicality: 1
+      }
+
       newburyport_stops =
         make_stops(
           ~w(place-north place-ER-0046 place-ER-0099 place-ER-0115 place-ER-0128 place-ER-0168 place-ER-0183 place-ER-0208 place-ER-0227 place-ER-0276 place-ER-0312 place-ER-0362)s
@@ -712,12 +722,15 @@ defmodule Stops.RouteStopTest do
 
       rockport_stops =
         make_stops(
-          ~w(place-north place-ER-0046 place-ER-0099 place-ER-0115 place-ER-0128 place-ER-0168 place-ER-0183 place-GB-0198 place-GB-0222 place-GB-0229 place-GB-0254 place-GB-0296 place-GB-0316 place-GB-0353)s
+          ~w(place-north place-ER-0046 place-ER-0099 place-ER-0115 place-ER-0128 place-ER-0168 place-ER-0183 place-GB-0198 place-GB-0222 place-GB-0229 place-GB-0254 place-GB-0296)s
         )
+
+      shuttle_stops = make_stops(~w(place-GB-0296 place-GB-0316 place-GB-0353)s)
 
       route_patterns_with_stops = [
         {newburyport_route_pattern, newburyport_stops},
-        {rockport_route_pattern, rockport_stops}
+        {rockport_route_pattern, rockport_stops},
+        {shuttle_route_pattern, shuttle_stops}
       ]
 
       actual = list_from_route_patterns(route_patterns_with_stops, @newburyport_route, 0)

--- a/apps/stops/test/route_stop_test.exs
+++ b/apps/stops/test/route_stop_test.exs
@@ -12,6 +12,7 @@ defmodule Stops.RouteStopTest do
   @green_e_route %Route{id: "Green-E", type: 1}
   @orange_route %Route{id: "Orange", type: 1}
   @red_route %Route{id: "Red", type: 1}
+  @newburyport_route %Route{id: "CR-Newburyport", type: 0}
 
   describe "list_from_route_patterns/2" do
     test "Orange line (1 branch), direction 0" do
@@ -681,6 +682,138 @@ defmodule Stops.RouteStopTest do
                  false,
                  false
                ]
+    end
+
+    test "CR-Newburyport, direction 0" do
+      newburyport_route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "CR-Newburyport-801f0591-0",
+        name: "North Station - Newburyport",
+        representative_trip_id: "CR-Weekday-Summer-20-159",
+        route_id: "CR-Newburyport",
+        time_desc: nil,
+        typicality: 1
+      }
+
+      rockport_route_pattern = %RoutePattern{
+        direction_id: 0,
+        id: "CR-Newburyport-0d0a9699-0",
+        name: "North Station - Rockport",
+        representative_trip_id: "CR-Weekday-Summer-20-105",
+        route_id: "CR-Newburyport",
+        time_desc: nil,
+        typicality: 1
+      }
+
+      newburyport_stops =
+        make_stops(
+          ~w(place-north place-ER-0046 place-ER-0099 place-ER-0115 place-ER-0128 place-ER-0168 place-ER-0183 place-ER-0208 place-ER-0227 place-ER-0276 place-ER-0312 place-ER-0362)s
+        )
+
+      rockport_stops =
+        make_stops(
+          ~w(place-north place-ER-0046 place-ER-0099 place-ER-0115 place-ER-0128 place-ER-0168 place-ER-0183 place-GB-0198 place-GB-0222 place-GB-0229 place-GB-0254 place-GB-0296 place-GB-0316 place-GB-0353)s
+        )
+
+      route_patterns_with_stops = [
+        {newburyport_route_pattern, newburyport_stops},
+        {rockport_route_pattern, rockport_stops}
+      ]
+
+      actual = list_from_route_patterns(route_patterns_with_stops, @newburyport_route, 0)
+
+      assert_stop_ids(
+        actual,
+        ~w(place-north place-ER-0046 place-ER-0099 place-ER-0115 place-ER-0128 place-ER-0168 place-ER-0183 place-GB-0198 place-GB-0222 place-GB-0229 place-GB-0254 place-GB-0296 place-GB-0316 place-GB-0353 place-ER-0208 place-ER-0227 place-ER-0276 place-ER-0312 place-ER-0362)s
+      )
+
+      assert_branch_names(actual, [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        "North Station - Rockport",
+        "North Station - Rockport",
+        "North Station - Rockport",
+        "North Station - Rockport",
+        "North Station - Rockport",
+        "North Station - Rockport",
+        "North Station - Rockport",
+        "North Station - Newburyport",
+        "North Station - Newburyport",
+        "North Station - Newburyport",
+        "North Station - Newburyport",
+        "North Station - Newburyport"
+      ])
+    end
+
+    test "CR-Newburyport, direction 1" do
+      newburyport_route_pattern = %RoutePattern{
+        direction_id: 1,
+        id: "CR-Newburyport-0746071c-1",
+        name: "Newburyport - North Station",
+        representative_trip_id: "CR-Weekday-Summer-20-164",
+        route_id: "CR-Newburyport",
+        time_desc: nil,
+        typicality: 1
+      }
+
+      rockport_route_pattern = %RoutePattern{
+        direction_id: 1,
+        id: "CR-Newburyport-cba33080-1",
+        name: "Rockport - North Station",
+        representative_trip_id: "CR-Weekday-Summer-20-108",
+        route_id: "CR-Newburyport",
+        time_desc: nil,
+        typicality: 1
+      }
+
+      newburyport_stops =
+        make_stops(
+          ~w(place-ER-0362 place-ER-0312 place-ER-0276 place-ER-0227 place-ER-0208 place-ER-0183 place-ER-0168 place-ER-0128 place-ER-0115 place-ER-0099 place-ER-0046 place-north)s
+        )
+
+      rockport_stops =
+        make_stops(
+          ~w(place-GB-0353 place-GB-0316 place-GB-0296 place-GB-0254 place-GB-0229 place-GB-0222 place-GB-0198 place-ER-0183 place-ER-0168 place-ER-0128 place-ER-0115 place-ER-0099 place-ER-0046 place-north)s
+        )
+
+      route_patterns_with_stops = [
+        {newburyport_route_pattern, newburyport_stops},
+        {rockport_route_pattern, rockport_stops}
+      ]
+
+      actual = list_from_route_patterns(route_patterns_with_stops, @newburyport_route, 1)
+
+      assert_stop_ids(
+        actual,
+        ~w(place-ER-0362 place-ER-0312 place-ER-0276 place-ER-0227 place-ER-0208 place-GB-0353 place-GB-0316 place-GB-0296 place-GB-0254 place-GB-0229 place-GB-0222 place-GB-0198 place-ER-0183 place-ER-0168 place-ER-0128 place-ER-0115 place-ER-0099 place-ER-0046 place-north)s
+      )
+
+      assert_branch_names(actual, [
+        "Newburyport - North Station",
+        "Newburyport - North Station",
+        "Newburyport - North Station",
+        "Newburyport - North Station",
+        "Newburyport - North Station",
+        "Rockport - North Station",
+        "Rockport - North Station",
+        "Rockport - North Station",
+        "Rockport - North Station",
+        "Rockport - North Station",
+        "Rockport - North Station",
+        "Rockport - North Station",
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil
+      ])
     end
 
     test "Hingham/Hull Ferry, direction 0" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🚆 Line Diagram | Incorrectly identified shuttle stops, Rockport Line](https://app.asana.com/0/555089885850811/1183912994482917)

Stitch together linked lists of stops on the back-end

The first commit adds some tests that pass with the current data, and the second updates the tests to mirror the future data on dev-green and stitches the shuttle stops into the branch to correct the issues in the line diagram.

![Screen Shot 2020-10-27 at 11 30 31](https://user-images.githubusercontent.com/42339/97326265-358cd280-184a-11eb-8593-e4c954bb9479.png)

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
