### PR TITLE
Position header elements when resizing viewport or translating

### DIFF
--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -159,6 +159,7 @@ nav.m-menu--mobile {
   display: none;
   white-space: nowrap;
   transition: all .25s ease;
+  transition: top 0s;
   position: fixed;
   &::-webkit-scrollbar {
     display: none; /* Chrome */

--- a/apps/site/assets/js/google-translate.js
+++ b/apps/site/assets/js/google-translate.js
@@ -1,3 +1,5 @@
+import { setHeaderElementPositions } from "../ts/app/global-navigation";
+
 // maximum wait time to get a reference to Google Translate select DOM element
 const domPollLimitMilliseconds = 10000;
 
@@ -65,6 +67,11 @@ const registerEvents = translateEl => {
   // detect when the language has been changed from outside
   // this works because Google's JS mutates the DOM
   translateEl.addEventListener("DOMNodeInserted", () => {
+    const header = document.querySelector(".header--new");
+    if (header) {
+      setHeaderElementPositions(header);
+    }
+
     if (domMutateCallback) {
       clearTimeout(domMutateCallback);
     }

--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -89,10 +89,13 @@ export function setHeaderElementPositions(header: HTMLElement): void {
   const heightPx = `${height}px`;
 
   header.querySelectorAll(".m-menu--desktop__menu").forEach(el => {
+    // eslint-disable-next-line no-param-reassign
     (el as HTMLElement).style.top = heightPx;
   });
 
-  const content = header.querySelector(".m-menu--mobile .m-menu__content") as HTMLElement | null;
+  const content = header.querySelector(
+    ".m-menu--mobile .m-menu__content"
+  ) as HTMLElement | null;
   if (content) {
     content.style.top = bottomPx;
   }

--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -83,12 +83,37 @@ function makeScrollAccordionToTop(): (target: HTMLElement) => void {
   };
 }
 
+export function setHeaderElementPositions(header: HTMLElement): void {
+  const { bottom, height } = header.getBoundingClientRect();
+  const bottomPx = `${bottom}px`;
+  const heightPx = `${height}px`;
+
+  header.querySelectorAll(".m-menu--desktop__menu").forEach(el => {
+    (el as HTMLElement).style.top = heightPx;
+  });
+
+  const content = header.querySelector(".m-menu--mobile .m-menu__content") as HTMLElement | null;
+  if (content) {
+    content.style.top = bottomPx;
+  }
+
+  const cover = document.querySelector(".m-menu--cover") as HTMLElement | null;
+  if (cover) {
+    cover.style.top = bottomPx;
+  }
+}
+
 export default function setupGlobalNavigation(): void {
   document.addEventListener(
     "turbolinks:load",
     () => {
       const header = document.querySelector(".header--new")!;
       if (!header) return;
+
+      setHeaderElementPositions(header as HTMLElement);
+      window.addEventListener("resize", () => {
+        setHeaderElementPositions(header as HTMLElement);
+      });
 
       // On mobile, clicking Menu or the Search icon opens a menu
       header


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Menu button inaccessible](https://app.asana.com/0/385363666817452/1202041767361060/f)

This PR adds some JS logic to ensure that the header elements remain positioned on the page.

Things that are positioned:
- The desktop menu dropdowns
- The modal veil
- The tablet / mobile nav content

The mobile nav search doesn't need to be positioned.

The positioning logic is triggered on page load, when the viewport is resized, and when the translation language changes.
