### PR TITLE
Prepopulate 'to' field in Trip Planner

### DIFF
--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -185,6 +185,8 @@ defmodule SiteWeb.Router do
     get("/transit-near-me", TransitNearMeController, :index)
     resources("/alerts", AlertController, only: [:index, :show])
     get("/trip-planner", TripPlanController, :index)
+    get("/trip-planner/to/", Redirector, to: "/trip-planner")
+    get("/trip-planner/to/:address", TripPlanController, :to)
     get("/customer-support", CustomerSupportController, :index)
     get("/customer-support/thanks", CustomerSupportController, :thanks)
     post("/customer-support", CustomerSupportController, :submit)

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -233,6 +233,8 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
       |> json_response(200)
     end
 
+    @tag skip:
+           "Skipping this test temporarily. Pleasant Street station will be closed beginning on Sat, Feb 27, as part of the B Branch Station Consolidation project."
     test "handles green line trips from the generic Green page", %{conn: conn} do
       params = %{
         id: "Green",

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -224,9 +224,9 @@ defmodule SiteWeb.ScheduleControllerTest do
           trip_view_path(
             conn,
             :show,
-            "Green-B",
+            "Green-C",
             schedule_direction: %{
-              origin: "place-bland",
+              origin: "place-coecl",
               destination: "place-pktrm",
               direction_id: "1"
             }

--- a/apps/site/test/site_web/router_test.exs
+++ b/apps/site/test/site_web/router_test.exs
@@ -101,6 +101,11 @@ defmodule Phoenix.Router.RoutingTest do
       conn = get(conn, "/schedules/449/tab")
       assert redirected_to(conn, 301) == "/betterbus-440s"
     end
+
+    test "trip planner with 'to' but without an address", %{conn: conn} do
+      conn = get(conn, "/trip-planner/to/")
+      assert redirected_to(conn, 301) == "/trip-planner"
+    end
   end
 
   test "Adds noindex x-robots-tag HTTP header if config set", %{conn: conn} do

--- a/apps/trip_plan/lib/trip_plan/leg.ex
+++ b/apps/trip_plan/lib/trip_plan/leg.ex
@@ -24,7 +24,7 @@ defmodule TripPlan.Leg do
           start: DateTime.t(),
           stop: DateTime.t(),
           mode: mode,
-          from: NamedPosition.t(),
+          from: NamedPosition.t() | nil,
           to: NamedPosition.t(),
           name: String.t(),
           long_name: String.t(),


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trip Planner | Add ability to link to Trip Planner with pre-filled destination](https://app.asana.com/0/555089885850811/1199926921659622)

A new route `/to/[address]` has been created to geolocate the destination address in the Trip Planner. Example:
https://mbta.com/trip-planner/to/Boston%20Common will render:
<img width="738" alt="image" src="https://user-images.githubusercontent.com/61979382/108523055-7dbd7e00-729b-11eb-816f-006e81b93924.png">

Similarly, it will identify places as well:
https://mbta.com/trip-planner/to/mgh
<img width="738" alt="image" src="https://user-images.githubusercontent.com/61979382/108523359-ce34db80-729b-11eb-8042-9f929c47396c.png">

