### PR TITLE
Scroll menu accordion to top

### DIFF
--- a/apps/site/assets/package-lock.json
+++ b/apps/site/assets/package-lock.json
@@ -38,6 +38,7 @@
         "react-redux": "^7.2.0",
         "redux": "^4.0.5",
         "sifter": "^0.6.0",
+        "smoothscroll-polyfill": "^0.4.4",
         "stickyfilljs": "^2.1.0",
         "swr": "^0.1.18",
         "tether": "^1.4.7",
@@ -23112,6 +23113,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/smoothscroll-polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
+      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
@@ -46426,6 +46432,11 @@
           "dev": true
         }
       }
+    },
+    "smoothscroll-polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
+      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -34,6 +34,7 @@
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "sifter": "^0.6.0",
+    "smoothscroll-polyfill": "^0.4.4",
     "stickyfilljs": "^2.1.0",
     "swr": "^0.1.18",
     "tether": "^1.4.7",

--- a/apps/site/assets/webpack.config.base.js
+++ b/apps/site/assets/webpack.config.base.js
@@ -131,6 +131,7 @@ module.exports = {
     new CopyWebpackPlugin([
       { from: "static/**/*", to: "../../" },
       { from: "node_modules/focus-visible/dist/focus-visible.min.js", to: "../js" },
+      { from: "node_modules/smoothscroll-polyfill/dist/smoothscroll.min.js", to: "../js" },
     ], {}),
     new MiniCssExtractPlugin({ filename: "../css/[name].css" }),
     new webpack.ProvidePlugin({

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -84,14 +84,23 @@
       <div id="ie-warning" class="c-ie-warning"></div>
     </div>
 
-  <%# Load focus-visible polyfill if needed. Lifted from https://alistairshepherd.uk/writing/focus-visible-conditional-polyfill/ %>
+  <%# Load polyfills only if needed %>
   <script>
+    function loadScript(src) {
+      const script = document.createElement("script");
+      script.src = src;
+      document.body.appendChild(script);
+    }
+
+    // Lifted from https://alistairshepherd.uk/writing/focus-visible-conditional-polyfill/
     try {
       document.querySelector(":focus-visible");
     } catch (e) {
-      const script = document.createElement("script");
-      script.src = '<%= static_url(@conn, "/js/focus-visible.min.js") %>';
-      document.body.appendChild(script);
+      loadScript('<%= static_url(@conn, "/js/focus-visible.min.js") %>');
+    }
+
+    if (!('scrollBehavior' in document.documentElement.style)) {
+      loadScript('<%= static_url(@conn, "/js/smoothscroll.min.js") %>');
     }
   </script>
     <%= if google_tag_manager_id() do %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update scroll behavior when opening accordion](https://app.asana.com/0/555089885850811/1201764117487465/f)

This PR implements a scroll-to-top behavior when the accordions in the mobile nav menu are expanded. This functionality is not enabled if the user has indicated that they prefer reduced motion.

WebKit has only very, very recently gotten support for smooth scrolling behavior in the various `scroll*` functions, and as far as I can tell there are no WebKit-based browser releases that support it yet. Thus, I've added a polyfill for the smooth scrolling functionality, and taken an approach similar to #1190 for feature detection and lazy-loading.