### PR TITLE
PSL polish

### DIFF
--- a/apps/fares/lib/proposed_locations.ex
+++ b/apps/fares/lib/proposed_locations.ex
@@ -8,7 +8,7 @@ defmodule Fares.ProposedLocations do
 
   @base_url "https://services1.arcgis.com/ceiitspzDAHrdGO1/ArcGIS/rest/services/ProposedSalesNetworkSpringOutreach/FeatureServer/0/query?f=json&outFields=*&inSR=4326&outSR=4326&returnGeometry=true"
 
-  @distance_in_miles 10
+  @distance_in_miles 100
 
   @spec by_lat_lon(%GoogleMaps.Geocode.Address{}) :: [Location.t()] | nil
   def by_lat_lon(%{latitude: lat, longitude: lon}) do

--- a/apps/fares/lib/proposed_locations/location.ex
+++ b/apps/fares/lib/proposed_locations/location.ex
@@ -25,4 +25,9 @@ defmodule Fares.ProposedLocations.Location do
           latitude: float,
           longitude: float
         }
+
+  defimpl Util.Position do
+    def latitude(%{latitude: latitude}), do: latitude
+    def longitude(%{longitude: longitude}), do: longitude
+  end
 end

--- a/apps/fares/mix.exs
+++ b/apps/fares/mix.exs
@@ -21,7 +21,7 @@ defmodule Fares.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [extra_applications: [:logger], mod: {Fares.Application, []}]
+    [extra_applications: [:logger, :poison], mod: {Fares.Application, []}]
   end
 
   # Dependencies can be Hex packages:
@@ -39,6 +39,7 @@ defmodule Fares.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
+      {:poison, "~> 2.2", override: true},
       {:csv, "~> 2.3"},
       {:excoveralls, "~> 0.5", only: :test},
       {:sweet_xml, "~> 0.6.2", only: [:dev, :test]},

--- a/apps/fares/test/proposed_locations_test.exs
+++ b/apps/fares/test/proposed_locations_test.exs
@@ -6,6 +6,17 @@ defmodule Fares.ProposedLocationsTest do
 
   @location %{latitude: 42.42412295861601, longitude: -71.17941003354629}
 
+  @proposed_location %Fares.ProposedLocations.Location{
+    fid: 124,
+    latitude: 42.42412295861601,
+    line: "Bus",
+    longitude: -71.17941003354629,
+    municipality: "Arlington",
+    retail_fvm: "Fare vending machine",
+    routes: ["77", "79"],
+    stop_id: "2250",
+    stop_name: "Massachusetts Ave @ Daniels St"
+  }
   @arcgis_response "{
     \"objectIdFieldName\" : \"FID\",
     \"uniqueIdField\" :
@@ -40,23 +51,21 @@ defmodule Fares.ProposedLocationsTest do
     ]
   }"
 
+  describe "coordinates" do
+    test "latitude" do
+      assert Util.Position.latitude(@proposed_location) == 42.42412295861601
+    end
+
+    test "longitude" do
+      assert Util.Position.longitude(@proposed_location) == -71.17941003354629
+    end
+  end
+
   describe "requests data from ArcGIS and parses the response into a list of locations" do
     test "by_lat_lon - successful parsed response" do
       with_mock HTTPoison,
         get: fn _url -> {:ok, %{status_code: 200, body: @arcgis_response, headers: []}} end do
-        assert by_lat_lon(@location) == [
-                 %Fares.ProposedLocations.Location{
-                   fid: 124,
-                   latitude: 42.42412295861601,
-                   line: "Bus",
-                   longitude: -71.17941003354629,
-                   municipality: "Arlington",
-                   retail_fvm: "Fare vending machine",
-                   routes: ["77", "79"],
-                   stop_id: "2250",
-                   stop_name: "Massachusetts Ave @ Daniels St"
-                 }
-               ]
+        assert by_lat_lon(@location) == [@proposed_location]
       end
     end
 

