### PR TITLE
Remove `resetSessionToken` call

### DIFF
--- a/apps/site/assets/js/trip-planner-location-controls.js
+++ b/apps/site/assets/js/trip-planner-location-controls.js
@@ -298,8 +298,6 @@ export class TripPlannerLocControls {
         case "locations":
           GoogleMapsHelpers.lookupPlace(hit.place_id)
             .then(res => {
-              ac.resetSessionToken();
-
               const { latitude, longitude } = res;
               this.setAutocompleteValue(
                 ac,
@@ -311,9 +309,6 @@ export class TripPlannerLocControls {
               );
               ac._input.blur();
             })
-            .catch(() => {
-              // TODO: we should display an error here but NOT log to the console
-            });
           break;
         case "usemylocation":
           ac.useMyLocationSearch();


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Selecting custom locations in trip planner should populate map](https://app.asana.com/0/385363666817452/1202050563424979/f)

This was missed when previously deleting this method and was silently breaking selecting locations in the trip planner
