### PR TITLE
More retroactive test fixes + updates

### DIFF
--- a/apps/site/lib/green_line.ex
+++ b/apps/site/lib/green_line.ex
@@ -13,11 +13,11 @@ defmodule GreenLine do
 
   @termini %{
     {"Green-B", 0} => "place-lake",
-    {"Green-B", 1} => "place-pktrm",
+    {"Green-B", 1} => "place-gover",
     {"Green-C", 0} => "place-clmnl",
-    {"Green-C", 1} => "place-north",
+    {"Green-C", 1} => "place-gover",
     {"Green-D", 0} => "place-river",
-    {"Green-D", 1} => "place-gover",
+    {"Green-D", 1} => "place-north",
     {"Green-E", 0} => "place-hsmnl",
     # As of June 2020, Lechmere is closed for construction and the E-line will
     # be terminating at North Station for now.

--- a/apps/site/lib/site/content_rewriter.ex
+++ b/apps/site/lib/site/content_rewriter.ex
@@ -18,8 +18,9 @@ defmodule Site.ContentRewriter do
   """
   @spec rewrite(Phoenix.HTML.safe() | String.t(), Plug.Conn.t()) :: Phoenix.HTML.safe()
   def rewrite({:safe, content}, conn) do
-    content
-    |> Floki.parse()
+    {:ok, parsed} = Floki.parse_fragment(content)
+
+    parsed
     |> FlokiHelpers.traverse(&dispatch_rewrites(&1, conn))
     |> render
     |> Phoenix.HTML.raw()

--- a/apps/site/lib/site/content_rewriters/embedded_media.ex
+++ b/apps/site/lib/site/content_rewriters/embedded_media.ex
@@ -107,7 +107,9 @@ defmodule Site.ContentRewriters.EmbeddedMedia do
   end
 
   def build(_) do
-    Floki.parse(~s(<div class="incompatible-media"></div>))
+    {:ok, [parsed]} = Floki.parse_fragment(~s(<div class="incompatible-media"></div>))
+
+    parsed
   end
 
   @spec media_iframe?(String.t()) :: boolean

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -267,16 +267,17 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
           direction_id
         ) :: RouteStops.t()
   defp get_green_branch(branch_id, stops, shapes, direction_id) do
-    headsign =
+    shape_name =
       branch_id
       |> RoutesRepo.get()
       |> Map.get(:direction_destinations)
-      |> Map.get(direction_id)
+      |> Map.values()
+      |> Enum.join(" - ")
 
     branch =
       shapes
       |> Enum.reject(&is_nil(&1.name))
-      |> Enum.filter(&(&1.name =~ headsign))
+      |> Enum.filter(&(&1.name =~ shape_name))
       |> get_branches(%{branch_id => stops}, %Route{id: branch_id, type: 0}, direction_id)
       |> List.first()
 

--- a/apps/site/test/green_line_test.exs
+++ b/apps/site/test/green_line_test.exs
@@ -45,18 +45,25 @@ defmodule GreenLineTest do
         "Green-C" ->
           [
             %Stops.Stop{id: "place-clmnl"},
+            %Stops.Stop{id: "place-coecl"},
+            %Stops.Stop{id: "place-kencl"},
+            %Stops.Stop{id: "place-gover"}
+          ]
+
+        "Green-D" ->
+          [
+            %Stops.Stop{id: "place-river"},
+            %Stops.Stop{id: "place-coecl"},
+            %Stops.Stop{id: "place-kencl"},
             %Stops.Stop{id: "place-gover"},
             %Stops.Stop{id: "place-north"}
           ]
 
-        "Green-D" ->
-          [%Stops.Stop{id: "place-river"}, %Stops.Stop{id: "place-gover"}]
-
         "Green-E" ->
           [
             %Stops.Stop{id: "place-hsmnl"},
-            %Stops.Stop{id: "place-gover"}
-            # %Stops.Stop{id: "place-north"}
+            %Stops.Stop{id: "place-gover"},
+            %Stops.Stop{id: "place-north"}
             # %Stops.Stop{id: "place-lech"}
           ]
       end
@@ -65,15 +72,24 @@ defmodule GreenLineTest do
     test "each line returns a set of the ids of associated stops" do
       {_, stop_map} = calculate_stops_on_routes(0, Timex.today(), &stops_fn/3)
 
-      assert stop_map["Green-C"] == MapSet.new(["place-clmnl", "place-gover", "place-north"])
-      assert stop_map["Green-D"] == MapSet.new(["place-river", "place-gover"])
+      assert stop_map["Green-C"] ==
+               MapSet.new(["place-clmnl", "place-coecl", "place-gover", "place-kencl"])
+
+      assert stop_map["Green-D"] ==
+               MapSet.new([
+                 "place-north",
+                 "place-coecl",
+                 "place-gover",
+                 "place-kencl",
+                 "place-river"
+               ])
 
       # As of June 2020, Lechmere is closed for construction and the E-line will
       # be terminating at North Station for now.
       # assert stop_map["Green-E"] ==
       #          MapSet.new(["place-hsmnl", "place-gover", "place-north", "place-lech"])
       assert stop_map["Green-E"] ==
-               MapSet.new(["place-hsmnl", "place-gover"])
+               MapSet.new(["place-hsmnl", "place-gover", "place-north"])
     end
 
     test "a list of stops without duplicates is returned" do
@@ -84,6 +100,8 @@ defmodule GreenLineTest do
                  %Stops.Stop{id: "place-hsmnl"},
                  %Stops.Stop{id: "place-gover"},
                  %Stops.Stop{id: "place-north"},
+                 %Stops.Stop{id: "place-coecl"},
+                 %Stops.Stop{id: "place-kencl"},
                  # As of June 2020, Lechmere is closed for construction
                  #  %Stops.Stop{id: "place-lech"},
                  %Stops.Stop{id: "place-clmnl"},
@@ -106,15 +124,15 @@ defmodule GreenLineTest do
   end
 
   test "terminus?/2" do
-    for stop_id <- ["place-lake", "place-pktrm"] do
+    for stop_id <- ["place-lake", "place-gover"] do
       assert terminus?(stop_id, "Green-B")
     end
 
-    for stop_id <- ["place-north", "place-clmnl"] do
+    for stop_id <- ["place-gover", "place-clmnl"] do
       assert terminus?(stop_id, "Green-C")
     end
 
-    for stop_id <- ["place-river", "place-gover"] do
+    for stop_id <- ["place-river", "place-north"] do
       assert terminus?(stop_id, "Green-D")
     end
 
@@ -137,11 +155,11 @@ defmodule GreenLineTest do
   describe "naive_headsign/2" do
     test "correct headsign for route and direction" do
       assert naive_headsign("Green-B", 0) == "Boston College"
-      assert naive_headsign("Green-B", 1) == "Park Street"
+      assert naive_headsign("Green-B", 1) == "Government Center"
       assert naive_headsign("Green-C", 0) == "Cleveland Circle"
-      assert naive_headsign("Green-C", 1) == "North Station"
+      assert naive_headsign("Green-C", 1) == "Government Center"
       assert naive_headsign("Green-D", 0) == "Riverside"
-      assert naive_headsign("Green-D", 1) == "Government Center"
+      assert naive_headsign("Green-D", 1) == "North Station"
       assert naive_headsign("Green-E", 0) == "Heath Street"
       # As of June 2020, Lechmere is closed for construction and the E-line will
       # be terminating at North Station for now.
@@ -176,7 +194,7 @@ defmodule GreenLineTest do
         |> filter_lines("Green-B")
         |> Enum.map(fn %Stops.Stop{id: id} -> id end)
 
-      assert List.first(stops) == "place-pktrm"
+      assert List.first(stops) == "place-gover"
       assert List.last(stops) == "place-lake"
     end
   end

--- a/apps/site/test/site/floki_helpers_test.exs
+++ b/apps/site/test/site/floki_helpers_test.exs
@@ -4,8 +4,8 @@ defmodule Site.FlokiHelpersTest do
   import Site.FlokiHelpers
 
   setup do
-    html =
-      Floki.parse("""
+    {:ok, html} =
+      Floki.parse_fragment("""
         <div><span class="highlight">Hello, this is some text</span></div>
         <div>
           <ul>

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -256,8 +256,6 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
       |> json_response(200)
     end
 
-    @tag skip:
-           "Skipping this test temporarily. Pleasant Street station will be closed beginning on Sat, Feb 27, as part of the B Branch Station Consolidation project."
     test "handles green line trips from the generic Green page", %{conn: conn} do
       params = %{
         id: "Green",

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -395,7 +395,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       # We are temporarily adding the fix but this will need to be undone later on.
       for {id, idx} <- [
             # {"place-lech", 64},
-            # {"place-north", 62},
+            {"place-north", 61},
             {"place-gover", 59},
             {"place-pktrm", 58},
             {"place-coecl", 55},

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -381,8 +381,6 @@ defmodule SiteWeb.ScheduleController.LineTest do
       assert stops == []
     end
 
-    @tag skip:
-           "FIXME: I'm actually missing Copley and beyond on the eastern portion, and that's wrong wrong wrong."
     test "direction 1 returns a list of all stops in order from west to east" do
       route_stops = get_route_stops("Green", 0, @deps.stops_by_route_fn)
 
@@ -410,8 +408,6 @@ defmodule SiteWeb.ScheduleController.LineTest do
       end
     end
 
-    @tag skip:
-           "FIXME: the output is missing the trunk (shared portion of the line diagram), which is also wrong wrong wrong"
     test "direction 1 returns the correct number of bubbles for each stop" do
       route_stops = get_route_stops("Green", 0, @deps.stops_by_route_fn)
 
@@ -452,7 +448,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
       # We are temporarily adding the fix but this will need to be undone later on.
       # assert stop_id(List.last(trunk)) == "place-lech"
-      assert trunk |> List.last() |> stop_id() == "place-gover"
+      assert trunk |> List.last() |> stop_id() == "place-north"
     end
   end
 

--- a/apps/site/test/site_web/excluded_stops_test.exs
+++ b/apps/site/test/site_web/excluded_stops_test.exs
@@ -58,12 +58,10 @@ defmodule ExcludedStopsTest do
       assert "place-qamnl" in excluded_destination_stops("Red", "place-asmnl")
     end
 
-    @tag skip:
-           "No longer asserts that St. Mary's St (C line only) is not on the D line, and that's very wrong"
     test "excludes stops on different branches of the consolidated Green Line" do
       # As of June 2020, Lechmere has been closed so the commented lines will make the test fail.
       # We are temporarily adding the fix but this will need to be undone later on.
-      # assert "place-prmnl" in excluded_destination_stops("Green", "place-lake")
+      assert "place-prmnl" in excluded_destination_stops("Green", "place-lake")
       assert "place-river" in excluded_destination_stops("Green", "place-lake")
       assert "place-bland" in excluded_destination_stops("Green", "place-clmnl")
       assert "place-smary" in excluded_destination_stops("Green", "place-river")
@@ -72,8 +70,6 @@ defmodule ExcludedStopsTest do
       assert "place-hsmnl" in excluded_destination_stops("Green", "place-hymnl")
     end
 
-    @tag skip:
-           "Thinks that Park St (B,C,D,E) is on a totally different branch from Coolidge Corner (C), very wrong"
     test "doesn't exclude stops that are shared between branches of the consolidated Green line" do
       refute "place-pktrm" in excluded_destination_stops("Green", "place-cool")
       refute "place-gover" in excluded_destination_stops("Green", "place-river")
@@ -81,7 +77,7 @@ defmodule ExcludedStopsTest do
       # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
       # We are temporarily adding the fix but this will need to be undone later on.
       # refute "place-north" in excluded_destination_stops("Green", "place-lech")
-      refute "place-north" in excluded_destination_stops("Green", "place-north")
+      refute "place-gover" in excluded_destination_stops("Green", "place-north")
     end
   end
 end

--- a/apps/site/test/site_web/views/helpers_test.exs
+++ b/apps/site/test/site_web/views/helpers_test.exs
@@ -363,11 +363,12 @@ defmodule SiteWeb.ViewHelpersTest do
           :trolley
         ],
         size <- [:default, :small] do
-      assert {"span", [{"class", class}], _} =
+      assert [{"span", [{"class", class}], _}] =
                type
                |> mode_icon(size)
                |> safe_to_string()
-               |> Floki.parse()
+               |> Floki.parse_fragment()
+               |> elem(1)
 
       case type do
         :commuter_rail -> assert class == "notranslate c-svg__icon-mode-commuter-rail-#{size}"
@@ -377,21 +378,23 @@ defmodule SiteWeb.ViewHelpersTest do
       end
     end
 
-    assert {"span", [{"class", "notranslate c-svg__icon-the-ride-default"}], _} =
+    assert [{"span", [{"class", "notranslate c-svg__icon-the-ride-default"}], _}] =
              :the_ride
              |> mode_icon(:default)
              |> safe_to_string()
-             |> Floki.parse()
+             |> Floki.parse_fragment()
+             |> elem(1)
   end
 
   test "bw_circle_icon/2" do
     for type <- [0, 1, 2, 3, 4],
         size <- [:default] do
-      assert {"span", [{"class", class}], _} =
+      assert [{"span", [{"class", class}], _}] =
                type
                |> bw_circle_icon(size)
                |> safe_to_string()
-               |> Floki.parse()
+               |> Floki.parse_fragment()
+               |> elem(1)
 
       if type == 0 do
         assert class == "notranslate c-svg__icon-trolley-circle-bw-#{size}"

--- a/apps/site/test/site_web/views/mode_view_test.exs
+++ b/apps/site/test/site_web/views/mode_view_test.exs
@@ -10,21 +10,23 @@ defmodule SiteWeb.ModeViewTest do
 
   describe "mode_group_header/3" do
     test "renders an h2 if is_homepage? == false" do
-      assert {tag, _, _} =
+      assert [{tag, _, _}] =
                :commuter_rail
                |> ModeView.mode_group_header("/schedules/commuter-rail", false)
                |> safe_to_string()
-               |> Floki.parse()
+               |> Floki.parse_fragment()
+               |> elem(1)
 
       assert tag == "h2"
     end
 
     test "renders an h3 if is_homepage? == true" do
-      assert {tag, _, _} =
+      assert [{tag, _, _}] =
                :commuter_rail
                |> ModeView.mode_group_header("/schedules/commuter-rail", true)
                |> safe_to_string()
-               |> Floki.parse()
+               |> Floki.parse_fragment()
+               |> elem(1)
 
       assert tag == "h3"
     end

--- a/apps/site/test/site_web/views/partial_view_test.exs
+++ b/apps/site/test/site_web/views/partial_view_test.exs
@@ -28,8 +28,6 @@ defmodule SiteWeb.PartialViewTest do
       assert stop_selector_suffix(conn, "Wachusett") == ""
     end
 
-    @tag skip:
-           "Thinks North Station (D,E) only serves the E, and Park St (B,C,D,E) doesn't serve C, both are wrong"
     test "returns a comma-separated list of lines for the green line", %{conn: conn} do
       conn =
         conn

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -681,11 +681,19 @@ defmodule SiteWeb.ScheduleViewTest do
       route = %Routes.Route{}
       today = ~D[2018-01-01]
 
-      assert {"div", _, []} =
-               [] |> route_pdf_link(route, today) |> safe_to_string |> Floki.parse()
+      assert [{"div", _, []}] =
+               []
+               |> route_pdf_link(route, today)
+               |> safe_to_string
+               |> Floki.parse_fragment()
+               |> elem(1)
 
-      assert {"div", _, []} =
-               nil |> route_pdf_link(route, today) |> safe_to_string |> Floki.parse()
+      assert [{"div", _, []}] =
+               nil
+               |> route_pdf_link(route, today)
+               |> safe_to_string
+               |> Floki.parse_fragment()
+               |> elem(1)
     end
 
     test "shows all PDFs for the route" do

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -422,7 +422,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
     test "Correctly formats Green Line route" do
       route = %Route{name: "Green Line B", id: "Green-B", direction_names: %{1 => "Eastbound"}}
       actual = route |> format_additional_route(1) |> IO.iodata_to_binary()
-      assert actual == "Green Line (B) Eastbound towards Park Street"
+      assert actual == "Green Line (B) Eastbound towards Government Center"
     end
   end
 


### PR DESCRIPTION
No ticket, just took some time to dig into what was going on with the tests that we'd recently skipped. 
* The first two commits make additional fixes that were needed after we updated the GL eastbound termini, and updates the corresponding tests. 
* The third commit unskips a test that now works. 
* The fourth commit refactors several tests to get rid of the `Floki.parse` deprecation message. And then I decided to stop and make this PR. :) 