### PR TITLE
Do not hide schedule and maps tab when mobile for CR

### DIFF
--- a/apps/site/assets/css/_schedule.scss
+++ b/apps/site/assets/css/_schedule.scss
@@ -1026,12 +1026,6 @@ del .trip-list-realtime {
   color: $white;
 
   &.u-bg--commuter-rail {
-    .info-\&-maps-tab,
-    .schedule-\&-maps-tab {
-      @include media-breakpoint-down(xs) {
-        display: none;
-      }
-    }
 
     .info-tab,
     .schedule-tab {

--- a/apps/site/assets/css/_variables.scss
+++ b/apps/site/assets/css/_variables.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import 'colors';
 
 $grid-breakpoints: (
@@ -46,20 +47,20 @@ $space-12: $space-16 * .75;
 $space-18: $space-12 * 1.5;
 $space-24: $space-12 * 2;
 $space-36: $space-16 * 2.25;
-$space-8: $space-16 / 2; // 8px real, 4px Zeplin
-$space-6: $space-12 / 2; // 6px real, 3px Zeplin
-$space-4: $space-12 / 4; // 3px real, 1.5px Zeplin
-$space-2: $space-12 / 6; // 2px real, 1px Zeplin
-$space-1: $space-12 / 12; // 1px real, 0.5px Zeplin
+$space-8: math.div($space-16, 2); // 8px real, 4px Zeplin
+$space-6: math.div($space-12, 2); // 6px real, 3px Zeplin
+$space-4: math.div($space-12, 4); // 3px real, 1.5px Zeplin
+$space-2: math.div($space-12, 6); // 2px real, 1px Zeplin
+$space-1: math.div($space-12, 12); // 1px real, 0.5px Zeplin
 
 $base-spacing: $space-16;
 $base-spacing-sm: $space-8;
 $base-spacing-lg: $space-24;
 $base-spacing-xl: $space-36;
 
-$homepage-gutter: $base-spacing / 2;
-$half-gutter: $grid-gutter-width / 2;
-$col-width: 100% / $grid-columns;
+$homepage-gutter: math.div($base-spacing, 2);
+$half-gutter: math.div($grid-gutter-width, 2);
+$col-width: math.div(100%, $grid-columns);
 
 $font-family-base: 'Inter UI', $font-family-sans-serif;
 $headings-font-family: 'Helvetica Neue', Helvetica, Arial, $font-family-sans-serif;


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [CR Schedules | Schedules & Maps tab disappears on mobile](https://app.asana.com/0/1200650448662357/1200689234093004)

There was a CSS rule to hide the tab, I assume this must be an old snippet that was forgotten. Tab does not hide anymore!

**Before**:<br/>
<img width="491" alt="Screen Shot 2021-07-29 at 3 22 47 PM" src="https://user-images.githubusercontent.com/61979382/128905745-eac002a0-b32e-45c3-a91d-c993fb2b1630.png">


**After**:<br/>
<img width="300" alt="Screen Shot 2021-08-10 at 13 21 29" src="https://user-images.githubusercontent.com/61979382/128905790-791c5772-45f0-4cc9-b42e-8047e7c8b13f.png">
