### PR TITLE
Fixing various broken line diagram issues

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -82,6 +82,49 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
     |> get_route_patterns(direction_id, route_pattern_id)
     |> Enum.filter(&by_typicality(&1, route_pattern_id))
     |> Enum.map(&stops_for_route_pattern/1)
+    |> maybe_use_overarching_branch()
+  end
+
+  # Before constructing branches, detect whether one of the lists of stops is a
+  # superset of the other lists of stops. In that case we can just proceed with
+  # the superset stop list for display on the line diagram.
+  @spec maybe_use_overarching_branch([
+          {RoutePattern.t(), [Stop.t()]}
+        ]) :: [
+          {RoutePattern.t(), [Stop.t()]}
+        ]
+  defp maybe_use_overarching_branch(branches) do
+    case overarching_branch(branches) do
+      nil ->
+        branches
+
+      overarching_branch ->
+        [overarching_branch]
+    end
+  end
+
+  # Is there a route pattern whose stops cover all stops on all the given route
+  # patterns? If so, return it.
+  # For example, this happens on CR-Kingston, where one route pattern terminates
+  # at Kingston and another goes one stop further to Plymouth. In that case we
+  # want to display the route pattern to Plymouth as it emcompasses more stops
+  @spec overarching_branch([
+          {RoutePattern.t(), [Stop.t()]}
+        ]) :: {RoutePattern.t(), [Stop.t()]} | nil
+  defp overarching_branch(route_patterns_with_stops) do
+    all_stop_sets =
+      route_patterns_with_stops
+      |> Enum.map(&elem(&1, 1))
+      |> Enum.map(&MapSet.new/1)
+
+    route_patterns_with_stops
+    |> Enum.find(&has_all_stops?(&1, all_stop_sets))
+  end
+
+  @spec has_all_stops?({RoutePattern.t(), [Stop.t()]}, [MapSet.t(Stop.t())]) :: boolean
+  defp has_all_stops?({_route_pattern, stops}, all_stop_sets) do
+    all_stop_sets
+    |> Enum.all?(&MapSet.subset?(&1, MapSet.new(stops)))
   end
 
   # Gathers all of the shapes for the route. Green Line has to make a call for each branch separately, because of course

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -745,6 +745,30 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                  false
                ]
     end
+
+    test "handles CR-Kingston, returning one branch whose stops cover all route patterns" do
+      plymouth_route = %Route{id: "CR-Kingston"}
+
+      assert [%RouteStops{stops: plymouth_route_stops}] =
+               Helpers.get_branch_route_stops(plymouth_route, 0)
+
+      assert_stop_ids(
+        plymouth_route_stops,
+        [
+          "place-sstat",
+          "place-jfk",
+          "place-qnctr",
+          "place-brntn",
+          "place-PB-0158",
+          "place-PB-0194",
+          "place-PB-0212",
+          "place-PB-0245",
+          "place-PB-0281",
+          "place-KB-0351",
+          "place-PB-0356"
+        ]
+      )
+    end
   end
 
   describe "get_route_shapes" do

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -774,8 +774,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
     test "handles rail replacement shuttles for CR-Fitchburg stopping at Alewife" do
       fitchburg_route = %Route{id: "CR-Fitchburg"}
 
-      assert [%RouteStops{}] =
-               Helpers.get_branch_route_stops(fitchburg_route, 0),
+      assert [%RouteStops{}] = Helpers.get_branch_route_stops(fitchburg_route, 0),
              "should have only one 'branch'"
     end
   end

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -774,7 +774,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
     test "handles rail replacement shuttles for CR-Fitchburg stopping at Alewife" do
       fitchburg_route = %Route{id: "CR-Fitchburg"}
 
-      assert [%RouteStops{stops: fitchburg_route_stops}] =
+      assert [%RouteStops{}] =
                Helpers.get_branch_route_stops(fitchburg_route, 0),
              "should have only one 'branch'"
     end

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -750,7 +750,8 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
       plymouth_route = %Route{id: "CR-Kingston"}
 
       assert [%RouteStops{stops: plymouth_route_stops}] =
-               Helpers.get_branch_route_stops(plymouth_route, 0)
+               Helpers.get_branch_route_stops(plymouth_route, 0),
+             "should have only one 'branch'"
 
       assert_stop_ids(
         plymouth_route_stops,
@@ -768,6 +769,14 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
           "place-PB-0356"
         ]
       )
+    end
+
+    test "handles rail replacement shuttles for CR-Fitchburg stopping at Alewife" do
+      fitchburg_route = %Route{id: "CR-Fitchburg"}
+
+      assert [%RouteStops{stops: fitchburg_route_stops}] =
+               Helpers.get_branch_route_stops(fitchburg_route, 0),
+             "should have only one 'branch'"
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Line Diagram | Shuttles should not break the line](https://app.asana.com/0/385363666817452/1199904083874239/f)

There are actually two different problems being tackled here. Going to deploy on dev green to make it easier to check many routes with the green dev API data.

### First commit

CR-Kingston was broken because the line diagram decided that _South Station - Kingston_ and _South Station - Plymouth via Kingston_ were two separate branches. The latter route pattern covers all of the same stops the former one does, so we choose to show only _South Station - Plymouth via Kingston_ on the line diagram.

The chosen fix adds a new function, `overall_branch`, that takes lists of stops and finds the list whose stops cover all of the stops on all other lists. E.g. one branch to rule them all. If an "overall branch" is found, then use that for the line diagram instead of trying to piece together multiple branches.

### Second commit

CR-Fitchburg was broken because of new rail replacement bus shuttle service for portions of the route. These additional route patterns were creating extra "branches" for the line diagram. Both the normal rail version and the shuttle bus version are marked with same route pattern typicality value of 1.

This could have been automatically fixed by the `overall_branch` logic to select the normal rail route pattern, however this bus shuttle includes an extra stop that _isn't_ present in the rail version of the route. 

Ideally there would be a way to write some logic that inspects the rail_replacement_bus route pattern stops for stops that are not normally served by the particular rail line that that bus is replacing... but as far as I can tell there isn't.

So the fix chosen for this issue is more targeted, looking at this particular shuttle (Alewife-Littleton) and excluding the one known extra stop (Alewife) from consideration as part of the `overall_branch` logic.

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [ ] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
