### PR TITLE
Prevent stop name translation on line diagrams

### DIFF
--- a/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -17,7 +17,7 @@ exports[`can render green line 1`] = `
       >
         <GreenLineSelect>
           <div
-            className="m-schedule-direction__route-pattern m-schedule-direction__route-pattern--clickable"
+            className="m-schedule-direction__route-pattern m-schedule-direction__route-pattern--clickable notranslate"
             onClick={[Function]}
             onKeyUp={[Function]}
             role="button"
@@ -76,7 +76,7 @@ exports[`renders a CR component 1`] = `
         className="js-m-schedule-click-boundary"
       >
         <div
-          className="m-schedule-direction__route-pattern"
+          className="m-schedule-direction__route-pattern notranslate"
         >
           End
         </div>
@@ -121,7 +121,7 @@ exports[`renders a bus component 1`] = `
       >
         <BusMenuSelect>
           <div
-            className="m-schedule-direction__route-pattern"
+            className="m-schedule-direction__route-pattern notranslate"
             onClick={[Function]}
             onKeyUp={[Function]}
           >
@@ -169,7 +169,7 @@ exports[`renders a subway component 1`] = `
         className="js-m-schedule-click-boundary"
       >
         <div
-          className="m-schedule-direction__route-pattern"
+          className="m-schedule-direction__route-pattern notranslate"
         >
           End
         </div>
@@ -213,7 +213,7 @@ exports[`renders with a static map 1`] = `
         className="js-m-schedule-click-boundary"
       >
         <div
-          className="m-schedule-direction__route-pattern"
+          className="m-schedule-direction__route-pattern notranslate"
         >
           End
         </div>
@@ -274,7 +274,7 @@ exports[`respects the initially selected pattern ID, if specified 1`] = `
       >
         <BusMenuSelect>
           <div
-            className="m-schedule-direction__route-pattern m-schedule-direction__route-pattern--clickable"
+            className="m-schedule-direction__route-pattern m-schedule-direction__route-pattern--clickable notranslate"
             onClick={[Function]}
             onKeyUp={[Function]}
             role="button"

