### PR TITLE
ical generator makes an ICS file that passes validation

### DIFF
--- a/apps/site/lib/site/icalendar_generator.ex
+++ b/apps/site/lib/site/icalendar_generator.ex
@@ -1,4 +1,9 @@
 defmodule Site.IcalendarGenerator do
+  @moduledoc """
+  Takes event information and generates an ICS file.
+  File validation was checked with https://icalendar.org/validator.html.
+  """
+
   import SiteWeb.CmsRouterHelpers, only: [event_path: 3]
 
   alias CMS.Page.Event

--- a/apps/site/test/site/lib/icalendar_generator_test.exs
+++ b/apps/site/test/site/lib/icalendar_generator_test.exs
@@ -51,9 +51,9 @@ defmodule IcalendarGeneratorTest do
         |> IcalendarGenerator.to_ical(event)
         |> IO.iodata_to_binary()
 
-      assert result =~ "UID:event#{event.id}@mbta.com\n"
+      assert result =~ "UID:event#{event.id}@mbta.com\r\n"
       assert result =~ "SEQUENCE:"
-      refute result =~ "SEQUENCE:\n"
+      refute result =~ "SEQUENCE:\r\n"
     end
 
     test "includes the event start and end time with timezone information", %{conn: conn} do
@@ -71,15 +71,16 @@ defmodule IcalendarGeneratorTest do
       assert result =~ "DTEND:20170228T160000Z"
     end
 
-    test "when the event does not have an end time", %{conn: conn} do
-      event = event_factory(0, end_time: nil)
+    test "when the event does not have an end time, it just adds an hour", %{conn: conn} do
+      start_datetime = Timex.to_datetime(~N[2017-02-28T09:00:00], "America/New_York")
+      event = event_factory(0, start_time: start_datetime, end_time: nil)
 
       result =
         conn
         |> IcalendarGenerator.to_ical(event)
         |> IO.iodata_to_binary()
 
-      assert result =~ "DTEND:\n"
+      assert result =~ "DTEND:20170228T150000Z"
     end
 
     test "the imported_address field decode the ampersand html entity", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Events hub | ICS file validation errors](https://app.asana.com/0/555089885850811/1200114012363890)

Most adjustments were slight and formatting-related.  One additional change:  ICS files can't be validated without an end-time, so if there's no end-time, I just added an hour to the start-time.  Of course, this might not always be accurate, like in the case of FMCB meetings.  But I think Google calendar defaults to an hour for new meetings anyway, so does that make sense in our case?
