### PR TITLE
fix(LineDiagram): Don't poll live data for ferry

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -149,9 +149,16 @@ const LineDiagramAndStopListPage = ({
 
   /**
    * Live data, including realtime vehicle locations and predictions
+   * Available on all modes except ferry (route.type 4)
    */
+  const liveUrl =
+    route.type !== 4
+      ? `/schedules/line_api/realtime?id=${
+          route.id
+        }&direction_id=${directionId}`
+      : "";
   const { data: maybeLiveData } = useSWR(
-    `/schedules/line_api/realtime?id=${route.id}&direction_id=${directionId}`,
+    liveUrl,
     url => fetch(url).then(response => response.json()),
     { refreshInterval: 15000 }
   );


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Don't poll for live data on the ferry pages](https://app.asana.com/0/385363666817452/1200767316460648/f)

To be honest I'm not sure _why_ conditionally defining the URL as `""` works to achieve my goal. The internal workings of `useSWR` are beyond me. But it totally stops polling `/realtime` on ferry pages!

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
