### PR TITLE
debounce the Algolia autocomplete result list

### DIFF
--- a/apps/site/assets/js/algolia-autocomplete.js
+++ b/apps/site/assets/js/algolia-autocomplete.js
@@ -331,7 +331,8 @@ export default class AlgoliaAutocomplete {
       templates: {
         suggestion: this.renderResult(indexName),
         footer: this.renderFooterTemplate(indexName)
-      }
+      },
+      debounce: 500
     });
     return acc;
   }


### PR DESCRIPTION
Instead of sending queries on every input change, limit queries to being sent every .5 second. This should dramatically reduce the number of extraneous requests sent to Google's Places API while maintaining the interactivity and accuracy of autocomplete search results.

