### PR TITLE
Allow Scrolling After Link Click

### DIFF
--- a/apps/site/assets/ts/app/mobile-menu.ts
+++ b/apps/site/assets/ts/app/mobile-menu.ts
@@ -76,7 +76,7 @@ const setupMobileMenu = (): void => {
 
   // menu click closes
   const menu_links = document.querySelectorAll(".m-menu__link");
-  for (let i = 0; i < menu_links.length; i++) {
+  for (let i = 0; i < menu_links.length; i+=1) {
     menu_links[i].addEventListener("click", closeMenu);
   }
 

--- a/apps/site/assets/ts/app/mobile-menu.ts
+++ b/apps/site/assets/ts/app/mobile-menu.ts
@@ -76,7 +76,7 @@ const setupMobileMenu = (): void => {
 
   // menu click closes
   const menu_links = document.querySelectorAll(".m-menu__link");
-  for (let i = 0; i < menu_links.length; i+=1) {
+  for (let i = 0; i < menu_links.length; i += 1) {
     menu_links[i].addEventListener("click", closeMenu);
   }
 

--- a/apps/site/assets/ts/app/mobile-menu.ts
+++ b/apps/site/assets/ts/app/mobile-menu.ts
@@ -74,6 +74,12 @@ const setupMobileMenu = (): void => {
     .querySelector(".m-menu__cover")!
     .addEventListener("click", closeMenu);
 
+  // menu click closes
+  const menu_links = document.querySelectorAll(".m-menu__link");
+  for (let i = 0; i < menu_links.length; i++) {
+    menu_links[i].addEventListener("click", closeMenu);
+  }
+
   // Esc key closes
   document.body.addEventListener("keydown", e => {
     handleNativeEscapeKeyPress(e, closeMenu);


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Scroll disabled after clicking mobile menu link](https://app.asana.com/0/555089885850811/1201708898492559/f)

Added event listeners to menu links to close menu when clicked. This allows the page content to be scrollable again.