### PR TITLE
Updated headways, en dashes

### DIFF
--- a/apps/site/assets/ts/schedule/components/ScheduleNote.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleNote.tsx
@@ -42,7 +42,7 @@ const peakOffPeakTimes = ({
     <div className="m-schedule-page__schedule-note">
       <h4 className="m-schedule-page__service">Peak Service</h4>
       <div className="m-schedule-page__service-subheading">
-        Weekdays 7 AM - 9 AM, 4 PM - 6:30 PM
+        Weekdays 7 &ndash; 9 AM, 4 &ndash; 6:30 PM
       </div>
       {service(peakService)}
     </div>

--- a/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleNoteTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleNoteTest.tsx.snap
@@ -28,7 +28,7 @@ exports[`it renders 1`] = `
     <div
       className="m-schedule-page__service-subheading"
     >
-      Weekdays 7 - 9 AM, 4 - 6:30 PM
+      Weekdays 7 – 9 AM, 4 – 6:30 PM
     </div>
     <p
       className="m-schedule-page__service-note-time"
@@ -125,7 +125,7 @@ exports[`it renders without service exceptions 1`] = `
     <div
       className="m-schedule-page__service-subheading"
     >
-      Weekdays 7 - 9 AM, 4 - 6:30 PM
+      Weekdays 7 – 9 AM, 4 – 6:30 PM
     </div>
     <p
       className="m-schedule-page__service-note-time"

--- a/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleNoteTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleNoteTest.tsx.snap
@@ -28,7 +28,7 @@ exports[`it renders 1`] = `
     <div
       className="m-schedule-page__service-subheading"
     >
-      Weekdays 7 AM - 9 AM, 4 PM - 6:30 PM
+      Weekdays 7 - 9 AM, 4 - 6:30 PM
     </div>
     <p
       className="m-schedule-page__service-note-time"
@@ -125,7 +125,7 @@ exports[`it renders without service exceptions 1`] = `
     <div
       className="m-schedule-page__service-subheading"
     >
-      Weekdays 7 AM - 9 AM, 4 PM - 6:30 PM
+      Weekdays 7 - 9 AM, 4 - 6:30 PM
     </div>
     <p
       className="m-schedule-page__service-note-time"

--- a/apps/site/lib/site/schedule_note.ex
+++ b/apps/site/lib/site/schedule_note.ex
@@ -29,15 +29,15 @@ defmodule Site.ScheduleNote do
 
   def schedule_note(%Route{id: "Red"}) do
     %__MODULE__{
-      peak_service: "9 minutes",
-      offpeak_service: "12-16 minutes"
+      peak_service: "11 minutes",
+      offpeak_service: "12 \u2013 16 minutes"
     }
   end
 
   def schedule_note(%Route{id: "Mattapan"}) do
     %__MODULE__{
       peak_service: "5 minutes",
-      offpeak_service: "8-12 minutes",
+      offpeak_service: "8 \u2013 12 minutes",
       exceptions: [
         %{
           type: "weekend mornings and late night",
@@ -49,50 +49,50 @@ defmodule Site.ScheduleNote do
 
   def schedule_note(%Route{id: "Orange"}) do
     %__MODULE__{
-      peak_service: "6 minutes",
-      offpeak_service: "9-11 minutes"
+      peak_service: "7 \u2013 9 minutes",
+      offpeak_service: "10 \u2013 14 minutes"
     }
   end
 
   def schedule_note(%Route{id: "Blue"}) do
     %__MODULE__{
-      peak_service: "5 minutes",
-      offpeak_service: "9-13 minutes"
+      peak_service: "5 \u2013 6 minutes",
+      offpeak_service: "9 \u2013 11 minutes"
     }
   end
 
   def schedule_note(%Route{id: "Green"}) do
     %__MODULE__{
-      peak_service: "6-7 minutes",
-      offpeak_service: "7-13 minutes"
+      peak_service: "7 \u2013 10 minutes",
+      offpeak_service: "9 \u2013 13 minutes"
     }
   end
 
   def schedule_note(%Route{id: "Green-B"}) do
     %__MODULE__{
-      peak_service: "6 minutes",
-      offpeak_service: "7-12 minutes"
+      peak_service: "7 \u2013 8 minutes",
+      offpeak_service: "9 \u2013 12 minutes"
     }
   end
 
   def schedule_note(%Route{id: "Green-C"}) do
     %__MODULE__{
-      peak_service: "6-7 minutes",
-      offpeak_service: "7-12 minutes"
+      peak_service: "10 minutes",
+      offpeak_service: "11 \u2013 13 minutes"
     }
   end
 
   def schedule_note(%Route{id: "Green-D"}) do
     %__MODULE__{
-      peak_service: "6 minutes",
-      offpeak_service: "8-13 minutes"
+      peak_service: "8 \u2013 9 minutes",
+      offpeak_service: "10 \u2013 12 minutes"
     }
   end
 
   def schedule_note(%Route{id: "Green-E"}) do
     %__MODULE__{
-      peak_service: "6 minutes",
-      offpeak_service: "8-12 minutes"
+      peak_service: "10 minutes",
+      offpeak_service: "10 \u2013 12 minutes"
     }
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Fix current hardcoded times in "schedule note"](https://app.asana.com/0/555089885850811/1200183759760091)

Updated headways to match https://docs.google.com/spreadsheets/d/15c8yVzkr-NgRqbMqJiT4zXTG4-09Z2zQwvainq9uIVI/edit#gid=1202875852.
Replaced hyphens with en dashes
Removed redundant AM in the Peak Service time listing.