### PR TITLE
Undo breaking changes

### DIFF
--- a/apps/site/lib/site_web/views/partial_view.ex
+++ b/apps/site/lib/site_web/views/partial_view.ex
@@ -213,7 +213,7 @@ defmodule SiteWeb.PartialView do
       |> time_filter_params(filter)
 
     path =
-      apply(SiteWeb.Router.Helpers, path_method, [SiteWeb.Endpoint, :show, item.id, path_params])
+      apply(SiteWeb.Router.Helpers, path_method, [SiteWeb.Endpoint, :show, item, path_params])
 
     filter
     |> time_filter_text()

--- a/apps/site/test/site_web/views/partial_view_test.exs
+++ b/apps/site/test/site_web/views/partial_view_test.exs
@@ -239,31 +239,4 @@ defmodule SiteWeb.PartialViewTest do
       assert actual == expected
     end
   end
-
-  describe "alert_time_filters" do
-    test "returns the proper markup" do
-      path_opts = [
-        method: :alerts_path,
-        item: %Routes.Route{
-          color: "00843D",
-          custom_route?: false,
-          description: :rapid_transit,
-          direction_destinations: %{0 => "Heath Street", 1 => "North Station"},
-          direction_names: %{0 => "Westbound", 1 => "Eastbound"},
-          id: "Green-E",
-          long_name: "Green Line E",
-          name: "Green Line E",
-          sort_order: 10_035,
-          type: 0
-        }
-      ]
-
-      [_, links] = alert_time_filters(nil, path_opts)
-
-      expected =
-        "<div class=\"m-alerts__time-filters\"><a class=\"m-alerts__time-filter m-alerts__time-filter--selected\" href=\"/schedules/Green-E/alerts\">All Alerts</a><a class=\"m-alerts__time-filter\" href=\"/schedules/Green-E/alerts?alerts_timeframe=current\">Current Alerts</a><a class=\"m-alerts__time-filter\" href=\"/schedules/Green-E/alerts?alerts_timeframe=upcoming\">Planned Service Alerts</a></div>"
-
-      assert safe_to_string(links) == expected
-    end
-  end
 end


### PR DESCRIPTION
Undo PR #965 because it contains breaking changes for the alerts page.