### PR TITLE
Remove schedule tab

### DIFF
--- a/apps/site/assets/css/_schedule.scss
+++ b/apps/site/assets/css/_schedule.scss
@@ -1040,6 +1040,11 @@ del .trip-list-realtime {
       }
     }
   }
+
+  // hide the schedule tab
+  .schedule-tab {
+    display: none;
+  }
 }
 
 .schedule__header-container {

--- a/apps/site/lib/site_web/controllers/schedule/green.ex
+++ b/apps/site/lib/site_web/controllers/schedule/green.ex
@@ -47,14 +47,7 @@ defmodule SiteWeb.ScheduleController.Green do
   def show(conn, _params), do: line(conn, [])
 
   def trip_view(conn, _params) do
-    conn
-    |> assign(:tab, "trip-view")
-    |> call_plug_with_opts(SiteWeb.Plugs.BannerMessage,
-      message_key: :retirement_message,
-      message: SiteWeb.ScheduleView.build_retirement_message(conn)
-    )
-    |> put_view(ScheduleView)
-    |> render("show.html", [])
+    redirect(conn, to: line_path(conn, :show, "Green", Map.delete(conn.query_params, "tab")))
   end
 
   def alerts(conn, _params) do

--- a/apps/site/lib/site_web/controllers/schedule/trip_view_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/trip_view_controller.ex
@@ -20,15 +20,8 @@ defmodule SiteWeb.ScheduleController.TripViewController do
     redirect(conn, to: timetable_path(conn, :show, route_id, params))
   end
 
-  def show(conn, _) do
-    conn
-    |> SiteWeb.ControllerHelpers.call_plug_with_opts(
-      SiteWeb.Plugs.BannerMessage,
-      message_key: :retirement_message,
-      message: SiteWeb.ScheduleView.build_retirement_message(conn)
-    )
-    |> put_view(SiteWeb.ScheduleView)
-    |> render("show.html", [])
+  def show(%{assigns: %{route: %Route{id: route_id}}, query_params: query_params} = conn, _) do
+    redirect(conn, to: line_path(conn, :show, route_id, Map.delete(query_params, "tab")))
   end
 
   defp zone_map(%{assigns: %{route: %Route{type: 2}, all_stops: all_stops}} = conn, _) do

--- a/apps/site/lib/site_web/templates/schedule/_line.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line.html.eex
@@ -33,7 +33,7 @@
           <%= if @route.type == 2 do %>
             Schedule &amp; Maps
           <% else %>
-            Info &amp; Maps
+            Schedules &amp; Maps
           <% end %>
         </h2>
 

--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -393,7 +393,7 @@ defmodule SiteWeb.ScheduleView do
         _ ->
           [
             %HeaderTab{id: "trip-view", name: "Schedule", href: schedule_link},
-            %HeaderTab{id: "line", name: "Info & Maps", href: info_link} | tabs
+            %HeaderTab{id: "line", name: "Schedules & Maps", href: info_link} | tabs
           ]
       end
 

--- a/apps/site/test/site_web/controllers/schedule/green_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/green_test.exs
@@ -18,6 +18,7 @@ defmodule SiteWeb.ScheduleController.GreenTest do
       assert conn.assigns.tab == "line"
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test ~s(renders trip_view tab without redirecting when query params = %{tab => trip-view}), %{
       conn: conn
     } do
@@ -27,6 +28,15 @@ defmodule SiteWeb.ScheduleController.GreenTest do
       assert conn.status == 200
 
       assert conn.assigns.tab == "trip-view"
+    end
+
+    @tag todo: "Closing the Schedules Tab"
+    test "redirects trip_view tab to line tab", %{
+      conn: conn
+    } do
+      conn = get(conn, schedule_path(conn, :show, "Green", %{tab: "trip-view"}))
+      assert conn.status == 302
+      assert redirected_to(conn, 302) == line_path(conn, :show, "Green")
     end
 
     test ~s(renders alerts tab without redirecting when query params = %{tab => alerts}), %{

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -13,18 +13,21 @@ defmodule SiteWeb.ScheduleControllerTest do
   @routes_repo_api Application.get_env(:routes, :routes_repo_api)
 
   describe "Bus" do
+    @tag skip: "Closing the Schedules Tab"
     test "all stops is assigned for a route", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "1"))
       html_response(conn, 200)
       assert conn.assigns.all_stops != nil
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "origin is unassigned for a route when you first view the page", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "1"))
       html_response(conn, 200)
       assert conn.assigns.origin == nil
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "has the origin when it has been selected", %{conn: conn} do
       conn =
         get(
@@ -38,6 +41,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert conn.assigns.origin.id == @test_origin
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "finds a trip when origin has been selected", %{conn: conn} do
       conn =
         get(
@@ -52,6 +56,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert conn.assigns.trip_info
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "finds a trip list with origin and destination", %{conn: conn} do
       conn =
         get(
@@ -73,6 +78,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert conn.assigns.predictions != nil
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "assigns tab to \"trip-view\"", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "1"))
       assert conn.assigns.tab == "trip-view"
@@ -103,6 +109,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert redirected_to(conn, 302) =~ "timetable"
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "assigns information for the trip view", %{conn: conn} do
       conn =
         get(
@@ -153,6 +160,7 @@ defmodule SiteWeb.ScheduleControllerTest do
                |> Enum.map(&List.first/1)
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "assigns a map of stop ID to zone", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "CR-Lowell"))
       zone_map = conn.assigns.zone_map
