### PR TITLE
Button focus state

### DIFF
--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -560,27 +560,39 @@ nav.m-menu--mobile {
   }
 }
 
+@mixin focus-visible {
+  &.focus-visible {
+    @content;
+  }
+
+  &:focus-visible {
+    @content;
+  }
+}
+
 .m-menu__toggle, .m-menu--desktop__toggle, .header-search__toggle {
   background-color: unset;
   border: 2px solid $brand-primary-light-contrast;
   border-radius: 4px;
   margin: auto 0;
 
-  &:hover,
-  &:focus-visible,
-  &.focus-visible {
+  &:hover {
     background-color: $brand-primary-darkest;
   }
 
-  &:focus-visible,
-  &.focus-visible {
+  @include focus-visible {
+    background-color: $brand-primary-darkest;
     outline: 2px solid $brand-secondary;
   }
 
-  &[aria-expanded="true"]:hover,
-  &[aria-expanded="true"]:focus-visible,
-  &[aria-expanded="true"].focus-visible {
-    background-color: $brand-primary;
+  &[aria-expanded="true"] {
+    &:hover {
+      background-color: $brand-primary;
+    }
+
+    @include focus-visible {
+      background-color: $brand-primary;
+    }
   }
 }
 

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -562,6 +562,7 @@ nav.m-menu--mobile {
 
 @mixin focus-visible {
   &.focus-visible {
+    empty-cells: inherit;
     @content;
   }
 

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -577,8 +577,10 @@ nav.m-menu--mobile {
   border-radius: 4px;
   margin: auto 0;
 
-  &:hover {
-    background-color: $brand-primary-darkest;
+  @media (hover: hover) {
+    &:hover {
+      background-color: $brand-primary-darkest;
+    }
   }
 
   @include focus-visible {
@@ -587,8 +589,10 @@ nav.m-menu--mobile {
   }
 
   &[aria-expanded="true"] {
-    &:hover {
-      background-color: $brand-primary;
+    @media (hover: hover) {
+      &:hover {
+        background-color: $brand-primary;
+      }
     }
 
     @include focus-visible {

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -572,7 +572,7 @@ nav.m-menu--mobile {
   }
 
   &:focus-visible {
-    border-color: $brand-secondary;
+    outline: 2px solid $brand-secondary;
   }
 
   &[aria-expanded="true"]:hover,

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -158,11 +158,11 @@
     .c-svg__mbta-logo {
       display: none;
     }
-  
+
     // At XS size, use T logo only
     @include media-breakpoint-only(xs) {
       flex-grow: 1;
-      
+
       svg {
         display: unset;
         height: 24px;
@@ -567,16 +567,16 @@ nav.m-menu--mobile {
   margin: auto 0;
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background-color: $brand-primary-darkest;
   }
 
-  &:focus {
-    border-color: $brand-primary-light;
+  &:focus-visible {
+    border-color: $brand-secondary;
   }
 
   &[aria-expanded="true"]:hover,
-  &[aria-expanded="true"]:focus {
+  &[aria-expanded="true"]:focus-visible {
     background-color: $brand-primary;
   }
 }

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -1,5 +1,6 @@
 @import 'variables';
 @import 'typography';
+@import 'mixins';
 
 .desktop-menu-nav {
   float: right;
@@ -557,17 +558,6 @@ nav.m-menu--mobile {
 
   .m-menu__toggle {
     @extend %hide-button;
-  }
-}
-
-@mixin focus-visible {
-  &.focus-visible {
-    empty-cells: inherit;
-    @content;
-  }
-
-  &:focus-visible {
-    @content;
   }
 }
 

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -567,16 +567,19 @@ nav.m-menu--mobile {
   margin: auto 0;
 
   &:hover,
-  &:focus-visible {
+  &:focus-visible,
+  &.focus-visible {
     background-color: $brand-primary-darkest;
   }
 
-  &:focus-visible {
+  &:focus-visible,
+  &.focus-visible {
     outline: 2px solid $brand-secondary;
   }
 
   &[aria-expanded="true"]:hover,
-  &[aria-expanded="true"]:focus-visible {
+  &[aria-expanded="true"]:focus-visible,
+  &[aria-expanded="true"].focus-visible {
     background-color: $brand-primary;
   }
 }

--- a/apps/site/assets/css/_mixins.scss
+++ b/apps/site/assets/css/_mixins.scss
@@ -392,3 +392,22 @@
     display: flex;
   }
 }
+
+// Currently, WebKit has spotty support for :focus-visible. We're using a
+// polyfill to work around this, but WebKit also discards any "illegal"
+// rules, including when they are comma'd together. Thus, we need to
+// manually split the class-based polyfill solution from the
+// :focus-visible state selector.
+@mixin focus-visible {
+  &.focus-visible {
+    // Our CSS optimizer tries to merge any "redundant" rules into a
+    // single comma'd CSS declaration, thus we add this property to
+    // "break" the optimization. It shouldn't have any visible effect.
+    empty-cells: inherit;
+    @content;
+  }
+
+  &:focus-visible {
+    @content;
+  }
+}

--- a/apps/site/assets/package-lock.json
+++ b/apps/site/assets/package-lock.json
@@ -19,6 +19,7 @@
         "fast-deep-equal": "^3.1.3",
         "filesize": "^3.3.0",
         "focus-trap": "^5.0.1",
+        "focus-visible": "^5.2.0",
         "form-data": "^1.0.1",
         "formdata-polyfill": "^3.0.20",
         "hogan.js": "^3.0.2",
@@ -10300,6 +10301,11 @@
         "tabbable": "^4.0.0",
         "xtend": "^4.0.1"
       }
+    },
+    "node_modules/focus-visible": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "node_modules/focusable-selectors": {
       "version": "0.3.1",
@@ -35976,6 +35982,11 @@
         "tabbable": "^4.0.0",
         "xtend": "^4.0.1"
       }
+    },
+    "focus-visible": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "focusable-selectors": {
       "version": "0.3.1",

--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -15,6 +15,7 @@
     "fast-deep-equal": "^3.1.3",
     "filesize": "^3.3.0",
     "focus-trap": "^5.0.1",
+    "focus-visible": "^5.2.0",
     "form-data": "^1.0.1",
     "formdata-polyfill": "^3.0.20",
     "hogan.js": "^3.0.2",

--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -188,13 +188,6 @@ export default function setupGlobalNavigation(): void {
 
       if (header.previousElementSibling?.classList.contains("m-menu--cover"))
         header.previousElementSibling.addEventListener("click", closeAllMenus);
-
-      // Load focus-visible polyfill if needed.
-      try {
-        document.querySelector(":focus-visible");
-      } catch (e) {
-        require("focus-visible");
-      }
     },
     { passive: true }
   );

--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -188,6 +188,13 @@ export default function setupGlobalNavigation(): void {
 
       if (header.previousElementSibling?.classList.contains("m-menu--cover"))
         header.previousElementSibling.addEventListener("click", closeAllMenus);
+
+      // Load focus-visible polyfill if needed.
+      try {
+        document.querySelector(":focus-visible");
+      } catch (e) {
+        require("focus-visible");
+      }
     },
     { passive: true }
   );

--- a/apps/site/assets/webpack.config.base.js
+++ b/apps/site/assets/webpack.config.base.js
@@ -129,7 +129,8 @@ module.exports = {
 
   plugins: [
     new CopyWebpackPlugin([
-      { from: "static/**/*", to: "../../" }
+      { from: "static/**/*", to: "../../" },
+      { from: "node_modules/focus-visible/dist/focus-visible.min.js", to: "../js" },
     ], {}),
     new MiniCssExtractPlugin({ filename: "../css/[name].css" }),
     new webpack.ProvidePlugin({

--- a/apps/site/assets/webpack.config.base.js
+++ b/apps/site/assets/webpack.config.base.js
@@ -129,8 +129,7 @@ module.exports = {
 
   plugins: [
     new CopyWebpackPlugin([
-      { from: "static/**/*", to: "../../" },
-      { from: "node_modules/focus-visible/dist/focus-visible.min.js", to: "../js" },
+      { from: "static/**/*", to: "../../" }
     ], {}),
     new MiniCssExtractPlugin({ filename: "../css/[name].css" }),
     new webpack.ProvidePlugin({

--- a/apps/site/assets/webpack.config.base.js
+++ b/apps/site/assets/webpack.config.base.js
@@ -128,7 +128,10 @@ module.exports = {
   },
 
   plugins: [
-    new CopyWebpackPlugin([{ from: "static/**/*", to: "../../" }], {}),
+    new CopyWebpackPlugin([
+      { from: "static/**/*", to: "../../" },
+      { from: "node_modules/focus-visible/dist/focus-visible.min.js", to: "../js" },
+    ], {}),
     new MiniCssExtractPlugin({ filename: "../css/[name].css" }),
     new webpack.ProvidePlugin({
       Turbolinks: "turbolinks",

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -87,6 +87,17 @@
       <% end %>
       <div id="ie-warning" class="c-ie-warning"></div>
     </div>
+
+  <%# Load focus-visible polyfill if needed. Lifted from https://alistairshepherd.uk/writing/focus-visible-conditional-polyfill/ %>
+  <script>
+    try {
+      document.querySelector(":focus-visible");
+    } catch (e) {
+      const script = document.createElement("script");
+      script.src = '<%= static_url(@conn, "/js/focus-visible.min.js") %>';
+      document.body.appendChild(script);
+    }
+  </script>
     <%= if google_tag_manager_id() do %>
       <noscript><iframe src="//www.googletagmanager.com/ns.html?id=<%= google_tag_manager_id()%>&visitorType=noJS" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <script>(function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' }); var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f); })(window, document, 'script', 'dataLayer', '<%= google_tag_manager_id() %>');</script>

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -87,17 +87,6 @@
       <% end %>
       <div id="ie-warning" class="c-ie-warning"></div>
     </div>
-
-  <%# Load focus-visible polyfill if needed. Lifted from https://alistairshepherd.uk/writing/focus-visible-conditional-polyfill/ %>
-  <script>
-    try {
-      document.querySelector(":focus-visible");
-    } catch (e) {
-      const script = document.createElement("script");
-      script.src = '<%= static_url(@conn, "/js/focus-visible.min.js") %>';
-      document.body.appendChild(script);
-    }
-  </script>
     <%= if google_tag_manager_id() do %>
       <noscript><iframe src="//www.googletagmanager.com/ns.html?id=<%= google_tag_manager_id()%>&visitorType=noJS" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <script>(function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' }); var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f); })(window, document, 'script', 'dataLayer', '<%= google_tag_manager_id() %>');</script>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update button toggle color to default after it's been pressed](https://app.asana.com/0/555089885850811/1201764117487423/f)

This PR:
- Adds `focus-visible` to our dependencies (so that we can use `:focus-visible` in Safari. WebKit has recently merged support for the selector but it's still not widely available).
- Configures webpack to copy `focus-visible.min.js` to our output directory
- Conditionally loads the dependency based on whether or not the browser supports `:focus-visible`
- Updates the styles for the header menu toggle buttons to use `:focus-visible` and use `$brand-secondary` as the border color (matching the accordion buttons)

Let me know if the webpack configuration and load strategy makes sense :)

I've tested this locally on Firefox, Safari (desktop), and Chrome and they all seem to be working (though there's an additional outline added in Chrome, I didn't locate where it was coming from but I'm fairly certain it's not caused by this PR).

Demo:
https://user-images.githubusercontent.com/5061820/154130813-b7955ac4-efce-4a66-ace8-680f6db86166.mp4

