### PR TITLE
Show the Silver Line icon for South Station instead of the bus one

### DIFF
--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -302,7 +302,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       # includes the stop features
       assert List.last(stops).stop_features == [
                :red_line,
-               :bus,
+               :silver_line,
                :commuter_rail,
                :access,
                :parking_lot

--- a/apps/stops/lib/repo.ex
+++ b/apps/stops/lib/repo.ex
@@ -160,13 +160,8 @@ defmodule Stops.Repo do
     |> Keyword.get(:connections)
     |> get_stop_connections(stop_id)
     |> Enum.map(icon_fn)
-    |> Enum.map(&consolidate_silver_line_route_feature/1)
     |> Enum.uniq()
   end
-
-  @spec consolidate_silver_line_route_feature(atom) :: atom
-  def consolidate_silver_line_route_feature(:silver_line), do: :bus
-  def consolidate_silver_line_route_feature(icon_atom), do: icon_atom
 
   @spec get_stop_connections([Route.t()] | {:error, :not_fetched} | nil, Stop.id_t()) ::
           [Route.t()]

--- a/apps/stops/test/repo_test.exs
+++ b/apps/stops/test/repo_test.exs
@@ -147,31 +147,38 @@ defmodule Stops.RepoTest do
   end
 
   describe "stop_features/1" do
-    @stop %Stop{id: "place-sstat"}
+    @south_station %Stop{id: "place-sstat"}
+    @braintree %Stop{id: "place-brntn"}
+
     test "Returns stop features for a given stop" do
-      features = stop_features(@stop)
+      features = stop_features(@braintree)
       assert :commuter_rail in features
       assert :red_line in features
       assert :bus in features
     end
 
     test "returns stop features in correct order" do
-      assert stop_features(@stop) == [:red_line, :bus, :commuter_rail]
+      assert stop_features(@braintree) == [:red_line, :bus, :commuter_rail]
     end
 
     test "accessibility added if relevant" do
-      features = stop_features(%{@stop | accessibility: ["accessible"]})
+      features = stop_features(%{@braintree | accessibility: ["accessible"]})
       assert features == [:red_line, :bus, :commuter_rail, :access]
     end
 
     test "adds parking features if relevant" do
-      stop = %{@stop | parking_lots: [%Stop.ParkingLot{}]}
+      stop = %{@south_station | parking_lots: [%Stop.ParkingLot{}]}
       assert :parking_lot in stop_features(stop)
     end
 
     test "excluded features are not returned" do
-      assert stop_features(@stop, exclude: [:red_line]) == [:bus, :commuter_rail]
-      assert stop_features(@stop, exclude: [:red_line, :commuter_rail]) == [:bus]
+      assert stop_features(@braintree, exclude: [:red_line]) == [:bus, :commuter_rail]
+      assert stop_features(@braintree, exclude: [:red_line, :commuter_rail]) == [:bus]
+    end
+
+    test "South Station's features will include the Silver Line icon" do
+      features = stop_features(@south_station)
+      assert :silver_line in features
     end
 
     test "includes specific green_line branches if specified" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 Stations/Stops | South Station should have SL icon](https://app.asana.com/0/555089885850811/1163960794131366)

Show the silver line for South Station.
Before:
<img width="268" alt="image" src="https://user-images.githubusercontent.com/61979382/107654344-93ee8d00-6c50-11eb-8fde-0a63bc911bb8.png">

After:
<img width="268" alt="image" src="https://user-images.githubusercontent.com/61979382/107654152-60136780-6c50-11eb-90a2-abb71aaa1305.png">
<br/>
<img width="268" alt="image" src="https://user-images.githubusercontent.com/61979382/107654477-b41e4c00-6c50-11eb-8834-6e98b354148d.png">
