### PR TITLE
Broken search on projects pages

### DIFF
--- a/apps/site/assets/js/algolia-autocomplete-with-geo.js
+++ b/apps/site/assets/js/algolia-autocomplete-with-geo.js
@@ -56,18 +56,10 @@ class AlgoliaAutocompleteWithGeo extends AlgoliaAutocomplete {
 
   bind() {
     super.bind();
-    this.onFocus = this.onFocus.bind(this);
   }
 
   _addListeners() {
     super._addListeners();
-    this._input.addEventListener("focus", this.onFocus);
-  }
-
-  onFocus() {
-    if (!this.sessionToken) {
-      this.sessionToken = new window.google.maps.places.AutocompleteSessionToken();
-    }
   }
 
   resetSessionToken() {

--- a/apps/site/assets/js/algolia-autocomplete-with-geo.js
+++ b/apps/site/assets/js/algolia-autocomplete-with-geo.js
@@ -37,7 +37,6 @@ class AlgoliaAutocompleteWithGeo extends AlgoliaAutocomplete {
     containerEl = null
   }) {
     super({ id, selectors, indices, parent, containerEl });
-    this.sessionToken = null;
     this.debounceInterval = 250;
     if (!this._parent.getParams) {
       this._parent.getParams = () => ({});
@@ -52,18 +51,6 @@ class AlgoliaAutocompleteWithGeo extends AlgoliaAutocomplete {
     this._indices.splice(this._locationParams.position, 0, "locations");
     this._indices.push("usemylocation");
     this._indices.push("popular");
-  }
-
-  bind() {
-    super.bind();
-  }
-
-  _addListeners() {
-    super._addListeners();
-  }
-
-  resetSessionToken() {
-    this.sessionToken = null;
   }
 
   addUseMyLocationErrorEl() {
@@ -96,7 +83,6 @@ class AlgoliaAutocompleteWithGeo extends AlgoliaAutocomplete {
     return (input, callback) =>
       GoogleMapsHelpers.autocomplete({
         input,
-        sessionToken: this.sessionToken,
         hitLimit: this._locationParams.hitLimit
       }).then(results => this._onResults(callback, index, results));
   }
@@ -180,7 +166,6 @@ class AlgoliaAutocompleteWithGeo extends AlgoliaAutocomplete {
   }
 
   _onLocationSearchResult(result) {
-    this.resetSessionToken();
     return this.showLocation(result.latitude, result.longitude);
   }
 

--- a/apps/site/assets/js/algolia-homepage-search.js
+++ b/apps/site/assets/js/algolia-homepage-search.js
@@ -1,4 +1,3 @@
-import { doWhenGoogleMapsIsReady } from "./google-maps-loaded";
 import { AlgoliaEmbeddedSearch } from "./algolia-embedded-search";
 // eslint-disable-next-line import/no-unresolved
 import * as QueryHelpers from "../ts/helpers/query";
@@ -95,13 +94,11 @@ export const doInit = id => {
 
 export function init() {
   document.addEventListener("turbolinks:load", () => {
-    doWhenGoogleMapsIsReady(() => {
-      [
-        "search-homepage",
-        "search-header-desktop",
-        "search-header-mobile",
-        "search-error-page"
-      ].forEach(id => doInit(id));
-    });
+    [
+      "search-homepage",
+      "search-header-desktop",
+      "search-header-mobile",
+      "search-error-page"
+    ].forEach(id => doInit(id));
   });
 }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Navigating to /search from header shows no results](https://app.asana.com/0/385363666817452/1202012916713303/f)

Previously, we waiting to initialize the global header search until after Google maps had loaded. This was causing issues on pages where Google maps did not need to get loaded (e.g. project pages).