### PR TITLE
only show hidden agendas if preview is requested

### DIFF
--- a/apps/cms/lib/page/event_agenda.ex
+++ b/apps/cms/lib/page/event_agenda.ex
@@ -19,7 +19,8 @@ defmodule CMS.Page.EventAgenda do
             topics: [],
             collect_info: false,
             event_reference: nil,
-            formstack_url: nil
+            formstack_url: nil,
+            published: true
 
   @type t :: %__MODULE__{
           id: integer | nil,
@@ -27,7 +28,8 @@ defmodule CMS.Page.EventAgenda do
           topics: [Paragraph.AgendaTopic.t()],
           collect_info: boolean,
           event_reference: integer | nil,
-          formstack_url: Link.t() | nil
+          formstack_url: Link.t() | nil,
+          published: boolean
         }
 
   @spec from_api(map, Keyword.t()) :: t
@@ -38,7 +40,8 @@ defmodule CMS.Page.EventAgenda do
       topics: parse_paragraphs(data, preview_opts, "field_agenda_topics"),
       collect_info: field_value(data, "field_agenda_collect_user_info"),
       event_reference: int_or_string_to_int(field_value(data, "field_agenda_event")),
-      formstack_url: parse_link(data, "field_agenda_formstack_url")
+      formstack_url: parse_link(data, "field_agenda_formstack_url"),
+      published: field_value(data, "status")
     }
   end
 end

--- a/apps/cms/priv/event_agenda.json
+++ b/apps/cms/priv/event_agenda.json
@@ -46,7 +46,7 @@
   ],
   "status": [
     {
-      "value": false
+      "value": true
     }
   ],
   "uid": [

--- a/apps/cms/test/page/event_agenda_test.exs
+++ b/apps/cms/test/page/event_agenda_test.exs
@@ -17,7 +17,8 @@ defmodule CMS.Page.EventAgendaTest do
                topics: topics,
                collect_info: collect_info,
                event_reference: event_reference,
-               formstack_url: formstack_url
+               formstack_url: formstack_url,
+               published: published
              } = EventAgenda.from_api(api_page)
 
       # Test normal fields
@@ -34,6 +35,9 @@ defmodule CMS.Page.EventAgendaTest do
 
       # Test link (not yet implemented)
       assert formstack_url == nil
+
+      # Test published value
+      assert published == true
     end
   end
 end

--- a/apps/site/lib/site_web/templates/event/show.html.eex
+++ b/apps/site/lib/site_web/templates/event/show.html.eex
@@ -60,7 +60,7 @@
             <hr />
           </div>
 
-          <%= if @event.event_agenda do %>
+          <%= if agenda_visible?(@event.event_agenda, @conn.query_params) do %>
             <section class="m-event__agenda">
               <h2 class="mt-0">Agenda</h2>
               <%= render "_event_agenda.html", conn: @conn, agenda: @event.event_agenda, is_ended: is_ended?(@event) %>

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -10,6 +10,7 @@ defmodule SiteWeb.EventView do
     only: [file_description: 1, render_duration: 2, maybe_shift_timezone: 1, format_time: 1]
 
   alias CMS.Page.Event
+  alias CMS.Page.EventAgenda
   alias CMS.Partial.Teaser
 
   @type event_status :: :not_started | :started | :ended
@@ -173,6 +174,14 @@ defmodule SiteWeb.EventView do
       "#{event_path(conn, :index, month: month, year: year)}##{month}-#{year}"
     end
   end
+
+  @doc """
+  Only show Agenda if it's published or if preview query param is present.
+  """
+  @spec agenda_visible?(EventAgenda.t(), map()) :: boolean()
+  def agenda_visible?(%{published: true}, _conn), do: true
+  def agenda_visible?(_event_agenda, %{"preview" => _}), do: true
+  def agenda_visible?(_event_agenda, _conn), do: false
 
   @spec agenda_title(String.t(), :h3 | :h4) :: Phoenix.HTML.Safe.t()
   def agenda_title(title, tag_type \\ :h3)

--- a/apps/site/lib/site_web/views/event_view.ex
+++ b/apps/site/lib/site_web/views/event_view.ex
@@ -179,9 +179,11 @@ defmodule SiteWeb.EventView do
   Only show Agenda if it's published or if preview query param is present.
   """
   @spec agenda_visible?(EventAgenda.t(), map()) :: boolean()
-  def agenda_visible?(%{published: true}, _conn), do: true
+  def agenda_visible?(event_agenda, params \\ %{})
+
+  def agenda_visible?(%{published: true}, _params), do: true
   def agenda_visible?(_event_agenda, %{"preview" => _}), do: true
-  def agenda_visible?(_event_agenda, _conn), do: false
+  def agenda_visible?(_event_agenda, _params), do: false
 
   @spec agenda_title(String.t(), :h3 | :h4) :: Phoenix.HTML.Safe.t()
   def agenda_title(title, tag_type \\ :h3)

--- a/apps/site/test/site_web/views/event_view_test.exs
+++ b/apps/site/test/site_web/views/event_view_test.exs
@@ -3,8 +3,9 @@ defmodule SiteWeb.EventViewTest do
   import SiteWeb.EventView
   import CMS.Helpers, only: [parse_iso_datetime: 1]
   import Phoenix.HTML, only: [safe_to_string: 1]
-  alias CMS.Partial.Teaser
   alias CMS.Page.Event
+  alias CMS.Page.EventAgenda
+  alias CMS.Partial.Teaser
 
   describe "show.html" do
     test "the notes section is not rendered when the event notes are empty", %{conn: conn} do
@@ -17,7 +18,7 @@ defmodule SiteWeb.EventViewTest do
       refute html =~ "Notes"
     end
 
-    test "the agenda section is not renderd when the event agenda is empty", %{conn: conn} do
+    test "the agenda section is not rendered when the event agenda is empty", %{conn: conn} do
       event = event_factory(0, agenda: nil)
 
       html =
@@ -226,6 +227,20 @@ defmodule SiteWeb.EventViewTest do
 
     test ":ended value verified",
       do: assert(has_started?(%Event{started_status: :started}) == true)
+  end
+
+  describe "agenda_visible?/2 hides unpublished" do
+    test "normal published case is shown",
+      do: assert(agenda_visible?(%EventAgenda{published: true}) == true)
+
+    test "draft agendas are shown if preview param is present",
+      do: assert(agenda_visible?(%EventAgenda{published: false}, %{"preview" => ""}) == true)
+
+    test "false positives do not expose agenda",
+      do: assert(agenda_visible?(%EventAgenda{published: false}, %{"foobar" => ""}) == false)
+
+    test "draft agendas are not shown by default",
+      do: assert(agenda_visible?(%EventAgenda{published: false}) == false)
   end
 
   test "agenda_title/2 shows title" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐞 elixir isn't checking published status of an agenda that is displayed on an event](https://app.asana.com/0/553506286097126/1201886553089889/f)

If an agenda is not published, don't show it unless `?preview` is in query params.

Adds boolean prop for `published` which is checked on-the-fly when rendering the agenda section of the event show template.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
