### PR TITLE
Sentry 🐛| Added func to catch (& discard) feedback submissions from bots

### DIFF
--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -106,6 +106,15 @@ defmodule SiteWeb.CustomerSupportController do
     end
   end
 
+  def submit(conn, %{"support" => form_data}) do
+    comments = Map.get(form_data, "comments", nil)
+    Logger.warn("recaptcha validation missing")
+
+    conn
+    |> put_status(400)
+    |> render_form(%{errors: ["recaptcha"], comments: comments})
+  end
+
   @spec render_expandable_blocks(Plug.Conn.t(), list) :: [Phoenix.HTML.safe()]
   def render_expandable_blocks(assigns, content_blocks \\ @content_blocks) do
     content_blocks

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -332,6 +332,17 @@ defmodule SiteWeb.CustomerSupportControllerTest do
       assert "recaptcha" in conn.assigns.errors
     end
 
+    test "if the submission doesn't carry a recaptcha value, consider it an invalid recaptcha", %{conn: conn} do      
+      conn =
+        post(
+          conn,
+          customer_support_path(conn, :submit),
+          Map.delete(valid_request_response_data(), "g-recaptcha-response")
+        )
+
+      assert "recaptcha" in conn.assigns.errors
+    end
+
     test "adds date and time fields if not present in the form", %{conn: conn} do
       conn =
         post(


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Customer Support | Elixir.Phoenix.ActionClauseError: no function clause matching in SiteWeb.CustomerSupportController.submit/2](https://app.asana.com/0/555089885850811/1200334203657800)

This Sentry issue was triggered often from the customer feedback form, but all the submissions looked like they were from bots.  Sure enough, looks like bots were trying to bypass the recaptcha by posting directly to the page without the correct "g-recaptcha-response" value in the request.  We didn't have a function that matched this malformed request, so it threw a Sentry error.  I added one that does match, and it just captures the error.

To recreate the issue and test the fix, I used Postman to submit requests like the ones getting submitted by the bot.  Here's an example.  Submit this raw body to `localhost:4001/customer-support`

```
{"_csrf_token": "AxMPCwkKUns5YmkuVHweDHFlIwAoAAAAvB6Hs31JS0Zd6/Dy8PWFNw==", "_utf8": "✓", "submit": "", "support": {"comments": "What is your attitude towards rich people? Invest $ 598 and get passive income of $ 3700 per day   >>>>>>>>>>>>>>  http://www.youtube.com.ministeriomfef.org/news?679   <<<<<<<<<<<<<", "email": "tynmira@hotmail.fr", "name": "Gregorydib", "phone": "89926935463", "photo": "", "privacy": "on", "promotions": "on", "request_response": "false"}}
```