### PR TITLE
Github Actions: build cache, run all tests on master branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,15 +85,13 @@ jobs:
     needs: setup
     outputs:
       build-key: ${{ steps.cache-keys.outputs.build }}
-      digest-key: ${{ steps.cache-keys.outputs.digest }}
       assets-key: ${{ steps.cache-keys.outputs.assets }}
     steps:
       - uses: actions/checkout@v2
       - name: Set cache keys
         id: cache-keys
         run: |
-          echo "::set-output name=digest::${{ runner.os }}-digest-cache-${{ hashFiles('apps/site/priv/static/**') }}"
-          echo "::set-output name=build::${{ runner.os }}-build-cache-${{ hashFiles('**/lib/**.ex', 'apps/site/priv/static/**', '**/mix.lock') }}"
+          echo "::set-output name=build::${{ runner.os }}-build-cache-${{ hashFiles('**/lib/**.ex', '**/mix.lock') }}"
           echo "::set-output name=assets::${{ runner.os }}-assets-cache-${{ hashFiles('apps/site/assets/**', 'apps/site/react_renderer/**.js') }}"
       - uses: actions/cache@v2
         with:
@@ -115,7 +113,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            apps/site/priv/static/js
+            apps/site/priv/static
             apps/site/react_renderer/dist/app.js
           key: ${{ steps.cache-keys.outputs.assets }}
         id: assets-cache
@@ -125,14 +123,8 @@ jobs:
       - run: npm run build
         if: ${{ steps.assets-cache.outputs.cache-hit != 'true' }}
         working-directory: apps/site/react_renderer
-
-      - name: Digest assets # always, as the cache key hash needs these files
-        run: mix phx.digest
-      - name: Cache asset digest
-        uses: actions/cache@v2
-        with:
-          path: apps/site/priv/static
-          key: ${{ steps.cache-keys.outputs.digest }}
+      - run: mix phx.digest
+        if: ${{ steps.assets-cache.outputs.cache-hit != 'true' }}
       
       - name: Cache _build
         uses: actions/cache@v2
@@ -281,15 +273,10 @@ jobs:
             apps/site/assets/node_modules
             apps/site/react_renderer/node_modules
           key: ${{ needs.setup.outputs.nodejs-key }}
-
-      - uses: actions/cache@v2
-        with:
-          path: apps/site/priv/static
-          key: ${{ needs.build_app.outputs.digest-key }}
       - uses: actions/cache@v2
         with:
           path: |
-            apps/site/priv/static/js
+            apps/site/priv/static
             apps/site/react_renderer/dist/app.js
           key: ${{ needs.build_app.outputs.assets-key }}
       - uses: actions/cache@v2
@@ -358,8 +345,10 @@ jobs:
         key: ${{ needs.setup.outputs.nodejs-key }}
     - uses: actions/cache@v2
       with:
-        path: apps/site/priv/static
-        key: ${{ needs.build_app.outputs.digest-key }}
+        path: |
+          apps/site/priv/static
+          apps/site/react_renderer/dist/app.js
+        key: ${{ needs.build_app.outputs.assets-key }}
     - uses: actions/cache@v2
       with:
         path: _build
@@ -466,12 +455,8 @@ jobs:
           key: ${{ needs.setup.outputs.nodejs-key }}
       - uses: actions/cache@v2
         with:
-          path: apps/site/priv/static
-          key: ${{ needs.build_app.outputs.digest-key }}
-      - uses: actions/cache@v2
-        with:
           path: |
-            apps/site/priv/static/js
+            apps/site/priv/static
             apps/site/react_renderer/dist/app.js
           key: ${{ needs.build_app.outputs.assets-key }}
       - uses: actions/cache@v2
@@ -512,12 +497,8 @@ jobs:
           key: ${{ runner.os }}-cypress-${{ hashFiles('apps/site/*/package-lock.json') }}
       - uses: actions/cache@v2
         with:
-          path: apps/site/priv/static
-          key: ${{ needs.build_app.outputs.digest-key }}
-      - uses: actions/cache@v2
-        with:
           path: |
-            apps/site/priv/static/js
+            apps/site/priv/static
             apps/site/react_renderer/dist/app.js
           key: ${{ needs.build_app.outputs.assets-key }}
       - uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,61 @@ jobs:
         git config --global url."https://github.com/".insteadOf ssh://git@github.com/
         npm run install:ci
 
