### PR TITLE
dont remove secondary nav bar if mobile nav redsign flag is set

### DIFF
--- a/apps/site/lib/site_web/templates/page/_secondary_nav.html.eex
+++ b/apps/site/lib/site_web/templates/page/_secondary_nav.html.eex
@@ -2,7 +2,7 @@
 # divs with onClick events were used here because Google Translate
 # has a problem when other tags are nested inside of anchor tags
 %>
-<div class="m-secondary-nav <%= if Laboratory.enabled?(@conn, :nav_redesign), do: 'todo-remove' %>">
+<div class="m-secondary-nav">
   <div class="m-secondary-nav__items">
     <div class="m-secondary-nav__item" onclick="location.href='/schedules'">
       <span class="m-secondary-nav__icon notranslate">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Mobile menu: Missing secondary nav](https://app.asana.com/0/385363666817452/1201529194279319/f)

Removed the check to hide the secondary nav bar if the mobile nav redesign flag was set. 