--- a/apps/google_maps/test/google_maps/geocode_test.exs
+++ b/apps/google_maps/test/google_maps/geocode_test.exs
@@ -415,6 +415,60 @@ defmodule GoogleMaps.GeocodeTest do
     end
   end
 
+  describe "calculate_position/2" do
+    test "it calculates search position and address" do
+      params = %{"location" => %{"address" => "42.0, -71.0"}}
+
+      geocode_fn = fn _address ->
+        {:ok,
+         [%GoogleMaps.Geocode.Address{formatted: "address", latitude: 42.0, longitude: -70.1}]}
+      end
+
+      {position, formatted} = calculate_position(params, geocode_fn)
+
+      assert formatted == "address"
+      assert %{latitude: 42.0, longitude: -70.1} = position
+    end
+
+    test "does not geocode if latitude/longitude params exist" do
+      params = %{"latitude" => "42.0", "longitude" => "-71.0"}
+
+      geocode_fn = fn _ ->
+        send(self(), :geocode_called)
+        {:error, :no_results}
+      end
+
+      {position, formatted} = calculate_position(params, geocode_fn)
+      refute_received :geocode_called
+      assert formatted == "42.0,-71.0"
+      assert %{latitude: 42.0, longitude: -71.0} = position
+    end
+
+    test "handles bad lat/lng values" do
+      params = %{"latitude" => "foo", "longitude" => "bar"}
+
+      geocode_fn = fn _address ->
+        send(self(), :geocode_called)
+
+        {:ok,
+         [%GoogleMaps.Geocode.Address{formatted: "address", latitude: 42.0, longitude: -70.1}]}
+      end
+
+      {position, formatted} = calculate_position(params, geocode_fn)
+      refute_received :geocode_called
+      assert position == %{}
+      assert formatted == ""
+    end
+
+    test "when there is no location map there is no position" do
+      params = %{}
+      geocode_fn = fn _address -> %{formatted: "address", latitude: 42.0, longitude: -71.0} end
+      {position, formatted} = calculate_position(params, geocode_fn)
+      assert formatted == ""
+      assert position == %{}
+    end
+  end
+
   defp set_domain(new_domain) do
     old_domain = Application.get_env(:google_maps, :domain)
     Application.put_env(:google_maps, :domain, new_domain)

