### PR TITLE
Return the error when one is received

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/trip_info.ex
+++ b/apps/site/lib/site_web/controllers/schedule/trip_info.ex
@@ -93,15 +93,22 @@ defmodule SiteWeb.ScheduleController.TripInfo do
     # Compute the active stop that matches the one computed by the tooltips
     active_stop = VehicleLocations.active_stop(conn.assigns.vehicle_locations, trip_id)
 
-    with trips when is_list(trips) <- opts[:trip_fn].(trip_id, date: conn.assigns.date) do
-      trips
-      |> build_trip_times(conn.assigns, trip_id, opts[:prediction_fn])
-      |> TripInfo.from_list(
-        vehicle: opts[:vehicle_fn].(trip_id),
-        vehicle_stop_name: active_stop,
-        origin_id: conn.query_params["origin"],
-        destination_id: conn.query_params["destination"]
-      )
+    case opts[:trip_fn].(trip_id, date: conn.assigns.date) do
+      trips when is_list(trips) ->
+        trips
+        |> build_trip_times(conn.assigns, trip_id, opts[:prediction_fn])
+        |> TripInfo.from_list(
+          vehicle: opts[:vehicle_fn].(trip_id),
+          vehicle_stop_name: active_stop,
+          origin_id: conn.query_params["origin"],
+          destination_id: conn.query_params["destination"]
+        )
+
+      {:error, _} = error ->
+        error
+
+      error ->
+        {:error, error}
     end
   end
 

--- a/apps/site/test/site_web/controllers/schedule/trip_info_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/trip_info_test.exs
@@ -629,6 +629,22 @@ defmodule SiteWeb.ScheduleController.TripInfoTest do
     assert conn.assigns.trip_info == nil
   end
 
+  test "assigns a nil trip if there is an error", %{conn: conn} do
+    init_default = init([])
+
+    conn =
+      %{
+        conn
+        | request_path: schedule_path(conn, :show, "455"),
+          query_params: %{"trip" => "45710445"}
+      }
+      |> assign(:route, %Routes.Route{type: 3})
+      |> assign(:vehicle_locations, %{})
+      |> call(init_default)
+
+    assert conn.assigns.trip_info == nil
+  end
+
   describe "show_trips?/4" do
     test "it is false when looking at a future date for subway" do
       next_day = Timex.shift(@time, days: 1)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Elixir.UndefinedFunctionError: function nil.id/0 is undefined](https://app.asana.com/0/555089885850811/1196094168100899)

We weren't taking into account when something other than a list is returned: https://github.com/mbta/dotcom/blob/a34a39656e3cbc86ab0f5178e8511b9281526963/apps/site/lib/site_web/controllers/schedule/trip_info.ex#L96

<br/> With this fix we make sure even the error is returned for its subsequent handling (in `handle_trip`).