### PR TITLE
Use AWS for Autocomplete

### DIFF
--- a/apps/location_service/config/config.exs
+++ b/apps/location_service/config/config.exs
@@ -8,7 +8,8 @@ config :location_service, :http_pool, :google_http_pool
 if Mix.env() == :prod do
   config :location_service,
     geocode: if("${LOCATION_SERVICE}" == "AWS", do: :aws, else: :google),
-    reverse_geocode: if("${LOCATION_SERVICE}" == "AWS", do: :aws, else: :google)
+    reverse_geocode: if("${LOCATION_SERVICE}" == "AWS", do: :aws, else: :google),
+    autocomplete: if("${LOCATION_SERVICE}" == "AWS", do: :aws, else: :google)
 
   # place: :google,
   # maps: :google
@@ -20,7 +21,8 @@ if Mix.env() == :prod do
 else
   config :location_service,
     geocode: if(System.get_env("LOCATION_SERVICE") == "GOOGLE", do: :google, else: :aws),
-    reverse_geocode: if(System.get_env("LOCATION_SERVICE") == "GOOGLE", do: :google, else: :aws)
+    reverse_geocode: if(System.get_env("LOCATION_SERVICE") == "GOOGLE", do: :google, else: :aws),
+    autocomplete: if(System.get_env("LOCATION_SERVICE") == "GOOGLE", do: :google, else: :aws)
 
   # place: :google,
   # maps: :google

--- a/apps/location_service/lib/aws_location/aws_location.ex
+++ b/apps/location_service/lib/aws_location/aws_location.ex
@@ -28,9 +28,10 @@ defmodule AWSLocation do
   def autocomplete(search, limit) do
     case ExAws.request(%ExAws.Operation.RestQuery{
            http_method: :post,
-           body: (AWSLocation.Request.base_request_body
-           |> Map.put(:Text, search)
-           |> Map.put(:MaxResults, limit)),
+           body:
+             AWSLocation.Request.base_request_body()
+             |> Map.put(:Text, search)
+             |> Map.put(:MaxResults, limit),
            service: :places,
            path: "/places/v0/indexes/dotcom-dev-esri/search/suggestions"
          }) do
@@ -45,10 +46,12 @@ defmodule AWSLocation do
               end)
             }
 
-          {:error, error} -> LocationService.Result.internal_error(error, search)
+          {:error, error} ->
+            LocationService.Result.internal_error(error, search)
         end
 
-      {:error, error} -> LocationService.Result.internal_error(error, search)
+      {:error, error} ->
+        LocationService.Result.internal_error(error, search)
     end
   end
 end

--- a/apps/location_service/lib/aws_location/aws_location.ex
+++ b/apps/location_service/lib/aws_location/aws_location.ex
@@ -23,4 +23,32 @@ defmodule AWSLocation do
     Request.new([latitude, longitude])
     |> Result.handle_response([latitude, longitude])
   end
+
+  @spec autocomplete(String.t(), number) :: LocationService.Suggestion.result()
+  def autocomplete(search, limit) do
+    case ExAws.request(%ExAws.Operation.RestQuery{
+           http_method: :post,
+           body: (AWSLocation.Request.base_request_body
+           |> Map.put(:Text, search)
+           |> Map.put(:MaxResults, limit)),
+           service: :places,
+           path: "/places/v0/indexes/dotcom-dev-esri/search/suggestions"
+         }) do
+      {:ok, %{status_code: 200, body: body}} ->
+        case Jason.decode(body) do
+          {:ok, %{"Results" => results}} ->
+            {
+              :ok,
+              results
+              |> Enum.map(fn %{"Text" => text} ->
+                %LocationService.Suggestion{address: text}
+              end)
+            }
+
+          {:error, error} -> LocationService.Result.internal_error(error, search)
+        end
+
+      {:error, error} -> LocationService.Result.internal_error(error, search)
+    end
+  end
 end

--- a/apps/location_service/lib/aws_location/request.ex
+++ b/apps/location_service/lib/aws_location/request.ex
@@ -9,6 +9,8 @@ defmodule AWSLocation.Request do
     MaxResults: 50
   }
 
