### PR TITLE
Events page renders poorly in IE

### DIFF
--- a/apps/site/assets/package-lock.json
+++ b/apps/site/assets/package-lock.json
@@ -28017,6 +28017,11 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stickyfilljs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stickyfilljs/-/stickyfilljs-2.1.0.tgz",
+      "integrity": "sha512-LkG0BXArL5HbW2O09IAXfnBQfpScgGqJuUDUrI3Ire5YKjRz/EhakIZEJogHwgXeQ4qnTicM9sK9uYfWN11qKg=="
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",

--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -31,6 +31,7 @@
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "sifter": "^0.6.0",
+    "stickyfilljs": "^2.1.0",
     "swr": "^0.1.18",
     "tether": "^1.4.7",
     "turbolinks": "git+https://github.com/paulswartz/turbolinks.git#82b188e",

--- a/apps/site/assets/webpack.config.dev.js
+++ b/apps/site/assets/webpack.config.dev.js
@@ -18,6 +18,10 @@ module.exports = env =>
       headers: {
         "Access-Control-Allow-Origin": "*"
       },
+      watchOptions: {
+        poll: true,
+        ignored: "/node_modules/"
+      },
       writeToDisk: path => /\.css$/.test(path),
       port: env.port,
       contentBase: path.resolve(__dirname, "../priv/static/"),

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -1,7 +1,7 @@
 <% events_by_month = grouped_by_month(@events, @year) %>
 
 <div class="m-event-listing">
-  <nav class="m-event-list__nav--mobile-controls fixedsticky sticky-top">
+  <nav class="m-event-list__nav--mobile-controls sticky-top">
     <%= render "_month_select.html",
         conn: @conn,
         month: @month,
@@ -15,8 +15,7 @@
 
   <%= for {month_number, event_teasers} <- events_by_month do %>
     <section id="<%= month_number %>-<%= @year %>" class="m-event-list__month <%= if month_number == @month, do: 'm-event-list__month--active' %>">
-      <h2 class="m-event-list__month-header fixedsticky sticky-top"><%= render_event_month(month_number, @year) %></h2>
-      <!-- This list-group stuff is bootstrap -->
+      <h2 class="m-event-list__month-header sticky-top sticky-month"><%= render_event_month(month_number, @year) %></h2>
       <ul class="list-group list-group-flush">
         <!-- Previous months button. A JS script sets up a listener for button click -->
         <%= if Enum.any?(event_teasers, fn event -> event_ended(%{start: event.date, stop: event.date_end}) end) do %>

--- a/apps/site/lib/site_web/templates/event/index.html.eex
+++ b/apps/site/lib/site_web/templates/event/index.html.eex
@@ -12,7 +12,7 @@
   </header>
 
   <div class="row">
-    <nav class="m-event-list__nav col-sm-2 fixedsticky sticky-top">
+    <nav class="m-event-list__nav col-sm-2 sticky-top">
       <p class="u-bold">Jump to</p>
       <%= for month <- 1..12 do %>
         <%= link render_event_month(month, @year), to: event_path(@conn, :index, month: month, year: @year) %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Events listing page renders poorly in IE](https://app.asana.com/0/555089885850811/1200032439670460)

I had to use polyfills to avoid errors.
I also removed the class `fixedsticky` as it was causing issues on IE (and the "stickiness" seems to work even after said removal).

Also, the remaining errors in IE get fixed upgrading `phoenix_live_reload` to at least 1.1.4 (I checked): https://github.com/phoenixframework/phoenix_live_reload/blob/master/CHANGELOG.md