+  build:
+    name: Build application & cache it
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/.asdf
+          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+      - uses: mbta/actions/reshim-asdf@v1
+      - uses: actions/cache@v2
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: "apps/site/*/node_modules"
+          key: ${{ runner.os }}-nodejs-${{ hashFiles('apps/site/*/package-lock.json') }}
+      - name: Cache react_renderer output
+        uses: actions/cache@v2
+        with:
+          path: apps/site/react_renderer/dist/app.js
+          key: ${{ runner.os }}-react_renderer-${{ hashFiles('apps/site/react_renderer/package-lock.json') }}
+        id: react_renderer-cache
+      - run: npm run --prefix apps/site/react_renderer build
+        if: steps.react_renderer-cache.outputs.cache-hit != 'true'
+      
+      - name: Cache front end assets
+        uses: actions/cache@v2
+        with:
+          path: apps/site/priv/static/js
+          key: ${{ runner.os }}-assets-${{ hashFiles('apps/site/assets/package-lock.json') }}
+        id: assets-cache
+      - run: npm run --prefix apps/site/assets webpack:build
+        if: steps.assets-cache.outputs.cache-hit != 'true'
+
+      - name: Cache back end assets
+        uses: actions/cache@v2
+        with:
+          path: apps/site/priv/static
+          key: ${{ runner.os }}-digest-${{ hashFiles('apps/site/assets/package-lock.json') }}
+        id: digest-cache
+      - run: mix phx.digest
+        if: steps.digest-cache.outputs.cache-hit != 'true'
+      
+      - name: Cache _build
+        uses: actions/cache@v2
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}-${{ hashFiles('apps/site/*/package-lock.json') }}
+        id: build-cache
+      - run: mix compile --warnings-as-errors
+        if: steps.build-cache.outputs.cache-hit != 'true'
+
   file_changes:
     name: Before all / Note files changed
     runs-on: ubuntu-latest
@@ -168,7 +223,7 @@ jobs:
   elixir_unit:
     name: Unit tests / Elixir / --exclude wallaby --cover
     runs-on: ubuntu-latest
-    needs: [file_changes, setup]
+    needs: [file_changes, build]
     if: ${{ needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
@@ -184,9 +239,19 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: "apps/site/*/node_modules"
-          key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
-      - name: Build app
-        run: npm run build
+          key: ${{ runner.os }}-nodejs-${{ hashFiles('apps/site/*/package-lock.json') }}
+      - uses: actions/cache@v2
+        with:
+          path: apps/site/react_renderer/dist/app.js
+          key: ${{ runner.os }}-react_renderer-${{ hashFiles('apps/site/react_renderer/package-lock.json') }}
+      - uses: actions/cache@v2
+        with:
+          path: apps/site/priv/static
+          key: ${{ runner.os }}-digest-${{ hashFiles('apps/site/assets/package-lock.json') }}
+      - uses: actions/cache@v2
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}-${{ hashFiles('apps/site/*/package-lock.json') }}
       - env:
           RECAPTCHA_PUBLIC_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
           RECAPTCHA_PRIVATE_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
@@ -226,7 +291,7 @@ jobs:
   js_unit_2:
     name: Unit tests / JavaScript & TypeScript / Jest
     runs-on: ubuntu-latest
-    needs: [file_changes, setup]
+    needs: [file_changes, build]
     if: ${{ needs.file_changes.outputs.ts || needs.file_changes.outputs.js }}
     steps:
     - uses: actions/checkout@v2
@@ -242,9 +307,11 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: "apps/site/*/node_modules"
-        key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
-    - name: Build app
-      run: npm run build
+        key: ${{ runner.os }}-nodejs-${{ hashFiles('apps/site/*/package-lock.json') }}
+    - uses: actions/cache@v2
+      with:
+        path: _build
+        key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}-${{ hashFiles('apps/site/*/package-lock.json') }}
     - run: npm run ci:unit:jest
 
   type_dialyzer:
@@ -322,8 +389,9 @@ jobs:
   elixir_wallaby:
     name: Integration tests / Elixir
     runs-on: ubuntu-latest
-    needs: [file_changes, setup]
-    if: ${{ needs.file_changes.outputs.ex || needs.file_changes.outputs.js || needs.file_changes.outputs.ts }}
+    needs: [file_changes, build]
+    if: ${{ needs.file_changes.outputs.ex }}
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -338,9 +406,15 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: "apps/site/*/node_modules"
-          key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
-      - name: Build app
-        run: npm run build
+          key: ${{ runner.os }}-nodejs-${{ hashFiles('apps/site/*/package-lock.json') }}
+      - uses: actions/cache@v2
+        with:
+          path: apps/site/priv/static
+          key: ${{ runner.os }}-digest-${{ hashFiles('apps/site/assets/package-lock.json') }}
+      - uses: actions/cache@v2
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}-${{ hashFiles('apps/site/*/package-lock.json') }}
       - env:
           RECAPTCHA_PUBLIC_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
           RECAPTCHA_PRIVATE_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ on:
 
     # Don't bother running if it's just a script or docs change
     paths-ignore:
-      - ".github/**"
       - "bin/**"
       - Dockerfile
       - "*.sh"
@@ -24,38 +23,49 @@ jobs:
   setup:
     name: Before all / Load cached deps
     runs-on: ubuntu-latest
+    outputs:
+      asdf-key: ${{ steps.cache-keys.outputs.asdf }}
+      mix-key: ${{ steps.cache-keys.outputs.mix }}
+      nodejs-key: ${{ steps.cache-keys.outputs.nodejs }}
     steps:
     - uses: actions/checkout@v2
