### PR TITLE
Mobile menu | Address accessibility for accordion menus

### DIFF
--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -655,10 +655,20 @@ header.header.search-open {
 }
 
 .m-menu__toggle, .header-search__toggle {
- background-color: unset;
- border: 2px solid $brand-primary-light-contrast;
- border-radius: 4px;
- margin: auto 0;
+  background-color: unset;
+  border: 2px solid $brand-primary-light-contrast;
+  border-radius: 4px;
+  margin: auto 0;
+
+  &:hover,
+  &:focus {
+    background-color: $brand-primary-darkest;
+  }
+
+  &[aria-expanded="true"]:hover,
+  &[aria-expanded="true"]:focus {
+    background-color: $brand-primary;
+  }
 }
 
 .m-menu__toggle {

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -619,6 +619,11 @@ nav.m-menu {
   display: none;
 }
 
+header.header .c-search-bar__autocomplete {
+  // stylelint-disable-next-line declaration-no-important
+  z-index: calc(#{$z-index-modal} + 1) !important; // = 102. overwrites the 100 value added by autocomplete.js
+}
+
 header.header.menu-open {
   .m-menu__cover {
     display: block;

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -373,7 +373,9 @@ nav.m-menu {
 }
 .m-menu__title {
   background-color: $brand-primary-darkest;
+  margin: 0;
   padding: 10px 12px;
+
   @include media-breakpoint-up(sm) {
     display: none;
   }
@@ -474,6 +476,7 @@ nav.m-menu {
 
   .m-menu__section-heading {
     color: $brand-primary-lightest;
+    margin: 0;
     padding: 16px 0 0 16px;
   }
 

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -634,17 +634,21 @@ header.header.search-open {
     display: block;
     top: 112px;
   }
+
   .m-menu__search {
     display: block;
     height: 60px;
   }
+
   .m-menu__toggle {
     opacity: 0;
     pointer-events: none;
   }
+
   .fa-search {
     display: none;
   }
+
   .fa-close {
     display: inline;
   }

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -486,15 +486,17 @@ nav.m-menu {
   }
   // Accordion stuff
   .c-accordion-ui {
+    border: 0;
     margin-bottom: 0;
-    border: none;
-    .c-accordion-ui__trigger{
+
+    .c-accordion-ui__trigger {
       @include heading-4();
       color: $white;
       &:hover, &:active {
         background-color: inherit;
       }
     }
+
     .c-accordion-ui__content {
       background-color: $brand-primary-lightest-contrast;
       padding: 0;
@@ -504,7 +506,30 @@ nav.m-menu {
       }
     }
   }
-  
+
+  .m-menu__link {
+    @include font-link();
+    display: block;
+    padding: 12px 12px 12px 24px;
+
+    div {
+      display: inline-block;
+      margin-right: 4px;
+    }
+
+    &:focus {
+      color: $link-color;
+      outline: none;
+      text-decoration: none;
+
+      div {
+        border-radius: 4px;
+        box-shadow: 0 0 0 2px currentColor,
+          0 0 0 3px $brand-primary-lightest-contrast, 0 0 0 4px $brand-primary-darkest;
+      }
+    }
+  }
+
   .menu-container {
     background-color: $brand-primary-darkest;
     margin-top: 1rem;

--- a/apps/site/assets/package-lock.json
+++ b/apps/site/assets/package-lock.json
@@ -64,6 +64,7 @@
         "@types/react-test-renderer": "^16.8.3",
         "@typescript-eslint/eslint-plugin": "^4.14.2",
         "@typescript-eslint/parser": "^4.14.2",
+        "axe-core": "^4.3.5",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^27.1.0",
         "babel-loader": "^8.0.4",

--- a/apps/site/assets/package-lock.json
+++ b/apps/site/assets/package-lock.json
@@ -73,6 +73,7 @@
         "css-loader": "^1.0.0",
         "custom-event-autopolyfill": "^0.1.3",
         "cypress": "^9.2.1",
+        "cypress-axe": "^0.14.0",
         "cypress-file-upload": "^5.0.8",
         "cypress-iframe": "^1.0.1",
         "enzyme": "^3.11.0",
@@ -7256,6 +7257,19 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cypress-axe": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.14.0.tgz",
+      "integrity": "sha512-7Rdjnko0MjggCmndc1wECAkvQBIhuy+DRtjF7bd5YPZRFvubfMNvrxfqD8PWQmxm7MZE0ffS4Xr43V6ZmvLopg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
     "node_modules/cypress-file-upload": {
@@ -33637,6 +33651,13 @@
           }
         }
       }
+    },
+    "cypress-axe": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.14.0.tgz",
+      "integrity": "sha512-7Rdjnko0MjggCmndc1wECAkvQBIhuy+DRtjF7bd5YPZRFvubfMNvrxfqD8PWQmxm7MZE0ffS4Xr43V6ZmvLopg==",
+      "dev": true,
+      "requires": {}
     },
     "cypress-file-upload": {
       "version": "5.0.8",

--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -69,6 +69,7 @@
     "css-loader": "^1.0.0",
     "custom-event-autopolyfill": "^0.1.3",
     "cypress": "^9.2.1",
+    "cypress-axe": "^0.14.0",
     "cypress-file-upload": "^5.0.8",
     "cypress-iframe": "^1.0.1",
     "enzyme": "^3.11.0",

--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -60,6 +60,7 @@
     "@types/react-test-renderer": "^16.8.3",
     "@typescript-eslint/eslint-plugin": "^4.14.2",
     "@typescript-eslint/parser": "^4.14.2",
+    "axe-core": "^4.3.5",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^27.1.0",
     "babel-loader": "^8.0.4",

--- a/apps/site/assets/static/images/icon-circle-locations-default.svg
+++ b/apps/site/assets/static/images/icon-circle-locations-default.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 48 48" version="1.1" viewBox="0 0 48 48" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 48 48" version="1.1" viewBox="0 0 48 48" xml:space="preserve">
     <title>
         location
     </title>

--- a/apps/site/assets/static/images/icon-circle-locations-small.svg
+++ b/apps/site/assets/static/images/icon-circle-locations-small.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
     <title>
         location
     </title>

--- a/apps/site/assets/static/images/icon-circle-t-default.svg
+++ b/apps/site/assets/static/images/icon-circle-t-default.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 48 48" version="1.1" viewBox="0 0 48 48" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 48 48" version="1.1" viewBox="0 0 48 48" xml:space="preserve">
     <title>
         T
     </title>

--- a/apps/site/assets/static/images/icon-circle-t-small-grey.svg
+++ b/apps/site/assets/static/images/icon-circle-t-small-grey.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
     <title>
         T (Out of service)
     </title>

--- a/apps/site/assets/static/images/icon-circle-t-small.svg
+++ b/apps/site/assets/static/images/icon-circle-t-small.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
     <title>
         T
     </title>

--- a/apps/site/assets/static/images/icon-down-arrow.svg
+++ b/apps/site/assets/static/images/icon-down-arrow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" data-name="Layer 1" role="img" viewBox="0 0 48 48">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-name="Layer 1" role="img" viewBox="0 0 48 48">
     <title>
         down arrow
     </title>

--- a/apps/site/assets/static/images/icon-service-none-default.svg
+++ b/apps/site/assets/static/images/icon-service-none-default.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 48 48" version="1.1" viewBox="0 0 48 48" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 48 48" version="1.1" viewBox="0 0 48 48" xml:space="preserve">
     <title>
         no service
     </title>

--- a/apps/site/assets/static/images/icon-service-none-small.svg
+++ b/apps/site/assets/static/images/icon-service-none-small.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
     <title>
         no service
     </title>

--- a/apps/site/assets/static/images/icon-service-regular-default.svg
+++ b/apps/site/assets/static/images/icon-service-regular-default.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 48 48" version="1.1" viewBox="0 0 48 48" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 48 48" version="1.1" viewBox="0 0 48 48" xml:space="preserve">
     <title>
         regular service
     </title>

--- a/apps/site/assets/static/images/icon-service-regular-small.svg
+++ b/apps/site/assets/static/images/icon-service-regular-small.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
     <title>
         regular service
     </title>

--- a/apps/site/assets/static/images/icon-service-storm-default.svg
+++ b/apps/site/assets/static/images/icon-service-storm-default.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 48 48" version="1.1" viewBox="0 0 48 48" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 48 48" version="1.1" viewBox="0 0 48 48" xml:space="preserve">
     <title>
         storm service
     </title>

--- a/apps/site/assets/static/images/icon-service-storm-small.svg
+++ b/apps/site/assets/static/images/icon-service-storm-small.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" role="img" style="enable-background:new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve">
     <title>
         storm service
     </title>

--- a/apps/site/assets/static/images/icon-stop-circle-bordered.svg
+++ b/apps/site/assets/static/images/icon-stop-circle-bordered.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" role="img" viewBox="0 0 48 48">
+<svg xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" role="img" viewBox="0 0 48 48">
     <title>
         circle
     </title>

--- a/apps/site/assets/static/images/icon-the-ride-default.svg
+++ b/apps/site/assets/static/images/icon-the-ride-default.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" data-name="Layer 1" role="img" viewBox="0 0 48 48">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-name="Layer 1" role="img" viewBox="0 0 48 48">
     <title>
         the ride
     </title>

--- a/apps/site/assets/static/images/icon-the-ride-small.svg
+++ b/apps/site/assets/static/images/icon-the-ride-small.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" data-name="Layer 1" role="img" viewBox="0 0 16 16">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-name="Layer 1" role="img" viewBox="0 0 16 16">
     <title>
         the ride
     </title>

--- a/apps/site/assets/static/images/icon-vehicle-bordered.svg
+++ b/apps/site/assets/static/images/icon-vehicle-bordered.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" role="img" viewBox="0 0 48 48">
+<svg xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" role="img" viewBox="0 0 48 48">
     <title>
         vehicle
     </title>

--- a/apps/site/assets/ts/app/mobile-menu.ts
+++ b/apps/site/assets/ts/app/mobile-menu.ts
@@ -78,6 +78,15 @@ const setupMobileMenu = (): void => {
   document.body.addEventListener("keydown", e => {
     handleNativeEscapeKeyPress(e, closeMenu);
   });
+
+  // removes focus outline in Safari from open accordions
+  document
+    .querySelectorAll(".m-menu__content .js-focus-on-expand")
+    .forEach(acc => {
+      acc.addEventListener("focus", function undoOutline(this: HTMLElement) {
+        this.style.outline = "none";
+      });
+    });
 };
 
 export default (): void => {

--- a/apps/site/lib/site/phone_number.ex
+++ b/apps/site/lib/site/phone_number.ex
@@ -42,6 +42,27 @@ defmodule Site.PhoneNumber do
     end
   end
 
+  @doc """
+  Format read by screenreaders in a nicer manner
+  Inspired by https://jhalabi.com/blog/accessibility-phone-number-formatting
+  """
+  def aria_format(nil), do: nil
+
+  def aria_format(number) do
+    case parse_phone_number(number) do
+      {area_code, prefix, line} ->
+        [area_code, prefix, line]
+        |> Enum.map(fn num ->
+          String.split(num, "", trim: true)
+          |> Enum.join(" ")
+        end)
+        |> Enum.join(". ")
+
+      nil ->
+        nil
+    end
+  end
+
   @spec parse_phone_number(String.t()) :: {String.t(), String.t(), String.t()} | nil
   def parse_phone_number(number) do
     case number |> digits |> without_leading_one do

--- a/apps/site/lib/site_web/templates/layout/_footer.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_footer.html.eex
@@ -63,22 +63,18 @@
       </li>
       <li class="m-footer__group m-footer--mobile__group">
         <div class="m-footer__group-title">Customer Support</div>
-        <ul class="list-unstyled">
-          <div class="m-footer--mobile__items">
-            <li class="m-footer__item m-footer--mobile__item">
-              <%= link "Contact Us", to: customer_support_path(@conn, :index), data: [scroll: true]  %>
-            </li>
-            <li class="m-footer__item m-footer--mobile__item">
-              <%= link "Lost and Found", to: cms_static_page_path(@conn, "/customer-support/lost-and-found"), data: [scroll: true]  %>
-            </li>
-            <li class="m-footer__item m-footer--mobile__item">
-              <%= link "Policies", to: cms_static_page_path(@conn, "/policies"), data: [scroll: true]  %>
-            </li>
-          </div>
-          <div class="hidden-sm-down">
-            <li class="m-footer__item"><%= link "Request Public Records", to: "https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&COID=64D93B66", target: "_blank" %></li>
-            <li class="m-footer__item"><%= link "Civil Rights", to: cms_static_page_path(@conn, "/policies/title-vi"), data: [scroll: true]  %></li>
-          </div>
+        <ul class="list-unstyled m-footer--mobile__items">
+          <li class="m-footer__item m-footer--mobile__item">
+            <%= link "Contact Us", to: customer_support_path(@conn, :index), data: [scroll: true]  %>
+          </li>
+          <li class="m-footer__item m-footer--mobile__item">
+            <%= link "Lost and Found", to: cms_static_page_path(@conn, "/customer-support/lost-and-found"), data: [scroll: true]  %>
+          </li>
+          <li class="m-footer__item m-footer--mobile__item">
+            <%= link "Policies", to: cms_static_page_path(@conn, "/policies"), data: [scroll: true]  %>
+          </li>
+          <li class="m-footer__item hidden-sm-down"><%= link "Request Public Records", to: "https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&COID=64D93B66", target: "_blank" %></li>
+          <li class="m-footer__item hidden-sm-down"><%= link "Civil Rights", to: cms_static_page_path(@conn, "/policies/title-vi"), data: [scroll: true]  %></li>
         </ul>
       </li>
       <li class="m-footer__group">

--- a/apps/site/lib/site_web/templates/layout/_new_header.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_header.html.eex
@@ -18,7 +18,7 @@
         %>
       </div>
 
-      <button class="header-search__toggle" type="button" aria-expanded="false">
+      <button class="header-search__toggle" type="button" aria-expanded="false" aria-controls="search-header-mobile__container" aria-label="Search MBTA.com">
         <i class="fa fa-search" aria-hidden="true"></i>
         <i class="fa fa-close" aria-hidden="true"></i>
       </button>

--- a/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.eex
@@ -1,10 +1,10 @@
 <nav class="m-menu" id="navmenu">
   <div class="m-menu__cover"></div>
   <div class="m-menu__content">
-    <div class="m-menu__title heading-2">Main Menu</div>
+    <h1 class="m-menu__title heading-2">Main Menu</h1>
     <%= for %{menu_section: menu_section, sub_menus: sub_menus} <- nav_link_content_redesign(@conn) do %>
       <nav aria-labelledby="section-heading-<%= menu_section %>" class="m-menu__section">
-        <div id="section-heading-<%= menu_section %>" class="m-menu__section-heading"><%= menu_section %></div>
+        <h2 id="section-heading-<%= menu_section %>" class="m-menu__section-heading"><%= menu_section %></h2>
         <%= SiteWeb.PartialView.render("_accordion_ui.html",
             Map.merge(assigns, %{
               id: menu_section,

--- a/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.eex
@@ -3,10 +3,11 @@
   <div class="m-menu__content">
     <div class="m-menu__title heading-2">Main Menu</div>
     <%= for %{menu_section: menu_section, sub_menus: sub_menus} <- nav_link_content_redesign(@conn) do %>
-      <nav aria-labelledby="section-heading" class="m-menu__section">
-        <div id="section-heading" class="m-menu__section-heading"><%= menu_section %></div>
+      <nav aria-labelledby="section-heading-<%= menu_section %>" class="m-menu__section">
+        <div id="section-heading-<%= menu_section %>" class="m-menu__section-heading"><%= menu_section %></div>
         <%= SiteWeb.PartialView.render("_accordion_ui.html",
             Map.merge(assigns, %{
+              id: menu_section,
               multiselectable: false,
               sections:
                 for %{links: links} = sub_menu <- sub_menus do

--- a/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
@@ -1,4 +1,6 @@
-<div class="c-accordion-ui" id="accordion" role="presentation" <%= if @multiselectable do %> aria-multiselectable="true"<% end %>>
+<% id = if Map.get(assigns, :id), do: "#{Map.get(assigns, :id)}-accordion", else: "accordion" %>
+
+<div class="c-accordion-ui" id="<%= id %>" role="presentation" <%= if @multiselectable do %> aria-multiselectable="true"<% end %>>
   <%= for section <- @sections do %>
     <div class="panel" role="heading">
       <div class="c-accordion-ui__heading<%= if assigns[:sticky] do %> fixedsticky sticky-top<% end %>">
@@ -7,7 +9,7 @@
             aria-expanded="false"
             aria-controls="<%= section.prefix %>-section"
             data-toggle="collapse"
-            data-parent="#accordion">
+            data-parent="#<%= id %>">
           <span class="c-accordion-ui__title" id="<%= section.prefix %>-title">
             <%= section.title |> Site.ContentRewriter.rewrite(@conn) |> raw() %>
           </span>

--- a/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
@@ -2,7 +2,7 @@
 
 <div class="c-accordion-ui" id="<%= id %>" role="presentation" <%= if @multiselectable do %> aria-multiselectable="true"<% end %>>
   <%= for section <- @sections do %>
-    <div class="panel" role="heading">
+    <div class="panel" role="heading" aria-level="3">
       <div class="c-accordion-ui__heading<%= if assigns[:sticky] do %> fixedsticky sticky-top<% end %>">
         <button class="c-accordion-ui__trigger collapsed"
             data-target="#<%= section.prefix %>-section"

--- a/apps/site/lib/site_web/templates/partial/_search_input.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_search_input.html.eex
@@ -4,13 +4,14 @@
     [
       describedby: "search-#{@prefix}__instructions",
       autocomplete: "list",
+      label: @aria_label
     ]
   else
     []
   end
 %>
 <div id="search-<%= @prefix %>__container" class="c-form__input-container">
-  <label for="query" class="sr-only"><%= @aria_label %></label>
+  <label for="search-<%= @prefix %>__input" class="sr-only"><%= @aria_label %></label>
   <%= Phoenix.HTML.Form.text_input(
     Map.get(assigns, :form, :query),
     Map.get(assigns, :field, :input),

--- a/apps/site/lib/site_web/views/helpers.ex
+++ b/apps/site/lib/site_web/views/helpers.ex
@@ -263,7 +263,10 @@ defmodule SiteWeb.ViewHelpers do
         content_tag(:span, pretty_formatted, [])
 
       machine_formatted ->
-        content_tag(:a, pretty_formatted, href: "tel:#{machine_formatted}")
+        content_tag(:a, pretty_formatted,
+          href: "tel:#{machine_formatted}",
+          aria: [label: Site.PhoneNumber.aria_format(number)]
+        )
     end
   end
 

--- a/apps/site/test/site/phone_number_test.exs
+++ b/apps/site/test/site/phone_number_test.exs
@@ -41,4 +41,23 @@ defmodule Site.PhoneNumberTest do
       assert machine_format(nil) == nil
     end
   end
+
+  describe "aria_format/1" do
+    test "works with or without leading 1" do
+      assert aria_format("1-345-456-3456") == "3 4 5. 4 5 6. 3 4 5 6"
+      assert aria_format("345-456-3456") == "3 4 5. 4 5 6. 3 4 5 6"
+    end
+
+    test "strips other formatting" do
+      assert aria_format("(345) 456-3456") == "3 4 5. 4 5 6. 3 4 5 6"
+      assert aria_format("345.456.3456") == "3 4 5. 4 5 6. 3 4 5 6"
+    end
+
+    test "returns nil if it can't be formatted" do
+      assert aria_format("0118 999 881 999 119 7253") == nil
+      assert aria_format("222 3200") == nil
+      assert aria_format("") == nil
+      assert aria_format(nil) == nil
+    end
+  end
 end

--- a/apps/site/test/site_web/views/helpers_test.exs
+++ b/apps/site/test/site_web/views/helpers_test.exs
@@ -24,7 +24,10 @@ defmodule SiteWeb.ViewHelpersTest do
   describe "tel_link/1" do
     test "renders formattable numbers as a link" do
       assert tel_link("617-222-3200") ==
-               content_tag(:a, "617-222-3200", href: "tel:+1-617-222-3200")
+               content_tag(:a, "617-222-3200",
+                 href: "tel:+1-617-222-3200",
+                 aria: [label: "6 1 7. 2 2 2. 3 2 0 0"]
+               )
     end
 
     test "non-formattable numbers don't get processed and don't become links" do

--- a/cypress/integration/nav-menu/mobile_menu.spec.js
+++ b/cypress/integration/nav-menu/mobile_menu.spec.js
@@ -17,6 +17,27 @@ describe("Navigation redesign - mobile menu", () => {
     cy.get(".m-menu__content").as("menu");
   });
 
+  describe("has no detectable a11y violations", () => {
+    beforeEach(() => {
+      cy.injectAxe();
+    });
+
+    it("on load", () => {
+      cy.checkA11y();
+    });
+    
+    it("with menu open", () => {
+      cy.get("@menuButton").click();
+      cy.checkA11y();
+    });
+
+    it("with search open", () => {
+      cy.viewport("iphone-6");
+      cy.get("@searchButton").click();
+      cy.checkA11y();
+    });
+  });
+
   viewports.forEach(viewport => {
     describe(`${viewport} size`, () => {
       beforeEach(() => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -18,6 +18,20 @@
 // eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
+  on('task', {
+    // recommended for cypress-axe logging
+    log(message) {
+      console.log(message);
+
+      return null;
+    },
+    table(message) {
+      console.table(message);
+
+      return null;
+    }
+  });
+
   // `config` is the resolved Cypress config
   const port = process.env.PORT;
   if (!port) {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -15,6 +15,7 @@
 
 import "./../../apps/site/assets/node_modules/cypress-file-upload";
 import "./../../apps/site/assets/node_modules/cypress-iframe";
+import "./../../apps/site/assets/node_modules/cypress-axe";
 import "./commands";
 
 Cypress.Screenshot.defaults({


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Mobile menu | Address accessibility for accordion menus](https://app.asana.com/0/385363666817452/1201509005780670/f)

This PR sets up our first automated accessibility tests using the [cypress-axe](https://github.com/component-driven/cypress-axe) plugin, which is built on the mighty [axe-core](https://github.com/dequelabs/axe-core) accessibility engine. Such automated testing is not a complete substitute for human review and expertise, but it lets us catch low-hanging fruit! A few accessibility checks have been added to test the homepage and mobile menu.

3d55cbc..5c39b83 address various warnings and errors raised by the initial checks.

8c90275 fixes a regression I introduced earlier involving the logo placement shifting in the navbar

The last three commits add some enhancements based on my own assessment:

* An update to how we render phone number links, so that screen readers can read them in a way that resembles how the rest of us read a phone number, as [described in this blog post](https://jhalabi.com/blog/accessibility-phone-number-formatting).
* The addition of focus states to the navbar buttons and to the menu links. 😅 We'd just forgotten to implement these earlier!

---

Before getting review, please check the following:

* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
