### PR TITLE
fix(Application): Make SiteWeb.Endpoint last child

### DIFF
--- a/apps/site/lib/site/application.ex
+++ b/apps/site/lib/site/application.ex
@@ -31,11 +31,11 @@ defmodule Site.Application do
         ],
         [name: :line_diagram_realtime_cache]
       ]),
-      supervisor(SiteWeb.Endpoint, []),
       supervisor(Site.GreenLine.Supervisor, []),
       supervisor(Site.Stream.Vehicles, []),
       supervisor(Site.React, []),
-      supervisor(Site.RealtimeSchedule, [])
+      supervisor(Site.RealtimeSchedule, []),
+      supervisor(SiteWeb.Endpoint, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html


### PR DESCRIPTION
Now the endpoint will wait for the other processes to initialize before itself starting.

Asana ticket: [Tech Debt | Call supervisor children in correct order](https://app.asana.com/0/385363666817452/1200943226791246/f)
