### PR TITLE
fix: Check GLX opening in corrected TZ

### DIFF
--- a/apps/site/lib/site_web/plugs/glx_now_open.ex
+++ b/apps/site/lib/site_web/plugs/glx_now_open.ex
@@ -24,7 +24,12 @@ defmodule SiteWeb.Plugs.GlxNowOpen do
     conn
     |> assign(
       :glx_stations_open,
-      set_assigns(check_current_service_date(now_fn.(), Util.to_local_time(@opening_date)))
+      set_assigns(
+        check_current_service_date(
+          now_fn.(),
+          Util.convert_using_timezone(@opening_date, "America/New_York")
+        )
+      )
     )
   end
 

--- a/apps/site/test/green_line_test.exs
+++ b/apps/site/test/green_line_test.exs
@@ -14,12 +14,15 @@ defmodule GreenLineTest do
     test "returns a set of {stop_id, route_id} pairs" do
       {_, route_id_stop_map} = stops_on_routes(1)
 
+      refute "place-unsqu" in route_id_stop_map["Green-B"]
+      refute "place-unsqu" in route_id_stop_map["Green-C"]
+      refute "place-unsqu" in route_id_stop_map["Green-D"]
+      assert "place-unsqu" in route_id_stop_map["Green-E"]
+
       refute "place-lech" in route_id_stop_map["Green-B"]
       refute "place-lech" in route_id_stop_map["Green-C"]
       refute "place-lech" in route_id_stop_map["Green-D"]
-      # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
-      # We are temporarily adding the fix but this will need to be undone later on.
-      refute "place-lech" in route_id_stop_map["Green-E"]
+      assert "place-lech" in route_id_stop_map["Green-E"]
 
       assert "place-coecl" in route_id_stop_map["Green-B"]
       assert "place-coecl" in route_id_stop_map["Green-C"]
@@ -134,10 +137,7 @@ defmodule GreenLineTest do
       assert terminus?(stop_id, "Green-D")
     end
 
-    # As of June 2020, Lechmere is closed for construction and the E-line will
-    # be terminating at North Station for now.
-    # FIXME: Update with new GLX data
-    for stop_id <- ["place-north", "place-hsmnl"] do
+    for stop_id <- ["place-unsqu", "place-hsmnl"] do
       assert terminus?(stop_id, "Green-E")
     end
   end
@@ -145,12 +145,8 @@ defmodule GreenLineTest do
   test "terminus?/3" do
     assert terminus?("place-lake", "Green-B", 0)
     refute terminus?("place-lake", "Green-B", 1)
-    # As of June 2020, Lechmere is closed for construction and the E-line will
-    # be terminating at North Station for now.
-    # FIXME: Update with new GLX data
-    refute terminus?("place-north", "Green-E", 0)
-    # FIXME: Update with new GLX data
-    assert terminus?("place-north", "Green-E", 1)
+    refute terminus?("place-unsqu", "Green-E", 0)
+    assert terminus?("place-unsqu", "Green-E", 1)
   end
 
   describe "naive_headsign/2" do
@@ -163,9 +159,7 @@ defmodule GreenLineTest do
       assert naive_headsign("Green-D", 0) == "Riverside"
       assert naive_headsign("Green-D", 1) == "North Station"
       assert naive_headsign("Green-E", 0) == "Heath Street"
-      # As of June 2020, Lechmere is closed for construction and the E-line will
-      # be terminating at North Station for now.
-      assert naive_headsign("Green-E", 1) == "North Station"
+      assert naive_headsign("Green-E", 1) == "Union Square"
     end
   end
 

--- a/apps/site/test/site_web/controllers/schedule/green_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/green_test.exs
@@ -73,10 +73,7 @@ defmodule SiteWeb.ScheduleController.GreenTest do
        %{conn: conn} do
     conn = get(conn, green_path(conn, :line, %{"schedule_direction[direction_id]": 0}))
 
-    # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
-    # We are temporarily adding the fix but this will need to be reverted later on.
-    # assert [{_, %{id: "place-lech"}} | all_stops] = conn.assigns.all_stops
-    assert [{_, %{id: "place-north"}} | all_stops] = conn.assigns.all_stops
+    assert [{_, %{id: "place-unsqu"}} | all_stops] = conn.assigns.all_stops
 
     fenway = Enum.find(all_stops, fn {_, stop} -> stop.id == "place-fenwy" end)
     assert elem(fenway, 0) == [{"Green-B", :line}, {"Green-C", :line}, {"Green-D", :stop}]

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -304,15 +304,15 @@ defmodule SiteWeb.ScheduleController.LineTest do
       # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
       # We are temporarily adding the fix but this will need to be undone later on.
       for {id, idx} <- [
-            # {"place-lech", 0},
-            {"place-north", 0},
-            {"place-gover", 2},
-            {"place-pktrm", 3},
-            {"place-coecl", 6},
-            {"place-hsmnl", 17},
-            {"place-river", 32},
-            {"place-clmnl", 45},
-            {"place-lake", 61}
+            {"place-unsqu", 0},
+            {"place-north", 3},
+            {"place-gover", 5},
+            {"place-pktrm", 6},
+            {"place-coecl", 9},
+            {"place-hsmnl", 20},
+            {"place-river", 35},
+            {"place-clmnl", 48},
+            {"place-lake", 64}
           ] do
         assert stops |> Enum.at(idx) |> elem(1) == id
       end
