### PR TITLE
fix: Update file URL for subway map

### DIFF
--- a/apps/site/lib/site/map_helpers.ex
+++ b/apps/site/lib/site/map_helpers.ex
@@ -56,7 +56,7 @@ defmodule Site.MapHelpers do
   def image(:subway) do
     static_url(
       SiteWeb.Endpoint,
-      "/sites/default/files/maps/2019-04-08-rapid-transit-key-bus-routes-map-v33.png "
+      "/sites/default/files/media/2020-11/subway-map-june2020-v34a-GLX-shuttle.png"
     )
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Subway map image missing on hub page](https://app.asana.com/0/385363666817452/1199557225682592/f)

Updating the file URL so we don't have a broken map.