### PR TITLE
fix: Update isCurrentValidService logic

### DIFF
--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -86,10 +86,7 @@ export const isCurrentValidService = (
   }
 
   // check within rating dates
-  return (
-    isInCurrentRating(service, currentDate) &&
-    isInCurrentService(service, currentDate)
-  );
+  return isInCurrentRating(service, currentDate);
 };
 
 export const startToEnd = (


### PR DESCRIPTION
The schedule finder defaults to selecting Saturday service today, which is definitely a weekday and not a Saturday.
Turns out it's because this week there's no school! And we have separate `services` for that.

With this change, I'm enabling the service picker to pick the weekday service as today's default, even though (if you look at the service data in the API) the weekday service listed in the dropdown technically starts _next week_, and a different service (that's filtered out in our backend) covers today. From a user perspective those two services (which are basically `weekday` and `weekday (no school)`) can be treated as the same service, but from a technical perspective we need this... 😅 
 
#### Summary of changes
**Asana Ticket:** [Schedule Finder | Service picker defaults to wrong service](https://app.asana.com/0/385363666817452/1200227724801264/f)

Updates the logic to evaluate true for services that are within the current rating, even if the current date does not fall within the service's start/end dates.

This is done to accommodate services that are not active during school vacation days, but would otherwise be active throughout the rating.

If those services were not seen as true here, then on school vacation days we might not have a current service correctly selected in the front end -- this is an edge case where we cannot substitute with the relevant school-vacation-valid service, because those are already filtered out in the back end (because we didn't want to show them in the services dropdown).

