### PR TITLE
Fix for error when trying to convert "1A-2" to integer

### DIFF
--- a/apps/fares/lib/fares.ex
+++ b/apps/fares/lib/fares.ex
@@ -96,9 +96,9 @@ defmodule Fares do
   end
 
   defp calculate_combo(combo_zone, other_zone, _other_stop_id) do
-    combo_zone
-    |> Zone.general_zone()
-    |> calculate_commuter_rail(other_zone)
+    general_combo_zone = Zone.general_zone(combo_zone)
+    general_other_zone = Zone.general_zone(other_zone)
+    calculate_commuter_rail(general_combo_zone, general_other_zone)
   end
 
   def calculate_foxboro_zones(start_zone, "1A") when start_zone != "1A" do

--- a/apps/fares/test/fares_test.exs
+++ b/apps/fares/test/fares_test.exs
@@ -84,6 +84,12 @@ defmodule FaresTest do
       assert Fares.fare_for_stops(:commuter_rail, "place-GB-0254", "place-ER-0115") ==
                {:ok, {:interzone, "5"}}
     end
+
+    test "finds the interzone fares when combo zone includes '1A-2'" do
+      # Lynn (1A-2), River Works (1A-2)
+      assert Fares.fare_for_stops(:commuter_rail, "place-ER-0115", "place-ER-0099") ==
+               {:ok, {:interzone, "1"}}
+    end
   end
 
   describe "silver line rapid transit routes" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Elixir.ArgumentError: argument error](https://app.asana.com/0/385363666817452/1191566494821186)

The trip details could not be loaded because the logic was trying to convert "1A-2" to an integer.

Before:
<img width="728" alt="image" src="https://user-images.githubusercontent.com/61979382/97433032-3e85ae80-18f3-11eb-94ba-3f2b5ce44705.png">

After:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/61979382/97433055-45142600-18f3-11eb-9b10-d46806d5340e.png">



