### PR TITLE
Add event page flag

### DIFF
--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -27,7 +27,10 @@ config :logster, :allowed_headers, ["referer"]
 config :site, SiteWeb.ViewHelpers, google_tag_manager_id: System.get_env("GOOGLE_TAG_MANAGER_ID")
 
 config :laboratory,
-  features: [],
+  features: [
+    {:events_hub_redesign, "Events Hub Redesign (Feb. 2021)",
+     "Changes to the event listings and the event pages as part of the 🤝 Public Engagement epic"}
+  ],
   cookie: [
     # one month,
     max_age: 3600 * 24 * 30,

--- a/apps/site/lib/site_web/templates/event/show.html.eex
+++ b/apps/site/lib/site_web/templates/event/show.html.eex
@@ -1,3 +1,6 @@
+<%= if Laboratory.enabled?(@conn, :events_hub_redesign) do %>
+<%# New iterative development work here! %>
+<% else %>
 <% has_sidebar = @event.agenda_file || @event.minutes_file || Enum.empty?(@event.files) == false %>
 <% sidebar_class = if has_sidebar, do: "c-cms--with-sidebar c-cms--sidebar-right", else: "c-cms--no-sidebar" %>
 
@@ -97,3 +100,4 @@
     </div>
   </div>
 </div>
+<% end %>

--- a/apps/site/test/site_web/controllers/event_controller_test.exs
+++ b/apps/site/test/site_web/controllers/event_controller_test.exs
@@ -21,6 +21,7 @@ defmodule SiteWeb.EventControllerTest do
     end
   end
 
+  @tag todo: "Replacing with events_hub_redesign"
   describe "GET show" do
     test "renders and does not rewrite an unaliased event response", %{conn: conn} do
       event = event_factory(0, path_alias: nil)
@@ -85,6 +86,20 @@ defmodule SiteWeb.EventControllerTest do
     test "renders a 404 when event does not exist", %{conn: conn} do
       conn = get(conn, event_path(conn, :show, "2018", "invalid-event"))
       assert conn.status == 404
+    end
+  end
+
+  describe "GET show (events_hub_redesign)" do
+    setup %{conn: conn} do
+      conn = conn |> put_req_cookie("events_hub_redesign", "true")
+      {:ok, conn: conn}
+    end
+
+    test "renders show.html", %{conn: conn} do
+      event = event_factory(0, path_alias: nil)
+      conn = get(conn, event_path(conn, :show, event))
+      assert conn.status == 200
+      refute html_response(conn, 200) =~ "<h3>Agenda</h3>"
     end
   end
 


### PR DESCRIPTION
Recently, we'd been using feature branches to manage the development of medium-to-long-term work. This has proven to be somewhat tricky to manage, particularly as the master branch diverges over time.

### There's another way!

Earlier we used to use flags to enable/disable big features. I don't think you're all familiar with the `Laboratory` module -- so I will add some details over Slack on how to find it and use it! 😉

This PR implements that approach for the **event page**. (I should've done this with the current events listing work, but I think we're too far into it to set up a flag for that now. Better late than never!)

With this enabled, we can proceed with development while continuing to merge into master. When finally ready for the reveal, we can remove the flag and tweak the code to permanently show the new features.
