### PR TITLE
Update theme color to use lighter blue on initial page load

### DIFF
--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -10,7 +10,7 @@
     <% meta_description = assigns[:meta_description] || "Official website of the MBTA -- schedules, maps, and fare information for Greater Boston's public transportation system, including subway, commuter rail, bus routes, and boat lines." %>
     <meta name="description" content="<%= Phoenix.HTML.raw(meta_description) %>">
     <meta name="author" content="Massachusetts Bay Transportation Authority">
-    <meta name="theme-color" content="#0b2f4c">
+    <meta name="theme-color" content="#165c96">
     <%= Turbolinks.cache_meta @conn %>
 
     <%= # hide any page in /org directory from search engines


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update nav bar background color](https://app.asana.com/0/555089885850811/1201764117487457/f)

The page currently starts out using the darker blue as the theme color, which looks out-of-sync on initial page load on iOS Safari