### PR TITLE
Sentry:  URL with a faulty direction_id caused breakage

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line.ex
@@ -81,12 +81,11 @@ defmodule SiteWeb.ScheduleController.Line do
       schedule_direction = Map.get(conn.query_params, "schedule_direction", %{})
 
       direction_id_value =
-        case schedule_direction["direction_id"] do
-          nil ->
-            direction_id
-
-          _ ->
-            String.to_integer(schedule_direction["direction_id"])
+        if schedule_direction["direction_id"] do
+          parsed = Integer.parse(schedule_direction["direction_id"])
+          if parsed === :error, do: direction_id, else: elem(parsed, 0)
+        else
+          direction_id
         end
 
       deps = Keyword.get(args, :deps, %Dependencies{})

--- a/apps/site/lib/site_web/controllers/schedule/line.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line.ex
@@ -83,7 +83,7 @@ defmodule SiteWeb.ScheduleController.Line do
       direction_id_value =
         if schedule_direction["direction_id"] do
           parsed = Integer.parse(schedule_direction["direction_id"])
-          if parsed === :error, do: direction_id, else: elem(parsed, 0)
+          if parsed !== :error and elem(parsed, 0) <= 1, do: elem(parsed, 0), else: direction_id
         else
           direction_id
         end

--- a/apps/site/lib/site_web/controllers/schedule/line.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line.ex
@@ -83,7 +83,10 @@ defmodule SiteWeb.ScheduleController.Line do
       direction_id_value =
         if schedule_direction["direction_id"] do
           parsed = Integer.parse(schedule_direction["direction_id"])
-          if parsed !== :error and elem(parsed, 0) <= 1, do: elem(parsed, 0), else: direction_id
+
+          if parsed !== :error and (elem(parsed, 0) === 1 or elem(parsed, 0) === 0),
+            do: elem(parsed, 0),
+            else: direction_id
         else
           direction_id
         end

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -259,6 +259,15 @@ defmodule SiteWeb.ScheduleController.LineTest do
       assert conn.assigns.direction_id == 1
     end
 
+    test "ignores a negative direction_id", %{conn: conn} do
+      conn =
+        conn
+        |> Map.put(:query_params, %{"schedule_direction" => %{"direction_id" => "-1"}})
+        |> Line.call([])
+
+      assert conn.assigns.direction_id == 0
+    end
+
     test "ignores url direction_id if it's not a number", %{conn: conn} do
       conn =
         conn


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Line Diagram | Elixir.ArgumentError: argument error](https://app.asana.com/0/555089885850811/1200334263746937)

I think all possible ill-formed direction_ids from the URL should be filtered out now!  Added tests to catch all those cases.