### PR TITLE
Fix CI tests for Dependabot PRs

### DIFF
--- a/.github/workflows/tests-dependabot.yml
+++ b/.github/workflows/tests-dependabot.yml
@@ -55,7 +55,6 @@ jobs:
     # The Tests
     - name: Linting / TypeScript
       run: npm run ci:lint:ts
-      if: always()
     - name: Linting / JavaScript
       run: npm run ci:lint:js
       if: always()

--- a/.github/workflows/tests-dependabot.yml
+++ b/.github/workflows/tests-dependabot.yml
@@ -1,0 +1,94 @@
+name: CI (Dependabot branches)
+on:
+  pull_request_target:
+    branches: [master]
+
+env:
+  MIX_ENV: test
+  V3_URL: ${{ secrets.V3_URL }}
+  V3_API_KEY: ${{ secrets.V3_API_KEY }}
+  RECAPTCHA_PUBLIC_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+  RECAPTCHA_PRIVATE_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+  OPEN_TRIP_PLANNER_URL: ${{ secrets.OPEN_TRIP_PLANNER_URL }}
+
+# Run everything, no skipping, minimal caching.
+jobs:
+  ci:
+    name: Run entire CI suite
+    if: ${{ contains(github.head_ref, 'dependabot') }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    # ASDF. Used the cached.
+    - uses: asdf-vm/actions/setup@v1
+    - uses: actions/cache@v2
+      with:
+        path: ~/.asdf
+        key: ${{ runner.os }}-asdf-cache-${{ hashFiles('.tool-versions') }}
+      id: asdf-cache
+    - uses: asdf-vm/actions/install@v1
+      if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
+
+    - name: Install Elixir dependencies
+      run: |
+        mix local.hex --force
+        mix local.rebar --force
+        mix deps.get
+
+    - name: Install Node dependencies
+      run: |
+        git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+        npm run install:ci
+
+    # Build assets
+    - run: npm run webpack:build
+      working-directory: apps/site/assets
+    - run: npm run build
+      working-directory: apps/site/react_renderer
+    - run: mix phx.digest
+
+    - name: Build application
+      run: mix compile --warnings-as-errors
+
+    # The Tests
+    - name: Linting / TypeScript
+      run: npm run ci:lint:ts
+      if: always()
+    - name: Linting / JavaScript
+      run: npm run ci:lint:js
+      if: always()
+    - name: Linting / CSS
+      run: npm run ci:lint:scss
+      if: always()
+    - name: Linting / Elixir
+      run: npm run ci:lint:ex
+      if: always()
+    - name: Unit tests / Elixir / --exclude wallaby --cover
+      run: npm run ci:unit:exunit
+      if: always()
+    - name: Unit tests / JavaScript / Mocha
+      run: npm run ci:unit:mocha
+      if: always()
+    - name: Unit tests / JavaScript & TypeScript / Jest
+      run: npm run ci:unit:jest
+      if: always()
+    - name: Type checks / Elixir
+      uses: mbta/actions/dialyzer@v1
+      if: always()
+    - name: Type checks / TypeScript
+      run: npm run ci:types:ts
+      if: always()
+    - name: Formatting / Elixir
+      run: npm run ci:format:ex
+      if: always()
+    - name: Formatting / JavaScript & TypeScript
+      run: npm run ci:format:ts
+      if: always()
+    - name: Integration tests / Elixir
+      run: npm run ci:integration:ex
+      if: always()
+    - name: Integration tests / Cypress
+      run: npm run ci:integration:cypress
+      if: always()

--- a/.github/workflows/tests-dependabot.yml
+++ b/.github/workflows/tests-dependabot.yml
@@ -11,7 +11,7 @@ env:
   RECAPTCHA_PRIVATE_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
   OPEN_TRIP_PLANNER_URL: ${{ secrets.OPEN_TRIP_PLANNER_URL }}
 
-# Run everything, no skipping, minimal caching.
+# Run unit and integration tests, no skipping, minimal caching.
 jobs:
   ci:
     name: Run entire CI suite
@@ -53,37 +53,13 @@ jobs:
       run: mix compile --warnings-as-errors
 
     # The Tests
-    - name: Linting / TypeScript
-      run: npm run ci:lint:ts
-    - name: Linting / JavaScript
-      run: npm run ci:lint:js
-      if: always()
-    - name: Linting / CSS
-      run: npm run ci:lint:scss
-      if: always()
-    - name: Linting / Elixir
-      run: npm run ci:lint:ex
-      if: always()
     - name: Unit tests / Elixir / --exclude wallaby --cover
       run: npm run ci:unit:exunit
-      if: always()
     - name: Unit tests / JavaScript / Mocha
       run: npm run ci:unit:mocha
       if: always()
     - name: Unit tests / JavaScript & TypeScript / Jest
       run: npm run ci:unit:jest
-      if: always()
-    - name: Type checks / Elixir
-      uses: mbta/actions/dialyzer@v1
-      if: always()
-    - name: Type checks / TypeScript
-      run: npm run ci:types:ts
-      if: always()
-    - name: Formatting / Elixir
-      run: npm run ci:format:ex
-      if: always()
-    - name: Formatting / JavaScript & TypeScript
-      run: npm run ci:format:ts
       if: always()
     - name: Integration tests / Elixir
       run: npm run ci:integration:ex

--- a/.github/workflows/tests-dependabot.yml
+++ b/.github/workflows/tests-dependabot.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   ci:
     name: Run entire CI suite
-    if: ${{ contains(github.head_ref, 'dependabot') }}
+    if: ${{ contains(github.head_ref, 'refs/heads/dependabot/') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,7 +172,7 @@ jobs:
     name: Linting / TypeScript
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ts }}
+    if: ${{ needs.file_changes.outputs.ts }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -192,7 +192,7 @@ jobs:
     name: Linting / JavaScript
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.js }}
+    if: ${{ needs.file_changes.outputs.js }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -212,7 +212,7 @@ jobs:
     name: Linting / CSS
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.scss }}
+    if: ${{ needs.file_changes.outputs.scss }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -232,7 +232,7 @@ jobs:
     name: Linting / Elixir
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ex }}
+    if: ${{ needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -250,7 +250,7 @@ jobs:
     name: Unit tests / Elixir / --exclude wallaby --cover
     runs-on: ubuntu-latest
     needs: [setup, file_changes, build_app]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ex }}
