### PR TITLE
assorted error catching 🐞🔨

### DIFF
--- a/apps/route_patterns/lib/repo.ex
+++ b/apps/route_patterns/lib/repo.ex
@@ -1,5 +1,6 @@
 defmodule RoutePatterns.Repo do
   @moduledoc false
+  require Logger
   use RepoCache, ttl: :timer.hours(1)
 
   alias RoutePatterns.RoutePattern
@@ -44,16 +45,19 @@ defmodule RoutePatterns.Repo do
   end
 
   defp api_all(opts) do
-    opts
-    |> RoutePatternsApi.all()
-    |> parse_api_response()
-  end
+    case RoutePatternsApi.all(opts) do
+      {:error, error} ->
+        _ =
+          Logger.warn(
+            "module=#{__MODULE__} RoutePatternsApi.all with opts #{inspect(opts)} returned :error -> #{
+              inspect(error)
+            }"
+          )
 
-  defp parse_api_response({:error, error}) do
-    {:error, error}
-  end
+        []
 
-  defp parse_api_response(%JsonApi{data: data}) do
-    Enum.map(data, &RoutePattern.new/1)
+      %JsonApi{data: data} ->
+        Enum.map(data, &RoutePattern.new/1)
+    end
   end
 end

--- a/apps/site/lib/predicted_schedule.ex
+++ b/apps/site/lib/predicted_schedule.ex
@@ -84,6 +84,8 @@ defmodule PredictedSchedule do
     |> Enum.sort_by(sort_fn)
   end
 
+  defp create_map({:error, _error}), do: %{}
+
   defp create_map(predictions_or_schedules) do
     Map.new(predictions_or_schedules, &group_transform/1)
   end

--- a/apps/site/lib/site_web/controllers/schedule/finder_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/finder_api.ex
@@ -192,7 +192,20 @@ defmodule SiteWeb.ScheduleController.FinderApi do
 
     schedule_opts = [date: schedule_date, direction_id: direction_id, stop_ids: [stop_id]]
     schedules_fn = Map.get(conn.assigns, :schedules_fn, &Schedules.Repo.by_route_ids/2)
-    schedules = schedules_fn.(route_ids, schedule_opts)
+
+    schedules =
+      case schedules_fn.(route_ids, schedule_opts) do
+        {:error, error} ->
+          _ =
+            Logger.warn(
+              "module=#{__MODULE__} Error getting schedules for #{route_ids}: #{inspect(error)}"
+            )
+
+          []
+
+        schedules ->
+          schedules
+      end
 
     # Don't bother fetching predictions if we're looking at a future/past date.
     # We include predictions in the trip list because current day trips MAY have

--- a/apps/site/lib/site_web/controllers/schedule/vehicle_locations.ex
+++ b/apps/site/lib/site_web/controllers/schedule/vehicle_locations.ex
@@ -69,9 +69,12 @@ defmodule SiteWeb.ScheduleController.VehicleLocations do
 
   @spec find_locations(Plug.Conn.t(), %{}) :: __MODULE__.t()
   defp find_locations(
-         %Plug.Conn{assigns: %{route: route, direction_id: direction_id, date: date}},
+         %Plug.Conn{
+           assigns: %{route: route, direction_id: direction_id, date: date}
+         },
          opts
-       ) do
+       )
+       when not is_nil(route) do
     schedule_for_trip_fn = opts[:schedule_for_trip_fn]
 
     for vehicle <- opts[:location_fn].(route.id, direction_id: direction_id), into: %{} do
@@ -79,6 +82,8 @@ defmodule SiteWeb.ScheduleController.VehicleLocations do
       {key, vehicle}
     end
   end
+
+  defp find_locations(_, _), do: %{}
 
   @spec location_key(Vehicles.Vehicle.t(), Date.t(), any) :: {String.t() | nil, String.t() | nil}
   defp location_key(%Vehicles.Vehicle{status: :in_transit} = vehicle, date, schedule_for_trip_fn)

--- a/apps/site/test/site_web/controllers/schedule/vehicle_locations_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/vehicle_locations_test.exs
@@ -49,6 +49,15 @@ defmodule SiteWeb.ScheduleController.VehicleLocationsTest do
       assert conn.assigns.vehicle_locations == %{}
     end
 
+    test "works if the route is nil", %{conn: conn} do
+      conn =
+        conn
+        |> assign(:route, nil)
+        |> call(@opts)
+
+      assert conn.assigns.vehicle_locations
+    end
+
     test "assigns vehicle locations at a stop if they are stopped or incoming", %{conn: conn} do
       conn =
         conn


### PR DESCRIPTION
#### Summary of changes
**Asana Tickets:** 

- [Elixir.UndefinedFunctionError: function nil.id/0 is undefined](https://app.asana.com/0/0/1200037415890637/f) (https://github.com/mbta/dotcom/commit/eab4b374185b7e8c8269b004e4b236101916fb11)
- [Elixir.Protocol.UndefinedError: protocol Enumerable not implemented for {:error, %HTTPoison.Error{id: nil, reason: :checkout_time...](https://app.asana.com/0/0/1200037380808745/f) (https://github.com/mbta/dotcom/commit/12dd7b9257dfc10abe9f0773e8e82eee5fdf6f1d)
- [Elixir.Protocol.UndefinedError: protocol Enumerable not implemented for {:error, %HTTPoison.Error{id: nil, reason: :checkout_time...](https://app.asana.com/0/0/1200037278955026/f) - (https://github.com/mbta/dotcom/commit/6a97d1909728ac25b610c3e27dfda89f29f3332e and https://github.com/mbta/dotcom/commit/cf7693feee821a65ad18e1237e6db75cf834f917)

Generally, if an API request fails we'd like to handle that gracefully. Sometimes we do that, and sometimes we inadvertently cause errors downstream. Here are a few places where I attempt to account for a few errors encountered in getting schedules, route patterns, or a route ID.