### PR TITLE
feat(release): Actually specify commit

### DIFF
--- a/bin/lib/git.py
+++ b/bin/lib/git.py
@@ -19,8 +19,8 @@ def sha_for_tag(tag):
 def log_between(previous, current):
     return __call(["git", "log", "--abbrev-commit", "--no-decorate", "--pretty=oneline", "%s..%s" % (previous, current)])
 
-def release(tag, notes):
-    return __call(["gh", "release", "create", "%s" % tag, "--title", "%s" % tag, "--notes", "%s" % notes])
+def release(tag, sha, notes):
+    return __call(["gh", "release", "create", "%s" % tag, "--target", "%s" % sha, "--title", "%s" % tag, "--notes", "%s" % notes])
 
 def __call(cmd):
     return subprocess.check_output(cmd).decode('UTF-8').rstrip()

--- a/bin/release
+++ b/bin/release
@@ -27,7 +27,7 @@ def main():
 
     release_notes = git.log_between(git.sha_for_tag(previous_tag), deploy_sha)
 
-    git.release(deploy_tag, release_notes)
+    git.release(deploy_tag, deploy_sha, release_notes)
 
     print("")
     print("Generating a new release:")


### PR DESCRIPTION
This is more of a bug fix... the `bin/release` script defaults to using commits up to HEAD but also has a commit SHA as one of the interactive user inputs. The problem was the script didn't actually _use_ the inputted SHA to create the release on Github. Now it does!