### PR TITLE
Fix for year not updating properly in Trip Planner selection (left panel)

### DIFF
--- a/apps/site/assets/js/datepicker-input.js
+++ b/apps/site/assets/js/datepicker-input.js
@@ -131,17 +131,17 @@ export default class DatePickerInput {
   updateSelect(select) {
     const type = Object.keys(select)[0];
     const options = document.getElementById(this.selectors[type]);
-    const currentOpt = options.querySelector("option[selected='selected']");
+    const currentOpt =
+      options.querySelector("option[selected='selected']") ||
+      options.querySelector("option[selected]");
     const newOpt = options.querySelector(`option[value='${select[type]}']`);
     if (currentOpt) currentOpt.removeAttribute("selected");
     if (!newOpt) {
-      options.append(
-        $(
-          `<option value="${select[type]}" selected="selected">${
-            select[type]
-          }</option>`
-        )
-      );
+      const opt = document.createElement("option");
+      opt.value = select[type];
+      opt.text = select[type];
+      opt.setAttribute("selected", "selected");
+      options.append(opt);
     } else {
       newOpt.setAttribute("selected", "selected");
     }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞Trip Planner | Fields should clear when new form submitted](https://app.asana.com/0/555089885850811/1150378678618193)

The affected piece of code was mixing JS and jQuery. I updated it so the dreaded `[object Object]` doesn't get added to the selector.