### PR TITLE
chore: Adjust tests for Summer 2022 rating

### DIFF
--- a/apps/trip_plan/test/transfer_test.exs
+++ b/apps/trip_plan/test/transfer_test.exs
@@ -165,7 +165,7 @@ defmodule TransferTest do
           route_id: "Green-C"
         },
         to: %NamedPosition{
-          stop_id: "71199"
+          stop_id: "70200"
         }
       }
 


### PR DESCRIPTION
No ticket, but the new rating's schedules and data are up on dev-green so I figured I'd proactively see which tests would fail this time, and try to fix them!

(_Why is this needed?_ Some of our unit tests tend to fail after a rating change because the underlying data returned changes. Often the change is inconsequential, but it makes a test fail anyway because the test itself is usually seeking an overly specific set of IDs, or other specific order of data.)

So this PR has two test adjustments, described in more detail in the commit messages for each.