### PR TITLE
Sentry error | No function clause matching, related to trip planner url

### DIFF
--- a/apps/site/lib/site/trip_plan/query.ex
+++ b/apps/site/lib/site/trip_plan/query.ex
@@ -151,7 +151,7 @@ defmodule Site.TripPlan.Query do
       |> List.first()
       |> optimize_for(opts)
 
-      opts_from_query(Map.delete(query, "optimize_for"), val)
+    opts_from_query(Map.delete(query, "optimize_for"), val)
   end
 
   def opts_from_query(%{"modes" => modes} = query, opts) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trip Planner Query | Elixir.FunctionClauseError: no function clause matching in Site.TripPlan.Query.optimize_for/2](https://app.asana.com/0/385363666817452/1200033204917805)

Added function clause to match urls with (malicious or accidental) typo in the `optimize_for` param.  Looks like it's only bots causing this error.