+    if: ${{ needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -300,7 +300,7 @@ jobs:
     name: Unit tests / JavaScript / Mocha
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.js }}
+    if: ${{ needs.file_changes.outputs.js }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -320,7 +320,7 @@ jobs:
     name: Unit tests / JavaScript & TypeScript / Jest
     runs-on: ubuntu-latest
     needs: [setup, file_changes, build_app]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && (needs.file_changes.outputs.ts || needs.file_changes.outputs.js) }}
+    if: ${{ needs.file_changes.outputs.ts || needs.file_changes.outputs.js }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -354,7 +354,7 @@ jobs:
     name: Type checks / Elixir
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ex }}
+    if: ${{ needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -372,7 +372,7 @@ jobs:
     name: Type checks / TypeScript
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ts }}
+    if: ${{ needs.file_changes.outputs.ts }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -392,7 +392,7 @@ jobs:
     name: Formatting / Elixir
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ex }}
+    if: ${{ needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -410,7 +410,7 @@ jobs:
     name: Formatting / JavaScript & TypeScript
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && (needs.file_changes.outputs.js || needs.file_changes.outputs.ts) }}
+    if: ${{ needs.file_changes.outputs.js || needs.file_changes.outputs.ts }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -430,7 +430,7 @@ jobs:
     name: Integration tests / Elixir
     runs-on: ubuntu-latest
     needs: [setup, file_changes, build_app]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ex }}
