### PR TITLE
Track number in tooltip in line diagram

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/MergeTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/MergeTest.tsx
@@ -51,7 +51,7 @@ describe("Merge component", () => {
         <Merges lineDiagram={lineDiagram} />
       </redux.Provider>
     );
-    console.log(wrapperNoBranches.debug());
+
     expect(
       wrapperNoBranches.exists("g.line-diagram-svg__merge")
     ).not.toBeTruthy();

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -22,7 +22,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
         <Diagram lineDiagram={{...}} liveData={{...}}>
           <LiveVehicleIconSet stop={{...}} liveData={{...}} />
           <LiveVehicleIconSet stop={{...}} liveData={{...}}>
-            <VehicleIcons stop={{...}} vehicles={{...}}>
+            <VehicleIcons stop={{...}} vehicles={{...}} headsigns={{...}}>
               <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
                 <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest1 bus is arriving at Stop 1</div>\\" tooltipOptions={{...}}>
                   <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest1 bus is arriving at Stop 1</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest1 bus is arriving at Stop 1</div>\\">
@@ -40,7 +40,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
             </VehicleIcons>
           </LiveVehicleIconSet>
           <LiveVehicleIconSet stop={{...}} liveData={{...}}>
-            <VehicleIcons stop={{...}} vehicles={{...}}>
+            <VehicleIcons stop={{...}} vehicles={{...}} headsigns={{...}}>
               <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
                 <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest2 bus is on the way to Stop 2</div>\\" tooltipOptions={{...}}>
                   <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest2 bus is on the way to Stop 2</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest2 bus is on the way to Stop 2</div>\\">

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -7,7 +7,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
       <Diagram lineDiagram={{...}} liveData={{...}}>
         <LiveVehicleIconSet stop={{...}} liveData={{...}} />
         <LiveVehicleIconSet stop={{...}} liveData={{...}}>
-          <VehicleIcons stop={{...}} vehicles={{...}}>
+          <VehicleIcons stop={{...}} vehicles={{...}} headsigns={{...}}>
             <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
               <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest1 bus is arriving at Stop 1</div>\\" tooltipOptions={{...}}>
                 <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest1 bus is arriving at Stop 1</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest1 bus is arriving at Stop 1</div>\\">
@@ -25,7 +25,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
           </VehicleIcons>
         </LiveVehicleIconSet>
         <LiveVehicleIconSet stop={{...}} liveData={{...}}>
-          <VehicleIcons stop={{...}} vehicles={{...}}>
+          <VehicleIcons stop={{...}} vehicles={{...}} headsigns={{...}}>
             <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
               <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest2 bus is on the way to Stop 2</div>\\" tooltipOptions={{...}}>
                 <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest2 bus is on the way to Stop 2</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Dest2 bus is on the way to Stop 2</div>\\">

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/VehicleIconsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/VehicleIconsTest.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`VehicleIcons renders and matches snapshot 1`] = `
 "<Provider store={{...}}>
-  <VehicleIcons stop={{...}} vehicles={{...}}>
+  <VehicleIcons stop={{...}} vehicles={{...}} headsigns={{...}}>
     <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
       <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Vehicle is on the way to Test Stop</div>\\" tooltipOptions={{...}}>
         <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Vehicle is on the way to Test Stop</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">Vehicle is on the way to Test Stop</div>\\">

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Diagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Diagram.tsx
@@ -67,11 +67,15 @@ const LiveVehicleIconSet = ({
   const vehicleData = stop.route_stop["is_beginning?"]
     ? liveData[stopId].vehicles.filter(vehicle => vehicle.status === "stopped")
     : liveData[stopId].vehicles;
+
+  const headsignsForStop = liveData[stopId].headsigns;
+
   return (
     <VehicleIcons
       key={`${stopId}-vehicles`}
       stop={stop.route_stop}
       vehicles={vehicleData}
+      headsigns={headsignsForStop}
     />
   );
 };


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add arriving track number to vehicle tooltip on the timetable, line diagram, and map when we have it](https://app.asana.com/0/1200650448662357/1199653833933398)

Partial solution to the ticket. This PR only addresses showing the track number in the Line Diagram:<br/>
<img width="803" alt="Screen Shot 2021-08-04 at 11 56 54" src="https://user-images.githubusercontent.com/61979382/128222190-492bf88c-7847-4f56-8b3d-329436e0f345.png">
