### PR TITLE
Line Diagram hotfix for GLX

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/line-diagram-helpers.ts
+++ b/apps/site/assets/ts/schedule/components/line-diagram/line-diagram-helpers.ts
@@ -44,14 +44,23 @@ export const getTreeDirection = (
   // use the position of the merge stop to find this. assume default of outward
   let direction: BranchDirection = "outward";
   if (lineDiagram.some(isMergeStop)) {
-    const mergeIndices = lineDiagramIndexes(lineDiagram, isMergeStop);
+    const firstMergeIndex = lineDiagramIndexes(lineDiagram, isMergeStop)[0];
     const branchTerminiIndices = lineDiagramIndexes(
       lineDiagram,
       isBranchTerminusStop
     );
-    direction = branchTerminiIndices.some(i => mergeIndices[0] > i)
-      ? "inward"
-      : "outward";
+    // if there are more termini stops before the merge, then presume "inward" direction
+    // where 2+ branches converge as you go down the list. and vice versa
+    const terminiBeforeMerge = branchTerminiIndices.filter(
+      i => i < firstMergeIndex
+    );
+    const terminiAfterMerge = branchTerminiIndices.filter(
+      i => i > firstMergeIndex
+    );
+    direction =
+      terminiBeforeMerge.length > terminiAfterMerge.length
+        ? "inward"
+        : "outward";
   }
 
   return direction;

--- a/apps/site/lib/green_line.ex
+++ b/apps/site/lib/green_line.ex
@@ -11,19 +11,6 @@ defmodule GreenLine do
   @type branch_name :: String.t()
   @typep stops_by_routes_fn :: ([Route.id_t()], 0 | 1, Keyword.t() -> [Stop.t()] | {:error, any})
 
-  # FIXME: Stop hardcoding these
-  @termini %{
-    {"Green-B", 0} => "place-lake",
-    {"Green-B", 1} => "place-gover",
-    {"Green-C", 0} => "place-clmnl",
-    {"Green-C", 1} => "place-gover",
-    {"Green-D", 0} => "place-river",
-    {"Green-D", 1} => "place-north",
-    {"Green-E", 0} => "place-hsmnl",
-    # In Spring 2022, the GLX extends E to Union Square
-    {"Green-E", 1} => "place-unsqu"
-  }
-
   @doc """
   Returns the `calculate_stops_on_routes` results from the GreenLine.Cache.
   """
@@ -46,6 +33,17 @@ defmodule GreenLine do
   end
 
   @doc """
+  Terminal stops for each Green Line branch and direction.
+  TODO: Combine with calculate_stops_on_routes?
+  """
+  def termini_stops() do
+    for direction_id <- [0, 1], branch_id <- GreenLine.branch_ids(), into: %{} do
+      stop = Stops.Repo.by_route(branch_id, direction_id) |> List.last()
+      {{branch_id, direction_id}, stop}
+    end
+  end
+
+  @doc """
   Returns whether or not the given stop is a terminus for the line. Assumes the given stop is
   actually on the line.
   """
@@ -57,18 +55,18 @@ defmodule GreenLine do
   @doc """
   Returns whether or not the stop is a terminus for the line in the given direction. Assumes
   the stop is actually on the line.
+  TODO: Cache this and naive_headsign, probably
   """
   @spec terminus?(Stop.id_t(), branch_name, 0 | 1) :: boolean
   def terminus?(stop_id, branch_name, direction_id) do
-    Map.get(@termini, {branch_name, direction_id}) == stop_id
+    Map.get(termini_stops(), {branch_name, direction_id}, %{}) |> Map.get(:id) == stop_id
   end
 
   @doc "A naive guess at the destination of a green line train when no trip is available"
   @spec naive_headsign(branch_name, 0 | 1) :: String.t()
   def naive_headsign(branch_name, direction_id) do
-    @termini
-    |> Map.get({branch_name, direction_id})
-    |> Stops.Repo.get_parent()
+    termini_stops()
+    |> Map.get({branch_name, direction_id}, %{})
     |> Map.get(:name)
   end
 

--- a/apps/site/lib/green_line.ex
+++ b/apps/site/lib/green_line.ex
@@ -11,6 +11,7 @@ defmodule GreenLine do
   @type branch_name :: String.t()
   @typep stops_by_routes_fn :: ([Route.id_t()], 0 | 1, Keyword.t() -> [Stop.t()] | {:error, any})
 
+  # FIXME: Stop hardcoding these
   @termini %{
     {"Green-B", 0} => "place-lake",
     {"Green-B", 1} => "place-gover",
@@ -19,10 +20,8 @@ defmodule GreenLine do
     {"Green-D", 0} => "place-river",
     {"Green-D", 1} => "place-north",
     {"Green-E", 0} => "place-hsmnl",
-    # As of June 2020, Lechmere is closed for construction and the E-line will
-    # be terminating at North Station for now.
-    # {"Green-E", 1} => "place-lech"
-    {"Green-E", 1} => "place-north"
+    # In Spring 2022, the GLX extends E to Union Square
+    {"Green-E", 1} => "place-unsqu"
   }
 
   @doc """
@@ -111,8 +110,6 @@ defmodule GreenLine do
   @spec shared_stops() :: [Stop.id_t()]
   def shared_stops,
     do: [
-      "place-lech",
-      "place-spmnl",
       "place-north",
       "place-haecl",
       "place-gover",
@@ -129,16 +126,17 @@ defmodule GreenLine do
   """
   @spec excluded_shared_stops(branch_name) :: [Stop.id_t()]
   def excluded_shared_stops("Green-B"),
-    do: ["place-lech", "place-spmnl", "place-north", "place-haecl", "place-gover"]
+    do: ["place-north", "place-haecl"]
 
-  def excluded_shared_stops("Green-C"), do: ["place-lech", "place-spmnl"]
+  def excluded_shared_stops("Green-C"), do: ["place-north", "place-haecl"]
 
   def excluded_shared_stops("Green-D"),
-    do: ["place-lech", "place-spmnl", "place-north", "place-haecl"]
+    do: []
 
   def excluded_shared_stops("Green-E"), do: ["place-kencl", "place-hymnl"]
 
   @doc """
+  FIXME: This and split_id/1 won't make sense when there's branching at both ends.
   The stop at which a branch joins the other branches.
   """
   @spec merge_id(branch_name) :: Stop.id_t()

--- a/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/diagram_helpers.ex
@@ -378,6 +378,22 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
   # "Merge stop" IDs are hard-coded for the moment since we can't easily get data on *which* lines
   # are merging together at a given stop, and the E line needs a special case since it merges into
   # three other lines we want to represent as a single line.
+  defp combined_green_stop_bubble_types(%RouteStop{id: "place-unsqu"}) do
+    [{"Green-E", :terminus}]
+  end
+
+  defp combined_green_stop_bubble_types(%RouteStop{id: "place-lech"}) do
+    [{"Green-E", :stop}]
+  end
+
+  defp combined_green_stop_bubble_types(%RouteStop{id: "place-spmnl"}) do
+    [{"Green-E", :stop}]
+  end
+
+  defp combined_green_stop_bubble_types(%RouteStop{id: "place-north"}) do
+    [{nil, :stop}]
+  end
+
   defp combined_green_stop_bubble_types(%RouteStop{id: "place-coecl"}) do
     [{nil, :merge}, {"Green-E", :merge}]
   end
@@ -398,7 +414,7 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpers do
       end
 
     # Determine whether this stop should be drawn as a terminus on its branch. Since we are
-    # presenting everything inbound of Copley as a single combined line, only Lechmere should be
+    # presenting everything inbound of Copley as a single combined line, only Union should be
     # considered a terminus on that segment.
     stop_bubble =
       if GreenLine.terminus?(id, branch, 0) or GreenLine.terminus?(id, "Green-E", 1) do

--- a/apps/site/test/green_line_test.exs
+++ b/apps/site/test/green_line_test.exs
@@ -6,12 +6,9 @@ defmodule GreenLineTest do
   describe "stops_on_routes/1" do
     test "returns ordered stops on the green line by direction ID" do
       {stops, _} = stops_on_routes(0)
-
-      # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
-      # We are temporarily adding the fix but this will need to be undone later on.
-      # assert %Stops.Stop{id: "place-lech", name: "Lechmere"} = List.first(stops)
-      assert %Stops.Stop{id: "place-north", name: "North Station"} = List.first(stops)
-      assert %Stops.Stop{id: "place-lake", name: "Boston College"} = List.last(stops)
+      earlier_stop = Enum.find_index(stops, &(&1.id == "place-gover"))
+      later_stop = Enum.find_index(stops, &(&1.id == "place-lake"))
+      assert earlier_stop < later_stop
     end
 
     test "returns a set of {stop_id, route_id} pairs" do
@@ -132,12 +129,14 @@ defmodule GreenLineTest do
       assert terminus?(stop_id, "Green-C")
     end
 
+    # FIXME: Update with new GLX data
     for stop_id <- ["place-river", "place-north"] do
       assert terminus?(stop_id, "Green-D")
     end
 
     # As of June 2020, Lechmere is closed for construction and the E-line will
     # be terminating at North Station for now.
+    # FIXME: Update with new GLX data
     for stop_id <- ["place-north", "place-hsmnl"] do
       assert terminus?(stop_id, "Green-E")
     end
@@ -148,11 +147,14 @@ defmodule GreenLineTest do
     refute terminus?("place-lake", "Green-B", 1)
     # As of June 2020, Lechmere is closed for construction and the E-line will
     # be terminating at North Station for now.
+    # FIXME: Update with new GLX data
     refute terminus?("place-north", "Green-E", 0)
+    # FIXME: Update with new GLX data
     assert terminus?("place-north", "Green-E", 1)
   end
 
   describe "naive_headsign/2" do
+    # FIXME: Update with new GLX data
     test "correct headsign for route and direction" do
       assert naive_headsign("Green-B", 0) == "Boston College"
       assert naive_headsign("Green-B", 1) == "Government Center"

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
@@ -276,6 +276,7 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
              ] = DiagramHelpers.build_stop_list(branches, 0)
     end
 
