### PR TITLE
Prevent error when formatting duration

### DIFF
--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
@@ -1,4 +1,5 @@
 defmodule TripPlan.Api.OpenTripPlanner.Parser do
+  @moduledoc "Module for parsing the itinerary-related data from Open Trip Planner"
   require Logger
   alias TripPlan.Api.OpenTripPlanner, as: OTP
 
@@ -77,10 +78,12 @@ defmodule TripPlan.Api.OpenTripPlanner.Parser do
   end
 
   defp parse_time(ms_after_epoch) do
-    ms_after_epoch
-    |> DateTime.from_unix!(:millisecond)
-    |> Timex.set(microsecond: {0, 0})
-    |> Timex.to_datetime(OTP.config(:timezone))
+    {:ok, ms_after_epoch_dt} =
+      ms_after_epoch
+      |> Integer.floor_div(1000)
+      |> FastLocalDatetime.unix_to_datetime(OTP.config(:timezone))
+
+    ms_after_epoch_dt
   end
 
   defp parse_leg(json) do

--- a/apps/trip_plan/mix.exs
+++ b/apps/trip_plan/mix.exs
@@ -48,7 +48,8 @@ defmodule TripPlan.Mixfile do
       {:excoveralls, "~> 0.5", only: :test},
       {:bypass, "~> 1.0", only: :test},
       {:mock, "~> 0.3.3", only: :test},
-      {:exvcr_helpers, in_umbrella: true, only: :test}
+      {:exvcr_helpers, in_umbrella: true, only: :test},
+      {:fast_local_datetime, "~> 0.1.0"}
     ]
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Elixir.ArithmeticError: bad argument in arithmetic expression](https://app.asana.com/0/385363666817452/1196095462687838)

Use of `fast_local_datetime` to prevent errors when calculating the trip duration in the Trip Planner.