### PR TITLE
Previous event listings for month

### DIFF
--- a/apps/site/assets/css/_events.scss
+++ b/apps/site/assets/css/_events.scss
@@ -18,6 +18,23 @@
   display: inline-block;
 }
 
+.list-group-flush:first-child .list-group-item:first-child {
+  border-top: unset;
+  border: solid #ddd;
+  border-width: 1px 0;
+}
+
+.m-previous-events-button {
+  cursor: pointer;
+}
+
+.m-hidden-event {
+  display: none !important;
+}
+.m-hidden-button {
+  display: none !important;
+}
+
 .m-event {
   padding: 0 16px;
   @include media-breakpoint-down(xs) {

--- a/apps/site/assets/js/app.js
+++ b/apps/site/assets/js/app.js
@@ -45,6 +45,7 @@ import CRTrains from "./cr-timetable-trains";
 import { onload as alertItemLoad } from "./alert-item";
 import dismissFullscreenError from "../ts/app/dismiss-fullscreen-error";
 import tripPlannerWidget from "./trip-planner-widget";
+import previousEventsButton from "./view-previous-events";
 
 document.body.className = document.body.className.replace("no-js", "js");
 
@@ -363,3 +364,4 @@ channels();
 CRTrains();
 dismissFullscreenError();
 tripPlannerWidget();
+previousEventsButton();

--- a/apps/site/assets/js/view-previous-events.js
+++ b/apps/site/assets/js/view-previous-events.js
@@ -1,0 +1,19 @@
+const setupViewPreviousEventsButton = function() {
+  const viewPreviousEventsButton = document.querySelector(".m-previous-events-button")
+  const hiddenEventList = document.querySelectorAll(".m-hidden-event")
+
+  viewPreviousEventsButton.addEventListener("click", () => {
+    hiddenEventList.forEach(hiddenEvent => hiddenEvent.classList.remove("m-hidden-event"))
+    viewPreviousEventsButton.classList.add("m-hidden-button")
+  })
+}
+
+export default function() {
+  document.addEventListener(
+    "turbolinks:load",
+    () => {
+      setupViewPreviousEventsButton();
+    },
+    { passive: true }
+  );
+}

--- a/apps/site/assets/js/view-previous-events.js
+++ b/apps/site/assets/js/view-previous-events.js
@@ -2,7 +2,7 @@ const setupViewPreviousEventsButton = function() {
   const viewPreviousEventsButton = document.querySelector(
     ".m-previous-events-button"
   );
-  const hiddenEventList = document.querySelectorAll(".m-hidden-event");
+  const hiddenEventList = [...document.querySelectorAll(".m-hidden-event")];
 
   viewPreviousEventsButton.addEventListener("click", () => {
     hiddenEventList.forEach(hiddenEvent =>

--- a/apps/site/assets/js/view-previous-events.js
+++ b/apps/site/assets/js/view-previous-events.js
@@ -4,12 +4,14 @@ const setupViewPreviousEventsButton = function() {
   );
   const hiddenEventList = [...document.querySelectorAll(".m-hidden-event")];
 
-  viewPreviousEventsButton.addEventListener("click", () => {
-    hiddenEventList.forEach(hiddenEvent =>
-      hiddenEvent.classList.remove("m-hidden-event")
-    );
-    viewPreviousEventsButton.classList.add("m-hidden-button");
-  });
+  viewPreviousEventsButton &&
+    hiddenEventList &&
+    viewPreviousEventsButton.addEventListener("click", () => {
+      hiddenEventList.forEach(hiddenEvent =>
+        hiddenEvent.classList.remove("m-hidden-event")
+      );
+      viewPreviousEventsButton.classList.add("m-hidden-button");
+    });
 };
 
 export default function() {

--- a/apps/site/assets/js/view-previous-events.js
+++ b/apps/site/assets/js/view-previous-events.js
@@ -1,12 +1,16 @@
 const setupViewPreviousEventsButton = function() {
-  const viewPreviousEventsButton = document.querySelector(".m-previous-events-button")
-  const hiddenEventList = document.querySelectorAll(".m-hidden-event")
+  const viewPreviousEventsButton = document.querySelector(
+    ".m-previous-events-button"
+  );
+  const hiddenEventList = document.querySelectorAll(".m-hidden-event");
 
   viewPreviousEventsButton.addEventListener("click", () => {
-    hiddenEventList.forEach(hiddenEvent => hiddenEvent.classList.remove("m-hidden-event"))
-    viewPreviousEventsButton.classList.add("m-hidden-button")
-  })
-}
+    hiddenEventList.forEach(hiddenEvent =>
+      hiddenEvent.classList.remove("m-hidden-event")
+    );
+    viewPreviousEventsButton.classList.add("m-hidden-button");
+  });
+};
 
 export default function() {
   document.addEventListener(

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -1,13 +1,21 @@
 <div class="page-section event-listing">
-  <%= content_tag(:h2, @title, extra_classes) %>
   <!-- This list-group stuff is bootstrap -->
   <ul class="list-group list-group-flush">
+    <!-- Previous months button. A JS script sets up a listener for button click -->
+    <li class="list-group-item m-previous-events-button">
+      <a class="m-previous-events-button">
+        View Previous MONTH Events
+        <i class="fa fa-angle-down down" aria-hidden="true"></i>
+      </a>
+    </li>
     <%= for event_teaser <- @events do %>
       <%
         range = %{start: event_teaser.date, stop: event_teaser.date_end}
         path_fn = fn -> cms_static_page_path(@conn, event_teaser.path) end
       %>
-      <li class="list-group-item u-flex-container m-event">
+      <!-- If date is upcoming, display on init -->
+      <!-- Otherwise, add a 'hidden' class. On previous-button click, this class is removed -->
+      <li class="<%= if date_upcoming(range), do: 'list-group-item u-flex-container m-event', else: 'list-group-item u-flex-container m-event m-hidden-event' %>">
         <div class="m-event__date-circle">
           <div class="u-bold m-event__month"><%= pretty_date(range.start, "{Mshort}") %></div>
           <div class="u-bold m-event__day"><%= pretty_date(range.start, "{D}") %></div>

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -4,7 +4,7 @@
     <!-- Previous months button. A JS script sets up a listener for button click -->
     <li class="list-group-item m-previous-events-button">
       <a class="m-previous-events-button">
-        View Previous MONTH Events
+        View Previous <%= pretty_date(Timex.now("America/New_York"), "{Mfull} {YYYY}") %> Events
         <i class="fa fa-angle-down down" aria-hidden="true"></i>
       </a>
     </li>

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -2,12 +2,14 @@
   <!-- This list-group stuff is bootstrap -->
   <ul class="list-group list-group-flush">
     <!-- Previous months button. A JS script sets up a listener for button click -->
-    <li class="list-group-item m-previous-events-button">
-      <a class="m-previous-events-button">
-        View Previous <%= pretty_date(Timex.now("America/New_York"), "{Mfull} {YYYY}") %> Events
-        <i class="fa fa-angle-down down" aria-hidden="true"></i>
-      </a>
-    </li>
+    <%= if Enum.any?(@events, fn event -> event_ended(@conn, %{start: event.date, stop: event.date_end}) end) do %>
+      <li class="list-group-item m-previous-events-button">
+        <a class="m-previous-events-button">
+          View Previous <%= pretty_date(Timex.now("America/New_York"), "{Mfull} {YYYY}") %> Events
+          <i class="fa fa-angle-down down" aria-hidden="true"></i>
+        </a>
+      </li>
+    <% end %>
     <%= for event_teaser <- @events do %>
       <%
         range = %{start: event_teaser.date, stop: event_teaser.date_end}
@@ -15,7 +17,7 @@
       %>
       <!-- If date is upcoming, display on init -->
       <!-- Otherwise, add a 'hidden' class. On previous-button click, this class is removed -->
-      <li class="<%= if date_upcoming(range), do: 'list-group-item u-flex-container m-event', else: 'list-group-item u-flex-container m-event m-hidden-event' %>">
+      <li class="list-group-item u-flex-container m-event <%= if event_ended(@conn, range), do: 'm-hidden-event' %>">
         <div class="m-event__date-circle">
           <div class="u-bold m-event__month"><%= pretty_date(range.start, "{Mshort}") %></div>
           <div class="u-bold m-event__day"><%= pretty_date(range.start, "{D}") %></div>

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -2,7 +2,7 @@
   <!-- This list-group stuff is bootstrap -->
   <ul class="list-group list-group-flush">
     <!-- Previous months button. A JS script sets up a listener for button click -->
-    <%= if Enum.any?(@events, fn event -> event_ended(@conn, %{start: event.date, stop: event.date_end}) end) do %>
+    <%= if Enum.any?(@events, fn event -> event_ended(%{start: event.date, stop: event.date_end}) end) do %>
       <li class="list-group-item m-previous-events-button">
         <a class="m-previous-events-button">
           View Previous <%= pretty_date(Timex.now("America/New_York"), "{Mfull} {YYYY}") %> Events
@@ -17,7 +17,7 @@
       %>
       <!-- If date is upcoming, display on init -->
       <!-- Otherwise, add a 'hidden' class. On previous-button click, this class is removed -->
-      <li class="list-group-item u-flex-container m-event <%= if event_ended(@conn, range), do: 'm-hidden-event' %>">
+      <li class="list-group-item u-flex-container m-event <%= if event_ended(range), do: 'm-hidden-event' %>">
         <div class="m-event__date-circle">
           <div class="u-bold m-event__month"><%= pretty_date(range.start, "{Mshort}") %></div>
           <div class="u-bold m-event__day"><%= pretty_date(range.start, "{D}") %></div>

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -84,8 +84,12 @@ defmodule SiteWeb.EventView do
     } #{format_time(end_time)}"
   end
 
-  @spec date_upcoming(%{start: NaiveDateTime.t() | DateTime.t(), stop: NaiveDateTime.t() | DateTime.t()}) :: boolean
+  @spec date_upcoming(%{
+          start: NaiveDateTime.t() | DateTime.t(),
+          stop: NaiveDateTime.t() | DateTime.t()
+        }) :: boolean
   def date_upcoming(range) do
-    (!!range.stop and Date.compare(range.stop, Timex.now()) == :gt) or (!range.stop and Date.compare(range.start, Timex.now()) == :gt)
+    (!!range.stop and Date.compare(range.stop, Timex.now("America/New_York")) == :gt) or
+      (!range.stop and Date.compare(range.start, Timex.now("America/New_York")) == :gt)
   end
 end

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -86,22 +86,22 @@ defmodule SiteWeb.EventView do
     } #{format_time(end_time)}"
   end
 
-  @spec event_ended(Conn.t(), %{
+  @spec event_ended(%{
           start: NaiveDateTime.t() | DateTime.t(),
           stop: NaiveDateTime.t() | DateTime.t() | nil
         }) :: boolean
-  def event_ended(conn, %{start: %NaiveDateTime{} = start, stop: %NaiveDateTime{} = stop}) do
-    event_ended(conn, %{
-      start: convert_using_timezone(start, nil),
+  def event_ended(%{start: %NaiveDateTime{} = start, stop: %NaiveDateTime{} = stop}) do
+    event_ended(%{
+      start: start,
       stop: convert_using_timezone(stop, nil)
     })
   end
 
-  def event_ended(conn, %{start: %DateTime{} = start, stop: %DateTime{} = stop}) do
+  def event_ended(%{start: start, stop: %DateTime{} = stop}) do
     time_is_greater_or_equal?(now(), stop)
   end
 
-  def event_ended(conn, %{start: start, stop: nil}) do
+  def event_ended(%{start: start, stop: nil}) do
     Date.compare(now(), start) == :gt
   end
 end

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -97,7 +97,7 @@ defmodule SiteWeb.EventView do
     })
   end
 
-  def event_ended(%{start: start, stop: %DateTime{} = stop}) do
+  def event_ended(%{start: _start, stop: %DateTime{} = stop}) do
     time_is_greater_or_equal?(now(), stop)
   end
 

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -83,4 +83,9 @@ defmodule SiteWeb.EventView do
       pretty_date(end_time, "{WDshort}, {Mshort} {D}, {YYYY}")
     } #{format_time(end_time)}"
   end
+
+  @spec date_upcoming(%{start: NaiveDateTime.t() | DateTime.t(), stop: NaiveDateTime.t() | DateTime.t()}) :: boolean
+  def date_upcoming(range) do
+    (!!range.stop and Date.compare(range.stop, Timex.now()) == :gt) or (!range.stop and Date.compare(range.start, Timex.now()) == :gt)
+  end
 end

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -93,7 +93,7 @@ defmodule SiteWeb.EventView do
   def event_ended(%{start: %NaiveDateTime{} = start, stop: %NaiveDateTime{} = stop}) do
     event_ended(%{
       start: start,
-      stop: convert_using_timezone(stop, nil)
+      stop: convert_using_timezone(stop, "")
     })
   end
 

--- a/apps/site/test/site_web/views/event_view_test.exs
+++ b/apps/site/test/site_web/views/event_view_test.exs
@@ -134,4 +134,72 @@ defmodule SiteWeb.EventViewTest do
       assert expected == actual
     end
   end
+
+  describe "event_ended/2" do
+    test "when start and end are provided as datetimes", %{conn: conn} do
+      now = Util.now()
+
+      past =
+        now
+        |> Timex.shift(minutes: -3)
+
+      distant_past =
+        now
+        |> Timex.shift(minutes: -30)
+
+      future =
+        now
+        |> Timex.shift(minutes: 3)
+
+      distant_future =
+        now
+        |> Timex.shift(minutes: 30)
+
+      assert event_ended(conn, %{start: distant_past, stop: past})
+      assert !event_ended(conn, %{start: distant_past, stop: future})
+      assert !event_ended(conn, %{start: future, stop: distant_future})
+    end
+
+    test "when event only has a start, consider event ended when the day is over", %{conn: conn} do
+      now = Util.now()
+
+      earlier_today =
+        now
+        |> Timex.shift(seconds: -30)
+
+      later_today =
+        now
+        |> Timex.shift(seconds: 30)
+
+      yesterday =
+        now
+        |> Timex.shift(days: -1)
+
+      tomorrow =
+        now
+        |> Timex.shift(days: 1)
+
+      assert event_ended(conn, %{start: yesterday, stop: nil})
+      assert !event_ended(conn, %{start: earlier_today, stop: nil})
+      assert !event_ended(conn, %{start: later_today, stop: nil})
+      assert !event_ended(conn, %{start: tomorrow, stop: nil})
+    end
+
+    test "handles naive datetimes", %{conn: conn} do
+      naive_now =
+        Util.now()
+        |> DateTime.to_naive()
+
+      naive_past =
+        naive_now
+        |> NaiveDateTime.add(-500)
+
+      naive_distant_past =
+        naive_now
+        |> NaiveDateTime.add(-1000)
+
+      assert event_ended(conn, %{start: naive_distant_past, stop: naive_past})
+      assert !event_ended(conn, %{start: naive_distant_past, stop: nil})
+    end
+  end
 end

--- a/apps/site/test/site_web/views/event_view_test.exs
+++ b/apps/site/test/site_web/views/event_view_test.exs
@@ -136,7 +136,7 @@ defmodule SiteWeb.EventViewTest do
   end
 
   describe "event_ended/2" do
-    test "when start and end are provided as datetimes", %{conn: conn} do
+    test "when start and end are provided as datetimes" do
       now = Util.now()
 
       past =
@@ -155,12 +155,12 @@ defmodule SiteWeb.EventViewTest do
         now
         |> Timex.shift(minutes: 30)
 
-      assert event_ended(conn, %{start: distant_past, stop: past})
-      assert !event_ended(conn, %{start: distant_past, stop: future})
-      assert !event_ended(conn, %{start: future, stop: distant_future})
+      assert event_ended(%{start: distant_past, stop: past})
+      assert !event_ended(%{start: distant_past, stop: future})
+      assert !event_ended(%{start: future, stop: distant_future})
     end
 
-    test "when event only has a start, consider event ended when the day is over", %{conn: conn} do
+    test "when event only has a start, consider event ended when the day is over" do
       now = Util.now()
 
       earlier_today =
@@ -179,13 +179,13 @@ defmodule SiteWeb.EventViewTest do
         now
         |> Timex.shift(days: 1)
 
-      assert event_ended(conn, %{start: yesterday, stop: nil})
-      assert !event_ended(conn, %{start: earlier_today, stop: nil})
-      assert !event_ended(conn, %{start: later_today, stop: nil})
-      assert !event_ended(conn, %{start: tomorrow, stop: nil})
+      assert event_ended(%{start: yesterday, stop: nil})
+      assert !event_ended(%{start: earlier_today, stop: nil})
+      assert !event_ended(%{start: later_today, stop: nil})
+      assert !event_ended(%{start: tomorrow, stop: nil})
     end
 
-    test "handles naive datetimes", %{conn: conn} do
+    test "handles naive datetimes" do
       naive_now =
         Util.now()
         |> DateTime.to_naive()
@@ -198,8 +198,8 @@ defmodule SiteWeb.EventViewTest do
         naive_now
         |> NaiveDateTime.add(-1000)
 
-      assert event_ended(conn, %{start: naive_distant_past, stop: naive_past})
-      assert !event_ended(conn, %{start: naive_distant_past, stop: nil})
+      assert event_ended(%{start: naive_distant_past, stop: naive_past})
+      assert !event_ended(%{start: naive_distant_past, stop: nil})
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add "previous listing for the month" link to top of the page](https://app.asana.com/0/555089885850811/1199915858612052)

Currently, simplified to a button that says "View Previous { current month / year } Events".  Once we separate pages by month, we'll need to make button visibility conditional on whether we're looking at the current month.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [ ] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
