### PR TITLE
Retrieve crowding info for commuter rail routes

### DIFF
--- a/apps/schedules/lib/parser.ex
+++ b/apps/schedules/lib/parser.ex
@@ -59,7 +59,8 @@ defmodule Schedules.Parser do
       direction_id: direction_id,
       bikes_allowed?: bikes_allowed?(attributes),
       route_pattern_id: route_pattern_id(relationships),
-      shape_id: shape_id(relationships)
+      shape_id: shape_id(relationships),
+      occupancy: occupancy(relationships)
     }
   end
 
@@ -84,7 +85,8 @@ defmodule Schedules.Parser do
       direction_id: direction_id,
       shape_id: shape_id(relationships),
       route_pattern_id: route_pattern_id(relationships),
-      bikes_allowed?: bikes_allowed?(attributes)
+      bikes_allowed?: bikes_allowed?(attributes),
+      occupancy: occupancy(relationships)
     }
   end
 
@@ -154,4 +156,18 @@ defmodule Schedules.Parser do
   @spec bikes_allowed?(map) :: boolean
   defp bikes_allowed?(%{"bikes_allowed" => 1}), do: true
   defp bikes_allowed?(_), do: false
+
+  @spec occupancy(any) :: Schedules.Trip.crowding() | nil
+  defp occupancy(%{
+         "occupancies" => [%JsonApi.Item{attributes: %{"status" => status}}]
+       }) do
+    case status do
+      "MANY_SEATS_AVAILABLE" -> :not_crowded
+      "FEW_SEATS_AVAILABLE" -> :some_crowding
+      "FULL" -> :crowded
+      _ -> nil
+    end
+  end
+
+  defp occupancy(_), do: nil
 end

--- a/apps/schedules/lib/repo.ex
+++ b/apps/schedules/lib/repo.ex
@@ -93,7 +93,7 @@ defmodule Schedules.Repo do
 
   @spec trip(String.t(), trip_by_id_fn) :: Schedules.Trip.t() | nil
         when trip_by_id_fn: (String.t() -> JsonApi.t() | {:error, any})
-  def trip(trip_id, trip_by_id_fn \\ &V3Api.Trips.by_id/1)
+  def trip(trip_id, trip_by_id_fn \\ &V3Api.Trips.by_id/2)
 
   def trip("", _trip_fn) do
     # short circuit an known invalid trip ID

--- a/apps/schedules/lib/repo.ex
+++ b/apps/schedules/lib/repo.ex
@@ -108,7 +108,13 @@ defmodule Schedules.Repo do
   end
 
   defp fetch_trip(trip_id, trip_by_id_fn) do
-    case trip_by_id_fn.(trip_id) do
+    trip_opts =
+      case Util.config(:site, :enable_experimental_features) do
+        "true" -> [include: "occupancies"]
+        _ -> []
+      end
+
+    case trip_by_id_fn.(trip_id, trip_opts) do
       %JsonApi{} = response ->
         {:ok, Parser.trip(response)}
 

--- a/apps/schedules/lib/schedule.ex
+++ b/apps/schedules/lib/schedule.ex
@@ -70,11 +70,13 @@ defmodule Schedules.Trip do
     :direction_id,
     :shape_id,
     :route_pattern_id,
+    :occupancy,
     bikes_allowed?: false
   ]
 
   @type id_t :: String.t()
   @type headsign :: String.t()
+  @type crowding :: Vehicles.Vehicle.crowding()
   @type t :: %Schedules.Trip{
           id: id_t,
           name: String.t(),
@@ -82,7 +84,8 @@ defmodule Schedules.Trip do
           direction_id: 0 | 1,
           shape_id: Shape.id_t() | nil,
           route_pattern_id: RoutePattern.id_t() | nil,
-          bikes_allowed?: boolean
+          bikes_allowed?: boolean,
+          occupancy: crowding() | nil
         }
 end
 

--- a/apps/schedules/test/parser_test.exs
+++ b/apps/schedules/test/parser_test.exs
@@ -95,7 +95,8 @@ defmodule Schedules.ParserTest do
                headsign: "Alewife",
                id: "31562821",
                name: "",
-               bikes_allowed?: true
+               bikes_allowed?: true,
+               occupancy: nil
              }
     end
 
@@ -142,7 +143,17 @@ defmodule Schedules.ParserTest do
                   }
                 ],
                 "service" => [],
-                "vehicle" => []
+                "vehicle" => [],
+                "occupancies" => [
+                  %JsonApi.Item{
+                    attributes: %{
+                      "percentage" => 31,
+                      "status" => "MANY_SEATS_AVAILABLE"
+                    },
+                    id: "occupancy-1215",
+                    type: "occupancy"
+                  }
+                ]
               },
               type: "trip"
             }
@@ -156,7 +167,8 @@ defmodule Schedules.ParserTest do
                headsign: "North Station",
                id: "31174458-CR_MAY2016-hxl16011-Weekday-01",
                name: "300",
-               bikes_allowed?: true
+               bikes_allowed?: true,
+               occupancy: :not_crowded
              }
     end
 

--- a/apps/schedules/test/repo_test.exs
+++ b/apps/schedules/test/repo_test.exs
@@ -148,7 +148,7 @@ defmodule Schedules.RepoTest do
 
     test "returns nil if there's an error" do
       mock_response = {:error, "could not connect to the API"}
-      assert trip("trip ID with an error", fn _ -> mock_response end) == nil
+      assert trip("trip ID with an error", fn _, _ -> mock_response end) == nil
     end
   end
 

--- a/apps/stops/test/api_test.exs
+++ b/apps/stops/test/api_test.exs
@@ -52,6 +52,7 @@ defmodule Stops.ApiTest do
                  "NEC-2287-11",
                  "NEC-2287-12",
                  "NEC-2287-13",
+                 "NEC-2287-B",
                  "door-sstat-atlantic",
                  "door-sstat-bus",
                  "door-sstat-dewey",

--- a/apps/v3_api/lib/trips.ex
+++ b/apps/v3_api/lib/trips.ex
@@ -6,8 +6,8 @@ defmodule V3Api.Trips do
   """
   import V3Api
 
-  def by_id(id) do
-    get_json("/trips/" <> id)
+  def by_id(id, opts \\ []) do
+    get_json("/trips/" <> id, opts)
   end
 
   def by_route(route_id, opts \\ []) do

--- a/apps/vehicles/lib/parser.ex
+++ b/apps/vehicles/lib/parser.ex
@@ -50,7 +50,7 @@ defmodule Vehicles.Parser do
     nil
   end
 
-  @spec crowding(String.t()) :: Vehicle.crowding()
+  @spec crowding(String.t()) :: Vehicle.crowding() | nil
   defp crowding("MANY_SEATS_AVAILABLE"), do: :not_crowded
   defp crowding("FEW_SEATS_AVAILABLE"), do: :some_crowding
   defp crowding("FULL"), do: :crowded


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Retrieve crowding info for commuter rail routes](https://app.asana.com/0/385363666817452/1201303796115902/f)

Updated the API request for trips to get occupancy information via `[include: "occupancies"]`, and parse and save the resulting data.