### PR TITLE
Add recaptcha error to the list of errors to prevent crash

### DIFF
--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -275,6 +275,7 @@ defmodule SiteWeb.CustomerSupportController do
   @expected_recaptcha_errors [
     :challenge_failed,
     :invalid_input_response,
+    :missing_input_response,
     :timeout_or_duplicate,
     # https://github.com/samueljseay/recaptcha/issues/58
     :"invalid-input-response"

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -521,8 +521,8 @@ defmodule SiteWeb.ScheduleController.LineTest do
       for {id, idx} <- [
             {"place-sstat", 0},
             {"place-NEC-2139", 5},
-            {"place-NEC-2040", 7},
-            {"place-SB-0189", 14}
+            {"place-SB-0189", 7},
+            {"place-NEC-2040", 9}
           ] do
         assert stops |> Enum.at(idx) |> elem(1) == id
       end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Elixir.CaseClauseError: no case clause matching: {:error, [:missing_input_response]}](https://app.asana.com/0/385363666817452/1199384885875519)

A POST submission encountered an [error captured in Sentry](https://sentry.io/organizations/mbtace/issues/1574387026/?project=194344) due to a scenario that we were not taking into account. This is just a small PR to fix that.

Contains an unrelated fix for a test to make it pass.
