### PR TITLE
docs: add new doc for temporary features

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Then, visit the site at http://localhost:4001/
 
 ## Additional Documentation
 
-See [docs](docs) for information about [testing](docs/TESTING.md) and other development details.
+See [docs](docs) for information about [testing](docs/TESTING.md) and other development details. There is also documentation for some [features that have come and gone](docs/SeasonalFeatures.md).
 
 ### Nested Applications
 

--- a/docs/SeasonalFeatures.md
+++ b/docs/SeasonalFeatures.md
@@ -1,0 +1,20 @@
+Sometimes we add features to Dotcom then take them away again. Below is an attempt to document those features.
+
+# Polling Location Finder
+
+![](https://user-images.githubusercontent.com/18427346/97882194-55604280-1cf1-11eb-811f-5aa5222210df.png)
+
+
+Added late into the 2020 election season to help users within the MBTA service area get to the polls. 
+
+Revert [ee2e3ec](https://github.com/mbta/dotcom/commit/ee2e3ecace394c3e9c7f0b4de7fc913ed8a8484b) to bring back to life for the next election. Needs tests.
+
+
+# Shuttles Tab
+
+![](https://user-images.githubusercontent.com/2136286/69660665-c6fa3000-104e-11ea-8d95-1e99f34a875b.gif)
+
+
+Added in late 2019 to help riders see shuttles on certain train routes.
+
+Released in [#300](https://github.com/mbta/dotcom/pull/300) and removed in [#462](https://github.com/mbta/dotcom/pull/462)


### PR DESCRIPTION
I wanted to document how to bring the polling location map back and figured I can start a page to store notes on similar features, welcome any thoughts!