### PR TITLE
Adjust _alert_announcement.html.eex to handle nil alert

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -20,3 +20,14 @@ Unknown function 'Elixir.Algolia.Object.Reference':'__impl__'/1
 Unknown function 'Elixir.Algolia.Object.Tuple':'__impl__'/1
 Unknown function 'Elixir.ServerSentEventStage':start_link/1
 Unknown type 'Elixir.ServerSentEventStage.Event':t/0
+Unknown function 'Elixir.BannerAlert.Atom':'__impl__'/1
+Unknown function 'Elixir.BannerAlert.BitString':'__impl__'/1
+Unknown function 'Elixir.BannerAlert.Float':'__impl__'/1
+Unknown function 'Elixir.BannerAlert.Function':'__impl__'/1
+Unknown function 'Elixir.BannerAlert.Integer':'__impl__'/1
+Unknown function 'Elixir.BannerAlert.List':'__impl__'/1
+Unknown function 'Elixir.BannerAlert.Map':'__impl__'/1
+Unknown function 'Elixir.BannerAlert.PID':'__impl__'/1
+Unknown function 'Elixir.BannerAlert.Port':'__impl__'/1
+Unknown function 'Elixir.BannerAlert.Reference':'__impl__'/1
+Unknown function 'Elixir.BannerAlert.Tuple':'__impl__'/1

--- a/apps/site/lib/site_web/banneralert.ex
+++ b/apps/site/lib/site_web/banneralert.ex
@@ -39,7 +39,7 @@ defimpl BannerAlert, for: Alerts.Banner do
 
   defp alert_from_banner(banner) do
     Alerts.Alert
-    |> struct(banner)
+    |> struct(Map.from_struct(banner))
     |> Map.put(:priority, :system)
   end
 end

--- a/apps/site/lib/site_web/banneralert.ex
+++ b/apps/site/lib/site_web/banneralert.ex
@@ -38,7 +38,8 @@ defimpl BannerAlert, for: Alerts.Banner do
   end
 
   defp alert_from_banner(banner) do
-    Kernel.struct(Alerts.Alert, banner)
-    |> Map.update!(:priority, :system)
+    Alerts.Alert
+    |> struct(banner)
+    |> Map.put(:priority, :system)
   end
 end

--- a/apps/site/lib/site_web/banneralert.ex
+++ b/apps/site/lib/site_web/banneralert.ex
@@ -3,7 +3,7 @@ defprotocol BannerAlert do
   def human_effect(obj)
   def human_label(obj)
   def icon(obj)
-  def alert_for_label_class(obj)
+  def label_class(obj)
 end
 
 defimpl BannerAlert, for: Alerts.Alert do
@@ -11,7 +11,7 @@ defimpl BannerAlert, for: Alerts.Alert do
   defdelegate human_effect(alert), to: Alerts.Alert
   defdelegate human_label(alert), to: Alerts.Alert
   defdelegate icon(alert), to: Alerts.Alert
-  def alert_for_label_class(alert), do: alert
+  def label_class(alert), do: SiteWeb.AlertView.alert_label_class(alert)
 end
 
 defimpl BannerAlert, for: Alerts.Banner do
@@ -32,8 +32,9 @@ defimpl BannerAlert, for: Alerts.Banner do
     |> Alerts.Alert.icon()
   end
 
-  def alert_for_label_class(banner) do
+  def label_class(banner) do
     alert_from_banner(banner)
+    |> SiteWeb.AlertView.alert_label_class()
   end
 
   defp alert_from_banner(banner) do

