### PR TITLE
Add polyfill for `composedPath`

### DIFF
--- a/apps/site/assets/js/event-page-setup.js
+++ b/apps/site/assets/js/event-page-setup.js
@@ -19,6 +19,29 @@ function toggleAttributePolyfill() {
   }
 }
 
+function composedPathPolyfill() {
+  // Taken from:
+  // https://gist.github.com/rockinghelvetica/00b9f7b5c97a16d3de75ba99192ff05c
+  (function(e, d, w) {
+    if (!e.composedPath) {
+      e.composedPath = function() {
+        if (this.path) {
+          return this.path;
+        }
+        let { target } = this;
+
+        this.path = [];
+        while (target.parentNode !== null) {
+          this.path.push(target);
+          target = target.parentNode;
+        }
+        this.path.push(d, w);
+        return this.path;
+      };
+    }
+  })(Event.prototype, document, window);
+}
+
 function stickyPolyfill() {
   import("stickyfilljs").then(stickyfilljs => {
     const elements = document.querySelectorAll(".sticky-month");
@@ -29,6 +52,7 @@ function stickyPolyfill() {
 function addInternetExplorerPolyfills() {
   toggleAttributePolyfill();
   stickyPolyfill();
+  composedPathPolyfill();
 }
 
 function setupEventPopups() {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Overlays don't automatically close in IE](https://app.asana.com/0/555089885850811/1200196372897038)

Polyfill to avoid crashes in IE (although they're not visible/noticeable).

<img width="756" alt="image" src="https://user-images.githubusercontent.com/61979382/115590539-13c35400-a29f-11eb-9b20-18a4b590936d.png">
