### PR TITLE
Show scheduled time (not predicted) for CR when status is 'on time'

### DIFF
--- a/apps/site/assets/ts/components/__tests__/HeadsignTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/HeadsignTest.tsx
@@ -289,3 +289,28 @@ it("it displays cancelled status for CR", () => {
     wrapper.find(".m-tnm-sidebar__time-number.strikethrough").exists()
   ).toBeTruthy();
 });
+
+it("it displays on time status with the scheduled time and not the prediction time for CR", () => {
+  const headsign: Headsign = {
+    name: "Worcester",
+    train_number: "511",
+    times: [
+      {
+        delay: -1,
+        scheduled_time: ["10:21", " ", "AM"],
+        prediction: {
+          schedule_relationship: null,
+          time: ["10:19", " ", "AM"],
+          status: null,
+          track: null
+        }
+      }
+    ]
+  };
+  createReactRoot();
+  const tree = renderer.create(
+    <HeadsignComponent headsign={headsign} condensed={true} routeType={2} />
+  );
+  // should display 10:21 AM and On time
+  expect(tree.toJSON()).toMatchSnapshot();
+});

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/HeadsignTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/HeadsignTest.tsx.snap
@@ -48,6 +48,49 @@ exports[`it displays delayed status for CR 1`] = `
 </div>
 `;
 
+exports[`it displays on time status with the scheduled time and not the prediction time for CR 1`] = `
+<div
+  className="m-tnm-sidebar__headsign-schedule m-tnm-sidebar__headsign-schedule--condensed"
+>
+  <div
+    className="m-tnm-sidebar__headsign"
+  >
+    <div
+      className="m-tnm-sidebar__headsign-name m-tnm-sidebar__headsign-name--large"
+    >
+      Worcester
+    </div>
+    <div
+      className="m-tnm-sidebar__headsign-train"
+    >
+      Train 511
+    </div>
+  </div>
+  <div
+    className="m-tnm-sidebar__schedules"
+  >
+    <div
+      className="m-tnm-sidebar__schedule"
+    >
+      <div
+        className="m-tnm-sidebar__time m-tnm-sidebar__time--commuter-rail  "
+      >
+        <div
+          className=" m-tnm-sidebar__time-number"
+        >
+          10:21 AM
+        </div>
+        <div
+          className="m-tnm-sidebar__status"
+        >
+          On time
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`it renders 2 predictions 1`] = `
 <div
   className="m-tnm-sidebar__headsign-schedule"

--- a/apps/site/assets/ts/helpers/__tests__/date-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/date-test.ts
@@ -1,0 +1,18 @@
+import { compareStringTimes } from "../date";
+
+describe("compareStringTimes", () => {
+  it.each`
+    time1                   | time2                   | result
+    ${["9:05", " ", "AM"]}  | ${["9:08", " ", "AM"]}  | ${"lt"}
+    ${["9:05", " ", "AM"]}  | ${["9:05", " ", "AM"]}  | ${"eq"}
+    ${["9:08", " ", "AM"]}  | ${["9:05", " ", "AM"]}  | ${"gt"}
+    ${["11:55", " ", "AM"]} | ${["1:10", " ", "PM"]}  | ${"lt"}
+    ${["9:08", " ", "AM"]}  | ${["9:05", " ", "PM"]}  | ${"lt"}
+    ${["9:08", " ", "PM"]}  | ${["10:05", " ", "AM"]} | ${"gt"}
+  `(
+    "comparing times has expected result $result",
+    ({ time1, time2, result }) => {
+      expect(compareStringTimes(time1, time2)).toEqual(result);
+    }
+  );
+});

--- a/apps/site/assets/ts/helpers/date.ts
+++ b/apps/site/assets/ts/helpers/date.ts
@@ -36,4 +36,26 @@ export const shortDate = (date: Date): string =>
     timeZone: "UTC"
   });
 
+export const compareStringTimes = (
+  timeStr1: string[],
+  timeStr2: string[]
+): string => {
+  const today = new Date();
+  const dateFormatted = new Intl.DateTimeFormat("en-US").format(today);
+
+  const fullDate1 = `${dateFormatted} ${timeStr1.join("")}`; // "11/24/2013 2:10 PM"
+  const fullDate2 = `${dateFormatted} ${timeStr2.join("")}`;
+
+  const timeInMs1 = new Date(fullDate1).getTime();
+  const timeInMs2 = new Date(fullDate2).getTime();
+
+  let comparison = "eq";
+  if (timeInMs1 < timeInMs2) {
+    comparison = "lt";
+  } else if (timeInMs1 > timeInMs2) {
+    comparison = "gt";
+  }
+  return comparison;
+};
+
 export default formattedDate;

--- a/apps/site/assets/ts/helpers/prediction-helpers.tsx
+++ b/apps/site/assets/ts/helpers/prediction-helpers.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react";
 import { PredictedOrScheduledTime } from "../__v3api";
 import { isSkippedOrCancelled } from "../models/prediction";
 import { TripPrediction } from "../schedule/components/__trips";
+import { compareStringTimes } from "./date";
 
 const delayForCommuterRail = (
   data: PredictedOrScheduledTime,
@@ -27,7 +28,18 @@ export const timeForCommuterRail = (
     return delayForCommuterRail(data, className);
   }
 
-  const time = prediction ? prediction.time : scheduledTime;
+  let time = prediction ? prediction.time : scheduledTime;
+
+  // when 'On time', show the scheduled time only if it's later than the predicted time:
+  if (
+    scheduledTime &&
+    prediction &&
+    prediction.time[2] !== "min" &&
+    compareStringTimes(prediction.time, scheduledTime) === "lt"
+  ) {
+    // "On time"
+    time = scheduledTime;
+  }
 
   return <div className={className}>{time!.join("")}</div>;
 };