--- a/apps/site/lib/site_web/controllers/fare_controller.ex
+++ b/apps/site/lib/site_web/controllers/fare_controller.ex
@@ -4,12 +4,13 @@ defmodule SiteWeb.FareController do
   """
   use SiteWeb, :controller
   alias Fares.RetailLocations
+  alias GoogleMaps.Geocode
   import SiteWeb.ViewHelpers, only: [cms_static_page_path: 2]
 
   plug(:meta_description)
 
   @options %{
-    geocode_fn: &GoogleMaps.Geocode.geocode/1,
+    geocode_fn: &Geocode.geocode/1,
     nearby_fn: &Fares.RetailLocations.get_nearby/1
   }
 
@@ -17,7 +18,7 @@ defmodule SiteWeb.FareController do
         %Plug.Conn{assigns: %{date_time: date_time}} = conn,
         %{"id" => "retail-sales-locations"} = params
       ) do
-    {position, formatted} = calculate_position(params, @options.geocode_fn)
+    {position, formatted} = Geocode.calculate_position(params, @options.geocode_fn)
 
     conn
     |> assign(:breadcrumbs, [
@@ -38,39 +39,6 @@ defmodule SiteWeb.FareController do
     check_cms_or_404(conn)
   end
 
-  @spec calculate_position(
-          map(),
-          (String.t() -> GoogleMaps.Geocode.Address.t())
-        ) :: {GoogleMaps.Geocode.Address.t(), String.t()}
-  def calculate_position(%{"latitude" => lat_str, "longitude" => lng_str} = params, geocode_fn) do
-    case {Float.parse(lat_str), Float.parse(lng_str)} do
-      {{lat, ""}, {lng, ""}} ->
-        addr = %GoogleMaps.Geocode.Address{
-          latitude: lat,
-          longitude: lng,
-          formatted: lat_str <> "," <> lng_str
-        }
-
-        parse_geocode_response({:ok, [addr]})
-
-      _ ->
-        params
-        |> Map.delete("latitude")
-        |> Map.delete("longitude")
-        |> calculate_position(geocode_fn)
-    end
-  end
-
-  def calculate_position(%{"location" => %{"address" => address}}, geocode_fn) do
-    address
-    |> geocode_fn.()
-    |> parse_geocode_response()
-  end
-
-  def calculate_position(_params, _geocode_fn) do
-    {%{}, ""}
-  end
-
   @spec current_pass(DateTime.t()) :: String.t()
   def current_pass(%{day: day} = date) when day < 15 do
     Timex.format!(date, "{Mfull} {YYYY}")
@@ -81,17 +49,9 @@ defmodule SiteWeb.FareController do
     Timex.format!(next_month, "{Mfull} {YYYY}")
   end
 
-  defp parse_geocode_response({:ok, [location | _]}) do
-    {location, location.formatted}
-  end
-
-  defp parse_geocode_response(_) do
-    {%{}, ""}
-  end
-
   @spec fare_sales_locations(
-          GoogleMaps.Geocode.Address.t(),
-          (GoogleMaps.Geocode.Address.t() -> [{RetailLocations.Location.t(), float}])
+          Geocode.Address.t(),
+          (Geocode.Address.t() -> [{RetailLocations.Location.t(), float}])
         ) :: [{RetailLocations.Location.t(), float}]
   def fare_sales_locations(%{latitude: _lat, longitude: _long} = position, nearby_fn) do
     nearby_fn.(position)

--- a/apps/site/lib/site_web/templates/fare_transformation/proposed_sales_locations.html.eex
+++ b/apps/site/lib/site_web/templates/fare_transformation/proposed_sales_locations.html.eex
@@ -43,9 +43,8 @@
 <%= case @nearby_proposed_locations do %>
   <% [] -> %>
     <div class="container" style="display: flex">
-      <%= alert_icon() %>
       <div class="col-md-6">
-        <p><b>There are no proposed sales locations nearby. Please try to search again with a different location that's closer to areas the MBTA run.</b></p>
+        <p><b>The address you entered is more than 100 miles from the nearest proposed sales location. Please use an address that's closer to an MBTA service area.</b></p>
       </div>
     </div>
   <% _ -> %>

--- a/apps/site/lib/site_web/views/fare_transformation_view.ex
+++ b/apps/site/lib/site_web/views/fare_transformation_view.ex
@@ -3,6 +3,4 @@ defmodule SiteWeb.FareTransformationView do
   View for the Fare Transformation section of the website.
   """
   use SiteWeb, :view
-
-  def alert_icon(), do: svg("icon-alerts-triangle.svg")
 end

--- a/apps/site/test/site_web/controllers/fare_controller_test.exs
+++ b/apps/site/test/site_web/controllers/fare_controller_test.exs
@@ -56,60 +56,6 @@ defmodule SiteWeb.FareControllerTest do
     end
   end
 
