### PR TITLE
Account for JS disabled in overlays

### DIFF
--- a/apps/site/assets/css/_events.scss
+++ b/apps/site/assets/css/_events.scss
@@ -271,7 +271,7 @@ $mobile-control-height: 73px;
         background-color: $gray-lightest;
       }
     }
-    
+
     i {
       margin-left: 1px;
     }
@@ -323,13 +323,14 @@ $mobile-control-height: 73px;
     align-items: center;
     color: $gray-dark;
     background-color: $white;
-    text-decoration: none;
     border: 0;
     padding: 0;
-    &:hover, &:focus {
-      color: $brand-primary;
-      cursor: pointer;
+
+    // hide when JS is disabled
+    .no-js &[data-a11y-dialog-show] {
+        display: none;
     }
+
     .fa-circle {
       font-size: xx-small;
       padding-right: 8px;
@@ -347,6 +348,11 @@ $mobile-control-height: 73px;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+
+      &:hover, &:focus {
+        color: $brand-primary;
+        text-decoration: none;
+      }
     }
   }
 }

--- a/apps/site/lib/site_web/templates/event/_calendar.html.eex
+++ b/apps/site/lib/site_web/templates/event/_calendar.html.eex
@@ -25,7 +25,7 @@
             <%= if todays_events != nil do %>
               <%= for event <- todays_events do %>
                 <% event_ended = event_ended(%{start: event.date, stop: event.date_end}) %>
-                <button class="m-event-calendar__event" data-a11y-dialog-show="<%= event.id  %>">
+                <button class="m-event-calendar__event" data-a11y-dialog-show="<%= event.id %>">
                   <i class="fa fa-circle <%= if event_ended, do: 'ended' %>" aria-hidden="true"></i>
                   <%= if !event_ended do%>
                     <div class='m-event-calendar__event-time'><%= format_time(event.date) %></div>
@@ -38,6 +38,17 @@
                   conn: @conn,
                   event: event,
                   class: if index >= 4, do: "open-left" %>
+
+                  <noscript>
+                    <%= link to: cms_static_page_path(@conn, event.path), class: "m-event-calendar__event m-event-calendar__event-title", title: event.title do %>
+                      <i class="fa fa-circle <%= if event_ended, do: 'ended' %>" aria-hidden="true"></i>
+                      <%= if !event_ended do%>
+                        <div class='m-event-calendar__event-time'><%= format_time(event.date) %></div>
+                      <% end %>
+                      <%= event.title %>
+                    <% end %>
+                  </noscript>
+
               <% end %>
             <% end %>
           <% end %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Overlays don't appear when JS disabled](https://app.asana.com/0/555089885850811/1200196372897040)

When JS is disabled, instead of overlays, we'll have a system tooltip and a link to the corresponding event page:

![image](https://user-images.githubusercontent.com/61979382/118007111-d7bd6500-b319-11eb-9686-fe3e49c3526d.png)