@@ -332,10 +332,8 @@ defmodule SiteWeb.ScheduleController.LineTest do
         Enum.chunk_by(stops, fn {branches, _stop} -> Enum.count(branches) end)
 
       assert Enum.all?(trunk, &(&1 |> branches() |> length() == 1))
-      # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
-      # We are temporarily adding the fix but this will need to be undone later on.
-      # assert stop_id(List.first(trunk)) == "place-lech"
-      assert trunk |> List.first() |> stop_id() == "place-north"
+
+      assert trunk |> List.first() |> stop_id() == "place-unsqu"
       assert trunk |> List.last() |> stop_id() == "place-armnl"
 
       # E branch + merge

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -170,29 +170,16 @@ defmodule SiteWeb.ScheduleControllerTest do
       conn = get(conn, line_path(conn, :show, "Green", "schedule_direction[direction_id]": 0))
       assert html_response(conn, 200) =~ "Green Line"
 
-      # As of June 2020, Lechmere has been closed so the commented lines will make the test fail.
-      # We are temporarily adding the fix but this will need to be undone later on.
-
-      # stops are in West order, North Station (prev. Lechmere) -> Boston College (last stop on B)
+      # stops are in West order, Union Square -> Boston College (last stop on B)
       {_, first_stop} = List.first(conn.assigns.all_stops)
       {_, last_stop} = List.last(conn.assigns.all_stops)
 
-      # To be uncommented later:
-      # assert first_stop.id == "place-lech"
-      assert first_stop.id == "place-north"
+      assert first_stop.id == "place-unsqu"
 
       assert last_stop.id == "place-lake"
 
       # includes the stop features
-      # assert first_stop.stop_features == [:bus, :access]
-      assert [
-               :orange_line,
-               :green_line_d,
-               :commuter_rail,
-               :access,
-               :parking_lot
-             ]
-             |> Enum.all?(&Enum.member?(first_stop.stop_features, &1))
+      assert first_stop.stop_features == [:access]
 
       # spider map
       assert conn.assigns.map_img_src =~ "maps.googleapis.com"

--- a/apps/site/test/site_web/excluded_stops_test.exs
+++ b/apps/site/test/site_web/excluded_stops_test.exs
@@ -32,16 +32,13 @@ defmodule ExcludedStopsTest do
              ]
     end
 
-    test "excludes Lechmere on eastbound GL trips" do
+    test "excludes Union Square on eastbound GL trips" do
       all_stops =
         1
         |> GreenLine.stops_on_routes()
         |> GreenLine.all_stops()
 
-      # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
-      # We are temporarily adding the fix but this will need to be undone later on.
-      # assert excluded_origin_stops(1, "Green", all_stops) == ["place-lech"]
-      assert excluded_origin_stops(1, "Green", all_stops) == ["place-north"]
+      assert excluded_origin_stops(1, "Green", all_stops) == ["place-unsqu"]
     end
   end
 

--- a/apps/site/test/site_web/plugs/glx_now_open_test.exs
+++ b/apps/site/test/site_web/plugs/glx_now_open_test.exs
@@ -4,15 +4,18 @@ defmodule SiteWeb.Plugs.GlxNowOpenTest do
   import SiteWeb.Plugs.GlxNowOpen
 
   defp now_before_fn do
-    DateTime.from_naive!(~N[2022-03-21 00:00:00], "Etc/UTC")
+    ~N[2022-03-21 01:00:00]
+    |> Util.convert_using_timezone("America/New_York")
   end
 
   defp now_between_fn do
-    DateTime.from_naive!(~N[2022-03-21 04:55:00], "Etc/UTC")
+    ~N[2022-03-21 04:55:00]
+    |> Util.convert_using_timezone("America/New_York")
   end
 
   defp now_after_fn do
-    DateTime.from_naive!(~N[2022-06-21 04:55:00], "Etc/UTC")
+    ~N[2022-06-21 04:55:00]
+    |> Util.convert_using_timezone("America/New_York")
   end
 
   describe "init/1" do

--- a/apps/util/lib/util.ex
+++ b/apps/util/lib/util.ex
@@ -124,6 +124,7 @@ defmodule Util do
     |> handle_ambiguous_time()
   end
 
+  # important: assumes the NaiveDateTime is in UTC.
   def to_local_time(%NaiveDateTime{} = time) do
     time
     |> DateTime.from_naive!("Etc/UTC")


### PR DESCRIPTION
I noticed we were checking the date against `#DateTime<2022-03-21 00:55:00-04:00 EDT America/New_York>`, which isn't quite right.

Upon investigation I realized that `Util.to_local_time()` assumes an input `NaiveDateTime` is in UTC. 🤷🏼‍♀️ 
To fix I swapped it out for `Util.convert_using_timezone()` to get the right `DateTime`.