### PR TITLE
feat: Make a wrapper page for the Youth Pass form

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -10,6 +10,7 @@ export DRUPAL_ROOT=https://live-mbta.pantheonsite.io
 export OPEN_TRIP_PLANNER_URL=https://dev.otp.mbtace.com
 export RECAPTCHA_PUBLIC_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 export RECAPTCHA_PRIVATE_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+export REDUCED_FARES_URLS={"youth-pass":"https://mbta.preprod.simpligov.com/preprod/portal/ShowWorkFlow/AnonymousEmbed/86cadfa6-e8ea-46f1-b6e8-62498f066962"}
 # export STATIC_HOST=
 # export SUPPORT_TICKET_REPLY_EMAIL=
 # export SUPPORT_TICKET_TO_EMAIL=

--- a/apps/site/assets/css/_layout-wrapper.scss
+++ b/apps/site/assets/css/_layout-wrapper.scss
@@ -1,0 +1,12 @@
+.c-iframe-wrapper {
+  main,
+  iframe {
+    height: 100vh;
+    width: 100vw;
+  }
+
+  iframe {
+    border: none;
+    overflow: hidden;
+  }
+}

--- a/apps/site/assets/css/app.scss
+++ b/apps/site/assets/css/app.scss
@@ -89,6 +89,7 @@
 @import 'facets';
 @import 'photo-gallery';
 @import 'layout-cms';
+@import 'layout-wrapper';
 @import 'embedded-media';
 @import 'google-maps';
 @import 'checkbox';

--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -60,6 +60,8 @@ config :site, OldSiteFileController,
 
 config :site, StaticFileController, response_fn: {SiteWeb.StaticFileController, :send_file}
 
+config :site, SiteWeb.ReducedFaresView, reduced_fares_urls: System.get_env("REDUCED_FARES_URLS")
+
 config :util,
   router_helper_module: {:ok, SiteWeb.Router.Helpers},
   endpoint: {:ok, SiteWeb.Endpoint}

--- a/apps/site/lib/site/body_tag.ex
+++ b/apps/site/lib/site/body_tag.ex
@@ -26,7 +26,8 @@ defmodule Site.BodyTag do
       javascript_class(conn),
       error_class(conn),
       mticket_class(conn),
-      preview_class(conn)
+      preview_class(conn),
+      wrapper_class(conn)
     ]
     |> Enum.filter(&(&1 != ""))
     |> Enum.join(" ")
@@ -72,4 +73,10 @@ defmodule Site.BodyTag do
     do: "cms-preview"
 
   defp preview_class(_conn), do: ""
+
+  @spec wrapper_class(Plug.Conn.t()) :: String.t()
+  defp wrapper_class(%Plug.Conn{path_info: ["reduced-fares" | _]}),
+    do: "c-iframe-wrapper"
+
+  defp wrapper_class(_conn), do: ""
 end

--- a/apps/site/lib/site_web/controllers/reduced_fares_controller.ex
+++ b/apps/site/lib/site_web/controllers/reduced_fares_controller.ex
@@ -1,0 +1,16 @@
+defmodule SiteWeb.ReducedFaresController do
+  @moduledoc """
+  Embed a Reduced Fares form served by SimpliGov in an iframe that fills the entire viewport.
+  """
+  use SiteWeb, :controller
+
+  plug(:put_layout, "wrapper.html")
+
+  def show(conn, %{"form" => "youth-pass"}) do
+    render(conn, "show.html")
+  end
+
+  def show(conn, _params) do
+    SiteWeb.ControllerHelpers.render_404(conn)
+  end
+end

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -195,6 +195,7 @@ defmodule SiteWeb.Router do
     get("/search", SearchController, :index)
     post("/search/query", SearchController, :query)
     post("/search/click", SearchController, :click)
+    get("/reduced-fares/:form", ReducedFaresController, :show)
 
     for static_page <- StaticPage.static_pages() do
       get("/#{StaticPage.convert_path(static_page)}", StaticPageController, static_page)

