### PR TITLE
Customer support form: subway should not include Silver Line

### DIFF
--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -347,7 +347,7 @@ defmodule SiteWeb.CustomerSupportController do
       end
 
     subway_options =
-      Enum.map(SiteWeb.ViewHelpers.subway_lines(), fn mode ->
+      Enum.map(SiteWeb.ViewHelpers.subway_lines() -- [:silver_line], fn mode ->
         SiteWeb.ViewHelpers.mode_name(mode)
       end)
 

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -467,8 +467,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
                "Red Line",
                "Blue Line",
                "Orange Line",
-               "Green Line",
-               "Silver Line"
+               "Green Line"
              ]
 
       refute get_routes_for_mode(conn, :bus) == []


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Silver Line should not show under Subway mode](https://app.asana.com/0/555089885850811/1198980474686141)

Removing Silver Line from the list of options for Subway.