+  def base_request_body() do @base_request_body end
+
   @spec new(String.t() | [float] | nil) :: ExAws.Operation.RestQuery.t()
   @doc "Searches for text"
   def new(text) when is_binary(text) do

--- a/apps/location_service/lib/aws_location/request.ex
+++ b/apps/location_service/lib/aws_location/request.ex
@@ -9,7 +9,9 @@ defmodule AWSLocation.Request do
     MaxResults: 50
   }
 
-  def base_request_body() do @base_request_body end
+  def base_request_body() do
+    @base_request_body
+  end
 
   @spec new(String.t() | [float] | nil) :: ExAws.Operation.RestQuery.t()
   @doc "Searches for text"

--- a/apps/location_service/lib/location_service.ex
+++ b/apps/location_service/lib/location_service.ex
@@ -4,11 +4,29 @@ defmodule LocationService do
   """
   use RepoCache, ttl: :timer.hours(24)
 
+  defmodule Private do
+    @spec wrapped_google_autocomplete(String.t(), number) :: LocationService.Suggestion.result()
+    def wrapped_google_autocomplete(search, limit) do
+      {:ok, results} =
+        GoogleMaps.Place.autocomplete(%GoogleMaps.Place.AutocompleteQuery{
+          hit_limit: limit,
+          input: search,
+          session_token: ""
+        })
+
+      {:ok,
+       results
+       |> Enum.map(fn p ->
+         %LocationService.Suggestion{address: p.description}
+       end)}
+    end
+  end
+
   @type result ::
           {:ok, nonempty_list(LocationService.Address.t())}
           | {:error, :zero_results | :internal_error}
 
-  @doc "Uses either AWS Location Service or Google Maps Place API to perform a 
+  @doc "Uses either AWS Location Service or Google Maps Place API to perform a
   geocode lookup, selecting based on config value.
   Caches the result using the input address as key."
   @spec geocode(String.t()) :: result
@@ -34,5 +52,13 @@ defmodule LocationService do
     end)
   end
 
-  # TODO Add suggestion/place lookup
+  @doc "Uses either AWS Location Service or Google Maps Place API to do
+  autocompletion, selecting based on config value."
+  @spec autocomplete(String.t(), number) :: LocationService.Suggestion.result()
+  def autocomplete(search, limit) do
+    case Application.get_env(:location_service, :autocomplete) do
+      :aws -> AWSLocation.autocomplete(search, limit)
+      _ -> Private.wrapped_google_autocomplete(search, limit)
+    end
+  end
 end

--- a/apps/location_service/lib/location_service.ex
+++ b/apps/location_service/lib/location_service.ex
@@ -4,24 +4,6 @@ defmodule LocationService do
   """
   use RepoCache, ttl: :timer.hours(24)
 
-  defmodule Private do
-    @spec wrapped_google_autocomplete(String.t(), number) :: LocationService.Suggestion.result()
-    def wrapped_google_autocomplete(search, limit) do
-      {:ok, results} =
-        GoogleMaps.Place.autocomplete(%GoogleMaps.Place.AutocompleteQuery{
-          hit_limit: limit,
-          input: search,
-          session_token: ""
-        })
-
-      {:ok,
-       results
-       |> Enum.map(fn p ->
-         %LocationService.Suggestion{address: p.description}
-       end)}
-    end
-  end
-
   @type result ::
           {:ok, nonempty_list(LocationService.Address.t())}
           | {:error, :zero_results | :internal_error}
@@ -58,7 +40,7 @@ defmodule LocationService do
   def autocomplete(search, limit) do
     case Application.get_env(:location_service, :autocomplete) do
       :aws -> AWSLocation.autocomplete(search, limit)
-      _ -> Private.wrapped_google_autocomplete(search, limit)
+      _ -> LocationService.Wrappers.google_autocomplete(search, limit)
     end
   end
 end

--- a/apps/location_service/lib/result.ex
+++ b/apps/location_service/lib/result.ex
@@ -74,9 +74,9 @@ defmodule LocationService.Result do
     {:ok, results}
   end
 
