### PR TITLE
ci: Add action to create a Github release

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -47,3 +47,41 @@ jobs:
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
           job-status: ${{ job.status }}
+
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    needs: deploy
+    if: ${{ success() }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get tag values...
+        run: |
+          echo PREV_TAG=$(git describe --tags --abbrev=0) >> $GITHUB_ENV
+          echo TODAY=$(date +'%Y.%m.%d') >> $GITHUB_ENV
+      - name: List commits since last tag
+        run: |
+          echo BODY=$(git log --abbrev-commit --no-decorate --pretty=oneline $PREV_TAG..$GITHUB_REF) >> $GITHUB_ENV
+          echo "Commits to be released: ${BODY}"
+      - name: Compute new tag name by incrementing last tag
+        if: startsWith(env.PREV_TAG, env.TODAY)
+        run: |
+          TAG_NUM="${PREV_TAG##*.}"
+          NEW_NUM="$((10#${TAG_NUM}+1))"
+          NEW_NUM="$(printf %02d $NEW_NUM)"
+          echo TAG="${TODAY}.${NEW_NUM}" >> $GITHUB_ENV
+          echo "Incrementing tag from ${PREV_TAG} to ${TAG}"
+      - name: Compute new tag name
+        if: > 
+          !startsWith(env.PREV_TAG, env.TODAY)
+        run: |
+          echo TAG="${TODAY}.01" >> $GITHUB_ENV
+          echo "Creating tag ${TAG}"
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.TAG }}
+          release_name: ${{ env.TAG }}
+          body: ${{ env.BODY }}


### PR DESCRIPTION
On successful deploy to production, create a new release tagged by date and sequence (e.g. 2021.07.08.01, or 2021.07.08.02 for the second release that day, etc).

This process was done before by manually running the `bin/release` script. That script and the deploy script were our only Python code, so having those covered in Github Actions means we can remove Python as a dependency from this project too.