### PR TITLE
CMS: posted_on is now datetime string (news and update structs)

### DIFF
--- a/apps/cms/lib/helpers.ex
+++ b/apps/cms/lib/helpers.ex
@@ -132,6 +132,24 @@ defmodule CMS.Helpers do
     end
   end
 
+  @doc """
+  Temporary handler for CMS API transition. Prior to change,
+  data will hold a date-only value. Following the change,
+  data will hold a datetime string.
+  @deprecated upon next CMS API database update.
+  """
+  @spec parse_posted_on(map) :: Date.t() | nil
+  def parse_posted_on(data) do
+    data
+    |> field_value("field_posted_on")
+    |> parse_iso_datetime()
+    |> do_parse_posted_on(data)
+  end
+
+  # Return a date regardless of input format (time not required for this consumer)
+  defp do_parse_posted_on(nil, data), do: parse_date(data, "field_posted_on")
+  defp do_parse_posted_on(date, _), do: NaiveDateTime.to_date(date)
+
   @spec parse_link(map, String.t()) :: Link.t() | nil
   def parse_link(%{} = data, field) do
     case data[field] do

--- a/apps/cms/lib/page/news_entry.ex
+++ b/apps/cms/lib/page/news_entry.ex
@@ -12,6 +12,7 @@ defmodule CMS.Page.NewsEntry do
       handle_html: 1,
       int_or_string_to_int: 1,
       parse_body: 1,
+      parse_iso_datetime: 1,
       path_alias: 1
     ]
 
@@ -55,10 +56,14 @@ defmodule CMS.Page.NewsEntry do
       media_email: field_value(data, "field_media_email"),
       media_phone: field_value(data, "field_media_phone"),
       more_information: parse_more_information(data),
-      posted_on: parse_posted_date(data),
       teaser: handle_html(field_value(data, "field_teaser")),
       migration_id: field_value(data, "field_migration_id"),
-      path_alias: path_alias(data)
+      path_alias: path_alias(data),
+      posted_on:
+        data
+        |> field_value("field_posted_on")
+        |> parse_iso_datetime()
+        |> NaiveDateTime.to_date()
     }
   end
 
@@ -74,12 +79,5 @@ defmodule CMS.Page.NewsEntry do
 
   def number_of_recent_news_suggestions do
     @number_of_recent_news_suggestions
-  end
-
-  defp parse_posted_date(data) do
-    data
-    |> field_value("field_posted_on")
-    |> Timex.parse!("{YYYY}-{0M}-{0D}")
-    |> NaiveDateTime.to_date()
   end
 end

--- a/apps/cms/lib/page/news_entry.ex
+++ b/apps/cms/lib/page/news_entry.ex
@@ -12,7 +12,7 @@ defmodule CMS.Page.NewsEntry do
       handle_html: 1,
       int_or_string_to_int: 1,
       parse_body: 1,
-      parse_iso_datetime: 1,
+      parse_posted_on: 1,
       path_alias: 1
     ]
 
@@ -59,11 +59,7 @@ defmodule CMS.Page.NewsEntry do
       teaser: handle_html(field_value(data, "field_teaser")),
       migration_id: field_value(data, "field_migration_id"),
       path_alias: path_alias(data),
-      posted_on:
-        data
-        |> field_value("field_posted_on")
-        |> parse_iso_datetime()
-        |> NaiveDateTime.to_date()
+      posted_on: parse_posted_on(data)
     }
   end
 

--- a/apps/cms/lib/page/project_update.ex
+++ b/apps/cms/lib/page/project_update.ex
@@ -11,9 +11,9 @@ defmodule CMS.Page.ProjectUpdate do
       field_value: 2,
       int_or_string_to_int: 1,
       parse_body: 1,
-      parse_date: 2,
       parse_image: 2,
       parse_images: 2,
+      parse_iso_datetime: 1,
       parse_paragraphs: 2,
       path_alias: 1
     ]
@@ -57,12 +57,16 @@ defmodule CMS.Page.ProjectUpdate do
       image: parse_image(data, "field_image"),
       paragraphs: parse_paragraphs(data, preview_opts),
       photo_gallery: parse_images(data, "field_photo_gallery"),
-      posted_on: parse_date(data, "field_posted_on"),
       project_id: project_id,
       project_url: project_alias,
       teaser: field_value(data, "field_teaser"),
       title: field_value(data, "title"),
-      path_alias: path_alias(data)
+      path_alias: path_alias(data),
+      posted_on:
+        data
+        |> field_value("field_posted_on")
+        |> parse_iso_datetime()
+        |> NaiveDateTime.to_date()
     }
   end
 

--- a/apps/cms/lib/page/project_update.ex
+++ b/apps/cms/lib/page/project_update.ex
@@ -13,7 +13,7 @@ defmodule CMS.Page.ProjectUpdate do
       parse_body: 1,
       parse_image: 2,
       parse_images: 2,
-      parse_iso_datetime: 1,
+      parse_posted_on: 1,
       parse_paragraphs: 2,
       path_alias: 1
     ]
@@ -62,11 +62,7 @@ defmodule CMS.Page.ProjectUpdate do
       teaser: field_value(data, "field_teaser"),
       title: field_value(data, "title"),
       path_alias: path_alias(data),
