### PR TITLE
Fix for IE warning logic

### DIFF
--- a/apps/site/assets/js/app.js
+++ b/apps/site/assets/js/app.js
@@ -38,7 +38,6 @@ import photoGallery from "./photo-gallery";
 import { init as embeddedSearchInit } from "./algolia-embedded-search";
 import * as homepageSearch from "./algolia-homepage-search";
 import * as globalSearch from "./algolia-global-search";
-import AlgoliaResults from "./algolia-results";
 import fullstory from "./fullstory";
 import inputFocus from "./input-focus";
 import channels from "./channels";
@@ -48,7 +47,6 @@ import dismissFullscreenError from "../ts/app/dismiss-fullscreen-error";
 import tripPlannerWidget from "./trip-planner-widget";
 import eventPageSetup from "./event-page-setup";
 import previousEventsButton from "./view-previous-events";
-import IEWarning from "../ts/ie-warning/ie-warning";
 
 document.body.className = document.body.className.replace("no-js", "js");
 
@@ -369,4 +367,3 @@ dismissFullscreenError();
 tripPlannerWidget();
 eventPageSetup();
 previousEventsButton();
-IEWarning();

--- a/apps/site/assets/js/turbolinks-mods.js
+++ b/apps/site/assets/js/turbolinks-mods.js
@@ -1,5 +1,3 @@
-import IEWarning from "../ts/ie-warning/ie-warning";
-
 const turbolinks = ($, w = window, doc = document) => {
   var lastScrollPosition = null;
   var scrollBehavior = null;
@@ -68,7 +66,6 @@ const turbolinks = ($, w = window, doc = document) => {
   doc.addEventListener(
     "turbolinks:render",
     () => {
-      IEWarning();
       // if it's cached render, not a real one, set the scroll/focus positions,
       // but don't clear them until we have the true rendering.
       const cachedRender =

--- a/apps/site/assets/ts/ie-warning-entry.ts
+++ b/apps/site/assets/ts/ie-warning-entry.ts
@@ -1,0 +1,3 @@
+import IEWarning from "./ie-warning/IEWarning";
+
+IEWarning();

--- a/apps/site/assets/ts/ie-warning/IEWarning.tsx
+++ b/apps/site/assets/ts/ie-warning/IEWarning.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import IEWarning from "./components/IEWarningBanner";
+import { getCookie } from "../../js/cookies";
+
+const render = (): void => {
+  const showIEwarning = getCookie("show_ie_warning");
+
+  ReactDOM.render(
+    showIEwarning === "false" ? <></> : <IEWarning />,
+    document.getElementById("ie-warning")
+  );
+};
+
+export const browserIsIE = (): boolean => {
+  const ua = navigator.userAgent;
+  // MSIE is used to detect old browsers and Trident is used to newer ones
+  return ua.indexOf("MSIE ") > -1 || ua.indexOf("Trident/") > -1;
+};
+
+export default (): void => {
+  if (browserIsIE()) {
+    render();
+  }
+};

--- a/apps/site/assets/ts/ie-warning/__tests__/IEWarningTest.tsx
+++ b/apps/site/assets/ts/ie-warning/__tests__/IEWarningTest.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { mount } from "enzyme";
+import * as cookiesModule from "../../../js/cookies";
+import * as IEWarningModule from "../IEWarning";
+import * as IEWarningBannerModule from "../components/IEWarningBanner";
+
+const body = '<div id="ie-warning"></div>';
+
+it("it renders a warning", () => {
+  document.body.innerHTML = body;
+
+  const browserIsIEFn = jest
+    .spyOn(IEWarningModule, "browserIsIE")
+    .mockImplementation(() => true);
+
+  IEWarningModule.default();
+
+  expect(document.body.innerHTML).toEqual(expect.stringContaining("<aside"));
+
+  browserIsIEFn.mockRestore();
+});
+
+it("it renders nothing", () => {
+  document.body.innerHTML = body;
+
+  const browserIsIEFn = jest
+    .spyOn(IEWarningModule, "browserIsIE")
+    .mockImplementation(() => true);
+
+  const getCookieFn = jest
+    .spyOn(cookiesModule, "getCookie")
+    .mockImplementation(() => "false");
+
+  IEWarningModule.default();
+
+  expect(document.body.innerHTML).toEqual(body);
+
+  browserIsIEFn.mockRestore();
+  getCookieFn.mockRestore();
+});
+
+it("it shows expanded content", () => {
+  const wrapper = mount(<IEWarningBannerModule.default />);
+
+  // now click on the caret:
+  const caret = wrapper.find("#header-ie-warning");
+
+  caret.simulate("click");
+
+  expect(wrapper.find("#panel-ie-warning").exists()).toBeTruthy();
+
+  wrapper.unmount();
+});
+
+it("makes the banner go away", () => {
+  const wrapper = mount(<IEWarningBannerModule.default />);
+  const spy = jest.spyOn(IEWarningBannerModule, "setCookie");
+
+  // click to expand content:
+  const caret = wrapper.find("#header-ie-warning");
+
+  caret.simulate("click");
+
+  wrapper.find("button").simulate("click");
+
+  expect(spy).toHaveBeenCalledWith("show_ie_warning", "false", 20 * 365);
+
+  wrapper.unmount();
+});
+
+it("it renders nothing based on cookie", () => {
+  document.body.innerHTML = body;
+  document.cookie = "show_ie_warning=false";
+
+  IEWarningModule.default();
+
+  expect(document.body.innerHTML).toEqual(body);
+});
+
+it("it detects that browser is IE", () => {
+  Object.defineProperty(window.navigator, "userAgent", { value: "MSIE 11" });
+  const actual: boolean = IEWarningModule.browserIsIE();
+  expect(actual).toEqual(true);
+});
+
+it("it sets cookie", () => {
+  IEWarningBannerModule.setCookie("show_ie_warning", "true", 1);
+
+  expect(document.cookie).toEqual(
+    expect.stringContaining("show_ie_warning=true")
+  );
+});

--- a/apps/site/assets/ts/ie-warning/components/IEWarningBanner.tsx
+++ b/apps/site/assets/ts/ie-warning/components/IEWarningBanner.tsx
@@ -1,16 +1,18 @@
 import React, { ReactElement, useState } from "react";
-import ReactDOM from "react-dom";
-import { caret } from "../helpers/icon";
-import { getCookie } from "../../js/cookies";
+import { caret } from "../../helpers/icon";
 
-const setCookie = (key: string, value: string, expDays: number) => {
-  let date = new Date();
+export const setCookie = (
+  key: string,
+  value: string,
+  expDays: number
+): void => {
+  const date = new Date();
   date.setTime(date.getTime() + expDays * 24 * 60 * 60 * 1000);
   const expires = `expires=${date.toUTCString()}`;
   document.cookie = `${key}=${value}; ${expires}; path=/`;
 };
 
-const IEWarning = (): ReactElement => {
+const IEWarningContent = (): ReactElement => {
   const [expanded, setExpanded] = useState(false);
 
   const toggleBlockingState = (): void => {
@@ -102,36 +104,17 @@ const IEWarning = (): ReactElement => {
   );
 };
 
-const render = (): void => {
-  const showIEwarning = getCookie("show_ie_warning");
+const IEWarning = (): ReactElement<HTMLElement> => (
+  // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+  <aside
+    aria-modal
+    aria-label="Internet Explorer warning"
+    role="dialog"
+    className="c-aside-content"
+    tabIndex={-1}
+  >
+    <IEWarningContent />
+  </aside>
+);
 
-  ReactDOM.render(
-    showIEwarning === "false" ? (
-      <></>
-    ) : (
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-      <aside
-        aria-modal
-        aria-label="Internet Explorer warning"
-        role="dialog"
-        className="c-aside-content"
-        tabIndex={-1}
-      >
-        <IEWarning />
-      </aside>
-    ),
-    document.getElementById("ie-warning")
-  );
-};
-
-const browserIsIE = (): boolean => {
-  const ua = navigator.userAgent;
-  // MSIE is used to detect old browsers and Trident is used to newer ones
-  return ua.indexOf("MSIE ") > -1 || ua.indexOf("Trident/") > -1;
-};
-
-export default (): void => {
-  if (browserIsIE()) {
-    render();
-  }
-};
+export default IEWarning;

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -17,7 +17,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
     </div>
   </SearchBox>
   <Provider store={{...}}>
-    <LineDiagramWithStops stops={{...}} handleStopClick={[Function (anonymous)]} liveData={{...}}>
+    <LineDiagramWithStops stops={{...}} handleStopClick={[Function]} liveData={{...}}>
       <div className=\\"m-schedule-diagram u-no-crowding-data\\">
         <Diagram lineDiagram={{...}} liveData={{...}}>
           <LiveVehicleIconSet stop={{...}} liveData={{...}} />
@@ -89,7 +89,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
           </svg>
         </Diagram>
         <ol>
-          <StopCard stop={{...}} onClick={[Function (anonymous)]} liveData={[undefined]}>
+          <StopCard stop={{...}} onClick={[Function]} liveData={[undefined]}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -124,7 +124,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               </section>
             </li>
           </StopCard>
-          <StopCard stop={{...}} onClick={[Function (anonymous)]} liveData={{...}}>
+          <StopCard stop={{...}} onClick={[Function]} liveData={{...}}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -200,7 +200,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               </section>
             </li>
           </StopCard>
-          <StopCard stop={{...}} onClick={[Function (anonymous)]} liveData={{...}}>
+          <StopCard stop={{...}} onClick={[Function]} liveData={{...}}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -269,7 +269,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               </section>
             </li>
           </StopCard>
-          <StopCard stop={{...}} onClick={[Function (anonymous)]} liveData={[undefined]}>
+          <StopCard stop={{...}} onClick={[Function]} liveData={[undefined]}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
@@ -23,20 +23,6 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
           56
            minutes total
         </div>
-        <div>
-          <span
-            className="trip-details-table__title u-small-caps u-bold"
-          >
-            Fare
-          </span>
-          $12.25
-          <a
-            className="trip-details-table__link"
-            href="/fares/commuter_rail?destination=place-NEC-1851&origin=place-bbsta"
-          >
-            View fares
-          </a>
-        </div>
       </td>
     </tr>
     <tr>
@@ -543,20 +529,6 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
           14
            minutes total
         </div>
-        <div>
-          <span
-            className="trip-details-table__title u-small-caps u-bold"
-          >
-            Fare
-          </span>
-          $2.40
-          <a
-            className="trip-details-table__link"
-            href="/fares/bus-fares"
-          >
-            View fares
-          </a>
-        </div>
       </td>
     </tr>
     <tr>
@@ -799,20 +771,6 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
            stops, 
           32
            minutes total
-        </div>
-        <div>
-          <span
-            className="trip-details-table__title u-small-caps u-bold"
-          >
-            Fare
-          </span>
-          $1.70
-          <a
-            className="trip-details-table__link"
-            href="/fares/bus-fares"
-          >
-            View fares
-          </a>
         </div>
       </td>
     </tr>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/TripDetailsTest.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/TripDetailsTest.tsx
@@ -69,6 +69,20 @@ describe("TripDetails", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it("it renders the loading state", () => {
+    const loadingState = {
+      data: null,
+      isLoading: true,
+      error: false
+    } as State;
+
+    createReactRoot();
+    const tree = renderer.create(
+      <TripDetails state={loadingState} showFare={false} />
+    );
+    expect(tree).toMatchSnapshot();
+  });
+
   it("uses a predicted departure time in preference to a scheduled one", () => {
     createReactRoot();
     const tree = renderer.create(

--- a/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/__snapshots__/TripDetailsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/__snapshots__/TripDetailsTest.tsx.snap
@@ -225,6 +225,18 @@ exports[`TripDetails it renders an error if fetch failed 1`] = `
 </p>
 `;
 
+exports[`TripDetails it renders the loading state 1`] = `
+<div
+  className="c-spinner__container"
+>
+  <div
+    className="c-spinner"
+  >
+    Loading...
+  </div>
+</div>
+`;
+
 exports[`TripDetails it renders trip details for a CR trip 1`] = `
 <table
   className="trip-details-table"

--- a/apps/site/assets/webpack.config.base.js
+++ b/apps/site/assets/webpack.config.base.js
@@ -32,7 +32,8 @@ module.exports = {
     leaflet: ["./ts/leaflet-entry.ts"],
     schedule: ["./ts/schedule-entry.ts"],
     tripplanresults: ["./ts/trip-plan-results-entry.ts"],
-    projects: ["./ts/projects-entry.ts"]
+    projects: ["./ts/projects-entry.ts"],
+    iewarning: ["./ts/ie-warning-entry.ts"]
   },
 
   node: {

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -70,6 +70,14 @@
         <%= content_tag :main, render(@view_module, @view_template, assigns), id: "main", tabindex: -1 %>
       </div> <%# /container %>
       <%= render __MODULE__, "_footer.html", conn: @conn %>
+
+      <%# Show a warning when browser is Internet Explorer %>
+      <%= if Application.get_env(:site, :dev_server?) do %>
+        <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/iewarning.js" %>"></script>
+      <% else %>
+        <script defer src="<%= static_url(@conn, "/js/react.js") %>"></script>
+        <script defer src="<%= static_url(@conn, "/js/iewarning.js") %>"></script>
+      <% end %>
       <div id="ie-warning" class="c-ie-warning"></div>
     </div>
     <%= if google_tag_manager_id() do %>


### PR DESCRIPTION
A different way of loading the files needed to display the IE warning without making use of Turbolinks. Should go together with/fixes faulty behavior from #963.