### PR TITLE
Handle an empty list of RouteStop structs

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -55,6 +55,7 @@ const LineDiagramAndStopListPage = ({
   today,
   scheduleNote
 }: LineDiagramProps): ReactElement<HTMLElement> | null => {
+  if (!lineDiagram[0]) return null;
   /**
    * Setup state handling etc
    */

--- a/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
@@ -140,6 +140,11 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
 
   # Splits green branch into a tuple of shared stops and stops that are unique to that branch.
   @spec split_green_branch(RouteStops.t(), direction_id) :: {[RouteStop.t()], [RouteStop.t()]}
+
+  defp split_green_branch(%RouteStops{stops: []}, _direction_id) do
+    {[], []}
+  end
+
   defp split_green_branch(%RouteStops{branch: "Green-E", stops: stops}, _direction_id),
     do: {[], stops}
 

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -368,6 +368,19 @@ defmodule SiteWeb.ScheduleController.LineTest do
       assert b |> List.last() |> stop_id() == "place-lake"
     end
 
+    test "direction 0 handles an empty list of stops" do
+      stops =
+        [
+          %Stops.RouteStops{branch: "Green-E", stops: []},
+          %Stops.RouteStops{branch: "Green-D", stops: []},
+          %Stops.RouteStops{branch: "Green-C", stops: []},
+          %Stops.RouteStops{branch: "Green-B", stops: []}
+        ]
+        |> build_stop_list(0)
+
+      assert stops == []
+    end
+
     test "direction 1 returns a list of all stops in order from west to east" do
       route_stops = get_route_stops("Green", 0, @deps.stops_by_route_fn)
 

--- a/apps/stops/lib/route_stops.ex
+++ b/apps/stops/lib/route_stops.ex
@@ -46,7 +46,7 @@ defmodule Stops.RouteStops do
   end
 
   @spec from_list([RouteStop.t()]) :: t()
-  def from_list(stops) do
+  def from_list(stops) when stops != [] do
     %__MODULE__{
       branch: branch(stops),
       stops: stops
@@ -59,6 +59,8 @@ defmodule Stops.RouteStops do
     |> Enum.find(first, &green_branch?/1)
     |> Map.get(:branch)
   end
+
+  defp branch(_), do: nil
 
   @spec green_branch?(RouteStop.t()) :: boolean()
   defp green_branch?(%RouteStop{branch: branch}) when is_binary(branch),

--- a/apps/stops/lib/route_stops.ex
+++ b/apps/stops/lib/route_stops.ex
@@ -46,7 +46,7 @@ defmodule Stops.RouteStops do
   end
 
   @spec from_list([RouteStop.t()]) :: t()
-  def from_list(stops) when stops != [] do
+  def from_list(stops) do
     %__MODULE__{
       branch: branch(stops),
       stops: stops

--- a/apps/stops/test/route_stops_test.exs
+++ b/apps/stops/test/route_stops_test.exs
@@ -54,10 +54,6 @@ defmodule Stops.RouteStopsTest do
                }
              ] = RouteStops.from_route_stop_groups(route_patern_groups)
     end
-
-    test "handles an empty list of RouteStop structs" do
-      assert RouteStops.from_route_stop_groups([]) == []
-    end
   end
 
   describe "by_direction/2 returns a list of stops in one direction in the correct order" do

--- a/apps/stops/test/route_stops_test.exs
+++ b/apps/stops/test/route_stops_test.exs
@@ -54,6 +54,10 @@ defmodule Stops.RouteStopsTest do
                }
              ] = RouteStops.from_route_stop_groups(route_patern_groups)
     end
+
+    test "handles an empty list of RouteStop structs" do
+      assert RouteStops.from_route_stop_groups([]) == []
+    end
   end
 
   describe "by_direction/2 returns a list of stops in one direction in the correct order" do
@@ -311,6 +315,10 @@ defmodule Stops.RouteStopsTest do
       }
 
       assert RouteStops.from_list(route_stops) == expected
+    end
+
+    test "it handles route stops being []" do
+      assert RouteStops.from_list([]) == %Stops.RouteStops{branch: nil, stops: []}
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Elixir.FunctionClauseError: no function clause matching in Stops.RouteStops.branch/1](https://app.asana.com/0/385363666817452/1200033257113092)

I was unable to reproduce the error but I did force an 'empty list scenario' and added this fix for it.
