### PR TITLE
tests: Restore previously failing tests

### DIFF
--- a/apps/site/lib/site_web/controllers/helpers.ex
+++ b/apps/site/lib/site_web/controllers/helpers.ex
@@ -126,6 +126,7 @@ defmodule SiteWeb.ControllerHelpers do
   @spec forward_static_file(Conn.t(), String.t()) :: Conn.t()
   def forward_static_file(conn, url) do
     IO.inspect(url, label: "url in forward_static_file")
+
     case HTTPoison.get(url, [], hackney: [pool: @content_http_pool]) do
       {:ok, %{status_code: 200, body: body, headers: headers}} ->
         conn

--- a/apps/site/lib/site_web/controllers/helpers.ex
+++ b/apps/site/lib/site_web/controllers/helpers.ex
@@ -125,6 +125,7 @@ defmodule SiteWeb.ControllerHelpers do
   """
   @spec forward_static_file(Conn.t(), String.t()) :: Conn.t()
   def forward_static_file(conn, url) do
+    IO.inspect(url, label: "url in forward_static_file")
     case HTTPoison.get(url, [], hackney: [pool: @content_http_pool]) do
       {:ok, %{status_code: 200, body: body, headers: headers}} ->
         conn

--- a/apps/site/test/site_web/controllers/old_site_file_controller_test.exs
+++ b/apps/site/test/site_web/controllers/old_site_file_controller_test.exs
@@ -1,6 +1,13 @@
 defmodule SiteWeb.OldSiteFileControllerTest do
   use SiteWeb.ConnCase
 
+  setup do
+    # needed for HTTPoison to work
+    _ = Application.ensure_all_started(:hackney)
+
+    :ok
+  end
+
   describe "/uploadedfiles" do
     test "can return a file with spaces in the URL", %{conn: conn} do
       conn =

--- a/apps/site/test/site_web/controllers/old_site_file_controller_test.exs
+++ b/apps/site/test/site_web/controllers/old_site_file_controller_test.exs
@@ -2,7 +2,6 @@ defmodule SiteWeb.OldSiteFileControllerTest do
   use SiteWeb.ConnCase
 
   describe "/uploadedfiles" do
-    @tag skip: "FIXME: Failing possibly due to unrelated ITD work"
     test "can return a file with spaces in the URL", %{conn: conn} do
       conn =
         head(
@@ -13,7 +12,6 @@ defmodule SiteWeb.OldSiteFileControllerTest do
       assert conn.status == 200
     end
 
-    @tag skip: "FIXME: Failing possibly due to unrelated ITD work"
     test "can return file from /uploadedimages", %{conn: conn} do
       conn =
         head(conn, "/uploadedimages/About_the_T/Art_Collection/Map%20Runner%20Up%2015%20lg.jpg")
@@ -21,19 +19,16 @@ defmodule SiteWeb.OldSiteFileControllerTest do
       assert conn.status == 200
     end
 
-    @tag skip: "FIXME: Failing possibly due to unrelated ITD work"
     test "can return file from /uploadedImages", %{conn: conn} do
       conn = head(conn, "/uploadedImages/services/subway/braintree_station.jpg")
       assert conn.status == 200
     end
 
-    @tag skip: "FIXME: Failing possibly due to unrelated ITD work"
     test "can return file from /lib", %{conn: conn} do
       conn = head(conn, "/lib/css/T-Tracker.css")
       assert conn.status == 200
     end
 
-    @tag skip: "FIXME: Failing possibly due to unrelated ITD work"
     test "can return file from /images", %{conn: conn} do
       conn = head(conn, "/images/logo-mbta.gif")
       assert conn.status == 200


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Restore access to forbidden static files](https://app.asana.com/0/385363666817452/1201648677863847/f)

The root problem appears to have been solved, let's restore the tests and see everything pass!