### PR TITLE
Call `closeAllMenus` when clicking T logo

### DIFF
--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -181,6 +181,9 @@ export default function setupGlobalNavigation(): void {
         menu_links[i].addEventListener("click", closeAllMenus);
       }
 
+      // T logo click closes
+      header.querySelector(".navbar-logo")?.addEventListener("click", closeAllMenus);
+
       // Veil click or Esc key closes everything
       document.body.addEventListener("keydown", e => {
         handleNativeEscapeKeyPress(e, closeAllMenus);

--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -182,7 +182,9 @@ export default function setupGlobalNavigation(): void {
       }
 
       // T logo click closes
-      header.querySelector(".navbar-logo")?.addEventListener("click", closeAllMenus);
+      header
+        .querySelector(".navbar-logo")
+        ?.addEventListener("click", closeAllMenus);
 
       // Veil click or Esc key closes everything
       document.body.addEventListener("keydown", e => {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Remove flashing when clicking T logo](https://app.asana.com/0/555089885850811/1201764117487461/f)

This should fix a bunch of issues on the homepage when the mobile menu
is open, including:
- menu popping in when the T logo is clicked twice
- theme flickering on mobile Chrome and Safari
- modal veil remaining open