### PR TITLE
Hide fares from CR shuttle trips in Schedule Finder

### DIFF
--- a/apps/site/assets/js/event-page-setup.js
+++ b/apps/site/assets/js/event-page-setup.js
@@ -199,7 +199,7 @@ export default function() {
       const viewPreviousEventsLink = document.querySelector(
         ".m-view-previous-events"
       );
-      if (viewPreviousEventsLink) { 
+      if (viewPreviousEventsLink) {
         viewPreviousEventsLink.classList.remove("hidden");
       }
       if (document.querySelector(".m-events-hub")) {

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/TripDetails.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/TripDetails.tsx
@@ -11,9 +11,11 @@ interface Props {
 }
 
 const TripSummary = ({
-  tripInfo
+  tripInfo,
+  showFare
 }: {
   tripInfo: TripInfo;
+  showFare: boolean;
 }): ReactElement<HTMLElement> => (
   <tr className="trip-details-table__summary">
     <td colSpan={3} className="schedule-table__cell">
@@ -23,16 +25,18 @@ const TripSummary = ({
         </span>
         {tripInfo.times.length} stops, {tripInfo.duration} minutes total
       </div>
-      <div>
-        <span className="trip-details-table__title u-small-caps u-bold">
-          Fare
-        </span>
+      { showFare && (
+        <div>
+          <span className="trip-details-table__title u-small-caps u-bold">
+            Fare
+          </span>
 
-        {tripInfo.fare && tripInfo.fare.price}
-        <a className="trip-details-table__link" href={tripInfo.fare.fare_link}>
-          View fares
-        </a>
-      </div>
+          {tripInfo.fare && tripInfo.fare.price}
+          <a className="trip-details-table__link" href={tripInfo.fare.fare_link}>
+            View fares
+          </a>
+        </div>
+      )}
     </td>
   </tr>
 );
@@ -65,7 +69,7 @@ const TripDetailsTable = ({
             </th>
           </tr>
         )}
-        <TripSummary tripInfo={tripInfo} />
+        <TripSummary tripInfo={tripInfo} showFare={showFare}/>
         <tr>
           <th scope="col" className="schedule-table__cell">
             Stops

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/TripDetails.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/TripDetails.tsx
@@ -25,14 +25,17 @@ const TripSummary = ({
         </span>
         {tripInfo.times.length} stops, {tripInfo.duration} minutes total
       </div>
-      { showFare && (
+      {showFare && (
         <div>
           <span className="trip-details-table__title u-small-caps u-bold">
             Fare
           </span>
 
           {tripInfo.fare && tripInfo.fare.price}
-          <a className="trip-details-table__link" href={tripInfo.fare.fare_link}>
+          <a
+            className="trip-details-table__link"
+            href={tripInfo.fare.fare_link}
+          >
             View fares
           </a>
         </div>
@@ -69,7 +72,7 @@ const TripDetailsTable = ({
             </th>
           </tr>
         )}
-        <TripSummary tripInfo={tripInfo} showFare={showFare}/>
+        <TripSummary tripInfo={tripInfo} showFare={showFare} />
         <tr>
           <th scope="col" className="schedule-table__cell">
             Stops


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱️ Schedule Finder | Don't show normal fare next to shuttle](https://app.asana.com/0/385363666817452/1199903976071291)

showFares was already set up for another component in the same file, so only needed to copy it so it shows up in the ScheduleFinder