### PR TITLE
Remainder of GLX "NOW OPEN" treatment for /stops pages

### DIFF
--- a/apps/site/assets/css/_glx-open.scss
+++ b/apps/site/assets/css/_glx-open.scss
@@ -61,3 +61,9 @@
     width: 45px;
   }
 }
+
+.glx-open {
+  .m-stop-page__name {
+    color: $brand-green-line;
+  }
+}

--- a/apps/site/assets/css/_glx-open.scss
+++ b/apps/site/assets/css/_glx-open.scss
@@ -66,4 +66,15 @@
   .m-stop-page__name {
     color: $brand-green-line;
   }
+
+  .header-tab--selected:first-of-type,
+  &.m-stop-page__info-container {
+    background-color: $brand-green-line;
+    color: $white;
+  }
+
+  &.m-stop-page__info-container a {
+    color: inherit;
+    text-decoration: underline;
+  }
 }

--- a/apps/site/assets/css/_glx-open.scss
+++ b/apps/site/assets/css/_glx-open.scss
@@ -77,4 +77,8 @@
     color: inherit;
     text-decoration: underline;
   }
+
+  .c-alert-group {
+    color: black;
+  }
 }

--- a/apps/site/assets/css/_stop-page.scss
+++ b/apps/site/assets/css/_stop-page.scss
@@ -90,6 +90,24 @@
   }
 }
 
+.m-stop-page__info-container .m-stop-page__info {
+  @include make-container-max-widths();
+  margin: 0 auto;
+  padding: ($base-spacing * 2) 0;
+  width: 100%;
+
+  @include media-breakpoint-down(sm) {
+    padding: ($base-spacing * 1.5) calc($grid-gutter-width / 2);
+  }
+
+  h2 {
+    margin-top: 0;
+  }
+  :last-child {
+    margin-bottom: 0;
+  }
+}
+
 .m-stop-page__sidebar-pills {
   @include media-breakpoint-down(md) {
     display: none;

--- a/apps/site/assets/css/_stop-page.scss
+++ b/apps/site/assets/css/_stop-page.scss
@@ -104,7 +104,15 @@
     margin-top: 0;
   }
   :last-child {
-    margin-bottom: 0;
+    margin-bottom: 0; // remove spacing from station information <p>
+  }
+
+  .page-section {
+    margin-top: 0; // remove spacing left behind by unpopulated <Alerts />
+  }
+
+  .c-alert-group li:last-child {
+    padding-bottom: 1rem; // add space at bottom of populated <Alerts />
   }
 }
 

--- a/apps/site/assets/ts/components/Alerts.tsx
+++ b/apps/site/assets/ts/components/Alerts.tsx
@@ -144,7 +144,11 @@ const alertDescription = (alert: AlertType): ReactElement<HTMLElement> => (
   </div>
 );
 
