### PR TITLE
feat: Add validation for vehicle number field

### DIFF
--- a/apps/site/assets/css/_customer-support.scss
+++ b/apps/site/assets/css/_customer-support.scss
@@ -165,9 +165,12 @@ body {
   }
 }
 
-.support-form-text-input {
+// styles the input fields
+.support-form-input {
   border: 2px solid $brand-primary;
+  display: block;
   font-size: inherit; // Bootstrap override
+  padding: $base-spacing / 2;
 
   &--small {
     @include media-breakpoint-down(xs) {

--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -351,6 +351,13 @@ const validators = {
   },
   recaptcha: function($) {
     return !!$("#g-recaptcha-response").val();
+  },
+  vehicle: function($) {
+    const value = $("#vehicle").val();
+    if (value && value.length > 0) {
+      return /^[0-9]+$/.test(value);
+    }
+    return true;
   }
 };
 
@@ -365,7 +372,8 @@ function setupValidation($) {
     "#comments",
     "#email",
     "#first_name",
-    "#last_name"
+    "#last_name",
+    "#vehicle"
   ].forEach(selector => {
     const $selector = $(selector);
     $selector.on("keyup blur input change", () => {
@@ -398,6 +406,7 @@ function validateForm($) {
     subject = "#support_subject",
     comments = "#comments",
     service = "#service",
+    vehicle = "#vehicle",
     email = "#email",
     first_name = "#first_name",
     last_name = "#last_name",
@@ -436,6 +445,13 @@ function validateForm($) {
     errors.push(last_name);
   } else {
     displaySuccess($, last_name);
+  }
+  // Vehicle number
+  if (!validators.vehicle($)) {
+    displayError($, vehicle);
+    errors.push(vehicle);
+  } else {
+    displaySuccess($, vehicle);
   }
   // Phone and email
   if (!validators.email($)) {

--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -354,10 +354,7 @@ const validators = {
   },
   vehicle: function($) {
     const value = $("#vehicle").val();
-    if (value && value.length > 0) {
-      return /^[0-9]+$/.test(value);
-    }
-    return true;
+    return /^[0-9]*$/.test(value);
   }
 };
 

--- a/apps/site/assets/js/test/support-form_test.js
+++ b/apps/site/assets/js/test/support-form_test.js
@@ -649,7 +649,7 @@ describe("support form", () => {
        </select>
        <div id="charlie-card-or-ticket-number" class="form-group">
         <label class="form-control-label" for="support_ticket_number">CharlieCard or Ticket number (optional)</label>
-        <input class="support-form-text-input support-form-text-input--small form-control" id="support_ticket_number" name="support[ticket_number]" type="text">
+        <input class="support-form-input support-form-input--small form-control" id="support_ticket_number" name="support[ticket_number]" type="text">
        </div>
      `);
       handleSubjectChange($);

--- a/apps/site/assets/js/test/support-form_test.js
+++ b/apps/site/assets/js/test/support-form_test.js
@@ -285,6 +285,8 @@ describe("support form", () => {
             </select>
             <div class="support-comments-error-container hidden-xs-up" tabindex="-1"><div class="support-comments-error"></div></div>
             <textarea name="support[comments]" id="comments"></textarea>
+            <div class="support-vehicle-error-container hidden-xs-up" tabindex="-1"><div class="support-vehicle-error"></div></div>
+            <input id="vehicle" name="support[vehicle]" placeholder="00001" type="text" />
             <input name="support[photo]" id="photo" type="file" />
             <div class="support-first_name-error-container hidden-xs-up" tabindex="-1"><div class="support-first_name-error"></div></div>
             <input name="support[first_name]" id="first_name" />
@@ -323,6 +325,21 @@ describe("support form", () => {
       $("#support-submit").click();
       assert.isFalse(
         $(".support-comments-error-container").hasClass("hidden-xs-up")
+      );
+    });
+
+    it("requires vehicle number to have only numeric characters, if filled", () => {
+      $("#vehicle").val("Not a number");
+      $("#support-submit").click();
+      assert.isFalse(
+        $(".support-vehicle-error-container").hasClass("hidden-xs-up"),
+        "not false"
+      );
+      $("#vehicle").val("1234");
+      $("#support-submit").click();
+      assert.isTrue(
+        $(".support-vehicle-error-container").hasClass("hidden-xs-up"),
+        "not true"
       );
     });
 

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -253,13 +253,8 @@ defmodule SiteWeb.CustomerSupportController do
   defp validate_privacy(_), do: "privacy"
 
   @spec validate_vehicle(map) :: :ok | String.t()
-  defp validate_vehicle(%{"vehicle" => ""}), do: :ok
-
   defp validate_vehicle(%{"vehicle" => vehicle_number}) do
-    case Regex.run(~r/^[0-9]+$/, vehicle_number) do
-      nil -> "vehicle"
-      [_] -> :ok
-    end
+    if Regex.match?(~r/^[0-9]*$/, vehicle_number), do: :ok, else: "vehicle"
   end
 
   defp validate_vehicle(_), do: :ok

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -187,6 +187,7 @@ defmodule SiteWeb.CustomerSupportController do
           &validate_service/1,
           &validate_subject/1,
           &validate_photos/1,
+          &validate_vehicle/1,
           &validate_name/1,
           &validate_email/1,
           &validate_privacy/1,
@@ -198,6 +199,7 @@ defmodule SiteWeb.CustomerSupportController do
           &validate_service/1,
           &validate_subject/1,
           &validate_photos/1,
+          &validate_vehicle/1,
           &validate_recaptcha/1
         ]
       end
@@ -249,6 +251,18 @@ defmodule SiteWeb.CustomerSupportController do
   @spec validate_privacy(map) :: :ok | String.t()
   defp validate_privacy(%{"privacy" => "on"}), do: :ok
   defp validate_privacy(_), do: "privacy"
+
+  @spec validate_vehicle(map) :: :ok | String.t()
+  defp validate_vehicle(%{"vehicle" => ""}), do: :ok
+
+  defp validate_vehicle(%{"vehicle" => vehicle_number}) do
+    case Regex.run(~r/^[0-9]+$/, vehicle_number) do
+      nil -> "vehicle"
+      [_] -> :ok
+    end
+  end
+
+  defp validate_vehicle(_), do: :ok
 
   @spec validate_photos(map) :: :ok | String.t()
   defp validate_photos(%{"photos" => photos}) when is_list(photos) do

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -64,9 +64,10 @@
         </div>
       </div>
       <div class="plan-time-select">
-        <%= label f, "Vehicle", [id: "vehicleLabel", for: "support_vehicle", class: "form-control-label"] %>
-        <div>
-          <%= text_input(f, :vehicle, placeholder: placeholder_text("vehicle"), class: "plan-date-input") %>
+        <%= support_error_tag @errors, "vehicle" %>
+        <div class="form-group <%= class_for_error("vehicle", @errors, "has-danger", "has-success") %>">
+          <%= label f, "Vehicle", [id: "vehicleLabel", for: "vehicle", class: "form-control-label"] %>
+          <%= text_input(f, :vehicle, id: "vehicle", placeholder: placeholder_text("vehicle"), class: "form-control plan-date-input", value: assigns[:vehicle] ) %>
           <span data-toggle="tooltip" data-placement="right" title="Vehicle numbers are usually displayed overhead at either end of the vehicle, and always displayed on the exterior.">
             <span aria-hidden="true" class="c-search-result__content-icon fa fa-info">
             </span>

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -29,15 +29,15 @@
     </div>
     <div id="charlie-card-or-ticket-number" class="form-group">
       <%= label f, :ticket_number, "CharlieCard or Ticket number (optional)", [class: "form-control-label"] %>
-      <%= text_input f, :ticket_number, class: "support-form-text-input support-form-text-input--small form-control" %>
+      <%= text_input f, :ticket_number, class: "support-form-input support-form-input--small form-control" %>
     </div>
     <div class="form-group <%= class_for_error("comments", @errors, "has-danger", "has-success") %>">
       <%= support_error_tag @errors, "comments" %>
       <%= label f, :comments, "Let us know how we can help*", [for: "comments", class: "form-control-label"] %>
-      <%= textarea f, :comments, id: "comments", class: "support-form-text-input form-control #{class_for_error("comments", @errors, "form-control-danger", "form-control-success")}", "aria-describedby": "commentsHelp", maxlength: "3000", rows: "3", placeholder: placeholder_text("comments"), required: "required", value: assigns[:comments] %>
+      <%= textarea f, :comments, id: "comments", class: "support-form-input form-control #{class_for_error("comments", @errors, "form-control-danger", "form-control-success")}", "aria-describedby": "commentsHelp", maxlength: "3000", rows: "3", placeholder: placeholder_text("comments"), required: "required", value: assigns[:comments] %>
       <small id="commentsHelp" class="form-text">3000 characters maximum</small>
     </div>
-    <div id="support-datepicker" class="m-trip-plan__departure-last">
+    <div id="support-datepicker">
       <strong>Time/Date of incident</strong>
       <script id="form-data" type="text/plain">
         <%= raw(Poison.encode!(@support_datetime_selector_fields)) %>
@@ -52,26 +52,24 @@
     <div>Adding more details helps us more effectively respond to your concerns.</div>
     <div class="form-group">
       <%= label f, "Mode", [for: "support_mode", class: "form-control-label"] %>
-      <div class="plan-time-select">
-        <%= select(f, :mode, get_all_modes(), class: "c-select c-mode-selector") %>
-      </div>
+      <%= select(f, :mode, get_all_modes(), class: "form-control c-select support-form-input support-form-input--small") %>
     </div>
-    <div id="route-and-vehicle" class="form-group m-schedule-line__connection-line">
-      <div class="c-mode-selector">
+    <div id="route-and-vehicle" class="row">
+      <div class="col-sm-6 form-group">
         <%= label f, "Route", [for: "support_route", class: "form-control-label"] %>
-        <div class="plan-time-select">
-          <%= select(f, :route, [], class: "c-select c-route-selector") %>
-        </div>
+        <%= select(f, :route, [], class: "form-control c-select support-form-input") %>
       </div>
-      <div class="plan-time-select">
+      <div class="col-sm-6">
         <%= support_error_tag @errors, "vehicle" %>
         <div class="form-group <%= class_for_error("vehicle", @errors, "has-danger", "has-success") %>">
-          <%= label f, "Vehicle", [id: "vehicleLabel", for: "vehicle", class: "form-control-label"] %>
-          <%= text_input(f, :vehicle, id: "vehicle", placeholder: placeholder_text("vehicle"), class: "form-control plan-date-input", value: assigns[:vehicle] ) %>
-          <span data-toggle="tooltip" data-placement="right" title="Vehicle numbers are usually displayed overhead at either end of the vehicle, and always displayed on the exterior.">
-            <span aria-hidden="true" class="c-search-result__content-icon fa fa-info">
+          <div>
+            <%= label f, "Vehicle", [id: "vehicleLabel", for: "vehicle", class: "form-control-label"] %>
+            <span data-toggle="tooltip" data-placement="right" title="Vehicle numbers are usually displayed overhead at either end of the vehicle, and always displayed on the exterior.">
+              <span aria-hidden="true" class="c-search-result__content-icon fa fa-info">
+              </span>
             </span>
-          </span>
+          </div>
+          <%= text_input(f, :vehicle, id: "vehicle", placeholder: placeholder_text("vehicle"), class: "support-form-input form-control", value: assigns[:vehicle] ) %>
         </div>
       </div>
     </div>
@@ -100,22 +98,22 @@
       <div class="form-group <%= class_for_error("first_name", @errors, "has-danger", "has-success") %>">
         <%= label f, :first_name, "First Name*", [for: "first_name", class: "form-control-label"] %>
         <%= support_error_tag @errors, "first_name" %>
-        <%= text_input f, :first_name, placeholder: placeholder_text("first_name"), class: "support-form-text-input support-form-text-input--small form-control #{class_for_error("first_name", @errors, "form-control-danger", "form-control-success")}", autocomplete: "first_name", id: "first_name" %>
+        <%= text_input f, :first_name, placeholder: placeholder_text("first_name"), class: "support-form-input support-form-input--small form-control #{class_for_error("first_name", @errors, "form-control-danger", "form-control-success")}", autocomplete: "first_name", id: "first_name" %>
       </div>
       <div class="form-group <%= class_for_error("last_name", @errors, "has-danger", "has-success") %>">
         <%= label f, :name, "Last Name*", [for: "last_name", class: "form-control-label"] %>
         <%= support_error_tag @errors, "last_name" %>
-        <%= text_input f, :last_name, placeholder: placeholder_text("last_name"), class: "support-form-text-input support-form-text-input--small form-control #{class_for_error("last_name", @errors, "form-control-danger", "form-control-success")}", autocomplete: "last_name", id: "last_name" %>
+        <%= text_input f, :last_name, placeholder: placeholder_text("last_name"), class: "support-form-input support-form-input--small form-control #{class_for_error("last_name", @errors, "form-control-danger", "form-control-success")}", autocomplete: "last_name", id: "last_name" %>
       </div>
       <div class="form-group <%= class_for_error("email", @errors, "has-danger", "has-success") %>">
         <%= label f, :email, "Email*", [for: "email", class: "form-control-label"] %>
         <%= support_error_tag @errors, "email" %>
-        <%= text_input f, :email, placeholder: placeholder_text("email"), class: "form-control support-form-text-input support-form-text-input--small #{class_for_error("email", @errors, "form-control-danger", "form-control-success")}", autocomplete: "email", id: "email" %>
+        <%= text_input f, :email, placeholder: placeholder_text("email"), class: "form-control support-form-input support-form-input--small #{class_for_error("email", @errors, "form-control-danger", "form-control-success")}", autocomplete: "email", id: "email" %>
       </div>
       <div class="form-group">
         <%= help_text "phone" %>
         <%= label f, :phone, "Phone number", [for: "phone", class: "form-control-label"] %>
-        <%= telephone_input f, :phone, placeholder: placeholder_text("phone"), class: "support-form-text-input support-form-text-input--small form-control", "aria-describedby": "phoneHelp", autocomplete: "tel", id: "phone" %>
+        <%= telephone_input f, :phone, placeholder: placeholder_text("phone"), class: "support-form-input support-form-input--small form-control", "aria-describedby": "phoneHelp", autocomplete: "tel", id: "phone" %>
       </div>
       <div class="form-group <%= class_for_error("privacy", @errors, "has-danger", "has-success") %> mb-0 mt-1">
         <%= support_error_tag @errors, "privacy" %>

--- a/apps/site/lib/site_web/views/customer_support_view.ex
+++ b/apps/site/lib/site_web/views/customer_support_view.ex
@@ -63,7 +63,7 @@ defmodule SiteWeb.CustomerSupportView do
   def placeholder_text("last_name"), do: "Smith"
   def placeholder_text("email"), do: "janesmith@email.com"
   def placeholder_text("phone"), do: "(555)-555-5555"
-  def placeholder_text("vehicle"), do: "e.g. 00001"
+  def placeholder_text("vehicle"), do: "00001"
   def placeholder_text(_), do: ""
 
   def help_text("phone"),
@@ -124,6 +124,10 @@ defmodule SiteWeb.CustomerSupportView do
   defp error_msg("service"), do: "Please select the type of concern."
   defp error_msg("comments"), do: "Please enter a comment to continue."
   defp error_msg("upload"), do: "Sorry. We had trouble uploading your image. Please try again."
+
+  defp error_msg("vehicle"),
+    do: "Please enter a valid vehicle number with numeric characters only."
+
   defp error_msg("email"), do: "Please enter a valid email."
   defp error_msg("first_name"), do: "Please enter your first name to continue."
   defp error_msg("last_name"), do: "Please enter your last name to continue."

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -61,7 +61,8 @@ defmodule SiteWeb.CustomerSupportControllerTest do
             "hour" => 10,
             "minute" => 15,
             "am_pm" => "AM"
-          }
+          },
+          "vehicle" => ""
         },
         "g-recaptcha-response" => "valid_response"
       }
@@ -81,7 +82,8 @@ defmodule SiteWeb.CustomerSupportControllerTest do
             "hour" => 10,
             "minute" => 15,
             "am_pm" => "AM"
-          }
+          },
+          "vehicle" => ""
         },
         "g-recaptcha-response" => "valid_response"
       }
@@ -170,6 +172,26 @@ defmodule SiteWeb.CustomerSupportControllerTest do
         )
 
       assert "subject" in conn.assigns.errors
+    end
+
+    test "validates that the vehicle number, if filled, is a valid value", %{conn: conn} do
+      conn =
+        post(
+          conn,
+          customer_support_path(conn, :submit),
+          put_in(valid_request_response_data(), ["support", "vehicle"], "ABCDE")
+        )
+
+      assert "vehicle" in conn.assigns.errors
+
+      conn =
+        post(
+          conn,
+          customer_support_path(conn, :submit),
+          put_in(valid_request_response_data(), ["support", "vehicle"], "01243")
+        )
+
+      refute conn.assigns["errors"]
     end
 
     test "requires first_name if customer does want a response", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Customer Support | Don't allow letters in the vehicle number field](https://app.asana.com/0/385363666817452/1199530274677105/f)

Adds front and back end validation for the vehicle number field. Blank/no entry is ok since the field is optional, but if filled it should contain numeric characters only.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
