### PR TITLE
Fix rendering issues with CR zones

### DIFF
--- a/apps/site/assets/css/_icons.scss
+++ b/apps/site/assets/css/_icons.scss
@@ -295,6 +295,7 @@ a {
   padding-left: $base-spacing / 4;
   padding-right: $base-spacing / 4;
   white-space: nowrap;
+  display: inline-block;
 }
 
 .c-icon__bus-pill {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [CR zone badge cut off in suggestions](https://app.asana.com/0/0/1201994835377135/f)

On Chrome and Firefox on Windows in particular, the commuter rail zone "pill" was getting cut off vertically in different situations. Switching to `inline-block` alleviates this without otherwise affecting layout in my testing.
