### PR TITLE
fix(Router): ensure redirect to https:// dotcom

### DIFF
--- a/apps/site/lib/site_web/plugs/canonical_hostname.ex
+++ b/apps/site/lib/site_web/plugs/canonical_hostname.ex
@@ -27,8 +27,12 @@ defmodule SiteWeb.Plugs.CanonicalHostname do
       conn
     else
       rewritten_url =
-        Plug.Conn.request_url(conn)
-        |> String.replace(requested_hostname, canonical_hostname, global: false)
+        if requested_hostname == "www.mbtace.com" do
+          "https://www.mbta.com" <> conn.request_path
+        else
+          Plug.Conn.request_url(conn)
+          |> String.replace(requested_hostname, canonical_hostname, global: false)
+        end
 
       conn
       |> put_status(:moved_permanently)

--- a/apps/site/test/site_web/router_test.exs
+++ b/apps/site/test/site_web/router_test.exs
@@ -113,6 +113,18 @@ defmodule Phoenix.Router.RoutingTest do
       conn = get(conn, "/trip-planner/to/")
       assert redirected_to(conn, 301) == "/trip-planner"
     end
+
+    test "www.mbtace.com to www.mbta.com", %{conn: conn} do
+      System.put_env("HOST", "www.mbta.com")
+
+      on_exit(fn ->
+        System.delete_env("HOST")
+      end)
+
+      conn = %Plug.Conn{conn | host: "www.mbtace.com"}
+      conn = get(conn, "/")
+      assert redirected_to(conn, :moved_permanently) =~ "https://www.mbta.com/"
+    end
   end
 
   test "Adds noindex x-robots-tag HTTP header if config set", %{conn: conn} do


### PR DESCRIPTION
fixes security issue where mbtace.com first redirected to http://www.mbta.com before that redirected to https://www.mbta.com

...admittedly not sure how to actually test this outside prod. But I think this shortcut should work.

#### Summary of changes
**Asana Ticket:** [Insecure redirect in dotcom (HTTP vs. HTTPS)](https://app.asana.com/0/385363666817452/1201080431534538/f)
