### PR TITLE
Hide years without events

### DIFF
--- a/apps/site/lib/site_web/templates/event/_year_select.html.eex
+++ b/apps/site/lib/site_web/templates/event/_year_select.html.eex
@@ -1,6 +1,6 @@
 <select class="c-select m-event-list__select">
   <option disabled selected value="">Jump to</option>
-  <%= for year <- year_options(@conn) do %>
+  <%= for year <- years_for_selection(@conn) do %>
     <%= content_tag(
       :option,
       year,

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -24,24 +24,12 @@ defmodule SiteWeb.EventView do
     end
   end
 
-  @doc "Returns a list of years with which we can filter events.
-  Defaults to the current datetime if no assigns
-  "
-  @spec year_options(Plug.Conn.t()) :: %Range{:first => Calendar.year(), :last => Calendar.year()}
-  def year_options(%{assigns: %{date: %{year: year}}}) when is_integer(year) do
-    do_year_options(year)
-  end
+  @doc "Returns a list of years with existing events from conn"
+  @spec years_for_selection(Plug.Conn.t()) :: list
+  def years_for_selection(%Plug.Conn{assigns: %{years_for_selection: years_for_selection}}),
+    do: years_for_selection
 
-  def year_options(_) do
-    %{year: year} = Util.now()
-    do_year_options(year)
-  end
-
-  @spec do_year_options(Calendar.year()) :: %Range{
-          :first => Calendar.year(),
-          :last => Calendar.year()
-        }
-  defp do_year_options(year), do: Range.new(year - 4, year + 1)
+  def years_for_selection(_), do: []
 
   @doc "Returns a list of event teasers, grouped/sorted by month"
   @spec grouped_by_month([%Teaser{}], number) :: [{number, [%Teaser{}]}]

--- a/apps/site/test/site_web/controllers/event_controller_test.exs
+++ b/apps/site/test/site_web/controllers/event_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule SiteWeb.EventControllerTest do
   use SiteWeb.ConnCase
+
+  import SiteWeb.EventController
   import Mock
 
   @current_date ~D[2019-04-15]
@@ -232,6 +234,20 @@ defmodule SiteWeb.EventControllerTest do
       assert old_path == "/events/date/title/icalendar"
       conn = get(conn, old_path)
       assert conn.status == 302
+    end
+  end
+
+  describe "year_options/1" do
+    test "year_options/1 returns a range of -4/+1 years", %{conn: conn} do
+      assigns_with_date = Map.put(conn.assigns, :date, ~D[2019-03-03])
+      conn = %{conn | assigns: assigns_with_date}
+      assert 2015..2020 = year_options(conn)
+    end
+
+    test "year_options/1 defaults to Util.now", %{conn: conn} do
+      with_mock Util, [:passthrough], now: fn -> ~N[2020-01-02T05:00:00] end do
+        assert 2016..2021 = year_options(conn)
+      end
     end
   end
 end

--- a/apps/site/test/site_web/views/event_view_test.exs
+++ b/apps/site/test/site_web/views/event_view_test.exs
@@ -1,6 +1,5 @@
 defmodule SiteWeb.EventViewTest do
   use Site.ViewCase, async: true
-  import Mock
   import SiteWeb.EventView
   import CMS.Helpers, only: [parse_iso_datetime: 1]
   alias CMS.Partial.Teaser
@@ -68,21 +67,7 @@ defmodule SiteWeb.EventViewTest do
     end
   end
 
-  describe "year_options/1" do
-    test "year_options/1 returns a range of -4/+1 years", %{conn: conn} do
-      assigns_with_date = Map.put(conn.assigns, :date, ~D[2019-03-03])
-      conn = %{conn | assigns: assigns_with_date}
-      assert 2015..2020 = year_options(conn)
-    end
-
-    test "year_options/1 defaults to Util.now", %{conn: conn} do
-      with_mock Util, [:passthrough], now: fn -> ~N[2020-01-02T05:00:00] end do
-        assert 2016..2021 = year_options(conn)
-      end
-    end
-  end
-
-  describe "rendering event durations in list and calendar views" do
+  describe "render_event_duration/2" do
     test "with no end time, only renders start time" do
       actual = render_event_duration_list_view(~N[2016-11-15T10:00:00], nil)
       expected = "Tue, Nov 15, 2016 \u2022 10 AM"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Years without events should not appear in the year dropdown](https://app.asana.com/0/555089885850811/1200111821763338)

The logic makes sure that years without events are not part of the dropdown so they cannot be selected.

<img width="375" alt="image" src="https://user-images.githubusercontent.com/61979382/113912492-2de23a00-97a9-11eb-9e9b-e961682d0dfd.png">
