### PR TITLE
fix: Don't focus on the datepicker input on load

### DIFF
--- a/apps/site/assets/js/datepicker-input.js
+++ b/apps/site/assets/js/datepicker-input.js
@@ -28,7 +28,8 @@ export default class DatePickerInput {
       outputFormat: DatePickerInput.getDateFormatbyMediaQuery(),
       onUpdate: this.updateDate.bind(this),
       min: minAllowedDate,
-      max: maxAllowedDate
+      max: maxAllowedDate,
+      gainFocusOnConstruction: false
     });
 
     // disable clicking on the month to change the grid type
@@ -79,7 +80,6 @@ export default class DatePickerInput {
       .addListener(this.updateDateFormatToShort);
 
     this.dateInput.datepicker("setDate", date);
-    this.dateInput.datepicker("update");
   }
 
   static getDateFormatbyMediaQuery() {

--- a/apps/site/assets/js/test/datepicker-input_test.js
+++ b/apps/site/assets/js/test/datepicker-input_test.js
@@ -1,0 +1,98 @@
+import { assert } from "chai";
+import jsdom from "mocha-jsdom";
+import testConfig from "./../../ts/jest.config";
+import DatePickerInput from "../datepicker-input";
+const { testURL } = testConfig;
+
+const year = "support_date_time_year",
+  month = "support_date_time_month",
+  day = "support_date_time_day",
+  dateEl = {
+    select: "support-date-select",
+    label: "support-date-label",
+    input: "support-date-input",
+    container: "support-date"
+  };
+
+// very simplified HTML output
+// from DateTimeSelector.custom_date_time_select
+const initial_markup = `<div id=${dateEl.container}>
+  <label aria-label="Tuesday, January 19, 2021, click or press the enter or space key to edit the date" for=${
+    dateEl.input
+  } id=${dateEl.label}></label>
+  <input data-max-date="01/19/2021" data-min-date="01/19/2020" id=${
+    dateEl.input
+  } type="text">
+  <div id=${dateEl.select}>
+    <label class="sr-only" for=${month}>Month</label>
+    <select class="c-select" id=${month}>
+      <option value="1" selected="">January</option>
+      <option value="2">February</option>
+      <option value="3">March</option>
+    </select>
+    <label class="sr-only" for=${day}>Day</label>
+    <select class="c-select" id=${day}>
+      <option value="1">01</option>
+      <option value="2">02</option>
+      <option value="3">03</option>
+    </select>
+    <label class="sr-only" for=${year}>Year</label>
+    <select class="c-select" id=${year}>
+      <option value="2020">2020</option>
+      <option value="2021" selected="">2021</option>
+    </select>
+  </div>
+</div>`;
+
+describe("datepicker-input", () => {
+  jsdom({ url: testURL });
+
+  beforeEach(() => {
+    const $ = jsdom.rerequire("jquery");
+    global.$ = global.jQuery = $;
+    window.$ = window.jQuery = $;
+
+    // JSDOM doesn't support window.matchMedia, so mock it here
+    window.matchMedia = query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {}, // Deprecated
+      removeListener: () => {}, // Deprecated
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {}
+    });
+
+    // The datepicker input depends on the accessible-date-picker plugin, so we have to load it here
+    jsdom.rerequire("../../vendor/accessible-date-picker");
+    $("body").append("<div id=test />");
+    $("#test").html(initial_markup);
+  });
+
+  afterEach(() => {
+    $("#test").remove();
+  });
+
+  it("displays date picker", () => {
+    const input = new DatePickerInput({
+      selectors: { dateEl, month, day, year }
+    });
+
+    assert.notEqual($("#test").html(), initial_markup);
+
+    const datepicker_calendar = document.getElementById(
+      "datepicker-calendar-support-date-input"
+    );
+    assert.isNotNull(datepicker_calendar);
+  });
+
+  it("does not initially focus on the date picker input", () => {
+    const input = new DatePickerInput({
+      selectors: { dateEl, month, day, year }
+    });
+
+    const focused_el = document.activeElement;
+    assert.isFalse(focused_el.nodeName == "INPUT");
+  });
+});


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [☎️ Form focus should start at the first form entry](https://app.asana.com/0/1149164109017504/1199512946850968)

The date picker input (which I learned is distinct from the date picker! haha!) had no tests so I added some.

I interpreted the spirit of the ticket to be more "don't focus on the date picker on page load" rather than "must focus on the first input on page load", so that's what I did.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [ ] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
