### PR TITLE
Prevent overscroll in mobile menu 

### DIFF
--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -212,6 +212,7 @@ nav.m-menu--mobile {
   width: 0px;
   background-color: $brand-primary;
   padding-bottom: calc(200px - $base-spacing);
+  overscroll-behavior: none;
 
   .m-menu__section-heading {
     color: $brand-primary-lightest;


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update sticky behavior when pulling down menu](https://app.asana.com/0/555089885850811/1201764117487427/f)

This prevents overscroll effects in the mobile menu. WebKit has only recently merged support for this property, so the behavior is still observable on macOS and iOS Safari, but once broader support for the property rolls out this should solve the issue.
