### PR TITLE
Rework the search result text highlighting to work with both Google Maps and AWS

### DIFF
--- a/apps/location_service/lib/result.ex
+++ b/apps/location_service/lib/result.ex
@@ -52,7 +52,14 @@ defmodule LocationService.Result do
       |> Enum.map(fn
         # AWS suggestions
         %{"Text" => address} ->
-          %LocationService.Suggestion{address: address}
+          %LocationService.Suggestion{
+            address: address,
+            highlighted_spans:
+              LocationService.Utils.get_highlighted_spans(%{
+                search: input[:search],
+                text: address
+              })
+          }
 
         # AWS format
         %{"Place" => %{"Label" => label, "Geometry" => %{"Point" => [lon, lat]}}} ->

--- a/apps/location_service/lib/suggestion.ex
+++ b/apps/location_service/lib/suggestion.ex
@@ -4,9 +4,13 @@ defmodule LocationService.Suggestion do
   [todo] deprecate GoogleMaps.Place.Prediction
   """
   @type t :: %__MODULE__{
-          address: String.t()
+          address: String.t(),
+          highlighted_spans: [LocationService.Utils.highlighted_span()]
         }
-  defstruct address: ""
+
+  @enforce_keys [:address, :highlighted_spans]
+  defstruct address: nil,
+            highlighted_spans: nil
 
   @type result :: {:ok, [t()]} | {:error, :internal_error}
 end

--- a/apps/location_service/lib/suggestion.ex
+++ b/apps/location_service/lib/suggestion.ex
@@ -5,7 +5,7 @@ defmodule LocationService.Suggestion do
   """
   @type t :: %__MODULE__{
           address: String.t(),
-          highlighted_spans: [LocationService.Utils.highlighted_span()]
+          highlighted_spans: [LocationService.Utils.HighlightedSpan.t()]
         }
 
   @enforce_keys [:address, :highlighted_spans]

--- a/apps/location_service/lib/utils.ex
+++ b/apps/location_service/lib/utils.ex
@@ -1,0 +1,32 @@
+defmodule LocationService.Utils do
+  defmodule HighlightedSpan do
+    @type t :: %__MODULE__{
+            offset: number,
+            length: number
+          }
+
+    @enforce_keys [:offset, :length]
+    defstruct offset: nil,
+              length: nil
+  end
+
+  @spec get_highlighted_spans(%{search: String.t(), text: String.t()}) :: [HighlightedSpan]
+  def get_highlighted_spans(%{search: search, text: text}) do
+    parts = String.split(search)
+
+    Enum.map(parts, fn p ->
+      src = "(^|\\W)(?<t>" <> p <> "\\w*)"
+      {:ok, re} = Regex.compile(src, "i")
+
+      Regex.scan(re, text, return: :index, capture: :all_names)
+      |> Enum.map(fn
+        [{offset, length}] -> %HighlightedSpan{offset: offset, length: length}
+        nil -> nil
+      end)
+    end)
+    |> Enum.filter(& &1)
+    |> List.flatten()
+    |> Enum.uniq()
+    |> Enum.sort(&(&1.offset <= &2.offset))
+  end
+end

--- a/apps/location_service/lib/utils.ex
+++ b/apps/location_service/lib/utils.ex
@@ -23,7 +23,7 @@ defmodule LocationService.Utils do
   def get_highlighted_spans(%{search: search, text: text}) do
     parts = String.split(search)
 
-    Enum.map(parts, fn p ->
+    Enum.flat_map(parts, fn p ->
       src = "(^|\\W)(?<t>" <> p <> "\\w*)"
       {:ok, re} = Regex.compile(src, "i")
 
@@ -32,9 +32,8 @@ defmodule LocationService.Utils do
         [{offset, length}] -> %HighlightedSpan{offset: offset, length: length}
         nil -> nil
       end)
+      |> Enum.filter(& &1)
     end)
-    |> Enum.filter(& &1)
-    |> List.flatten()
     |> Enum.uniq()
     |> Enum.sort(&(&1.offset <= &2.offset))
   end

--- a/apps/location_service/lib/utils.ex
+++ b/apps/location_service/lib/utils.ex
@@ -10,7 +10,7 @@ defmodule LocationService.Utils do
               length: nil
   end
 
-  @spec get_highlighted_spans(%{search: String.t(), text: String.t()}) :: [HighlightedSpan]
+  @spec get_highlighted_spans(%{search: String.t(), text: String.t()}) :: [HighlightedSpan.t()]
   def get_highlighted_spans(%{search: search, text: text}) do
     parts = String.split(search)
 

--- a/apps/location_service/lib/utils.ex
+++ b/apps/location_service/lib/utils.ex
@@ -10,6 +10,15 @@ defmodule LocationService.Utils do
               length: nil
   end
 
+  @doc """
+  Gets indices of spans of text that should be highlighted in the
+  autocomplete dropdown.
+
+  Essentially, `search` is split on whitespace, and then we search `text`
+  for words that start with any of the `search` terms. The spans are
+  non-overlapping, and sorted by `offset`. There are examples in the tests
+  that should further clarify the behavior.
+  """
   @spec get_highlighted_spans(%{search: String.t(), text: String.t()}) :: [HighlightedSpan.t()]
   def get_highlighted_spans(%{search: search, text: text}) do
     parts = String.split(search)

--- a/apps/location_service/lib/utils.ex
+++ b/apps/location_service/lib/utils.ex
@@ -1,8 +1,8 @@
 defmodule LocationService.Utils do
   defmodule HighlightedSpan do
     @type t :: %__MODULE__{
-            offset: number,
-            length: number
+            offset: integer(),
+            length: non_neg_integer()
           }
 
     @enforce_keys [:offset, :length]

--- a/apps/location_service/lib/utils.ex
+++ b/apps/location_service/lib/utils.ex
@@ -24,6 +24,11 @@ defmodule LocationService.Utils do
     parts = String.split(search)
 
     Enum.flat_map(parts, fn p ->
+      # (^|\\W) -- Match start of string or non-word character
+      # (?<t>   -- Begin a capture group named `t`
+      # p       -- Match the current part
+      # \\w*    -- Match any number of word characters
+      # )       -- Close `t`
       src = "(^|\\W)(?<t>" <> p <> "\\w*)"
       {:ok, re} = Regex.compile(src, "i")
 

--- a/apps/location_service/lib/wrappers.ex
+++ b/apps/location_service/lib/wrappers.ex
@@ -10,7 +10,17 @@ defmodule LocationService.Wrappers do
         {:ok,
          results
          |> Enum.map(fn p ->
-           %LocationService.Suggestion{address: p.description, highlighted_spans: []}
+           %LocationService.Suggestion{
+             address: p.description,
+             highlighted_spans:
+               p.matched_substrings
+               |> Enum.map(
+                 &%LocationService.Utils.HighlightedSpan{
+                   offset: &1["offset"],
+                   length: &1["length"]
+                 }
+               )
+           }
          end)}
 
       e ->

--- a/apps/location_service/lib/wrappers.ex
+++ b/apps/location_service/lib/wrappers.ex
@@ -10,7 +10,7 @@ defmodule LocationService.Wrappers do
         {:ok,
          results
          |> Enum.map(fn p ->
-           %LocationService.Suggestion{address: p.description}
+           %LocationService.Suggestion{address: p.description, highlighted_spans: []}
          end)}
 
       e ->

--- a/apps/location_service/test/utils_test.exs
+++ b/apps/location_service/test/utils_test.exs
@@ -1,0 +1,61 @@
+defmodule LocationService.UtilsTest do
+  use ExUnit.Case, async: false
+
+  import LocationService.Utils
+  alias LocationService.Utils.HighlightedSpan
+
+  defp get_highlighted_spans_text(query) do
+    get_highlighted_spans(query)
+    |> Enum.map(fn %HighlightedSpan{offset: offset, length: length} ->
+      String.slice(query[:text], offset, length)
+    end)
+  end
+
+  describe "get_highlighted_spans/1" do
+    test "returns empty when no matches" do
+      assert [] = get_highlighted_spans(%{search: "Lame", text: "Cool"})
+    end
+
+    test "returns matched word case-insensitively" do
+      spans = get_highlighted_spans_text(%{search: "ses", text: "Sesame Street"})
+
+      assert ["Sesame"] = spans
+    end
+
+    test "returns matched words case-insensitively" do
+      spans = get_highlighted_spans_text(%{search: "ses str", text: "Sesame Street"})
+
+      assert ["Sesame", "Street"] = spans
+    end
+
+    test "returns matched words case-insensitively, out of order, in the order they appear in the text" do
+      spans = get_highlighted_spans_text(%{search: "str ses", text: "Sesame Street"})
+
+      assert ["Sesame", "Street"] = spans
+    end
+
+    test "ignores non-matching parts" do
+      spans = get_highlighted_spans_text(%{search: "ses cool", text: "Sesame Street"})
+
+      assert ["Sesame"] = spans
+    end
+
+    test "removes overlapping spans" do
+      spans = get_highlighted_spans_text(%{search: "ses ses", text: "Sesame Street"})
+
+      assert ["Sesame"] = spans
+    end
+
+    test "catches double matches" do
+      spans = get_highlighted_spans_text(%{search: "ses", text: "Sesame Sesame Street"})
+
+      assert ["Sesame", "Sesame"] = spans
+    end
+
+    test "only matches start of words" do
+      spans = get_highlighted_spans_text(%{search: "ses eet", text: "Sesame Street"})
+
+      assert ["Sesame"] = spans
+    end
+  end
+end

--- a/apps/location_service/test/wrappers_test.exs
+++ b/apps/location_service/test/wrappers_test.exs
@@ -11,7 +11,8 @@ defmodule LocationService.WrappersTest do
           {:ok,
            [
              %{
-               description: "Test"
+               description: "Test",
+               matched_substrings: [%{"offset" => 0, "length" => 2}]
              }
            ]}
         end do
@@ -19,7 +20,13 @@ defmodule LocationService.WrappersTest do
 
         assert [
                  %LocationService.Suggestion{
-                   address: "Test"
+                   address: "Test",
+                   highlighted_spans: [
+                     %LocationService.Utils.HighlightedSpan{
+                       length: 2,
+                       offset: 0
+                     }
+                   ]
                  }
                ] = results
       end

--- a/apps/site/assets/js/algolia-result.js
+++ b/apps/site/assets/js/algolia-result.js
@@ -1,5 +1,6 @@
 import hogan from "hogan.js";
 import * as Icons from "./icons";
+import { highlightText } from "../ts/helpers/text.ts";
 
 /* eslint-disable no-underscore-dangle */
 
@@ -329,7 +330,9 @@ function _contentTitle(hit) {
 export function getTitle(hit, type) {
   switch (type) {
     case "locations":
-      return hit.address;
+      const { address: text, highlighted_spans: spans } = hit;
+
+      return highlightText(text, spans);
     case "stops":
       return hit._highlightResult.stop.name.value;
 

--- a/apps/site/assets/ts/helpers/__tests__/text-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/text-test.ts
@@ -1,17 +1,32 @@
-import { breakTextAtSlash } from "../text";
+import { breakTextAtSlash, highlightText } from "../text";
 
-test("doesn't change text without slashes", () => {
-  const str = "this text doesn't contain a slash";
+describe("breakTextAtSlash", () => {
+  test("doesn't change text without slashes", () => {
+    const str = "this text doesn't contain a slash";
 
-  expect(breakTextAtSlash(str)).toEqual(str);
+    expect(breakTextAtSlash(str)).toEqual(str);
+  });
+
+  test("adds zero width spaces after slashes", () => {
+    const str = "abc/123/xyz";
+
+    const result = breakTextAtSlash(str);
+
+    expect(result.length).toEqual(13);
+    // There are now zero-widt spaces after each slash
+    expect(result).toEqual("abc/​123/​xyz");
+  });
 });
 
-test("adds zero width spaces after slashes", () => {
-  const str = "abc/123/xyz";
+describe("highlightText", () => {
+  test("generates proper <em> spans", () => {
+    const text = "Sesame Street";
+    const spans = [
+      { offset: 0, length: 6 },
+      { offset: 7, length: 6 }
+    ];
 
-  const result = breakTextAtSlash(str);
-
-  expect(result.length).toEqual(13);
-  // There are now zero-widt spaces after each slash
-  expect(result).toEqual("abc/​123/​xyz");
+    const highlighted = highlightText(text, spans);
+    expect(highlighted).toEqual("<em>Sesame</em> <em>Street</em>");
+  });
 });

--- a/apps/site/assets/ts/helpers/text.ts
+++ b/apps/site/assets/ts/helpers/text.ts
@@ -5,3 +5,22 @@
 // eslint-disable-next-line import/prefer-default-export
 export const breakTextAtSlash = (str: string): string =>
   str.replace(/\//g, "/​");
+
+interface HighlightedSpan {
+  offset: number;
+  length: number;
+}
+export function highlightText(text: string, spans: HighlightedSpan[]): string {
+  const parts = [];
+  let cursor = 0;
+  for (const span of spans) {
+    const { offset, length } = span;
+
+    parts.push(text.slice(cursor, offset));
+    parts.push(`<em>${text.slice(offset, offset + length)}</em>`);
+    cursor = length + offset;
+  }
+  parts.push(text.slice(cursor));
+
+  return parts.join("");
+}

--- a/apps/site/test/site_web/controllers/places_controller_test.exs
+++ b/apps/site/test/site_web/controllers/places_controller_test.exs
@@ -15,7 +15,7 @@ defmodule SiteWeb.PlacesControllerTest do
       input = "controller1"
 
       autocomplete_fn = fn _, _, _ ->
-        {:ok, [%LocationService.Suggestion{address: "123 Sesame Street"}]}
+        {:ok, [%LocationService.Suggestion{address: "123 Sesame Street", highlighted_spans: []}]}
       end
 
       conn = assign(conn, :autocomplete_fn, autocomplete_fn)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Rework the search result text highlighting to work with both Google Maps and AWS](https://app.asana.com/0/555089885850811/1201936731451754/f)

This PR implements the search result highlighting in a backend-agnostic manner. The basic approach is:
- For Google suggestion results, simply take the `matched_substrings` field and re-encode it to our internal structure
- For AWS suggestion results, apply some simple regex-based logic to determine which parts of the address should be highlighted (there are examples of how the logic works in the associated text)
- On the frontend, take this information from the backend and build a string with `<em>` tags inserted at the proper locations.

The AWS highlighting logic is not 1:1 with the highlighting information that Google applies, but it should be close enough to be useful.