### PR TITLE
Include prediction in the tooltip for vehicle

### DIFF
--- a/apps/site/assets/ts/schedule/components/Map.tsx
+++ b/apps/site/assets/ts/schedule/components/Map.tsx
@@ -82,18 +82,24 @@ export const iconOpts = (
 const zIndex = (icon: string | null): number | undefined =>
   icon === "vehicle-bordered-expanded" ? 1000 : undefined;
 
-const updateMarker = (marker: Marker): Marker => ({
+export const updateMarker = (marker: Marker): Marker => ({
   ...marker,
   tooltip: (
-    <div>
+    <>
       {marker.vehicle_crowding && (
         <>
           <CrowdingPill crowding={marker.vehicle_crowding} />
           <br />
         </>
       )}
-      {marker.tooltip_text}
-    </div>
+      {/* marker.tooltip_text can contain just the name of the stop OR some markup with the vehicle and prediction info */}
+      {marker.tooltip_text && (
+        <div
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: marker.tooltip_text }}
+        />
+      )}
+    </>
   ),
   icon_opts: iconOpts(marker.icon), // eslint-disable-line camelcase
   z_index: zIndex(marker.icon) // eslint-disable-line camelcase

--- a/apps/site/assets/ts/schedule/components/__tests__/MapTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/MapTest.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
-import Map, { iconOpts, reducer } from "../Map";
+import Map, { iconOpts, reducer, updateMarker } from "../Map";
 import {
   MapData,
   MapMarker as Marker
@@ -194,5 +194,25 @@ describe("iconOpts", () => {
 
   it("does not throw error when icon is null", () => {
     expect(iconOpts(null)).toEqual({});
+  });
+
+  it("creates a tooltip containing track info (for Commuter Rail)", () => {
+    const vehicleMarkerWithTrackInfo: Marker = {
+      icon: "vehicle-bordered-expanded",
+      latitude: 42.43668,
+      longitude: -71.071097,
+      rotation_angle: 0,
+      tooltip: null,
+      id: "veh2",
+      z_index: 1000,
+      tooltip_text:
+        "<p class='prediction-tooltip'>Train has arrived on Track 9 and ¾</p>"
+    };
+
+    const updatedMarker = updateMarker(vehicleMarkerWithTrackInfo);
+
+    const wrapper = mount(<>{updatedMarker.tooltip}</>);
+
+    expect(wrapper.html()).toContain("Train has arrived on Track 9 and ¾");
   });
 });

--- a/apps/site/lib/site_web/channels/vehicle_channel.ex
+++ b/apps/site/lib/site_web/channels/vehicle_channel.ex
@@ -45,6 +45,15 @@ defmodule SiteWeb.VehicleChannel do
     stop_name = get_stop_name(vehicle.stop_id)
     trip = Schedules.Repo.trip(vehicle.trip_id)
 
+    prediction =
+      Predictions.Repo.all(
+        route: vehicle.route_id,
+        stop: vehicle.stop_id,
+        trip: vehicle.trip_id,
+        direction_id: vehicle.direction_id
+      )
+      |> List.first()
+
     %{
       data: %{vehicle: vehicle, stop_name: stop_name},
       marker:
@@ -58,14 +67,13 @@ defmodule SiteWeb.VehicleChannel do
           vehicle_crowding: vehicle.crowding,
           tooltip_text:
             %VehicleTooltip{
-              prediction: nil,
+              prediction: prediction,
               vehicle: vehicle,
               route: route,
               stop_name: stop_name,
               trip: trip
             }
             |> VehicleHelpers.tooltip()
-            |> Floki.text()
         )
     }
   end

--- a/apps/site/test/leaflet/map_data/polyline_test.exs
+++ b/apps/site/test/leaflet/map_data/polyline_test.exs
@@ -15,7 +15,7 @@ defmodule Leaflet.MapData.PolylineTest do
 
       assert color == "#FF0000"
       assert [first | _] = positions
-      assert first == [42.37427, -71.11901]
+      assert first == [42.37428, -71.119]
     end
 
     test "makes polyline with default options" do
@@ -27,7 +27,7 @@ defmodule Leaflet.MapData.PolylineTest do
 
       assert color == "#000000"
       assert [first | _] = positions
-      assert first == [42.37427, -71.11901]
+      assert first == [42.37428, -71.119]
     end
   end
 end

--- a/apps/stops/test/nearby_test.exs
+++ b/apps/stops/test/nearby_test.exs
@@ -187,6 +187,7 @@ defmodule Stops.NearbyTest do
         {"65", 1},
         {"8", 0},
         {"8", 1},
+        {"9", 1},
         {"Green-B", 0},
         {"Green-B", 1},
         {"Green-C", 0},


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add arriving track number to vehicle tooltip on the timetable, line diagram, and map when we have it](https://app.asana.com/0/1200650448662357/1199653833933398)

`prediction` is now part of the information passed to `VehicleHelpers.tooltip` so we can grab the track number (if available) to display in both the map and the timetable.