### PR TITLE
Prevent stop name translation in Schedule Finder

### DIFF
--- a/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleFinderTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleFinderTest.tsx.snap
@@ -17,7 +17,7 @@ exports[`ScheduleFinder matches snapshot 1`] = `
             Choose a direction
             <SelectContainer>
               <div tabIndex={0} className=\\"c-select-custom__container \\" role=\\"button\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
-                <select className=\\"c-select-custom\\" value={0} onChange={[Function: onChange]}>
+                <select className=\\"c-select-custom notranslate\\" value={0} onChange={[Function: onChange]}>
                   <option value={0} aria-label=\\"INBOUND \\\\n  Oak Grove\\">
                     INBOUND 
                       Oak Grove

--- a/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleFinderTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleFinderTest.tsx.snap
@@ -35,7 +35,7 @@ exports[`ScheduleFinder matches snapshot 1`] = `
             Choose an origin stop
             <SelectContainer error={false} handleClick={[Function: handleOriginClick]}>
               <div tabIndex={0} className=\\"c-select-custom__container \\" role=\\"button\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
-                <select className=\\"c-select-custom c-select-custom--noclick\\" value=\\"\\" onChange={[Function: onChange]}>
+                <select className=\\"c-select-custom c-select-custom--noclick notranslate\\" value=\\"\\" onChange={[Function: onChange]}>
                   <option value=\\"\\">
                     Select
                   </option>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/OriginModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/OriginModalContent.tsx
@@ -45,7 +45,7 @@ const OriginModalContent = ({
       <p className="schedule-finder__origin-text">
         Select from the list below.
       </p>
-      <div className="schedule-finder__origin-list">
+      <div className="schedule-finder__origin-list notranslate">
         {stopListSearchFilter(stops, originSearch).map((stop: SimpleStop) => (
           <OriginListItem
             key={stop.id}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleFinderForm.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleFinderForm.tsx
@@ -83,7 +83,7 @@ export default ({
             Choose a direction
             <SelectContainer>
               <select
-                className="c-select-custom"
+                className="c-select-custom notranslate"
                 value={selectedDirection}
                 onChange={e =>
                   onDirectionChange(parseInt(e.target.value, 10) as DirectionId)

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleFinderForm.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleFinderForm.tsx
@@ -109,7 +109,7 @@ export default ({
               handleClick={handleOriginClick}
             >
               <select
-                className="c-select-custom c-select-custom--noclick"
+                className="c-select-custom c-select-custom--noclick notranslate"
                 value={selectedOrigin || ""}
                 onChange={e => onOriginChange(e.target.value || null)}
               >

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderFormTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderFormTest.tsx.snap
@@ -33,7 +33,7 @@ exports[`ScheduleFinderForm matches snapshot 1`] = `
         Choose a direction
         <SelectContainer>
           <select
-            className="c-select-custom"
+            className="c-select-custom notranslate"
             onChange={[Function]}
             value={0}
           >

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderFormTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderFormTest.tsx.snap
@@ -67,7 +67,7 @@ exports[`ScheduleFinderForm matches snapshot 1`] = `
           handleClick={[Function]}
         >
           <select
-            className="c-select-custom c-select-custom--noclick"
+            className="c-select-custom c-select-custom--noclick notranslate"
             onChange={[Function]}
             value=""
           >

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderModalTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderModalTest.tsx.snap
@@ -31,7 +31,7 @@ exports[`ScheduleFinderModal matches snapshot in origin mode 1`] = `
                   <p className=\\"schedule-finder__origin-text\\">
                     Select from the list below.
                   </p>
-                  <div className=\\"schedule-finder__origin-list\\">
+                  <div className=\\"schedule-finder__origin-list notranslate\\">
                     <OriginListItem stop={{...}} changeOrigin={[Function: handleChangeOrigin]} selectedOrigin={{...}} lastStop={{...}}>
                       <div tabIndex={0} role=\\"button\\" className=\\"schedule-finder__origin-list-item  disabled\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
                         <div className=\\"schedule-finder__origin-list-leftpad\\">
@@ -106,7 +106,7 @@ exports[`ScheduleFinderModal matches snapshot in origin mode with origin selecte
                   <p className=\\"schedule-finder__origin-text\\">
                     Select from the list below.
                   </p>
-                  <div className=\\"schedule-finder__origin-list\\">
+                  <div className=\\"schedule-finder__origin-list notranslate\\">
                     <OriginListItem stop={{...}} changeOrigin={[Function: handleChangeOrigin]} selectedOrigin={{...}} lastStop={{...}}>
                       <div tabIndex={0} role=\\"button\\" className=\\"schedule-finder__origin-list-item  disabled\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
                         <div className=\\"schedule-finder__origin-list-leftpad\\">
@@ -178,7 +178,7 @@ exports[`ScheduleFinderModal matches snapshot in schedule mode 1`] = `
                             Choose a direction
                             <SelectContainer>
                               <div tabIndex={0} className=\\"c-select-custom__container \\" role=\\"button\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
-                                <select className=\\"c-select-custom\\" value={0} onChange={[Function: onChange]}>
+                                <select className=\\"c-select-custom notranslate\\" value={0} onChange={[Function: onChange]}>
                                   <option value={0} aria-label=\\"INBOUND \\\\n  Oak Grove\\">
                                     INBOUND 
                                       Oak Grove

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderModalTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderModalTest.tsx.snap
@@ -196,7 +196,7 @@ exports[`ScheduleFinderModal matches snapshot in schedule mode 1`] = `
                             Choose an origin stop
                             <SelectContainer error={false} handleClick={[Function: handleOriginClick]}>
                               <div tabIndex={0} className=\\"c-select-custom__container \\" role=\\"button\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
-                                <select className=\\"c-select-custom c-select-custom--noclick\\" value=\\"place-welln\\" onChange={[Function: onChange]}>
+                                <select className=\\"c-select-custom c-select-custom--noclick notranslate\\" value=\\"place-welln\\" onChange={[Function: onChange]}>
                                   <option value=\\"\\">
                                     Select
                                   </option>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleModalContentTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleModalContentTest.tsx.snap
@@ -42,7 +42,7 @@ Array [
             tabIndex={0}
           >
             <select
-              className="c-select-custom"
+              className="c-select-custom notranslate"
               onChange={[Function]}
               value={0}
             >

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleModalContentTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleModalContentTest.tsx.snap
@@ -86,7 +86,7 @@ Array [
             tabIndex={0}
           >
             <select
-              className="c-select-custom c-select-custom--noclick"
+              className="c-select-custom c-select-custom--noclick notranslate"
               onChange={[Function]}
               value="place-mlmnl"
             >

--- a/apps/site/lib/site_web/templates/schedule/_line_header.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line_header.html.eex
@@ -1,5 +1,5 @@
 <div class="schedule__header <%= header_class(@route) %>">
-  <div class="schedule__header-container notranslate">
+  <div class="schedule__header-container">
     <h1 class="schedule__route-name">
       <%= route_header_text(@route) %>
     </h1>

--- a/apps/site/lib/site_web/templates/schedule/_line_header.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_line_header.html.eex
@@ -1,5 +1,5 @@
 <div class="schedule__header <%= header_class(@route) %>">
-  <div class="schedule__header-container">
+  <div class="schedule__header-container notranslate">
     <h1 class="schedule__route-name">
       <%= route_header_text(@route) %>
     </h1>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Prevent stop name translation in Schedule Finder](https://app.asana.com/0/555089885850811/1201984535304524/f)

Add notranslate tag to schedule finder dropdown menu, schedule modal, and stop name header.