### PR TITLE
Add content-type to aws s3 sync for fonts

### DIFF
--- a/upload_assets.sh
+++ b/upload_assets.sh
@@ -12,8 +12,14 @@ unzip $BUILD_ARTIFACT "lib/site-$VERSION/priv/static/*" -d $TEMP_DIR
 # sync the digested files with a cache control header
 aws s3 sync $STATIC_DIR/css s3://mbta-dotcom/css --size-only --exclude "*" --include "*-*" --cache-control=$CACHE_CONTROL
 aws s3 sync $STATIC_DIR/js s3://mbta-dotcom/js --size-only --exclude "*" --include "*-*" --cache-control=$CACHE_CONTROL
-aws s3 sync $STATIC_DIR/fonts s3://mbta-dotcom/fonts --size-only --exclude "*" --include "*-*" --cache-control=$CACHE_CONTROL
 aws s3 sync $STATIC_DIR/images s3://mbta-dotcom/images --size-only --exclude "*" --include "*-*" --cache-control=$CACHE_CONTROL
+
+# font content-types need to be specified manually
+aws s3 sync $STATIC_DIR/fonts s3://mbta-dotcom/fonts --size-only --exclude "*" --include "*.eot" --cache-control=$CACHE_CONTROL --content-type "application/vnd.ms-fontobject"
+aws s3 sync $STATIC_DIR/fonts s3://mbta-dotcom/fonts --size-only --exclude "*" --include "*.svg" --cache-control=$CACHE_CONTROL --content-type "image/svg+xml"
+aws s3 sync $STATIC_DIR/fonts s3://mbta-dotcom/fonts --size-only --exclude "*" --include "*.ttf" --cache-control=$CACHE_CONTROL --content-type "font/ttf"
+aws s3 sync $STATIC_DIR/fonts s3://mbta-dotcom/fonts --size-only --exclude "*" --include "*.woff" --cache-control=$CACHE_CONTROL --content-type "font/woff"
+aws s3 sync $STATIC_DIR/fonts s3://mbta-dotcom/fonts --size-only --exclude "*" --include "*.woff2" --cache-control=$CACHE_CONTROL --content-type "font/woff2"
 
 # sync everything else normally
 aws s3 sync $STATIC_DIR/css s3://mbta-dotcom/css --size-only


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔧 uploaded fonts have the wrong content-type](https://app.asana.com/0/385363666817452/1130215014531939)

Initial attempt at fixing the font content-type issue. AWS tries to guess the mime-types for files, and it's usually correct, except for fonts.

I have no idea when this upload_assets.sh script is run, or where it's expected to be run from, so I'm not sure this would actually fix anything! Hoping someone who knows more than me here can chime in.