-  defp internal_error(error, input, extra \\ %{})
+  def internal_error(error, input, extra \\ %{})
 
-  defp internal_error(:zero_results, input, extra) do
+  def internal_error(:zero_results, input, extra) do
     _ =
       Logger.info(fn ->
         "#{__MODULE__} input=#{inspect(input)} result=ZERO_RESULTS #{extra_messages(extra)}"
@@ -85,7 +85,7 @@ defmodule LocationService.Result do
     {:error, :zero_results}
   end
 
-  defp internal_error(error, input, extra) do
+  def internal_error(error, input, extra) do
     case error do
       %Jason.DecodeError{} ->
         _ =

--- a/apps/location_service/lib/suggestion.ex
+++ b/apps/location_service/lib/suggestion.ex
@@ -1,0 +1,12 @@
+defmodule LocationService.Suggestion do
+  @moduledoc """
+  An autocomplete suggestion.
+  [todo] deprecate GoogleMaps.Place.Prediction
+  """
+  @type t :: %__MODULE__{
+          address: String.t()
+        }
+  defstruct address: ""
+
+  @type result :: {:ok, [t()]} | {:error, :internal_error}
+end

--- a/apps/location_service/lib/wrappers.ex
+++ b/apps/location_service/lib/wrappers.ex
@@ -1,0 +1,20 @@
+defmodule LocationService.Wrappers do
+  @spec google_autocomplete(String.t(), number) :: LocationService.Suggestion.result()
+  def google_autocomplete(search, limit) do
+    case GoogleMaps.Place.autocomplete(%GoogleMaps.Place.AutocompleteQuery{
+           hit_limit: limit,
+           input: search,
+           session_token: ""
+         }) do
+      {:ok, results} ->
+        {:ok,
+         results
+         |> Enum.map(fn p ->
+           %LocationService.Suggestion{address: p.description}
+         end)}
+
+      e ->
+        e
+    end
+  end
+end

--- a/apps/location_service/test/aws_location/aws_location_test.exs
+++ b/apps/location_service/test/aws_location/aws_location_test.exs
@@ -71,4 +71,32 @@ defmodule AWSLocationTest do
 
   describe "reverse_geocode/2" do
   end
+
+  describe "autocomplete/2" do
+    test "can parse a response with results" do
+      {:ok, body_string} =
+        %{
+          "Results" => [
+            %{
+              "Text" => "Test Location"
+            }
+          ]
+        }
+        |> Jason.encode()
+
+      with_mock ExAws,
+        request: fn _ -> {:ok, %{status_code: 200, body: body_string}} end do
+        assert {:ok, result} = autocomplete("Tes", 2)
+
+        assert [%LocationService.Suggestion{address: "Test Location"}] = result
+      end
+    end
+
+    test "can parse a response with error" do
+      with_mock ExAws,
+        request: fn _ -> {:error, {:http_error, 500, "bad news"}} end do
+        assert {:error, :internal_error} = autocomplete("test", 2)
+      end
+    end
+  end
 end

--- a/apps/location_service/test/location_service_test.exs
+++ b/apps/location_service/test/location_service_test.exs
@@ -101,4 +101,51 @@ defmodule LocationServiceTest do
       end
     end
   end
+
+  describe "autocomplete/2" do
+    setup do
+      old_value = Application.get_env(:location_service, :autocomplete)
+
+      on_exit(fn ->
+        Application.put_env(:location_service, :autocomplete, old_value)
+      end)
+    end
+
+    test "selects function based on application environment variable" do
+      with_mocks [
+        {AWSLocation, [], [autocomplete: fn _, _ -> "i use the amazon one" end]},
+        {LocationService.Private, [],
+         [wrapped_google_autocomplete: fn _, _ -> "i use the google one" end]}
+      ] do
+        Application.put_env(:location_service, :autocomplete, :google)
+        assert "i use the google one" = autocomplete("a thing", 2)
+
+        Application.put_env(:location_service, :autocomplete, :aws)
+        assert "i use the amazon one" = autocomplete("some other thing", 2)
+      end
+    end
+  end
+
+  describe "wrapped_google_autocomplete/2" do
+    test "formats google results" do
+      with_mock GoogleMaps.Place,
+        autocomplete: fn _ ->
+          {:ok,
+           [
+             %{
+               description: "Test"
+             }
+           ]}
+        end do
+        {:ok, results} =
+          LocationService.Private.wrapped_google_autocomplete("test", 2)
+
+        assert [
+                 %LocationService.Suggestion{
+                   address: "Test"
+                 }
+               ] = results
+      end
+    end
+  end
 end

--- a/apps/location_service/test/location_service_test.exs
+++ b/apps/location_service/test/location_service_test.exs
@@ -114,36 +114,14 @@ defmodule LocationServiceTest do
     test "selects function based on application environment variable" do
       with_mocks [
         {AWSLocation, [], [autocomplete: fn _, _ -> "i use the amazon one" end]},
-        {LocationService.Private, [],
-         [wrapped_google_autocomplete: fn _, _ -> "i use the google one" end]}
+        {LocationService.Wrappers, [],
+         [google_autocomplete: fn _, _ -> "i use the google one" end]}
       ] do
         Application.put_env(:location_service, :autocomplete, :google)
         assert "i use the google one" = autocomplete("a thing", 2)
 
         Application.put_env(:location_service, :autocomplete, :aws)
         assert "i use the amazon one" = autocomplete("some other thing", 2)
-      end
-    end
-  end
-
-  describe "wrapped_google_autocomplete/2" do
-    test "formats google results" do
-      with_mock GoogleMaps.Place,
-        autocomplete: fn _ ->
-          {:ok,
-           [
-             %{
-               description: "Test"
-             }
-           ]}
-        end do
-        {:ok, results} = LocationService.Private.wrapped_google_autocomplete("test", 2)
-
-        assert [
-                 %LocationService.Suggestion{
-                   address: "Test"
-                 }
-               ] = results
       end
     end
   end

--- a/apps/location_service/test/location_service_test.exs
+++ b/apps/location_service/test/location_service_test.exs
@@ -137,8 +137,7 @@ defmodule LocationServiceTest do
              }
            ]}
         end do
