### PR TITLE
Put all the months on the same page (show all events for the year)

### DIFF
--- a/apps/site/assets/css/_events.scss
+++ b/apps/site/assets/css/_events.scss
@@ -4,11 +4,6 @@
   padding-top: $base-spacing-lg;
 }
 
-.arrow-icon:hover {
-  color: $brand-primary-lightest;
-  text-decoration: none;
-}
-
 .event-info-label {
   font-weight: bold;
 
@@ -19,22 +14,6 @@
 
 .events-paragraph {
   margin: $base-spacing-lg 0;
-}
-
-.events-paged-list-header {
-  background-color: $brand-primary-darkest;
-  color: $white;
-  line-height: 2em;
-  margin-bottom: 0;
-  text-align: center;
-  text-transform: uppercase;
-
-  a {
-    color: $white;
-    display: inline-block;
-    padding: 0 $space-12;
-    vertical-align: bottom;
-  }
 }
 
 .event-inline-block {

--- a/apps/site/lib/site_web/controllers/event_controller.ex
+++ b/apps/site/lib/site_web/controllers/event_controller.ex
@@ -24,7 +24,7 @@ defmodule SiteWeb.EventController do
     end
 
     conn
-    |> assign(:month, date_range.start_time_gt)
+    |> assign(:year, date_range.start_time_gt)
     |> async_assign_default(:events, event_teasers_fn, [])
     |> assign(:breadcrumbs, [Breadcrumb.build("Events")])
     |> await_assign_all_default(__MODULE__)

--- a/apps/site/lib/site_web/controllers/event_controller.ex
+++ b/apps/site/lib/site_web/controllers/event_controller.ex
@@ -1,4 +1,5 @@
 defmodule SiteWeb.EventController do
+  @moduledoc "Handles fetching event data for event views"
   use SiteWeb, :controller
 
   alias CMS.{API, Page, Repo}

--- a/apps/site/lib/site_web/controllers/event_controller.ex
+++ b/apps/site/lib/site_web/controllers/event_controller.ex
@@ -10,8 +10,8 @@ defmodule SiteWeb.EventController do
   alias SiteWeb.EventView
 
   def index(conn, params) do
-    {:ok, current_month} = Date.new(Util.today().year, Util.today().month, 1)
-    date_range = EventDateRange.build(params, current_month)
+    {:ok, current_year} = Date.new(Util.today().year, 1, 1)
+    date_range = EventDateRange.build(params, current_year)
 
     event_teasers_fn = fn ->
       Repo.teasers(

--- a/apps/site/lib/site_web/query_builders/event_date_range.ex
+++ b/apps/site/lib/site_web/query_builders/event_date_range.ex
@@ -8,6 +8,13 @@ defmodule SiteWeb.EventDateRange do
     end
   end
 
+  def build(%{"year" => year}, current_date) do
+    case Date.from_iso8601(year) do
+      {:ok, date} -> for_year(date)
+      {:error, _error} -> for_year(current_date)
+    end
+  end
+
   def build(_month_missing, current_date) do
     for_month(current_date)
   end
@@ -16,6 +23,14 @@ defmodule SiteWeb.EventDateRange do
   def for_month(date) do
     start_date = date |> Timex.beginning_of_month()
     end_date = date |> Timex.end_of_month() |> Timex.shift(days: 1)
+
+    date_range(start_date: start_date, end_date: end_date)
+  end
+
+  @spec for_year(Date.t()) :: map
+  def for_year(date) do
+    start_date = date |> Timex.beginning_of_year()
+    end_date = date |> Timex.end_of_year() |> Timex.shift(days: 1)
 
     date_range(start_date: start_date, end_date: end_date)
   end

--- a/apps/site/lib/site_web/query_builders/event_date_range.ex
+++ b/apps/site/lib/site_web/query_builders/event_date_range.ex
@@ -16,7 +16,7 @@ defmodule SiteWeb.EventDateRange do
   end
 
   def build(_month_missing, current_date) do
-    for_month(current_date)
+    for_year(current_date)
   end
 
   @spec for_month(Date.t()) :: map

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -1,6 +1,4 @@
-<% extra_classes = if assigns[:nav], do: [class: "events-paged-list-header"], else: [] %>
 <div class="page-section event-listing">
-  <%= content_tag(:h2, @title, extra_classes) %>
   <ul class="list-group list-group-flush">
     <%= for event_teaser <- @events do %>
       <%

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -16,8 +16,6 @@
     <% end %>
   </ul>
   <%= if Enum.empty?(@events) do %>
-    <div>
-      <%= assigns[:empty_placeholder_text] || "No events" %>
-    </div>
+    <p>No events</p>
   <% end %>
 </div>

--- a/apps/site/lib/site_web/templates/event/index.html.eex
+++ b/apps/site/lib/site_web/templates/event/index.html.eex
@@ -12,8 +12,7 @@
         <div class="page-section">
           <%= render "_event_list.html",
             events: @events,
-            conn: @conn,
-            empty_placeholder_text: no_results_message(@year) %>
+            conn: @conn %>
         </div>
       </div>
     </div>

--- a/apps/site/lib/site_web/templates/event/index.html.eex
+++ b/apps/site/lib/site_web/templates/event/index.html.eex
@@ -13,9 +13,7 @@
           <%= render "_event_list.html",
             events: @events,
             conn: @conn,
-            title: month_navigation_header(@conn, @month),
-            nav: true,
-            empty_placeholder_text: no_results_message(@month) %>
+            empty_placeholder_text: no_results_message(@year) %>
         </div>
       </div>
     </div>

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -19,11 +19,6 @@ defmodule SiteWeb.EventView do
   @spec calendar_title(String.t()) :: String.t()
   def calendar_title(month), do: name_of_month(month)
 
-  @spec no_results_message(String.t()) :: String.t()
-  def no_results_message(year) do
-    "There are no events in #{name_of_year(year)}."
-  end
-
   @spec name_of_year(String.t()) :: String.t()
   def name_of_year(iso_string) do
     iso_string

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -20,8 +20,15 @@ defmodule SiteWeb.EventView do
   def calendar_title(month), do: name_of_month(month)
 
   @spec no_results_message(String.t()) :: String.t()
-  def no_results_message(month) do
-    "There are no events in #{name_of_month(month)}."
+  def no_results_message(year) do
+    "There are no events in #{name_of_year(year)}."
+  end
+
+  @spec name_of_year(String.t()) :: String.t()
+  def name_of_year(iso_string) do
+    iso_string
+    |> Timex.parse!("{ISOdate}")
+    |> Timex.format!("{YYYY}")
   end
 
   @spec name_of_month(String.t()) :: String.t()

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -45,29 +45,4 @@ defmodule SiteWeb.EventView do
       "#{city}, #{state}"
     end
   end
-
-  @spec month_navigation_header(Plug.Conn.t(), String.t()) :: Phoenix.HTML.Safe.t()
-  def month_navigation_header(conn, month) do
-    html_escape([
-      link(
-        to: event_path(conn, :index, month: shift_date_range(month, -1)),
-        class: "arrow-icon"
-      ) do
-        [
-          content_tag(:span, "Previous Month", class: "sr-only"),
-          fa("chevron-circle-left")
-        ]
-      end,
-      calendar_title(month),
-      link(
-        to: event_path(conn, :index, month: shift_date_range(month, 1)),
-        class: "arrow-icon"
-      ) do
-        [
-          content_tag(:span, "Next Month", class: "sr-only"),
-          fa("chevron-circle-right")
-        ]
-      end
-    ])
-  end
 end

--- a/apps/site/test/site_web/controllers/event_controller_test.exs
+++ b/apps/site/test/site_web/controllers/event_controller_test.exs
@@ -2,9 +2,14 @@ defmodule SiteWeb.EventControllerTest do
   use SiteWeb.ConnCase
 
   describe "GET index" do
-    test "renders a list of upcoming events", %{conn: conn} do
+    test "renders a list of events", %{conn: conn} do
       conn = get(conn, event_path(conn, :index))
-      assert html_response(conn, 200) =~ Timex.format!(Util.today(), "{Mfull}")
+
+      event_links =
+        html_response(conn, 200)
+        |> Floki.find(".event-listing a")
+
+      assert Enum.count(event_links) > 0
     end
 
     test "scopes events based on provided dates", %{conn: conn} do

--- a/apps/site/test/site_web/query_builders/event_date_range_test.exs
+++ b/apps/site/test/site_web/query_builders/event_date_range_test.exs
@@ -33,13 +33,15 @@ defmodule SiteWeb.EventDateRangeTest do
              }
     end
 
-    test "returns a date range for the current month when given a partial date" do
-      params = %{"month" => "2017-01"}
+    test "returns a date range for the current year when given an invalid date" do
+      params = %{"year" => "nope"}
       current_month = ~D[2017-04-15]
 
       assert EventDateRange.build(params, current_month) == %{
-               start_time_gt: "2017-04-01",
-               start_time_lt: "2017-05-01"
+               start_time_gt: "2017-01-01",
+               start_time_lt: "2018-01-01"
+             }
+    end
 
     test "returns a date range for the given year" do
       params = %{"year" => "2017-02-01"}
@@ -50,6 +52,13 @@ defmodule SiteWeb.EventDateRangeTest do
                start_time_lt: "2018-01-01"
              }
     end
+
+    test "returns a date range for the current year when a year is not provided" do
+      current_year = ~D[2019-04-15]
+
+      assert EventDateRange.build(%{}, current_year) == %{
+               start_time_gt: "2019-01-01",
+               start_time_lt: "2020-01-01"
              }
     end
   end

--- a/apps/site/test/site_web/query_builders/event_date_range_test.exs
+++ b/apps/site/test/site_web/query_builders/event_date_range_test.exs
@@ -3,22 +3,13 @@ defmodule SiteWeb.EventDateRangeTest do
   alias SiteWeb.EventDateRange
 
   describe "build/2" do
-    test "returns a date range for the given a month" do
+    test "returns a date range for the given month" do
       params = %{"month" => "2017-02-01"}
       current_month = ~D[2017-04-15]
 
       assert EventDateRange.build(params, current_month) == %{
                start_time_gt: "2017-02-01",
                start_time_lt: "2017-03-01"
-             }
-    end
-
-    test "returns a date range for the current month when a month is not provided" do
-      current_month = ~D[2017-04-15]
-
-      assert EventDateRange.build(%{}, current_month) == %{
-               start_time_gt: "2017-04-01",
-               start_time_lt: "2017-05-01"
              }
     end
 
@@ -41,6 +32,26 @@ defmodule SiteWeb.EventDateRangeTest do
                start_time_lt: "2017-05-01"
              }
     end
