### PR TITLE
Stop Pages | Show predictions when we don't have arrival or departure times

### DIFF
--- a/apps/site/assets/ts/components/Headsign.tsx
+++ b/apps/site/assets/ts/components/Headsign.tsx
@@ -115,7 +115,9 @@ const HeadsignComponent = (props: Props): ReactElement<HTMLElement> => {
       <div className="m-tnm-sidebar__headsign">
         {renderHeadsignName(props)}
 
-        {routeType === 2 && renderTrainName(`Train ${headsign.train_number}`)}
+        {routeType === 2 && headsign.train_number
+          ? renderTrainName(`Train ${headsign.train_number}`)
+          : null}
       </div>
       <div className="m-tnm-sidebar__schedules">
         {headsign.times.map((time, idx) => {

--- a/apps/site/assets/ts/tnm/helpers/process-realtime-data.ts
+++ b/apps/site/assets/ts/tnm/helpers/process-realtime-data.ts
@@ -121,7 +121,7 @@ const buildHeadsign = (
           ? {
               track: prediction.track,
               time: prediction.time,
-              status: null,
+              status: prediction.status,
               // eslint-disable-next-line camelcase
               schedule_relationship: prediction.schedule_relationship
             }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🚉 Stop Pages | Show predictions when we don't have arrival or departure times](https://app.asana.com/0/385363666817452/1199651847560606/f)

The data feeding into the `<StopCard>` component which displays on Transit Near Me and on Stop pages had `status: null` hardcoded into the prediction when processing data from the backend to frontend 🤦🏻‍♀️

The other commit is because I saw a `Train null` -- now we check if there's a `train_number` first.

For example, looking at rail results for /transit-near-me?from=search-homepage&query=1%20International%20Place%2C%20Boston%2C%20MA%2C%20USA&latitude=42.35604&longitude=-71.0521404&address=1%20International%20Place%2C%20Boston%2C%20MA%2C%20USA

**Updated version on left -------- original on right**

![image](https://user-images.githubusercontent.com/2136286/139871361-46fcffc1-682a-4241-9eda-4a85ed0bfdd5.png)

![image](https://user-images.githubusercontent.com/2136286/139871462-3a942f95-5082-4b2d-a6ce-bf67cc3a1f4c.png)

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