+    # FIXME: Update with new GLX data
     test "builds a list of stops with bubble info for Green line (4 branches), direction 0" do
       branches = [
         %RouteStops{
@@ -635,7 +636,7 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
 
       assert [
                {
-                 [nil: :terminus],
+                 [nil: :stop],
                  %RouteStop{id: "place-north"}
                },
                {
@@ -705,6 +706,7 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
              ] = DiagramHelpers.build_stop_list(branches, 0)
     end
 
+    # FIXME: Update with new GLX data
     test "builds a list of stops with bubble info for Green line (4 branches), direction 1" do
       branches = [
         %RouteStops{

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -591,7 +591,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       stop = %RouteStop{id: "place-north"}
       branches = {nil, GreenLine.branch_ids()}
 
-      bubbles = [{nil, :terminus}]
+      bubbles = [{nil, :stop}]
 
       assert build_branched_stop(stop, [], branches) == [{bubbles, stop}]
     end


### PR DESCRIPTION
No ticket, but this is a short-term fix to accommodate the upcoming extra Green-E stops by extending the end of the consolidated Green line diagram.

See it on dev-blue or run it locally against the api-dev-blue API to see it with the upcoming GLX stops to open next month.

**Front-end change:**
* Adjusts the logic of determining whether a branched line diagram is branching inward or outward.

**Back-end changes** 
* Adjusts `SiteWeb.ScheduleController.Line.DiagramHelpers` to display the new stops, 
* adjusts `GreenLine` to stop hardcoding the termini stops.
    * This is probably an expensive way to calculate it so frequently and I might change approaches