### PR TITLE
Sentry Bugfix:  Function Clause Error in CMS.Page.Basic.from_api

### DIFF
--- a/apps/cms/lib/page/basic.ex
+++ b/apps/cms/lib/page/basic.ex
@@ -45,7 +45,7 @@ defmodule CMS.Page.Basic do
   end
 
   @spec parse_menu_links(map) :: MenuLinks.t() | nil
-  defp parse_menu_links(%{"field_sidebar_menu" => [menu_links_data]}) do
+  defp parse_menu_links(%{"field_sidebar_menu" => [menu_links_data]}) when not is_nil(menu_links_data) do
     MenuLinks.from_api(menu_links_data)
   end
 

--- a/apps/cms/lib/page/basic.ex
+++ b/apps/cms/lib/page/basic.ex
@@ -45,7 +45,8 @@ defmodule CMS.Page.Basic do
   end
 
   @spec parse_menu_links(map) :: MenuLinks.t() | nil
-  defp parse_menu_links(%{"field_sidebar_menu" => [menu_links_data]}) when not is_nil(menu_links_data) do
+  defp parse_menu_links(%{"field_sidebar_menu" => [menu_links_data]})
+       when not is_nil(menu_links_data) do
     MenuLinks.from_api(menu_links_data)
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Elixir.FunctionClauseError: no function clause matching in CMS.Partial.MenuLinks.from_api/1](https://app.asana.com/0/555089885850811/1199555004763320)

If a CMS page has the attribute field_sidebar_menu, the value should either be populated or an empty array.  But there was a continual issue with the page http://mbta.com/sustainability/community-programs/, in which the field_sidebar_menu value was getting parsed as [nil] (an array with just the value nil.)

In the solution, I was able to adjust the function match for this situation.  Still, I don't know how to determine why that value was getting parsed as [nil] instead of nil or [], since the above link redirects to http://mbta.com/sustainability/, a different page.
