### PR TITLE
fix: unclosed  h5 tag in template

### DIFF
--- a/apps/site/lib/site_web/templates/trip_plan/vote.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/vote.html.eex
@@ -7,7 +7,7 @@
   <p>We're piloting this tool for the 2020 election. You can also use our regular <a href="/trip-planner">Trip Planner</a> to find directions to your polling location.</p>
   <div class="row" style="display: flex;">
     <div class="col-12 col-md-4 mt-0 mb-0 h-100 callout">
-      <h5 class="c-search-bar__header">Your Address</label>
+      <h5 class="c-search-bar__header">Your Address</h5>
       <%=
         content_tag(:div, [
           SiteWeb.PartialView.render("_search_input.html",


### PR DESCRIPTION
just fixing an unclosed `h5` tag that was causing slight styling issues.

## Before
<img width="1006" alt="Screen Shot 2020-10-27 at 8 15 56 PM" src="https://user-images.githubusercontent.com/18427346/97375465-444aa800-1891-11eb-817b-526034f71cb3.png">

## After
<img width="1000" alt="Screen Shot 2020-10-27 at 8 15 19 PM" src="https://user-images.githubusercontent.com/18427346/97375495-54fb1e00-1891-11eb-8d8d-829bc80876f1.png">


Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [ ] Are interactive elements accessible to screen readers?
* [ ] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [ ] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
