### PR TITLE
hotfix: Handle service date correctly

### DIFF
--- a/apps/site/assets/js/event-page-setup.js
+++ b/apps/site/assets/js/event-page-setup.js
@@ -199,7 +199,7 @@ export default function() {
       const viewPreviousEventsLink = document.querySelector(
         ".m-view-previous-events"
       );
-      if (viewPreviousEventsLink) { 
+      if (viewPreviousEventsLink) {
         viewPreviousEventsLink.classList.remove("hidden");
       }
       if (document.querySelector(".m-events-hub")) {

--- a/apps/site/assets/ts/helpers/date.ts
+++ b/apps/site/assets/ts/helpers/date.ts
@@ -1,3 +1,4 @@
+// this returns a Date() in the browser time zone, unlike new Date(unformatted)
 export const stringToDateObject = (unformatted: string): Date => {
   const [year, month, day] = unformatted
     .split(/-/)

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -17,7 +17,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
     </div>
   </SearchBox>
   <Provider store={{...}}>
-    <LineDiagramWithStops stops={{...}} handleStopClick={[Function]} liveData={{...}}>
+    <LineDiagramWithStops stops={{...}} handleStopClick={[Function (anonymous)]} liveData={{...}}>
       <div className=\\"m-schedule-diagram u-no-crowding-data\\">
         <Diagram lineDiagram={{...}} liveData={{...}}>
           <LiveVehicleIconSet stop={{...}} liveData={{...}} />
@@ -89,7 +89,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
           </svg>
         </Diagram>
         <ol>
-          <StopCard stop={{...}} onClick={[Function]} liveData={[undefined]}>
+          <StopCard stop={{...}} onClick={[Function (anonymous)]} liveData={[undefined]}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -124,7 +124,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               </section>
             </li>
           </StopCard>
-          <StopCard stop={{...}} onClick={[Function]} liveData={{...}}>
+          <StopCard stop={{...}} onClick={[Function (anonymous)]} liveData={{...}}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -200,7 +200,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               </section>
             </li>
           </StopCard>
-          <StopCard stop={{...}} onClick={[Function]} liveData={{...}}>
+          <StopCard stop={{...}} onClick={[Function (anonymous)]} liveData={{...}}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -269,7 +269,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               </section>
             </li>
           </StopCard>
-          <StopCard stop={{...}} onClick={[Function]} liveData={[undefined]}>
+          <StopCard stop={{...}} onClick={[Function (anonymous)]} liveData={[undefined]}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useReducer, useEffect } from "react";
 import { DirectionId, Route } from "../../../__v3api";
-import { formattedDate } from "../../../helpers/date";
+import { formattedDate, stringToDateObject } from "../../../helpers/date";
 import { reducer } from "../../../helpers/fetch";
 import { isInCurrentService } from "../../../helpers/service";
 import {
@@ -94,7 +94,7 @@ const ScheduleModalContent = ({
   );
 
   const serviceToday = services.some(service =>
-    isInCurrentService(service, new Date(today))
+    isInCurrentService(service, stringToDateObject(today))
   );
 
   const input: UserInput = {

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
@@ -47,7 +47,9 @@ const ServiceOptGroup = ({
               if (addedNote === "") {
                 return `${shortDate(stringToDateObject(addedDate))}`;
               }
-              return `${addedNote}, ${shortDate(stringToDateObject(addedDate))}`;
+              return `${addedNote}, ${shortDate(
+                stringToDateObject(addedDate)
+              )}`;
             })
             .join(", ");
         } else if (label === ServiceGroupNames.OTHER) {

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react";
 import { Service } from "../../../../__v3api";
-import { shortDate } from "../../../../helpers/date";
+import { shortDate, stringToDateObject } from "../../../../helpers/date";
 import {
   ServiceGroupNames,
   serviceDays,
@@ -28,8 +28,8 @@ const ServiceOptGroup = ({
           service.type === "weekday" &&
           service.typicality !== "holiday_service";
 
-        const startDate = new Date(service.start_date);
-        const endDate = new Date(service.end_date);
+        const startDate = stringToDateObject(service.start_date);
+        const endDate = stringToDateObject(service.end_date);
         let optionText = "";
 
         if (
@@ -45,9 +45,9 @@ const ServiceOptGroup = ({
             .map(entry => {
               const [addedDate, addedNote] = entry;
               if (addedNote === "") {
-                return `${shortDate(new Date(addedDate))}`;
+                return `${shortDate(stringToDateObject(addedDate))}`;
               }
-              return `${addedNote}, ${shortDate(new Date(addedDate))}`;
+              return `${addedNote}, ${shortDate(stringToDateObject(addedDate))}`;
             })
             .join(", ");
         } else if (label === ServiceGroupNames.OTHER) {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedule Finder | Says no service on date with service](https://app.asana.com/0/385363666817452/1200532032193761/f)

Even though the `today` parameter was correct (2021-06-28), inputting it into `new Date()` brought it back to yesterday (a Sunday with no service on this and many lines), thanks UTC. 🤦🏻‍♀️ So when we checked if there was service today, today meant yesterday instead of today.

This corrects for that so that `CR-Franklin` can now show upcoming departures instead of the "there is no schedule service today" message.

I also decided to apply the same correction in a couple other locations where I'd similarly used `new Date()`.