-
+    - name: Set cache keys
+      id: cache-keys
+      run: |
+        echo "::set-output name=asdf::${{ runner.os }}-asdf-cache-${{ hashFiles('.tool-versions') }}"
+        echo "::set-output name=mix::${{ runner.os }}-mix-cache-${{ hashFiles('**/mix.lock') }}"
+        echo "::set-output name=nodejs::${{ runner.os }}-nodejs-cache-${{ hashFiles('apps/site/**/package-lock.json') }}"
     - name: <asdf> Restore cache of languages from .tool-versions
       uses: actions/cache@v2
       with:
         path: ~/.asdf
-        key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+        key: ${{ steps.cache-keys.outputs.asdf }}
       id: asdf-cache
     - name: <asdf> Install languages from .tool-versions (if needed)
       uses: asdf-vm/actions/install@v1
-      if: steps.asdf-cache.outputs.cache-hit != 'true'
+      if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
     - name: <Mix> Install Hex/Rebar (if needed)
       run: |
         mix local.hex --force
         mix local.rebar --force
-      if: steps.asdf-cache.outputs.cache-hit != 'true'
+      if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
     - uses: mbta/actions/reshim-asdf@v1
     - name: <elixir> Restore dependencies cache
       uses: actions/cache@v2
       with:
         path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        key: ${{ steps.cache-keys.outputs.mix }}
       id: elixir-cache
     - name: <elixir> Install dependencies (if needed)
-      if: steps.elixir-cache.outputs.cache-hit != 'true'
+      if: ${{ steps.elixir-cache.outputs.cache-hit != 'true' }}
       run: mix deps.get
     - name: <node> Restore dependencies cache
       uses: actions/cache@v2
       with:
-        path: "apps/site/*/node_modules"
-        key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
+        path: |
+          apps/site/assets/node_modules
+          apps/site/react_renderer/node_modules
+        key: ${{ steps.cache-keys.outputs.nodejs }}
       id: node-cache
     - name: <node> Restore Cypress cache
       uses: actions/cache@v2
@@ -64,71 +74,79 @@ jobs:
         key: ${{ runner.os }}-cypress-${{ hashFiles('apps/site/*/package-lock.json') }}
       id: cypress-cache
     - name: <node> Install dependencies (if needed)
-      if: steps.node-cache.outputs.cache-hit != 'true'
+      if: ${{ steps.node-cache.outputs.cache-hit != 'true' }}
       run: |
         git config --global url."https://github.com/".insteadOf ssh://git@github.com/
         npm run install:ci
 
-  build:
-    name: Build application & cache it
+  build_app:
+    name: Build & cache app
     runs-on: ubuntu-latest
     needs: setup
+    outputs:
+      build-key: ${{ steps.cache-keys.outputs.build }}
+      digest-key: ${{ steps.cache-keys.outputs.digest }}
     steps:
       - uses: actions/checkout@v2
+      - name: Set cache keys
+        id: cache-keys
+        run: |
+          echo "::set-output name=digest::${{ runner.os }}-digest-cache-${{ hashFiles('apps/site/priv/static/**') }}"
+          echo "::set-output name=build::${{ runner.os }}-build-cache-${{ hashFiles('**/lib/**.ex', 'apps/site/priv/static/**', '**/mix.lock') }}"
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+          key: ${{ needs.setup.outputs.asdf-key }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ needs.setup.outputs.mix-key }}
       - uses: actions/cache@v2
         with:
-          path: "apps/site/*/node_modules"
-          key: ${{ runner.os }}-nodejs-${{ hashFiles('apps/site/*/package-lock.json') }}
-      - name: Cache react_renderer output
-        uses: actions/cache@v2
-        with:
-          path: apps/site/react_renderer/dist/app.js
-          key: ${{ runner.os }}-react_renderer-${{ hashFiles('apps/site/react_renderer/package-lock.json') }}
-        id: react_renderer-cache
-      - run: npm run --prefix apps/site/react_renderer build
-        if: steps.react_renderer-cache.outputs.cache-hit != 'true'
+          path: |
+            apps/site/assets/node_modules
+            apps/site/react_renderer/node_modules
+          key: ${{ needs.setup.outputs.nodejs-key }}
       
       - name: Cache front end assets
         uses: actions/cache@v2
         with:
-          path: apps/site/priv/static/js
-          key: ${{ runner.os }}-assets-${{ hashFiles('apps/site/assets/package-lock.json') }}
+          path: |
+            apps/site/priv/static/js
+            apps/site/react_renderer/dist/app.js
+          key: ${{ runner.os }}-assets-${{ hashFiles('apps/site/assets/**', 'apps/site/react_renderer/**.js') }}
         id: assets-cache
-      - run: npm run --prefix apps/site/assets webpack:build
-        if: steps.assets-cache.outputs.cache-hit != 'true'
+      - run: npx webpack --version
+        working-directory: apps/site/assets
+      - run: npm run webpack:build
+        if: ${{ steps.assets-cache.outputs.cache-hit != 'true' }}
+        working-directory: apps/site/assets
+      - run: npm run build
+        if: ${{ steps.assets-cache.outputs.cache-hit != 'true' }}
+        working-directory: apps/site/react_renderer
 
-      - name: Cache back end assets
+      - name: Cache asset digest
         uses: actions/cache@v2
         with:
           path: apps/site/priv/static
