### PR TITLE
Reduce top spacing in desktop menu dropdown

### DIFF
--- a/apps/site/assets/css/_global-navigation.scss
+++ b/apps/site/assets/css/_global-navigation.scss
@@ -145,6 +145,7 @@ nav.m-menu--desktop {
   grid-template-columns: repeat(auto-fit, minmax(10px, 1fr)); // space unknown number of columns evenly
   grid-template-rows: auto 1fr;
   margin: $base-spacing * 2 0;
+  margin-top: 24px;
 
   .m-menu__section-heading {
     grid-row: 1;
@@ -199,7 +200,7 @@ nav.m-menu--desktop {
   margin-bottom: $space-4_new;
   padding-bottom: $base-spacing__new;
   text-transform: uppercase;
-  white-space: break-spaces;
+  white-space: normal;
 
   .m-menu--mobile & {
     font-size: $font-size-base-xs;


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Reduce spacing between lists of links and top of menus](https://app.asana.com/0/555089885850811/1201764117511355/f)

This more closely matches the amount of space present in the mocks