### PR TITLE
refactor(FinderApi): Get trip route ID via route pattern

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/finder_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/finder_api.ex
@@ -502,18 +502,13 @@ defmodule SiteWeb.ScheduleController.FinderApi do
 
   @spec get_route_id(Route.id_t(), Trip.id_t()) :: Route.id_t() | nil
   defp get_route_id("Green", trip_id) do
-    schedule_for_trip =
-      trip_id
-      |> Schedules.Repo.schedule_for_trip()
+    case Schedules.Repo.trip(trip_id) do
+      %Schedules.Trip{route_pattern_id: route_pattern_id} ->
+        RoutePatterns.Repo.get(route_pattern_id)
+        |> Map.get(:route_id)
 
-    if Enum.empty?(schedule_for_trip) do
-      nil
-    else
-      schedule =
-        schedule_for_trip
-        |> List.first()
-
-      schedule.route.id
+      _ ->
+        nil
     end
   end
 

--- a/apps/site/lib/site_web/views/layout_view.ex
+++ b/apps/site/lib/site_web/views/layout_view.ex
@@ -47,7 +47,7 @@ defmodule SiteWeb.LayoutView do
       {"More", "About Us, Business Center, Projects...", static_page_path(conn, :about)}
     ]
 
-  def nav_link_content_redesign(conn),
+  def nav_link_content_redesign(_conn),
     do: [
       %{
         menu_section: "Transit",
@@ -145,7 +145,7 @@ defmodule SiteWeb.LayoutView do
                :internal_link}
             ]
           },
-          # special 
+          # special
           %{sub_menu_section: "Contact numbers"}
         ]
       },


### PR DESCRIPTION
No ticket, just noticed a `[warn] route_id_not_found route_id=Green, trip_id=ADDED-1591071232` logged while working on another task. Similar warnings are logged many times a day (see chart from Splunk below!).

<img width="1426" alt="image" src="https://user-images.githubusercontent.com/2136286/142139841-ac7ed038-058f-42e2-85d3-135ab64cd078.png">


---

Sometimes trips don't have associated schedules: for example trip id `ADDED-1591071232` was added to the rotation but wasn't originally scheduled to run. This can also happen with shuttle trips. In these cases, using `Schedules.Repo.schedule_for_trip()` will return empty.

Since `get_route_id` is just trying to fetch the route ID for the trip, we can do that by fetching the trip directly, and then fetching the trip's associated route pattern, from which we can get the ID.