-          key: ${{ runner.os }}-digest-${{ hashFiles('apps/site/assets/package-lock.json') }}
+          key: ${{ steps.cache-keys.outputs.digest }}
         id: digest-cache
       - run: mix phx.digest
-        if: steps.digest-cache.outputs.cache-hit != 'true'
+        if: ${{ steps.digest-cache.outputs.cache-hit != 'true' }}
       
       - name: Cache _build
         uses: actions/cache@v2
         with:
           path: _build
-          key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}-${{ hashFiles('apps/site/*/package-lock.json') }}
+          key: ${{ steps.cache-keys.outputs.build }}
         id: build-cache
       - run: mix compile --warnings-as-errors
-        if: steps.build-cache.outputs.cache-hit != 'true'
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
 
   file_changes:
     name: Before all / Note files changed
     runs-on: ubuntu-latest
-    env:
-      isDevPR: ${{ github.event_name == 'pull_request' && github.actor != "dependabot[bot]" }}
     outputs:
       js: ${{ steps.changes.outputs.js }}
       ts: ${{ steps.changes.outputs.ts }}
@@ -138,22 +156,25 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - if: env.isDevPR
-        name: "PR: Compute changed files"
+      - id: changes
+        name: "Compute changed files"
+        shell: bash
         run: |
-          changes () { git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} ; }
-          echo "changed files? $(changes)"
-          echo "::set-output name=js::$(changes | grep -E 'apps/site/assets/js/.*\.jsx?' | xargs)"
-          echo "::set-output name=ts::$(changes | grep -E 'apps/site/assets/ts/.*\.tsx?' | xargs)"
-          echo "::set-output name=scss::$(changes | grep -E 'apps/site/assets/css/.*\.scss' | xargs)"
-          echo "::set-output name=ex::$(changes | grep -E '.*(\.exs?|\.eex)' | xargs)"
-      - if: !env.isDevPR
-        name: "Not a PR by a dev. Use placeholder value so all tests run"
-        run: |
-          echo "::set-output name=js::skip"
-          echo "::set-output name=ts::skip"
-          echo "::set-output name=scss::skip"
-          echo "::set-output name=ex::skip"
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.actor }}" != "dependabot[bot]" ]]; then
+              changes () { git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} ; }
+              echo "changed files? $(changes)"
+              echo "::set-output name=js::$(changes | grep -E 'apps/site/assets/js/.*\.jsx?' | xargs)"
+              echo "::set-output name=ts::$(changes | grep -E 'apps/site/assets/ts/.*\.tsx?' | xargs)"
+              echo "::set-output name=scss::$(changes | grep -E 'apps/site/assets/css/.*\.scss' | xargs)"
+              echo "::set-output name=ex::$(changes | grep -E '.*(\.exs?|\.eex)' | xargs)"
+          else
+              echo "Not a PR by a dev. Use placeholder value so all tests run"
+              echo "::set-output name=js::skip"
+              echo "::set-output name=ts::skip"
+              echo "::set-output name=scss::skip"
+              echo "::set-output name=ex::skip"
+          fi
+      
       - name: "List changed files:"
         run: |
           echo "JS? ${{ steps.changes.outputs.js }}"
