### PR TITLE
Add a script to assist with creating GitHub releases

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,2 +1,3 @@
 # Ignore wiremock jar files
 *.jar
+__pycache__/

--- a/bin/lib/git.py
+++ b/bin/lib/git.py
@@ -1,0 +1,23 @@
+import subprocess
+
+
+def current_branch():
+    return __call(["git", "branch", "--show-current"])
+
+def clean_status():
+    return __call(["git", "status", "--porcelain"]) == ""
+
+def current_commit():
+    return __call(["git", "rev-parse", "--short", "HEAD"])
+
+def latest_tag():
+    return __call(["git", "describe", "--tags", "--abbrev=0"])
+
+def sha_for_tag(tag):
+    return __call(["git", "show-ref", "-s", "--abbrev", tag])
+
+def log_between(previous, current):
+    return __call(["git", "log", "--abbrev-commit", "--no-decorate", "--pretty=oneline", "%s..%s" % (previous, current)])
+
+def __call(cmd):
+    return subprocess.check_output(cmd).decode('UTF-8').rstrip()

--- a/bin/lib/input.py
+++ b/bin/lib/input.py
@@ -1,0 +1,3 @@
+
+def with_default(prompt, default):
+	return input("%s [%s]: " % (prompt, default)) or default

--- a/bin/lib/tag.py
+++ b/bin/lib/tag.py
@@ -1,0 +1,13 @@
+from datetime import date
+import re
+
+
+def date_tag(latest_tag):
+      today = date.today().strftime("%Y.%m.%d")
+      return "%s.%s" % (today, __count(latest_tag, today))
+
+
+def __count(latest_tag, today):
+    m = re.match(r'%s\.(\d+)' % today, latest_tag)
+    previous_count = int(m and m.group(1) or '0')
+    return previous_count + 1

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Make a new GitHub release for a production deploy.
+
+Usage:
+    release
+    release -h | --help
+"""
+
+import lib.git as git
+import lib.input as input
+import lib.tag as tag
+import sys
+
+
+def main():
+    if not git.current_branch() == "master":
+        sys.exit("Error: You need to be on master to run this script.")
+
+    if not git.clean_status():
+        sys.exit("Error: Git needs to be clean to run this script.")
+
+    latest_tag = git.latest_tag()
+
+    deploy_sha = input.with_default("Commit to deploy", git.current_commit())
+
+    deploy_tag = input.with_default("Tag to apply", tag.date_tag(latest_tag))
+
+    previous_tag = input.with_default("Tag for last deploy", latest_tag)
+
+    print("")
+    print("Make a new release:")
+    print("https://github.com/mbta/dotcom/releases/new")
+    print("")
+    print("Tag version: %s" % (deploy_tag))
+    print("Target commit: %s" % (deploy_sha))
+    print("Release title: %s" % (deploy_tag))
+    print("")
+    print("Body:")
+    print(git.log_between(git.sha_for_tag(previous_tag), deploy_sha))
+    print("")
+    
+
+if __name__ == '__main__':
+    main()

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -7,7 +7,7 @@ Prerequisites:
 1. Use `aws configure` to configure your AWS credentials. (This only needs to be done once to set up a computer.)
 1. The commit you wish to deploy must have already been built and deploy to the Dev environment. Semaphore will do this automatically for everything that is merged into `master`.
 1. Test the build on the [Dev server](https://dev.mbtace.com).
-1. Make a [Release in GitHub](https://github.com/mbta/dotcom/releases).
+1. Run our release script `./bin/release` and use the output to make a [Release in GitHub](https://github.com/mbta/dotcom/releases).
 
 Run the production deploy using our deploy script:
 
@@ -25,9 +25,10 @@ When deploying to our servers, Semaphore performs these steps for us. But for te
 
 1. (once) Install Docker: https://docs.docker.com/engine/installation/
 2. Build the .ZIP package:
-  * `sh build.sh`
 
-This will build the release in a Docker container, and put the files in `site-build.zip`.  This file contains all of our code, an Erlang distribution, and a Dockerfile to run the application.
+   - `sh build.sh`
+
+This will build the release in a Docker container, and put the files in `site-build.zip`. This file contains all of our code, an Erlang distribution, and a Dockerfile to run the application.
 
 The root `Dockerfile` is responsible the build. Because most of us develop on a Mac but the servers are Linux, we need to run the build inside a Docker container so that everything is compiled correctly. The build uses `distillery` to make the Erlang release, along with all our dependencies. We then copy all those files out of the Docker build container, .zip them up, and send them along to Amazon.
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Determine the info from git to be able to print out everything you need to make a release manually](https://app.asana.com/0/385363666817452/1198965985597277/f)
which is the first step for [🔧 Use a script to automate GitHub releases](https://app.asana.com/0/385363666817452/1185680283158788/f)

Add a script to assist with creating GitHub releases

Currently, it asks you to confirm some defaults and generates everything
you'll need to create a release manually in your browser. For a next
phase, it would be nice if it used the GitHub API to create the release
for you. I want to get that going next, but this already provides substantial value during the deploy process so it seems like it's worth getting in right away.

<img width="805" alt="Screen Shot 2020-10-28 at 18 44 22" src="https://user-images.githubusercontent.com/42339/97580220-66dfdc80-19c9-11eb-9bfb-94870937a9be.png">

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
