### PR TITLE
Account for JS disabled in the "View Previous ... Events" button

### DIFF
--- a/apps/site/assets/css/_events.scss
+++ b/apps/site/assets/css/_events.scss
@@ -49,7 +49,6 @@ $mobile-control-height: 73px;
     @include media-breakpoint-down(xs) {
       padding-left: $base-spacing;
       transition: top .2s ease-in-out;
-      z-index: 12; // overwrite 13 that's default so it doesn't show on top of the mobile nav
 
       .js-nav-down & {
         top: 0;
@@ -134,6 +133,8 @@ $mobile-control-height: 73px;
   height: $mobile-control-height;
   padding: $base-spacing;
   transition: top .2s ease-in-out;
+  position: sticky;
+  z-index: 14; // one-up value so the mobile nav shows on top
 
   .m-event-list__select {
     height: 100%;

--- a/apps/site/assets/js/event-page-setup.js
+++ b/apps/site/assets/js/event-page-setup.js
@@ -181,6 +181,10 @@ export default function() {
   document.addEventListener(
     "turbolinks:load",
     () => {
+      const viewPreviousEventsLink = document.querySelector(
+        ".m-view-previous-events"
+      );
+      viewPreviousEventsLink.classList.remove("hidden");
       if (document.querySelector(".m-events-hub")) {
         const isIE = !!document.documentMode;
         if (isIE) {
@@ -188,9 +192,6 @@ export default function() {
         }
 
         setupEventsListing();
-      }
-
-      if (document.querySelector(".m-events-hub")) {
         setupEventPopups();
       }
     },

--- a/apps/site/assets/js/event-page-setup.js
+++ b/apps/site/assets/js/event-page-setup.js
@@ -99,6 +99,19 @@ function setupEventPopups() {
   }
 }
 
+function MakeCollapsedHeadersSticky(eventsListing) {
+  const sections = eventsListing.querySelectorAll(".m-event-list__month");
+  for (let i = 0; i < sections.length; i++) {
+    const section = sections[i];
+    const header = section.querySelectorAll(".c-expandable-block__link");
+    if (header[0].getAttribute("aria-expanded") == "false") {
+      section.classList.add("sticky-top");
+    } else {
+      section.classList.remove("sticky-top");
+    }
+  }
+}
+
 export function setupEventsListing() {
   const eventsHubPage = document.querySelector(".m-events-hub");
   // add event listener to navigate to page on dropdown select
@@ -164,6 +177,8 @@ export function setupEventsListing() {
           }
 
           prevScroll = curScroll;
+
+          MakeCollapsedHeadersSticky(eventsListing);
         });
       },
       { capture: false, passive: true }

--- a/apps/site/assets/js/test/event-page-setup__test.js
+++ b/apps/site/assets/js/test/event-page-setup__test.js
@@ -26,9 +26,7 @@ const eventsHubHTML = `
               ${m === 2 ? "m-event-list__month--active" : ""}">
                 <button class="c-expandable-block__link sticky-top sticky-month" data-target="#panel-1" tabindex="0" id="header-1" aria-expanded="true" aria-controls="panel-1" data-toggle="collapse">
                   <h2 class="m-event-list__month-header">
-                    <div class="c-expandable-block__header-container">
-                      ${m} 2021<span class="c-expandable-block-caret--black"></span>
-                    </div>
+                    ${m} 2021<span class="c-expandable-block-caret--black"></span>
                   </h2>
                 </button>
                 <div class="collapse in js-focus-on-expand" tabindex="0" role="region" id="panel-${m}" aria-labelledby="header-${m}">

--- a/apps/site/assets/js/test/view-previous-events__test.js
+++ b/apps/site/assets/js/test/view-previous-events__test.js
@@ -45,9 +45,7 @@ const eventListHtml = `
     <section id="1-2021" class="m-event-list__month">
       <button class="c-expandable-block__link sticky-top sticky-month" data-target="#panel-1" tabindex="0" id="header-1" aria-expanded="true" aria-controls="panel-1" data-toggle="collapse">
         <h2 class="m-event-list__month-header">
-          <div class="c-expandable-block__header-container">
-            January 2021<span class="c-expandable-block-caret--black"></span>
-          </div>
+          January 2021<span class="c-expandable-block-caret--black"></span>
         </h2>
       </button>
       <div class="collapse in js-focus-on-expand" tabindex="0" role="region" id="panel-1" aria-labelledby="header-1">
@@ -73,9 +71,7 @@ const eventListHtml = `
     <section id="2-2021" class="m-event-list__month m-event-list__month--active">
       <button class="c-expandable-block__link sticky-top sticky-month" data-target="#panel-1" tabindex="0" id="header-1" aria-expanded="true" aria-controls="panel-1" data-toggle="collapse">
         <h2 class="m-event-list__month-header">
-          <div class="c-expandable-block__header-container">
-            February 2021<span class="c-expandable-block-caret--black"></span>
-          </div>
+          February 2021<span class="c-expandable-block-caret--black"></span>
         </h2>
       </button>
       <div class="collapse in js-focus-on-expand" tabindex="0" role="region" id="panel-2" aria-labelledby="header-2">

--- a/apps/site/lib/site_web/templates/event/_event_list.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_list.html.eex
@@ -1,5 +1,5 @@
 <div class="m-event-listing">
-  <nav class="m-event-list__nav--mobile-controls sticky-top">
+  <nav class="m-event-list__nav--mobile-controls">
     <%= render "_month_select.html",
         conn: @conn,
         month: @month,

--- a/apps/site/lib/site_web/templates/event/_expandable_month.html.eex
+++ b/apps/site/lib/site_web/templates/event/_expandable_month.html.eex
@@ -10,10 +10,8 @@
     aria-controls="<%= panel_id %>"
     data-toggle="collapse">
     <h2 class="m-event-list__month-header">
-      <div class="c-expandable-block__header-container">
-        <%= render_event_month(@month_number, @year) %>
-        <span class="c-expandable-block-caret--black"></span>
-      </div>
+      <%= render_event_month(@month_number, @year) %>
+      <span class="c-expandable-block-caret--black"></span>
     </h2>
   </button>
   <div

--- a/apps/site/lib/site_web/templates/event/_month.html.eex
+++ b/apps/site/lib/site_web/templates/event/_month.html.eex
@@ -3,20 +3,34 @@
   <%= if @conn.assigns.date.year == @year and @conn.assigns.date.month == @month_number do %>
 
     <!-- Previous months button. A JS script sets up a listener for button click -->
-    <li class="list-group-item">
-      <a tabindex="0" role="button" class="m-previous-events-button" data-group="<%= render_event_month_slug(@month_number, @year) %>">
-        View Previous <%= render_event_month(@month_number, @year) %> Events
-        <i class="fa fa-angle-down down" aria-hidden="true"></i>
-      </a>
-    </li>
-    <%= for event_teaser <- @event_teasers do %>
-      <%= render "_event_teaser.html",
-          event_teaser: event_teaser,
-          check_event_ended: true,
-          conn: @conn,
-          month_number: @month_number,
-          year: @year %>
-    <% end %>
+    <div class="m-view-previous-events hidden">
+      <li class="list-group-item">
+        <a tabindex="0" role="button" class="m-previous-events-button" data-group="<%= render_event_month_slug(@month_number, @year) %>">
+          View Previous <%= render_event_month(@month_number, @year) %> Events
+          <i class="fa fa-angle-down down" aria-hidden="true"></i>
+        </a>
+      </li>
+      <%= for event_teaser <- @event_teasers do %>
+        <%= render "_event_teaser.html",
+            event_teaser: event_teaser,
+            check_event_ended: true,
+            conn: @conn,
+            month_number: @month_number,
+            year: @year %>
+      <% end %>
+    </div>
+
+    <!-- Show all events for the month if JS is disabled (instead of the div.m-view-previous-events) -->
+    <noscript>
+      <%= for event_teaser <- @event_teasers do %>
+        <%= render "_event_teaser.html",
+            event_teaser: event_teaser,
+            check_event_ended: false,
+            conn: @conn,
+            month_number: @month_number,
+            year: @year %>
+      <% end %>
+    </noscript>
 
   <% else %>
     <%= for event_teaser <- @event_teasers do %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [With js disabled "View previous ..." links don't do anything (Firefox on Mac)](https://app.asana.com/0/555089885850811/1200154247705852)

Enclosed the existing logic in a div that will be shown if JS is enabled. Otherwise, this div will be hidden and the `<noscript>` block will be displayed.