### PR TITLE
Restore profanity sanitizer to an IE-compatible version

### DIFF
--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import Filter from "bad-words";
 
 export default function($ = window.jQuery) {
   document.addEventListener(
@@ -463,9 +464,13 @@ export function handleSubmitClick($, toUpload) {
     }
     deactivateSubmitButton($);
     const formData = new FormData();
+    const filter = new Filter();
     $("#support-form")
       .serializeArray()
       .forEach(({ name: name, value: value }) => {
+        if (name === "support[comments]") {
+          value = filter.clean(value);
+        }
         formData.append(name, value);
       });
 

--- a/apps/site/assets/package-lock.json
+++ b/apps/site/assets/package-lock.json
@@ -7890,6 +7890,19 @@
         }
       }
     },
+    "bad-words": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-1.6.5.tgz",
+      "integrity": "sha512-KzDrzFtzS8Z+v4I+KuanePuaj7g6aRms2WYQOt7n+UugfqMPheYS7zcyTypokxMno2Ss6xfo062ya1aVrviB2g==",
+      "requires": {
+        "badwords-list": "^1.0.0"
+      }
+    },
+    "badwords-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
+      "integrity": "sha1-XphW2/E0gqKVw7CzBK+51M/FxXk="
+    },
     "bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",

--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -6,6 +6,7 @@
     "@types/dot-prop-immutable": "^1.5.0",
     "algoliasearch": "^3.25.1",
     "autocomplete.js": "git+https://github.com/mbta/autocomplete.js.git#ad94896",
+    "bad-words": "^1.6.5",
     "bootstrap": "4.0.0-alpha.2",
     "core-js": "^2.6.5",
     "dot-prop-immutable": "^1.5.0",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Restore profanity sanitizer in Customer Support form](https://app.asana.com/0/555089885850811/1199207412558094)

It's essentially the same changes from PR #646 but with the downgraded version so the new customer support form works in IE without breaking.
