### PR TITLE
Remove Maps Static API integration on Trip Planner

### DIFF
--- a/apps/site/lib/site/trip_plan/map.ex
+++ b/apps/site/lib/site/trip_plan/map.ex
@@ -6,8 +6,7 @@ defmodule Site.TripPlan.Map do
   alias TripPlan.{Leg, NamedPosition, TransitDetail}
   alias Util.Position
 
-  @type static_map :: String.t()
-  @type t :: {MapData.t(), static_map}
+  @type t :: MapData.t()
   @type route_mapper :: (String.t() -> Route.t() | nil)
   @type stop_mapper :: (String.t() -> Stops.Stop.t() | nil)
 

--- a/apps/site/lib/site/trip_plan/map.ex
+++ b/apps/site/lib/site/trip_plan/map.ex
@@ -20,17 +20,6 @@ defmodule Site.TripPlan.Map do
   Handles generating the maps displayed within the TripPlan Controller
   """
 
-  @doc """
-  Returns the url for the initial map for the Trip Planner
-  """
-  @spec initial_map_src() :: static_map
-  def initial_map_src do
-    {630, 400}
-    |> MapData.new(14)
-    |> MapData.to_google_map_data()
-    |> GoogleMaps.static_map_url()
-  end
-
   def initial_map_data do
     {630, 400}
     |> MapData.new(14)
@@ -44,8 +33,7 @@ defmodule Site.TripPlan.Map do
   """
   @spec itinerary_map([Leg.t()], Keyword.t()) :: t
   def itinerary_map(itinerary, opts \\ []) do
-    map_data = itinerary_map_data(itinerary, Keyword.merge(@default_opts, opts))
-    {map_data, map_data |> MapData.to_google_map_data() |> GoogleMaps.static_map_url()}
+    itinerary_map_data(itinerary, Keyword.merge(@default_opts, opts))
   end
 
   @spec itinerary_map_data([Leg.t()], Keyword.t()) :: MapData.t()

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -81,7 +81,7 @@ defmodule SiteWeb.TripPlanController do
         now = Util.now()
 
         # build map information for a single leg with the 'to' field:
