### PR TITLE
Add space between alert type and pill

### DIFF
--- a/apps/site/lib/site_web/templates/alert/_banner.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_banner.html.eex
@@ -6,7 +6,7 @@
   <div class="c-alert-item__top">
     <div class="c-alert-item__top-text-container">
       <div class="c-alert-item__effect">
-        <%= BannerAlert.human_effect(@alert) %>
+        <%= "#{BannerAlert.human_effect(@alert)} " %>
         <%= unless label == "" do
           content_tag(:span, [label], class: BannerAlert.label_class(@alert))
         end %>

--- a/apps/site/lib/site_web/templates/alert/_item.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_item.html.eex
@@ -11,7 +11,7 @@
   <div class="c-alert-item__top">
     <div class="c-alert-item__top-text-container">
       <div class="c-alert-item__effect">
-        <%= effect_name(@alert) %>
+        <%= "#{effect_name(@alert)} " %>
         <%= unless label == "" do
           content_tag(:span, [label], class: alert_label_class(@alert))
         end %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Lack of a space between the alert type and the upcoming/ongoing pill](https://app.asana.com/0/555089885850811/1199649873115875)

Before:
<img width="386" alt="image" src="https://user-images.githubusercontent.com/61979382/106060765-77841980-60c2-11eb-9f32-95c89a218957.png">
<br/>
After:
<img width="835" alt="image" src="https://user-images.githubusercontent.com/61979382/106060799-84a10880-60c2-11eb-9aa2-8e471a7b578d.png">
