### PR TITLE
PSL stops link to stop page

### DIFF
--- a/apps/site/lib/site_web/templates/fare_transformation/_nearby_locations.html.eex
+++ b/apps/site/lib/site_web/templates/fare_transformation/_nearby_locations.html.eex
@@ -1,11 +1,11 @@
 <div class="c-proposed-location-cards">
-  <%= for {%Fares.ProposedLocations.Location{stop_name: name, retail_fvm: retail_fvm, latitude: latitude, longitude: longitude} = _location, distance} <- @nearby_proposed_locations do %>
+  <%= for {%Fares.ProposedLocations.Location{stop_name: name, retail_fvm: retail_fvm, latitude: latitude, longitude: longitude, stop_id: stop_id} = _location, distance} <- @nearby_proposed_locations do %>
 
     <div class="c-location-card c-location-card--resp">
 
       <div class="c-flex-space-between">
         <div class="c-location-card__place">
-          <%= name %>
+          <%= link name, to: stop_path(@conn, :show, stop_id) %>
         </div>
 
         <div class="c-location-card__distance">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [PSL | Add links to station/stop pages](https://app.asana.com/0/555089885850811/1200107561895262)

For PSL location cards, the stop / station name links to the stop / station page.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Are interactive elements accessible to screen readers?