### PR TITLE
Attempt to find the analogous route pattern

### DIFF
--- a/apps/site/assets/.stylelintrc
+++ b/apps/site/assets/.stylelintrc
@@ -8,7 +8,7 @@
     "stylelint-selector-no-mergeable"
   ],
   "rules": {
-    "at-rule-blacklist": [
+    "at-rule-disallowed-list": [
       "debug"
     ],
     "block-opening-brace-space-before": "always",
@@ -23,7 +23,7 @@
     "declaration-colon-space-after": "always",
     "declaration-colon-space-before": "never",
     "declaration-no-important": true,
-    "declaration-property-value-blacklist": {
+    "declaration-property-value-disallowed-list": {
       "/^border/": [
         "none"
       ]
@@ -32,7 +32,7 @@
     "function-parentheses-space-inside": "never",
     "function-url-no-scheme-relative": true,
     "function-url-quotes": "always",
-    "function-url-scheme-whitelist": [
+    "function-url-scheme-allowed-list": [
       "data"
     ],
     "indentation": [
@@ -149,7 +149,7 @@
     "selector-pseudo-element-colon-notation": "double",
     "shorthand-property-no-redundant-values": true,
     "string-quotes": "single",
-    "unit-whitelist": [
+    "unit-allowed-list": [
       "ch",
       "em",
       "ex",

--- a/apps/site/assets/ts/schedule/components/direction/__tests__/reducer-test.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/__tests__/reducer-test.tsx
@@ -1,0 +1,94 @@
+import { menuReducer, MenuAction, State } from "../reducer";
+import { EnhancedRoutePattern } from "../../__schedule";
+import { Shape } from "../../../../__v3api";
+
+const routePatternsForInbound: EnhancedRoutePattern[] = [
+  {
+    direction_id: 1,
+    headsign: "Haymarket",
+    id: "111-5-1",
+    name: "Woodlawn - Haymarket Station",
+    representative_trip_id: "46824427",
+    route_id: "111",
+    shape_id: "1110177",
+    time_desc: null,
+    typicality: 1
+  },
+  {
+    direction_id: 1,
+    headsign: "Haymarket",
+    id: "111-6-1",
+    name: "Washington Ave & Revere Beach Pkwy - Haymarket Station",
+    representative_trip_id: "46824445",
+    route_id: "111",
+    shape_id: "1110157",
+    time_desc: "Weekdays only",
+    typicality: 2
+  }
+];
+
+const shape: Shape = {
+  direction_id: 1,
+  id: "1110177",
+  name: "Woodlawn - Haymarket Station",
+  priority: 3,
+  polyline: "polyline",
+  stop_ids: []
+};
+
+const initialState: State = {
+  routePattern: {
+    direction_id: 0,
+    headsign: "Woodlawn",
+    id: "111-5-0",
+    name: "Haymarket Station - Woodlawn",
+    representative_trip_id: "46824432",
+    route_id: "111",
+    shape_id: "1110180",
+    time_desc: null,
+    typicality: 1
+  },
+  shape: {
+    direction_id: 0,
+    id: "1110180",
+    name: "Haymarket Station - Woodlawn",
+    polyline: "polyline",
+    priority: 3,
+    stop_ids: []
+  },
+  directionId: 0,
+  shapesById: {
+    1110177: shape
+  },
+  routePatternsByDirection: {
+    0: [],
+    1: routePatternsForInbound
+  },
+  routePatternMenuOpen: true,
+  routePatternMenuAll: true,
+  itemFocus: null
+};
+
+it("menuReducer handles 'toggleDirection'", () => {
+  const action: MenuAction = { type: "toggleDirection" };
+
+  const expected = {
+    ...initialState,
+    itemFocus: "first",
+    shape,
+    directionId: 1,
+    routePattern: {
+      direction_id: 1,
+      headsign: "Haymarket",
+      id: "111-5-1",
+      name: "Woodlawn - Haymarket Station",
+      representative_trip_id: "46824427",
+      route_id: "111",
+      shape_id: "1110177",
+      time_desc: null,
+      typicality: 1
+    }
+  };
+
+  expect(menuReducer(initialState, action)).toEqual(expected);
+});

--- a/apps/site/assets/ts/schedule/components/direction/reducer.ts
+++ b/apps/site/assets/ts/schedule/components/direction/reducer.ts
@@ -76,9 +76,20 @@ const updateDirectionAndVariantInURL = (
 
 const toggleDirection = (state: State): State => {
   const nextDirection = state.directionId === 0 ? 1 : 0;
-  const [defaultRoutePatternForDirection] = state.routePatternsByDirection[
-    nextDirection
-  ];
+
+  // attempt to find the same route pattern for the opposite direction
+  const possibleNextRoutePattern = `${state.routePattern.id.slice(
+    0,
+    -1
+  )}${nextDirection}`;
+
+  const nextRoutePattern = state.routePatternsByDirection[nextDirection].find(
+    element => element.id === possibleNextRoutePattern
+  );
+
+  const defaultRoutePatternForDirection =
+    nextRoutePattern || state.routePatternsByDirection[nextDirection][0];
+
   updateDirectionAndVariantInURL(
     nextDirection,
     defaultRoutePatternForDirection.id

--- a/apps/site/test/predicted_schedule_test.exs
+++ b/apps/site/test/predicted_schedule_test.exs
@@ -259,6 +259,10 @@ defmodule PredictedScheduleTest do
         assert schedule.trip.id == prediction.trip.id
       end
     end
+
+    test "returns empty in case of error" do
+      assert group({:error, "error in predictions"}, {:error, "error in schedules"}) == []
+    end
   end
 
   describe "stop/1" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 The schedule view changes your route variant when you change direction](https://app.asana.com/0/555089885850811/1179129122227742)

When toggling `directionId` having an existing route pattern, an attempt to get the "analogous" route pattern for the toggled directionId will be made.

E.g.: if we toggle from `directionId=0` and `route pattern=111-5-0` to `directionId=1`, we'll try to see if `route pattern=111-5-1` exists. Otherwise, default to the first route pattern from the list (for the new directionId).
