### PR TITLE
fix: revert old desktop nav to original style

### DIFF
--- a/apps/site/assets/css/_global-navigation.scss
+++ b/apps/site/assets/css/_global-navigation.scss
@@ -1,16 +1,7 @@
 // Navigation bar on both desktop and mobile
+// Eventually we can phase out _header.scss file, and all relevant styling will be here
 
-.header { // old header on desktop is still white bg
-  @include media-breakpoint-up(lg) {
-    background-color: unset;
-    color: unset;
-  }
-}
-
-header.header--new {
-  background-color: $brand-primary-dark;
-  color: $white;
-
+header {
   .navbar-logo,
   .navbar-logo:hover,
   .navbar-logo:focus {
@@ -20,10 +11,25 @@ header.header--new {
 
   .c-svg__mbta-logo,
   .c-svg__mbta-name-and-logo {
-    text,
-    path {
+    path,
+    text {
       fill: currentColor;
     }
+  }
+
+  &.header { // old header 
+    background-color: $brand-primary;
+    color: $white;
+
+    @include media-breakpoint-up(xxl) {
+      background-color: unset;
+      color: unset;
+    }
+  }
+
+  &.header--new {
+    background-color: $brand-primary-dark;
+    color: $white;
   }
 }
 


### PR DESCRIPTION
restore `$brand-primary` background and `$white` foreground to the old navigation bar's tablet view.

#### Summary of changes
**Asana Ticket:** [Revert old desktop nav button color](https://app.asana.com/0/385363666817452/1201817254333359/f)

old:

![image](https://user-images.githubusercontent.com/2136286/153907900-ef34c158-2f86-4ad2-bc50-62618d319879.png)

new... same as it looks on current mbta.com 