### PR TITLE
Remove 553/554/556/558 from inner express routes

### DIFF
--- a/apps/fares/lib/fares.ex
+++ b/apps/fares/lib/fares.ex
@@ -13,7 +13,7 @@ defmodule Fares do
   @silver_line_rapid_transit ~w(741 742 743 746)
   @silver_line_rapid_transit_set MapSet.new(@silver_line_rapid_transit)
 
-  @inner_express_routes ~w(170 325 326 351 426 428 434 450 459 501 502 503 504 553 554 556 558)
+  @inner_express_routes ~w(170 325 326 351 426 428 434 450 459 501 502 503 504)
   @inner_express_route_set MapSet.new(@inner_express_routes)
 
   @outer_express_routes ~w(352 354 505)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trip Planner + Line Pages | update route 553/554/556/558 fares to the local fare $1.70](https://app.asana.com/0/555089885850811/1200267766698596)

Those 4 routes have now a fare of $1.70

![image](https://user-images.githubusercontent.com/61979382/117978555-fe6ea200-b2ff-11eb-870a-830e4d336071.png)






