### PR TITLE
Roll back removal of references to the shape endpoint

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -7,6 +7,8 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
   alias RoutePatterns.RoutePattern
   alias Routes.Repo, as: RoutesRepo
   alias Routes.{Route, Shape}
+  alias Schedules.Repo, as: SchedulesRepo
+  alias Schedules.Trip
   alias Stops.Repo, as: StopsRepo
   alias Stops.{RouteStop, RouteStops, Stop}
 
@@ -299,9 +301,31 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
 
   @spec stops_for_route_pattern(RoutePattern.t()) :: {RoutePattern.t(), [Stop.t()]}
   defp stops_for_route_pattern(route_pattern) do
-    stops = Enum.map(route_pattern.stop_ids, &StopsRepo.get!/1)
+    stops =
+      route_pattern
+      |> trip_for_route_pattern()
+      |> shape_for_trip()
+      |> stops_for_shape()
+
     {route_pattern, stops}
   end
+
+  @spec trip_for_route_pattern(RoutePattern.t()) :: Trip.t() | nil
+  defp trip_for_route_pattern(%RoutePattern{representative_trip_id: representative_trip_id}),
+    do: SchedulesRepo.trip(representative_trip_id)
+
+  @spec shape_for_trip(Trip.t() | nil) :: Shape.t() | nil
+  defp shape_for_trip(nil), do: nil
+
+  defp shape_for_trip(%Trip{shape_id: shape_id}) do
+    shape_id
+    |> RoutesRepo.get_shape()
+    |> List.first()
+  end
+
+  @spec stops_for_shape(Shape.t() | nil) :: [Stop.t()]
+  defp stops_for_shape(nil), do: []
+  defp stops_for_shape(%Shape{stop_ids: stop_ids}), do: Enum.map(stop_ids, &StopsRepo.get!/1)
 
   @spec get_line_route_patterns(Route.id_t(), direction_id(), RoutePattern.id_t() | nil) :: [
           RoutePattern.t()


### PR DESCRIPTION
This work will need to be done eventually, but the way it was done in this PR was incorrect and undertested.

https://github.com/mbta/dotcom/commit/8fefd340dcfdf2f79026546556c037600c127242