### PR TITLE
fix: exit Wallaby tests with a non-zero exit code

### DIFF
--- a/semaphore/wallaby.sh
+++ b/semaphore/wallaby.sh
@@ -15,3 +15,5 @@ do
     fi
   fi
 done
+# exit with a non-zero exit code
+exit 1


### PR DESCRIPTION
They'd been exiting with 0 even if the tests didn't pass.

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [ ] Are interactive elements accessible to screen readers?
* [ ] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [ ] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
