### PR TITLE
List.first Sentry bug

### DIFF
--- a/apps/site/lib/site_web/views/partial_view.ex
+++ b/apps/site/lib/site_web/views/partial_view.ex
@@ -87,6 +87,8 @@ defmodule SiteWeb.PartialView do
   def render_teasers(teasers, conn, opts \\ [])
 
   def render_teasers([], _, _), do: {:safe, []}
+  
+  def render_teasers(nil, _, _), do: {:safe, []}
 
   def render_teasers(teasers, conn, opts) do
     display_fields =

--- a/apps/site/lib/site_web/views/partial_view.ex
+++ b/apps/site/lib/site_web/views/partial_view.ex
@@ -87,7 +87,7 @@ defmodule SiteWeb.PartialView do
   def render_teasers(teasers, conn, opts \\ [])
 
   def render_teasers([], _, _), do: {:safe, []}
-  
+
   def render_teasers(nil, _, _), do: {:safe, []}
 
   def render_teasers(teasers, conn, opts) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules | Elixir.FunctionClauseError: no function clause matching in List.first/1](https://app.asana.com/0/555089885850811/1201042269068385)

We assign CMS teasers with an async function.  The default value for "featured_content" teasers is set to nil until the content is populated by the async function.  We didn't have a render_teaser function that could accept nil, so any time the assign was going on too long, an error is generated.