-const Alert = ({ alert }: { alert: AlertType }): ReactElement<HTMLElement> => {
+export const Alert = ({
+  alert
+}: {
+  alert: AlertType;
+}): ReactElement<HTMLElement> => {
   const [expanded, toggleExpanded] = useState(false);
   const onClick = (): void => toggleExpanded(!expanded);
 

--- a/apps/site/assets/ts/components/GlxOpen.tsx
+++ b/apps/site/assets/ts/components/GlxOpen.tsx
@@ -16,7 +16,7 @@ const GlxOpen = ({
   pageType: "station-page" | "schedule-finder" | "line-diagram";
   stopId: string;
 }): ReactElement<HTMLElement> | null => {
-  const isGlxOpen = useIsGlxOpen(stopId);
+  const isGlxOpen = useIsGlxOpen(stopId)[0];
   let textContent;
 
   if (pageType === "station-page") {

--- a/apps/site/assets/ts/components/GlxOpen.tsx
+++ b/apps/site/assets/ts/components/GlxOpen.tsx
@@ -1,20 +1,7 @@
-import React, { ReactElement, useState, useEffect } from "react";
+import React, { ReactElement } from "react";
+import useIsGlxOpen from "../hooks/useIsGlxOpen";
 import renderSvg from "../helpers/render-svg";
 import glxLogo from "../../static/images/glx-logo.svg";
-
-export const getIsGlxOpen = (stationId: string): boolean => {
-  if (!document) return false;
-
-  const glxStationsOpen = document.querySelector(".glx-stations-open");
-
-  if (
-    glxStationsOpen instanceof HTMLElement &&
-    glxStationsOpen.dataset.stations
-  ) {
-    return glxStationsOpen.dataset.stations.includes(stationId);
-  }
-  return false;
-};
 
 const glxLogoElement = (pageType: string): JSX.Element | null => {
   if (pageType === "schedule-finder") return null;
@@ -29,10 +16,7 @@ const GlxOpen = ({
   pageType: "station-page" | "schedule-finder" | "line-diagram";
   stopId: string;
 }): ReactElement<HTMLElement> | null => {
-  const [isGlxOpen, setIsGlxOpen] = useState(false);
-  useEffect(() => {
-    setIsGlxOpen(getIsGlxOpen(stopId));
-  }, [stopId]);
+  const isGlxOpen = useIsGlxOpen(stopId);
   let textContent;
 
   if (pageType === "station-page") {

--- a/apps/site/assets/ts/hooks/useIsGlxOpen.ts
+++ b/apps/site/assets/ts/hooks/useIsGlxOpen.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+
+const getIsGlxOpen = (stationId: string): boolean => {
+  if (!document) return false;
+
+  const glxStationsOpen = document.querySelector(".glx-stations-open");
+
+  if (
+    glxStationsOpen instanceof HTMLElement &&
+    glxStationsOpen.dataset.stations
+  ) {
+    return glxStationsOpen.dataset.stations.includes(stationId);
+  }
+  return false;
+};
+
+const useIsGlxOpen = (stopId: string): GlxOpenStatus => {
+  const [isGlxOpen, setIsGlxOpen] = useState(false);
+  useEffect(() => {
+    setIsGlxOpen(getIsGlxOpen(stopId));
+  }, [stopId]);
+
+  return isGlxOpen;
+};
+
+export default useIsGlxOpen;

--- a/apps/site/assets/ts/hooks/useIsGlxOpen.ts
+++ b/apps/site/assets/ts/hooks/useIsGlxOpen.ts
@@ -1,26 +1,29 @@
 import { useState, useEffect } from "react";
 
-const getIsGlxOpen = (stationId: string): boolean => {
-  if (!document) return false;
+type GlxOpenStatus = [boolean, string | null]; // [status, Date string if true status]
 
-  const glxStationsOpen = document.querySelector(".glx-stations-open");
-
-  if (
-    glxStationsOpen instanceof HTMLElement &&
-    glxStationsOpen.dataset.stations
-  ) {
-    return glxStationsOpen.dataset.stations.includes(stationId);
-  }
-  return false;
+const getIsGlxOpen = (stationId: string): GlxOpenStatus => {
+  if (!document) return [false, null];
+  const glxStationsOpen: HTMLElement | null = document.querySelector(
+    ".glx-stations-open"
+  );
+  if (!glxStationsOpen) return [false, null];
+  const { stations, opening } = glxStationsOpen.dataset;
+  const isStationOpen = stations ? stations.includes(stationId) : false;
+  const stationOpenDate = !opening ? null : opening;
+  return [isStationOpen, stationOpenDate];
 };
 
 const useIsGlxOpen = (stopId: string): GlxOpenStatus => {
-  const [isGlxOpen, setIsGlxOpen] = useState(false);
+  const [[isGlxOpen, glxOpenDate], setIsGlxOpen] = useState<GlxOpenStatus>([
+    false,
+    null
+  ]);
   useEffect(() => {
     setIsGlxOpen(getIsGlxOpen(stopId));
   }, [stopId]);
 
-  return isGlxOpen;
+  return [isGlxOpen, glxOpenDate];
 };
 
 export default useIsGlxOpen;

--- a/apps/site/assets/ts/schedule/components/direction/GreenLineMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/GreenLineMenu.tsx
@@ -15,7 +15,6 @@ import iconGreenD from "../../../../static/images/icon-green-line-d-small.svg";
 import iconGreenE from "../../../../static/images/icon-green-line-e-small.svg";
 import iconGreen from "../../../../static/images/icon-green-line-small.svg";
 import { handleReactEnterKeyPress } from "../../../helpers/keyboard-events";
-import { getIsGlxOpen } from "../../../components/GlxOpen";
 
 interface GreenLineSelectProps {
   routeId: string;
@@ -72,9 +71,7 @@ const greenRoutes: GreenRoute[] = [
   {
     id: "Green-E",
     name: "Green Line E",
-    direction_destinations: getIsGlxOpen("place-unsqu")
-      ? ["Heath Street", "Union Square"]
-      : ["Heath Street", "Lechmere"],
+    direction_destinations: ["Heath Street", "Union Square"],
     icon: iconGreenE
   }
 ];

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
@@ -205,53 +205,57 @@ Array [
       className="m-stop-page__info"
     >
       <div
-        className="page-section"
+        className="container"
       >
-        <ul
-          className="c-alert-group"
+        <div
+          className="page-section"
         >
-          <li
-            aria-expanded={false}
-            className="c-alert-item c-alert-item--low"
-            id="alert-00005"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
+          <ul
+            className="c-alert-group"
           >
-            <div
-              className="c-alert-item__icon"
-            />
-            <div
-              className="c-alert-item__top"
+            <li
+              aria-expanded={false}
+              className="c-alert-item c-alert-item--low"
+              id="alert-00005"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
             >
               <div
-                className="c-alert-item__top-text-container"
+                className="c-alert-item__icon"
+              />
+              <div
+                className="c-alert-item__top"
               >
                 <div
-                  className="c-alert-item__effect"
+                  className="c-alert-item__top-text-container"
                 >
-                  Other 
-                  <span
-                    className="u-small-caps c-alert-item__badge c-alert-item__badge--upcoming"
+                  <div
+                    className="c-alert-item__effect"
                   >
-                    Upcoming
-                  </span>
+                    Other 
+                    <span
+                      className="u-small-caps c-alert-item__badge c-alert-item__badge--upcoming"
+                    >
+                      Upcoming
+                    </span>
+                  </div>
+                  <div
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "There is construction at this station.<span>&nbsp;</span><a href=\\"https://www.mbta.com\\" target=\\"_blank\\">MBTA.com</a>",
+                      }
+                    }
+                  />
                 </div>
                 <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "There is construction at this station.<span>&nbsp;</span><a href=\\"https://www.mbta.com\\" target=\\"_blank\\">MBTA.com</a>",
-                    }
-                  }
+                  className="c-alert-item__top-caret-container"
                 />
               </div>
-              <div
-                className="c-alert-item__top-caret-container"
-              />
-            </div>
-          </li>
-        </ul>
+            </li>
+          </ul>
+        </div>
       </div>
       <h2>
         Station Information

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
@@ -199,67 +199,67 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="m-stop-page__info-container"
   >
     <div
-      className="page-section"
+      className="m-stop-page__info"
     >
-      <ul
-        className="c-alert-group"
+      <div
+        className="page-section"
       >
-        <li
-          aria-expanded={false}
-          className="c-alert-item c-alert-item--low"
-          id="alert-00005"
-          onClick={[Function]}
-          onKeyPress={[Function]}
-          role="button"
-          tabIndex={0}
+        <ul
+          className="c-alert-group"
         >
-          <div
-            className="c-alert-item__icon"
-          />
-          <div
-            className="c-alert-item__top"
+          <li
+            aria-expanded={false}
+            className="c-alert-item c-alert-item--low"
+            id="alert-00005"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
           >
             <div
-              className="c-alert-item__top-text-container"
+              className="c-alert-item__icon"
+            />
+            <div
+              className="c-alert-item__top"
             >
               <div
-                className="c-alert-item__effect"
+                className="c-alert-item__top-text-container"
               >
-                Other 
-                <span
-                  className="u-small-caps c-alert-item__badge c-alert-item__badge--upcoming"
+                <div
+                  className="c-alert-item__effect"
                 >
-                  Upcoming
-                </span>
+                  Other 
+                  <span
+                    className="u-small-caps c-alert-item__badge c-alert-item__badge--upcoming"
+                  >
+                    Upcoming
+                  </span>
+                </div>
+                <div
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "There is construction at this station.<span>&nbsp;</span><a href=\\"https://www.mbta.com\\" target=\\"_blank\\">MBTA.com</a>",
+                    }
+                  }
+                />
               </div>
               <div
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "There is construction at this station.<span>&nbsp;</span><a href=\\"https://www.mbta.com\\" target=\\"_blank\\">MBTA.com</a>",
-                  }
-                }
+                className="c-alert-item__top-caret-container"
               />
             </div>
-            <div
-              className="c-alert-item__top-caret-container"
-            />
-          </div>
-        </li>
-      </ul>
+          </li>
+        </ul>
+      </div>
+      <h2>
+        Station Information
+      </h2>
+      <p>
+        See upcoming departures, maps, and other features at this location.
+      </p>
     </div>
-  </div>,
-  <div
-    className="container"
-  >
-    <h2>
-      Station Information
-    </h2>
-    <p>
-      See upcoming departures, maps, and other features at this location.
-    </p>
   </div>,
   <div
     className="m-stop-page__hero"

--- a/apps/site/assets/ts/stop/components/Header.tsx
+++ b/apps/site/assets/ts/stop/components/Header.tsx
@@ -12,6 +12,7 @@ import {
 } from "../state";
 import { modeByV3ModeType } from "../../components/ModeFilter";
 import GlxOpen from "../../components/GlxOpen";
+import useIsGlxOpen from "../../hooks/useIsGlxOpen";
 
 interface Props {
   stop: Stop;
@@ -171,8 +172,9 @@ const Header = ({
 }: Props): ReactElement<HTMLElement> => {
   const emptyFunc = (): void => {};
   const dispatchOrEmptyFunc = dispatch || emptyFunc;
+  const isGlxOpen = useIsGlxOpen(stop.id)[0];
   return (
-    <div className="m-stop-page__header">
+    <div className={`m-stop-page__header${isGlxOpen ? " glx-open" : ""}`}>
       <div className="m-stop-page__header-container">
         <GlxOpen pageType="station-page" stopId={stop.id} />
         <h1 className={`m-stop-page__name ${nameUpcaseClass(routes)}`}>

--- a/apps/site/assets/ts/stop/components/StopPage.tsx
+++ b/apps/site/assets/ts/stop/components/StopPage.tsx
@@ -5,7 +5,7 @@ import { StopPageData, StopMapData, TypedRoutes } from "./__stop";
 import { EnhancedRoute } from "../../__v3api";
 import StopPageHeader from "./StopPageHeader";
 import { reducer, initialState, Dispatch, updateRoutesAction } from "../state";
-import { Alert } from "../../components/Alerts";
+import Alerts from "../../components/Alerts";
 import AlertsTab from "./AlertsTab";
 import Sidebar from "./Sidebar";
 import LocationBlock from "./LocationBlock";
@@ -92,15 +92,7 @@ export default ({
             }`}
           >
             <div className="m-stop-page__info">
-              {highPriorityAlerts.length > 0 ? (
-                <div className="page-section">
-                  <ul className="c-alert-group">
-                    {highPriorityAlerts.map(alert => (
-                      <Alert key={alert.id} alert={alert} />
-                    ))}
-                  </ul>
-                </div>
-              ) : null}
+              <Alerts alerts={highPriorityAlerts} />
               <h2>Station Information</h2>
               {stationInformation}
             </div>

--- a/apps/site/assets/ts/stop/components/StopPage.tsx
+++ b/apps/site/assets/ts/stop/components/StopPage.tsx
@@ -13,6 +13,7 @@ import Departures from "./Departures";
 import SuggestedTransfers from "./SuggestedTransfers";
 import { isHighSeverityOrHighPriority } from "../../models/alert";
 import useIsGlxOpen from "../../hooks/useIsGlxOpen";
+import { formattedDate } from "../../helpers/date";
 
 interface Props {
   stopPageData: StopPageData;
@@ -60,8 +61,20 @@ export default ({
   }, 15000);
 
   const highPriorityAlerts = alerts.filter(isHighSeverityOrHighPriority);
-
   const [isGlxOpen, glxOpenDate] = useIsGlxOpen(stop.id);
+  const stationInformation =
+    isGlxOpen && glxOpenDate ? (
+      <p>
+        <strong>Open to riders on {formattedDate(glxOpenDate)}</strong>, this
+        station is one of several to join the Green Line as part of the{" "}
+        <a href="https://www.mbta.com/projects/green-line-extension-glx">
+          Green Line Extension (GLX)
+        </a>
+        .
+      </p>
+    ) : (
+      <p>See upcoming departures, maps, and other features at this location.</p>
+    );
   return (
     <>
       <StopPageHeader
@@ -89,8 +102,7 @@ export default ({
                 </div>
               ) : null}
               <h2>Station Information</h2>
-              <p>See upcoming departures, maps, and other features at this 
-              location.</p>
+              {stationInformation}
             </div>
           </div>
           <div className="m-stop-page__hero">

--- a/apps/site/assets/ts/stop/components/StopPage.tsx
+++ b/apps/site/assets/ts/stop/components/StopPage.tsx
@@ -12,6 +12,7 @@ import LocationBlock from "./LocationBlock";
 import Departures from "./Departures";
 import SuggestedTransfers from "./SuggestedTransfers";
 import { isHighSeverityOrHighPriority } from "../../models/alert";
+import useIsGlxOpen from "../../hooks/useIsGlxOpen";
 
 interface Props {
   stopPageData: StopPageData;
@@ -60,6 +61,7 @@ export default ({
 
   const highPriorityAlerts = alerts.filter(isHighSeverityOrHighPriority);
 
+  const [isGlxOpen, glxOpenDate] = useIsGlxOpen(stop.id);
   return (
     <>
       <StopPageHeader
@@ -71,7 +73,11 @@ export default ({
         <AlertsTab alertsTab={alertsTab} />
       ) : (
         <>
-          <div className="m-stop-page__info-container">
+          <div
+            className={`m-stop-page__info-container${
+              isGlxOpen ? " glx-open" : ""
+            }`}
+          >
             <div className="m-stop-page__info">
               {highPriorityAlerts.length > 0 ? (
                 <div className="page-section">

--- a/apps/site/assets/ts/stop/components/StopPage.tsx
+++ b/apps/site/assets/ts/stop/components/StopPage.tsx
@@ -5,7 +5,7 @@ import { StopPageData, StopMapData, TypedRoutes } from "./__stop";
 import { EnhancedRoute } from "../../__v3api";
 import StopPageHeader from "./StopPageHeader";
 import { reducer, initialState, Dispatch, updateRoutesAction } from "../state";
-import Alerts from "../../components/Alerts";
+import { Alert } from "../../components/Alerts";
 import AlertsTab from "./AlertsTab";
 import Sidebar from "./Sidebar";
 import LocationBlock from "./LocationBlock";
@@ -71,13 +71,21 @@ export default ({
         <AlertsTab alertsTab={alertsTab} />
       ) : (
         <>
-          <Alerts alerts={highPriorityAlerts} />
-          <div className="container">
-            <h2>Station Information</h2>
-            <p>
-              See upcoming departures, maps, and other features at this
-              location.
-            </p>
+          <div className="m-stop-page__info-container">
+            <div className="m-stop-page__info">
+              {highPriorityAlerts.length > 0 ? (
+                <div className="page-section">
+                  <ul className="c-alert-group">
+                    {highPriorityAlerts.map(alert => (
+                      <Alert key={alert.id} alert={alert} />
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              <h2>Station Information</h2>
+              <p>See upcoming departures, maps, and other features at this 
+              location.</p>
+            </div>
           </div>
           <div className="m-stop-page__hero">
             <StopMapContainer

--- a/apps/site/lib/site_web/plugs/glx_now_open.ex
+++ b/apps/site/lib/site_web/plugs/glx_now_open.ex
@@ -21,16 +21,14 @@ defmodule SiteWeb.Plugs.GlxNowOpen do
 
   @impl true
   def call(conn, now_fn: now_fn) do
+    opens = @opening_date |> Util.convert_using_timezone("America/New_York")
+
     conn
     |> assign(
       :glx_stations_open,
-      set_assigns(
-        check_current_service_date(
-          now_fn.(),
-          Util.convert_using_timezone(@opening_date, "America/New_York")
-        )
-      )
+      set_assigns(check_current_service_date(now_fn.(), opens))
     )
+    |> assign(:glx_opening_date, DateTime.to_iso8601(opens))
   end
 
   defp set_assigns(true), do: Enum.join(@glx_stations, ",")

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -82,7 +82,7 @@
       <% end %>
       <div id="ie-warning" class="c-ie-warning"></div>
       <%= if assigns[:glx_stations_open] do %>
-        <div class="glx-stations-open" style="display: none;" data-stations='<%= assigns[:glx_stations_open] %>' />
+        <div class="glx-stations-open" style="display: none;" data-opening='<%= assigns[:glx_opening_date] %>' data-stations='<%= assigns[:glx_stations_open] %>' />
       <% end %>
     </div>
 

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -138,6 +138,9 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
       assert Enum.map(e_stops, & &1.branch) ==
                [
+                 "Green-E",
+                 "Green-E",
+                 "Green-E",
                  nil,
                  nil,
                  nil,
@@ -159,6 +162,9 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                ]
 
       assert_stop_ids(e_stops, [
+        "place-unsqu",
+        "place-lech",
+        "place-spmnl",
         "place-north",
         "place-haecl",
         "place-gover",
@@ -198,12 +204,18 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                  false,
                  false,
                  false,
+                 false,
+                 false,
+                 false,
                  true
                ]
 
       assert Enum.map(e_stops, & &1.is_beginning?) ==
                [
                  true,
+                 false,
+                 false,
+                 false,
                  false,
                  false,
                  false,
@@ -591,16 +603,19 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                ]
     end
 
-    test "handles the E line with the Lechmere shuttle" do
+    test "handles the E line" do
       assert [
-               %RouteStops{branch: "North Station - Heath Street", stops: stops}
+               %RouteStops{branch: "Union Square - Heath Street", stops: stops}
              ] = Helpers.get_branch_route_stops(%Route{id: "Green-E"}, 0)
 
-      assert Enum.all?(stops, &(&1.branch == "North Station - Heath Street"))
+      assert Enum.all?(stops, &(&1.branch == "Union Square - Heath Street"))
 
       assert Enum.map(stops, & &1.is_terminus?) ==
                [
                  true,
+                 false,
+                 false,
+                 false,
                  false,
                  false,
                  false,
@@ -623,6 +638,9 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
       assert Enum.map(stops, & &1.is_beginning?) ==
                [
                  true,
+                 false,
+                 false,
+                 false,
                  false,
                  false,
                  false,

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -435,10 +435,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
 
       assert Enum.all?(trunk, &(&1 |> branches() |> length() == 1))
       assert trunk |> List.first() |> stop_id() == "place-armnl"
-      # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
-      # We are temporarily adding the fix but this will need to be undone later on.
-      # assert stop_id(List.last(trunk)) == "place-lech"
-      assert trunk |> List.last() |> stop_id() == "place-north"
+      assert trunk |> List.last() |> stop_id() == "place-unsqu"
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Remainder of GLX "NOW OPEN" treatment for /stops pages](https://app.asana.com/0/555089885850811/1201984803295268/f)

This was fairly involved! I attempted to organize this info smaller, logically self-contained commits.

- To be able to render the desired text, I had to explicitly add the date as well as the new stop IDs to be assigned in the plug.
- Extracted a hook from the existing React component file to be able to reuse the DOM-querying logic in other places
- Added the desired coloring to the stop page's stop name and station information tab
- Added the desired text under Station Information


![image](https://user-images.githubusercontent.com/2136286/159293553-c75f9a47-84ab-4326-bc0e-9f86788cea14.png)

Also: Updated some failing unit tests
TODO: I still need to add a unit test to test the new hook.