### PR TITLE
fix: don't try to format nil departure_time

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/finder_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/finder_api.ex
@@ -328,6 +328,7 @@ defmodule SiteWeb.ScheduleController.FinderApi do
 
   # Check for predictions w/o a schedule (added in predictions)
   # If there's a prediction and a schedule, use the schedule time
+  @spec set_departure_time(Journey.t()) :: Journey.t()
   defp set_departure_time(%{departure: departure} = journey) do
     departure_time =
       case departure do
@@ -335,7 +336,18 @@ defmodule SiteWeb.ScheduleController.FinderApi do
         %{schedule: s, prediction: _} -> s.time
       end
 
-    update_in(journey, [:departure], &Map.put_new(&1, :time, format_time(departure_time)))
+    update_in(
+      journey,
+      [:departure],
+      &Map.put_new(
+        &1,
+        :time,
+        case departure_time do
+          nil -> nil
+          _ -> format_time(departure_time)
+        end
+      )
+    )
   end
 
   # Removes problematic/unnecessary data from JSON response:


### PR DESCRIPTION
This error popped up a bunch on Sentry today so I decided to take a glance at it. This can be seen in the Schedule Finder for CR-Fitchburg, e.g. from `/schedules/CR-Fitchburg/line?schedule_finder%5Bdirection_id%5D=0&schedule_finder%5Borigin%5D=place-north` (the only user-facing glitch is the Upcoming Departures section never loads, but the backend produces the aforementioned error)

It turns out that a journey might have a prediction and nil schedule, but that prediction might have a nil time. This update stops trying to format a time that doesn't exist.

#### Summary of changes
**Asana Ticket:** [Elixir.UndefinedFunctionError: function nil.hour/0 is undefined](https://app.asana.com/0/385363666817452/1199209864845488/f)

