### PR TITLE
Misc. bugfixes

### DIFF
--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -106,9 +106,17 @@ defmodule SiteWeb.CustomerSupportController do
     end
   end
 
-  def submit(conn, %{"support" => form_data}) do
-    comments = Map.get(form_data, "comments", nil)
+  def submit(conn, params) do
     Logger.warn("recaptcha validation missing")
+
+    comments =
+      case params do
+        %{"support" => form_data} ->
+          Map.get(form_data, "comments", nil)
+
+        _ ->
+          nil
+      end
 
     conn
     |> put_status(400)

--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -136,7 +136,7 @@ defmodule SiteWeb.ScheduleController.TimetableController do
   end
 
   @spec trip_schedule(Schedules.Schedule.t()) ::
-          {{Schedules.Trip.id_t() | nil, Stops.Stop.id_t()}, Schedules.Schedule.t()}
+          {{Schedules.Trip.id_t() | nil, Stops.Stop.id_t() | nil}, Schedules.Schedule.t()}
   defp trip_schedule(%Schedules.Schedule{trip: trip, stop: stop} = schedule)
        when not is_nil(trip) and not is_nil(stop) do
     {{trip.id, stop.id}, schedule}

--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -137,13 +137,20 @@ defmodule SiteWeb.ScheduleController.TimetableController do
 
   @spec trip_schedule(Schedules.Schedule.t()) ::
           {{Schedules.Trip.id_t() | nil, Stops.Stop.id_t()}, Schedules.Schedule.t()}
-  defp trip_schedule(%Schedules.Schedule{trip: trip} = schedule) when not is_nil(trip) do
-    {{trip.id, schedule.stop.id}, schedule}
+  defp trip_schedule(%Schedules.Schedule{trip: trip, stop: stop} = schedule)
+       when not is_nil(trip) and not is_nil(stop) do
+    {{trip.id, stop.id}, schedule}
   end
 
   defp trip_schedule(schedule) do
-    :ok = Logger.warn("schedule_without_trip: #{inspect(schedule)}")
-    {{nil, schedule.stop.id}, schedule}
+    :ok =
+      Logger.warn(
+        "module=#{__MODULE__} trip_schedule schedule=#{inspect(schedule)} #{
+          if is_nil(schedule.trip), do: "no_trip"
+        } #{if is_nil(schedule.stop), do: "no_stop"}"
+      )
+
+    {{nil, nil}, schedule}
   end
 
   @spec header_schedules(list) :: list

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -341,6 +341,17 @@ defmodule SiteWeb.CustomerSupportControllerTest do
       assert "recaptcha" in conn.assigns.errors
     end
 
+    test "handles invalid response", %{conn: conn} do
+      conn =
+        post(
+          conn,
+          customer_support_path(conn, :submit),
+          %{}
+        )
+
+      assert "recaptcha" in conn.assigns.errors
+    end
+
     test "if the submission doesn't carry a recaptcha value, consider it an invalid recaptcha", %{
       conn: conn
     } do


### PR DESCRIPTION
A couple tweaks to avoid known sources of server errors in user flows. These two problems were found in Sentry months ago and keep coming up, usually around times when certain routes have shuttles. Investigating/debugging the underlying data is beyond the scope of fixing these errors.

#### Summary of changes
**Asana Ticket:** [no function clause matching in SiteWeb.CustomerSupportController.submit/2](https://app.asana.com/0/0/1200334203657800)

Turns out we thought we had fixed this in https://github.com/mbta/dotcom/pull/969 but had left out one case.
* Function clause added to the submit function to handle cases where the second argument does not include the "support" key.


**Asana Ticket:** [function nil.id/0 is undefined](https://app.asana.com/0/0/1200951746296209)
This seems related to https://github.com/mbta/dotcom/pull/1220 where the schedule's stop happens to be `nil`.
* Check for nil schedule before requesting its id