### PR TITLE
wip: update language selector to use native select box

### DIFF
--- a/apps/site/assets/css/_custom-language-select.scss
+++ b/apps/site/assets/css/_custom-language-select.scss
@@ -45,3 +45,24 @@
 .navbar-toggle-moble--language {
   margin-right: $base-spacing;
 }
+
+.custom-language-selector {
+  -webkit-appearance: none;
+  appearance: none;
+  outline: none;
+  border: none;
+  cursor: pointer;
+  color: #a1c6ed;
+  text-decoration: none;
+  background: transparent;
+
+  &:hover {
+    color: #5da9e8;
+    text-decoration: underline;
+  }
+
+  &:active {
+    color: #165c96;
+    text-decoration: underline;
+  }
+}

--- a/apps/site/assets/css/_custom-language-select.scss
+++ b/apps/site/assets/css/_custom-language-select.scss
@@ -65,4 +65,12 @@
     color: #165c96;
     text-decoration: underline;
   }
+
+  &:focus {
+    outline: 2px solid #ffce0c;
+  }
+}
+
+.globe-icon {
+  color: #a1c6ed;
 }

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -647,3 +647,11 @@ header.header.search-open {
     width: 16px;
   }
 }
+
+.custom-language-selector-mobile-container {
+  padding: 16px;
+}
+
+.custom-language-selector-desktop-container {
+  padding: 11px;
+}

