### PR TITLE
Change image in Ferry pages

### DIFF
--- a/apps/site/lib/site/map_helpers.ex
+++ b/apps/site/lib/site/map_helpers.ex
@@ -1,4 +1,8 @@
 defmodule Site.MapHelpers do
+  @moduledoc """
+  Map-related helper functions.
+  """
+
   alias GoogleMaps.MapData.Marker
 
   import SiteWeb.Router.Helpers, only: [static_url: 2]
@@ -65,7 +69,10 @@ defmodule Site.MapHelpers do
   end
 
   def image(:ferry) do
-    static_url(SiteWeb.Endpoint, "/sites/default/files/maps/2018-08-ferry-map.png")
+    static_url(
+      SiteWeb.Endpoint,
+      "/sites/default/files/media/2021-01/2021-01-23-ferry-map-f2h-only-schedule-pages.png"
+    )
   end
 
   @doc """

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -325,7 +325,8 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert List.last(stops).id == "Boat-Charlestown"
 
       # Map
-      assert conn.assigns.map_img_src =~ "/sites/default/files/maps/2018-08-ferry-map.png"
+      assert conn.assigns.map_img_src =~
+               "/sites/default/files/media/2021-01/2021-01-23-ferry-map-f2h-only-schedule-pages.png"
     end
 
     test "Bus data", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⛴️ Update ferry map image on schedule pages on 1/23](https://app.asana.com/0/385363666817452/1199557187663968)

Changed the Ferry images' URL (to go live on January 23rd, 2021).