@@ -171,12 +192,14 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+          key: ${{ needs.setup.outputs.asdf-key }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
-          path: "apps/site/*/node_modules"
-          key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
+          path: |
+            apps/site/assets/node_modules
+            apps/site/react_renderer/node_modules
+          key: ${{ needs.setup.outputs.nodejs-key }}
       - run: npm run ci:lint:ts
 
   jslint:
@@ -189,12 +212,14 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+          key: ${{ needs.setup.outputs.asdf-key }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
-          path: "apps/site/*/node_modules"
-          key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
+          path: |
+            apps/site/assets/node_modules
+            apps/site/react_renderer/node_modules
+          key: ${{ needs.setup.outputs.nodejs-key }}
       - run: npm run ci:lint:js
 
   stylelint:
@@ -207,12 +232,14 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ~/.asdf
-        key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+        key: ${{ needs.setup.outputs.asdf-key }}
     - uses: mbta/actions/reshim-asdf@v1
     - uses: actions/cache@v2
       with:
-        path: "apps/site/*/node_modules"
-        key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
+        path: |
+          apps/site/assets/node_modules
+          apps/site/react_renderer/node_modules
+        key: ${{ needs.setup.outputs.nodejs-key }}
     - run: npm run ci:lint:scss
 
   elixirlint:
@@ -225,46 +252,45 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+          key: ${{ needs.setup.outputs.asdf-key }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ needs.setup.outputs.mix-key }}
       - run: npm run ci:lint:ex
 
   elixir_unit:
     name: Unit tests / Elixir / --exclude wallaby --cover
     runs-on: ubuntu-latest
-    needs: [file_changes, build]
+    needs: [setup, file_changes, build_app]
     if: ${{ needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+          key: ${{ needs.setup.outputs.asdf-key }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ needs.setup.outputs.mix-key }}
       - uses: actions/cache@v2
         with:
-          path: "apps/site/*/node_modules"
-          key: ${{ runner.os }}-nodejs-${{ hashFiles('apps/site/*/package-lock.json') }}
-      - uses: actions/cache@v2
-        with:
-          path: apps/site/react_renderer/dist/app.js
-          key: ${{ runner.os }}-react_renderer-${{ hashFiles('apps/site/react_renderer/package-lock.json') }}
+          path: |
+            apps/site/assets/node_modules
+            apps/site/react_renderer/node_modules
+          key: ${{ needs.setup.outputs.nodejs-key }}
+
       - uses: actions/cache@v2
         with:
           path: apps/site/priv/static
-          key: ${{ runner.os }}-digest-${{ hashFiles('apps/site/assets/package-lock.json') }}
+          key: ${{ needs.build_app.outputs.digest-key }}
       - uses: actions/cache@v2
         with:
           path: _build
-          key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}-${{ hashFiles('apps/site/*/package-lock.json') }}
+          key: ${{ needs.build_app.outputs.build-key }}
       - env:
           RECAPTCHA_PUBLIC_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
           RECAPTCHA_PRIVATE_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
@@ -276,7 +302,7 @@ jobs:
           cat apps/*/cover/* > cover/lcov.info
           echo "${{ github.event.pull_request.number }}" > cover/PR_NUMBER
           echo "${{ github.event.pull_request.head.sha }}" > cover/PR_SHA
-        if: github.event.pull_request
+        if: ${{ github.event.pull_request }}
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v2
         with:
@@ -293,38 +319,42 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ~/.asdf
-        key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+        key: ${{ needs.setup.outputs.asdf-key }}
     - uses: mbta/actions/reshim-asdf@v1
     - uses: actions/cache@v2
       with:
-        path: "apps/site/*/node_modules"
-        key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
+        path: |
+          apps/site/assets/node_modules
+          apps/site/react_renderer/node_modules
+        key: ${{ needs.setup.outputs.nodejs-key }}
     - run: npm run ci:unit:mocha
 
   js_unit_2:
     name: Unit tests / JavaScript & TypeScript / Jest
     runs-on: ubuntu-latest
-    needs: [file_changes, build]
+    needs: [setup, file_changes, build_app]
     if: ${{ needs.file_changes.outputs.ts || needs.file_changes.outputs.js }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
       with:
         path: ~/.asdf
-        key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+        key: ${{ needs.setup.outputs.asdf-key }}
     - uses: mbta/actions/reshim-asdf@v1
     - uses: actions/cache@v2
       with:
         path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        key: ${{ needs.setup.outputs.mix-key }}
     - uses: actions/cache@v2
       with:
-        path: "apps/site/*/node_modules"
-        key: ${{ runner.os }}-nodejs-${{ hashFiles('apps/site/*/package-lock.json') }}
+        path: |
+          apps/site/assets/node_modules
+          apps/site/react_renderer/node_modules
+        key: ${{ needs.setup.outputs.nodejs-key }}
     - uses: actions/cache@v2
       with:
         path: _build
-        key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}-${{ hashFiles('apps/site/*/package-lock.json') }}
+        key: ${{ needs.build_app.outputs.build-key }}
     - run: npm run ci:unit:jest
 
   type_dialyzer:
@@ -337,12 +367,12 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+          key: ${{ needs.setup.outputs.asdf-key }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ needs.setup.outputs.mix-key }}
       - uses: mbta/actions/dialyzer@v1
 
   type_typescript:
@@ -355,12 +385,14 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+          key: ${{ needs.setup.outputs.asdf-key }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
-          path: "apps/site/*/node_modules"
-          key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
+          path: |
+            apps/site/assets/node_modules
+            apps/site/react_renderer/node_modules
+          key: ${{ needs.setup.outputs.nodejs-key }}
       - run: npm run ci:types:ts
 
   elixir_format_check:
@@ -373,12 +405,12 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+          key: ${{ needs.setup.outputs.asdf-key }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ needs.setup.outputs.mix-key }}
       - run: npm run ci:format:ex
 
   js_format_check:
@@ -391,18 +423,20 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ~/.asdf
-        key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+        key: ${{ needs.setup.outputs.asdf-key }}
     - uses: mbta/actions/reshim-asdf@v1
     - uses: actions/cache@v2
       with:
-        path: "apps/site/*/node_modules"
-        key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
+        path: |
+          apps/site/assets/node_modules
+          apps/site/react_renderer/node_modules
+        key: ${{ needs.setup.outputs.nodejs-key }}
     - run: npm run ci:format:ts
 
   elixir_wallaby:
     name: Integration tests / Elixir
     runs-on: ubuntu-latest
-    needs: [file_changes, build]
+    needs: [setup, file_changes, build_app]
     if: ${{ needs.file_changes.outputs.ex }}
     continue-on-error: true
     steps:
@@ -410,24 +444,26 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+          key: ${{ needs.setup.outputs.asdf-key }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ needs.setup.outputs.mix-key }}
       - uses: actions/cache@v2
         with:
