### PR TITLE
Ensure alerts are for the proper route using its id

### DIFF
--- a/apps/site/lib/site_web/views/partial_view.ex
+++ b/apps/site/lib/site_web/views/partial_view.ex
@@ -213,7 +213,7 @@ defmodule SiteWeb.PartialView do
       |> time_filter_params(filter)
 
     path =
-      apply(SiteWeb.Router.Helpers, path_method, [SiteWeb.Endpoint, :show, item, path_params])
+      apply(SiteWeb.Router.Helpers, path_method, [SiteWeb.Endpoint, :show, item.id, path_params])
 
     filter
     |> time_filter_text()

--- a/apps/site/test/site_web/views/partial_view_test.exs
+++ b/apps/site/test/site_web/views/partial_view_test.exs
@@ -239,4 +239,31 @@ defmodule SiteWeb.PartialViewTest do
       assert actual == expected
     end
   end
+
+  describe "alert_time_filters" do
+    test "returns the proper markup" do
+      path_opts = [
+        method: :alerts_path,
+        item: %Routes.Route{
+          color: "00843D",
+          custom_route?: false,
+          description: :rapid_transit,
+          direction_destinations: %{0 => "Heath Street", 1 => "North Station"},
+          direction_names: %{0 => "Westbound", 1 => "Eastbound"},
+          id: "Green-E",
+          long_name: "Green Line E",
+          name: "Green Line E",
+          sort_order: 10_035,
+          type: 0
+        }
+      ]
+
+      [_, links] = alert_time_filters(nil, path_opts)
+
+      expected =
+        "<div class=\"m-alerts__time-filters\"><a class=\"m-alerts__time-filter m-alerts__time-filter--selected\" href=\"/schedules/Green-E/alerts\">All Alerts</a><a class=\"m-alerts__time-filter\" href=\"/schedules/Green-E/alerts?alerts_timeframe=current\">Current Alerts</a><a class=\"m-alerts__time-filter\" href=\"/schedules/Green-E/alerts?alerts_timeframe=upcoming\">Planned Service Alerts</a></div>"
+
+      assert safe_to_string(links) == expected
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes:
**Asana Ticket:** [⏱️ Schedules | Clicking an alert filter should not change which line page you are on](https://app.asana.com/0/385363666817452/1199671198523838)

E.g. for the case of the Green Line branches, it shouldn't show the generic Green Line alerts but the ones for the particular branch (see link at bottom of screenshot):

![image](https://user-images.githubusercontent.com/61979382/120818726-e0701800-c520-11eb-8b3e-38a0dfa71b59.png)
