### PR TITLE
feat: authenticate with Docker Hub if credentials are available

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -18,3 +18,7 @@ export V3_URL=https://dev.api.mbtace.com
 # export WIREMOCK_PATH=
 export WIREMOCK_PROXY_URL=https://dev.api.mbtace.com
 export WIREMOCK_TRIP_PLAN_PROXY_URL=https://dev.otp.mbtace.com
+
+# You can also log in manually with `docker login`.
+# export DOCKER_USERNAME=
+# export DOCKER_PASSWORD=

--- a/apps/site/lib/site/schedule_note.ex
+++ b/apps/site/lib/site/schedule_note.ex
@@ -122,7 +122,7 @@ defmodule Site.ScheduleNote do
                   "For regular weekday service to Foxboro please visit: "
                 ),
                 link(
-                  "Franklin Line/Foxboro Pilot",
+                  "Franklin Line",
                   to: Helpers.timetable_path(SiteWeb.Endpoint, :show, "CR-Franklin")
                 )
               ],

--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -491,7 +491,7 @@ defmodule SiteWeb.ScheduleView do
           content_tag(:strong, "Note:"),
           " For regular weekday service to and from Foxboro please visit ",
           link(to: timetable_path(SiteWeb.Endpoint, :show, "CR-Franklin")) do
-            "Franklin Line/Foxboro Pilot"
+            "Franklin Line"
           end
         ])
       ]

--- a/apps/site/test/detailed_stop_group_test.exs
+++ b/apps/site/test/detailed_stop_group_test.exs
@@ -13,7 +13,7 @@ defmodule DetailedStopGroupTest do
           "Fitchburg Line",
           "Foxboro Event Service",
           "Framingham/Worcester Line",
-          "Franklin Line/Foxboro Pilot",
+          "Franklin Line",
           "Greenbush Line",
           "Haverhill Line",
           "Kingston/Plymouth Line",

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-set -e -x
+set -e
 PREFIX=_build/prod/
 APP=site
 BUILD_TAG=$APP:_build
 VERSION=$(grep -o 'version: .*"' apps/$APP/mix.exs  | grep -E -o '([0-9]+\.)+[0-9]+')
 BUILD_ARTIFACT=$APP-build.zip
+
+# log into docker hub if needed
+if [ "x$DOCKER_USERNAME" != x ]; then
+    echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+fi
 
 docker build -t $BUILD_TAG --build-arg SENTRY_DSN=$SENTRY_DSN .
 CONTAINER=$(docker run -d ${BUILD_TAG} sleep 2000)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Authenticate Docker pulls in Semaphore](https://app.asana.com/0/555089885850811/1198513525489765)

In Semaphore, we use DOCKER_USERNAME and DOCKER_PASSWORD for our DockerHub credentials. This changes the `build.sh` script to log in to DockerHub before doing other actions if those credentials are available.

The removal of `-x` from the `set` command prevents the password from being echoed during the build.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
