### PR TITLE
fix: always assign `:all_options_per_mode`

### DIFF
--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -70,19 +70,11 @@ defmodule SiteWeb.CustomerSupportController do
   plug(:assign_ip)
   plug(:meta_description)
   plug(:assign_datetime_selector_fields)
+  plug(:assign_all_options_per_mode)
 
-  def index(conn, %{"comments" => comments}) do
-    render_form(
-      conn
-      |> assign(:all_options_per_mode, get_options_per_mode()),
-      %{comments: comments}
-    )
-  end
-
-  def index(conn, _params) do
-    conn
-    |> assign(:all_options_per_mode, get_options_per_mode())
-    |> render_form(%{comments: nil})
+  def index(conn, params) do
+    comments = Map.get(params, "comments", nil)
+    render_form(conn, %{comments: comments})
   end
 
   def thanks(conn, _params) do
@@ -401,5 +393,10 @@ defmodule SiteWeb.CustomerSupportController do
   defp assign_datetime_selector_fields(conn, _) do
     conn
     |> assign(:support_datetime_selector_fields, @support_datetime_selector_fields)
+  end
+
+  @spec assign_all_options_per_mode(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
+  defp assign_all_options_per_mode(conn, _) do
+    assign(conn, :all_options_per_mode, get_options_per_mode())
   end
 end

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -116,7 +116,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     test "validates presence of comments", %{conn: conn} do
       conn =
         post(
-          conn |> assign(:all_options_per_mode, %{}),
+          conn,
           customer_support_path(conn, :submit),
           put_in(valid_request_response_data(), ["support", "comments"], "")
         )
@@ -127,7 +127,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     test "validates the presence of the service type", %{conn: conn} do
       conn =
         post(
-          conn |> assign(:all_options_per_mode, %{}),
+          conn,
           customer_support_path(conn, :submit),
           put_in(valid_request_response_data(), ["support", "service"], "")
         )
@@ -138,7 +138,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     test "validates that the service is one of the allowed values", %{conn: conn} do
       conn =
         post(
-          conn |> assign(:all_options_per_mode, %{}),
+          conn,
           customer_support_path(conn, :submit),
           put_in(valid_request_response_data(), ["support", "service"], "Hug")
         )
@@ -149,7 +149,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     test "validates that the subject is one of the allowed values for the service", %{conn: conn} do
       conn =
         post(
-          conn |> assign(:all_options_per_mode, %{}),
+          conn,
           customer_support_path(conn, :submit),
           put_in(valid_request_response_data(), ["support", "subject"], "Bad")
         )
@@ -160,7 +160,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     test "requires first_name if customer does want a response", %{conn: conn} do
       conn =
         post(
-          conn |> assign(:all_options_per_mode, %{}),
+          conn,
           customer_support_path(conn, :submit),
           put_in(valid_request_response_data(), ["support", "first_name"], "")
         )
@@ -171,7 +171,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     test "requires last_name if customer does want a response", %{conn: conn} do
       conn =
         post(
-          conn |> assign(:all_options_per_mode, %{}),
+          conn,
           customer_support_path(conn, :submit),
           put_in(valid_request_response_data(), ["support", "last_name"], "")
         )
@@ -180,8 +180,6 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     end
 
     test "invalid with no email when the customer wants a response", %{conn: conn} do
-      conn = conn |> assign(:all_options_per_mode, %{})
-
       conn =
         post(
           conn,
@@ -195,7 +193,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     test "requires a real email", %{conn: conn} do
       conn =
         post(
-          conn |> assign(:all_options_per_mode, %{}),
+          conn,
           customer_support_path(conn, :submit),
           put_in(valid_request_response_data(), ["support", "email"], "not an email")
         )
@@ -204,8 +202,6 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     end
 
     test "invalid with phone but no email when the customer wants a response", %{conn: conn} do
-      conn = conn |> assign(:all_options_per_mode, %{})
-
       conn =
         post(
           conn,
@@ -221,7 +217,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     test "requires privacy checkbox when customer wants a response", %{conn: conn} do
       conn =
         post(
-          conn |> assign(:all_options_per_mode, %{}),
+          conn,
           customer_support_path(conn, :submit),
           put_in(valid_request_response_data(), ["support", "privacy"], "")
         )
@@ -261,7 +257,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
 
       conn =
         post(
-          conn |> assign(:all_options_per_mode, %{}),
+          conn,
           customer_support_path(conn, :submit),
           params
         )
@@ -278,7 +274,6 @@ defmodule SiteWeb.CustomerSupportControllerTest do
             Enum.reduce(1..4, conn, fn _, acc ->
               acc
               |> recycle()
-              |> assign(:all_options_per_mode, %{})
               |> post(path, valid_request_response_data())
             end)
 
@@ -292,7 +287,7 @@ defmodule SiteWeb.CustomerSupportControllerTest do
     test "requires a successful recaptcha response", %{conn: conn} do
       conn =
         post(
-          conn |> assign(:all_options_per_mode, %{}),
+          conn,
           customer_support_path(conn, :submit),
           put_in(valid_no_response_data(), ["g-recaptcha-response"], "invalid_response")
         )


### PR DESCRIPTION
Previously, we only assigned this data in the `index/2` function. However,
this is also required if the submission fails, when we re-render the form. We
can see this by removing all of extra `assign/3` calls in the unit tests.

To fix, we pull this behavior into a plug, so that we will always assign this
data regardless of function is originally called.

Asana: https://app.asana.com/0/555089885850811/1198960312594553
 
---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [ ] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
