### PR TITLE
fix trip planner returning 500 when suggested itinerary route is not queryable via api

### DIFF
--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -418,6 +418,7 @@ defmodule SiteWeb.TripPlanController do
           custom_route
           | type: "Massport-" <> type
         }
+
       # Handle MBTA busses not present via api
       {"1", "BUS"} ->
         %Route{

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -411,12 +411,18 @@ defmodule SiteWeb.TripPlanController do
       color: "000000"
     }
 
-    case {url, description} do
+    case {type, description} do
       # Workaround for Massport buses, manually assign type
-      {"https://massport.com/", "BUS"} ->
+      {"2", "BUS"} ->
         %Route{
           custom_route
           | type: "Massport-" <> type
+        }
+      # Handle MBTA busses not present via api
+      {"1", "BUS"} ->
+        %Route{
+          custom_route
+          | type: 3
         }
 
       _ ->


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fix: Trip Planner returns error on Union Square - NEU plan](https://app.asana.com/0/555089885850811/1201500059383446/f)

Change allow the trip planner to suggest the returned OTP itinerary for an MBTA Bus even if a specific leg of a trip is not present via the api to fetch additional details for things such as shuttle buses. 

Details not fully present so from the detailed view it's not indicated fully that this is a shuttle bus, but the icon indicates that it is a shuttle bus. 

![image](https://user-images.githubusercontent.com/526017/156459205-f9d49f61-cade-4569-aa68-b441e0e454b7.png)
![image](https://user-images.githubusercontent.com/526017/156459236-92667928-b698-48e3-b052-a891857ac1c3.png)



