### PR TITLE
Add calendar grid

### DIFF
--- a/apps/site/assets/css/_events.scss
+++ b/apps/site/assets/css/_events.scss
@@ -215,3 +215,29 @@ $mobile-control-height: 73px;
   width: 96px;
   color: $gray;
 }
+
+.m-event-calendar {
+  font-size: small;
+  table-layout: fixed;
+  width: 100%;
+
+  th {
+    color: $gray;
+    font-family: $headings-font-family;
+    text-align: center;
+  }
+
+  &__day {
+    border: 1px solid $gray-lightest;
+    height: $base-spacing * 6; // works like min-height
+    padding: $base-spacing / 4;
+    vertical-align: top;
+  }
+
+  &__day-label {
+    color: $gray;
+    font-family: $headings-font-family;
+    font-weight: bold;
+    margin-bottom: $base-spacing / 2;
+  }
+}

--- a/apps/site/assets/js/event-page-setup.js
+++ b/apps/site/assets/js/event-page-setup.js
@@ -1,4 +1,5 @@
 export function setupEventsListing() {
+  const eventsHubPage = document.querySelector(".m-events-hub");
   const eventsListing = document.querySelector(".m-events-hub--list-view");
   const control = eventsListing.querySelector(
     ".m-event-list__nav--mobile-controls"
@@ -74,7 +75,7 @@ export default function() {
   document.addEventListener(
     "turbolinks:load",
     () => {
-      if (document.querySelector(".m-events-hub--list-view")) setupEventsListing();
+      if (document.querySelector(".m-events-hub")) setupEventsListing();
     },
     { passive: true }
   );

--- a/apps/site/assets/js/event-page-setup.js
+++ b/apps/site/assets/js/event-page-setup.js
@@ -1,6 +1,6 @@
-export function setupEventsPage() {
-  const eventsHubPage = document.querySelector(".m-events-hub");
-  const control = eventsHubPage.querySelector(
+export function setupEventsListing() {
+  const eventsListing = document.querySelector(".m-events-hub--list-view");
+  const control = eventsListing.querySelector(
     ".m-event-list__nav--mobile-controls"
   );
   let prevScroll = window.scrollY || document.documentElement.scrollTop;
@@ -14,7 +14,7 @@ export function setupEventsPage() {
       () => {
         window.requestAnimationFrame(() => {
           // 1. toggle a shadow on the month header depending on if it's sticky
-          eventsHubPage
+          eventsListing
             .querySelectorAll(".m-event-list__month-header")
             .forEach(el => {
               const stickyStyleTop = parseInt(
@@ -38,12 +38,12 @@ export function setupEventsPage() {
             // toggle the controls
             if (direction === 2 && curScroll > controlHeight) {
               // hide the controls
-              eventsHubPage.classList.add("js-nav-down");
-              eventsHubPage.classList.remove("js-nav-up");
+              eventsListing.classList.add("js-nav-down");
+              eventsListing.classList.remove("js-nav-up");
             } else if (direction === 1) {
               // show the controls
-              eventsHubPage.classList.add("js-nav-up");
-              eventsHubPage.classList.remove("js-nav-down");
+              eventsListing.classList.add("js-nav-up");
+              eventsListing.classList.remove("js-nav-down");
             }
             prevDirection = direction;
           }
@@ -56,7 +56,7 @@ export function setupEventsPage() {
   });
 
   // scroll to active heading if available
-  const activeMonthElement = eventsHubPage.querySelector(
+  const activeMonthElement = eventsListing.querySelector(
     ".m-event-list__month--active"
   );
   if (activeMonthElement) activeMonthElement.scrollIntoView();
@@ -74,7 +74,7 @@ export default function() {
   document.addEventListener(
     "turbolinks:load",
     () => {
-      if (document.querySelector(".m-events-hub")) setupEventsPage();
+      if (document.querySelector(".m-events-hub--list-view")) setupEventsListing();
     },
     { passive: true }
   );

--- a/apps/site/assets/js/test/address-search_test.js
+++ b/apps/site/assets/js/test/address-search_test.js
@@ -13,7 +13,7 @@ describe("input-location", () => {
   var $;
   jsdom({ url: testURL });
 
-  beforeEach(() => {
+  before(() => {
     $ = jsdom.rerequire("jquery");
   });
 

--- a/apps/site/assets/js/test/algolia-global-search_test.js
+++ b/apps/site/assets/js/test/algolia-global-search_test.js
@@ -18,7 +18,7 @@ describe("AlgoliaGlobalSearch", function() {
     ]
   });
 
-  beforeEach(function() {
+  before(() => {
     window.jQuery = jsdom.rerequire("jquery");
     window.$ = window.jQuery;
     window.encodeURIComponent = string =>
@@ -26,7 +26,9 @@ describe("AlgoliaGlobalSearch", function() {
         .replace(/\s/g, "%20")
         .replace(/&/g, "%26")
         .replace(/,/g, "%2C");
+  });
 
+  beforeEach(function() {
     document.body.innerHTML = "";
     Object.keys(AlgoliaGlobalSearch.SELECTORS).forEach(key => {
       document.body.innerHTML += `<div id="${

--- a/apps/site/assets/js/test/event-page-setup__test.js
+++ b/apps/site/assets/js/test/event-page-setup__test.js
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import sinon from "sinon";
 import jsdom from "mocha-jsdom";
-import { setupEventsPage } from "../event-page-setup";
+import { setupEventsListing } from "../event-page-setup";
 import testConfig from "../../ts/jest.config";
 
 const { testURL } = testConfig;
@@ -44,7 +44,7 @@ function triggerScrollEvent(clock) {
   clock.tick(); // fast forward set timeout (gets past window.requestAnimationFrame)
 }
 
-describe("setupEventsPage", () => {
+describe("setupEventsListing", () => {
   let $;
   let scrollIntoViewSpy;
   let getComputedStyleSpy;
@@ -109,7 +109,7 @@ describe("setupEventsPage", () => {
       getBoundingClientRectSpy.callsFake(() => ({ top: t }));
       getComputedStyleSpy.callsFake(el => ({ top: `${t}px` }));
 
-      setupEventsPage();
+      setupEventsListing();
       sinon.assert.notCalled(getComputedStyleSpy);
       sinon.assert.notCalled(getBoundingClientRectSpy);
       sinon.assert.notCalled(toggleAttributeSpy);
@@ -129,32 +129,32 @@ describe("setupEventsPage", () => {
     });
 
     it("will toggle 'js-nav-*' class name based on scroll direction", () => {
-      const eventsHubPage = document.querySelector(".m-events-hub");
+      const eventsListing = document.querySelector(".m-events-hub");
       getBoundingClientRectSpy.callsFake(() => ({ height: 10 }));
 
       // mock window.Y for this test with initial scroll position
       global.window = Object.assign(global.window, {
         scrollY: 222
       });
-      setupEventsPage();
-      assert.isFalse(eventsHubPage.classList.contains("js-nav-up"));
-      assert.isFalse(eventsHubPage.classList.contains("js-nav-down"));
+      setupEventsListing();
+      assert.isFalse(eventsListing.classList.contains("js-nav-up"));
+      assert.isFalse(eventsListing.classList.contains("js-nav-down"));
 
       // mock scroll up
       global.window = Object.assign(global.window, {
         scrollY: 20
       });
       triggerScrollEvent(clock);
-      assert.isTrue(eventsHubPage.classList.contains("js-nav-up"));
-      assert.isFalse(eventsHubPage.classList.contains("js-nav-down"));
+      assert.isTrue(eventsListing.classList.contains("js-nav-up"));
+      assert.isFalse(eventsListing.classList.contains("js-nav-down"));
 
       // mock scroll down
       global.window = Object.assign(global.window, {
         scrollY: 442
       });
       triggerScrollEvent(clock);
-      assert.isTrue(eventsHubPage.classList.contains("js-nav-down"));
-      assert.isFalse(eventsHubPage.classList.contains("js-nav-up"));
+      assert.isTrue(eventsListing.classList.contains("js-nav-down"));
+      assert.isFalse(eventsListing.classList.contains("js-nav-up"));
     });
   });
 
@@ -165,13 +165,13 @@ describe("setupEventsPage", () => {
     assert.isOk(activeMonth);
     assert.equal(activeMonth.length, 1);
 
-    setupEventsPage();
+    setupEventsListing();
 
     sinon.assert.calledOnce(scrollIntoViewSpy);
   });
 
   it("navigates when .m-event-list__select changes", () => {
-    setupEventsPage();
+    setupEventsListing();
 
     const windowLocationSpy = sinon.spy(window.location, "assign");
     sinon.assert.notCalled(windowLocationSpy);

--- a/apps/site/assets/js/test/event-page-setup__test.js
+++ b/apps/site/assets/js/test/event-page-setup__test.js
@@ -7,7 +7,7 @@ import testConfig from "../../ts/jest.config";
 const { testURL } = testConfig;
 
 const eventsHubHTML = `
-    <div class="container m-events-hub">
+    <div class="container m-events-hub m-events-hub--list-view">
       <h1>Events</h1>
       <div class="row">
         <nav class="m-event-list__nav col-sm-3 fixedsticky sticky-top"></nav>

--- a/apps/site/assets/js/test/trip-plan_test.js
+++ b/apps/site/assets/js/test/trip-plan_test.js
@@ -33,18 +33,16 @@ describe("trip-plan", () => {
     ]
   });
 
-  beforeEach(() => {
+  before(() => {
     $ = jsdom.rerequire("jquery");
+    window.$ = $;
     window.jQuery = jsdom.rerequire("jquery");
     window.autocomplete = jsdom.rerequire("autocomplete.js");
   });
 
   describe("reverseTrip", () => {
     beforeEach(() => {
-      const $ = jsdom.rerequire("jquery");
-      window.$ = $;
-      window.jQuery = $;
-      $("body").append(tripPlanForm);
+      $("body").html(tripPlanForm);
     });
 
     it("swaps the contents of to and from and the from/to lat/lng", () => {
@@ -75,13 +73,6 @@ describe("trip-plan", () => {
   });
 
   describe("TripPlannerLocControls", () => {
-    beforeEach(() => {
-      const $ = jsdom.rerequire("jquery");
-      window.$ = $;
-      ``;
-      window.jQuery = $;
-    });
-
     it("can initialize without options", () => {
       $("body").append(tripPlanForm);
       const tplc = new TripPlannerLocControls();

--- a/apps/site/lib/site_web/templates/event/_calendar.html.eex
+++ b/apps/site/lib/site_web/templates/event/_calendar.html.eex
@@ -13,10 +13,13 @@
     <%= for week <- week_rows(@month, @year) do %>
       <tr>
       <%= for day <- week do %>
+        <% day_in_month? = day.month == @month %>
         <td class="m-event-calendar__day">
-          <div class="m-event-calendar__day-label">
-          <%= Timex.format!(day, "%-d", :strftime) %>
-          </div>
+          <%= if day_in_month? do %>
+            <div class="m-event-calendar__day-label">
+            <%= Timex.format!(day, "%-d", :strftime) %>
+            </div>
+          <% end %>
         </td>
       <% end %>
       </tr>

--- a/apps/site/lib/site_web/templates/event/_calendar.html.eex
+++ b/apps/site/lib/site_web/templates/event/_calendar.html.eex
@@ -1,0 +1,25 @@
+<h2 class="m-event-list__month-header"><%= render_event_month(@month, @year) %></h2>
+<table class="m-event-calendar">
+  <thead>
+    <tr>
+    <%= for day_name <- Enum.map([7, 1, 2, 3, 4, 5, 6], &Timex.day_name/1) do %>
+      <th scope="col">
+        <%= day_name %>
+      </th>
+    <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <%= for week <- week_rows(@month, @year) do %>
+      <tr>
+      <%= for day <- week do %>
+        <td class="m-event-calendar__day">
+          <div class="m-event-calendar__day-label">
+          <%= Timex.format!(day, "%-d", :strftime) %>
+          </div>
+        </td>
+      <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/apps/site/lib/site_web/templates/event/index.html.eex
+++ b/apps/site/lib/site_web/templates/event/index.html.eex
@@ -1,4 +1,4 @@
-<div class="container m-events-hub">
+<div class="container m-events-hub <%= if Map.get(@conn.query_params, "calendar"), do: 'm-events-hub--calendar-view', else: 'm-events-hub--list-view' %>">
   <header>
     <h1>Events</h1>
     <nav class="m-events-hub__nav--controls">

--- a/apps/site/lib/site_web/templates/event/index.html.eex
+++ b/apps/site/lib/site_web/templates/event/index.html.eex
@@ -12,19 +12,29 @@
   </header>
 
   <div class="row">
-    <nav class="m-event-list__nav col-sm-3 fixedsticky sticky-top">
+    <nav class="m-event-list__nav col-sm-2 fixedsticky sticky-top">
       <p class="u-bold">Jump to</p>
       <%= for month <- 1..12 do %>
         <%= link render_event_month(month, @year), to: event_path(@conn, :index, month: month, year: @year) %>
       <% end %>
     </nav>
 
-    <div class="col-sm-offset-1 col-sm-8">
-      <%= render "_event_list.html",
+    <%= if Map.get(@conn.query_params, "calendar") do %>
+      <div class="col-sm-10">
+        <%= render "_calendar.html",
             events: @events,
             conn: @conn,
             month: @month,
             year: @year %>
-    </div>
+      </div>
+    <% else %>
+      <div class="col-sm-offset-2 col-sm-8">
+        <%= render "_event_list.html",
+              events: @events,
+              conn: @conn,
+              month: @month,
+              year: @year %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -132,6 +132,7 @@ defmodule SiteWeb.EventView do
       start_date
       |> Timex.end_of_month()
       |> Timex.end_of_week(:sun)
+      |> Timex.shift(days: 1)
 
     Timex.Interval.new(from: first, until: last)
     |> Enum.map(& &1)

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -119,4 +119,22 @@ defmodule SiteWeb.EventView do
     |> String.downcase()
     |> String.replace(~r/(\s)+/, "-")
   end
+
+  defp week_rows(month, year) do
+    {:ok, start_date} = Date.new(year, month, 1)
+
+    first =
+      start_date
+      |> Timex.beginning_of_month()
+      |> Timex.beginning_of_week(:sun)
+
+    last =
+      start_date
+      |> Timex.end_of_month()
+      |> Timex.end_of_week(:sun)
+
+    Timex.Interval.new(from: first, until: last)
+    |> Enum.map(& &1)
+    |> Enum.chunk_every(7)
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add event listings to the grid](https://app.asana.com/0/385363666817452/1199915858612066/f)

There are a few noticeable issues which I plan to address in the 'Add toggle between views to navigation' ticket, including:

* rename URL parameter from calendar to cal
* keep all months in the left nav, not just the current one
* hide the calendar on mobile (presumably showing the list in its place)
* adding the working toggle