-  describe "calculate_position/2" do
-    test "it calculates search position and address" do
-      params = %{"location" => %{"address" => "42.0, -71.0"}}
-
-      geocode_fn = fn _address ->
-        {:ok,
-         [%GoogleMaps.Geocode.Address{formatted: "address", latitude: 42.0, longitude: -70.1}]}
-      end
-
-      {position, formatted} = calculate_position(params, geocode_fn)
-
-      assert formatted == "address"
-      assert %{latitude: 42.0, longitude: -70.1} = position
-    end
-
-    test "does not geocode if latitude/longitude params exist" do
-      params = %{"latitude" => "42.0", "longitude" => "-71.0"}
-
-      geocode_fn = fn _ ->
-        send(self(), :geocode_called)
-        {:error, :no_results}
-      end
-
-      {position, formatted} = calculate_position(params, geocode_fn)
-      refute_received :geocode_called
-      assert formatted == "42.0,-71.0"
-      assert %{latitude: 42.0, longitude: -71.0} = position
-    end
-
-    test "handles bad lat/lng values" do
-      params = %{"latitude" => "foo", "longitude" => "bar"}
-
-      geocode_fn = fn _address ->
-        send(self(), :geocode_called)
-
-        {:ok,
-         [%GoogleMaps.Geocode.Address{formatted: "address", latitude: 42.0, longitude: -70.1}]}
-      end
-
-      {position, formatted} = calculate_position(params, geocode_fn)
-      refute_received :geocode_called
-      assert position == %{}
-      assert formatted == ""
-    end
-
-    test "when there is no location map there is no position" do
-      params = %{}
-      geocode_fn = fn _address -> %{formatted: "address", latitude: 42.0, longitude: -71.0} end
-      {position, formatted} = calculate_position(params, geocode_fn)
-      assert formatted == ""
-      assert position == %{}
-    end
-  end
-
   describe "current_pass/1" do
     test "is the current month when the date given is prior to the 15th" do
       {:ok, date} = Timex.parse("2016-12-01T12:12:12-05:00", "{ISO:Extended}")

--- a/apps/site/test/site_web/controllers/fare_transformation_controller_test.exs
+++ b/apps/site/test/site_web/controllers/fare_transformation_controller_test.exs
@@ -12,11 +12,25 @@ defmodule SiteWeb.FareTransformationControllerTest do
       assert redirected_to(conn, 302) == "/fares/retail-sales-locations"
     end
 
-    test "renders the proposed sales locations page with results", %{conn: conn} do
+    test "renders the proposed sales locations page with results by giving it an address", %{
+      conn: conn
+    } do
       conn =
         get(conn, "/fare-transformation/proposed-sales-locations", %{
           "latitude" => "42.3576135",
           "location" => %{"address" => "Park Street Place, Boston, MA, USA"},
+          "longitude" => "-71.0625776"
+        })
+
+      assert html_response(conn, 200) =~ "Get Directions"
+    end
+
+    test "renders the proposed sales locations page with results by giving it coordinates", %{
+      conn: conn
+    } do
+      conn =
+        get(conn, "/fare-transformation/proposed-sales-locations", %{
+          "latitude" => "42.3576135",
           "longitude" => "-71.0625776"
         })
 

--- a/apps/util/lib/distance.ex
+++ b/apps/util/lib/distance.ex
@@ -5,6 +5,7 @@ defmodule Util.Distance do
 
   """
   alias Util.Position
+  alias Fares.ProposedLocations.Location
   import Util.Position
 
   @degrees_to_radians :math.pi() / 180
@@ -12,7 +13,7 @@ defmodule Util.Distance do
   @globe_diameter 3958.7613 * 2
 
   @doc "Sorts the items by their distance from position."
-  @spec sort([Position.t()], Position.t()) :: [Position.t()]
+  @spec sort([Position.t()] | [Location.t()], Position.t() | Location.t()) :: [Position.t()]
   def sort(items, position) do
     items
     |> Enum.sort_by(&haversine(position, &1))
@@ -31,7 +32,7 @@ defmodule Util.Distance do
   end
 
   @doc "Return the haversine distance between the two positions"
-  @spec haversine(Position.t(), Position.t()) :: float
+  @spec haversine(Position.t() | Location.t(), Position.t() | Location.t()) :: float
   def haversine(first, second) do
     lat1 = latitude(first)
     lat2 = latitude(second)


### PR DESCRIPTION
Polish work for the Proposed Sales Location page:

- Minor tweaks (increase radius, rewording sentences).
- sort locations by distance
- stronger address validation to accept a string with different location formats (address or lat/lon).