### PR TITLE
Massport trip plan fix

### DIFF
--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -65,6 +65,7 @@ defmodule Routes.Route do
   def type_atom("ferry"), do: :ferry
   def type_atom("909"), do: :logan_express
   def type_atom("983"), do: :massport_shuttle
+  def type_atom("Massport-1"), do: :massport_shuttle
 
   @spec types_for_mode(gtfs_route_type | subway_lines_type) :: [0..4]
   def types_for_mode(:subway), do: [0, 1]

--- a/apps/routes/test/route_test.exs
+++ b/apps/routes/test/route_test.exs
@@ -12,7 +12,8 @@ defmodule Routes.RouteTest do
             {3, :bus},
             {4, :ferry},
             {"909", :logan_express},
-            {"983", :massport_shuttle}
+            {"983", :massport_shuttle},
+            {"Massport-1", :massport_shuttle}
           ] do
         assert type_atom(int) == atom
       end

--- a/apps/site/lib/site_web/views/helpers.ex
+++ b/apps/site/lib/site_web/views/helpers.ex
@@ -180,7 +180,10 @@ defmodule SiteWeb.ViewHelpers do
   def mode_name(type) when type in [3, :bus], do: "Bus"
   def mode_name(type) when type in [4, :ferry], do: "Ferry"
   def mode_name(type) when type in ["909", :logan_express], do: "Logan Express"
-  def mode_name(type) when type in ["983", :massport_shuttle], do: "Massport Shuttle"
+
+  def mode_name(type) when type in ["983", "Massport-1", :massport_shuttle],
+    do: "Massport Shuttle"
+
   def mode_name(:access), do: "Access"
   def mode_name(:the_ride), do: "The Ride"
   def mode_name(:mattapan_trolley), do: "Mattapan Trolley"

--- a/apps/site/test/site_web/views/helpers_test.exs
+++ b/apps/site/test/site_web/views/helpers_test.exs
@@ -163,6 +163,7 @@ defmodule SiteWeb.ViewHelpersTest do
     test "returns correct name for custom routes" do
       assert mode_name("909") == "Logan Express"
       assert mode_name("983") == "Massport Shuttle"
+      assert mode_name("Massport-1") == "Massport Shuttle"
     end
   end
 

--- a/apps/trip_plan/lib/trip_plan/leg.ex
+++ b/apps/trip_plan/lib/trip_plan/leg.ex
@@ -106,8 +106,12 @@ defmodule TripPlan.Leg do
        }) do
     route = Routes.Repo.get(route_id)
 
-    Routes.Route.type_atom(route) == :commuter_rail and
-      not Enum.all?([origin_id, destination_id], &Stops.Stop.has_zone?(&1))
+    if route do
+      Routes.Route.type_atom(route) == :commuter_rail and
+        not Enum.all?([origin_id, destination_id], &Stops.Stop.has_zone?(&1))
+    else
+      true
+    end
   end
 
   defp leg_missing_zone?(_), do: false


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trip Planner | 🐛 Massport trip plans don't cause 500 errors](https://app.asana.com/0/385363666817452/1200911564672884/f)

Massports GTFS file was slightly tweaked at the start of Sept, which I believe created this issue! I'd guess most trip plans involving Logan Airport were affected. Here's a fix!

You can test with this trip plan url - /trip-planner?_utf8=✓&plan%5Bfrom%5D=Boston+Logan+Airport&plan%5Bfrom_latitude%5D=42.365396&plan%5Bfrom_longitude%5D=-71.017547&plan%5Bto%5D=Suffolk+Downs&plan%5Bto_latitude%5D=42.390501&plan%5Bto_longitude%5D=-70.997123&plan%5Btime%5D=depart&plan%5Bdate_time%5D%5Bhour%5D=2&plan%5Bdate_time%5D%5Bminute%5D=15&plan%5Bdate_time%5D%5Bam_pm%5D=PM&plan%5Bdate_time%5D%5Bmonth%5D=9&plan%5Bdate_time%5D%5Bday%5D=9&plan%5Bdate_time%5D%5Byear%5D=2021&plan%5Bmodes%5D%5Bsubway%5D=false&plan%5Bmodes%5D%5Bsubway%5D=true&plan%5Bmodes%5D%5Bcommuter_rail%5D=false&plan%5Bmodes%5D%5Bcommuter_rail%5D=true&plan%5Bmodes%5D%5Bbus%5D=false&plan%5Bmodes%5D%5Bbus%5D=true&plan%5Bmodes%5D%5Bferry%5D=false&plan%5Bmodes%5D%5Bferry%5D=true&plan%5Boptimize_for%5D=best_route#plan_result_focus