--- a/apps/site/lib/site_web/templates/layout/_head.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_head.html.eex
@@ -1,0 +1,46 @@
+<%
+  google_maps_js_url = raw GoogleMaps.unsigned_url("https://maps.googleapis.com/maps/api/js?libraries=places,geometry&callback=mapsCallback")
+%>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <% meta_description = assigns[:meta_description] || "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines." %>
+  <meta name="description" content="<%= Phoenix.HTML.raw(meta_description) %>">
+  <meta name="author" content="Massachusetts Bay Transportation Authority">
+  <%= Turbolinks.cache_meta @conn %>
+
+  <%= # hide any page in /org directory from search engines
+  if @conn.request_path == "/org" || String.slice(@conn.request_path, 0..4) == "/org/" do %>
+    <meta name="robots" content="noindex, nofollow">
+  <% end %>
+
+  <% title = if @view_template == "404.html", do: "Page Not Found | MBTA - Massachusetts Bay Transportation Authority", else: title_breadcrumbs(@conn) %>
+  <title><%= title %></title>
+  <link rel="apple-touch-icon" href="<%= static_url(@conn, "/images/mbta-logo-t-180.png") %>" type="image/png">
+  <link rel="icon" href="<%= static_url(@conn, "/images/mbta-logo-t-favicon.png") %>" sizes="32x32" type="image/png">
+  <link rel="icon" href="<%= static_url(@conn, "/favicon.ico") %>" sizes="16x16" type="image/vnd.microsoft.icon">
+
+  <%= if google_tag_manager_id() do %>
+    <link rel="preconnect" href="//www.google-analytics.com">
+  <% end %>
+
+  <link rel="stylesheet" href="<%= static_url(@conn, "/css/core.css") %>" data-turbolinks-track="reload">
+  <link rel="stylesheet" href="<%= static_url(@conn, "/css/app.css") %>" data-turbolinks-track="reload">
+
+  <%= if Application.get_env(:site, :dev_server?) do %>
+    <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/core.js" %>" data-turbolinks-track="reload" ></script>
+    <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/app.js" %>" data-turbolinks-track="reload" ></script>
+  <% else %>
+    <script defer src="<%= static_url(@conn, "/js/vendors.js") %>" data-turbolinks-track="reload"></script>
+    <script defer src="<%= static_url(@conn, "/js/app.js") %>" data-turbolinks-track="reload"></script>
+  <% end %>
+
+  <%= if assigns[:requires_google_maps?] do %>
+    <script type="application/javascript">if (!window.mapsCallback) { window.mapsCallback = function () { window.isMapReady = true; } }</script>
+    <script async src="<%= google_maps_js_url %>"></script>
+  <% else %>
+    <link rel="prefetch" href="<%= google_maps_js_url %>" as="script">
+  <% end %>
+</head>

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -1,50 +1,6 @@
-<%
-  google_maps_js_url = raw GoogleMaps.unsigned_url("https://maps.googleapis.com/maps/api/js?libraries=places,geometry&callback=mapsCallback")
-%>
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <% meta_description = assigns[:meta_description] || "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines." %>
-    <meta name="description" content="<%= Phoenix.HTML.raw(meta_description) %>">
-    <meta name="author" content="Massachusetts Bay Transportation Authority">
-    <%= Turbolinks.cache_meta @conn %>
-
-    <%= # hide any page in /org directory from search engines
-    if @conn.request_path == "/org" || String.slice(@conn.request_path, 0..4) == "/org/" do %>
-      <meta name="robots" content="noindex, nofollow">
-    <% end %>
-
-    <% title = if @view_template == "404.html", do: "Page Not Found | MBTA - Massachusetts Bay Transportation Authority", else: title_breadcrumbs(@conn) %>
-    <title><%= title %></title>
-    <link rel="apple-touch-icon" href="<%= static_url(@conn, "/images/mbta-logo-t-180.png") %>" type="image/png">
-    <link rel="icon" href="<%= static_url(@conn, "/images/mbta-logo-t-favicon.png") %>" sizes="32x32" type="image/png">
-    <link rel="icon" href="<%= static_url(@conn, "/favicon.ico") %>" sizes="16x16" type="image/vnd.microsoft.icon">
-
-    <%= if google_tag_manager_id() do %>
-      <link rel="preconnect" href="//www.google-analytics.com">
-    <% end %>
-
-    <link rel="stylesheet" href="<%= static_url(@conn, "/css/core.css") %>" data-turbolinks-track="reload">
-    <link rel="stylesheet" href="<%= static_url(@conn, "/css/app.css") %>" data-turbolinks-track="reload">
-
-    <%= if Application.get_env(:site, :dev_server?) do %>
-      <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/core.js" %>" data-turbolinks-track="reload" ></script>
-      <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/app.js" %>" data-turbolinks-track="reload" ></script>
-    <% else %>
-      <script defer src="<%= static_url(@conn, "/js/vendors.js") %>" data-turbolinks-track="reload"></script>
-      <script defer src="<%= static_url(@conn, "/js/app.js") %>" data-turbolinks-track="reload"></script>
-    <% end %>
-
-    <%= if assigns[:requires_google_maps?] do %>
-      <script type="application/javascript">if (!window.mapsCallback) { window.mapsCallback = function () { window.isMapReady = true; } }</script>
-      <script async src="<%= google_maps_js_url %>"></script>
-    <% else %>
-      <link rel="prefetch" href="<%= google_maps_js_url %>" as="script">
-    <% end %>
-  </head>
+  <%= render "_head.html", assigns %>
   <%= Site.BodyTag.render(@conn) %>
     <div class="body-wrapper" id="body-wrapper">
       <a href="#main" class="sr-only sr-only-focusable" data-turbolinks="false">Skip to main content</a>

