### PR TITLE
Remove "Powered by Google" when using AWS

### DIFF
--- a/apps/location_service/lib/location_service.ex
+++ b/apps/location_service/lib/location_service.ex
@@ -46,7 +46,7 @@ defmodule LocationService do
     end)
   end
 
-  defp active_service(key) do
+  def active_service(key) do
     {:system, env_var, default} = Application.get_env(:location_service, key)
     if value = System.get_env(env_var), do: String.to_atom(value), else: default
   end

--- a/apps/site/assets/js/algolia-embedded-search.js
+++ b/apps/site/assets/js/algolia-embedded-search.js
@@ -107,7 +107,10 @@ export class AlgoliaEmbeddedSearch {
   }
 
   static renderFooterTemplate(indexName) {
-    if (indexName === "locations") {
+    if (
+      indexName === "locations"
+      && AlgoliaResult.AUTOCOMPLETE_POWERED_BY_GOOGLE
+    ) {
       return AlgoliaResult.TEMPLATES.poweredByGoogleLogo.render({
         logo: document.getElementById("powered-by-google-logo").innerHTML
       });

--- a/apps/site/assets/js/algolia-result.js
+++ b/apps/site/assets/js/algolia-result.js
@@ -7,6 +7,9 @@ export const SELECTORS = {
   result: "js-search-result"
 };
 
+export const AUTOCOMPLETE_POWERED_BY_GOOGLE =
+  window.location_autocomplete_backing === "google";
+
 export const TEMPLATES = {
   poweredByGoogleLogo: hogan.compile(
     `<div class="c-search-result__hit c-search-result__google">{{{logo}}}</div>`

--- a/apps/site/assets/js/algolia-result.js
+++ b/apps/site/assets/js/algolia-result.js
@@ -8,7 +8,7 @@ export const SELECTORS = {
 };
 
 export const AUTOCOMPLETE_POWERED_BY_GOOGLE =
-  window.location_autocomplete_backing === "google";
+  window.locationAutocompleteBacking === "google";
 
 export const TEMPLATES = {
   poweredByGoogleLogo: hogan.compile(

--- a/apps/site/assets/js/algolia-results.js
+++ b/apps/site/assets/js/algolia-results.js
@@ -227,9 +227,12 @@ export class AlgoliaResults {
       hasHits: results[group].nbHits > 0,
       showMore: results[group].hits.length < results[group].nbHits,
       group: group,
-      googleLogo: AlgoliaResult.TEMPLATES.poweredByGoogleLogo.render({
-        logo: document.getElementById("powered-by-google-logo").innerHTML
-      }),
+      googleLogo:
+        AlgoliaResult.AUTOCOMPLETE_POWERED_BY_GOOGLE
+          ? AlgoliaResult.TEMPLATES.poweredByGoogleLogo.render({
+            logo: document.getElementById("powered-by-google-logo").innerHTML
+          })
+          : null,
       hits: results[group].hits.map(this.renderResult(group, results[group]))
     });
   }

--- a/apps/site/assets/js/trip-planner-location-controls.js
+++ b/apps/site/assets/js/trip-planner-location-controls.js
@@ -343,7 +343,10 @@ export class TripPlannerLocControls {
   }
 
   renderFooterTemplate(indexName) {
-    if (indexName === "locations") {
+    if (
+      indexName === "locations"
+      && AlgoliaResult.AUTOCOMPLETE_POWERED_BY_GOOGLE
+    ) {
       return AlgoliaResult.TEMPLATES.poweredByGoogleLogo.render({
         logo: document.getElementById("powered-by-google-logo").innerHTML
       });

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -40,6 +40,9 @@
       <script defer src="<%= static_url(@conn, "/js/app.js") %>" data-turbolinks-track="reload"></script>
     <% end %>
 
+    <script type="application/javascript">
+      locationAutocompleteBacking = "<%= LocationService.active_service(:autocomplete) %>";
+    </script>
     <%= if assigns[:requires_location_service?] do %>
       <script type="application/javascript">if (!window.mapsCallback) { window.mapsCallback = function () { window.isMapReady = true; } }</script>
       <script async src="<%= location_service_js_url %>"></script>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Remove "Powered by Google" when using AWS](https://app.asana.com/0/555089885850811/1201936731451755/f)

This PR prevents the "Powered by Google" logo from rendering when we're not using Google to drive the autocomplete. The basic approach is as follows:
- Inject the current autocomplete backend into the page by querying `LocationService.active_service(:autocomplete)`
- Check that in each place where we render the "Powered by Google" logo, and prevent the rendering if we're not using Google

If there's a better way to go about this than the injection method here, let me know