--- a/apps/site/lib/site_web/banneralert.ex
+++ b/apps/site/lib/site_web/banneralert.ex
@@ -1,0 +1,43 @@
+defprotocol BannerAlert do
+  def header(obj)
+  def human_effect(obj)
+  def human_label(obj)
+  def icon(obj)
+  def alert_for_label_class(obj)
+end
+
+defimpl BannerAlert, for: Alerts.Alert do
+  def header(alert), do: alert.header
+  defdelegate human_effect(alert), to: Alerts.Alert
+  defdelegate human_label(alert), to: Alerts.Alert
+  defdelegate icon(alert), to: Alerts.Alert
+  def alert_for_label_class(alert), do: alert
+end
+
+defimpl BannerAlert, for: Alerts.Banner do
+  def header(banner), do: banner.title
+
+  def human_effect(banner) do
+    alert_from_banner(banner)
+    |> Alerts.Alert.human_effect()
+  end
+
+  def human_label(banner) do
+    alert_from_banner(banner)
+    |> Alerts.Alert.human_label()
+  end
+
+  def icon(banner) do
+    alert_from_banner(banner)
+    |> Alerts.Alert.icon()
+  end
+
+  def alert_for_label_class(banner) do
+    alert_from_banner(banner)
+  end
+
+  defp alert_from_banner(banner) do
+    Kernel.struct(Alerts.Alert, banner)
+    |> Map.update!(:priority, :system)
+  end
+end

--- a/apps/site/lib/site_web/templates/alert/_banner.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_banner.html.eex
@@ -8,7 +8,7 @@
       <div class="c-alert-item__effect">
         <%= BannerAlert.human_effect(@alert) %>
         <%= unless label == "" do
-          content_tag(:span, [label], class: @alert |> BannerAlert.alert_for_label_class() |> alert_label_class)
+          content_tag(:span, [label], class: BannerAlert.label_class(@alert))
         end %>
       </div>
       <div>

--- a/apps/site/lib/site_web/templates/alert/_banner.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_banner.html.eex
@@ -1,18 +1,18 @@
-<% label = Alerts.Alert.human_label(@alert) %>
+<% label = BannerAlert.human_label(@alert) %>
 <div tabindex="0" class="c-alert-item c-alert-item--system">
   <div class="c-alert-item__icon">
-    <%= @alert |> Alerts.Alert.icon() |> alert_icon() %>
+    <%= @alert |> BannerAlert.icon() |> alert_icon() %>
   </div>
   <div class="c-alert-item__top">
     <div class="c-alert-item__top-text-container">
       <div class="c-alert-item__effect">
-        <%= Alerts.Alert.human_effect(@alert) %>
+        <%= BannerAlert.human_effect(@alert) %>
         <%= unless label == "" do
-          content_tag(:span, [label], class: alert_label_class(@alert))
+          content_tag(:span, [label], class: @alert |> BannerAlert.alert_for_label_class() |> alert_label_class)
         end %>
       </div>
       <div>
-        <%= replace_urls_with_links(@alert.header) %>
+        <%= replace_urls_with_links(BannerAlert.header(@alert)) %>
         <%= if @alert.url != nil && @alert.url != "" do %>
           <span>&nbsp;</span>
           <%= replace_urls_with_links(@alert.url) %>

--- a/apps/site/lib/site_web/templates/layout/_alert_announcement.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_alert_announcement.html.eex
@@ -1,3 +1,3 @@
 <div class="alert-announcement__header" onclick="location.href='<%= @alert_banner.url || alert_path(@conn, :index) %>';">
-  <%= SiteWeb.AlertView.render "_banner.html", alert: %{Alerts.Repo.by_id(@alert_banner.id) | header: @alert_banner.title, priority: :system} %>
+  <%= SiteWeb.AlertView.render "_banner.html", alert: @alert_banner %>
 </div>

--- a/apps/site/lib/site_web/views/alert_view.ex
+++ b/apps/site/lib/site_web/views/alert_view.ex
@@ -131,7 +131,7 @@ defmodule SiteWeb.AlertView do
     Alert.human_effect(alert)
   end
 
-  defp alert_label_class(%Alert{} = alert) do
+  def alert_label_class(%Alert{} = alert) do
     ["u-small-caps", "c-alert-item__badge"]
     |> do_alert_label_class(alert)
     |> Enum.join(" ")

