### PR TITLE
Always render acccessibility icon for bus stops

### DIFF
--- a/apps/site/assets/ts/components/StopCard.tsx
+++ b/apps/site/assets/ts/components/StopCard.tsx
@@ -76,8 +76,12 @@ export const StopCard = ({
         <a href={stop.href} className="m-tnm-sidebar__stop-name">
           {renderStopIcon(stop)}
           {stop.name}
-          {!!stop.accessibility.length &&
-            !stop.accessibility.includes("unknown") &&
+          {(
+            // NOTE: Bus stops are always considered accessible, see
+            // https://app.asana.com/0/1201653980996886/1201894234147725/f
+            route.type === 3 ||
+            (!!stop.accessibility.length &&
+              !stop.accessibility.includes("unknown"))) &&
             accessibleIcon("m-tnm-sidebar__stop-accessible")}
         </a>
         <div className="m-tnm-sidebar__stop-distance">{distance}</div>

--- a/apps/site/assets/ts/components/StopCard.tsx
+++ b/apps/site/assets/ts/components/StopCard.tsx
@@ -8,6 +8,7 @@ import { accessibleIcon, alertIcon } from "../helpers/icon";
 import stationSymbol from "../../static/images/icon-circle-t-small.svg";
 import { effectNameForAlert } from "./Alerts";
 import { isDiversion, alertsByStop, uniqueByEffect } from "../models/alert";
+import { isABusRoute } from "../models/route";
 
 interface Props {
   stop: Stop;
@@ -78,7 +79,7 @@ export const StopCard = ({
           {stop.name}
           {// NOTE: Bus stops are always considered accessible, see
           // https://app.asana.com/0/1201653980996886/1201894234147725/f
-          (route.type === 3 ||
+          (isABusRoute(route) ||
             (!!stop.accessibility.length &&
               !stop.accessibility.includes("unknown"))) &&
             accessibleIcon("m-tnm-sidebar__stop-accessible")}

--- a/apps/site/assets/ts/components/StopCard.tsx
+++ b/apps/site/assets/ts/components/StopCard.tsx
@@ -76,10 +76,9 @@ export const StopCard = ({
         <a href={stop.href} className="m-tnm-sidebar__stop-name">
           {renderStopIcon(stop)}
           {stop.name}
-          {(
-            // NOTE: Bus stops are always considered accessible, see
-            // https://app.asana.com/0/1201653980996886/1201894234147725/f
-            route.type === 3 ||
+          {// NOTE: Bus stops are always considered accessible, see
+          // https://app.asana.com/0/1201653980996886/1201894234147725/f
+          (route.type === 3 ||
             (!!stop.accessibility.length &&
               !stop.accessibility.includes("unknown"))) &&
             accessibleIcon("m-tnm-sidebar__stop-accessible")}

--- a/apps/site/assets/ts/helpers/__tests__/routes-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/routes-test.ts
@@ -1,0 +1,46 @@
+import {
+  isBusRouteStop,
+  routesWithDirectionsAreAllBusStops,
+  typedRoutesHasBusRoute
+} from "../routes";
+
+test("isBusRouteStop returns false when no route", () => {
+  expect(isBusRouteStop({} as any)).toBe(false);
+});
+
+describe("routesWithDirectionsAreAllBusStops", () => {
+  test("empty list returns false", () => {
+    expect(routesWithDirectionsAreAllBusStops([])).toBe(false);
+  });
+
+  test("all routes must be bus", () => {
+    expect(
+      routesWithDirectionsAreAllBusStops([
+        { route: { type: 3 } },
+        { route: { type: 3 } }
+      ] as any[])
+    ).toBe(true);
+
+    expect(
+      routesWithDirectionsAreAllBusStops([
+        { route: { type: 3 } },
+        { route: { type: 0 } }
+      ] as any[])
+    ).toBe(false);
+  });
+});
+
+describe("typedRoutesHasBusRoute", () => {
+  test("returns true when 'bus' group present", () => {
+    expect(
+      typedRoutesHasBusRoute([
+        { group_name: "bus" },
+        { group_name: "subway" }
+      ] as any[])
+    ).toBe(true);
+  });
+
+  test("returns false with empty list", () => {
+    expect(typedRoutesHasBusRoute([] as any[])).toBe(false);
+  });
+});

--- a/apps/site/assets/ts/helpers/routes.ts
+++ b/apps/site/assets/ts/helpers/routes.ts
@@ -1,0 +1,20 @@
+import { RouteStop } from "../schedule/components/__schedule";
+import { RouteWithDirection, TypedRoutes } from "../stop/components/__stop";
+import { isABusRoute } from "../models/route";
+
+export function isBusRouteStop(stop: RouteStop): boolean {
+  return !!stop.route && isABusRoute(stop.route);
+}
+
+export function routesWithDirectionsAreAllBusStops(
+  routes: RouteWithDirection[]
+): boolean {
+  return (
+    routes.length > 0 &&
+    routes.reduce((acc: boolean, r) => isABusRoute(r.route) && acc, true)
+  );
+}
+
+export function typedRoutesHasBusRoute(routes: TypedRoutes[]): boolean {
+  return !!routes.find(r => r.group_name === "bus");
+}

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopFeatures.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopFeatures.tsx
@@ -19,7 +19,10 @@ const StopFeatures = (routeStop: RouteStop): JSX.Element => (
         )}
       </TooltipWrapper>
     ) : null}
-    {routeStop.stop_features.includes("access") ? (
+    {// NOTE: Bus routes are always considered accessible, see
+    // https://app.asana.com/0/1201653980996886/1201894234147725/f
+    routeStop.route?.type === 3 ||
+    routeStop.stop_features.includes("access") ? (
       <TooltipWrapper
         tooltipText="Accessible"
         tooltipOptions={{ placement: "bottom" }}

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopFeatures.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopFeatures.tsx
@@ -6,6 +6,7 @@ import {
   accessibleIcon
 } from "../../../helpers/icon";
 import { isACommuterRailRoute } from "../../../models/route";
+import { isBusRouteStop } from "../../../helpers/routes";
 
 const StopFeatures = (routeStop: RouteStop): JSX.Element => (
   <div className="m-schedule-diagram__features">
@@ -21,8 +22,7 @@ const StopFeatures = (routeStop: RouteStop): JSX.Element => (
     ) : null}
     {// NOTE: Bus routes are always considered accessible, see
     // https://app.asana.com/0/1201653980996886/1201894234147725/f
-    routeStop.route?.type === 3 ||
-    routeStop.stop_features.includes("access") ? (
+    isBusRouteStop(routeStop) || routeStop.stop_features.includes("access") ? (
       <TooltipWrapper
         tooltipText="Accessible"
         tooltipOptions={{ placement: "bottom" }}

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -109,6 +109,11 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                         <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       </span>
                     </TooltipWrapper>
+                    <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
+                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                        <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                      </span>
+                    </TooltipWrapper>
                   </div>
                 </header>
                 <div className=\\"m-schedule-diagram__stop-details\\">
@@ -144,7 +149,13 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                       </MatchHighlight>
                     </a>
                   </h4>
-                  <div className=\\"m-schedule-diagram__features\\" />
+                  <div className=\\"m-schedule-diagram__features\\">
+                    <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
+                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                        <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                      </span>
+                    </TooltipWrapper>
+                  </div>
                 </header>
                 <div className=\\"m-schedule-diagram__stop-details\\">
                   <div className=\\"m-schedule-diagram__connections\\">

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -94,6 +94,11 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                       <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                     </span>
                   </TooltipWrapper>
+                  <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
+                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                      <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                    </span>
+                  </TooltipWrapper>
                 </div>
               </header>
               <div className=\\"m-schedule-diagram__stop-details\\">
@@ -129,7 +134,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                     </MatchHighlight>
                   </a>
                 </h4>
-                <div className=\\"m-schedule-diagram__features\\" />
+                <div className=\\"m-schedule-diagram__features\\">
+                  <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
+                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                      <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                    </span>
+                  </TooltipWrapper>
+                </div>
               </header>
               <div className=\\"m-schedule-diagram__stop-details\\">
                 <div className=\\"m-schedule-diagram__connections\\">

--- a/apps/site/assets/ts/stop/components/Header.tsx
+++ b/apps/site/assets/ts/stop/components/Header.tsx
@@ -151,7 +151,7 @@ const features = (
   <div className="m-stop-page__header-features">
     {modes(routes, dispatch)}
     {crZone(zoneNumber, dispatch)}
-    {accessible(stop, dispatch)}
+    {accessible(stop, !!routes.find(r => r.group_name === "bus"), dispatch)}
     {parking(stop, dispatch)}
   </div>
 );

--- a/apps/site/assets/ts/stop/components/Header.tsx
+++ b/apps/site/assets/ts/stop/components/Header.tsx
@@ -12,6 +12,7 @@ import {
 } from "../state";
 import { modeByV3ModeType } from "../../components/ModeFilter";
 import GlxOpen from "../../components/GlxOpen";
+import { typedRoutesHasBusRoute } from "../../helpers/routes";
 
 interface Props {
   stop: Stop;
@@ -151,7 +152,7 @@ const features = (
   <div className="m-stop-page__header-features">
     {modes(routes, dispatch)}
     {crZone(zoneNumber, dispatch)}
-    {accessible(stop, !!routes.find(r => r.group_name === "bus"), dispatch)}
+    {accessible(stop, typedRoutesHasBusRoute(routes), dispatch)}
     {parking(stop, dispatch)}
   </div>
 );

--- a/apps/site/assets/ts/stop/components/StopAccessibilityIcon.tsx
+++ b/apps/site/assets/ts/stop/components/StopAccessibilityIcon.tsx
@@ -5,9 +5,12 @@ import { Dispatch, clickFeaturePillAction } from "../state";
 
 export default (
   { accessibility }: Stop,
+  isBusStop: boolean,
   dispatch?: Dispatch
 ): ReactElement<HTMLElement> | false =>
-  accessibility.includes("accessible") && (
+  // NOTE: Bus stops are always considered accessible, see
+  // https://app.asana.com/0/1201653980996886/1201894234147725/f
+  (isBusStop || accessibility.includes("accessible")) && (
     <a
       className="m-stop-page__access-icon"
       href="#header-accessibility"

--- a/apps/site/assets/ts/stop/components/StopCard.tsx
+++ b/apps/site/assets/ts/stop/components/StopCard.tsx
@@ -4,6 +4,7 @@ import { RouteWithDirection } from "./__stop";
 import { modeIcon, parkingIcon } from "../../helpers/icon";
 import { isABusRoute } from "../../models/route";
 import accessible from "./StopAccessibilityIcon";
+import { routesWithDirectionsAreAllBusStops } from "../../helpers/routes";
 
 const formatMilesToFeet = (miles: number): number => Math.floor(miles * 5280.0);
 
@@ -60,9 +61,7 @@ const StopCard = ({
         }))
       : routesWithDirection;
 
-  const isBusStop =
-    routesWithDirection.length > 0 &&
-    routesWithDirection.reduce((acc, r) => r.route.type === 3 && acc, true);
+  const allAreBusStops = routesWithDirectionsAreAllBusStops(routesToRender);
 
   return (
     <div className="c-stop-card">
@@ -71,7 +70,7 @@ const StopCard = ({
         {stop.name}
       </a>
       <div className="c-stop-card__icon-container">
-        {accessible(stop, isBusStop)}
+        {accessible(stop, allAreBusStops)}
         {stop.parking_lots.length > 0 ? (
           <span className="c-stop-page__icon">
             {parkingIcon("c-svg__icon-parking-default")}

--- a/apps/site/assets/ts/stop/components/StopCard.tsx
+++ b/apps/site/assets/ts/stop/components/StopCard.tsx
@@ -60,6 +60,10 @@ const StopCard = ({
         }))
       : routesWithDirection;
 
+  const isBusStop =
+    routesWithDirection.length > 0 &&
+    routesWithDirection.reduce((acc, r) => r.route.type === 3 && acc, true);
+
   return (
     <div className="c-stop-card">
       {renderDistance(distance, distanceFormatted)}
@@ -67,7 +71,7 @@ const StopCard = ({
         {stop.name}
       </a>
       <div className="c-stop-card__icon-container">
-        {accessible(stop)}
+        {accessible(stop, isBusStop)}
         {stop.parking_lots.length > 0 ? (
           <span className="c-stop-page__icon">
             {parkingIcon("c-svg__icon-parking-default")}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Show accessibility icon for all bus stops](https://app.asana.com/0/385363666817452/1201894234147725/f)

This PR updates the gating logic for the accessibility icons to always render for bus routes. The following locations have been updated:
- Line Diagram
- Stop pages (both the header and the nearby transfers)
- Transit Near Me

I decided to tackle this on the front end since I figured it was more of a rendering concern, and didn't want to muck with any of the accessibility data we return from the back end.

I did some light testing, and don't believe that these changes should have any unexpected side effects, but let me know if there is a cleaner approach for any of these. 


