### PR TITLE
Add a plug so that if URI is malformed, the 404 page is rendered

### DIFF
--- a/apps/site/lib/site_web/controllers/helpers.ex
+++ b/apps/site/lib/site_web/controllers/helpers.ex
@@ -2,7 +2,7 @@ defmodule SiteWeb.ControllerHelpers do
   @moduledoc false
 
   import Plug.Conn, only: [halt: 1, put_resp_content_type: 2, put_status: 2]
-  import Phoenix.Controller, only: [render: 3, put_view: 2]
+  import Phoenix.Controller, only: [render: 3, put_view: 2, put_layout: 2]
 
   alias Alerts.{Alert, InformedEntity, Match, Repo}
   alias Phoenix.Controller
@@ -33,6 +33,15 @@ defmodule SiteWeb.ControllerHelpers do
   def render_404(conn) do
     conn
     |> put_status(:not_found)
+    |> put_view(SiteWeb.ErrorView)
+    |> render("404.html", [])
+    |> halt()
+  end
+
+  def render_not_found(conn) do
+    conn
+    |> put_status(:not_found)
+    |> put_layout({SiteWeb.LayoutView, "app.html"})
     |> put_view(SiteWeb.ErrorView)
     |> render("404.html", [])
     |> halt()

--- a/apps/site/lib/site_web/endpoint.ex
+++ b/apps/site/lib/site_web/endpoint.ex
@@ -61,5 +61,6 @@ defmodule SiteWeb.Endpoint do
     signing_salt: "TInvb4GN"
   )
 
+  plug(SiteWeb.Plugs.UriChecker)
   plug(SiteWeb.Router)
 end

--- a/apps/site/lib/site_web/plugs/uri_checker.ex
+++ b/apps/site/lib/site_web/plugs/uri_checker.ex
@@ -1,0 +1,24 @@
+defmodule SiteWeb.Plugs.UriChecker do
+  @moduledoc """
+  Checks for a malformed URI and if it exists, redirects with a 404
+  (and renders the 404 bus page)
+  """
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts) do
+    opts
+  end
+
+  @impl true
+  def call(conn, _) do
+    try do
+      Enum.map(conn.path_info, &URI.decode/1)
+      conn
+    catch
+      _kind, %ArgumentError{message: "malformed URI " <> _uri} ->
+        SiteWeb.ControllerHelpers.render_not_found(conn)
+    end
+  end
+end

--- a/apps/site/lib/site_web/redirector.ex
+++ b/apps/site/lib/site_web/redirector.ex
@@ -2,7 +2,7 @@ defmodule SiteWeb.Redirector do
   @behaviour Plug
 
   import Plug.Conn, only: [put_status: 2, halt: 1]
-  import Phoenix.Controller, only: [redirect: 2, render: 3, put_layout: 2, put_view: 2]
+  import Phoenix.Controller, only: [redirect: 2]
 
   alias CMS.Repo
 
@@ -16,7 +16,7 @@ defmodule SiteWeb.Redirector do
   @spec call(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
   def call(%Plug.Conn{params: %{"id" => id}} = conn, to: to) when to not in ["/projects"] do
     case find_record(id, to) do
-      :not_found -> render_not_found(conn)
+      :not_found -> SiteWeb.ControllerHelpers.render_not_found(conn)
       record -> redirect_to_show(conn, to, record)
     end
   end
@@ -43,15 +43,6 @@ defmodule SiteWeb.Redirector do
     conn
     |> put_status(:moved_permanently)
     |> redirect(to: to <> "/#{record.id}")
-    |> halt()
-  end
-
-  defp render_not_found(conn) do
-    conn
-    |> put_status(:not_found)
-    |> put_layout({SiteWeb.LayoutView, "app.html"})
-    |> put_view(SiteWeb.ErrorView)
-    |> render("404.html", [])
     |> halt()
   end
 end

--- a/apps/site/test/site_web/controllers/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/helpers_test.exs
@@ -22,6 +22,18 @@ defmodule SiteWeb.ControllerHelpersTest do
     end
   end
 
+  describe "render_not_found/1" do
+    test "renders the 404 bus page", %{conn: conn} do
+      rendered =
+        conn
+        |> put_private(:phoenix_endpoint, SiteWeb.Endpoint)
+        |> render_not_found()
+        |> html_response(404)
+
+      assert rendered =~ "This page is no longer in service."
+    end
+  end
+
   describe "return_internal_error/1" do
     test "renders an 'Internal error' 500 json response" do
       response =

--- a/apps/site/test/site_web/plugs/uri_checker_test.exs
+++ b/apps/site/test/site_web/plugs/uri_checker_test.exs
@@ -1,0 +1,24 @@
+defmodule SiteWeb.Plugs.UriCheckerTest do
+  @moduledoc """
+  Tests for the UriChecker plug
+  """
+  use SiteWeb.ConnCase, async: true
+  import SiteWeb.Plugs.UriChecker
+
+  describe "URI checker" do
+    test "does nothing because URI is not malformed", %{conn: conn} do
+      assert conn == call(conn, [])
+    end
+
+    test "redirects with a 404 because URI is malformed", %{conn: conn} do
+      conn =
+        %{conn | path_info: ["pass-program", "perq%"]}
+        |> put_private(:phoenix_endpoint, SiteWeb.Endpoint)
+
+      conn = call(conn, [])
+
+      assert conn.status == 404
+      assert conn.halted
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Elixir.ArgumentError: malformed URI "Potential%20MBTA%"](https://app.asana.com/0/555089885850811/1198971266994640)

I created a simple plug that attempts to check whether `conn.path_info` contains malformed information before calling the router. If so, it redirects to the 404 page.<br/>
Refactor: since I was going to use `render_not_found` in this new plug, I moved it to `SiteWeb.ControllerHelpers`.

