### PR TITLE
add theme-color meta tag to app template

### DIFF
--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -10,7 +10,7 @@
     <% meta_description = assigns[:meta_description] || "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines." %>
     <meta name="description" content="<%= Phoenix.HTML.raw(meta_description) %>">
     <meta name="author" content="Massachusetts Bay Transportation Authority">
-    <meta name="theme-color" content="#071d2e">
+    <meta name="theme-color" content="#0b2f4c">
     <%= Turbolinks.cache_meta @conn %>
 
     <%= # hide any page in /org directory from search engines

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -10,6 +10,7 @@
     <% meta_description = assigns[:meta_description] || "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines." %>
     <meta name="description" content="<%= Phoenix.HTML.raw(meta_description) %>">
     <meta name="author" content="Massachusetts Bay Transportation Authority">
+    <meta name="theme-color" content="#071d2e">
     <%= Turbolinks.cache_meta @conn %>
 
     <%= # hide any page in /org directory from search engines


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Mobile menu: Dark blue background should extend to very top of screen](https://app.asana.com/0/385363666817452/1201529194279336/f)

Change via the theme-color meta tag which explicitly sets the status bar background color rather than the os/browser trying to determine what color it should be. 