-          path: "apps/site/*/node_modules"
-          key: ${{ runner.os }}-nodejs-${{ hashFiles('apps/site/*/package-lock.json') }}
+          path: |
+            apps/site/assets/node_modules
+            apps/site/react_renderer/node_modules
+          key: ${{ needs.setup.outputs.nodejs-key }}
       - uses: actions/cache@v2
         with:
           path: apps/site/priv/static
-          key: ${{ runner.os }}-digest-${{ hashFiles('apps/site/assets/package-lock.json') }}
+          key: ${{ needs.build_app.outputs.digest-key }}
       - uses: actions/cache@v2
         with:
           path: _build
-          key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}-${{ hashFiles('apps/site/*/package-lock.json') }}
+          key: ${{ needs.build_app.outputs.build-key }}
       - env:
           RECAPTCHA_PUBLIC_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
           RECAPTCHA_PRIVATE_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,10 +168,10 @@ jobs:
               echo "::set-output name=ex::$(changes | grep -E '.*(\.exs?|\.eex)' | xargs)"
           else
               echo "Not a PR by a dev. Use placeholder value so all tests run"
-              echo "::set-output name=js::skip"
-              echo "::set-output name=ts::skip"
-              echo "::set-output name=scss::skip"
-              echo "::set-output name=ex::skip"
+              echo "::set-output name=js::all"
+              echo "::set-output name=ts::all"
+              echo "::set-output name=scss::all"
+              echo "::set-output name=ex::all"
           fi
       
       - name: "List changed files:"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -438,7 +438,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, file_changes, build_app]
     if: ${{ needs.file_changes.outputs.ex }}
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -473,29 +472,33 @@ jobs:
   cypress:
     name: Integration tests / Cypress
     runs-on: ubuntu-latest
-    needs: [file_changes, setup]
+    needs: [file_changes, setup, build_app]
     if: ${{ needs.file_changes.outputs.ex || needs.file_changes.outputs.js || needs.file_changes.outputs.ts }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
+          key: ${{ needs.setup.outputs.asdf-key }}
       - uses: mbta/actions/reshim-asdf@v1
       - uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ needs.setup.outputs.mix-key }}
       - uses: actions/cache@v2
         with:
-          path: "apps/site/*/node_modules"
-          key: ${{ runner.os }}-nodejs2-${{ hashFiles('apps/site/*/package-lock.json') }}
+          path: |
+            apps/site/assets/node_modules
+            apps/site/react_renderer/node_modules
+          key: ${{ needs.setup.outputs.nodejs-key }}
       - uses: actions/cache@v2
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('apps/site/*/package-lock.json') }}
-      - name: Build app
-        run: npm run build
+      - uses: actions/cache@v2
+        with:
+          path: _build
+          key: ${{ needs.build_app.outputs.build-key }}
       - env:
           RECAPTCHA_PUBLIC_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
           RECAPTCHA_PRIVATE_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -352,6 +352,10 @@ jobs:
         key: ${{ needs.setup.outputs.nodejs-key }}
     - uses: actions/cache@v2
       with:
+        path: apps/site/priv/static
+        key: ${{ needs.build_app.outputs.digest-key }}
+    - uses: actions/cache@v2
+      with:
         path: _build
         key: ${{ needs.build_app.outputs.build-key }}
     - run: npm run ci:unit:jest
@@ -494,6 +498,10 @@ jobs:
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('apps/site/*/package-lock.json') }}
+      - uses: actions/cache@v2
+        with:
+          path: apps/site/priv/static
+          key: ${{ needs.build_app.outputs.digest-key }}
       - uses: actions/cache@v2
         with:
           path: _build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: CI
 on:
+  push:
+    branches: master
   pull_request:
     # Don't bother running if it's a PR on a feature branch
     branches: [master]
@@ -134,7 +136,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - id: changes
+      - if: github.event_name == 'pull_request'
+        name: "PR: Compute changed files"
         run: |
           changes () { git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} ; }
           echo "changed files? $(changes)"
@@ -142,7 +145,15 @@ jobs:
           echo "::set-output name=ts::$(changes | grep -E 'apps/site/assets/ts/.*\.tsx?' | xargs)"
           echo "::set-output name=scss::$(changes | grep -E 'apps/site/assets/css/.*\.scss' | xargs)"
           echo "::set-output name=ex::$(changes | grep -E '.*(\.exs?|\.eex)' | xargs)"
-      - run: |
+      - if: github.event_name != 'pull_request'
+        name: "Not a PR. Use placeholder value so all tests run"
+        run: |
+          echo "::set-output name=js::skip"
+          echo "::set-output name=ts::skip"
+          echo "::set-output name=scss::skip"
+          echo "::set-output name=ex::skip"
+      - name: "List changed files:"
+        run: |
           echo "JS? ${{ steps.changes.outputs.js }}"
           echo "TS? ${{ steps.changes.outputs.ts }}"
           echo "EX? ${{ steps.changes.outputs.ex }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,14 +126,13 @@ jobs:
         if: ${{ steps.assets-cache.outputs.cache-hit != 'true' }}
         working-directory: apps/site/react_renderer
 
