### PR TITLE
a few Cypress enhancements

### DIFF
--- a/apps/site/config/dev.exs
+++ b/apps/site/config/dev.exs
@@ -5,10 +5,13 @@ use Mix.Config
 #
 # The watchers configuration can be used to run external
 # watchers to your application. For example, we use it
-# with brunch.io to recompile .js and .css sources.
+# with Webpack to recompile .js and .css sources.
 
 port = String.to_integer(System.get_env("PORT") || "4001")
 host = System.get_env("HOST") || "localhost"
+
+Mix.shell().info([:green, "Starting dev server on " <> host <> ":" <> Integer.to_string(port)])
+
 webpack_port = String.to_integer(System.get_env("WEBPACK_PORT") || "8090")
 
 static_url =

--- a/cypress/integration/customer-support-form/support_form.spec.js
+++ b/cypress/integration/customer-support-form/support_form.spec.js
@@ -2,7 +2,7 @@ import faker from "../../../apps/site/assets/node_modules/faker/locale/en_US";
 
 describe("Customer Support Form", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:4004/customer-support");
+    cy.visit("/customer-support");
   });
 
   it("shows an error state for missing type and comments", () => {

--- a/cypress/integration/screenshots.spec.js
+++ b/cypress/integration/screenshots.spec.js
@@ -1,0 +1,17 @@
+/** Take and compare screenshots of pages and elements.
+ * If it goes well it might be the basis for some regression tests!
+ */
+
+describe.skip("Screenshots look good:", () => {
+  afterEach(() => {
+    cy.takeFullScreenshot();
+  });
+  
+  [
+    "/",
+    "/stops/subway"
+  ]
+  .forEach((url) => {
+    it(url, () => { cy.visit(url) });
+  });
+});

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -19,4 +19,11 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  const port = process.env.PORT;
+  if (!port) {
+    throw new Error(`missing PORT environment variable`)
+  }
+
+  config.baseUrl = `http://localhost:${port}`;
+  return config
 };

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -67,3 +67,23 @@ Cypress.Commands.add("selectRandomServiceAndSubject", () => {
         .as("selectedSubject");
     });
 });
+
+/**
+ * Use the same way as cy.screenshot()
+ * 
+ * This includes a hack so that full page snapshots can be properly captured.
+ */
+Cypress.Commands.add("takeFullScreenshot", (subject, name, options={}) => {
+  /**
+   * Hack for dealing with screenshots.
+   * See Cypress bugs: https://github.com/cypress-io/cypress/issues/2681
+   * and https://github.com/cypress-io/cypress/issues/3200
+   */
+  cy.get('html')
+    .invoke('css', 'height', 'initial')
+    .invoke('css', 'scrollBehavior', 'initial');
+  cy.get('body').invoke('css', 'height', 'initial');
+
+  cy.wait(100);
+  cy.screenshot(subject, name, options);
+});

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "backstop:approve": "cd apps/site/test && ../assets/node_modules/.bin/backstop approve",
     "backstop:test": "cd apps/site/test && ../assets/node_modules/.bin/backstop test --docker",
     "dialyzer": "mix dialyzer --halt-exit-status",
-    "cypress:run": "$(npm bin --prefix apps/site/assets)/cypress run",
-    "cypress:open": "$(npm bin --prefix apps/site/assets)/cypress open",
+    "cypress:run": "PORT=4004 $(npm bin --prefix apps/site/assets)/cypress run",
+    "cypress:open": "PORT=4004 $(npm bin --prefix apps/site/assets)/cypress open",
     "test:cypress:run": "$(npm bin --prefix apps/site/assets)/start-server-and-test 'MIX_ENV=test PORT=4004 mix phx.server' 4004 cypress:run",
     "test:cypress:open": "$(npm bin --prefix apps/site/assets)/start-server-and-test 'MIX_ENV=test PORT=4004 mix phx.server' 4004 cypress:open"
   }


### PR DESCRIPTION
Asana ticket [Assorted fixes for aiding consistent snapshot recording](https://app.asana.com/0/385363666817452/1200881265733025/f)

Not much to _see_ here but if you unskip the new tests you can see the screenshots it generates! I didn't want to commit screenshots to this repo quite yet, so that's why the tests that create the screenshots are skipped here.

Also threw in the ability to specify a port to run tests on on the fly, and added a baseUrl configuration so that tests don't have to specify the base URL every time.