### PR TITLE
Account for empty route id

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -17,6 +17,8 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
   @typep stops_by_route :: %{String.t() => [Stop.t()]}
 
   @spec get_route(String.t()) :: {:ok, Route.t()} | :not_found
+  def get_route(""), do: :not_found
+
   def get_route(route_id) do
     route = do_get_route(route_id)
 

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -29,6 +29,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
     test "returns :not_found if given a bad route ID" do
       assert Helpers.get_route("Puce") == :not_found
+      assert Helpers.get_route("") == :not_found
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules Map API | Elixir.CaseClauseError: no case clause matching: %JsonApi{data: %JsonApi.Item{attributes: %{"color" => "DA291C", "descri...](https://app.asana.com/0/555089885850811/1200280548002897)

A small check to avoid a crash when route_id is empty.