+      - name: Digest assets # always, as the cache key hash needs these files
+        run: mix phx.digest
       - name: Cache asset digest
         uses: actions/cache@v2
         with:
           path: apps/site/priv/static
           key: ${{ steps.cache-keys.outputs.digest }}
-        id: digest-cache
-      - run: mix phx.digest
-        if: ${{ steps.digest-cache.outputs.cache-hit != 'true' }}
       
       - name: Cache _build
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,7 @@ jobs:
     outputs:
       build-key: ${{ steps.cache-keys.outputs.build }}
       digest-key: ${{ steps.cache-keys.outputs.digest }}
+      assets-key: ${{ steps.cache-keys.outputs.assets }}
     steps:
       - uses: actions/checkout@v2
       - name: Set cache keys
@@ -93,6 +94,7 @@ jobs:
         run: |
           echo "::set-output name=digest::${{ runner.os }}-digest-cache-${{ hashFiles('apps/site/priv/static/**') }}"
           echo "::set-output name=build::${{ runner.os }}-build-cache-${{ hashFiles('**/lib/**.ex', 'apps/site/priv/static/**', '**/mix.lock') }}"
+          echo "::set-output name=assets::${{ runner.os }}-assets-cache-${{ hashFiles('apps/site/assets/**', 'apps/site/react_renderer/**.js') }}"
       - uses: actions/cache@v2
         with:
           path: ~/.asdf
@@ -115,10 +117,8 @@ jobs:
           path: |
             apps/site/priv/static/js
             apps/site/react_renderer/dist/app.js
-          key: ${{ runner.os }}-assets-${{ hashFiles('apps/site/assets/**', 'apps/site/react_renderer/**.js') }}
+          key: ${{ steps.cache-keys.outputs.assets }}
         id: assets-cache
-      - run: npx webpack --version
-        working-directory: apps/site/assets
       - run: npm run webpack:build
         if: ${{ steps.assets-cache.outputs.cache-hit != 'true' }}
         working-directory: apps/site/assets
