### PR TITLE
Fix tests affected by how we set x-robots-tag

### DIFF
--- a/apps/site/config/dev.exs
+++ b/apps/site/config/dev.exs
@@ -9,9 +9,6 @@ use Mix.Config
 
 port = String.to_integer(System.get_env("PORT") || "4001")
 host = System.get_env("HOST") || "localhost"
-
-Mix.shell().info([:green, "Starting dev server on " <> host <> ":" <> Integer.to_string(port)])
-
 webpack_port = String.to_integer(System.get_env("WEBPACK_PORT") || "8090")
 
 static_url =

--- a/apps/site/test/site_web/controllers/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/helpers_test.exs
@@ -406,12 +406,7 @@ defmodule SiteWeb.ControllerHelpersTest do
 
     test "does not set an unavailable_after x-robots-tag HTTP header if x-robots-tag set to noindex",
          %{conn: conn} do
-      old_value = Application.get_env(:site, :allow_indexing)
-
-      on_exit(fn ->
-        Application.put_env(:site, :allow_indexing, old_value)
-      end)
-
+      # causes x-robots-tag to set to noindex
       Application.put_env(:site, :allow_indexing, false)
 
       conn = get(conn, "/basic_page_no_sidebar")

--- a/apps/site/test/site_web/controllers/news_entry_controller_test.exs
+++ b/apps/site/test/site_web/controllers/news_entry_controller_test.exs
@@ -22,6 +22,8 @@ defmodule SiteWeb.NewsEntryControllerTest do
     end
 
     test "does not include an unavailable_after x-robots-tag HTTP header", %{conn: conn} do
+      # unavailable_after header only gets applied when allow_indexing is true
+      Application.put_env(:site, :allow_indexing, true)
       conn = get(conn, news_entry_path(conn, :index))
 
       refute Enum.find(conn.resp_headers, fn {key, value} ->
@@ -97,6 +99,8 @@ defmodule SiteWeb.NewsEntryControllerTest do
       news_entry = news_entry_factory(0, path_alias: nil)
       path = news_entry_path(conn, :show, news_entry)
 
+      # unavailable_after header only gets applied when allow_indexing is true
+      Application.put_env(:site, :allow_indexing, true)
       conn = get(conn, path)
 
       assert Enum.find(conn.resp_headers, fn {key, value} ->


### PR DESCRIPTION
No ticket - quick fix for some failing Elixir tests as a result of merging in #1088. 

These values change based on the application configuration, which varies between prod/dev/test environments. So these particular tests need to make sure to be set a particular way to enable these tests to test the things they are trying to test. 🙂 