--- a/apps/site/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
@@ -305,6 +305,18 @@ it("renders a CR component", () => {
   expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
 });
 
+it("can render green line", () => {
+  createReactRoot();
+  const tree = mount(getGreenLineComponent());
+  expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
+});
+
+it("respects the initially selected pattern ID, if specified", () => {
+  createReactRoot();
+  const tree = mount(getVariantComponent());
+  expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
+});
+
 it.skip("renders with a static map", () => {
   // FIXME: An update to Enzyme made the <LineDiagram> disappear from this
   // snapshot. It's unclear why only this one is affected, but we may have been
@@ -428,6 +440,47 @@ it("can change route pattern for bus mode (accessible)", () => {
     .simulate("click");
 
   wrapper.find("#route-pattern_uncommon").simulate("keyUp", { key: "Enter" });
+});
+
+it("can change route for green line with click", () => {
+  const stubFn = jest
+    .spyOn(window.location, "assign")
+    .mockImplementation(url => url);
+
+  document.body.innerHTML = body;
+  const component = getGreenLineComponent();
+  const wrapper = mount(component);
+
+  // click to open
+  wrapper
+    .find(".m-schedule-direction__route-pattern--clickable")
+    .simulate("click");
+  expect(wrapper.find(".m-schedule-direction__menu").exists()).toEqual(true);
+
+  // enter to close
+  wrapper
+    .find(".m-schedule-direction__route-pattern--clickable")
+    .simulate("keyUp", { key: "Enter" });
+  expect(wrapper.find(".m-schedule-direction__menu").exists()).toEqual(false);
+
+  // open again
+  wrapper
+    .find(".m-schedule-direction__route-pattern--clickable")
+    .simulate("click");
+
+  // click and item
+  wrapper.find("#route-pattern_Green-C").simulate("click");
+  expect(stubFn).toHaveBeenCalledTimes(1);
+  expect(stubFn).toHaveBeenCalledWith("/schedules/Green-C?direction_id=1");
+
+  // enter on an item
+  wrapper.find("#route-pattern_Green-D").simulate("keyUp", { key: "Enter" });
+  expect(stubFn).toHaveBeenCalledWith("/schedules/Green-C?direction_id=1");
+
+  // get code coverage of keyboard navigation
+  wrapper
+    .find("#route-pattern_Green")
+    .simulate("keydown", { key: "ArrowRight" });
 });
 
 it("reducer can change state correctly for closeRoutePatternMenu", () => {
@@ -558,57 +611,4 @@ describe("fetchLineData", () => {
       });
     });
   });
-});
-
-it("can render green line", () => {
-  createReactRoot();
-  const tree = mount(getGreenLineComponent());
-  expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
-});
-
-it("can change route for green line with click", () => {
-  const stubFn = jest
-    .spyOn(window.location, "assign")
-    .mockImplementation(url => url);
-
-  document.body.innerHTML = body;
-  const component = getGreenLineComponent();
-  const wrapper = mount(component);
-
-  // click to open
-  wrapper
-    .find(".m-schedule-direction__route-pattern--clickable")
-    .simulate("click");
-  expect(wrapper.find(".m-schedule-direction__menu").exists()).toEqual(true);
-
-  // enter to close
-  wrapper
-    .find(".m-schedule-direction__route-pattern--clickable")
-    .simulate("keyUp", { key: "Enter" });
-  expect(wrapper.find(".m-schedule-direction__menu").exists()).toEqual(false);
-
-  // open again
-  wrapper
-    .find(".m-schedule-direction__route-pattern--clickable")
-    .simulate("click");
-
-  // click and item
-  wrapper.find("#route-pattern_Green-C").simulate("click");
-  expect(stubFn).toHaveBeenCalledTimes(1);
-  expect(stubFn).toHaveBeenCalledWith("/schedules/Green-C?direction_id=1");
-
-  // enter on an item
-  wrapper.find("#route-pattern_Green-D").simulate("keyUp", { key: "Enter" });
-  expect(stubFn).toHaveBeenCalledWith("/schedules/Green-C?direction_id=1");
-
-  // get code coverage of keyboard navigation
-  wrapper
-    .find("#route-pattern_Green")
-    .simulate("keydown", { key: "ArrowRight" });
-});
-
-it("respects the initially selected pattern ID, if specified", () => {
-  createReactRoot();
-  const tree = mount(getVariantComponent());
-  expect(enzymeToJsonWithoutProps(tree)).toMatchSnapshot();
 });

--- a/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
+++ b/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
@@ -472,7 +472,7 @@ exports[`render it renders 1`] = `
                       <div
                         className=" m-tnm-sidebar__time-number"
                       >
-                        5:53 PM
+                        5:54 PM
                       </div>
                       <div
                         className="m-tnm-sidebar__status"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏱ Schedules | "Arrival" time is confusing to customers](https://app.asana.com/0/555089885850811/1200119447648715)

Putting this together in case it's a valid solution.<br/>
I just added a slight modification whenever the commuter rail's status is 'On time'. If so, the time displayed is the one from the scheduled time and not the prediction.