-      posted_on:
-        data
-        |> field_value("field_posted_on")
-        |> parse_iso_datetime()
-        |> NaiveDateTime.to_date()
+      posted_on: parse_posted_on(data)
     }
   end
 

--- a/apps/cms/lib/partial/teaser.ex
+++ b/apps/cms/lib/partial/teaser.ex
@@ -128,7 +128,7 @@ defmodule CMS.Partial.Teaser do
     end
   end
 
-  # The Event start time includes time and timezone data
+  # Drupal datetime values include time and timezone data
   @spec do_datetime(String.t()) :: NaiveDateTime.t() | nil
   defp do_datetime(date) do
     case NaiveDateTime.from_iso8601(date) do

--- a/apps/cms/priv/repo/news.json
+++ b/apps/cms/priv/repo/news.json
@@ -140,7 +140,7 @@
     "field_page_type": [],
     "field_posted_on": [
       {
-        "value": "2018-03-29"
+        "value": "2018-03-29T08:00:00-04:00"
       }
     ],
     "field_related_transit": [],
@@ -289,7 +289,7 @@
     "field_page_type": [],
     "field_posted_on": [
       {
-        "value": "2018-03-29"
+        "value": "2018-03-29T08:00:00-04:00"
       }
     ],
     "field_related_transit": [],
@@ -434,7 +434,7 @@
     "field_page_type": [],
     "field_posted_on": [
       {
-        "value": "2018-03-23"
+        "value": "2018-03-23T08:00:00-04:00"
       }
     ],
     "field_related_transit": [],
@@ -579,7 +579,7 @@
     "field_page_type": [],
     "field_posted_on": [
       {
-        "value": "2018-03-23"
+        "value": "2018-03-23T08:00:00-04:00"
       }
     ],
     "field_related_transit": [],
@@ -724,7 +724,7 @@
     "field_page_type": [],
     "field_posted_on": [
       {
-        "value": "2018-03-20"
+        "value": "2018-03-20T08:00:00-04:00"
       }
     ],
     "field_related_transit": [],

--- a/apps/cms/priv/repo/project-updates.json
+++ b/apps/cms/priv/repo/project-updates.json
@@ -117,7 +117,7 @@
     "field_photo_gallery": [],
     "field_posted_on": [
       {
-        "value": "2018-04-02"
+        "value": "2018-04-02T08:00:00-04:00"
       }
     ],
     "field_project": [
@@ -259,7 +259,7 @@
     "field_photo_gallery": [],
     "field_posted_on": [
       {
-        "value": "2018-03-31"
+        "value": "2018-03-31T08:00:00-04:00"
       }
     ],
     "field_project": [
@@ -401,7 +401,7 @@
     "field_photo_gallery": [],
     "field_posted_on": [
       {
-        "value": "2018-03-30"
+        "value": "2018-03-30T08:00:00-04:00"
       }
     ],
     "field_project": [
@@ -543,7 +543,7 @@
     "field_photo_gallery": [],
     "field_posted_on": [
       {
-        "value": "2018-03-29"
+        "value": "2018-03-29T08:00:00-04:00"
       }
     ],
     "field_project": [
@@ -685,7 +685,7 @@
     "field_photo_gallery": [],
     "field_posted_on": [
       {
-        "value": "2018-03-22"
+        "value": "2018-03-22T08:00:00-04:00"
       }
     ],
     "field_project": [
@@ -1113,7 +1113,7 @@
     "field_photo_gallery": [],
     "field_posted_on": [
       {
-        "value": "2019-07-29"
+        "value": "2019-07-29T08:00:00-04:00"
       }
     ],
     "field_project": [
@@ -1541,7 +1541,7 @@
     "field_photo_gallery": [],
     "field_posted_on": [
       {
-        "value": "2019-07-29"
+        "value": "2019-07-29T08:00:00-04:00"
       }
     ],
     "field_project": [
@@ -1969,7 +1969,7 @@
     "field_photo_gallery": [],
     "field_posted_on": [
       {
-        "value": "2019-07-29"
+        "value": "2019-07-29T08:00:00-04:00"
       }
     ],
     "field_project": [

--- a/apps/cms/test/helpers_test.exs
+++ b/apps/cms/test/helpers_test.exs
@@ -149,6 +149,19 @@ defmodule CMS.HelpersTest do
     end
   end
 
+  describe "parse_posted_on/1" do
+    test "can parse string as date" do
+      map = %{"field_posted_on" => [%{"value" => "2017-01-01"}]}
+
+      assert parse_posted_on(map) == ~D[2017-01-01]
+    end
+
+    test "can parse string as datetime and convert back to date" do
+      map = %{"field_posted_on" => [%{"value" => "2021-04-13T08:00:00-04:00"}]}
+      assert parse_posted_on(map) == ~D[2021-04-13]
+    end
+  end
+
   describe "parse_link/2" do
     test "it parses a link field into a Link" do
       data = %{


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 RSS | Only one news entry goes to Slack per day; add timestamp](https://app.asana.com/0/553506286097126/1177077206704269)

This change is intended for non-dotcom consumers of the API, so we are simply parsing it differently and converting back into a normal date w/o time, so no downstream changes are necessary.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [ ] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [ ] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