--- a/apps/site/lib/site_web/templates/layout/wrapper.html.eex
+++ b/apps/site/lib/site_web/templates/layout/wrapper.html.eex
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+  <%= render "_head.html", assigns %>
+  <%# <body> %>
+  <%= Site.BodyTag.render(@conn) %>
+    <%= content_tag :main, render(@view_module, @view_template, assigns), id: "main", tabindex: -1 %>
+  </body>
+</html>

--- a/apps/site/lib/site_web/templates/reduced_fares/show.html.eex
+++ b/apps/site/lib/site_web/templates/reduced_fares/show.html.eex
@@ -1,0 +1,1 @@
+<iframe src="<%= reduced_fares_url(@conn) %>"></iframe>

--- a/apps/site/lib/site_web/views/reduced_fares_view.ex
+++ b/apps/site/lib/site_web/views/reduced_fares_view.ex
@@ -1,0 +1,30 @@
+defmodule SiteWeb.ReducedFaresView do
+  @moduledoc """
+  View for the Reduced Fares section of the website.
+  """
+  use SiteWeb, :view
+
+  alias Plug.Conn
+
+  @type form_id :: String.t()
+  @type url :: String.t()
+  @type url_mapping :: %{form_id() => url()}
+
+  @spec reduced_fares_url(Conn.t()) :: url()
+  def reduced_fares_url(%Conn{path_info: ["reduced-fares", form_id | _]}) do
+    reduced_fares_urls()
+    |> Map.get(form_id)
+  end
+
+  @spec reduced_fares_urls() :: url_mapping()
+  def reduced_fares_urls do
+    case env(:reduced_fares_urls) do
+      "" -> %{}
+      json -> Poison.Parser.parse!(json)
+    end
+  end
+
+  defp env(key) do
+    Application.get_env(:site, __MODULE__)[key]
+  end
+end

--- a/apps/site/test/site/body_tag_test.exs
+++ b/apps/site/test/site/body_tag_test.exs
@@ -52,5 +52,10 @@ defmodule Site.BodyTagTest do
 
       refute safe_to_string(render(conn)) =~ "no-js cms-preview"
     end
+
+    test "returns 'c-iframe-wrapper' for the /reduced-fares/* path" do
+      conn = %{build_conn() | path_info: ["reduced-fares", "youth-pass"]}
+      assert safe_to_string(render(conn)) =~ "c-iframe-wrapper"
+    end
   end
 end

--- a/apps/site/test/site_web/controllers/reduced_fares_controller_test.exs
+++ b/apps/site/test/site_web/controllers/reduced_fares_controller_test.exs
@@ -1,4 +1,4 @@
-defmodule SiteWeb.StyleGuideControllerTest do
+defmodule SiteWeb.ReducedFaresControllerTest do
   use SiteWeb.ConnCase
 
   test "renders a wrapper page with the requested form embedded in an iframe", %{conn: conn} do

--- a/apps/site/test/site_web/controllers/reduced_fares_controller_test.exs
+++ b/apps/site/test/site_web/controllers/reduced_fares_controller_test.exs
@@ -4,7 +4,7 @@ defmodule SiteWeb.ReducedFaresControllerTest do
   test "renders a wrapper page with the requested form embedded in an iframe", %{conn: conn} do
     conn = get(conn, "/reduced-fares/youth-pass")
     rendered = html_response(conn, 200)
-    assert rendered =~ "body"
+    assert rendered =~ "iframe"
   end
 
   test "a request for an unknown form returns a 404", %{conn: conn} do

--- a/apps/site/test/site_web/controllers/reduced_fares_controller_test.exs
+++ b/apps/site/test/site_web/controllers/reduced_fares_controller_test.exs
@@ -1,14 +1,50 @@
 defmodule SiteWeb.ReducedFaresControllerTest do
   use SiteWeb.ConnCase
 
+  @youth_pass_url "https://example.com/TEST-YOUTH-PASS-FORM-URL"
+
   test "renders a wrapper page with the requested form embedded in an iframe", %{conn: conn} do
+    original_env = Application.get_env(:site, SiteWeb.ReducedFaresView)
+
+    on_exit(fn ->
+      Application.put_env(
+        :site,
+        SiteWeb.ReducedFaresView,
+        original_env
+      )
+    end)
+
+    Application.put_env(
+      :site,
+      SiteWeb.ReducedFaresView,
+      reduced_fares_urls: Poison.encode!(%{"youth-pass" => @youth_pass_url})
+    )
+
     conn = get(conn, "/reduced-fares/youth-pass")
     rendered = html_response(conn, 200)
