### PR TITLE
Some tests  improvements around schedule finder's default day

### DIFF
--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -21,20 +21,13 @@ export const serviceStartDateComparator = (
   stringToDateObject(service1.start_date).getTime() -
   stringToDateObject(service2.start_date).getTime();
 
-const isInRemovedDates = (
-  service: Service,
-  currentDate: Date = new Date()
-): boolean => service.removed_dates.includes(dateObjectToString(currentDate));
+const isInRemovedDates = (service: Service, currentDate: Date): boolean =>
+  service.removed_dates.includes(dateObjectToString(currentDate));
 
-const isInAddedDates = (
-  service: Service,
-  currentDate: Date = new Date()
-): boolean => service.added_dates.includes(dateObjectToString(currentDate));
+const isInAddedDates = (service: Service, currentDate: Date): boolean =>
+  service.added_dates.includes(dateObjectToString(currentDate));
 
-const isOnValidDay = (
-  service: Service,
-  currentDate: Date = new Date()
-): boolean => {
+const isOnValidDay = (service: Service, currentDate: Date): boolean => {
   let currentDay = currentDate.getDay();
   // different numbering from valid_days for sunday
   currentDay = currentDay === 0 ? 7 : currentDay;
@@ -43,7 +36,7 @@ const isOnValidDay = (
 
 export const isInCurrentService = (
   service: Service,
-  currentDate: Date = new Date()
+  currentDate: Date
 ): boolean => {
   const serviceStartDate = stringToDateObject(service.start_date);
   const serviceEndDate = stringToDateObject(service.end_date);
@@ -52,7 +45,7 @@ export const isInCurrentService = (
 
 export const isInCurrentRating = (
   service: Service,
-  currentDate: Date = new Date()
+  currentDate: Date
 ): boolean => {
   if (!service.rating_start_date) {
     return false;
@@ -68,7 +61,7 @@ export const isInCurrentRating = (
 
 export const isCurrentValidService = (
   service: Service,
-  currentDate: Date = new Date()
+  currentDate: Date
 ): boolean => {
   // check against added dates
   if (isInAddedDates(service, currentDate)) {
@@ -96,7 +89,7 @@ export const startToEnd = (
 
 export const isInFutureService = (
   service: Service,
-  currentDate: Date = new Date()
+  currentDate: Date
 ): boolean => {
   const serviceStartDate = stringToDateObject(service.start_date);
   const serviceEndDate = stringToDateObject(service.end_date);
@@ -105,7 +98,7 @@ export const isInFutureService = (
 
 export const isInFutureRating = (
   service: Service,
-  currentDate: Date = new Date()
+  currentDate: Date
 ): boolean => {
   if (!service.rating_end_date) {
     if (service.rating_start_date) {
@@ -142,7 +135,7 @@ export const dedupeServices = (services: Service[]): Service[] =>
 
 export const groupServicesByDateRating = (
   services: Service[],
-  currentDate: Date = new Date()
+  currentDate: Date
 ): Dictionary<Service[]> =>
   _.groupBy(services, (service: Service) => {
     if (service.typicality === "holiday_service") {

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleFinderModal.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleFinderModal.tsx
@@ -30,7 +30,7 @@ interface Props {
   handleOriginSelectClick: () => void;
 }
 
-export default ({
+const ScheduleFinderModal = ({
   closeModal,
   directionChanged,
   initialMode,
@@ -116,3 +116,5 @@ export default ({
     </Modal>
   );
 };
+
+export default ScheduleFinderModal;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderModalTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderModalTest.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ScheduleFinderModal matches snapshot in origin mode 1`] = `
-"<Component closeModal={[Function: closeModal]} initialMode=\\"origin\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin={{...}} originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]}>
+"<ScheduleFinderModal closeModal={[Function: closeModal]} initialMode=\\"origin\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin={{...}} originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]}>
   <WrappedModal focusElementId=\\"origin-filter\\" ariaLabel={{...}} className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]}>
     <Modal focusElementId=\\"origin-filter\\" ariaLabel={{...}} className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]} priorPadding=\\"0px\\" paddingRight={0}>
       <ModalContent bodyPadding=\\"0px\\" scrollBarPadding={0} closeText=\\"Close\\" role=\\"dialog\\" ariaLabel={{...}} focusElementId=\\"origin-filter\\" className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]}>
@@ -72,11 +72,11 @@ exports[`ScheduleFinderModal matches snapshot in origin mode 1`] = `
       </ModalContent>
     </Modal>
   </WrappedModal>
-</Component>"
+</ScheduleFinderModal>"
 `;
 
 exports[`ScheduleFinderModal matches snapshot in origin mode with origin selected 1`] = `
-"<Component closeModal={[Function: closeModal]} initialMode=\\"origin\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin={{...}} originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]}>
+"<ScheduleFinderModal closeModal={[Function: closeModal]} initialMode=\\"origin\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin={{...}} originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]}>
   <WrappedModal focusElementId=\\"origin-filter\\" ariaLabel={{...}} className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]}>
     <Modal focusElementId=\\"origin-filter\\" ariaLabel={{...}} className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]} priorPadding=\\"0px\\" paddingRight={0}>
       <ModalContent bodyPadding=\\"0px\\" scrollBarPadding={0} closeText=\\"Close\\" role=\\"dialog\\" ariaLabel={{...}} focusElementId=\\"origin-filter\\" className=\\"schedule-finder__origin-modal\\" closeModal={[Function: closeModal]}>
@@ -147,11 +147,11 @@ exports[`ScheduleFinderModal matches snapshot in origin mode with origin selecte
       </ModalContent>
     </Modal>
   </WrappedModal>
-</Component>"
+</ScheduleFinderModal>"
 `;
 
 exports[`ScheduleFinderModal matches snapshot in schedule mode 1`] = `
-"<Component closeModal={[Function: closeModal]} initialMode=\\"schedule\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin=\\"place-welln\\" originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]}>
+"<ScheduleFinderModal closeModal={[Function: closeModal]} initialMode=\\"schedule\\" route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} services={{...}} stops={{...}} today=\\"2019-12-05\\" updateURL={[Function: updateURL]} initialDirection={0} directionChanged={[undefined]} initialOrigin=\\"place-welln\\" originChanged={[undefined]} handleOriginSelectClick={[Function: handleOriginSelectClick]}>
   <WrappedModal focusElementId=\\"modal-close\\" ariaLabel={{...}} className=\\"\\" closeModal={[Function: closeModal]}>
     <Modal focusElementId=\\"modal-close\\" ariaLabel={{...}} className=\\"\\" closeModal={[Function: closeModal]} priorPadding=\\"0px\\" paddingRight={0}>
       <ModalContent bodyPadding=\\"0px\\" scrollBarPadding={0} closeText=\\"Close\\" role=\\"dialog\\" ariaLabel={{...}} focusElementId=\\"modal-close\\" className=\\"\\" closeModal={[Function: closeModal]}>
@@ -277,5 +277,5 @@ exports[`ScheduleFinderModal matches snapshot in schedule mode 1`] = `
       </ModalContent>
     </Modal>
   </WrappedModal>
-</Component>"
+</ScheduleFinderModal>"
 `;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/ServiceOptGroupTest.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/ServiceOptGroupTest.tsx
@@ -1,7 +1,9 @@
+import { mount } from "enzyme";
 import React from "react";
 import renderer from "react-test-renderer";
 import { createReactRoot } from "../../../../../app/helpers/testUtils";
 import { services } from "../../../../../helpers/__tests__/service-test";
+import { Service } from "../../../../../__v3api";
 import ServiceOptGroup from "../ServiceOptGroup";
 
 describe("ServiceOptGroup", () => {
@@ -31,5 +33,75 @@ describe("ServiceOptGroup", () => {
       />
     );
     expect(tree.toJSON()).toBeNull();
+  });
+
+  const makeSimpleService = (
+    [start_date, end_date]: [string, string],
+    [rating_start_date, rating_end_date]: [string, string],
+    name: string,
+    id: string
+  ): Service => ({
+    valid_days: [1, 2, 3, 4, 5],
+    typicality: "typical_service",
+    type: "weekday",
+    start_date,
+    removed_dates_notes: {},
+    removed_dates: [],
+    name,
+    id,
+    end_date,
+    description: `${name} schedule`,
+    added_dates_notes: {},
+    added_dates: [],
+    rating_start_date,
+    rating_end_date,
+    rating_description: "Test Rating"
+  });
+
+  const servicesList: Service[] = [
+    makeSimpleService(
+      ["2019-04-01", "2019-05-01"],
+      ["2019-04-01", "2019-08-01"],
+      "Spring",
+      "s"
+    ),
+    makeSimpleService(
+      ["2019-06-01", "2019-07-01"],
+      ["2019-04-01", "2019-08-01"],
+      "First Summer",
+      "fs"
+    ),
+    makeSimpleService(
+      ["2019-08-06", "2019-09-01"],
+      ["2019-08-01", "2019-10-01"],
+      "Second Summer",
+      "ss"
+    )
+  ];
+
+  it("adds (now) to today's service based on todayServiceId prop", () => {
+    const wrapper = mount(
+      <ServiceOptGroup
+        label={"Test services"}
+        services={servicesList}
+        multipleWeekdays={false}
+        todayServiceId="fs"
+      />
+    );
+    expect(wrapper.text()).toContain(
+      "First Summer schedule, Test Rating (now)"
+    );
+  });
+
+  it("does not mark any service as (now) if no current services", () => {
+    const wrapper = mount(
+      <ServiceOptGroup
+        label={"Test services"}
+        services={servicesList}
+        multipleWeekdays={false}
+        todayServiceId=""
+      />
+    );
+    expect(wrapper.text()).not.toContain("(now)");
   });
 });


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱️ Schedule Finder | Weekend schedule defaulting on a weekday](https://app.asana.com/0/385363666817452/1199963269146218/f)

I'm somewhat sure this particular issue was fixed in #893 or #994 but in the meantime I've added at least a few basic test cases around the schedule finder displaying the no-trips-today message and the service selector indicating which schedule is 'now'.

There's more tech debt to tackle than I'd like, so no big changes here 😓 

---

Before getting review, please check the following:

* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
