### PR TITLE
Add additional spacing below the sidebar language selector

### DIFF
--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -414,6 +414,7 @@ nav.m-menu--mobile {
   box-shadow: 0px 7px 14px 0px $gray-shadow;
   width: 0px;
   background-color: $brand-primary;
+  padding-bottom: calc(200px - $base-spacing);
 
   .m-menu__section-heading {
     color: $brand-primary-lightest;


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add spacing at the end of the open menu](https://app.asana.com/0/555089885850811/1201764117487425/f)

Before:
![2022-02-10_11-09](https://user-images.githubusercontent.com/5061820/153449082-13ae95b2-3dde-4908-aeb5-fe879c181062.png)

After:
![2022-02-10_10-53](https://user-images.githubusercontent.com/5061820/153449125-7a59b6ac-dd7b-40c1-b465-128b4aa6c3c7.png)

Let me know if this is overkill, but this should give us pretty close to the 200px spacing that Yinka mentioned in the ticket.