-        {:ok, results} =
-          LocationService.Private.wrapped_google_autocomplete("test", 2)
+        {:ok, results} = LocationService.Private.wrapped_google_autocomplete("test", 2)
 
         assert [
                  %LocationService.Suggestion{

--- a/apps/location_service/test/wrappers_test.exs
+++ b/apps/location_service/test/wrappers_test.exs
@@ -1,0 +1,35 @@
+defmodule LocationService.WrappersTest do
+  use ExUnit.Case, async: true
+
+  import LocationService.Wrappers
+  import Mock
+
+  describe "google_autocomplete/2" do
+    test "formats google results" do
+      with_mock GoogleMaps.Place,
+        autocomplete: fn _ ->
+          {:ok,
+           [
+             %{
+               description: "Test"
+             }
+           ]}
+        end do
+        {:ok, results} = google_autocomplete("test", 2)
+
+        assert [
+                 %LocationService.Suggestion{
+                   address: "Test"
+                 }
+               ] = results
+      end
+    end
+
+    test "bubbles errors" do
+      with_mock GoogleMaps.Place,
+        autocomplete: fn _ -> {:error, :oops} end do
+        assert {:error, :oops} = google_autocomplete("oops", 6)
+      end
+    end
+  end
+end

--- a/apps/site/assets/js/algolia-autocomplete-with-geo.js
+++ b/apps/site/assets/js/algolia-autocomplete-with-geo.js
@@ -151,8 +151,8 @@ class AlgoliaAutocompleteWithGeo extends AlgoliaAutocomplete {
     const index = hit._args[1];
     switch (index) {
       case "locations":
-        this._input.value = hit._args[0].description;
-        this._doLocationSearch(hit._args[0].id);
+        this._input.value = hit._args[0].address;
+        this._doLocationSearch(hit._args[0].address);
         break;
       case "usemylocation":
         this.useMyLocationSearch();

--- a/apps/site/assets/js/algolia-autocomplete-with-geo.js
+++ b/apps/site/assets/js/algolia-autocomplete-with-geo.js
@@ -181,8 +181,8 @@ class AlgoliaAutocompleteWithGeo extends AlgoliaAutocomplete {
     }
   }
 
-  _doLocationSearch(placeId) {
-    return GoogleMapsHelpers.lookupPlace(placeId).then(result =>
+  _doLocationSearch(address) {
+    return GoogleMapsHelpers.lookupPlace(address).then(result =>
       this._onLocationSearchResult(result)
     );
   }

--- a/apps/site/assets/js/algolia-result.js
+++ b/apps/site/assets/js/algolia-result.js
@@ -327,19 +327,9 @@ function _contentTitle(hit) {
 }
 
 export function getTitle(hit, type) {
-  let orig;
   switch (type) {
     case "locations":
-      orig = hit.description.split("");
-      hit.matched_substrings.forEach(match => {
-        orig[match.offset] = `<em>${orig[match.offset]}`;
-        if (match.offset + match.length < orig.length) {
-          orig[match.offset + match.length] = `</em>${
-            orig[match.offset + match.length]
-          }`;
-        }
-      });
-      return orig.join("");
+      return hit.address;
     case "stops":
       return hit._highlightResult.stop.name.value;
 
@@ -537,7 +527,7 @@ export function parseResult(hit, index) {
       index === "projects" ||
       null,
     hitFeatureIcons: getFeatureIcons(hit, index),
-    id: hit.place_id || null
+    id: hit.id || null,
   });
 }
 

--- a/apps/site/assets/js/algolia-results.js
+++ b/apps/site/assets/js/algolia-results.js
@@ -68,10 +68,10 @@ export class AlgoliaResults {
 
   _addLocationListeners(results) {
     if (results["locations"]) {
-      results["locations"].hits.forEach(hit => {
-        const elem = document.getElementById(`hit-${hit.place_id}`);
+      results["locations"].hits.forEach((hit, idx) => {
+        const elem = document.getElementById(`hit-location-${idx}`);
         if (elem) {
-          elem.addEventListener("click", this._locationSearch(hit.place_id));
+          elem.addEventListener("click", this._locationSearch(hit.address));
         }
       });
       const useLocation = document.getElementById(

--- a/apps/site/assets/js/algolia-results.js
+++ b/apps/site/assets/js/algolia-results.js
@@ -162,9 +162,9 @@ export class AlgoliaResults {
       });
   }
 
-  _locationSearch(placeId) {
+  _locationSearch(address) {
     return () => {
-      GoogleMapsHelpers.lookupPlace(placeId)
+      GoogleMapsHelpers.lookupPlace(address)
         .then(result => {
           this._parent.resetSessionToken();
           this._showLocation(

--- a/apps/site/assets/js/google-maps-helpers.js
+++ b/apps/site/assets/js/google-maps-helpers.js
@@ -20,7 +20,7 @@ export function autocomplete({ input, hitLimit, sessionToken }) {
 export const lookupPlace = placeId =>
   new Promise((resolve, reject) => {
     window.jQuery
-      .getJSON(`/places/details/${placeId}`)
+      .getJSON(`/places/details/${encodeURIComponent(placeId)}`)
       .done(processPlacesCallback(resolve))
       .fail(reject);
   });
@@ -38,7 +38,7 @@ const processAutocompleteResults = resolve => ({ predictions }) =>
 
 const predictionResults = predictions => ({
   locations: {
-    hits: predictions,
+    hits: predictions.map((p, i) => ({...p, id: `location-${i}`})),
     nbHits: predictions.length
   }
 });

--- a/apps/site/assets/js/google-maps-helpers.js
+++ b/apps/site/assets/js/google-maps-helpers.js
@@ -17,10 +17,10 @@ export function autocomplete({ input, hitLimit, sessionToken }) {
   });
 }
 
-export const lookupPlace = placeId =>
+export const lookupPlace = address =>
   new Promise((resolve, reject) => {
     window.jQuery
-      .getJSON(`/places/details/${encodeURIComponent(placeId)}`)
+      .getJSON(`/places/details/${encodeURIComponent(address)}`)
       .done(processPlacesCallback(resolve))
       .fail(reject);
   });

--- a/apps/site/assets/js/trip-planner-location-controls.js
+++ b/apps/site/assets/js/trip-planner-location-controls.js
@@ -296,14 +296,14 @@ export class TripPlannerLocControls {
           );
           break;
         case "locations":
-          GoogleMapsHelpers.lookupPlace(hit.place_id)
+          GoogleMapsHelpers.lookupPlace(hit.address)
             .then(res => {
               ac.resetSessionToken();
 
               const { latitude, longitude } = res;
               this.setAutocompleteValue(
                 ac,
-                hit.description,
+                hit.address,
                 lat,
                 lng,
                 latitude,

--- a/apps/site/lib/site_web/controllers/places_controller.ex
+++ b/apps/site/lib/site_web/controllers/places_controller.ex
@@ -9,8 +9,7 @@ defmodule SiteWeb.PlacesController do
 
   @spec autocomplete(Conn.t(), map) :: Conn.t()
   def autocomplete(conn, %{"input" => input, "hit_limit" => hit_limit_str, "token" => token}) do
-    autocomplete_fn =
-      Map.get(conn.assigns, :autocomplete_fn, &LocationService.autocomplete/2)
+    autocomplete_fn = Map.get(conn.assigns, :autocomplete_fn, &LocationService.autocomplete/2)
 
     with {hit_limit, ""} <- Integer.parse(hit_limit_str),
          {:ok, predictions} <-
@@ -27,8 +26,7 @@ defmodule SiteWeb.PlacesController do
 
   @spec details(Conn.t(), map) :: Conn.t()
   def details(conn, %{"place_id" => place_id}) do
-    geocode_fn =
-      Map.get(conn.assigns, :geocode_by_place_id_fn, &LocationService.geocode/1)
+    geocode_fn = Map.get(conn.assigns, :geocode_by_place_id_fn, &LocationService.geocode/1)
 
     case geocode_fn.(place_id) do
       {:ok, results} ->
@@ -44,7 +42,8 @@ defmodule SiteWeb.PlacesController do
 
   @spec reverse_geocode(Conn.t(), map) :: Conn.t()
   def reverse_geocode(conn, params) do
-    reverse_geocode_fn = Map.get(conn.assigns, :reverse_geocode_fn, &LocationService.reverse_geocode/2)
+    reverse_geocode_fn =
+      Map.get(conn.assigns, :reverse_geocode_fn, &LocationService.reverse_geocode/2)
 
     with {:ok, latitude, longitude} <- parse_location(params),
          {:ok, results} <- reverse_geocode_fn.(latitude, longitude) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add front-end logic to use AWS for geocoding + place lookup](https://app.asana.com/0/555089885850811/1201846410385721/f)

(The Asana ticket was about the front-end changes, but I ended up implementing both ends of this here)

This PR makes it possible for us to use AWS-powered location autocompletion in our search bars.

There are a few significant differences between what AWS and what Google return to us:
1. Google returns a concept of which "place_id" each suggestion is associated with, whereas only gives us the suggested address.
2. Google returns some data to indicate which span of the suggested text to highlight on the frontend, AWS does not include this data.

To unify these two, I've created a `LocationService.Suggestion` type that we'll now return from our endpoint. For now it just includes `address`, which is the text we display in the autocomplete list.

With regards to that and `1.` above, I've changed the logic such that instead of passing around place IDs to our front end helpers (`google-maps-helpers.js`), we're just passing the full addresses. I've also updated the `details` endpoint to account for this. If anyone has any other suggestions here, let me know.

With regards to `2.` above, I've logged a separate ticket to address adding the span highlighting functionality back, though I haven't decided on whether to do that in the backend or the frontend. If anyone has any strong opinions here, let me know.

Please critique my elixir code :) 
