### PR TITLE
Show no upcoming departures when last stop

### DIFF
--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -30,6 +30,7 @@ export interface Props {
   today: string;
   scheduleNote: ScheduleNoteType | null;
   initialSelectedRoutePatternId: string | null;
+  variantStops: string[];
 }
 
 export const fetchMapData = (
@@ -97,7 +98,8 @@ const ScheduleDirection = ({
   stops,
   today,
   scheduleNote,
-  initialSelectedRoutePatternId
+  initialSelectedRoutePatternId,
+  variantStops
 }: Props): ReactElement<HTMLElement> => {
   const routePatternsInCurrentDirection = routePatternsByDirection[directionId];
   const defaultRoutePattern =
@@ -223,6 +225,7 @@ const ScheduleDirection = ({
           stops={stops}
           today={today}
           scheduleNote={scheduleNote}
+          variantStops={variantStops}
         />
       )}
     </>

--- a/apps/site/assets/ts/schedule/components/ScheduleFinder.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleFinder.tsx
@@ -28,6 +28,7 @@ interface Props {
   closeModal: () => void;
   modalMode: ModalMode;
   modalOpen: boolean;
+  variantStops: string[];
 }
 
 const ScheduleFinder = ({
@@ -44,7 +45,8 @@ const ScheduleFinder = ({
   changeDirection,
   changeOrigin,
   modalOpen,
-  closeModal
+  closeModal,
+  variantStops
 }: Props): ReactElement<HTMLElement> => {
   const openOriginModal = (): void => {
     const currentState = getCurrentState();
@@ -110,6 +112,7 @@ const ScheduleFinder = ({
           stops={stops}
           today={today}
           updateURL={updateURL}
+          variantStops={variantStops}
         />
       )}
     </div>

--- a/apps/site/assets/ts/schedule/components/ScheduleLoader.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleLoader.tsx
@@ -124,7 +124,8 @@ export const ScheduleLoader = ({
     today,
     line_diagram: lineDiagram,
     shape_map: shapesById,
-    variant: initialSelectedRoutePatternId
+    variant: initialSelectedRoutePatternId,
+    variant_stops: variantStops
   } = schedulePageData;
 
   const currentState = getCurrentState();
@@ -191,6 +192,7 @@ export const ScheduleLoader = ({
               stops={stops}
               today={today}
               updateURL={updateURL}
+              variantStops={variantStops}
             />
           )}
         </>
@@ -214,6 +216,7 @@ export const ScheduleLoader = ({
           selectedOrigin={selectedOrigin}
           changeOrigin={changeOrigin}
           closeModal={closeModal}
+          variantStops={variantStops}
         />
       );
     }
@@ -245,6 +248,7 @@ export const ScheduleLoader = ({
           today={today}
           scheduleNote={scheduleNote}
           initialSelectedRoutePatternId={initialSelectedRoutePatternId}
+          variantStops={variantStops}
         />
       );
     }

--- a/apps/site/assets/ts/schedule/components/SchedulePage.tsx
+++ b/apps/site/assets/ts/schedule/components/SchedulePage.tsx
@@ -41,7 +41,8 @@ const SchedulePage = ({
     services,
     stops,
     route_patterns: routePatternsByDirection,
-    today
+    today,
+    variant_stops: variantStops
   },
   updateURL,
   closeModal,
@@ -84,6 +85,7 @@ const SchedulePage = ({
               stops={stops}
               today={today}
               updateURL={updateURL}
+              variantStops={variantStops}
             />
           )}
         </>
@@ -103,6 +105,7 @@ const SchedulePage = ({
           closeModal={closeModal}
           modalMode={modalMode}
           modalOpen={modalOpen}
+          variantStops={variantStops}
         />
       )}
       <ContentTeasers teasers={teasers} />

--- a/apps/site/assets/ts/schedule/components/__schedule.d.ts
+++ b/apps/site/assets/ts/schedule/components/__schedule.d.ts
@@ -48,6 +48,7 @@ export interface SchedulePageData {
   line_diagram: LineDiagramStop[];
   today: string;
   variant: string | null;
+  variant_stops: string[];
 }
 
 interface StopData {

--- a/apps/site/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
@@ -168,6 +168,7 @@ const getComponent = () => (
     today="2019-12-05"
     scheduleNote={null}
     initialSelectedRoutePatternId={null}
+    variantStops={[]}
   />
 );
 
@@ -184,6 +185,7 @@ const getSingleDirectionComponent = () => (
     today="2019-12-05"
     scheduleNote={null}
     initialSelectedRoutePatternId={null}
+    variantStops={[]}
   />
 );
 
@@ -200,6 +202,7 @@ const getSubwayComponent = () => (
     today="2019-12-05"
     scheduleNote={null}
     initialSelectedRoutePatternId={null}
+    variantStops={[]}
   />
 );
 
@@ -216,6 +219,7 @@ const getStaticMapComponent = () => (
     today="2019-12-05"
     scheduleNote={null}
     initialSelectedRoutePatternId={null}
+    variantStops={[]}
   />
 );
 
@@ -248,6 +252,7 @@ const getGreenLineComponent = () => {
       today="2019-12-05"
       scheduleNote={null}
       initialSelectedRoutePatternId={null}
+      variantStops={[]}
     />
   );
 };
@@ -265,6 +270,7 @@ const getVariantComponent = () => (
     today="2019-12-05"
     scheduleNote={null}
     initialSelectedRoutePatternId="pattern-3"
+    variantStops={[]}
   />
 );
 

--- a/apps/site/assets/ts/schedule/components/__tests__/ScheduleFinderTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/ScheduleFinderTest.tsx
@@ -180,6 +180,7 @@ describe("ScheduleFinder", () => {
         closeModal={() => {}}
         modalMode="schedule"
         modalOpen={false}
+        variantStops={[]}
       />
     );
 
@@ -205,6 +206,7 @@ describe("ScheduleFinder", () => {
         closeModal={() => {}}
         modalMode="schedule"
         modalOpen={true}
+        variantStops={[]}
       />
     );
 
@@ -263,6 +265,7 @@ describe("ScheduleFinder", () => {
         closeModal={() => {}}
         modalMode="origin"
         modalOpen={true}
+        variantStops={[]}
       />
     );
 
@@ -291,6 +294,7 @@ describe("ScheduleFinder", () => {
         closeModal={() => {}}
         modalMode="schedule"
         modalOpen={true}
+        variantStops={[]}
       />
     );
 

--- a/apps/site/assets/ts/schedule/components/__tests__/ScheduleLoaderTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/ScheduleLoaderTest.tsx
@@ -253,7 +253,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -285,7 +286,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -319,7 +321,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -364,7 +367,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -397,7 +401,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -440,7 +445,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -480,7 +486,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -513,7 +520,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -565,7 +573,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -632,7 +641,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -678,7 +688,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -733,7 +744,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -772,7 +784,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -829,7 +842,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -876,7 +890,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />
@@ -925,7 +940,8 @@ describe("ScheduleLoader", () => {
             route_patterns: routes,
             line_diagram: lineDiagram,
             today: "2019-12-05",
-            variant: null
+            variant: null,
+            variant_stops: []
           }}
           updateURL={() => {}}
         />

--- a/apps/site/assets/ts/schedule/components/__tests__/SchedulePageTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/SchedulePageTest.tsx
@@ -151,7 +151,8 @@ it("it renders", () => {
           route_patterns: {},
           line_diagram: lineDiagram,
           today: "2019-12-05",
-          variant: null
+          variant: null,
+          variant_stops: []
         }}
         updateURL={() => {}}
         modalOpen={false}
@@ -197,7 +198,8 @@ it("it renders with conditional components", () => {
         route_patterns: {},
         line_diagram: lineDiagram,
         today: "2019-12-05",
-        variant: null
+        variant: null,
+        variant_stops: []
       }}
       updateURL={() => {}}
       modalOpen={false}
@@ -245,7 +247,8 @@ it("it renders with Schedule modal", () => {
         route_patterns: {},
         line_diagram: lineDiagram,
         today: "2019-12-05",
-        variant: null
+        variant: null,
+        variant_stops: []
       }}
       updateURL={() => {}}
       modalOpen={true}
@@ -294,7 +297,8 @@ it("it handles change in origin", () => {
         route_patterns: {},
         line_diagram: lineDiagram,
         today: "2019-12-05",
-        variant: null
+        variant: null,
+        variant_stops: []
       }}
       updateURL={() => {}}
       modalOpen={true}

--- a/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleFinderTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleFinderTest.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ScheduleFinder matches snapshot 1`] = `
-"<ScheduleFinder route={{...}} stops={{...}} directionId={0} services={{...}} routePatternsByDirection={{...}} today=\\"2019-12-05\\" scheduleNote={{...}} updateURL={[Function: updateURL]} changeDirection={[Function: changeDirection]} selectedOrigin={{...}} changeOrigin={[Function: changeOrigin]} closeModal={[Function: closeModal]} modalMode=\\"schedule\\" modalOpen={false}>
+"<ScheduleFinder route={{...}} stops={{...}} directionId={0} services={{...}} routePatternsByDirection={{...}} today=\\"2019-12-05\\" scheduleNote={{...}} updateURL={[Function: updateURL]} changeDirection={[Function: changeDirection]} selectedOrigin={{...}} changeOrigin={[Function: changeOrigin]} closeModal={[Function: closeModal]} modalMode=\\"schedule\\" modalOpen={false} variantStops={{...}}>
   <div className=\\"schedule-finder\\">
     <Component onDirectionChange={[Function: changeDirection]} onOriginChange={[Function: changeOrigin]} onOriginSelectClick={[Function: openOriginModal]} onSubmit={[Function: openScheduleModal]} route={{...}} selectedDirection={0} selectedOrigin={{...}} stopsByDirection={{...}}>
       <form onSubmit={[Function: handleSubmit]}>

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -34,6 +34,7 @@ interface LineDiagramProps {
   stops: SimpleStopMap;
   today: string;
   scheduleNote: ScheduleNoteType | null;
+  variantStops: string[];
 }
 
 const stationsOrStops = (routeType: number): string =>
@@ -53,7 +54,8 @@ const LineDiagramAndStopListPage = ({
   services,
   stops,
   today,
-  scheduleNote
+  scheduleNote,
+  variantStops
 }: LineDiagramProps): ReactElement<HTMLElement> | null => {
   /**
    * Setup state handling etc
@@ -221,6 +223,7 @@ const LineDiagramAndStopListPage = ({
           stops={stops}
           today={today}
           updateURL={updateURL}
+          variantStops={variantStops}
         />
       )}
     </>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramTest.tsx
@@ -83,6 +83,7 @@ describe("LineDiagram", () => {
         stops={{ 0: stops, 1: stops }}
         today="2019-12-05"
         scheduleNote={null}
+        variantStops={[]}
       />
     );
   });
@@ -190,6 +191,7 @@ it.each`
         stops={{ 0: stops, 1: stops }}
         today="2019-12-05"
         scheduleNote={null}
+        variantStops={[]}
       />
     );
     expect(wrapper.find(".m-schedule-diagram__heading").text()).toContain(name);

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/MergeTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/MergeTest.tsx
@@ -51,7 +51,6 @@ describe("Merge component", () => {
         <Merges lineDiagram={lineDiagram} />
       </redux.Provider>
     );
-    console.log(wrapperNoBranches.debug());
     expect(
       wrapperNoBranches.exists("g.line-diagram-svg__merge")
     ).not.toBeTruthy();

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LineDiagram renders and matches snapshot 1`] = `
-"<LineDiagramAndStopListPage lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" scheduleNote={{...}}>
+"<LineDiagramAndStopListPage lineDiagram={{...}} route={{...}} directionId={1} routePatternsByDirection={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" scheduleNote={{...}} variantStops={{...}}>
   <h3 className=\\"m-schedule-diagram__heading\\">
     Stops
   </h3>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleFinderModal.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleFinderModal.tsx
@@ -5,7 +5,8 @@ import {
   RoutePatternsByDirection,
   ServiceInSelector,
   ScheduleNote as ScheduleNoteType,
-  SelectedOrigin
+  SelectedOrigin,
+  SimpleStop
 } from "../__schedule";
 import Modal from "../../../components/Modal";
 import OriginModalContent from "./OriginModalContent";
@@ -28,6 +29,7 @@ interface Props {
   today: string;
   updateURL: (origin: SelectedOrigin, direction?: DirectionId) => void;
   handleOriginSelectClick: () => void;
+  variantStops: string[];
 }
 
 export default ({
@@ -44,7 +46,8 @@ export default ({
   stops,
   today,
   updateURL,
-  handleOriginSelectClick
+  handleOriginSelectClick,
+  variantStops
 }: Props): ReactElement => {
   const handleChangeDirection = (newDirection: DirectionId): void => {
     if (directionChanged) directionChanged(newDirection);
@@ -57,14 +60,13 @@ export default ({
     updateURL(newOrigin, initialDirection);
   };
 
-  const originModalContent = (): ReactElement => {
+  const originModalContent = (filteredStops: SimpleStop[]): ReactElement => {
     const origin = initialOrigin;
-    const direction = initialDirection;
     return (
       <OriginModalContent
         handleChangeOrigin={handleChangeOrigin}
         selectedOrigin={origin}
-        stops={stops[direction] || []}
+        stops={filteredStops}
       />
     );
   };
@@ -82,11 +84,22 @@ export default ({
       services={services}
       stops={stops}
       today={today}
+      variantStops={variantStops}
     />
   );
 
   const direction = initialDirection;
   const origin = initialOrigin;
+
+  // make the list of stops dependent on the variant (if there is one)
+  const selectedStops = stops[direction] || [];
+
+  const filteredStops =
+    variantStops.length !== 0
+      ? selectedStops.filter((stop: SimpleStop) =>
+          variantStops.includes(stop.id)
+        )
+      : selectedStops;
 
   return (
     <Modal
@@ -104,7 +117,7 @@ export default ({
       }
       closeModal={closeModal}
     >
-      {initialMode === "origin" && originModalContent()}
+      {initialMode === "origin" && originModalContent(filteredStops)}
       {initialMode === "schedule" &&
         origin !== null &&
         scheduleModalContent(origin)}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -5,6 +5,7 @@ import { reducer } from "../../../helpers/fetch";
 import { isInCurrentService } from "../../../helpers/service";
 import {
   SimpleStopMap,
+  SimpleStop,
   RoutePatternsByDirection,
   ServiceInSelector,
   ScheduleNote as ScheduleNoteType,
@@ -57,6 +58,7 @@ interface Props {
   routePatternsByDirection: RoutePatternsByDirection;
   today: string;
   scheduleNote: ScheduleNoteType | null;
+  variantStops: string[];
 }
 
 const ScheduleModalContent = ({
@@ -70,7 +72,8 @@ const ScheduleModalContent = ({
   stops,
   routePatternsByDirection,
   today,
-  scheduleNote
+  scheduleNote,
+  variantStops
 }: Props): ReactElement<HTMLElement> | null => {
   const { id: routeId } = route;
 
@@ -104,6 +107,23 @@ const ScheduleModalContent = ({
     direction: selectedDirection
   };
 
+  // make the list of stops dependent on the variant (if there is one)
+  const selectedStops = stops[selectedDirection] || [];
+
+  const filteredStops =
+    variantStops.length !== 0
+      ? selectedStops.filter((stop: SimpleStop) =>
+          variantStops.includes(stop.id)
+        )
+      : selectedStops;
+
+  const indexOfSelectedOrigin = filteredStops.findIndex(
+    (stop: SimpleStop) => stop.id === selectedOrigin
+  );
+
+  const showUpcomingDepartures =
+    indexOfSelectedOrigin !== filteredStops.length - 1;
+
   return (
     <>
       <div className="schedule-finder schedule-finder--modal">
@@ -119,7 +139,11 @@ const ScheduleModalContent = ({
       </div>
 
       {serviceToday ? (
-        <UpcomingDepartures state={state} input={input} />
+        <UpcomingDepartures
+          state={state}
+          input={input}
+          showUpcomingDepartures={showUpcomingDepartures}
+        />
       ) : (
         <div className="callout text-center u-bold">
           There are no scheduled trips for {formattedDate(today)}.

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/ScheduleFinderModalTest.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/ScheduleFinderModalTest.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../__schedule";
 import * as routePatternsByDirectionData from "../../__tests__/test-data/routePatternsByDirectionData.json";
 import ScheduleFinderModal, { Mode as ModalMode } from "../ScheduleFinderModal";
+import OriginListItem from "../OriginListItem";
 
 jest.mock("../../../../helpers/use-fetch", () => ({
   __esModule: true,
@@ -143,7 +144,8 @@ describe("ScheduleFinderModal", () => {
     direction: DirectionId,
     origin: SelectedOrigin,
     directionChanged?: (direction: DirectionId) => void,
-    originChanged?: (origin: SelectedOrigin) => void
+    originChanged?: (origin: SelectedOrigin) => void,
+    variantStops: string[] = []
   ) =>
     mount(
       <ScheduleFinderModal
@@ -161,6 +163,7 @@ describe("ScheduleFinderModal", () => {
         initialOrigin={origin}
         originChanged={originChanged}
         handleOriginSelectClick={() => {}}
+        variantStops={variantStops}
       />
     );
 
@@ -270,5 +273,13 @@ describe("ScheduleFinderModal", () => {
     expect(
       wrapper.find(".schedule-finder__origin-list").children().length
     ).toEqual(1);
+  });
+
+  it("Filters the list of available stops in the origin modal", () => {
+    const wrapper = mountComponent("origin", 0, null, undefined, undefined, [
+      "123"
+    ]);
+
+    expect(wrapper.find(OriginListItem)).toHaveLength(1);
   });
 });

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/ScheduleModalContentTest.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/ScheduleModalContentTest.tsx
@@ -80,6 +80,7 @@ describe("ScheduleModalContent", () => {
           routePatternsByDirection={{}}
           today={today}
           scheduleNote={null}
+          variantStops={[]}
         />
       );
     });
@@ -102,6 +103,7 @@ describe("ScheduleModalContent", () => {
         routePatternsByDirection={{}}
         today={today}
         scheduleNote={scheduleNoteData}
+        variantStops={[]}
       />
     );
     expect(

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderModalTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderModalTest.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ScheduleFinderModal matches snapshot in origin mode 1`] = `
-"<Component closeModal={[Function: closeModal]} initialMode=\\"origin\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin={{...}} originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]}>
+"<Component closeModal={[Function: closeModal]} initialMode=\\"origin\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin={{...}} originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]} variantStops={{...}}>
   <WrappedModal focusElementId=\\"origin-filter\\" ariaLabel={{...}} className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]}>
     <Modal focusElementId=\\"origin-filter\\" ariaLabel={{...}} className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]} priorPadding=\\"0px\\" paddingRight={0}>
       <ModalContent bodyPadding=\\"0px\\" scrollBarPadding={0} closeText=\\"Close\\" role=\\"dialog\\" ariaLabel={{...}} focusElementId=\\"origin-filter\\" className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]}>
@@ -76,7 +76,7 @@ exports[`ScheduleFinderModal matches snapshot in origin mode 1`] = `
 `;
 
 exports[`ScheduleFinderModal matches snapshot in origin mode with origin selected 1`] = `
-"<Component closeModal={[Function: closeModal]} initialMode=\\"origin\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin={{...}} originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]}>
+"<Component closeModal={[Function: closeModal]} initialMode=\\"origin\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin={{...}} originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]} variantStops={{...}}>
   <WrappedModal focusElementId=\\"origin-filter\\" ariaLabel={{...}} className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]}>
     <Modal focusElementId=\\"origin-filter\\" ariaLabel={{...}} className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]} priorPadding=\\"0px\\" paddingRight={0}>
       <ModalContent bodyPadding=\\"0px\\" scrollBarPadding={0} closeText=\\"Close\\" role=\\"dialog\\" ariaLabel={{...}} focusElementId=\\"origin-filter\\" className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]}>
@@ -151,7 +151,7 @@ exports[`ScheduleFinderModal matches snapshot in origin mode with origin selecte
 `;
 
 exports[`ScheduleFinderModal matches snapshot in schedule mode 1`] = `
-"<Component closeModal={[Function: closeModal]} initialMode=\\"schedule\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin=\\"place-welln\\" originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]}>
+"<Component closeModal={[Function: closeModal]} initialMode=\\"schedule\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin=\\"place-welln\\" originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]} variantStops={{...}}>
   <WrappedModal focusElementId=\\"modal-close\\" ariaLabel={{...}} className=\\"\\" closeModal={[Function: closeModal]}>
     <Modal focusElementId=\\"modal-close\\" ariaLabel={{...}} className=\\"\\" closeModal={[Function: closeModal]} priorPadding=\\"0px\\" paddingRight={0}>
       <ModalContent bodyPadding=\\"0px\\" scrollBarPadding={0} closeText=\\"Close\\" role=\\"dialog\\" ariaLabel={{...}} focusElementId=\\"modal-close\\" className=\\"\\" closeModal={[Function: closeModal]}>
@@ -162,7 +162,7 @@ exports[`ScheduleFinderModal matches snapshot in schedule mode 1`] = `
                 Close
               </button>
               <div className=\\"c-modal__content\\">
-                <ScheduleModalContent handleChangeDirection={[Function: handleChangeDirection]} handleChangeOrigin={[Function: handleChangeOrigin]} handleOriginSelectClick={[Function: handleOriginSelectClick]} route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} selectedDirection={0} selectedOrigin=\\"place-welln\\" services={{...}} stops={{...}} today=\\"2019-12-05\\">
+                <ScheduleModalContent handleChangeDirection={[Function: handleChangeDirection]} handleChangeOrigin={[Function: handleChangeOrigin]} handleOriginSelectClick={[Function: handleOriginSelectClick]} route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} selectedDirection={0} selectedOrigin=\\"place-welln\\" services={{...}} stops={{...}} today=\\"2019-12-05\\" variantStops={{...}}>
                   <div className=\\"schedule-finder schedule-finder--modal\\">
                     <Component onDirectionChange={[Function: handleChangeDirection]} onOriginChange={[Function: handleChangeOrigin]} onOriginSelectClick={[Function: handleOriginSelectClick]} route={{...}} selectedDirection={0} selectedOrigin=\\"place-welln\\" stopsByDirection={{...}}>
                       <form onSubmit={[Function: handleSubmit]}>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/UpcomingDepartures.tsx
@@ -27,6 +27,7 @@ interface State {
 interface Props {
   state: State;
   input: UserInput;
+  showUpcomingDepartures: boolean;
 }
 
 interface AccordionProps {
@@ -321,7 +322,8 @@ export const upcomingDeparturesTable = (
 
 export const UpcomingDepartures = ({
   state: stateFromProps,
-  input
+  input,
+  showUpcomingDepartures
 }: Props): ReactElement<HTMLElement> | null => {
   const [state, dispatch] = useReducer(reducer, {
     data: null,
@@ -333,7 +335,12 @@ export const UpcomingDepartures = ({
 
   useEffect(
     () => {
-      if (
+      if (!showUpcomingDepartures) {
+        dispatch({
+          type: "FETCH_COMPLETE",
+          payload: null
+        });
+      } else if (
         stateFromProps.data !== null &&
         !stateFromProps.isLoading &&
         !stateFromProps.error &&
@@ -385,7 +392,13 @@ export const UpcomingDepartures = ({
 
   const journeysWithTripInfo = state.data;
 
-  return <>{upcomingDeparturesTable(journeysWithTripInfo, state, input)}</>;
+  return journeysWithTripInfo ? (
+    <>{upcomingDeparturesTable(journeysWithTripInfo, state, input)}</>
+  ) : (
+    <div className="callout text-center u-bold">
+      There are no upcoming departures. This is the last stop.
+    </div>
+  );
 };
 
 export default UpcomingDepartures;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/UpcomingDeparturesTest.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/UpcomingDeparturesTest.tsx
@@ -4,17 +4,20 @@ import { mount, ReactWrapper } from "enzyme";
 import { UserInput } from "../../../__schedule";
 import { EnhancedJourney } from "../../../__trips";
 import departuresResponse from "../../__tests__/test-data/departures.json";
-import UpcomingDepartures, {
+import * as upcomingDeparturesModule from "../UpcomingDepartures";
+import crDeparturesResponse from "./test-data/crDepartures.json";
+import enhancedBusJourneysResponse from "./test-data/enhancedBusJourneys.json";
+import enhancedCRjourneysResponse from "./test-data/enhancedCRjourneys.json";
+import LiveCrowdingIcon from "../../../line-diagram/LiveCrowdingIcon";
+
+const {
+  UpcomingDepartures,
   upcomingDeparturesTable,
   fetchData,
   crowdingInformation,
   BusTableRow,
   CrTableRow
-} from "../UpcomingDepartures";
-import crDeparturesResponse from "./test-data/crDepartures.json";
-import enhancedBusJourneysResponse from "./test-data/enhancedBusJourneys.json";
-import enhancedCRjourneysResponse from "./test-data/enhancedCRjourneys.json";
-import LiveCrowdingIcon from "../../../line-diagram/LiveCrowdingIcon";
+} = upcomingDeparturesModule;
 
 const busDepartures = (departuresResponse as unknown) as EnhancedJourney[];
 const crDepartures = (crDeparturesResponse as unknown) as EnhancedJourney[];
@@ -63,7 +66,13 @@ describe("UpcomingDepartures", () => {
 
       jest.spyOn(React, "useEffect").mockImplementation(f => f());
 
-      wrapper = mount(<UpcomingDepartures state={state} input={input} />);
+      wrapper = mount(
+        <UpcomingDepartures
+          state={state}
+          input={input}
+          showUpcomingDepartures={true}
+        />
+      );
 
       expect(wrapper.html()).toBeNull();
     });
@@ -189,7 +198,13 @@ describe("UpcomingDepartures", () => {
     return fetchData(input, [busDepartures[0]], dispatchSpy).then(() => {
       expect(dispatchSpy).toHaveBeenCalledWith({ type: "FETCH_STARTED" });
 
-      wrapper = mount(<UpcomingDepartures state={state} input={input} />);
+      wrapper = mount(
+        <UpcomingDepartures
+          state={state}
+          input={input}
+          showUpcomingDepartures={true}
+        />
+      );
 
       expect(wrapper.find(".c-spinner__container")).toHaveLength(1);
     });
@@ -251,5 +266,29 @@ describe("UpcomingDepartures", () => {
       wrapper = mount(<>{crowdingInformation(journey, journey.trip.id)}</>);
       expect(wrapper.find(LiveCrowdingIcon).prop("crowding")).toBeFalsy();
     });
+  });
+
+  it("displays a message indicating that it's the last stop and does not call fetchData", () => {
+    const state = {
+      data: busDepartures,
+      error: false,
+      isLoading: false
+    };
+
+    const fetchDataSpy = jest.spyOn(upcomingDeparturesModule, "fetchData");
+
+    wrapper = mount(
+      <UpcomingDepartures
+        state={state}
+        input={input}
+        showUpcomingDepartures={false}
+      />
+    );
+
+    expect(wrapper.find(".callout").text()).toEqual(
+      "There are no upcoming departures. This is the last stop."
+    );
+
+    expect(fetchDataSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/site/assets/ts/schedule/schedule-loader.tsx
+++ b/apps/site/assets/ts/schedule/schedule-loader.tsx
@@ -14,10 +14,6 @@ import {
   getCurrentState
 } from "./store/ScheduleStore";
 
-interface Props {
-  schedulePageData: SchedulePageData;
-}
-
 const renderMap = ({
   route_patterns: routePatternsByDirection,
   direction_id: directionId

--- a/apps/site/lib/site_web/controllers/schedule/line.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line.ex
@@ -117,6 +117,14 @@ defmodule SiteWeb.ScheduleController.Line do
     shape_map = get_route_shape_map(route.id)
     active_shapes = LineHelpers.get_active_shapes(route_shapes, route, variant)
     filtered_shapes = LineHelpers.filter_route_shapes(route_shapes, active_shapes, route)
+
+    variant_stops =
+      if variant != nil do
+        List.first(filtered_shapes).stop_ids
+      else
+        []
+      end
+
     branches = LineHelpers.get_branches(filtered_shapes, route_stops, route, direction_id)
     map_stops = Maps.map_stops(branches, {route_shapes, active_shapes}, route.id)
 
@@ -159,6 +167,7 @@ defmodule SiteWeb.ScheduleController.Line do
     |> assign(:connections, connections(branches))
     |> assign(:time_data_by_stop, time_data_by_stop)
     |> assign(:variant, variant)
+    |> assign(:variant_stops, variant_stops)
   end
 
   defp flatten_route_stops(route_stops) do

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -85,7 +85,8 @@ defmodule SiteWeb.ScheduleController.LineController do
             conn.assigns.date_time
           ),
         today: conn.assigns.date_time |> DateTime.to_date() |> Date.to_iso8601(),
-        variant: conn.assigns.variant
+        variant: conn.assigns.variant,
+        variant_stops: conn.assigns.variant_stops
       }
     )
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Schedule Finder | Error Loading Trip Details](https://app.asana.com/0/555089885850811/1191999214380060)

Slight improvements related to Upcoming Departures:
* Show filtered-by-variant stops (if variant exists) in the origin modal
* Do not fetch trips if it's the last stop (and show a message instead)