+    if: ${{ needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -468,7 +468,7 @@ jobs:
     name: Integration tests / Cypress
     runs-on: ubuntu-latest
     needs: [setup, file_changes, build_app]
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && (needs.file_changes.outputs.ex || needs.file_changes.outputs.js || needs.file_changes.outputs.ts) }}
+    if: ${{ needs.file_changes.outputs.ex || needs.file_changes.outputs.js || needs.file_changes.outputs.ts }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   setup:
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') }}
+    if: ${{ !contains(github.head_ref, 'refs/heads/dependabot/') }}
     name: Before all / Load cached deps
     runs-on: ubuntu-latest
     outputs:
@@ -81,7 +81,7 @@ jobs:
         npm run install:ci
 
   build_app:
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') }}
+    if: ${{ !contains(github.head_ref, 'refs/heads/dependabot/') }}
     name: Build & cache app
     runs-on: ubuntu-latest
     needs: setup
@@ -138,7 +138,7 @@ jobs:
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
 
   file_changes:
-    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') }}
+    if: ${{ !contains(github.head_ref, 'refs/heads/dependabot/') }}
     name: Before all / Note files changed
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: master
+    branches: [master]
   pull_request:
     # Don't bother running if it's a PR on a feature branch
     branches: [master]
@@ -21,6 +21,7 @@ env:
 
 jobs:
   setup:
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') }}
     name: Before all / Load cached deps
     runs-on: ubuntu-latest
     outputs:
@@ -80,6 +81,7 @@ jobs:
         npm run install:ci
 
   build_app:
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') }}
     name: Build & cache app
     runs-on: ubuntu-latest
     needs: setup
@@ -136,6 +138,7 @@ jobs:
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
 
   file_changes:
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') }}
     name: Before all / Note files changed
     runs-on: ubuntu-latest
     outputs:
@@ -151,20 +154,12 @@ jobs:
         name: "Compute changed files"
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.actor }}" != "dependabot[bot]" ]]; then
-              changes () { git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} ; }
-              echo "changed files? $(changes)"
-              echo "::set-output name=js::$(changes | grep -E 'apps/site/assets/js/.*\.jsx?' | xargs)"
-              echo "::set-output name=ts::$(changes | grep -E 'apps/site/assets/ts/.*\.tsx?' | xargs)"
-              echo "::set-output name=scss::$(changes | grep -E 'apps/site/assets/css/.*\.scss' | xargs)"
-              echo "::set-output name=ex::$(changes | grep -E '.*(\.exs?|\.eex)' | xargs)"
-          else
-              echo "Not a PR by a dev. Use placeholder value so all tests run"
-              echo "::set-output name=js::all"
-              echo "::set-output name=ts::all"
-              echo "::set-output name=scss::all"
-              echo "::set-output name=ex::all"
-          fi
+          changes () { git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} ; }
+          echo "changed files? $(changes)"
+          echo "::set-output name=js::$(changes | grep -E 'apps/site/assets/js/.*\.jsx?' | xargs)"
+          echo "::set-output name=ts::$(changes | grep -E 'apps/site/assets/ts/.*\.tsx?' | xargs)"
+          echo "::set-output name=scss::$(changes | grep -E 'apps/site/assets/css/.*\.scss' | xargs)"
+          echo "::set-output name=ex::$(changes | grep -E '.*(\.exs?|\.eex)' | xargs)"
       
       - name: "List changed files:"
         run: |
@@ -177,7 +172,7 @@ jobs:
     name: Linting / TypeScript
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ needs.file_changes.outputs.ts }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ts }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -197,7 +192,7 @@ jobs:
     name: Linting / JavaScript
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ needs.file_changes.outputs.js }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.js }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -217,7 +212,7 @@ jobs:
     name: Linting / CSS
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ needs.file_changes.outputs.scss }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.scss }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -237,7 +232,7 @@ jobs:
     name: Linting / Elixir
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ needs.file_changes.outputs.ex }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -255,7 +250,7 @@ jobs:
     name: Unit tests / Elixir / --exclude wallaby --cover
     runs-on: ubuntu-latest
     needs: [setup, file_changes, build_app]
