### PR TITLE
feat: activate feature flag via URL

### DIFF
--- a/apps/site/test/site_web/router_test.exs
+++ b/apps/site/test/site_web/router_test.exs
@@ -146,4 +146,18 @@ defmodule Phoenix.Router.RoutingTest do
     conn = get(conn, "/")
     refute Enum.find(conn.resp_headers, &(&1 == {"x-robots-tag", "noindex"}))
   end
+
+  test "Assigns cookie for known flagged features via URL params", %{conn: conn} do
+    conn = Plug.Conn.fetch_cookies(conn)
+    refute conn.cookies["some_feature"]
+
+    # add a feature flag
+    Application.put_env(:laboratory, :features, [
+      {:some_feature, "", ""}
+      | Application.get_env(:laboratory, :features)
+    ])
+
+    assert get(conn, "/?active_flag=some_feature") |> Laboratory.enabled?(:some_feature)
+    refute get(conn, "/?active_flag=unknown_feature") |> Laboratory.enabled?(:unknown_feature)
+  end
 end


### PR DESCRIPTION
No ticket.

Adds the ability to activate a feature flag via URL. This was added with the intent of sharing flagged features with stakeholders in an easier manner. Maybe it'll help! 🙂

Deployed on dev-blue for the time being.

Some open questions...

* Technically this sets a cookie that expires after a month (which is exactly what the "enable" button does). So you can activate it by navigating to the appropriate URL with query parameter. But if you subsequently go to the URL without the query parameter, the feature is still activated! So how problematic is that?
* Should this support activating more than one feature at once?
* Maybe the function belongs in `SiteWeb.Plugs.Cookies`
