### PR TITLE
Update command to use AWS CLI v2

### DIFF
--- a/semaphore/build_push.sh
+++ b/semaphore/build_push.sh
@@ -20,8 +20,8 @@ docker tag $APP:latest $DOCKER_REPO:$awsenv
 docker tag $APP:latest $DOCKER_REPO:git-$githash
 
 # retrieve the`docker login` command from AWS ECR and execute it
-logincmd=$(aws ecr get-login --no-include-email --region us-east-1)
-eval $logincmd
+# AWS CLI v2
+aws ecr get-login-password | docker login --username AWS --password-stdin ${DOCKER_REPO}
 
 # push images to ECS (Elastic Container Service) image repo
 docker push $DOCKER_REPO:$awsenv


### PR DESCRIPTION
This is causing authentication errors in Semaphore:
https://semaphoreci.com/mbta/dotcom/servers/docker-test/deploys/4
I had included this fix in PR #693 but it got overwritten somehow 😞 