### PR TITLE
Item can be a mode or a Route in Alerts pages

### DIFF
--- a/apps/site/lib/site_web/views/partial_view.ex
+++ b/apps/site/lib/site_web/views/partial_view.ex
@@ -205,7 +205,8 @@ defmodule SiteWeb.PartialView do
   defp time_filter(filter, current_timeframe, path_opts) do
     path_method = Keyword.fetch!(path_opts, :method)
 
-    item = Keyword.fetch!(path_opts, :item)
+    # item can be an atom (representing a mode) or a Route
+    item = Keyword.fetch!(path_opts, :item) |> get_item_value()
 
     path_params =
       path_opts
@@ -222,6 +223,10 @@ defmodule SiteWeb.PartialView do
       to: path
     )
   end
+
+  @spec get_item_value(Route.t() | atom) :: Route.id_t() | atom
+  defp get_item_value(route_or_mode) when is_atom(route_or_mode), do: route_or_mode
+  defp get_item_value(route_or_mode), do: route_or_mode.id
 
   @spec time_filter_text(atom) :: String.t()
   defp time_filter_text(nil), do: "All Alerts"

--- a/apps/site/test/site_web/views/partial_view_test.exs
+++ b/apps/site/test/site_web/views/partial_view_test.exs
@@ -239,4 +239,45 @@ defmodule SiteWeb.PartialViewTest do
       assert actual == expected
     end
   end
+
+  describe "alert_time_filters" do
+    test "returns the proper markup when item is Route" do
+      path_opts = [
+        method: :alerts_path,
+        item: %Routes.Route{
+          color: "00843D",
+          custom_route?: false,
+          description: :rapid_transit,
+          direction_destinations: %{0 => "Heath Street", 1 => "North Station"},
+          direction_names: %{0 => "Westbound", 1 => "Eastbound"},
+          id: "Green-E",
+          long_name: "Green Line E",
+          name: "Green Line E",
+          sort_order: 10_035,
+          type: 0
+        }
+      ]
+
+      [_, links] = alert_time_filters(nil, path_opts)
+
+      expected =
+        "<div class=\"m-alerts__time-filters\"><a class=\"m-alerts__time-filter m-alerts__time-filter--selected\" href=\"/schedules/Green-E/alerts\">All Alerts</a><a class=\"m-alerts__time-filter\" href=\"/schedules/Green-E/alerts?alerts_timeframe=current\">Current Alerts</a><a class=\"m-alerts__time-filter\" href=\"/schedules/Green-E/alerts?alerts_timeframe=upcoming\">Planned Service Alerts</a></div>"
+
+      assert safe_to_string(links) == expected
+    end
+
+    test "returns the proper markup when item is atom" do
+      path_opts = [
+        method: :alerts_path,
+        item: :subway
+      ]
+
+      [_, links] = alert_time_filters(nil, path_opts)
+
+      expected =
+        "<div class=\"m-alerts__time-filters\"><a class=\"m-alerts__time-filter m-alerts__time-filter--selected\" href=\"/schedules/subway/alerts\">All Alerts</a><a class=\"m-alerts__time-filter\" href=\"/schedules/subway/alerts?alerts_timeframe=current\">Current Alerts</a><a class=\"m-alerts__time-filter\" href=\"/schedules/subway/alerts?alerts_timeframe=upcoming\">Planned Service Alerts</a></div>"
+
+      assert safe_to_string(links) == expected
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Alerts | Alerts should be for proper route_id when route_id is relevant](https://app.asana.com/0/555089885850811/1200500758083708)

Refining the work done in #965 because it was breaking the alert page for modes. With these changes, all alert pages should not give any errors.

