### PR TITLE
feat: replace Green Line Transformation links with Capital Transformation link

### DIFF
--- a/apps/site/lib/site_web/templates/layout/_desktop_menu_more.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_desktop_menu_more.html.eex
@@ -81,7 +81,7 @@
           <%= link "Fare Transformation", to: cms_static_page_path(@conn, "/fare-transformation"), class: "ga-nav-sublink" %>
         </li>
         <li>
-          <%= link "Green Line Transformation", to: "https://www.mbta.com/projects/green-line-transformation", target: "_blank", class: "ga-nav-sublink" %>
+          <%= link "Capital Transformation", to: "https://www.mbta.com/projects/capital-transformation-programs", target: "_blank", class: "ga-nav-sublink" %>
         </li>
         <li>
           <%= link "See All Projects", to: project_path(@conn, :index), class: "ga-nav-sublink" %>

--- a/apps/site/lib/site_web/templates/static_page/about.html.eex
+++ b/apps/site/lib/site_web/templates/static_page/about.html.eex
@@ -27,7 +27,7 @@
     <div class="c-grid-buttons">
       <%= render "_link.html", text: "Commuter Rail Positive Train Control", href: project_path(@conn, :show , "commuter-rail-positive-train-control-ptc"), class: "col-xs-12 col-sm-4" %>
       <%= render "_link.html", text: "Fare Transformation", href: cms_static_page_path(@conn, "/fare-transformation"), class: "col-xs-12 col-sm-4" %>
-      <%= render "_link.html", text: "Green Line Transformation", href: "https://www.mbta.com/projects/green-line-transformation", class: "col-xs-12 col-sm-4", target: "_blank" %>
+      <%= render "_link.html", text: "Capital Transformation", href: "https://www.mbta.com/projects/capital-transformation-programs", class: "col-xs-12 col-sm-4", target: "_blank" %>
       <%= render "_link.html", text: "Wollaston Station", href: cms_static_page_path(@conn, "/wollaston"), class: "col-xs-12 col-sm-4" %>
       <%= render "_link.html", text: "See All Projects", href: project_path(@conn, :index), class: "col-xs-12 col-sm-4" %>
     </div>

--- a/apps/site/lib/site_web/views/layout_view.ex
+++ b/apps/site/lib/site_web/views/layout_view.ex
@@ -187,7 +187,7 @@ defmodule SiteWeb.LayoutView do
             links: [
               {"Sustainability", "/sustainability", :internal_link},
               {"Building a Better T", "/projects/building-better-t-2020", :internal_link},
-              {"Green Line Transformation", "/projects/green-line-transformation",
+              {"Capital Transformation", "/projects/capital-transformation-programs",
                :internal_link},
               {"Commuter Rail Positive Train Control",
                "/projects/commuter-rail-positive-train-control-ptc", :internal_link},


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [replace GLT page with new Capital Transformation page in header & footer navigation](https://app.asana.com/0/385363666817452/1201782887147816/f)

swapped out Green Line Transformation page references with Capital Transformation page link.
