### PR TITLE
fix(PredictedSchedule): add function clause

### DIFF
--- a/apps/site/lib/predicted_schedule.ex
+++ b/apps/site/lib/predicted_schedule.ex
@@ -6,7 +6,8 @@ defmodule PredictedSchedule do
   * prediction: The prediction for this trip (optional)
   """
   alias Predictions.Prediction
-  alias Schedules.{Schedule, ScheduleCondensed}
+  alias Schedules.{Schedule, ScheduleCondensed, Trip}
+  alias Stops.Stop
 
   @derive Jason.Encoder
 
@@ -133,9 +134,11 @@ defmodule PredictedSchedule do
     {{trip_id, stop_id, stop_sequence}, ps}
   end
 
-  defp group_transform(%{trip: trip, stop: stop} = ps)
-       when not is_nil(trip) and not is_nil(stop) do
-    {{ps.trip.id, ps.stop.id, ps.stop_sequence}, ps}
+  defp group_transform(%{trip: %Trip{id: trip_id}, stop: stop} = ps) do
+    case stop do
+      %Stop{} -> {{trip_id, stop.id, ps.stop_sequence}, ps}
+      _ -> {{trip_id, nil, ps.stop_sequence}, ps}
+    end
   end
 
   @doc """

--- a/apps/site/test/predicted_schedule_test.exs
+++ b/apps/site/test/predicted_schedule_test.exs
@@ -325,6 +325,19 @@ defmodule PredictedScheduleTest do
       end
     end
 
+    test "works with schedules without stop" do
+      modified_trip_schedules =
+        @trip_schedules
+        |> Enum.map(fn schedule ->
+          %Schedule{
+            schedule
+            | stop: nil
+          }
+        end)
+
+      assert group(@trip_predictions, modified_trip_schedules)
+    end
+
     test "returns empty in case of error" do
       assert group({:error, "error in predictions"}, {:error, "error in schedules"}) == []
     end


### PR DESCRIPTION

#### Summary of changes
**Asana Ticket:** [Transit Near Me | Elixir.FunctionClauseError: no function clause matching in PredictedSchedule.group_transform/1](https://app.asana.com/0/385363666817452/1200951629013373/f)

(Asana ticket contains linked Sentry issue).

This particular function was erroring whenever it faced a %PredictedSchedule{} that contained a schedule where the stop was nil. This change adds the logic to handle Schedules that don't have a Stop defined. 

This seems to happen with shuttles sometimes.

