### PR TITLE
feat: Add class name when map tiles loaded

### DIFF
--- a/apps/site/assets/ts/leaflet/components/Map.tsx
+++ b/apps/site/assets/ts/leaflet/components/Map.tsx
@@ -74,8 +74,15 @@ const Component = ({
     const boundsOrByMarkers = bounds || (boundsByMarkers && getBounds(markers));
     const position = mapCenter(markers, defaultCenter);
     const nonNullZoom = zoom === null ? undefined : zoom;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mapRef = React.createRef<any>();
+    const onTilesLoaded = (): void => {
+      mapRef.current.container.parentElement.classList += " map--loaded";
+    };
+
     return (
       <Map
+        ref={mapRef}
         bounds={boundsOrByMarkers}
         center={position}
         zoom={nonNullZoom}
@@ -84,6 +91,7 @@ const Component = ({
         <TileLayer
           attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url={`${tileServerUrl}/osm_tiles/{z}/{x}/{y}.png`}
+          onload={onTilesLoaded}
         />
         {polylines.map(
           /* istanbul ignore next */

--- a/apps/site/assets/ts/schedule/components/__tests__/MapTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/MapTest.tsx
@@ -5,6 +5,7 @@ import {
   MapData,
   MapMarker as Marker
 } from "../../../leaflet/components/__mapdata";
+import { TileLayer } from "react-leaflet";
 
 /* eslint-disable camelcase */
 const data: MapData = {
@@ -64,6 +65,39 @@ describe("Schedule Map", () => {
       />
     );
     expect(() => wrapper.render()).not.toThrow();
+  });
+
+  it("renders and matches snapshot", () => {
+    const wrapper = mount(
+      <Map
+        data={data}
+        channel="vehicles:Red:0"
+        currentShapes={["1", "2"]}
+        currentStops={["stop-place-alfcl", "22", "33"]}
+      />
+    );
+    expect(wrapper.debug()).toMatchSnapshot();
+  });
+
+  it("adds class name after map load", () => {
+    const wrapper = mount(
+      <Map
+        data={data}
+        channel="vehicles:Red:0"
+        currentShapes={["1", "2"]}
+        currentStops={["stop-place-alfcl", "22", "33"]}
+      />
+    );
+
+    expect(wrapper.html()).not.toContain("map--loaded");
+
+    const onMapLoad: Function = wrapper.find(TileLayer).prop("onload");
+    expect(onMapLoad).toBeInstanceOf(Function);
+
+    // simulate the map load event being fired
+    onMapLoad();
+
+    expect(wrapper.html()).toContain("map--loaded");
   });
 });
 

--- a/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/MapTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/MapTest.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Schedule Map renders and matches snapshot 1`] = `
+"<Component data={{...}} channel=\\"vehicles:Red:0\\" currentShapes={{...}} currentStops={{...}}>
+  <div className=\\"m-schedule__map\\">
+    <Component bounds={{...}} mapData={{...}}>
+      <Map bounds={{...}} center={{...}} zoom={16} maxZoom={18} minZoom={9} scrollWheelZoom={false} style={{...}}>
+        <div className={[undefined]} id={[undefined]} style={{...}}>
+          <ForwardRef(Leaflet(TileLayer)) attribution=\\"&copy <a href=\\"http://osm.org/copyright\\">OpenStreetMap</a> contributors\\" url=\\"https://mbta-map-tiles-dev.s3.amazonaws.com/osm_tiles/{z}/{x}/{y}.png\\" onload={[Function: onTilesLoaded]}>
+            <TileLayer attribution=\\"&copy <a href=\\"http://osm.org/copyright\\">OpenStreetMap</a> contributors\\" url=\\"https://mbta-map-tiles-dev.s3.amazonaws.com/osm_tiles/{z}/{x}/{y}.png\\" onload={[Function: onTilesLoaded]} leaflet={{...}} />
+          </ForwardRef(Leaflet(TileLayer))>
+          <ForwardRef(Leaflet(Marker)) icon={{...}} position={{...}} zIndexOffset={[undefined]} keyboard={false}>
+            <Marker icon={{...}} position={{...}} zIndexOffset={[undefined]} keyboard={false} leaflet={{...}}>
+              <ForwardRef(Leaflet(Popup)) maxHeight={175}>
+                <Popup maxHeight={175} leaflet={{...}} pane=\\"popupPane\\" />
+              </ForwardRef(Leaflet(Popup))>
+            </Marker>
+          </ForwardRef(Leaflet(Marker))>
+          <ForwardRef(Leaflet(FullscreenControl))>
+            <FullscreenControl leaflet={{...}} />
+          </ForwardRef(Leaflet(FullscreenControl))>
+        </div>
+      </Map>
+    </Component>
+  </div>
+</Component>"
+`;


### PR DESCRIPTION
Asana ticket TBA

This change listens to Leaflet's `onload` event to add a class to the component after all visible tiles have loaded.

I plan to use that class in the future to get visual tests to wait until all the tiles are loaded before taking a screenshot!