### PR TITLE
Remove journeys without a prediction nor a schedule

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/finder_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/finder_api.ex
@@ -257,10 +257,17 @@ defmodule SiteWeb.ScheduleController.FinderApi do
   defp prepare_journeys_for_json(journeys) do
     journeys
     |> Enum.map(&destruct_journey/1)
+    |> Enum.filter(&journey_has_valid_departure?/1)
     |> Enum.map(&lift_up_route/1)
     |> Enum.map(&set_departure_time/1)
     |> Enum.map(&json_safe_journey/1)
   end
+
+  @spec journey_has_valid_departure?(Journey.t()) :: boolean
+  defp journey_has_valid_departure?(%{departure: departure}),
+    do: !PredictedSchedule.empty?(struct(PredictedSchedule, departure))
+
+  defp journey_has_valid_departure?(_), do: true
 
   # Break down structs in order to use Access functions
   @spec destruct_journey(Journey.t()) :: map


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Elixir.BadMapError: expected a map, got: nil](https://app.asana.com/0/385363666817452/1199209865060987)

As mentioned in [this comment from a previous PR](https://github.com/mbta/dotcom/pull/755#discussion_r562965381), we don't want to discard journeys where the schedule is nil and the prediction is not, but when _both_ are nil we might want to, since they contain no useful information.

