### PR TITLE
Added a `get_shapes_by_direction` test 

### DIFF
--- a/apps/routes/lib/mock_repo_api.ex
+++ b/apps/routes/lib/mock_repo_api.ex
@@ -893,6 +893,9 @@ defmodule Routes.MockRepoApi do
   end
 
   @impl Routes.RepoApi
+  def get_shapes("27", direction_id: 0), do: []
+
+  @impl Routes.RepoApi
   def by_type(1) do
     all() |> Enum.filter(&(&1.type == 1))
   end

--- a/apps/routes/lib/mock_repo_api.ex
+++ b/apps/routes/lib/mock_repo_api.ex
@@ -606,6 +606,9 @@ defmodule Routes.MockRepoApi do
   end
 
   @impl Routes.RepoApi
+  def get_shapes("27", direction_id: 0), do: []
+
+  @impl Routes.RepoApi
   def get_shapes("36", direction_id: 1) do
     [
       %Routes.Shape{
@@ -891,9 +894,6 @@ defmodule Routes.MockRepoApi do
       }
     ]
   end
-
-  @impl Routes.RepoApi
-  def get_shapes("27", direction_id: 0), do: []
 
   @impl Routes.RepoApi
   def by_type(1) do

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -864,6 +864,10 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                }
              ]
     end
+
+    test "for bus without scheduled trips" do
+      assert Helpers.get_shapes_by_direction("27", 3, 0) == []
+    end
   end
 
   describe "get_branches/4" do


### PR DESCRIPTION
... to catch cases where there aren't scheduled trips.  Prompted during the development of this branch, waaaay back when:  https://github.com/mbta/dotcom/pull/848 

#### Summary of changes
**Asana Ticket:** [Testing | Cover route without scheduled trips](https://app.asana.com/0/555089885850811/1200172434828846)