### PR TITLE
Convert incident datetime to UTC

### DIFF
--- a/apps/feedback/lib/mailer.ex
+++ b/apps/feedback/lib/mailer.ex
@@ -109,8 +109,9 @@ defmodule Feedback.Mailer do
     end
   end
 
-  defp formatted_utc_timestamp(date) do
+  def formatted_utc_timestamp(date) do
     date
+    |> Timex.Timezone.convert("Etc/UTC")
     |> Timex.format!("{0M}/{0D}/{YYYY} {h24}:{m}")
   end
 

--- a/apps/feedback/test/mailer_test.exs
+++ b/apps/feedback/test/mailer_test.exs
@@ -251,5 +251,20 @@ defmodule Feedback.MailerTest do
       refute Test.latest_message()["text"]
              |> String.contains?("123abc")
     end
+
+    test "converts 'America/New_York' date to UTC" do
+      dt = Util.convert_using_timezone(~N[2016-12-12T12:12:12], "America/New_York")
+      assert Mailer.formatted_utc_timestamp(dt) == "12/12/2016 17:12"
+    end
+
+    test "converts 'America/New_York' date to UTC accounting for beginning of daylight saving time" do
+      dt = Util.convert_using_timezone(~N[2020-03-08T02:00:00], "America/New_York")
+      assert Mailer.formatted_utc_timestamp(dt) == "03/08/2020 06:00"
+    end
+
+    test "converts 'America/New_York' date to UTC accounting for end of daylight saving time" do
+      dt = Util.convert_using_timezone(~N[2020-11-01T01:00:00], "America/New_York")
+      assert Mailer.formatted_utc_timestamp(dt) == "11/01/2020 05:00"
+    end
   end
 end

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -290,7 +290,7 @@ defmodule SiteWeb.CustomerSupportController do
 
   @spec validate_incident_date_time(map) :: DateTime.t()
   defp validate_incident_date_time(incident_date_time) do
-    now = Util.now() |> Util.to_local_time()
+    now = Util.now() |> Util.to_local_time() |> DateTime.truncate(:second)
 
     parsed_date_time =
       case Util.parse(incident_date_time) do
@@ -301,7 +301,7 @@ defmodule SiteWeb.CustomerSupportController do
           parsed_dt
       end
 
-    local_parsed_date_time = Util.to_local_time(parsed_date_time)
+    local_parsed_date_time = Util.convert_using_timezone(parsed_date_time, "America/New_York")
 
     # if date and time is in the future, set it to now
     # otherwise leave as it is

--- a/apps/util/lib/util.ex
+++ b/apps/util/lib/util.ex
@@ -92,6 +92,21 @@ defmodule Util do
     |> Date.to_string()
   end
 
+  @doc "Converts a NaiveDateTime to a DateTime with the given time zone, handling ambiguities. Defaults to America/New_York if errors"
+  @spec convert_using_timezone(NaiveDateTime.t(), String.t()) :: DateTime.t()
+  def convert_using_timezone(time, time_zone) do
+    tz =
+      if Timex.is_valid_timezone?(time_zone) do
+        time_zone
+      else
+        "America/New_York"
+      end
+
+    time
+    |> Timex.to_datetime(tz)
+    |> handle_ambiguous_time()
+  end
+
   @doc "Converts a DateTime.t into the America/New_York zone, handling ambiguities"
   @spec to_local_time(DateTime.t() | NaiveDateTime.t() | Timex.AmbiguousDateTime.t()) ::
           DateTime.t() | {:error, any}

--- a/apps/util/test/util_test.exs
+++ b/apps/util/test/util_test.exs
@@ -60,6 +60,37 @@ defmodule UtilTest do
     end
   end
 
+  describe "convert_using_timezone/2" do
+    test "converts to 'America/New_York' timezone" do
+      # DateTime<2016-12-12 12:12:12-05:00 EST America/New_York>
+      assert Util.convert_using_timezone(~N[2016-12-12T12:12:12], "America/New_York") ==
+               Timex.to_datetime({{2016, 12, 12}, {12, 12, 12}}, "America/New_York")
+    end
+
+    test "converts to 'Europe/Madrid' timezone" do
+      # DateTime<2020-12-12 12:12:12+01:00 CET Europe/Madrid>
+      assert Util.convert_using_timezone(~N[2020-12-12T12:12:12], "Europe/Madrid") ==
+               Timex.to_datetime({{2020, 12, 12}, {12, 12, 12}}, "Europe/Madrid")
+    end
+
+    test "attempts to convert to an invalid timezone, defaulting to America/New_York" do
+      assert Util.convert_using_timezone(~N[2020-12-12T12:12:12], "Atlantis") ==
+               Timex.to_datetime({{2020, 12, 12}, {12, 12, 12}}, "America/New_York")
+    end
+
+    test "converts to 'America/New_York' timezone accounting for beginning of daylight saving time" do
+      assert Util.convert_using_timezone(~N[2020-03-08T02:00:00], "America/New_York") ==
+               Timex.to_datetime({{2020, 3, 8}, {2, 0, 0}}, "America/New_York")
+    end
+
+    test "converts 'America/New_York' timezone accounting for end of daylight saving time" do
+      ambiguous = Timex.to_datetime({{2020, 11, 1}, {1, 0, 0}}, "America/New_York")
+
+      assert Util.convert_using_timezone(~N[2020-11-01T01:00:00], "America/New_York") ==
+               ambiguous.before
+    end
+  end
+
   describe "service_date/0" do
     test "returns the service date for the current time" do
       assert service_date() == service_date(now())


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Times (not) coming through in UTC time](https://app.asana.com/0/555089885850811/1198956720242891)

Ensure the date and time of incident is properly converted to UTC time in the message sent to HEAT.