--- a/apps/site/assets/js/google-translate.js
+++ b/apps/site/assets/js/google-translate.js
@@ -119,7 +119,7 @@ const render = () => {
 
 const renderCustomSelect = () => `
   <div>
-    <i class="fa fa-globe" aria-hidden="true"></i>
+    <i class="fa fa-globe globe-icon" aria-hidden="true"></i>
     <select class="custom-language-selector">
     ${languages
       .map(

--- a/apps/site/assets/js/google-translate.js
+++ b/apps/site/assets/js/google-translate.js
@@ -106,99 +106,39 @@ const render = () => {
   // render desktop
   document.getElementById(
     "custom-language-selector"
-  ).innerHTML = `${renderCustomDesktopSelect()}${renderCustomDesktopMenu()}`;
+  ).innerHTML = renderCustomSelect();
 
   // render mobile
   document.getElementById(
-    "custom-language-button-mobile"
-  ).innerHTML = renderCustomMobileSelect();
-
-  document.getElementById(
-    "custom-language-menu-mobile"
-  ).innerHTML = renderCustomMobileMenu();
-
-  // handle keyboard events on links
-  document
-    .getElementById("custom-language-selector")
-    .addEventListener("keyup", triggerClick("language-menu-toggle"));
-  document
-    .getElementById("custom-language-selector-mobile")
-    .addEventListener("keyup", triggerClick("custom-language-selector-mobile"));
+    "custom-language-selector-mobile"
+  ).innerHTML = renderCustomSelect();
 
   // add DOM event handling to rendered links in menu
   registerLinkEvents();
 };
 
-const renderCustomDesktopSelect = () =>
-  `<a tabindex="0" id="language-menu-toggle" class="notranslate desktop-nav-link js-header-link navbar-toggle toggle-up-down collapsed" aria-expanded="false" aria-controls="languageMenu" data-parent="#desktop-menu" data-target="#languageMenu" role="tab" data-toggle="collapse">
-    <div class="nav-link-content js-header-link__content">
-      <span class="nav-link-name"><i class="fa fa-globe" aria-hidden="true"></i> ${currentLanguage.toUpperCase()}</span>
-      <div class="nav-link-arrows js-header-link__carets">
-        <i class="fa fa-angle-up up" aria-hidden="true"></i>
-        <i class="fa fa-angle-down down" aria-hidden="true"></i>
-      </div>
-    </div>
-  </a>`;
-
-const renderCustomDesktopMenu = () => `
-  <div class="desktop-menu desktop-menu--language">
-    <div class="container">
-      <div class="desktop-menu-body panel">
-        <div class="collapse" id="languageMenu" role="tabpanel" aria-expanded="false">
-          <div class="col-xs-4 header-column">
-            <div class="col-xs-12 p-a-0">
-              <ul class="language__linkcontainer">
-              ${languages
-                .map(
-                  ([code, name]) =>
-                    `<li><a tabindex="0" class="language__link ${
-                      code === currentLanguage ? "language__link--active" : ""
-                    }" data-toggle="language" data-lang="${code}">${name}</a></li>`
-                )
-                .join("")}
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-`;
-
-const renderCustomMobileSelect = () =>
-  `<button id="custom-language-selector-mobile" tabindex="0" class="u-pointer navbar-toggle-moble--language navbar-toggle navbar-toggle-mobile collapsed toggle-up-down" aria-expanded="false" type="button" data-toggle="collapse" data-target="#languageMenuMobile">
-    <div class="nav-link-content js-header-link__content">
-      <span class="nav-link-name notranslate"><i class="fa fa-globe" aria-hidden="true"></i> ${currentLanguage.toUpperCase()}</span>
-      <div class="nav-link-arrows js-header-link__carets">
-        <i class="fa fa-angle-up up" aria-hidden="true"></i>
-        <i class="fa fa-angle-down down" aria-hidden="true"></i>
-      </div>
-    </div>
-  </button>`;
-
-const renderCustomMobileMenu = () => `
-  <nav class="row collapse" id="languageMenuMobile" role="navigation" aria-expanded="true">
-    <ul class="mobile-nav">
+const renderCustomSelect = () => `
+  <div>
+    <i class="fa fa-globe" aria-hidden="true"></i>
+    <select class="custom-language-selector">
     ${languages
       .map(
         ([code, name]) =>
-          `<li class="mobile-nav-item"><a tabindex="0" class="language__link language__link--mobile ${
-            code === currentLanguage ? "language__link--mobile-active" : ""
-          }" data-toggle="language" data-lang="${code}">${name}</a></li>`
-      )
-      .join("")}
-    </ul>
-  </nav>
-`;
+          `<option ${code === currentLanguage ? "selected" : ""} data-toggle="language" data-lang="${code}">${name}</option>`
+      )}
+    </select>
+  </div>
+`
 
 const registerLinkEvents = () => {
   const translateEl = document.querySelector(".goog-te-combo");
-  [...document.querySelectorAll("a[data-toggle='language']")].forEach(
+
+  [...document.querySelectorAll(".custom-language-selector")].forEach(
     linkEl => {
       linkEl.addEventListener(
-        "click",
+        "change",
         event => {
-          setTranslation(translateEl, event.target.getAttribute("data-lang"));
+          setTranslation(translateEl, event.target.selectedOptions[0].getAttribute("data-lang"));
           render();
         },
         false

--- a/apps/site/lib/site_web/templates/layout/_nav_desktop.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_nav_desktop.html.eex
@@ -35,16 +35,8 @@
         </div>
       </div>
     <% end %>
-  
-    <div id="custom-language-selector" class="nav-item u-pointer">
-      <a tabindex="0" id="language-menu-toggle" class="notranslate desktop-nav-link js-header-link navbar-toggle toggle-up-down collapsed" aria-expanded="false" aria-controls="languageMenu" data-parent="#desktop-menu" data-target="#languageMenu" role="tab" data-toggle="collapse">
-        <div class="nav-link-content js-header-link__content">
-          <span class="nav-link-name"><i class="fa fa-globe" aria-hidden="true"></i> EN</span>
-          <div class="nav-link-arrows js-header-link__carets"></div>
-        </div>
-      </a>
+    <div id="custom-language-selector" class="nav-item u-pointer custom-language-selector-desktop-container">
     </div>
-
     <div class="nav-item">
       <%=
         link([

--- a/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.eex
@@ -72,7 +72,9 @@
         <% end %>
       </nav>
     <% end %>
-    <div id="custom-language-selector-mobile" />
+    <div class="custom-language-selector-mobile-container">
+      <div id="custom-language-selector-mobile" />
+    </div>
   </div>
   <div class="m-menu__search">
     <%= render SiteWeb.PageView, "_search_bar.html", conn: @conn, placeholder: "Search for routes, info, and more", id: "header-mobile" %>

--- a/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.eex
@@ -72,6 +72,7 @@
         <% end %>
       </nav>
     <% end %>
+    <div id="custom-language-selector-mobile" />
   </div>
   <div class="m-menu__search">
     <%= render SiteWeb.PageView, "_search_bar.html", conn: @conn, placeholder: "Search for routes, info, and more", id: "header-mobile" %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Include language translation link in mobile menu as native](https://app.asana.com/0/385363666817452/1201529194279329/f)

Update language selector implementation to use native select box instead of custom dropdown select.

todo: Update styling to appropriately match. Currently at functional implementation.

![image](https://user-images.githubusercontent.com/526017/150779838-d0a64907-da75-49ee-891b-0e6246b4a13a.png)
![image](https://user-images.githubusercontent.com/526017/150779861-4eeed8f8-52ea-462d-b7fb-69ee7d22a5e0.png)
![image](https://user-images.githubusercontent.com/526017/150779913-e73caa64-08a8-454d-86ae-ecc3c5a543f6.png)
![image](https://user-images.githubusercontent.com/526017/150779956-585e5a25-83fa-414b-8d8c-c74ddd1caec8.png)
