### PR TITLE
Expandable blocks in line page for suspended routes

### DIFF
--- a/apps/site/assets/ts/schedule/components/ScheduleLoader.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleLoader.tsx
@@ -1,6 +1,8 @@
 import React, { ReactElement } from "react";
 import { connect } from "react-redux";
 import { useQueryParams, StringParam } from "use-query-params";
+import ContentTeasers from "./ContentTeasers";
+import UpcomingHolidays from "./UpcomingHolidays";
 import AdditionalLineInfo from "../components/AdditionalLineInfo";
 import ScheduleNote from "../components/ScheduleNote";
 import ScheduleDirection from "../components/ScheduleDirection";
@@ -126,6 +128,8 @@ export const ScheduleLoader = ({
     variant: busVariantId
   } = schedulePageData;
 
+  const routeIsSuspended = Object.keys(routePatternsByDirection).length === 0;
+
   const currentState = getCurrentState();
   if (!!currentState && Object.keys(currentState).length !== 0) {
     const {
@@ -138,6 +142,7 @@ export const ScheduleLoader = ({
     // check first if this is a unidirectional route:
     let readjustedDirectionId: DirectionId = currentDirection;
     if (
+      !routeIsSuspended &&
       !Object.keys(routePatternsByDirection).includes(
         currentDirection.toString()
       )
@@ -161,6 +166,15 @@ export const ScheduleLoader = ({
         hours,
         holidays
       } = schedulePageData;
+
+      if (routeIsSuspended) {
+        return (
+          <>
+            <ContentTeasers teasers={teasers} />
+            <UpcomingHolidays holidays={holidays} />
+          </>
+        );
+      }
 
       return (
         <AdditionalLineInfo

--- a/apps/site/assets/ts/schedule/schedule-loader.tsx
+++ b/apps/site/assets/ts/schedule/schedule-loader.tsx
@@ -58,7 +58,7 @@ const updateURL = (origin: SelectedOrigin, direction?: DirectionId): void => {
   }
 };
 
-export const renderSchedulePage = (
+export const renderAdditionalLineInformation = (
   schedulePageData: SchedulePageData
 ): void => {
   const { schedule_note: scheduleNote } = schedulePageData;
@@ -144,10 +144,11 @@ const render = (): void => {
     direction_id: directionId,
     route_patterns: routePatterns
   } = schedulePageData;
+
   createScheduleStore(directionId);
+  renderAdditionalLineInformation(schedulePageData);
 
   if (!isEmpty(routePatterns)) {
-    renderSchedulePage(schedulePageData);
     renderDirectionOrMap(schedulePageData);
   }
 };


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | 🐞 Right side accordions don't open on suspended routes](https://app.asana.com/0/555089885850811/1200532824750507)

`renderAdditionalLineInformation` should also be called for suspended routes, so that React _kicks in_ and enables the expand/collapse functionality of the blocks on the right rail.

Also, for these same suspended routes, we only want to show teasers and upcoming holidays, no other information like fares or connections, etc.