### PR TITLE
add glx now open messaging to line diagrams

### DIFF
--- a/apps/site/assets/css/_glx-open.scss
+++ b/apps/site/assets/css/_glx-open.scss
@@ -43,3 +43,21 @@
   vertical-align: middle;
   width: 45px;
 }
+
+.m-schedule-diagram__content {
+  .glx-logo {
+    svg {
+      height: 20px;
+      width: 45px;
+
+      @include media-breakpoint-down(md) {
+        height: 16px;
+        width: 36px;
+      }
+    }
+
+    height: 20px;
+    vertical-align: middle;
+    width: 45px;
+  }
+}

--- a/apps/site/assets/ts/components/GlxOpen.tsx
+++ b/apps/site/assets/ts/components/GlxOpen.tsx
@@ -26,7 +26,7 @@ const GlxOpen = ({
   pageType,
   stopId
 }: {
-  pageType: "station-page" | "schedule-finder";
+  pageType: "station-page" | "schedule-finder" | "line-diagram";
   stopId: string;
 }): ReactElement<HTMLElement> | null => {
   const [isGlxOpen, setIsGlxOpen] = useState(false);

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -17,6 +17,7 @@ import MatchHighlight from "../../../components/MatchHighlight";
 import StopFeatures from "./StopFeatures";
 import { StopRefContext } from "./LineDiagramWithStops";
 import { effectNameForAlert } from "../../../components/Alerts";
+import GlxOpen from "../../../components/GlxOpen";
 
 interface StopCardProps {
   stop: LineDiagramStop;
@@ -83,6 +84,7 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
       style={{ paddingLeft: searchQuery ? "0.5rem" : `${width}px` }}
     >
       <section className="m-schedule-diagram__content">
+        <GlxOpen pageType="line-diagram" stopId={routeStop.id} />
         {hasBranchLabel(stop) && (
           <div className="u-bold u-small-caps">{lineName(routeStop)}</div>
         )}

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -92,6 +92,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
           <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
+                <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-origin\\" />
                 <header className=\\"m-schedule-diagram__stop-heading\\">
                   <h4 className=\\"m-schedule-diagram__stop-link\\">
                     <a href=\\"/stops/line-origin\\">
@@ -127,6 +128,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
           <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={{...}}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
+                <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-stop1\\" />
                 <header className=\\"m-schedule-diagram__stop-heading\\">
                   <h4 className=\\"m-schedule-diagram__stop-link\\">
                     <a href=\\"/stops/line-stop1\\">
@@ -203,6 +205,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
           <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={{...}}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
+                <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-stop2\\" />
                 <header className=\\"m-schedule-diagram__stop-heading\\">
                   <h4 className=\\"m-schedule-diagram__stop-link\\">
                     <a href=\\"/stops/line-stop2\\">
@@ -272,6 +275,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
           <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
+                <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-destination\\" />
                 <header className=\\"m-schedule-diagram__stop-heading\\">
                   <h4 className=\\"m-schedule-diagram__stop-link\\">
                     <a href=\\"/stops/line-destination\\">

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -77,6 +77,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
         <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
           <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
             <section className=\\"m-schedule-diagram__content\\">
+              <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-origin\\" />
               <header className=\\"m-schedule-diagram__stop-heading\\">
                 <h4 className=\\"m-schedule-diagram__stop-link\\">
                   <a href=\\"/stops/line-origin\\">
@@ -112,6 +113,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
         <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={{...}}>
           <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
             <section className=\\"m-schedule-diagram__content\\">
+              <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-stop1\\" />
               <header className=\\"m-schedule-diagram__stop-heading\\">
                 <h4 className=\\"m-schedule-diagram__stop-link\\">
                   <a href=\\"/stops/line-stop1\\">
@@ -188,6 +190,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
         <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={{...}}>
           <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
             <section className=\\"m-schedule-diagram__content\\">
+              <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-stop2\\" />
               <header className=\\"m-schedule-diagram__stop-heading\\">
                 <h4 className=\\"m-schedule-diagram__stop-link\\">
                   <a href=\\"/stops/line-stop2\\">
@@ -257,6 +260,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
         <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
           <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
             <section className=\\"m-schedule-diagram__content\\">
+              <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-destination\\" />
               <header className=\\"m-schedule-diagram__stop-heading\\">
                 <h4 className=\\"m-schedule-diagram__stop-link\\">
                   <a href=\\"/stops/line-destination\\">

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopListWithBranchesTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopListWithBranchesTest.tsx.snap
@@ -7,6 +7,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
       <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
           <section className=\\"m-schedule-diagram__content\\">
+            <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-destination\\" />
             <div className=\\"u-bold u-small-caps\\">
               Destination Line
             </div>
@@ -36,6 +37,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
       <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
           <section className=\\"m-schedule-diagram__content\\">
+            <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-stopC\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
               <h4 className=\\"m-schedule-diagram__stop-link\\">
                 <a href=\\"/stops/tree-stopC\\">
@@ -62,6 +64,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
       <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
           <section className=\\"m-schedule-diagram__content\\">
+            <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-stopB\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
               <h4 className=\\"m-schedule-diagram__stop-link\\">
                 <a href=\\"/stops/tree-stopB\\">
@@ -88,6 +91,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
       <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
           <section className=\\"m-schedule-diagram__content\\">
+            <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-stopA\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
               <h4 className=\\"m-schedule-diagram__stop-link\\">
                 <a href=\\"/stops/tree-stopA\\">
@@ -114,6 +118,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
       <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
           <section className=\\"m-schedule-diagram__content\\">
+            <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-twig-destination\\" />
             <div className=\\"u-bold u-small-caps\\">
               Twig Destination Line
             </div>
@@ -146,6 +151,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
             <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
               <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                 <section className=\\"m-schedule-diagram__content\\">
+                  <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-twig-stop\\" />
                   <header className=\\"m-schedule-diagram__stop-heading\\">
                     <h4 className=\\"m-schedule-diagram__stop-link\\">
                       <a href=\\"/stops/tree-twig-stop\\">
@@ -175,6 +181,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
       <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
           <section className=\\"m-schedule-diagram__content\\">
+            <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-branch-destination\\" />
             <div className=\\"u-bold u-small-caps\\">
               Branch Destination Line
             </div>
@@ -240,6 +247,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
       <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
           <section className=\\"m-schedule-diagram__content\\">
+            <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-stop1\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
               <h4 className=\\"m-schedule-diagram__stop-link\\">
                 <a href=\\"/stops/tree-stop1\\">
@@ -266,6 +274,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
       <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
           <section className=\\"m-schedule-diagram__content\\">
+            <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-stop0\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
               <h4 className=\\"m-schedule-diagram__stop-link\\">
                 <a href=\\"/stops/tree-stop0\\">
@@ -292,6 +301,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
       <StopCard stop={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
           <section className=\\"m-schedule-diagram__content\\">
+            <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-origin\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
               <h4 className=\\"m-schedule-diagram__stop-link\\">
                 <a href=\\"/stops/tree-origin\\">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [GLX "NOW OPEN" in line diagrams](https://app.asana.com/0/555089885850811/1201915536508565/f)

add glx now open component to show in line diagrams.

![image](https://user-images.githubusercontent.com/526017/158909995-f44644c4-f899-44d0-ac3d-a3c40f64dc1b.png)
![image](https://user-images.githubusercontent.com/526017/158910025-85cd2859-25da-4fc0-9d01-497d9c21fa10.png)
