### PR TITLE
Meeting info in sidebar

### DIFF
--- a/apps/site/assets/css/_event-details.scss
+++ b/apps/site/assets/css/_event-details.scss
@@ -13,4 +13,7 @@
     font-weight: bold;
   }
 
+  .c-paragraph {
+    padding-bottom: $base-spacing * 2;
+  }
 }

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -196,6 +196,10 @@
   margin-bottom: 0 !important;
 }
 
+.mb-05 {
+  margin-bottom: $base-spacing / 2 !important;
+}
+
 .mb-1 {
   margin-bottom: $base-spacing !important;
 }

--- a/apps/site/lib/site_web/templates/event/_meeting_info.html.eex
+++ b/apps/site/lib/site_web/templates/event/_meeting_info.html.eex
@@ -1,0 +1,21 @@
+<div class="c-paragraph <%= if @style do @style end %>">
+  <h2>Meeting Info</h2>
+  <div class="u-small-caps u-bold mb-05 mt-1">Date and Time</div>
+  <% %{date: date, time: time} = get_formatted_date_time_map(@event.start_time, @event.end_time, "{WDfull}, {Mfull} {D}, {YYYY}") %>
+  <div><%= date %></div>
+  <div><%= time %></div>
+  <%= link to: event_icalendar_path(@conn, :show, @event),
+    data: [turbolinks: false] do %>
+    <%= fa "calendar" %> Add to Calendar
+  <% end %>
+  <div class="u-small-caps u-bold mb-05 mt-1">Location</div>
+  <%= if @event.location do %>
+    <div><%= @event.location %></div>
+    <div><%= @event.street_address %></div>
+    <div><%= city_and_state(@event) %></div>
+  <% else %>
+    <div><%= @event.imported_address %></div>
+  <% end %>
+  <div class="u-small-caps u-bold mb-05 mt-1">Intended Audience</div>
+  <div><%= @event.who %></div>
+</div>

--- a/apps/site/lib/site_web/templates/event/show.html.eex
+++ b/apps/site/lib/site_web/templates/event/show.html.eex
@@ -17,11 +17,6 @@
 
       <div class="c-cms__content">
         <div class="c-cms__body">
-          <div class="page-section">
-            <h2>Meeting Info</h2>
-            <p><%= render "_address.html", event: @event %></p>
-            <p><span class="event-info-label">Attendees:</span> <%= @event.who %></p>
-          </div>
 
           <div class="page-section">
             <div class="event-hr-row">
@@ -51,43 +46,27 @@
 
         <%= if has_sidebar do %>
           <div class="c-cms__sidebar">
-            <%= if @event.agenda_file do %>
-              <div class="page-section">
-                <h3>Agenda</h3>
-                <div>
-                  <%= link to: @event.agenda_file.url, target: "_blank", data: [turbolinks: false] do %>
-                    <span class="content-file-icon"><%= fa_icon_for_file_type(@event.agenda_file.type) %></span>
-                    <%= file_description(@event.agenda_file) %>
-                  <% end %>
-                </div>
-                <hr />
-              </div>
-            <% end %>
-            <%= if @event.minutes_file do %>
-              <div class="page-section">
-                <h3>Minutes</h3>
-                <div>
-                  <%= link to: @event.minutes_file.url, target: "_blank", data: [turbolinks: false] do %>
-                    <span class="content-file-icon"><%= fa_icon_for_file_type(@event.minutes_file.type) %></span>
-                    <%= file_description(@event.minutes_file) %>
-                  <% end %>
-                </div>
-                <hr />
-              </div>
-            <% end %>
-            <%= unless Enum.empty?(@event.files) do %>
-              <div class="page-section">
-                <h3>Related Files</h3>
-                <%= for file <- @event.files do %>
-                  <div>
-                    <%= link to: file.url, target: "_blank", data: [turbolinks: false] do %>
-                      <span class="content-file-icon"><%= fa_icon_for_file_type(file.type) %></span>
-                      <%= file_description(file) %>
-                    <% end %>
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
+            <div class="c-paragraph">
+              <h2>Meeting Info</h2>
+              <div class="u-small-caps u-bold mb-05 mt-1">Date and Time</div>
+              <% %{date: date, time: time} = get_formatted_date_time_map(@event.start_time, @event.end_time, "{WDfull}, {Mfull} {D}, {YYYY}") %>
+              <div><%= date %></div>
+              <div><%= time %></div>
+              <%= link to: event_icalendar_path(@conn, :show, @event),
+                data: [turbolinks: false] do %>
+                <%= fa "calendar" %> Add to Calendar
+              <% end %>
+              <div class="u-small-caps u-bold mb-05 mt-1">Location</div>
+              <%= if @event.location do %>
+                <div><%= @event.location %></div>
+                <div><%= @event.street_address %></div>
+                <div><%= city_and_state(@event) %></div>
+              <% else %>
+                <div><%= @event.imported_address %></div>
+              <% end %>
+              <div class="u-small-caps u-bold mb-05 mt-1">Intended Audience</div>
+              <div><%= @event.who %></div>
+            </div>
           </div>
         <% end %>
       </div>

--- a/apps/site/lib/site_web/templates/event/show.html.eex
+++ b/apps/site/lib/site_web/templates/event/show.html.eex
@@ -19,6 +19,10 @@
         <div class="c-cms__body">
 
           <div class="page-section">
+            <%= render "_meeting_info.html", conn: @conn, event: @event, style: "c-paragraph--right-rail u-full-bleed mt-0" %>
+          </div>
+
+          <div class="page-section">
             <div class="event-hr-row">
               <h2>Event Description</h2>
               <%= Site.ContentRewriter.rewrite(@event.body, @conn) %>
@@ -75,28 +79,9 @@
         </div>
 
         <div class="c-cms__sidebar">
-          <div class="c-paragraph">
-            <h2>Meeting Info</h2>
-            <div class="u-small-caps u-bold mb-05 mt-1">Date and Time</div>
-            <% %{date: date, time: time} = get_formatted_date_time_map(@event.start_time, @event.end_time, "{WDfull}, {Mfull} {D}, {YYYY}") %>
-            <div><%= date %></div>
-            <div><%= time %></div>
-            <%= link to: event_icalendar_path(@conn, :show, @event),
-              data: [turbolinks: false] do %>
-              <%= fa "calendar" %> Add to Calendar
-            <% end %>
-            <div class="u-small-caps u-bold mb-05 mt-1">Location</div>
-            <%= if @event.location do %>
-              <div><%= @event.location %></div>
-              <div><%= @event.street_address %></div>
-              <div><%= city_and_state(@event) %></div>
-            <% else %>
-              <div><%= @event.imported_address %></div>
-            <% end %>
-            <div class="u-small-caps u-bold mb-05 mt-1">Intended Audience</div>
-            <div><%= @event.who %></div>
-          </div>
+          <%= render "_meeting_info.html", conn: @conn, event: @event, style: nil %>
         </div>
+
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add Meeting info section to right-hand rail](https://app.asana.com/0/555089885850811/1199945602717945)

Meeting info details moved to sidebar.  The location doesn't match the design perfectly, because the "Location" field on events includes the floor number.  If that was a separate field, then I could tweak the design a little more precisely.

---

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Are interactive elements accessible to screen readers?