### PR TITLE
Account for empty list of stops

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/map_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/map_api.ex
@@ -37,7 +37,7 @@ defmodule SiteWeb.ScheduleController.MapApi do
   defp get_map_data(route, direction_id, shape_id) do
     route_shapes = LineHelpers.get_route_shapes(route.id, direction_id)
     active_shapes = LineHelpers.get_active_shapes(route_shapes, route, shape_id)
-    branches = LineHelpers.get_branch_route_stops(route, direction_id, shape_id)
+    branches = LineHelpers.get_branch_route_stops(route, direction_id)
     map_stops = Maps.map_stops(branches, {route_shapes, active_shapes}, route.id)
 
     {_map_img_src, dynamic_map_data} = Maps.map_data(route, map_stops, [], [])

--- a/apps/site/test/site_web/controllers/schedule/map_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/map_api_test.exs
@@ -37,6 +37,24 @@ defmodule SiteWeb.ScheduleController.MapApiTest do
              } = response
     end
 
+    test "accepts a shape_id for the Green Line and returns valid map data", %{conn: conn} do
+      conn =
+        get(conn, map_api_path(conn, :show, id: "Green", direction_id: "0", shape_id: "813_0006"))
+
+      assert response = json_response(conn, 200)
+
+      assert %{
+               "default_center" => %{"latitude" => _, "longitude" => _},
+               "height" => _,
+               "markers" => _,
+               "polylines" => _,
+               "stop_markers" => _,
+               "tile_server_url" => _,
+               "width" => _,
+               "zoom" => _
+             } = response
+    end
+
     test "returns 400 if given a bad route", %{conn: conn} do
       conn = get(conn, map_api_path(conn, :show, id: "Puce"))
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Elixir.FunctionClauseError: no function clause matching in Stops.RouteStops.branch/1](https://app.asana.com/0/555089885850811/1191546277787129)

I'm not sure if this is a valid solution, hence the draft PR. If it is, I will create the corresponding test for it.