@@ -286,6 +286,12 @@ jobs:
         with:
           path: apps/site/priv/static
           key: ${{ needs.build_app.outputs.digest-key }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            apps/site/priv/static/js
+            apps/site/react_renderer/dist/app.js
+          key: ${{ needs.build_app.outputs.assets-key }}
       - uses: actions/cache@v2
         with:
           path: _build
@@ -464,6 +470,12 @@ jobs:
           key: ${{ needs.build_app.outputs.digest-key }}
       - uses: actions/cache@v2
         with:
+          path: |
+            apps/site/priv/static/js
+            apps/site/react_renderer/dist/app.js
+          key: ${{ needs.build_app.outputs.assets-key }}
+      - uses: actions/cache@v2
+        with:
           path: _build
           key: ${{ needs.build_app.outputs.build-key }}
       - env:
@@ -502,6 +514,12 @@ jobs:
         with:
           path: apps/site/priv/static
           key: ${{ needs.build_app.outputs.digest-key }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            apps/site/priv/static/js
+            apps/site/react_renderer/dist/app.js
+          key: ${{ needs.build_app.outputs.assets-key }}
       - uses: actions/cache@v2
         with:
           path: _build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,6 +127,8 @@ jobs:
   file_changes:
     name: Before all / Note files changed
     runs-on: ubuntu-latest
+    env:
+      isDevPR: ${{ github.event_name == 'pull_request' && github.actor != "dependabot[bot]" }}
     outputs:
       js: ${{ steps.changes.outputs.js }}
       ts: ${{ steps.changes.outputs.ts }}
@@ -136,7 +138,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - if: github.event_name == 'pull_request'
+      - if: env.isDevPR
         name: "PR: Compute changed files"
         run: |
           changes () { git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} ; }
@@ -145,8 +147,8 @@ jobs:
           echo "::set-output name=ts::$(changes | grep -E 'apps/site/assets/ts/.*\.tsx?' | xargs)"
           echo "::set-output name=scss::$(changes | grep -E 'apps/site/assets/css/.*\.scss' | xargs)"
           echo "::set-output name=ex::$(changes | grep -E '.*(\.exs?|\.eex)' | xargs)"
-      - if: github.event_name != 'pull_request'
-        name: "Not a PR. Use placeholder value so all tests run"
+      - if: !env.isDevPR
+        name: "Not a PR by a dev. Use placeholder value so all tests run"
         run: |
           echo "::set-output name=js::skip"
           echo "::set-output name=ts::skip"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -472,7 +472,7 @@ jobs:
   cypress:
     name: Integration tests / Cypress
     runs-on: ubuntu-latest
-    needs: [file_changes, setup, build_app]
+    needs: [setup, file_changes, build_app]
     if: ${{ needs.file_changes.outputs.ex || needs.file_changes.outputs.js || needs.file_changes.outputs.ts }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -528,4 +528,4 @@ jobs:
           RECAPTCHA_PUBLIC_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
           RECAPTCHA_PRIVATE_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
           OPEN_TRIP_PLANNER_URL: ${{ secrets.OPEN_TRIP_PLANNER_URL }}
-        run: npm run test:cypress:run
+        run: npm run ci:integration:cypress

--- a/apps/site/assets/css/_ie-warning.scss
+++ b/apps/site/assets/css/_ie-warning.scss
@@ -58,7 +58,7 @@
     border: 0;
     display: flex;
     justify-content: space-between;
-    padding: 8px 40px 24px 40px;
+    padding: 8px 40px 24px;
 
     @include media-breakpoint-down(xs) {
       flex-flow: column wrap;

--- a/apps/site/config/test.exs
+++ b/apps/site/config/test.exs
@@ -3,7 +3,7 @@ use Mix.Config
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :site, SiteWeb.Endpoint,
-  http: [port: 4002],
+  http: [port: System.get_env("PORT") || 4002],
   server: true
 
 # Print only warnings and errors during test

--- a/apps/site/test/site/application_test.exs
+++ b/apps/site/test/site/application_test.exs
@@ -3,9 +3,14 @@ defmodule Site.ApplicationTest do
   use ExUnit.Case
 
   describe "start/2" do
+    setup do
+      :ok = Application.stop(:site)
+      Process.sleep(5000)
+      :ok
+    end
+
     test "can start the application" do
       # ensures that our supervision tree gets coverage tracked
-      Application.stop(:site)
       assert {:ok, _} = Application.ensure_all_started(:site)
     end
   end

--- a/cypress/integration/customer-support-form/support_form.spec.js
+++ b/cypress/integration/customer-support-form/support_form.spec.js
@@ -2,7 +2,7 @@ import faker from "../../../apps/site/assets/node_modules/faker/locale/en_US";
 
 describe("Customer Support Form", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:4002/customer-support");
+    cy.visit("http://localhost:4004/customer-support");
   });
 
   it("shows an error state for missing type and comments", () => {

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "ci:lint:js": "npm run --prefix apps/site/assets eslint:js",
     "ci:lint:scss": "npm run --prefix apps/site/assets stylelint",
     "ci:lint:ex": "mix credo diff master -a",
-    "ci:unit:exunit": "mix test --exclude wallaby --cover",
+    "ci:unit:exunit": "PORT=4002 mix test --exclude wallaby --cover",
     "ci:unit:mocha": "npm run --prefix apps/site/assets mocha",
     "ci:unit:jest": "npm run --prefix apps/site/assets jest",
     "ci:types:ex": "mix dialyzer --halt-exit-status",
     "ci:types:ts": "npm run --prefix apps/site/assets tsc:check",
     "ci:format:ex": "mix format --check-formatted",
     "ci:format:ts": "npm run --prefix apps/site/assets prettier:check",
-    "ci:integration:ex": "mix test --only wallaby",
+    "ci:integration:ex": "PORT=4003 mix test --only wallaby",
     "build": "mix phx.digest",
     "prebuild": "npm run --prefix apps/site/react_renderer build && npm run --prefix apps/site/assets webpack:build",
     "postbuild": "mix compile --warnings-as-errors",
@@ -27,7 +27,7 @@
     "dialyzer": "mix dialyzer --halt-exit-status",
     "cypress:run": "$(npm bin --prefix apps/site/assets)/cypress run",
     "cypress:open": "$(npm bin --prefix apps/site/assets)/cypress open",
-    "test:cypress:run": "$(npm bin --prefix apps/site/assets)/start-server-and-test 'MIX_ENV=test mix phx.server' 4002 cypress:run",
-    "test:cypress:open": "$(npm bin --prefix apps/site/assets)/start-server-and-test 'MIX_ENV=test mix phx.server' 4002 cypress:open"
+    "test:cypress:run": "$(npm bin --prefix apps/site/assets)/start-server-and-test 'MIX_ENV=test PORT=4004 mix phx.server' 4004 cypress:run",
+    "test:cypress:open": "$(npm bin --prefix apps/site/assets)/start-server-and-test 'MIX_ENV=test PORT=4004 mix phx.server' 4004 cypress:open"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ci:format:ex": "mix format --check-formatted",
     "ci:format:ts": "npm run --prefix apps/site/assets prettier:check",
     "ci:integration:ex": "PORT=4003 mix test --only wallaby",
+    "ci:integration:cypress": "npm run test:cypress:run",
     "build": "mix phx.digest",
     "prebuild": "npm run --prefix apps/site/react_renderer build && npm run --prefix apps/site/assets webpack:build",
     "postbuild": "mix compile --warnings-as-errors",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Tech Debt | All CI steps should run on main branch](https://app.asana.com/0/385363666817452/1200549651204429/f)

The first commit is unrelated to the linked Asana ticket. It restructures the `tests.yml` workflow jobs, mainly adding a `build` job that basically does the same as `npm run build` but more methodically and with caching. The whole workflow ends up a bit faster since it's not building the same build several times.
You can see the effect of this change: https://github.com/thecristen/dotcom/actions/runs/1054828882

The second and third commit: lets the `tests.yml` workflow run on pushes to the master branch. Tweaks the job logic so that every test will run on master (whereas in PRs, some tests might get skipped depending on the types of files that have changed). The last commit tweaks this further so that PRs opened by Dependabot should trigger all tests to run.
