### PR TITLE
fix: Show description for planned disruptions

### DIFF
--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
@@ -32,7 +32,10 @@ const ServiceOptGroup = ({
         const endDate = new Date(service.end_date);
         let optionText = "";
 
-        if (service.typicality === "unplanned_disruption") {
+        if (
+          service.typicality === "unplanned_disruption" ||
+          service.typicality === "planned_disruption"
+        ) {
           optionText = service.description;
         } else if (
           service.typicality === "holiday_service" &&


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Services picker should show distinctive title for CR shuttles](https://app.asana.com/0/385363666817452/1199903984955228/f)

Prior logic wouldn't show the description in the services picker when it's for a planned disruption. Probably will deploy on dev green.

Thanks @jfabi for tipping us off on this!