-        {map_data, map_src} =
+        map_data =
           TripPlanMap.itinerary_map([
             %Leg{
               from: nil,
@@ -100,11 +100,10 @@ defmodule SiteWeb.TripPlanController do
 
         %{markers: [marker]} = map_data
         to_marker = %{marker | id: "B"}
-        map_info_for_to_destination = {%{map_data | markers: [to_marker]}, map_src}
 
         conn
         |> assign(:query, query)
-        |> assign(:map_info, map_info_for_to_destination)
+        |> assign(:map_data, %{map_data | markers: [to_marker]})
         |> render(:index)
 
       {:error, _} ->
@@ -316,7 +315,7 @@ defmodule SiteWeb.TripPlanController do
   @spec assign_initial_map(Plug.Conn.t(), any()) :: Plug.Conn.t()
   def assign_initial_map(conn, _opts) do
     conn
-    |> assign(:map_info, {TripPlanMap.initial_map_data(), TripPlanMap.initial_map_src()})
+    |> assign(:map_data, TripPlanMap.initial_map_data())
   end
 
   @spec modes(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()

--- a/apps/site/lib/site_web/templates/trip_plan/index.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/index.html.eex
@@ -23,8 +23,8 @@
             <script defer src="<%= static_url(@conn, "/js/tripplanresults.js") %>"></script>
           <% end %>
        <% _ -> %>
-        <%= if assigns[:map_info] do %>
-          <% %{map_info: {map_data, map_src} } = assigns %>
+        <%= if assigns[:map_data] do %>
+          <% %{map_data: map_data} = assigns %>
           <% map_data = Map.put(map_data, :tile_server_url, Application.fetch_env!(:site, :tile_server_url)) %>
           <script id="js-trip-planner-map-data" type="text/plain"><%= raw Poison.encode!(map_data) %></script>
           <link rel="stylesheet" href="<%= static_url(@conn, "/css/map.css") %>" data-turbolinks-track="reload">

--- a/apps/site/lib/site_web/templates/trip_plan/index.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/index.html.eex
@@ -35,9 +35,6 @@
                 <script defer src="<%= static_url(@conn, "/js/react.js") %>"></script>
                 <script defer src="<%= static_url(@conn, "/js/tripplanner.js") %>"></script>
               <% end %>
-              <div class="map-static" style="background-image:url(<%= map_src %>);">
-                <span class="sr-only">Map of downtown Boston"</span>
-              </div>
           <% end %>
       <% end %>
     </div>

--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -423,10 +423,9 @@ defmodule SiteWeb.TripPlanView do
     template |> render(data) |> HTML.safe_to_string()
   end
 
-  def itinerary_map({map_data, map_src}) do
+  def itinerary_map(map_data) do
     map_data
     |> Map.put(:tile_server_url, Application.fetch_env!(:site, :tile_server_url))
-    |> Map.put(:src, map_src)
   end
 
   @spec itinerary_html(any, %{conn: atom | %{assigns: atom | map}, expanded: any}) :: [any]

--- a/apps/site/test/site/trip_plan/map_test.exs
+++ b/apps/site/test/site/trip_plan/map_test.exs
@@ -18,10 +18,4 @@ defmodule Site.TripPlan.MapTest do
       assert initial_map_data() == expected
     end
   end
-
-  describe "initial_map_src/0" do
-    test "gives the initial map src" do
-      assert initial_map_src() =~ "https://maps.googleapis.com/maps/api/staticmap?"
-    end
-  end
 end

--- a/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
+++ b/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
@@ -158,7 +158,7 @@ defmodule SiteWeb.TripPlanControllerTest do
 
     test "assigns initial map data", %{conn: conn} do
       conn = get(conn, trip_plan_path(conn, :index))
-      assert conn.assigns.map_info
+      assert conn.assigns.map_data
     end
 
     test "assigns modes to empty map", %{conn: conn} do

--- a/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
+++ b/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
@@ -4,7 +4,6 @@ defmodule SiteWeb.TripPlanControllerTest do
   alias Site.TripPlan.Query
   alias SiteWeb.TripPlanController
   alias TripPlan.{Api.MockPlanner, Itinerary, PersonalDetail, TransitDetail}
-  import Phoenix.HTML, only: [html_escape: 1, safe_to_string: 1]
   doctest SiteWeb.TripPlanController
 
   import Mock

--- a/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
+++ b/apps/site/test/site_web/controllers/trip_plan_controller_test.exs
@@ -341,12 +341,6 @@ defmodule SiteWeb.TripPlanControllerTest do
       assert %Query{} = conn.assigns.query
     end
 
-    test "renders a prereq error with the initial map", %{conn: conn} do
-      conn = get(conn, trip_plan_path(conn, :index, plan: %{"from" => "", "to" => ""}))
-      response = html_response(conn, 200)
-      assert response =~ conn.assigns.map_info |> elem(1) |> html_escape |> safe_to_string
-    end
-
     test "assigns maps for each itinerary", %{conn: conn} do
       conn = get(conn, trip_plan_path(conn, :index, @good_params))
       assert conn.assigns.itinerary_maps

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -690,7 +690,6 @@ closest arrival to 12:00 AM, Thursday, January 1st."
       modes: %{},
       optimize_for: :best_route,
       initial_map_data: Site.TripPlan.Map.initial_map_data(),
-      initial_map_src: Site.TripPlan.Map.initial_map_src(),
       plan_datetime_selector_fields: plan_datetime_selector_fields
     }
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Remove Maps Static API integration on Trip Planner](https://app.asana.com/0/555089885850811/1202072976283731/f)

Remove references to google static map within different views of trip planner and code that sets the url within the page(s).