### PR TITLE
Fix shifting logo on large tablet breakpoint

### DIFF
--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -120,7 +120,7 @@
   }
 }
 
-nav.m-menu, .m-menu__toggle {
+nav.m-menu, .header-navbar .m-menu__toggle {
   @include media-breakpoint-up(lg) {
     display: none;
   }
@@ -356,6 +356,14 @@ nav.m-menu--mobile {
   .m-menu__toggle {
     @extend %hide-button;
   }
+}
+
+.m-menu__toggle {
+  width: 5em;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .m-menu__toggle, .m-menu--desktop__toggle, .header-search__toggle {

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -120,7 +120,7 @@
   }
 }
 
-nav.m-menu, .header-navbar .m-menu__toggle {
+nav.m-menu {
   @include media-breakpoint-up(lg) {
     display: none;
   }
@@ -364,6 +364,10 @@ nav.m-menu--mobile {
   display: flex;
   justify-content: center;
   align-items: center;
+
+  @include media-breakpoint-up(lg) {
+    display: none;
+  }
 }
 
 .m-menu__toggle, .m-menu--desktop__toggle, .header-search__toggle {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update T logo to stay in the same place](https://app.asana.com/0/555089885850811/1201764117487441/f)

Specifically on the large tablet breakpoint, the text changing from `Menu` to `Close` caused the menu button to expand ever so slightly, causing visual shifting of the MBTA logo. To fix this, I've set a static width and centered the text, and there appears to be no more visual shifting when expanding the menu.

