### PR TITLE
Sentry issue: nil lat / lng should be discarded in Transit Near Me

### DIFF
--- a/apps/site/lib/site_web/controllers/transit_near_me/location.ex
+++ b/apps/site/lib/site_web/controllers/transit_near_me/location.ex
@@ -72,6 +72,8 @@ defmodule SiteWeb.TransitNearMeController.Location do
     :no_address
   end
 
+  defp parse_float(nil), do: {:error, :bad_float}
+
   defp parse_float(<<str::binary>>) do
     case Float.parse(str) do
       {float, ""} -> {:ok, float}

--- a/apps/site/lib/site_web/controllers/transit_near_me_controller.ex
+++ b/apps/site/lib/site_web/controllers/transit_near_me_controller.ex
@@ -29,7 +29,6 @@ defmodule SiteWeb.TransitNearMeController do
   end
 
   defp assign_location(conn) do
-    # Why do we check for location_fn?  It's never assigned
     location_fn = Map.get(conn.assigns, :location_fn, &Location.get/2)
 
     location = location_fn.(conn.params, [])

--- a/apps/site/lib/site_web/controllers/transit_near_me_controller.ex
+++ b/apps/site/lib/site_web/controllers/transit_near_me_controller.ex
@@ -29,6 +29,7 @@ defmodule SiteWeb.TransitNearMeController do
   end
 
   defp assign_location(conn) do
+    # Why do we check for location_fn?  It's never assigned
     location_fn = Map.get(conn.assigns, :location_fn, &Location.get/2)
 
     location = location_fn.(conn.params, [])


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Transit Near Me | Elixir.FunctionClauseError: no function clause matching in SiteWeb.TransitNearMeController.Location.parse_float/1](https://app.asana.com/0/555089885850811/1200280531064861)

Not quite sure how "nil" lat or lng is getting input in the url string -- is there any way for us to verify whether we generate a url like that anywhere?  That seems like an impossibly hard to answer question.  But anywho -- now the nil value is getting handled properly.

