### PR TITLE
Show fare zones only for commuter rail

### DIFF
--- a/apps/site/lib/site_web/templates/stop/_detailed_stop.html.eex
+++ b/apps/site/lib/site_web/templates/stop/_detailed_stop.html.eex
@@ -4,9 +4,4 @@
     <%= if assigns[:include_route_icon?], do: stop_feature_icon(@detailed_stop.route_icon, :small) %>
     <%= feature_icons(@detailed_stop)%>
   </div>
-  <div class="m-detailed-stop__zone">
-    <%= if @detailed_stop.zone do %>
-      <span class="commuter-rail-zone">Zone <%= @detailed_stop.zone %></span>
-    <% end %>
-  </div>
 </a>

--- a/apps/site/lib/site_web/templates/stop/_hub_stops.html.eex
+++ b/apps/site/lib/site_web/templates/stop/_hub_stops.html.eex
@@ -10,11 +10,6 @@
               <%= link detailed_stop.stop.name, to: stop_path(@conn, :show, detailed_stop.stop.id), class: "hub-stop-name" %>
             <% end %>
             <span class="stop-features-list"><%= feature_icons(detailed_stop)%></span>
-            <%= if detailed_stop.zone do %>
-              <div class="commuter-rail-zone">
-                Zone <%= detailed_stop.zone %>
-              </div>
-            <% end %>
           </div>
         <% end %>
       <% end %>

--- a/apps/stops/lib/api.ex
+++ b/apps/stops/lib/api.ex
@@ -420,5 +420,11 @@ defmodule Stops.Api do
 
   @spec get_zone_number(String.t() | nil) :: String.t() | nil
   defp get_zone_number(nil), do: nil
-  defp get_zone_number(zone), do: String.trim_leading(zone, "CR-zone-")
+
+  defp get_zone_number(zone) do
+    case zone do
+      "CR-zone-" <> zone_number -> zone_number
+      _ -> nil
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Fare Zones should not show for bus, ferry, and subway](https://app.asana.com/0/555089885850811/1199882294203912)

In the Stations page we won't be showing fare zones. Before:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/61979382/107055740-9ad45600-679f-11eb-8ef2-81bba4e855ed.png">

After:
<img width="412" alt="image" src="https://user-images.githubusercontent.com/61979382/107055787-a45dbe00-679f-11eb-8e04-eb2e30a12cf0.png">

In the schedule finder modal, we won't be showing zones unless it's a commuter rail route. E.g. for buses:
<img width="516" alt="image" src="https://user-images.githubusercontent.com/61979382/107056159-08808200-67a0-11eb-9b33-13aa45ca2579.png">
For commuter rail:
<img width="516" alt="image" src="https://user-images.githubusercontent.com/61979382/107056292-31087c00-67a0-11eb-87a7-a730f17fe095.png">

Same for a specific stop:
Commuter rail:
<img width="516" alt="image" src="https://user-images.githubusercontent.com/61979382/107056670-92304f80-67a0-11eb-895e-8a449e868ab9.png">

Bus before:
<img width="575" alt="image" src="https://user-images.githubusercontent.com/61979382/107056797-b855ef80-67a0-11eb-9cc2-ea677a71b786.png">

Bus now:
<img width="575" alt="image" src="https://user-images.githubusercontent.com/61979382/107056932-de7b8f80-67a0-11eb-89ed-1fc0211a012a.png">









