### PR TITLE
Account for JS disabled for accordions and expandable blocks

### DIFF
--- a/apps/site/assets/css/_accordion-ui.scss
+++ b/apps/site/assets/css/_accordion-ui.scss
@@ -51,6 +51,10 @@
   }
 }
 
+.c-accordion-ui__content-nojs {
+  border-bottom: 1px solid $brand-primary-dark;
+}
+
 .c-accordion-ui__trigger,
 .c-accordion-ui__content {
   // Character/line-height includes some space, so here we

--- a/apps/site/assets/css/_trip-plan-results.scss
+++ b/apps/site/assets/css/_trip-plan-results.scss
@@ -1,3 +1,7 @@
+.no-js .trip-plan-body .c-accordion-ui .panel {
+  display: none;
+}
+
 .m-trip-plan-results__itinerary {
   margin-bottom: $base-spacing * 1.5;
 

--- a/apps/site/assets/css/_trip-plan.scss
+++ b/apps/site/assets/css/_trip-plan.scss
@@ -185,6 +185,10 @@
   }
 }
 
+.no-js .trip-plan-map {
+  display: none;
+}
+
 .trip-plan-initial-map {
   height: 100%;
   margin-bottom: $base-spacing;

--- a/apps/site/assets/ts/components/Accordion.tsx
+++ b/apps/site/assets/ts/components/Accordion.tsx
@@ -11,6 +11,27 @@ interface Props {
   children: ReactElement<HTMLElement>;
 }
 
+export const AccordionNoJS = ({
+  id,
+  children
+}: {
+  id: string;
+  children: ReactElement<HTMLElement>;
+}): ReactElement<HTMLElement> => (
+  <div className="c-accordion-ui">
+    <div role="heading" aria-level={3}>
+      <div
+        className="c-accordion-ui__target"
+        id={`${id}-section`}
+        role="region"
+        aria-labelledby={`${id}-title`}
+      >
+        <div className="c-accordion-ui__content">{children}</div>
+      </div>
+    </div>
+  </div>
+);
+
 const Accordion = (props: Props): ReactElement<HTMLElement> => {
   const { id, title, children } = props;
   const [isExpanded, toggleExpanded] = useState(false);

--- a/apps/site/assets/ts/trip-plan-results/__tests__/TripPlannerResultsTest.tsx
+++ b/apps/site/assets/ts/trip-plan-results/__tests__/TripPlannerResultsTest.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import renderer, { act } from "react-test-renderer";
 import { createReactRoot } from "../../app/helpers/testUtils";
 import TripPlannerResults from "../components/TripPlannerResults";
+import Accordion, { AccordionNoJS } from "../../components/Accordion";
 import { TileServerUrl } from "../../leaflet/components/__mapdata";
 
 const html = "<div>Lots of content about the itinerary</div>";
@@ -90,9 +91,12 @@ it("it renders ItineraryBody when clicking to expand", () => {
 
   act(button.props.onClick);
 
+  expect(tree.root.findAllByType(Accordion).length).toBe(2);
+  expect(tree.root.findAllByType(AccordionNoJS).length).toBe(2);
+
   expect(
     tree.root.findAllByProps({
       html: "<div>Lots of content about the itinerary</div>"
     }).length
-  ).toBe(1);
+  ).toBe(2);
 });

--- a/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
+++ b/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
@@ -77,6 +77,42 @@ exports[`it renders 1`] = `
       />
     </div>
   </div>
+  <noscript>
+    <div
+      className="c-accordion-ui"
+    >
+      <div
+        aria-level={3}
+        role="heading"
+      >
+        <div
+          aria-labelledby="itinerary-1-title"
+          className="c-accordion-ui__target"
+          id="itinerary-1-section"
+          role="region"
+        >
+          <div
+            className="c-accordion-ui__content"
+          >
+            <div
+              className="m-trip-plan-results__itinerary-body"
+            >
+              <div
+                className="trip-plan-map map"
+              />
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<div>Lots of content about the itinerary</div>",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </noscript>
   <div
     className="c-accordion-ui"
   >
@@ -118,5 +154,34 @@ exports[`it renders 1`] = `
       />
     </div>
   </div>
+  <noscript>
+    <div
+      className="c-accordion-ui"
+    >
+      <div
+        aria-level={3}
+        role="heading"
+      >
+        <div
+          aria-labelledby="itinerary-1-fare-calculator-title"
+          className="c-accordion-ui__target"
+          id="itinerary-1-fare-calculator-section"
+          role="region"
+        >
+          <div
+            className="c-accordion-ui__content"
+          >
+            <div
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "<div>HTML content for fare calculator</div>",
+                }
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </noscript>
 </div>
 `;

--- a/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
+++ b/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect } from "react";
-import Accordion from "../../components/Accordion";
+import Accordion, { AccordionNoJS } from "../../components/Accordion";
 import { Itinerary } from "./TripPlannerResults";
 import Map from "../../leaflet/components/Map";
 import {
@@ -99,6 +99,12 @@ const ItineraryAccordion = ({
     >
       <ItineraryBody {...itinerary} />
     </Accordion>
+    <noscript>
+      <AccordionNoJS id={`itinerary-${itinerary.id}`}>
+        <ItineraryBody {...itinerary} />
+      </AccordionNoJS>
+    </noscript>
+
     <Accordion
       id={`itinerary-${itinerary.id}-fare-calculator`}
       title={{
@@ -110,6 +116,13 @@ const ItineraryAccordion = ({
         dangerouslySetInnerHTML={{ __html: itinerary.fare_calculator_html }} // eslint-disable-line react/no-danger
       />
     </Accordion>
+    <noscript>
+      <AccordionNoJS id={`itinerary-${itinerary.id}-fare-calculator`}>
+        <div
+          dangerouslySetInnerHTML={{ __html: itinerary.fare_calculator_html }} // eslint-disable-line react/no-danger
+        />
+      </AccordionNoJS>
+    </noscript>
   </div>
 );
 

--- a/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
@@ -30,6 +30,16 @@
           <% end %>
         </div>
       </div>
+      <noscript>
+        <div class="c-accordion-ui__content c-accordion-ui__content-nojs">
+          <%= if assigns[:parent_view] do %>
+            <% template = if (assigns[:content_template]), do: @content_template, else: section.content_template %>
+            <%= render(@parent_view, template, Map.merge(assigns, section)) %>
+          <% else %>
+            <%= section.content %>
+          <% end %>
+        </div>
+      </noscript>
     </div>
   <% end %>
 </div>

--- a/apps/site/lib/site_web/templates/partial/_expandable_block.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_expandable_block.html.eex
@@ -28,3 +28,16 @@
 >
 <%= render @view_module, @view_template, assigns %>
 </div>
+<noscript>
+  <%= if not @initially_expanded do %>
+    <div
+      class="c-expandable-block__panel collapse in"
+      tabIndex="0"
+      role="region"
+      id="<%= panel_id %>"
+      aria-labelledby="<%= header_id %>"
+    >
+    <%= render @view_module, @view_template, assigns %>
+    </div>
+  <% end %>
+</noscript>

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -700,7 +700,8 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         |> render(Map.put(@index_assigns, :conn, conn))
         |> safe_to_string()
 
-      assert [{"div", _, form}] = Floki.find(html, ".plan-date-time")
+      # two blocks because of the <noscript> block
+      assert [{"div", _, form}, {"div", _, no_script_form}] = Floki.find(html, ".plan-date-time")
       assert [{"select", _, _year_opts}] = Floki.find(form, ~s([name="plan[date_time][year]"]))
       assert [{"select", _, _month_opts}] = Floki.find(form, ~s([name="plan[date_time][month]"]))
       assert [{"select", _, _month_opts}] = Floki.find(form, ~s([name="plan[date_time][day]"]))
@@ -716,7 +717,9 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         |> render(Map.put(@index_assigns, :conn, conn))
         |> safe_to_string()
 
-      assert [{"input", _, _}] = Floki.find(html, ~s(input#plan-date-input[type="text"]))
+      # two inputs because of the <noscript> block
+      assert [{"input", _, _}, {"input", _, _}] =
+               Floki.find(html, ~s(input#plan-date-input[type="text"]))
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Accordions | Accordions should work without JS](https://app.asana.com/0/555089885850811/1200191571993850)

Added some blocks to show content that wasn't being shown earlier and might be relevant for riders. Some examples are:
- Itineraries in Trip Planner results.
- Blocks in the right rail in the Customer Support form and in the line page.
- Icon Key section in the Commuter Rail timetable.
- /fares/reduced page
- ...