### PR TITLE
Plug to check if within range of glx opening date

### DIFF
--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -397,8 +397,7 @@ defmodule SiteWeb.TripPlanController do
       mode: mode,
       long_name: long_name,
       name: name,
-      type: type,
-      url: url
+      type: type
     } = Enum.find(legs, &(Leg.route_id(&1) == {:ok, id}))
 
     custom_route = %Route{

--- a/apps/site/lib/site_web/plugs/glx_now_open.ex
+++ b/apps/site/lib/site_web/plugs/glx_now_open.ex
@@ -10,7 +10,7 @@ defmodule SiteWeb.Plugs.GlxNowOpen do
       Science Park/West End (place-spmnl)
   """
 
-  @opening_date ~N[2022-03-21T03:00:00]
+  @opening_date ~N[2022-03-21T04:55:00]
 
   @behaviour Plug
   import Plug.Conn, only: [assign: 3]

--- a/apps/site/lib/site_web/plugs/glx_now_open.ex
+++ b/apps/site/lib/site_web/plugs/glx_now_open.ex
@@ -21,7 +21,10 @@ defmodule SiteWeb.Plugs.GlxNowOpen do
   @impl true
   def call(conn, now_fn: now_fn) do
     conn
-    |> assign(:glx_now_open?, check_current_service_date(now_fn.(), Util.to_local_time(@opening_date)))
+    |> assign(
+      :glx_now_open?,
+      check_current_service_date(now_fn.(), Util.to_local_time(@opening_date))
+    )
   end
 
   defp check_current_service_date(current_date, opening_date) do

--- a/apps/site/lib/site_web/plugs/glx_now_open.ex
+++ b/apps/site/lib/site_web/plugs/glx_now_open.ex
@@ -29,7 +29,7 @@ defmodule SiteWeb.Plugs.GlxNowOpen do
   end
 
   defp after_open_date?(current_date, opening_date) do
-    Util.time_is_greater_or_equal?(opening_date, current_date)
+    Util.time_is_greater_or_equal?(current_date, opening_date)
   end
 
   defp before_end_date?(current_date, opening_date) do

--- a/apps/site/lib/site_web/plugs/glx_now_open.ex
+++ b/apps/site/lib/site_web/plugs/glx_now_open.ex
@@ -1,0 +1,39 @@
+defmodule SiteWeb.Plugs.GlxNowOpen do
+  @moduledoc """
+    assigns glx_now_open? value if the current date is after the set date for the
+    glx expansion to open (March 21, 2022) and not greater than 3 months post-opening
+    date (June, 21, 2022).
+
+    Stations set to open:
+      Lechmere (place-lech)
+      Union Square (place-unsqu)
+      Science Park/West End (place-spmnl)
+  """
+
+  @opening_date ~N[2022-03-21T00:00:00]
+
+  @behaviour Plug
+  import Plug.Conn
+
+  @impl true
+  def init([]), do: [now_fn: &Util.now/0, to_local_fn: &Util.to_local_time/1]
+
+  @impl true
+  def call(conn, now_fn: now_fn, to_local_fn: to_local_fn) do
+    conn
+    |> assign(:glx_now_open?, check_current_service_date(now_fn.(), to_local_fn.(@opening_date)))
+  end
+
+  defp check_current_service_date(current_date, opening_date) do
+    after_open_date?(current_date, opening_date) && before_end_date?(current_date, opening_date)
+  end
+
+  defp after_open_date?(current_date, opening_date) do
+    DateTime.compare(current_date, opening_date) != :lt
+  end
+
+  defp before_end_date?(current_date, opening_date) do
+    end_date = Timex.shift(opening_date, months: 3)
+    DateTime.compare(current_date, end_date) != :gt
+  end
+end

--- a/apps/site/lib/site_web/plugs/glx_now_open.ex
+++ b/apps/site/lib/site_web/plugs/glx_now_open.ex
@@ -13,15 +13,15 @@ defmodule SiteWeb.Plugs.GlxNowOpen do
   @opening_date ~N[2022-03-21T00:00:00]
 
   @behaviour Plug
-  import Plug.Conn
+  import Plug.Conn, only: [assign: 3]
 
   @impl true
-  def init([]), do: [now_fn: &Util.now/0, to_local_fn: &Util.to_local_time/1]
+  def init([]), do: [now_fn: &Util.now/0]
 
   @impl true
-  def call(conn, now_fn: now_fn, to_local_fn: to_local_fn) do
+  def call(conn, now_fn: now_fn) do
     conn
-    |> assign(:glx_now_open?, check_current_service_date(now_fn.(), to_local_fn.(@opening_date)))
+    |> assign(:glx_now_open?, check_current_service_date(now_fn.(), Util.to_local_time(@opening_date)))
   end
 
   defp check_current_service_date(current_date, opening_date) do
@@ -29,11 +29,12 @@ defmodule SiteWeb.Plugs.GlxNowOpen do
   end
 
   defp after_open_date?(current_date, opening_date) do
-    DateTime.compare(current_date, opening_date) != :lt
+    Util.time_is_greater_or_equal?(opening_date, current_date)
   end
 
   defp before_end_date?(current_date, opening_date) do
     end_date = Timex.shift(opening_date, months: 3)
-    DateTime.compare(current_date, end_date) != :gt
+
+    Util.time_is_greater_or_equal?(end_date, current_date)
   end
 end

--- a/apps/site/lib/site_web/plugs/glx_now_open.ex
+++ b/apps/site/lib/site_web/plugs/glx_now_open.ex
@@ -10,7 +10,7 @@ defmodule SiteWeb.Plugs.GlxNowOpen do
       Science Park/West End (place-spmnl)
   """
 
-  @opening_date ~N[2022-03-21T00:00:00]
+  @opening_date ~N[2022-03-21T03:00:00]
 
   @behaviour Plug
   import Plug.Conn, only: [assign: 3]
@@ -38,6 +38,6 @@ defmodule SiteWeb.Plugs.GlxNowOpen do
   defp before_end_date?(current_date, opening_date) do
     end_date = Timex.shift(opening_date, months: 3)
 
-    Util.time_is_greater_or_equal?(end_date, current_date)
+    !Util.time_is_greater_or_equal?(current_date, end_date)
   end
 end

--- a/apps/site/test/site_web/plugs/glx_now_open_test.exs
+++ b/apps/site/test/site_web/plugs/glx_now_open_test.exs
@@ -23,19 +23,21 @@ defmodule SiteWeb.Plugs.GlxNowOpenTest do
 
   describe "call/2" do
     test "assigns glx_now_open? with false if current date is before opening date", %{conn: conn} do
-      updated_conn = call(conn, now_fn: now_before_fn, to_local_fn: &Util.to_local_time/1)
+      updated_conn = call(conn, now_fn: &now_before_fn/0, to_local_fn: &Util.to_local_time/1)
 
       assert updated_conn.assigns.glx_now_open? == false
     end
 
-    test "assigns glx_now_open? with true if current date is between opening date and 3 months post opening", %{conn: conn} do
-      updated_conn = call(conn, now_fn: now_between_fn, to_local_fn: &Util.to_local_time/1)
+    test "assigns glx_now_open? with true if current date is between opening date and 3 months post opening",
+         %{conn: conn} do
+      updated_conn = call(conn, now_fn: &now_between_fn/0, to_local_fn: &Util.to_local_time/1)
 
       assert updated_conn.assigns.glx_now_open? == true
     end
 
-    test "assigns glx_now_open? with false if current date is after 3 months post opening date", %{conn: conn} do
-      updated_conn = call(conn, now_fn: now_after_fn, to_local_fn: &Util.to_local_time/1)
+    test "assigns glx_now_open? with false if current date is after 3 months post opening date",
+         %{conn: conn} do
+      updated_conn = call(conn, now_fn: &now_after_fn/0, to_local_fn: &Util.to_local_time/1)
 
       assert updated_conn.assigns.glx_now_open? == false
     end

--- a/apps/site/test/site_web/plugs/glx_now_open_test.exs
+++ b/apps/site/test/site_web/plugs/glx_now_open_test.exs
@@ -1,0 +1,43 @@
+defmodule SiteWeb.Plugs.GlxNowOpenTest do
+  use SiteWeb.ConnCase, async: true
+
+  import SiteWeb.Plugs.GlxNowOpen
+
+  defp now_before_fn do
+    DateTime.from_naive!(~N[2022-03-08 00:00:00], "Etc/UTC")
+  end
+
+  defp now_between_fn do
+    DateTime.from_naive!(~N[2022-03-25 00:00:00], "Etc/UTC")
+  end
+
+  defp now_after_fn do
+    DateTime.from_naive!(~N[2022-07-01 00:00:00], "Etc/UTC")
+  end
+
+  describe "init/1" do
+    test "defaults to Schedules.Repo.rating_dates/0" do
+      assert init([]) == [now_fn: &Util.now/0, to_local_fn: &Util.to_local_time/1]
+    end
+  end
+
+  describe "call/2" do
+    test "assigns glx_now_open? with false if current date is before opening date", %{conn: conn} do
+      updated_conn = call(conn, now_fn: now_before_fn, to_local_fn: &Util.to_local_time/1)
+
+      assert updated_conn.assigns.glx_now_open? == false
+    end
+
+    test "assigns glx_now_open? with true if current date is between opening date and 3 months post opening", %{conn: conn} do
+      updated_conn = call(conn, now_fn: now_between_fn, to_local_fn: &Util.to_local_time/1)
+
+      assert updated_conn.assigns.glx_now_open? == true
+    end
+
+    test "assigns glx_now_open? with false if current date is after 3 months post opening date", %{conn: conn} do
+      updated_conn = call(conn, now_fn: now_after_fn, to_local_fn: &Util.to_local_time/1)
+
+      assert updated_conn.assigns.glx_now_open? == false
+    end
+  end
+end

--- a/apps/site/test/site_web/plugs/glx_now_open_test.exs
+++ b/apps/site/test/site_web/plugs/glx_now_open_test.exs
@@ -4,15 +4,15 @@ defmodule SiteWeb.Plugs.GlxNowOpenTest do
   import SiteWeb.Plugs.GlxNowOpen
 
   defp now_before_fn do
-    DateTime.from_naive!(~N[2022-03-08 00:00:00], "Etc/UTC")
+    DateTime.from_naive!(~N[2022-03-21 00:00:00], "Etc/UTC")
   end
 
   defp now_between_fn do
-    DateTime.from_naive!(~N[2022-03-25 00:00:00], "Etc/UTC")
+    DateTime.from_naive!(~N[2022-03-21 03:00:00], "Etc/UTC")
   end
 
   defp now_after_fn do
-    DateTime.from_naive!(~N[2022-07-01 00:00:00], "Etc/UTC")
+    DateTime.from_naive!(~N[2022-06-21 03:00:00], "Etc/UTC")
   end
 
   describe "init/1" do

--- a/apps/site/test/site_web/plugs/glx_now_open_test.exs
+++ b/apps/site/test/site_web/plugs/glx_now_open_test.exs
@@ -16,7 +16,7 @@ defmodule SiteWeb.Plugs.GlxNowOpenTest do
   end
 
   describe "init/1" do
-    test "defaults to Schedules.Repo.rating_dates/0" do
+    test "defaults to Util.now/0" do
       assert init([]) == [now_fn: &Util.now/0]
     end
   end

--- a/apps/site/test/site_web/plugs/glx_now_open_test.exs
+++ b/apps/site/test/site_web/plugs/glx_now_open_test.exs
@@ -17,27 +17,27 @@ defmodule SiteWeb.Plugs.GlxNowOpenTest do
 
   describe "init/1" do
     test "defaults to Schedules.Repo.rating_dates/0" do
-      assert init([]) == [now_fn: &Util.now/0, to_local_fn: &Util.to_local_time/1]
+      assert init([]) == [now_fn: &Util.now/0]
     end
   end
 
   describe "call/2" do
     test "assigns glx_now_open? with false if current date is before opening date", %{conn: conn} do
-      updated_conn = call(conn, now_fn: &now_before_fn/0, to_local_fn: &Util.to_local_time/1)
+      updated_conn = call(conn, now_fn: &now_before_fn/0)
 
       assert updated_conn.assigns.glx_now_open? == false
     end
 
     test "assigns glx_now_open? with true if current date is between opening date and 3 months post opening",
          %{conn: conn} do
-      updated_conn = call(conn, now_fn: &now_between_fn/0, to_local_fn: &Util.to_local_time/1)
+      updated_conn = call(conn, now_fn: &now_between_fn/0)
 
       assert updated_conn.assigns.glx_now_open? == true
     end
 
     test "assigns glx_now_open? with false if current date is after 3 months post opening date",
          %{conn: conn} do
-      updated_conn = call(conn, now_fn: &now_after_fn/0, to_local_fn: &Util.to_local_time/1)
+      updated_conn = call(conn, now_fn: &now_after_fn/0)
 
       assert updated_conn.assigns.glx_now_open? == false
     end

--- a/apps/site/test/site_web/plugs/glx_now_open_test.exs
+++ b/apps/site/test/site_web/plugs/glx_now_open_test.exs
@@ -8,11 +8,11 @@ defmodule SiteWeb.Plugs.GlxNowOpenTest do
   end
 
   defp now_between_fn do
-    DateTime.from_naive!(~N[2022-03-21 03:00:00], "Etc/UTC")
+    DateTime.from_naive!(~N[2022-03-21 04:55:00], "Etc/UTC")
   end
 
   defp now_after_fn do
-    DateTime.from_naive!(~N[2022-06-21 03:00:00], "Etc/UTC")
+    DateTime.from_naive!(~N[2022-06-21 04:55:00], "Etc/UTC")
   end
 
   describe "init/1" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Store station opening dates and check age](https://app.asana.com/0/555089885850811/1201708898492590/f)

Added plug to set an assign within conn if the current date after the set opening date for the glx expansion and not more than 3 months after that date.

