### PR TITLE
Hide line diagram branches created by multi route trips

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -338,11 +338,13 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
           RoutePattern.t()
         ]
   defp get_route_patterns(route_id, direction_id, nil),
-    do: RoutePatternsRepo.by_route_id(route_id, direction_id: direction_id)
+    do:
+      RoutePatternsRepo.by_route_id(route_id, direction_id: direction_id)
+      |> Enum.filter(&(&1.route_id == route_id))
 
-  defp get_route_patterns(_route_id, _direction_id, route_pattern_id) do
+  defp get_route_patterns(route_id, _direction_id, route_pattern_id) do
     case RoutePatternsRepo.get(route_pattern_id) do
-      %RoutePattern{} = route_pattern ->
+      %RoutePattern{route_id: ^route_id} = route_pattern ->
         [route_pattern]
 
       nil ->

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -150,8 +150,6 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                  nil,
                  nil,
                  nil,
-                 nil,
-                 nil,
                  "Green-E",
                  "Green-E",
                  "Green-E",
@@ -166,8 +164,6 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                ]
 
       assert_stop_ids(e_stops, [
-        "place-lech",
-        "14159",
         "place-north",
         "place-haecl",
         "place-gover",
@@ -207,16 +203,12 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                  false,
                  false,
                  false,
-                 false,
-                 false,
                  true
                ]
 
       assert Enum.map(e_stops, & &1.is_beginning?) ==
                [
                  true,
-                 false,
-                 false,
                  false,
                  false,
                  false,
@@ -630,16 +622,12 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                  false,
                  false,
                  false,
-                 false,
-                 false,
                  true
                ]
 
       assert Enum.map(stops, & &1.is_beginning?) ==
                [
                  true,
-                 false,
-                 false,
                  false,
                  false,
                  false,

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -42,6 +42,9 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
   end
 
   describe "get_branch_route_stops/3" do
+    @tag skip: "We'll mock route patterns soon"
+    test "does not return branches for route patterns from multi trip routes"
+
     test "returns a list of RouteStops, one for each branch of the line" do
       assert [
                %RouteStops{branch: nil, stops: trunk_route_stops},

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -663,8 +663,8 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
       assert [
                %RouteStops{branch: nil, stops: trunk_route_stops},
-               %RouteStops{branch: "North Station - Manchester", stops: rockport_route_stops},
-               %RouteStops{branch: "North Station - Newburyport", stops: newburyport_route_stops}
+               %RouteStops{branch: "North Station - Newburyport", stops: newburyport_route_stops},
+               %RouteStops{branch: "North Station - Manchester", stops: rockport_route_stops}
              ] = Helpers.get_branch_route_stops(newburyport_route, 0)
 
       assert Enum.all?(trunk_route_stops, &(&1.branch == nil))
@@ -703,11 +703,16 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
       assert Enum.all?(rockport_route_stops, &(&1.branch == "North Station - Manchester"))
 
-      assert_stop_ids(rockport_route_stops, ["place-GB-0198", "place-GB-0229", "place-GB-0254"])
+      assert_stop_ids(rockport_route_stops, [
+        "place-GB-0198",
+        "place-GB-0229",
+        "place-GB-0254",
+        "place-GB-0296"
+      ])
 
-      assert Enum.map(rockport_route_stops, & &1.is_terminus?) == [false, false, true]
+      assert Enum.map(rockport_route_stops, & &1.is_terminus?) == [false, false, false, true]
 
-      assert Enum.map(rockport_route_stops, & &1.is_beginning?) == [false, false, false]
+      assert Enum.map(rockport_route_stops, & &1.is_beginning?) == [false, false, false, false]
 
       assert Enum.all?(newburyport_route_stops, &(&1.branch == "North Station - Newburyport"))
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Should not include route patterns for multi route trips](https://app.asana.com/0/385363666817452/1200081044003352/f)

Added in after a test failure led me to find broken line diagrams as described in the ticket.
Also includes fixes for a few failing Green-E tests.

This fixes the line diagram but does not fix the map polylines -- I have a tentative approach for those but wanted to prioritize fixing the branching on the line diagram here, and also wanted to hold off since I know the map is being worked on right now anyway.