### PR TITLE
Filter trips without tripInfo

### DIFF
--- a/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/UpcomingDepartures.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/UpcomingDepartures.tsx
@@ -353,9 +353,13 @@ export const UpcomingDepartures = ({
         ) {
           fetchData(input, journeys, dispatch)
             .then((retrievedJourneysWithTripInfo: EnhancedJourney[]) => {
+              const filteredJourneysWithTripInfo = retrievedJourneysWithTripInfo.filter(
+                journey => journey.tripInfo !== null
+              );
+
               dispatch({
                 type: "FETCH_COMPLETE",
-                payload: retrievedJourneysWithTripInfo
+                payload: filteredJourneysWithTripInfo
               });
             })
             .catch(() => dispatch({ type: "FETCH_ERROR" }));


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Partial solution to [🐞 Schedule Finder | Error Loading Trip Details](https://app.asana.com/0/555089885850811/1191999214380060)

Filter trips with a `tripInfo` value of `null` in Upcoming Departures.
