### PR TITLE
WIP - don't choke on NULL paragraphs

### DIFF
--- a/apps/cms/lib/helpers.ex
+++ b/apps/cms/lib/helpers.ex
@@ -166,8 +166,13 @@ defmodule CMS.Helpers do
     |> Enum.map(&Paragraph.from_api(&1, preview_opts))
   end
 
-  @spec show_paragraph?(map, Keyword.t()) :: boolean
+  @spec show_paragraph?(map | nil, Keyword.t()) :: boolean
   defp show_paragraph?(field_data, preview_opts)
+
+  # Skip broken/missing paragraphs (CMS unable to load and returns NULL)
+  defp show_paragraph?(nil, _) do
+    false
+  end
 
   # Reusable paragraphs instance aren't automatically removed when their child
   # paragraphs are deleted from the database, so catch that here.

--- a/apps/cms/test/helpers_test.exs
+++ b/apps/cms/test/helpers_test.exs
@@ -365,6 +365,16 @@ defmodule CMS.HelpersTest do
              ]
     end
 
+    test "it skips missing paragraphs" do
+      map_data = %{
+        "field_paragraphs" => [nil]
+      }
+
+      parsed_map = parse_paragraphs(map_data, [])
+
+      assert parsed_map == []
+    end
+
     test "it skips reusable paragraphs whose source paragraph no longer exists" do
       map_data = %{
         "field_paragraphs" => [


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Accessibility | Page History, July 1, 2018](https://app.asana.com/0/inbox/443102729541666/1199897989131032/1199901496261429)

On rare occasion, the CMS may provide a NULL paragraph in its JSON response. Add a clause for this and don't attempt to render it. Related to mbta/cms#353

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
