### PR TITLE
Account for `end_of_rating` returning nil

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -164,7 +164,15 @@ defmodule SiteWeb.ScheduleController.LineController do
   defp is_current_service?(service) do
     service_date_string = Date.to_iso8601(service.service_date)
 
-    in_current_rating? = Date.compare(service.start_date, Schedules.Repo.end_of_rating()) != :gt
+    end_of_rating = Schedules.Repo.end_of_rating()
+
+    in_current_rating? =
+      if is_nil(end_of_rating) do
+        false
+      else
+        Date.compare(service.start_date, end_of_rating) != :gt
+      end
+
     added_in? = Enum.member?(service.added_dates, service_date_string)
     removed? = Enum.member?(service.removed_dates, service_date_string)
 

--- a/apps/site/test/site_web/controllers/schedule/line_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_controller_test.exs
@@ -2,6 +2,7 @@ defmodule SiteWeb.Schedule.LineControllerTest do
   use SiteWeb.ConnCase
   alias Services.Service
   alias SiteWeb.ScheduleController.LineController
+  import Mock
 
   describe "services/3" do
     test "omits services in the past" do
@@ -91,6 +92,25 @@ defmodule SiteWeb.Schedule.LineControllerTest do
       services = LineController.services("1", service_date, repo_fn)
       assert length(services) == 2
       refute Enum.member?(services, subset_service)
+    end
+
+    test "does not break even when there's an error getting the current rating" do
+      with_mock(Schedules.Repo, end_of_rating: fn -> nil end) do
+        service_date = ~D[2021-05-01]
+
+        repo_fn = fn _ ->
+          [
+            %Service{
+              start_date: ~D[2021-05-01],
+              end_date: ~D[2021-05-01]
+            }
+          ]
+        end
+
+        services = LineController.services("1", service_date, repo_fn)
+
+        assert length(services) == 1
+      end
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Elixir.UndefinedFunctionError: function nil.calendar/0 is undefined](https://app.asana.com/0/555089885850811/1199903866102716)

This error happened back in late January and the details are not available in Sentry anymore.
I tried my best to investigate what happened and it looks like `Schedules.Repo.end_of_rating` might return nil in some scenarios. So I added a small tweak to avoid `Date.compare` to break.

