### PR TITLE
bugfix: correctly allow matching of 0 index in glx open stations

### DIFF
--- a/apps/site/assets/ts/components/GlxOpen.tsx
+++ b/apps/site/assets/ts/components/GlxOpen.tsx
@@ -11,7 +11,7 @@ const getIsGlxOpen = (stationId: string): boolean => {
     glxStationsOpen instanceof HTMLElement &&
     glxStationsOpen.dataset.stations
   ) {
-    return glxStationsOpen.dataset.stations.split(",").indexOf(stationId) > -1;
+    return glxStationsOpen.dataset.stations.includes(stationId);
   }
   return false;
 };

--- a/apps/site/assets/ts/components/GlxOpen.tsx
+++ b/apps/site/assets/ts/components/GlxOpen.tsx
@@ -11,7 +11,7 @@ const getIsGlxOpen = (stationId: string): boolean => {
     glxStationsOpen instanceof HTMLElement &&
     glxStationsOpen.dataset.stations
   ) {
-    return glxStationsOpen.dataset.stations.split(",").indexOf(stationId) > 0;
+    return glxStationsOpen.dataset.stations.split(",").indexOf(stationId) > -1;
   }
   return false;
 };


### PR DESCRIPTION
Updated glx now open station list checking to include 0 (first) index. 
