### PR TITLE
fix(ControllerHelpers): no overwrite x-robots-tag

### DIFF
--- a/apps/site/lib/site_web/controllers/helpers.ex
+++ b/apps/site/lib/site_web/controllers/helpers.ex
@@ -147,7 +147,16 @@ defmodule SiteWeb.ControllerHelpers do
   end
 
   def unavailable_after_one_year(conn, posted_on) do
-    Conn.put_resp_header(conn, "x-robots-tag", "unavailable_after: #{one_year_after(posted_on)}")
+    # only add tag if there isn't already a "noindex" value
+    if Conn.get_resp_header(conn, "x-robots-tag") |> Enum.member?("noindex") do
+      conn
+    else
+      Conn.put_resp_header(
+        conn,
+        "x-robots-tag",
+        "unavailable_after: #{one_year_after(posted_on)}"
+      )
+    end
   end
 
   @spec environment_allows_indexing?() :: boolean()

--- a/apps/site/test/site_web/controllers/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/helpers_test.exs
@@ -403,6 +403,23 @@ defmodule SiteWeb.ControllerHelpersTest do
 
       refute {"x-robots-tag", "unavailable_after: 13 Nov 2019 00:00:00 EST"} in transformed_conn.resp_headers
     end
+
+    test "does not set an unavailable_after x-robots-tag HTTP header if x-robots-tag set to noindex",
+         %{conn: conn} do
+      old_value = Application.get_env(:site, :allow_indexing)
+
+      on_exit(fn ->
+        Application.put_env(:site, :allow_indexing, old_value)
+      end)
+
+      Application.put_env(:site, :allow_indexing, false)
+
+      conn = get(conn, "/basic_page_no_sidebar")
+      transformed_conn = unavailable_after_one_year(conn, nil)
+
+      refute {"x-robots-tag", "unavailable_after: 13 Nov 2019 00:00:00 EST"} in transformed_conn.resp_headers
+      assert Enum.find(conn.resp_headers, &(&1 == {"x-robots-tag", "noindex"}))
+    end
   end
 
   test "green_routes/0" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Really block dev environments from search engines](https://app.asana.com/0/385363666817452/1201031900628965/f)

It turns out a function was adding an `unavailable_after` value for `x-robots-tag` indiscriminately for events and news entries, which was butting against how we add the `noindex` value for `x-robots-tag` for all pages in our non-prod environments. This change aims to fix that.


---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] Are interactive elements accessible to screen readers?
* [ ] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
