### PR TITLE
fix: Tighter logic for fetching route id

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/finder_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/finder_api.ex
@@ -502,11 +502,12 @@ defmodule SiteWeb.ScheduleController.FinderApi do
 
   @spec get_route_id(Route.id_t(), Trip.id_t()) :: Route.id_t() | nil
   defp get_route_id("Green", trip_id) do
-    case Schedules.Repo.trip(trip_id) do
-      %Schedules.Trip{route_pattern_id: route_pattern_id} when not is_nil(route_pattern_id) ->
-        RoutePatterns.Repo.get(route_pattern_id)
-        |> Map.get(:route_id)
-
+    with %Schedules.Trip{route_pattern_id: route_pattern_id} when not is_nil(route_pattern_id) <-
+           Schedules.Repo.trip(trip_id),
+         %RoutePatterns.RoutePattern{route_id: route_id} <-
+           RoutePatterns.Repo.get(route_pattern_id) do
+      route_id
+    else
       _ ->
         nil
     end


### PR DESCRIPTION
Sometimes, for certain unusual route pattern IDs on added trips, we can't actually find the route pattern! In that case we should return nil rather than trying to retrieve the (nonexistent) route pattern's route ID.

#### Summary of changes
**Asana Ticket:** [Schedules Finder API | Elixir.BadMapError: expected a map, got: nil](https://app.asana.com/0/385363666817452/1202045696470901/f)

See ticket for the Sentry bug report.