+
+    test "returns a date range for the current month when given a partial date" do
+      params = %{"month" => "2017-01"}
+      current_month = ~D[2017-04-15]
+
+      assert EventDateRange.build(params, current_month) == %{
+               start_time_gt: "2017-04-01",
+               start_time_lt: "2017-05-01"
+
+    test "returns a date range for the given year" do
+      params = %{"year" => "2017-02-01"}
+      current_year = ~D[2020-04-15]
+
+      assert EventDateRange.build(params, current_year) == %{
+               start_time_gt: "2017-01-01",
+               start_time_lt: "2018-01-01"
+             }
+    end
+             }
+    end
   end
 
   describe "for_month/1" do
@@ -50,6 +61,17 @@ defmodule SiteWeb.EventDateRangeTest do
       assert EventDateRange.for_month(date) == %{
                start_time_gt: "2017-04-01",
                start_time_lt: "2017-05-01"
+             }
+    end
+  end
+
+  describe "for_year/1" do
+    test "returns query params for the beginning and end of the given month" do
+      date = ~D[2017-04-10]
+
+      assert EventDateRange.for_year(date) == %{
+               start_time_gt: "2017-01-01",
+               start_time_lt: "2018-01-01"
              }
     end
   end

--- a/apps/site/test/site_web/views/event_view_test.exs
+++ b/apps/site/test/site_web/views/event_view_test.exs
@@ -51,14 +51,6 @@ defmodule SiteWeb.EventViewTest do
     end
   end
 
