### PR TITLE
chore: Update test for CR-Fitchburg shuttle stop

### DIFF
--- a/apps/stops/test/repo_test.exs
+++ b/apps/stops/test/repo_test.exs
@@ -74,6 +74,7 @@ defmodule Stops.RepoTest do
                {"place-FR-0098", "Waltham"},
                {"place-FR-0074", "Waverley"},
                {"place-FR-0064", "Belmont"},
+               {"place-alfcl", "Alewife"},
                {"place-portr", "Porter"},
                {"place-north", "North Station"}
              ]


### PR DESCRIPTION
The newly added shuttle for CR-Fitchburg has Alewife as a stop, which wasn't accounted for in our test. Let's update this value to match so CI can finally pass.