### PR TITLE
fix for Investigation: Blue bars appear above and below open sub-menu

### DIFF
--- a/apps/site/assets/ts/app/mobile-menu.ts
+++ b/apps/site/assets/ts/app/mobile-menu.ts
@@ -81,6 +81,15 @@ const setupMobileMenu = (): void => {
 
   // Changing viewport size closes
   window.addEventListener("resize", closeMenu);
+
+  // removes focus outline in Safari from open accordions
+  document
+    .querySelectorAll(".m-menu__content .js-focus-on-expand")
+    .forEach(acc => {
+      acc.addEventListener("focus", function undoOutline(this: HTMLElement) {
+        this.style.outline = "none";
+      });
+    });
 };
 
 export default (): void => {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigation: Blue bars appear above and below open sub-menu](https://app.asana.com/0/385363666817452/1201529194279341/f)

Awkwardly, this was mainly a Safari problem. 
I tried...

* unsetting the blue outline through CSS, but no `!important` or higher specificity made the Safari user agent stop rendering its blue outline.
* listening to the `show.bs.collapse` or `shown.bs.collapse` events from Bootstrap's collapse plugin (which the accordions use when opening/closing) to intercept the adding of the blue outline. But I couldn't get this working either.

I settled on listening to the `focus` event on the accordion target, and removing the outline there.