### PR TITLE
Hide  Registration if Null

### DIFF
--- a/apps/site/lib/site_web/templates/event/show.html.eex
+++ b/apps/site/lib/site_web/templates/event/show.html.eex
@@ -65,7 +65,11 @@
               <h2 class="m-event__registration-header">Join the Virtual Meeting</h2>
               <div>
                 <div class="mb-1">The meeting will be held over Zoom.</div>
-                <a class="btn btn-primary btn-block" href="<%= @event.registration_link %>">Register for the meeting</a>
+                <%= if @event.registration_link do %>
+                  <a class="btn btn-primary btn-block" href="<%= @event.registration_link %>">Register for the meeting</a>
+                <% else %>
+                  <p>Virtual meeting registration will be available soon.</p>
+                <% end %>
               </div>
             </div>
             <hr />

--- a/apps/site/lib/site_web/templates/event/show.html.eex
+++ b/apps/site/lib/site_web/templates/event/show.html.eex
@@ -65,7 +65,7 @@
               <h2 class="m-event__registration-header">Join the Virtual Meeting</h2>
               <div>
                 <div class="mb-1">The meeting will be held over Zoom.</div>
-                <%= if @event.registration_link do %>
+                <%= if !is_nil(@event.registration_link) do %>
                   <a class="btn btn-primary btn-block" href="<%= @event.registration_link %>">Register for the meeting</a>
                 <% else %>
                   <p>Virtual meeting registration will be available soon.</p>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Hide registration section when registration URL isn't provided](https://app.asana.com/0/385363666817452/1201348288803391/f)

Don''t show registration link if it isn't available. Instead uses previous copy of `Virtual meeting registration will be available soon`