--- a/apps/site/assets/ts/schedule/components/direction/BusMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/BusMenu.tsx
@@ -239,7 +239,7 @@ export const BusMenuSelect = ({
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={isMenuClickable ? 0 : undefined}
       role={isMenuClickable ? "button" : undefined}
-      className={`m-schedule-direction__route-pattern${linkClass}`}
+      className={`m-schedule-direction__route-pattern${linkClass} notranslate`}
       onClick={handleClick}
       onKeyUp={e =>
         handleReactEnterKeyPress(e, () => {

--- a/apps/site/assets/ts/schedule/components/direction/GreenLineMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/GreenLineMenu.tsx
@@ -101,7 +101,7 @@ export const GreenLineItem = ({
       id={`route-pattern_${route.id}`}
       tabIndex={0}
       role="menuitem"
-      className={`m-schedule-direction__menu-item${selectedClass}`}
+      className={`m-schedule-direction__menu-item${selectedClass} notranslate`}
       onClick={handleClick}
       onKeyUp={(e: ReactKeyboardEvent) => {
         handleReactEnterKeyPress(e, () => {
@@ -113,7 +113,7 @@ export const GreenLineItem = ({
       }}
       ref={item => item && focused && item.focus()}
     >
-      <div className="m-schedule-direction__menu-item-headsign">
+      <div className="m-schedule-direction__menu-item-headsign notranslate">
         {icon}
         {renderSvg(
           "c-svg__icon m-schedule-direction__menu-item-icon",
@@ -132,7 +132,7 @@ export const ExpandedGreenMenu = ({
 }: ExpandedGreenMenuProps): ReactElement<HTMLElement> => {
   const routeIds = greenRoutes.map(greenRoute => greenRoute.id);
   return (
-    <div className="m-schedule-direction__menu" role="menu">
+    <div className="m-schedule-direction__menu notranslate" role="menu">
       {greenRoutes.map((greenRoute: GreenRoute, index: number) => (
         <GreenLineItem
           directionId={directionId}
@@ -164,7 +164,7 @@ export const GreenLineSelect = ({
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
       role="button"
-      className="m-schedule-direction__route-pattern m-schedule-direction__route-pattern--clickable"
+      className="m-schedule-direction__route-pattern m-schedule-direction__route-pattern--clickable notranslate"
       onClick={handleClick}
       onKeyUp={e =>
         handleReactEnterKeyPress(e, () => {

--- a/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/ScheduleDirectionMenu.tsx
@@ -77,13 +77,13 @@ const ScheduleDirectionMenu = ({
       )}
       {// Mattapan Trolley
       route.id === "Mattapan" && (
-        <div className="m-schedule-direction__route-pattern">
+        <div className="m-schedule-direction__route-pattern notranslate">
           {route.direction_destinations[directionId]}
         </div>
       )}
       {// Subway, CR, Ferry
       [1, 2, 4].indexOf(route.type) !== -1 && (
-        <div className="m-schedule-direction__route-pattern">
+        <div className="m-schedule-direction__route-pattern notranslate">
           {route.direction_destinations[directionId]}
         </div>
       )}

--- a/apps/site/assets/ts/schedule/components/direction/__tests__/__snapshots__/BusMenuTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/direction/__tests__/__snapshots__/BusMenuTest.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`BusMenuSelect renders a menu with a single route pattern 1`] = `
 <div
-  className="m-schedule-direction__route-pattern"
+  className="m-schedule-direction__route-pattern notranslate"
   onClick={[Function]}
   onKeyUp={[Function]}
 >
@@ -13,7 +13,7 @@ exports[`BusMenuSelect renders a menu with a single route pattern 1`] = `
 
 exports[`BusMenuSelect renders a menu with multiple route patterns 1`] = `
 <div
-  className="m-schedule-direction__route-pattern m-schedule-direction__route-pattern--clickable"
+  className="m-schedule-direction__route-pattern m-schedule-direction__route-pattern--clickable notranslate"
   onClick={[Function]}
   onKeyUp={[Function]}
   role="button"

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -92,7 +92,7 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
           className="m-schedule-diagram__stop-heading"
           ref={refs[routeStop.id]}
         >
-          <h4 className="m-schedule-diagram__stop-link">
+          <h4 className="m-schedule-diagram__stop-link notranslate">
             <a href={`/stops/${routeStop.id}`}>
               {MaybeAlert(stopAlerts)}
               <MatchHighlight text={routeStop.name} matchQuery={searchQuery} />

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopPredictions.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopPredictions.tsx
@@ -75,7 +75,7 @@ const StopPredictions = ({
         <div
           // eslint-disable-next-line react/no-array-index-key
           key={`headsign.name-${index}`}
-          className="m-schedule-diagram__prediction"
+          className="m-schedule-diagram__prediction notranslate"
         >
           <div>{headsign.name}</div>
           <div className="m-schedule-diagram__prediction-time">

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -94,7 +94,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               <section className=\\"m-schedule-diagram__content\\">
                 <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-origin\\" />
                 <header className=\\"m-schedule-diagram__stop-heading\\">
-                  <h4 className=\\"m-schedule-diagram__stop-link\\">
+                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                     <a href=\\"/stops/line-origin\\">
                       <MatchHighlight text=\\"Origin\\" matchQuery={[undefined]}>
                         <span>
@@ -135,7 +135,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               <section className=\\"m-schedule-diagram__content\\">
                 <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-stop1\\" />
                 <header className=\\"m-schedule-diagram__stop-heading\\">
-                  <h4 className=\\"m-schedule-diagram__stop-link\\">
+                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                     <a href=\\"/stops/line-stop1\\">
                       <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       <span className=\\"sr-only\\">
@@ -176,7 +176,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                   </div>
                   <StopPredictions headsigns={{...}} isCommuterRail={false}>
                     <div className=\\"m-schedule-diagram__predictions\\">
-                      <div className=\\"m-schedule-diagram__prediction\\">
+                      <div className=\\"m-schedule-diagram__prediction notranslate\\">
                         <div>
                           Dest1
                         </div>
@@ -189,7 +189,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                           </div>
                         </LiveCrowdingIcon>
                       </div>
-                      <div className=\\"m-schedule-diagram__prediction\\">
+                      <div className=\\"m-schedule-diagram__prediction notranslate\\">
                         <div>
                           Dest2
                         </div>
@@ -218,7 +218,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               <section className=\\"m-schedule-diagram__content\\">
                 <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-stop2\\" />
                 <header className=\\"m-schedule-diagram__stop-heading\\">
-                  <h4 className=\\"m-schedule-diagram__stop-link\\">
+                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                     <a href=\\"/stops/line-stop2\\">
                       <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       <span className=\\"sr-only\\">
@@ -259,7 +259,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                   </div>
                   <StopPredictions headsigns={{...}} isCommuterRail={false}>
                     <div className=\\"m-schedule-diagram__predictions\\">
-                      <div className=\\"m-schedule-diagram__prediction\\">
+                      <div className=\\"m-schedule-diagram__prediction notranslate\\">
                         <div>
                           Dest2
                         </div>
@@ -288,7 +288,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               <section className=\\"m-schedule-diagram__content\\">
                 <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-destination\\" />
                 <header className=\\"m-schedule-diagram__stop-heading\\">
-                  <h4 className=\\"m-schedule-diagram__stop-link\\">
+                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                     <a href=\\"/stops/line-destination\\">
                       <MatchHighlight text=\\"Destination\\" matchQuery={[undefined]}>
                         <span>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -79,7 +79,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
             <section className=\\"m-schedule-diagram__content\\">
               <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-origin\\" />
               <header className=\\"m-schedule-diagram__stop-heading\\">
-                <h4 className=\\"m-schedule-diagram__stop-link\\">
+                <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                   <a href=\\"/stops/line-origin\\">
                     <MatchHighlight text=\\"Origin\\" matchQuery={[undefined]}>
                       <span>
@@ -120,7 +120,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
             <section className=\\"m-schedule-diagram__content\\">
               <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-stop1\\" />
               <header className=\\"m-schedule-diagram__stop-heading\\">
-                <h4 className=\\"m-schedule-diagram__stop-link\\">
+                <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                   <a href=\\"/stops/line-stop1\\">
                     <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                     <span className=\\"sr-only\\">
@@ -161,7 +161,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                 </div>
                 <StopPredictions headsigns={{...}} isCommuterRail={false}>
                   <div className=\\"m-schedule-diagram__predictions\\">
-                    <div className=\\"m-schedule-diagram__prediction\\">
+                    <div className=\\"m-schedule-diagram__prediction notranslate\\">
                       <div>
                         Dest1
                       </div>
@@ -174,7 +174,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                         </div>
                       </LiveCrowdingIcon>
                     </div>
-                    <div className=\\"m-schedule-diagram__prediction\\">
+                    <div className=\\"m-schedule-diagram__prediction notranslate\\">
                       <div>
                         Dest2
                       </div>
@@ -203,7 +203,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
             <section className=\\"m-schedule-diagram__content\\">
               <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-stop2\\" />
               <header className=\\"m-schedule-diagram__stop-heading\\">
-                <h4 className=\\"m-schedule-diagram__stop-link\\">
+                <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                   <a href=\\"/stops/line-stop2\\">
                     <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                     <span className=\\"sr-only\\">
@@ -244,7 +244,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                 </div>
                 <StopPredictions headsigns={{...}} isCommuterRail={false}>
                   <div className=\\"m-schedule-diagram__predictions\\">
-                    <div className=\\"m-schedule-diagram__prediction\\">
+                    <div className=\\"m-schedule-diagram__prediction notranslate\\">
                       <div>
                         Dest2
                       </div>
@@ -273,7 +273,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
             <section className=\\"m-schedule-diagram__content\\">
               <GlxOpen pageType=\\"line-diagram\\" stopId=\\"line-destination\\" />
               <header className=\\"m-schedule-diagram__stop-heading\\">
-                <h4 className=\\"m-schedule-diagram__stop-link\\">
+                <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                   <a href=\\"/stops/line-destination\\">
                     <MatchHighlight text=\\"Destination\\" matchQuery={[undefined]}>
                       <span>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopListWithBranchesTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopListWithBranchesTest.tsx.snap
@@ -12,7 +12,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
               Destination Line
             </div>
             <header className=\\"m-schedule-diagram__stop-heading\\">
-              <h4 className=\\"m-schedule-diagram__stop-link\\">
+              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                 <a href=\\"/stops/tree-destination\\">
                   <MatchHighlight text=\\"Destination\\" matchQuery={[undefined]}>
                     <span>
@@ -39,7 +39,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
           <section className=\\"m-schedule-diagram__content\\">
             <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-stopC\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
-              <h4 className=\\"m-schedule-diagram__stop-link\\">
+              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                 <a href=\\"/stops/tree-stopC\\">
                   <MatchHighlight text=\\"Stop C\\" matchQuery={[undefined]}>
                     <span>
@@ -66,7 +66,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
           <section className=\\"m-schedule-diagram__content\\">
             <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-stopB\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
-              <h4 className=\\"m-schedule-diagram__stop-link\\">
+              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                 <a href=\\"/stops/tree-stopB\\">
                   <MatchHighlight text=\\"Stop B\\" matchQuery={[undefined]}>
                     <span>
@@ -93,7 +93,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
           <section className=\\"m-schedule-diagram__content\\">
             <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-stopA\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
-              <h4 className=\\"m-schedule-diagram__stop-link\\">
+              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                 <a href=\\"/stops/tree-stopA\\">
                   <MatchHighlight text=\\"Stop A\\" matchQuery={[undefined]}>
                     <span>
@@ -123,7 +123,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
               Twig Destination Line
             </div>
             <header className=\\"m-schedule-diagram__stop-heading\\">
-              <h4 className=\\"m-schedule-diagram__stop-link\\">
+              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                 <a href=\\"/stops/tree-twig-destination\\">
                   <MatchHighlight text=\\"Twig Destination\\" matchQuery={[undefined]}>
                     <span>
@@ -153,7 +153,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
                 <section className=\\"m-schedule-diagram__content\\">
                   <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-twig-stop\\" />
                   <header className=\\"m-schedule-diagram__stop-heading\\">
-                    <h4 className=\\"m-schedule-diagram__stop-link\\">
+                    <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                       <a href=\\"/stops/tree-twig-stop\\">
                         <MatchHighlight text=\\"Twig Stop\\" matchQuery={[undefined]}>
                           <span>
@@ -186,7 +186,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
               Branch Destination Line
             </div>
             <header className=\\"m-schedule-diagram__stop-heading\\">
-              <h4 className=\\"m-schedule-diagram__stop-link\\">
+              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                 <a href=\\"/stops/tree-branch-destination\\">
                   <MatchHighlight text=\\"Branch Destination\\" matchQuery={[undefined]}>
                     <span>
@@ -249,7 +249,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
           <section className=\\"m-schedule-diagram__content\\">
             <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-stop1\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
-              <h4 className=\\"m-schedule-diagram__stop-link\\">
+              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                 <a href=\\"/stops/tree-stop1\\">
                   <MatchHighlight text=\\"Stop 1\\" matchQuery={[undefined]}>
                     <span>
@@ -276,7 +276,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
           <section className=\\"m-schedule-diagram__content\\">
             <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-stop0\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
-              <h4 className=\\"m-schedule-diagram__stop-link\\">
+              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                 <a href=\\"/stops/tree-stop0\\">
                   <MatchHighlight text=\\"Stop 0\\" matchQuery={[undefined]}>
                     <span>
@@ -303,7 +303,7 @@ exports[`StopListWithBranches renders and matches snapshot 1`] = `
           <section className=\\"m-schedule-diagram__content\\">
             <GlxOpen pageType=\\"line-diagram\\" stopId=\\"tree-origin\\" />
             <header className=\\"m-schedule-diagram__stop-heading\\">
-              <h4 className=\\"m-schedule-diagram__stop-link\\">
+              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                 <a href=\\"/stops/tree-origin\\">
                   <MatchHighlight text=\\"Origin\\" matchQuery={[undefined]}>
                     <span>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopPredictionsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopPredictionsTest.tsx.snap
@@ -5,7 +5,7 @@ exports[`StopPredictions renders bus predictions 1`] = `
   className="m-schedule-diagram__predictions"
 >
   <div
-    className="m-schedule-diagram__prediction"
+    className="m-schedule-diagram__prediction notranslate"
   >
     <div>
       Harvard


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Prevent stop name translation on line diagrams](https://app.asana.com/0/555089885850811/1201938268964507/f)

Don't translate stop names on line diagram pages, including direction selector