### PR TITLE
Close search completely when closing keyboard

### DIFF
--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -188,6 +188,11 @@ export default function setupGlobalNavigation(): void {
 
       if (header.previousElementSibling?.classList.contains("m-menu--cover"))
         header.previousElementSibling.addEventListener("click", closeAllMenus);
+
+      // Focusout on search input closes expanded search bar
+      document
+        .querySelector(".m-menu__search input")
+        ?.addEventListener("focusout", closeAllMenus);
     },
     { passive: true }
   );


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🛑 Close search completely when closing keyboard](https://app.asana.com/0/555089885850811/1201764117487453/f)

Added an extra event listener to close open menus (includes search bar) when the search input has a `focusout` event.