-  describe "no_results_message/1" do
-    test "includes the year" do
-      expected_message = "There are no events in 2017."
-
-      assert no_results_message("2017-01-01") == expected_message
-    end
-  end
-
   describe "shift_date_range/2" do
     test "shifts the month by the provided value" do
       assert shift_date_range("2017-04-15", -1) == "2017-03-01"

--- a/apps/site/test/site_web/views/event_view_test.exs
+++ b/apps/site/test/site_web/views/event_view_test.exs
@@ -2,6 +2,8 @@ defmodule SiteWeb.EventViewTest do
   use Site.ViewCase, async: true
   import SiteWeb.EventView
 
+  @date_iso_string "2020-02-24"
+
   describe "show.html" do
     test "the notes section is not rendered when the event notes are empty", %{conn: conn} do
       event = event_factory(0, notes: nil)
@@ -79,5 +81,13 @@ defmodule SiteWeb.EventViewTest do
 
       assert city_and_state(event) == nil
     end
+  end
+
+  test "name_of_month/1 returns month" do
+    assert name_of_month(@date_iso_string) == "February"
+  end
+
+  test "name_of_year/1 returns year" do
+    assert name_of_year(@date_iso_string) == "2020"
   end
 end

--- a/apps/site/test/site_web/views/event_view_test.exs
+++ b/apps/site/test/site_web/views/event_view_test.exs
@@ -2,22 +2,6 @@ defmodule SiteWeb.EventViewTest do
   use Site.ViewCase, async: true
   import SiteWeb.EventView
 
