### PR TITLE
Remove Feature Flag for New Event Agendas

### DIFF
--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -26,8 +26,6 @@ config :site, SiteWeb.ViewHelpers, google_tag_manager_id: System.get_env("GOOGLE
 
 config :laboratory,
   features: [
-    {:events_hub_redesign, "Events Hub Redesign (Feb. 2021)",
-     "Changes to the event listings and the event pages as part of the 🤝 Public Engagement epic"},
     {:nav_redesign, "Navigation Menu Redesign (Nov. 2021)",
      "Changes to the navigation menus on mobile and desktop as part of the IA + Navigation epic"}
   ],

--- a/apps/site/lib/site_web/templates/event/show.html.eex
+++ b/apps/site/lib/site_web/templates/event/show.html.eex
@@ -1,7 +1,7 @@
 <% has_related_files = @event.agenda_file || @event.minutes_file || Enum.empty?(@event.files) == false %>
 <% sidebar_class = if has_related_files, do: "c-cms--with-sidebar c-cms--sidebar-right", else: "c-cms--no-sidebar" %>
 
-<%= if Laboratory.enabled?(@conn, :events_hub_redesign) and (!is_nil(@event.registration_link) or !is_nil(@event.event_agenda)) do %>
+<%= if !is_nil(@event.registration_link) or !is_nil(@event.event_agenda) do %>
 
   <%# if has_started?(@event) and not is_nil(@event.livestream_link) do %>
     <!-- TODO: Get appropriate video embed code

--- a/apps/site/test/site_web/controllers/event_controller_test.exs
+++ b/apps/site/test/site_web/controllers/event_controller_test.exs
@@ -137,6 +137,15 @@ defmodule SiteWeb.EventControllerTest do
     end
   end
 
+  describe "GET show (events_hub_redesign)" do
+    test "renders show.html", %{conn: conn} do
+      event = event_factory(0, path_alias: nil)
+      conn = get(conn, event_path(conn, :show, event))
+      assert conn.status == 200
+      refute html_response(conn, 200) =~ "<h3>Agenda</h3>"
+    end
+  end
+
   describe "GET icalendar" do
     test "returns an icalendar file as an attachment when event does not have an alias", %{
       conn: conn

--- a/apps/site/test/site_web/controllers/event_controller_test.exs
+++ b/apps/site/test/site_web/controllers/event_controller_test.exs
@@ -137,20 +137,6 @@ defmodule SiteWeb.EventControllerTest do
     end
   end
 
-  describe "GET show (events_hub_redesign)" do
-    setup %{conn: conn} do
-      conn = conn |> put_req_cookie("events_hub_redesign", "true")
-      {:ok, conn: conn}
-    end
-
-    test "renders show.html", %{conn: conn} do
-      event = event_factory(0, path_alias: nil)
-      conn = get(conn, event_path(conn, :show, event))
-      assert conn.status == 200
-      refute html_response(conn, 200) =~ "<h3>Agenda</h3>"
-    end
-  end
-
   describe "GET icalendar" do
     test "returns an icalendar file as an attachment when event does not have an alias", %{
       conn: conn


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Remove feature flag for new event agendas](https://app.asana.com/0/555089885850811/1201507862161340/f)

Remove feature flag from new event agendas. If new agenda is not used fallback to old style. 