+
     assert rendered =~ "iframe"
   end
 
   test "a request for an unknown form returns a 404", %{conn: conn} do
+    original_env = Application.get_env(:site, SiteWeb.ReducedFaresView)
+
+    on_exit(fn ->
+      Application.put_env(
+        :site,
+        SiteWeb.ReducedFaresView,
+        original_env
+      )
+    end)
+
+    Application.put_env(
+      :site,
+      SiteWeb.ReducedFaresView,
+      reduced_fares_urls: Poison.encode!(%{"youth-pass" => @youth_pass_url})
+    )
+
     conn = get(conn, "/reduced-fares/unknown-form")
+
     assert html_response(conn, 404)
   end
 end

--- a/apps/site/test/site_web/controllers/reduced_fares_controller_test.exs
+++ b/apps/site/test/site_web/controllers/reduced_fares_controller_test.exs
@@ -1,0 +1,14 @@
+defmodule SiteWeb.StyleGuideControllerTest do
+  use SiteWeb.ConnCase
+
+  test "renders a wrapper page with the requested form embedded in an iframe", %{conn: conn} do
+    conn = get(conn, "/reduced-fares/youth-pass")
+    rendered = html_response(conn, 200)
+    assert rendered =~ "body"
+  end
+
+  test "a request for an unknown form returns a 404", %{conn: conn} do
+    conn = get(conn, "/reduced-fares/unknown-form")
+    assert html_response(conn, 404)
+  end
+end

--- a/apps/site/test/site_web/controllers/schedule/green_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/green_test.exs
@@ -111,7 +111,7 @@ defmodule SiteWeb.ScheduleController.GreenTest do
     assert "place-sthld" in all_stops
     assert "place-clmnl" in all_stops
     assert "place-river" in all_stops
-    assert "place-hsmnl" in all_stops
+    assert "place-brmnl" in all_stops
   end
 
   test "line tab :all_stops is a list of {bubble_info, %RouteStops{}} for all stops on all branches",

--- a/apps/site/test/site_web/views/reduced_fares_view_test.exs
+++ b/apps/site/test/site_web/views/reduced_fares_view_test.exs
@@ -1,0 +1,58 @@
+defmodule SiteWeb.ReducedFaresViewTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias SiteWeb.ReducedFaresView
+
+  @youth_pass_url "https://example.com/TEST-YOUTH-PASS-FORM-URL"
+
+  describe "reduced_fares_url/1" do
+    test "returns the URL for the current form" do
+      original_env = Application.get_env(:site, SiteWeb.ReducedFaresView)
+
+      on_exit(fn ->
+        Application.put_env(
+          :site,
+          SiteWeb.ReducedFaresView,
+          original_env
+        )
+      end)
+
+      Application.put_env(
+        :site,
+        SiteWeb.ReducedFaresView,
+        reduced_fares_urls: Poison.encode!(%{"youth-pass" => @youth_pass_url})
+      )
+
+      conn = %{Phoenix.ConnTest.build_conn() | path_info: ["reduced-fares", "youth-pass"]}
+
+      assert ReducedFaresView.reduced_fares_url(conn) == @youth_pass_url
+    end
+  end
+
+  describe "reduced_fares_urls/0" do
+    test "returns a map of form IDs to URLs" do
+      original_env = Application.get_env(:site, SiteWeb.ReducedFaresView)
+
+      on_exit(fn ->
+        Application.put_env(
+          :site,
+          SiteWeb.ReducedFaresView,
+          original_env
+        )
+      end)
+
+      reduced_fares_url_mapping = %{
+        "youth-pass" => @youth_pass_url
+      }
+
+      Application.put_env(
+        :site,
+        SiteWeb.ReducedFaresView,
+        reduced_fares_urls: Poison.encode!(reduced_fares_url_mapping)
+      )
+
+      assert ReducedFaresView.reduced_fares_urls() == reduced_fares_url_mapping
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Make a wrapper page for the Youth Pass form](https://app.asana.com/0/1200240595613188/1200716785062691)

The Youth Pass form is the first of a series of reduced fares forms that
will be hosted by SimpliGov. Use a custom wrapper layout to embed an
iframe. The iframe fills the viewport, there are no visible elements
from this project. In the future we will add support for Google
Analytics and potentially additional user analytics tools.

Add configuration support for per-environment reduced fares form URLs.

**Action Item**

After this is approved but before merging I will define the new environment variable in each environment (dotcom-dev, dotcom-dev-blue, dotcom-dev-green, and dotcom-prod). I'll start with the pre-production version of the form (https://mbta.preprod.simpligov.com/preprod/portal/ShowWorkFlow/AnonymousEmbed/86cadfa6-e8ea-46f1-b6e8-62498f066962) and later we can update prod to point to the production version once it is live.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic?
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
