### PR TITLE
Expand months in past years

### DIFF
--- a/apps/site/lib/site_web/templates/event/_event_teaser.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_teaser.html.eex
@@ -1,0 +1,30 @@
+<% path_fn = fn -> cms_static_page_path(@conn, @event_teaser.path) end %>
+<% range = %{start: @event_teaser.date, stop: @event_teaser.date_end} %>
+<% event_is_hidden = if @check_event_ended, do: event_ended(range), else: false %>
+<!-- If date is upcoming, display on init -->
+<!-- Otherwise, add a 'hidden' class. On previous-button click, this class is removed -->
+<li class="list-group-item u-flex-container m-event <%= if event_is_hidden, do: 'hidden' %>" data-group="<%= render_event_month_slug(@month_number, @year) %>">
+  <div class="m-event__date-circle">
+    <div class="u-bold m-event__month"><%= pretty_date(range.start, "{Mshort}") %></div>
+    <div class="u-bold m-event__day"><%= pretty_date(range.start, "{D}") %></div>
+  </div>
+  <div class="u-flex-one">
+    <div class="m-event__date-range">
+      <%= render_event_duration(range.start, range.stop) %>
+    </div>
+    <div class="m-event__title">
+      <%= link @event_teaser.title, to: path_fn.() %>
+    </div>
+  </div>
+  <div class="m-event__status-message">
+    <%= if !event_ended(range) do %>
+      <%= link to: event_icalendar_path(@conn, @event_teaser.path),
+        data: [turbolinks: false], class: "btn btn-secondary btn-lg" do %>
+          <%= fa "calendar-plus-o" %>
+          <span class="m-event__add-text">Add</span>
+      <% end %>
+    <% else %>
+      <div class="m-event__ended-message">Ended</div>
+    <% end %>
+  </div>
+</li>

--- a/apps/site/lib/site_web/templates/event/_list_of_events.html.eex
+++ b/apps/site/lib/site_web/templates/event/_list_of_events.html.eex
@@ -2,47 +2,32 @@
   <section id="<%= month_number %>-<%= @year %>" class="m-event-list__month <%= if month_number == @month, do: 'm-event-list__month--active' %>">
     <h2 class="m-event-list__month-header sticky-top sticky-month"><%= render_event_month(month_number, @year) %></h2>
     <ul class="list-group list-group-flush">
-      <!-- Previous months button. A JS script sets up a listener for button click -->
-      <%= if Enum.any?(event_teasers, fn event -> event_ended(%{start: event.date, stop: event.date_end}) end) do %>
+
+      <%= if @conn.assigns.date.year == @year and Enum.any?(event_teasers, fn event -> event_ended(%{start: event.date, stop: event.date_end}) end) do %>
+        <!-- Previous months button. A JS script sets up a listener for button click -->
         <li class="list-group-item">
           <a tabindex="0" role="button" class="m-previous-events-button" data-group="<%= render_event_month_slug(month_number, @year) %>">
             View Previous <%= render_event_month(month_number, @year) %> Events
             <i class="fa fa-angle-down down" aria-hidden="true"></i>
           </a>
         </li>
-      <% end %>
-      <%= for event_teaser <- event_teasers do %>
-        <%
-          range = %{start: event_teaser.date, stop: event_teaser.date_end}
-          path_fn = fn -> cms_static_page_path(@conn, event_teaser.path) end
-        %>
-        <!-- If date is upcoming, display on init -->
-        <!-- Otherwise, add a 'hidden' class. On previous-button click, this class is removed -->
-        <li class="list-group-item u-flex-container m-event <%= if event_ended(range), do: 'hidden' %>" data-group="<%= render_event_month_slug(month_number, @year) %>">
-          <div class="m-event__date-circle">
-            <div class="u-bold m-event__month"><%= pretty_date(range.start, "{Mshort}") %></div>
-            <div class="u-bold m-event__day"><%= pretty_date(range.start, "{D}") %></div>
-          </div>
-          <div class="u-flex-one">
-            <div class="m-event__date-range">
-              <%= render_event_duration(range.start, range.stop) %>
-            </div>
-            <div class="m-event__title">
-              <%= link event_teaser.title, to: path_fn.() %>
-            </div>
-          </div>
-          <div class="m-event__status-message">
-            <%= if !event_ended(range) do %>
-              <%= link to: event_icalendar_path(@conn, event_teaser.path),
-                data: [turbolinks: false], class: "btn btn-secondary btn-lg" do %>
-                  <%= fa "calendar-plus-o" %>
-                  <span class="m-event__add-text">Add</span>
-              <% end %>
-            <% else %>
-              <div class="m-event__ended-message">Ended</div>
-            <% end %>
-          </div>
-        </li>
+        <%= for event_teaser <- event_teasers do %>
+          <%= render "_event_teaser.html",
+              event_teaser: event_teaser,
+              check_event_ended: true,
+              conn: @conn,
+              month_number: month_number,
+              year: @year %>
+        <% end %>
+      <% else %>
+        <%= for event_teaser <- event_teasers do %>
+          <%= render "_event_teaser.html",
+              event_teaser: event_teaser,
+              check_event_ended: false,
+              conn: @conn,
+              month_number: month_number,
+              year: @year %>
+        <% end %>
       <% end %>
     </ul>
   </section>

--- a/apps/site/test/detailed_stop_group_test.exs
+++ b/apps/site/test/detailed_stop_group_test.exs
@@ -29,7 +29,7 @@ defmodule DetailedStopGroupTest do
           "Franklin Line",
           "Greenbush Line",
           "Haverhill Line",
-          "Kingston/Plymouth Line",
+          "Kingston Line",
           "Lowell Line",
           "Middleborough/Lakeville Line",
           "Needham Line",

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -666,8 +666,8 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
       assert [
                %RouteStops{branch: nil, stops: trunk_route_stops},
-               %RouteStops{branch: "North Station - Newburyport", stops: newburyport_route_stops},
-               %RouteStops{branch: "North Station - Manchester", stops: rockport_route_stops}
+               %RouteStops{branch: "North Station - Manchester", stops: rockport_route_stops},
+               %RouteStops{branch: "North Station - Newburyport", stops: newburyport_route_stops}
              ] = Helpers.get_branch_route_stops(newburyport_route, 0)
 
       assert Enum.all?(trunk_route_stops, &(&1.branch == nil))
@@ -765,8 +765,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
           "place-PB-0212",
           "place-PB-0245",
           "place-PB-0281",
-          "place-KB-0351",
-          "place-PB-0356"
+          "place-KB-0351"
         ]
       )
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Months in past years should be expanded by default](https://app.asana.com/0/555089885850811/1200111821763336)

Whenever we want to display events from years other than the current year, those events per month will be all expanded.

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/61979382/114085922-00b48b00-9880-11eb-9293-f35d7f2f7746.png">



