### PR TITLE
fix: Hide subject when category is not selected

### DIFF
--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -275,20 +275,27 @@ export function setupSubject($) {
   const support_service_opts = JSON.parse(
     document.getElementById("js-subjects-by-service").innerHTML
   );
+
+  // initially hide the choices for subject
+  $("#subject").hide();
+
   // show the field once a category is selected
   $("[name='support[service]']").change(function() {
-    // remove all <options> except the first
-    $("#support_subject option")
-      .nextAll()
-      .remove();
     const selectedCategory = $("[name='support[service]']:checked").val();
     const selectedOptions = support_service_opts[selectedCategory];
     if (selectedOptions) {
+      // remove all <options> except the first
+      $("#support_subject option")
+        .nextAll()
+        .remove();
       $("#support_subject").append(
         selectedOptions.map(
           opt => `<option value=${encodeURIComponent(opt)}>${opt}</option>`
         )
       );
+      $("#subject").show();
+    } else {
+      $("#subject").hide();
     }
   });
 }
@@ -314,7 +321,7 @@ const validators = {
   comments: function($) {
     return $("#comments").val().length !== 0;
   },
-  subject: function($) {
+  support_subject: function($) {
     return $("#support_subject").val().length !== 0;
   },
   service: function($) {
@@ -417,7 +424,7 @@ function validateForm($) {
     displaySuccess($, service);
   }
   // Subject
-  if (!validators.subject($)) {
+  if (!validators.support_subject($)) {
     displayError($, subject);
     errors.push(subject);
   } else {

--- a/apps/site/assets/js/test/support-form_test.js
+++ b/apps/site/assets/js/test/support-form_test.js
@@ -233,7 +233,9 @@ describe("support form", () => {
           <input type="radio" name="support[service]" value="Complaint">Complaint</input>
           <input type="radio" name="support[service]" value="Inquiry">Question</input>
         </div>
+        <div id="subject">
         <select class="form-control c-select" id="support_subject" name="support[subject]"><option value="">Please choose a subject</option></select>
+        </div>
       `);
 
       setupSubject($);

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -23,7 +23,7 @@
         <% end %>
       </div>
     </fieldset>
-    <div class="form-group <%= class_for_error("subject", @errors, "has-danger", "has-success") %>">
+    <div id="subject" class="form-group <%= class_for_error("subject", @errors, "has-danger", "has-success") %>">
       <%= label f, :subject, "Subject*", [for: "support_subject", class: "form-control-label"] %>
       <%= select f, :subject, [], prompt: "Please choose a subject", value: "", required: "required", class: "form-control c-select" %>
     </div>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Customer Support | Indicate customers need to choose category before subject](https://app.asana.com/0/385363666817452/1199530274677101/f)

On the Customer Support form, dynamically show the Subject selector once the user selects a Category. Deploying on [dev-blue](https://dev-blue.mbtace.com/ ) for review.

