### PR TITLE
WIP: front-end logic to call geocoding & related functions

### DIFF
--- a/apps/site/lib/site_web/controllers/location_service_controller.ex
+++ b/apps/site/lib/site_web/controllers/location_service_controller.ex
@@ -1,0 +1,91 @@
+defmodule SiteWeb.LocationServiceController do
+  @moduledoc """
+  Routes for requesting data from a location service
+  """
+  use SiteWeb, :controller
+
+  alias Plug.Conn
+
+  @doc "
+  ⚠️ Hacky WIP
+  Will phase out our usage of the Google Maps API Place Autocomplete
+
+  This endpoint is set up so we can compare between the two location services.
+
+  In many places throughout Dotcom, we use partial text and Google Maps API 
+  provides suggested results, which contain a place_id that we later on geocode
+  via Google Maps.
+
+  Of course, AWS Location Service, while it does provide suggested results, does
+  not have such a robust place database. It merely gives us a suggested address.
+
+  Anyway, navigating to /locations/suggestions/<search text> will look up the 
+  text in both services and return, in JSON format, a list of suggested results.
+  "
+  @spec suggestions(Conn.t(), map) :: Conn.t()
+  def suggestions(conn, %{"input" => input}) do
+    # TODO: Add this functionality to AWSLocation.Request
+    {:ok, %{status_code: 200, body: body}} =
+      %ExAws.Operation.RestQuery{
+        http_method: :post,
+        body: %{
+          Text: input,
+          FilterBBox: [-71.9380, 41.3193, -69.6189, 42.8266]
+        },
+        service: :places,
+        path: "/places/v0/indexes/dotcom-dev-esri/search/suggestions"
+      }
+      |> ExAws.request()
+
+    {:ok, %{"Results" => aws_results}} = Jason.decode(body)
+
+    {:ok, google_results} =
+      %GoogleMaps.Place.AutocompleteQuery{
+        hit_limit: 15,
+        session_token: "",
+        input: input
+      }
+      |> GoogleMaps.Place.autocomplete()
+
+    # TODO: PlacesController.autocomplete returns %{predictions: results} and
+    # encodes the results.
+    json(conn, %{
+      input: input,
+      lists: %{
+        aws: Enum.map(aws_results, & &1["Text"]),
+        google: Enum.map(google_results, & &1.description)
+      },
+      aws_results: aws_results,
+      google_results: google_results
+    })
+  end
+
+  @doc "/locations/text/<address>"
+  @spec geocode(Conn.t(), map) :: Conn.t()
+  def geocode(conn, %{"address" => address}) do
+    # TODO: Use LocationService.Geocode.geocode(address) and return its result
+    # rather than returning both Google and AWS results
+    {:ok, a} = AWSLocation.geocode(address)
+    {:ok, b} = GoogleMaps.Geocode.geocode(address)
+
+    # TODO: match PlacesController.geocode by returning %{results: results}?
+    # TODO: match PlacesController.geocode by encoding the results?
+    json(conn, %{input: address, aws_results: a, google_results: b})
+  end
+
+  @doc "/locations/position/<lat>/<lon>"
+  @spec position(Conn.t(), map) :: Conn.t()
+  def position(conn, %{"latitude" => lat, "longitude" => lon}) do
+    with {latitude, ""} <- Float.parse(lat),
+         {longitude, ""} <- Float.parse(lon) do
+      # TODO: Use LocationService.ReverseGeocode.reverse_geocode(address) and return its
+      # result rather than returning both Google and AWS results
+      {:ok, a} = AWSLocation.reverse_geocode(latitude, longitude)
+      {:ok, b} = GoogleMaps.Geocode.reverse_geocode(latitude, longitude)
+
+      # TODO: match PlacesController.reverse_geocode by returning %{results: results}?
+      # TODO: match PlacesController.reverse_geocode by encoding the results?
+      json(conn, %{input: [latitude, longitude], aws_results: a, google_results: b})
+    end
+  end
+end

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -187,12 +187,19 @@ defmodule SiteWeb.Router do
     end
   end
 
+  # TODO replace with /locations
   scope "/places", SiteWeb do
     pipe_through([:api])
 
     get("/autocomplete/:input/:hit_limit/:token", PlacesController, :autocomplete)
     get("/details/:place_id", PlacesController, :details)
     get("/reverse-geocode/:latitude/:longitude", PlacesController, :reverse_geocode)
+  end
+
+  scope "/locations", SiteWeb do
+    get("/suggestion/:input", LocationServiceController, :suggestions)
+    get("/text/:address", LocationServiceController, :geocode)
+    get("/position/:latitude/:longitude", LocationServiceController, :position)
   end
 
   # static files


### PR DESCRIPTION
While investigating/refining tickets I created a few new endpoints to experiment with, just wanted to share them here for whoever will work on [Add front-end logic to use AWS for geocoding + place lookup](https://app.asana.com/0/0/1201846410385721/f) or [Add front-end logic to use AWS for reverse geocoding](https://app.asana.com/0/0/1201846410385722/f)

They will return both AWS and Google results in a JSON response, which I found useful for a quick view/comparison to debug what's returned for a given query. 🤷🏼‍♀️ 

Just to be clear, it's super hacky.