### PR TITLE
Remove duplicate related links from trip planner

### DIFF
--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -114,10 +114,10 @@ defmodule SiteWeb.TripPlanController do
   end
 
   defp get_route(link) do
-    if is_list(Enum.at(link.text, 0)) do
-      Enum.at(Enum.at(link.text, 0), 1)
+    if is_bitstring(link.text) do
+      link.text
     else
-      Enum.at(link.text, 0)
+      link.text |> List.to_string()
     end
   end
 

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -113,6 +113,18 @@ defmodule SiteWeb.TripPlanController do
     end
   end
 
+  defp get_route(link) do
+    if is_list(Enum.at(link.text, 0)) do
+      Enum.at(Enum.at(link.text, 0),1)
+    else
+      Enum.at(link.text, 0)
+    end
+  end
+
+  defp filter_duplicate_links(related_links) do
+    Enum.map(related_links, fn x -> Enum.uniq_by(x, fn y -> get_route(y) end) end)
+  end
+
   @spec render_plan(Plug.Conn.t(), map) :: Plug.Conn.t()
   defp render_plan(conn, plan) do
     query =
@@ -141,7 +153,7 @@ defmodule SiteWeb.TripPlanController do
       itinerary_maps:
         Enum.map(itineraries, &TripPlanMap.itinerary_map(&1, route_mapper: route_mapper)),
       related_links:
-        Enum.map(itineraries, &RelatedLink.links_for_itinerary(&1, route_by_id: route_mapper)),
+        filter_duplicate_links(Enum.map(itineraries, &RelatedLink.links_for_itinerary(&1, route_by_id: route_mapper))),
       itinerary_row_lists: itinerary_row_lists
     )
   end

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -115,7 +115,7 @@ defmodule SiteWeb.TripPlanController do
 
   defp get_route(link) do
     if is_list(Enum.at(link.text, 0)) do
-      Enum.at(Enum.at(link.text, 0),1)
+      Enum.at(Enum.at(link.text, 0), 1)
     else
       Enum.at(link.text, 0)
     end
@@ -153,7 +153,9 @@ defmodule SiteWeb.TripPlanController do
       itinerary_maps:
         Enum.map(itineraries, &TripPlanMap.itinerary_map(&1, route_mapper: route_mapper)),
       related_links:
-        filter_duplicate_links(Enum.map(itineraries, &RelatedLink.links_for_itinerary(&1, route_by_id: route_mapper))),
+        filter_duplicate_links(
+          Enum.map(itineraries, &RelatedLink.links_for_itinerary(&1, route_by_id: route_mapper))
+        ),
       itinerary_row_lists: itinerary_row_lists
     )
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trip Planner | Remove duplicate related link](https://app.asana.com/0/385363666817452/1200984438570060/f)

Filtered out duplicate schedule links in trip planner itinerary.