### PR TITLE
🔧 Use a script to automate GitHub releases

### DIFF
--- a/bin/lib/git.py
+++ b/bin/lib/git.py
@@ -7,6 +7,12 @@ def current_branch():
 def clean_status():
     return __call(["git", "status", "--porcelain"]) == ""
 
+def has_gh_cli():
+    try:
+        return __call(["gh", "auth", "status"]) != "You are not logged into any GitHub hosts. Run gh auth login to authenticate."
+    except:
+        return False
+
 def current_commit():
     return __call(["git", "rev-parse", "--short", "HEAD"])
 
@@ -18,6 +24,9 @@ def sha_for_tag(tag):
 
 def log_between(previous, current):
     return __call(["git", "log", "--abbrev-commit", "--no-decorate", "--pretty=oneline", "%s..%s" % (previous, current)])
+
+def release(tag, notes):
+    return __call(["gh", "release", "create", "%s" % tag, "--title", "%s" % tag, "--notes", "%s" % notes])
 
 def __call(cmd):
     return subprocess.check_output(cmd).decode('UTF-8').rstrip()

--- a/bin/lib/git.py
+++ b/bin/lib/git.py
@@ -1,20 +1,14 @@
 import subprocess
 
 
-def current_branch():
-    return __call(["git", "branch", "--show-current"])
-
-def clean_status():
-    return __call(["git", "status", "--porcelain"]) == ""
-
 def has_gh_cli():
     try:
         return __call(["gh", "auth", "status"]) != "You are not logged into any GitHub hosts. Run gh auth login to authenticate."
     except:
         return False
 
-def current_commit():
-    return __call(["git", "rev-parse", "--short", "HEAD"])
+def current_master_commit():
+    return __call(["git", "rev-parse", "--short", "origin/master"])
 
 def latest_tag():
     return __call(["git", "describe", "--tags", "--abbrev=0"])

--- a/bin/release
+++ b/bin/release
@@ -14,18 +14,12 @@ import sys
 
 
 def main():
-    if not git.current_branch() == "master":
-        sys.exit("Error: You need to be on master to run this script.")
-
-    if not git.clean_status():
-        sys.exit("Error: Git needs to be clean to run this script.")
-
     if not git.has_gh_cli():
         sys.exit("Error: Requires the GitHub CLI to create a release. Install and authenticate https://github.com/cli/cli#installation")
 
     latest_tag = git.latest_tag()
 
-    deploy_sha = input.with_default("Commit to deploy", git.current_commit())
+    deploy_sha = input.with_default("Commit to deploy", git.current_master_commit())
 
     deploy_tag = input.with_default("Tag to apply", tag.date_tag(latest_tag))
 

--- a/bin/release
+++ b/bin/release
@@ -20,6 +20,9 @@ def main():
     if not git.clean_status():
         sys.exit("Error: Git needs to be clean to run this script.")
 
+    if not git.has_gh_cli():
+        sys.exit("Error: Requires the GitHub CLI to create a release. Install and authenticate https://github.com/cli/cli#installation")
+
     latest_tag = git.latest_tag()
 
     deploy_sha = input.with_default("Commit to deploy", git.current_commit())
@@ -28,8 +31,12 @@ def main():
 
     previous_tag = input.with_default("Tag for last deploy", latest_tag)
 
+    release_notes = git.log_between(git.sha_for_tag(previous_tag), deploy_sha)
+
+    git.release(deploy_tag, release_notes)
+
     print("")
-    print("Make a new release:")
+    print("Generating a new release:")
     print("https://github.com/mbta/dotcom/releases/new")
     print("")
     print("Tag version: %s" % (deploy_tag))
@@ -37,7 +44,7 @@ def main():
     print("Release title: %s" % (deploy_tag))
     print("")
     print("Body:")
-    print(git.log_between(git.sha_for_tag(previous_tag), deploy_sha))
+    print("%s" % release_notes)
     print("")
     
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔧 Use a script to automate GitHub releases](https://app.asana.com/0/385363666817452/1185680283158788/f)

I pretty much used the approach described in the ticket. I thought about using GitHub actions, but this was easier for me to wrap my head around and quick enough to implement for now!

One change to the previous functionality is that it no longer looks at `HEAD` - it'll default to the latest commit on `origin/master`. This made it easier for me to use and I think makes more sense for this case.

It worked to create https://github.com/mbta/dotcom/releases/tag/2021.01.08.1 for me.