-  describe "index.html" do
-    test "includes links to the previous and next month", %{conn: conn} do
-      html =
-        SiteWeb.EventView
-        |> render_to_string(
-          "index.html",
-          conn: conn,
-          events: [],
-          month: "2017-01-15"
-        )
-
-      assert html =~ "href=\"/events?month=2016-12-01\""
-      assert html =~ "href=\"/events?month=2017-02-01\""
-    end
-  end
-
   describe "show.html" do
     test "the notes section is not rendered when the event notes are empty", %{conn: conn} do
       event = event_factory(0, notes: nil)
@@ -102,29 +86,6 @@ defmodule SiteWeb.EventViewTest do
       event = event_factory(0, state: nil)
 
       assert city_and_state(event) == nil
-    end
-  end
-
-  describe "month_navigation_header/2" do
-    test "links to next and previous months", %{conn: conn} do
-      [prev_link, _title, next_link] =
-        conn
-        |> month_navigation_header("2018-06-01")
-        |> Phoenix.HTML.safe_to_string()
-        |> Floki.parse()
-
-      assert Floki.attribute(prev_link, "a", "href") == ["/events?month=2018-05-01"]
-      assert Floki.attribute(next_link, "a", "href") == ["/events?month=2018-07-01"]
-    end
-
-    test "displays current month", %{conn: conn} do
-      [_prev_link, title, _next_link] =
-        conn
-        |> month_navigation_header("2018-06-01")
-        |> Phoenix.HTML.safe_to_string()
-        |> Floki.parse()
-
-      assert title == "June"
     end
   end
 end

--- a/apps/site/test/site_web/views/event_view_test.exs
+++ b/apps/site/test/site_web/views/event_view_test.exs
@@ -68,8 +68,8 @@ defmodule SiteWeb.EventViewTest do
   end
 
   describe "no_results_message/1" do
-    test "includes the name of the month" do
-      expected_message = "There are no events in January."
+    test "includes the year" do
+      expected_message = "There are no events in 2017."
 
       assert no_results_message("2017-01-01") == expected_message
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Put all the months on the same page (show all events for the year)](https://app.asana.com/0/385363666817452/1199915858612058/f)

Removes the month navigation header entirely.
I thought about removing/replacing the `EventDateRange` functions that work with months, but I figure we'll want them for the calendar view later on so I left them in. 

<img width="1189" alt="image" src="https://user-images.githubusercontent.com/2136286/107808056-06d23380-6d37-11eb-87c0-c805173e3e59.png">


---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
