### PR TITLE
Uncaught error was preventing some JS from loading

### DIFF
--- a/apps/site/assets/js/event-page-setup.js
+++ b/apps/site/assets/js/event-page-setup.js
@@ -199,7 +199,9 @@ export default function() {
       const viewPreviousEventsLink = document.querySelector(
         ".m-view-previous-events"
       );
-      viewPreviousEventsLink.classList.remove("hidden");
+      if (viewPreviousEventsLink) { 
+        viewPreviousEventsLink.classList.remove("hidden");
+      }
       if (document.querySelector(".m-events-hub")) {
         const isIE = !!document.documentMode;
         if (isIE) {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Events | When you're in a previous year, you can't click to a different year in the drop down](https://app.asana.com/0/555089885850811/1200448490117396)

Turns out, the JS setup function wasn't running all the way because we didn't check to make sure the the "previous events" button existed before trying to alter its classlist.  Simple conditional fixed the whole shebang.
