### PR TITLE
Fix: should be using Date instead of DateTime function

### DIFF
--- a/apps/site/lib/site/transit_near_me.ex
+++ b/apps/site/lib/site/transit_near_me.ex
@@ -144,7 +144,7 @@ defmodule Site.TransitNearMe do
       {:error, error} ->
         _ =
           Logger.warn(
-            "module=#{__MODULE__} route_id=#{route_id} date=#{DateTime.to_string(date)} Other error fetching schedule: #{
+            "module=#{__MODULE__} route_id=#{route_id} date=#{Date.to_string(date)} Other error fetching schedule: #{
               inspect(error)
             }"
           )


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Schedules Line API | Elixir.MatchError: no match of right hand side value: ~D[2021-08-31]](https://app.asana.com/0/555089885850811/1200951784769772)

Easy peasy!  This function will only ever receive a Date struct, and using the DateTime func on it errors out.  Need to use the appropriate Date.to_string() func.