-    if: ${{ needs.file_changes.outputs.ex }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -305,7 +300,7 @@ jobs:
     name: Unit tests / JavaScript / Mocha
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ needs.file_changes.outputs.js }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.js }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -325,7 +320,7 @@ jobs:
     name: Unit tests / JavaScript & TypeScript / Jest
     runs-on: ubuntu-latest
     needs: [setup, file_changes, build_app]
-    if: ${{ needs.file_changes.outputs.ts || needs.file_changes.outputs.js }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && (needs.file_changes.outputs.ts || needs.file_changes.outputs.js) }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -359,7 +354,7 @@ jobs:
     name: Type checks / Elixir
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ needs.file_changes.outputs.ex }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -377,7 +372,7 @@ jobs:
     name: Type checks / TypeScript
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ needs.file_changes.outputs.ts }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ts }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -397,7 +392,7 @@ jobs:
     name: Formatting / Elixir
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ needs.file_changes.outputs.ex }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -415,7 +410,7 @@ jobs:
     name: Formatting / JavaScript & TypeScript
     runs-on: ubuntu-latest
     needs: [file_changes, setup]
-    if: ${{ needs.file_changes.outputs.js || needs.file_changes.outputs.ts }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && (needs.file_changes.outputs.js || needs.file_changes.outputs.ts) }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -435,7 +430,7 @@ jobs:
     name: Integration tests / Elixir
     runs-on: ubuntu-latest
     needs: [setup, file_changes, build_app]
-    if: ${{ needs.file_changes.outputs.ex }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && needs.file_changes.outputs.ex }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -473,7 +468,7 @@ jobs:
     name: Integration tests / Cypress
     runs-on: ubuntu-latest
     needs: [setup, file_changes, build_app]
-    if: ${{ needs.file_changes.outputs.ex || needs.file_changes.outputs.js || needs.file_changes.outputs.ts }}
+    if: ${{ !(contains(github.head_ref, 'dependabot') || github.actor == 'dependabot[bot]') && (needs.file_changes.outputs.ex || needs.file_changes.outputs.js || needs.file_changes.outputs.ts) }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fix CI tests for Dependabot PRs](https://app.asana.com/0/385363666817452/1200701591068667/f)

Turns out it seems to make more sense to create two similar-but-different CI workflows, one which gets triggered by Dependabot PRs, and other by everything else.

The Dependabot PR CI workflow uses the `pull_request_target` event to get around the issues around accessing secrets (which are needed to run a few CI tests) cited here: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

I mainly identify Dependabot PRs by checking `github.head_ref` and `github.actor`. 
* The head ref value will be the branch name in the case of PRs (e.g. `refs/heads/dependabot/npm_and_yarn/apps/site/react_renderer/babel/core-7.15.5`). I don't believe this has a value on pushes to master branch.
* The actor value is who initiated the event, which varies. It's `dependabot[bot]` who opens a PR, but if I trigger a rebase on that branch then the new actor for the next workflow run is me! 

I tested these workflows out a bit [on my fork](https://github.com/thecristen/dotcom/actions). 

The screenshot below shows a PR I made with a small JS change running the normal CI workflow, and a dependabot PR triggering the CI (Dependabot) workflow.

<img width="855" alt="image" src="https://user-images.githubusercontent.com/2136286/132899739-2602e1ec-f448-48a3-ae6c-ba418d21a661.png">

(The first happens to fail because I neglected to update snapshots, and the second happens to fail because the branch doesn't have the recent Elixir test fixes. But this is just to demonstrate that the right workflows are running for each PR!)