### PR TITLE
fix(TripPlanController): set Massport route type

### DIFF
--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -383,10 +383,11 @@ defmodule SiteWeb.TripPlanController do
       mode: mode,
       long_name: long_name,
       name: name,
-      type: type
+      type: type,
+      url: url
     } = Enum.find(legs, &(Leg.route_id(&1) == {:ok, id}))
 
-    %Route{
+    custom_route = %Route{
       description: description,
       id: mode.route_id,
       long_name: long_name,
@@ -394,6 +395,18 @@ defmodule SiteWeb.TripPlanController do
       type: type,
       custom_route?: true
     }
+
+    case {url, description} do
+      # Workaround for Massport buses, manually assign type
+      {"https://massport.com/", "BUS"} ->
+        %Route{
+          custom_route
+          | type: "Massport-1"
+        }
+
+      _ ->
+        custom_route
+    end
   end
 
   defp meta_description(conn, _) do


### PR DESCRIPTION
Our last workaround, accommodating "Massport-1" as a route type, stopped working because now the Massport buses are returning as route type "1". So for the sake of the Trip Planner, let's stop relying on the given type and stick to "Massport-1". This ensures that the correct icon (bus) and naming ("Massport shuttle") shows in the itinerary information.


#### Summary of changes
**Asana Ticket:** [Trip Planner | Crashes when using Massport routes](https://app.asana.com/0/385363666817452/1201105996476530/f)