@@ -163,6 +171,7 @@ defmodule SiteWeb.ScheduleControllerTest do
   end
 
   describe "subway" do
+    @tag skip: "Closing the Schedules Tab"
     test "assigns schedules, frequency table, origin, and destination", %{conn: conn} do
       conn =
         get(
@@ -187,6 +196,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert conn.assigns.destination
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "assigns schedules, frequency table, and origin", %{conn: conn} do
       conn =
         get(
@@ -201,6 +211,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       refute conn.assigns.destination
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "frequency table not assigned when no origin is selected", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "Red"))
       refute :frequency_table in Map.keys(conn.assigns)
@@ -208,6 +219,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       refute :schedules in Map.keys(conn.assigns)
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "assigns schedules, frequency table, and origin for green line", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "Green-D", origin: "place-pktrm"))
       assert conn.assigns.schedules
@@ -217,6 +229,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       refute conn.assigns.destination
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "assigns schedules, frequency table, origin, destination for green line", %{conn: conn} do
       conn =
         get(
@@ -241,6 +254,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert conn.assigns.destination
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "assigns trip info and journeys for Mattapan line", %{conn: conn} do
       conn =
         get(
@@ -254,11 +268,24 @@ defmodule SiteWeb.ScheduleControllerTest do
   end
 
   describe "all modes" do
+    @tag todo: "Closing the Schedules Tab"
+    test "redirects from schedules tab to line tab with query params", %{
+      conn: conn
+    } do
+      conn = get(conn, trip_view_path(conn, :show, "1", origin: "64", destination: "6"))
+      assert conn.status == 302
+
+      assert redirected_to(conn, 302) ==
+               line_path(conn, :show, "1", destination: "6", origin: "64")
+    end
+
+    @tag skip: "Closing the Schedules Tab"
     test "assigns breadcrumbs", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "1"))
       assert conn.assigns.breadcrumbs
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "shows a checkmark next to the last stop", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "Red", origin: "place-pktrm"))
       response = html_response(conn, 200)
@@ -488,6 +515,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       refute path =~ "tab="
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "trip_view tab", %{conn: conn} do
       conn =
         get(
@@ -538,6 +566,7 @@ defmodule SiteWeb.ScheduleControllerTest do
   end
 
   describe "schedule tab" do
+    @tag skip: "Closing the Schedules Tab"
     test "a retirement message exists for buses", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "1"))
       html_response(conn, 200)
@@ -545,6 +574,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert conn.assigns.retirement_message != nil
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "a retirement message exists for subway", %{conn: conn} do
       conn = get(conn, trip_view_path(conn, :show, "Blue"))
       html_response(conn, 200)
@@ -552,6 +582,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert conn.assigns.retirement_message != nil
     end
 
+    @tag skip: "Closing the Schedules Tab"
     test "a retirement message does not exist for CR", %{conn: conn} do
       conn = get(conn, timetable_path(conn, :show, "CR-Lowell"))
       html_response(conn, 200)

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -898,7 +898,7 @@ defmodule SiteWeb.ScheduleViewTest do
         |> safe_to_string()
 
       assert tabs =~ "schedule-tab"
-      assert tabs =~ "info-&amp;-maps-tab"
+      assert tabs =~ "schedules-&amp;-maps-tab"
       assert tabs =~ "alerts-tab"
       refute tabs =~ "info-tab"
       refute tabs =~ "timetable-tab"

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -888,7 +888,7 @@ defmodule SiteWeb.ScheduleViewTest do
       assert tabs =~ "alerts-tab"
     end
 
-    test "returns 3 tabs for other routes", %{conn: conn} do
+    test "returns 3 tabs for other routes (1 hidden by CSS)", %{conn: conn} do
       tabs =
         conn
         |> assign(:route, %Route{type: 3})


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [⏱Remove Schedule Tab](https://app.asana.com/0/385363666817452/1144217912503868/f)

For March 1 - this change (a) hides the schedules tab, (b) redirects schedule tab URLs to the info & maps tab, bringing along query params, (c) renames "info & maps" tab to "schedules & maps"
