### PR TITLE
Fix schedule finder navigation scroll issue

### DIFF
--- a/apps/site/assets/ts/components/Modal.tsx
+++ b/apps/site/assets/ts/components/Modal.tsx
@@ -70,12 +70,11 @@ const ModalContent = ({
     });
     trap.activate();
 
-    const htmlElement = document.getElementsByTagName("html")[0];
     const bodyWrapper = document.getElementById("body-wrapper");
     if (bodyWrapper) {
       // aria-hidden for mobile devices where we want to emulate "focus" behavior
       bodyWrapper.setAttribute("aria-hidden", "true");
-      htmlElement.classList.add("modal-open");
+      document.body.classList.add("modal-open");
       bodyWrapper.style.paddingRight = `${scrollBarPadding}px`;
     }
 
@@ -83,7 +82,7 @@ const ModalContent = ({
     return () => {
       if (bodyWrapper) {
         bodyWrapper.setAttribute("aria-hidden", "false");
-        htmlElement.classList.remove("modal-open");
+        document.body.classList.remove("modal-open");
         bodyWrapper.style.paddingRight = bodyPadding;
       }
       trap.deactivate();

--- a/apps/site/assets/ts/components/Modal.tsx
+++ b/apps/site/assets/ts/components/Modal.tsx
@@ -22,7 +22,7 @@ interface Props {
   ariaLabel: AriaLabel | AriaLabelledBy;
   focusElementId?: string; // a selector string to the DOM node that will receive focus when the model is first opened
   className?: string;
-  closeModal: Function;
+  closeModal: () => void;
 }
 
 interface ModalContentProps {
@@ -30,7 +30,7 @@ interface ModalContentProps {
   closeText: string | ReactElement<HTMLElement>;
   role: string;
   ariaLabel: AriaLabel | AriaLabelledBy;
-  closeModal: Function;
+  closeModal: () => void;
   focusElementId: string;
   bodyPadding: string;
   scrollBarPadding: number;
@@ -61,6 +61,15 @@ const ModalContent = ({
       scrollRef.current.scrollTo({ top: 0 });
     }
   }, [children]);
+
+  useEffect(() => {
+    document.addEventListener("turbolinks:before-visit", closeModal, {
+      passive: true
+    });
+
+    return () =>
+      document.removeEventListener("turbolinks:before-visit", closeModal);
+  }, [closeModal]);
 
   useLayoutEffect(() => {
     // Activate trap and disable scroll on background body

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/ModalTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/ModalTest.tsx.snap
@@ -6,7 +6,9 @@ exports[`it renders 1`] = `
     <ModalContent>
       <Portal
         containerInfo={
-          <body>
+          <body
+            class="modal-open"
+          >
             <div
               aria-hidden="true"
               id="body-wrapper"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Can't scroll in Schedule Finder](https://app.asana.com/0/555089885850811/1201973783756879/f)

The linked ticket has a video showing reproduction steps of a specific case, but more generally what is happening here is that turbolinks doesn't touch the root `html` element between loads, thus the `modal-open` class is sticking around. This PR moves the `modal-open` class to the `body` element, which turbolinks will properly merge between loads. As far as I can tell this should be safe to do, but let me know if I've missed anything.

This also adds a `turbolinks:before-visit` event listener which closes the modal. This is to fix a bug I noticed where going back to the previous page would open 2 modals.