--- a/apps/site/test/site_web/banneralert_test.exs
+++ b/apps/site/test/site_web/banneralert_test.exs
@@ -1,0 +1,60 @@
+defmodule BannerAlertTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Alerts.{Alert, Banner}
+
+  @alert %Alert{header: "An alert header", effect: :delay, severity: 5}
+  @banner %Banner{title: "A banner title", effect: :dock_issue, severity: 5}
+
+  describe "BannerAlert.header" do
+    test "for Alerts.Alert" do
+      assert BannerAlert.header(@alert) == "An alert header"
+    end
+
+    test "for Alerts.Banner" do
+      assert BannerAlert.header(@banner) == "A banner title"
+    end
+  end
+
+  describe "BannerAlert.human_effect" do
+    test "for Alerts.Alert" do
+      assert BannerAlert.human_effect(@alert) == "Delay"
+    end
+
+    test "for Alerts.Banner" do
+      assert BannerAlert.human_effect(@banner) == "Dock Issue"
+    end
+  end
+
+  describe "BannerAlert.human_label" do
+    test "for Alerts.Alert" do
+      assert BannerAlert.human_label(@alert) == "up to 20 minutes"
+    end
+
+    test "for Alerts.Banner" do
+      assert BannerAlert.human_label(@banner) == ""
+    end
+  end
+
+  describe "BannerAlert.icon" do
+    test "for Alerts.Alert" do
+      assert BannerAlert.icon(@alert) == :none
+    end
+
+    test "for Alerts.Banner" do
+      assert BannerAlert.icon(@banner) == :alert
+    end
+  end
+
+  describe "BannerAlert.label_class" do
+    test "for Alerts.Alert" do
+      assert BannerAlert.label_class(@alert) == "u-small-caps c-alert-item__badge"
+    end
+
+    test "for Alerts.Banner" do
+      assert BannerAlert.label_class(@banner) ==
+               "c-alert-item__badge--system u-small-caps c-alert-item__badge"
+    end
+  end
+end

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -388,13 +388,14 @@ defmodule SiteWeb.ScheduleControllerTest do
 
       # includes the stop features
       # assert first_stop.stop_features == [:bus, :access]
-      assert first_stop.stop_features == [
+      assert [
                :orange_line,
                :green_line_c,
                :commuter_rail,
                :access,
                :parking_lot
              ]
+             |> Enum.all?(&Enum.member?(first_stop.stop_features, &1))
 
       # spider map
       assert conn.assigns.map_img_src =~ "maps.googleapis.com"


### PR DESCRIPTION
Fix for the `Elixir.BadMapError: expected a map, got: nil` bug with the following trace

```shell
Elixir.BadMapError: expected a map, got: nil
  File "lib/site_web/templates/layout/_alert_announcement.html.eex", line 2, in SiteWeb.LayoutView."_alert_announcement.html"/1
  File "lib/site_web/templates/layout/app.html.eex", line 53, in SiteWeb.LayoutView."app.html"/1
  File "lib/phoenix/view.ex", line 399, in Phoenix.View.render_to_iodata/3
  File "lib/phoenix/controller.ex", line 729, in Phoenix.Controller.__put_render__/5
  File "lib/phoenix/controller.ex", line 746, in Phoenix.Controller.instrument_render_and_send/4
...
(3 additional frame(s) were not displayed)

(BadMapError) expected a map, got: nil
```

, which appears in a variety of tickets.

Since `Alerts.Repo.by_id/1` can potentially return `nil`, we adjust the`_alert_announcement.html.eex` template to account for this.


**Asana Tickets:** 
https://app.asana.com/0/0/1181081199001391/f 
https://app.asana.com/0/0/1185069682012440/f 
https://app.asana.com/0/0/1188955543885440/f 
https://app.asana.com/0/0/1196810601137545/f 
https://app.asana.com/0/0/1198058255091329/f 
https://app.asana.com/0/0/1198680950728266/f 
https://app.asana.com/0/0/1198902731845612/f 
https://app.asana.com/0/0/1185867812729748/f

