### PR TITLE
Export header and footer again

### DIFF
--- a/apps/site/assets/.eslintrc.js
+++ b/apps/site/assets/.eslintrc.js
@@ -31,6 +31,14 @@ const baseConfig = {
   globals: {
     google: "readonly",
     $: true
+  },
+  settings: {
+    "import/resolver": {
+      node: {
+        extensions: [".js", ".jsx", ".ts", ".tsx"],
+        moduleDirectory: ["node_modules", "src/"]
+      }
+    }
   }
 };
 

--- a/apps/site/assets/css/_header.scss
+++ b/apps/site/assets/css/_header.scss
@@ -360,14 +360,14 @@ nav.m-menu--mobile {
 }
 
 .m-menu__toggle {
-  width: 4rem;
+  min-width: 4rem;
 
   display: flex;
   justify-content: center;
   align-items: center;
 
   @include media-breakpoint-up(lg) {
-    display: none;
+    display: none !important; // works when extracted via dotcomchrome
   }
 }
 

--- a/apps/site/assets/css/export-headerfooter.scss
+++ b/apps/site/assets/css/export-headerfooter.scss
@@ -1,3 +1,20 @@
+// slight rewrite from core.scss.
+// we overwrite .no-js with .js class on mbta.com
+// but outside mbta.com we can just add .js class
+.hidden-no-js {
+  display: none;
+}
+
+.js {
+  .hidden-no-js {
+    display: initial;
+  }
+
+  .hidden-js {
+    display: none;
+  }
+}
+
 @import "functions";
 @import "variables";
 @import "mixins";
@@ -9,6 +26,7 @@
 @import "layout";
 @import "vendor/font-awesome-4.6.3/scss/font-awesome";
 @import "icons";
-@import "fare-summary";
 @import "buttons";
-@import "header-desktop-menu";
+@import "accordion-ui"; // involved in mobile nav styles
+@import "header"; // some nav styles still here
+@import "global-navigation"; // other nav styles

--- a/apps/site/assets/css/export-headerfooter.scss
+++ b/apps/site/assets/css/export-headerfooter.scss
@@ -1,7 +1,7 @@
 // slight rewrite from core.scss.
 // we overwrite .no-js with .js class on mbta.com
 // but outside mbta.com we can just add .js class
-.hidden-no-js {
+:not(.js) .hidden-no-js {
   display: none;
 }
 

--- a/apps/site/assets/export-headerfooter.js
+++ b/apps/site/assets/export-headerfooter.js
@@ -2,7 +2,9 @@ import "bootstrap/dist/js/umd/util";
 import "bootstrap/dist/js/umd/collapse";
 import "bootstrap/dist/js/umd/tooltip";
 import collapse from "./js/collapse";
-import { initCarets } from "./js/header-dropdowns";
+import { setup } from "./ts/app/global-navigation.ts";
 
 collapse();
-initCarets();
+setup();
+
+document.body.classList.add("js");

--- a/apps/site/assets/export-headerfooter.js
+++ b/apps/site/assets/export-headerfooter.js
@@ -8,3 +8,9 @@ collapse();
 setup();
 
 document.body.classList.add("js");
+
+// Remove event listeners from header search button, then hide
+const searchButton = document.querySelector(".header-search__toggle");
+const blankButton = searchButton.cloneNode(true);
+blankButton.style.opacity = "0";
+searchButton.replaceWith(blankButton);

--- a/apps/site/assets/js/trip-planner-location-controls.js
+++ b/apps/site/assets/js/trip-planner-location-controls.js
@@ -296,19 +296,18 @@ export class TripPlannerLocControls {
           );
           break;
         case "locations":
-          GoogleMapsHelpers.lookupPlace(hit.place_id)
-            .then(res => {
-              const { latitude, longitude } = res;
-              this.setAutocompleteValue(
-                ac,
-                hit.description,
-                lat,
-                lng,
-                latitude,
-                longitude
-              );
-              ac._input.blur();
-            })
+          GoogleMapsHelpers.lookupPlace(hit.place_id).then(res => {
+            const { latitude, longitude } = res;
+            this.setAutocompleteValue(
+              ac,
+              hit.description,
+              lat,
+              lng,
+              latitude,
+              longitude
+            );
+            ac._input.blur();
+          });
           break;
         case "usemylocation":
           ac.useMyLocationSearch();

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -13,8 +13,8 @@ import ScheduleDirectionButton from "./direction/ScheduleDirectionButton";
 import { reducer as fetchReducer } from "../../helpers/fetch";
 import { menuReducer, FetchAction } from "./direction/reducer";
 import { MapData, StaticMapData } from "../../leaflet/components/__mapdata";
-import Map from "../components/Map";
-import LineDiagramAndStopListPage from "../components/line-diagram/LineDiagram";
+import Map from "./Map";
+import LineDiagramAndStopListPage from "./line-diagram/LineDiagram";
 import { isABusRoute, isACommuterRailRoute } from "../../models/route";
 
 export interface Props {

--- a/apps/site/assets/ts/schedule/components/ScheduleLoader.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleLoader.tsx
@@ -3,17 +3,17 @@ import { connect } from "react-redux";
 import { useQueryParams, StringParam } from "use-query-params";
 import ContentTeasers from "./ContentTeasers";
 import UpcomingHolidays from "./UpcomingHolidays";
-import AdditionalLineInfo from "../components/AdditionalLineInfo";
-import ScheduleNote from "../components/ScheduleNote";
-import ScheduleDirection from "../components/ScheduleDirection";
+import AdditionalLineInfo from "./AdditionalLineInfo";
+import ScheduleNote from "./ScheduleNote";
+import ScheduleDirection from "./ScheduleDirection";
 import {
   SchedulePageData,
   SelectedOrigin,
   ComponentToRender
 } from "../components/__schedule";
 import { MapData, StaticMapData } from "../../leaflet/components/__mapdata";
-import ScheduleFinder from "../components/ScheduleFinder";
-import ScheduleFinderModal from "../components/schedule-finder/ScheduleFinderModal";
+import ScheduleFinder from "./ScheduleFinder";
+import ScheduleFinderModal from "./schedule-finder/ScheduleFinderModal";
 import { DirectionId } from "../../__v3api";
 import {
   mapStateToProps,

--- a/apps/site/assets/webpack.config.export-headerfooter.js
+++ b/apps/site/assets/webpack.config.export-headerfooter.js
@@ -1,13 +1,29 @@
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const SriPlugin = require('webpack-subresource-integrity');
+const SriPlugin = require("webpack-subresource-integrity");
 const TerserPlugin = require("terser-webpack-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const webpack = require("webpack");
 const path = require("path");
 const postcssPresetEnv = require("postcss-preset-env");
 const sass = require("sass");
+
+
+const babelLoader = {
+  loader: "babel-loader",
+  options: {
+    configFile: path.resolve(__dirname, 'babel.config.js'),
+  }
+};
+
+const tsLoader = {
+  loader: "ts-loader",
+  options: {
+    configFile: path.resolve(__dirname, 'tsconfig.webpack.json')
+  }
+};
+
 
 /**
  * Special configuration that outputs JavaScript, CSS, and static assets
@@ -23,7 +39,8 @@ module.exports = (env, argv) => {
     new CopyWebpackPlugin([
       { from: "static/fonts/*", to: "fonts/[name].[ext]" },
       { from: "static/favicon.ico", to: "favicon.ico" },
-      { from: "static/images/map-abstract-bkg-overlay.png", to: "images/map-abstract-bkg-overlay.png" },
+      { from: "static/images/mbta-logo.svg", to: "images/mbta-logo.svg" },
+      { from: "static/images/mbta-name-and-logo.svg", to: "images/mbta-name-and-logo.svg" },
     ], {}),
     new SriPlugin({
       hashFuncNames: ['sha256', 'sha384'],
@@ -56,12 +73,14 @@ module.exports = (env, argv) => {
     module: {
       rules: [
         {
+          test: /\.(ts)$/,
+          exclude: [/node_modules/],
+          use: [babelLoader, tsLoader]
+        },
+        {
           test: /\.(js)$/,
           exclude: ['/node_modules/'],
-          loader: "babel-loader",
-          options: {
-            configFile: path.resolve(__dirname, 'babel.config.js'),
-          }
+          use: babelLoader,
         },
         {
           test: /\.scss$/,
@@ -150,6 +169,10 @@ module.exports = (env, argv) => {
           },
         }),
       ],
+    },
+
+    resolve: {
+      extensions: [".ts", ".js"]
     }
   })
 };

--- a/apps/site/lib/mix/tasks/header_footer.ex
+++ b/apps/site/lib/mix/tasks/header_footer.ex
@@ -81,14 +81,15 @@ defmodule Mix.Tasks.Export.HeaderFooter do
 
     html =
       tree
-      |> Floki.find(".header, .m-footer")
+      |> Floki.find(".header--new, .m-footer")
       |> update_links()
+      |> remove_search_bar()
       |> remove_language_selector()
 
     IO.puts("#{IO.ANSI.yellow()}writing HTML")
 
-    header_html = Floki.find(html, ".header") |> Floki.raw_html(encode: true, pretty: true)
-    footer_html = Floki.find(html, ".m-footer") |> Floki.raw_html(encode: true, pretty: true)
+    header_html = Floki.find(html, ".header--new") |> Floki.raw_html(encode: true, pretty: false)
+    footer_html = Floki.find(html, ".m-footer") |> Floki.raw_html(encode: true, pretty: false)
 
     File.mkdir_p("export")
     :ok = File.write("export/header.html", header_html)
@@ -135,10 +136,15 @@ defmodule Mix.Tasks.Export.HeaderFooter do
     end)
   end
 
+  defp remove_search_bar(html_tree) do
+    IO.puts("#{IO.ANSI.magenta()}removing search bar")
+    Floki.find_and_update(html_tree, ".search-wrapper > div", fn _ -> :delete end)
+  end
+
   defp remove_language_selector(html_tree) do
     IO.puts("#{IO.ANSI.magenta()}removing Google Translate stuff")
 
-    Floki.find_and_update(html_tree, "#custom-language-selector", fn _ -> :delete end)
+    Floki.find_and_update(html_tree, "#m-menu__language", fn _ -> :delete end)
     |> Floki.find_and_update("#google_translate_element", fn _ -> :delete end)
     |> Floki.find_and_update("#custom-language-menu-mobile", fn _ -> :delete end)
     |> Floki.find_and_update("#custom-language-button-mobile", fn _ -> :delete end)
@@ -171,15 +177,9 @@ defmodule Mix.Tasks.Export.HeaderFooter do
           :ok
 
         _ ->
-          if String.contains?(message, "ERROR") do
-            # This one's not actually an error
-            IO.puts(" * webpack did ok and no error")
-            :ok
-          else
-            IO.puts(message)
-            IO.puts(" * webpack did not ok")
-            :error
-          end
+          IO.puts(message)
+          IO.puts(" * webpack did not ok")
+          :error
       end
     end
   end


### PR DESCRIPTION
This PR builds upon the work from https://github.com/mbta/dotcom/pull/1170, tweaking it a bit to be compatible with our newly designed navigation.

The output of the revised `mix export.header_footer` task is currently in a PR over at the dotcomchrome repo: https://github.com/mbta/dotcomchrome/pull/5 - and there's details in _that_ repo's README on how to preview the output in the browser.

#### Summary of changes
**Asana Ticket:** [Update dotcomchrome repo with new desktop/mobile menu output](https://app.asana.com/0/385363666817452/1202012916713299/f)

* Updates the header and footer with the latest content
* Adds the mobile menu to the extracted header, and makes it work

The first two commits are small adjustments to our current navigation implementation that I found that I needed to do in order to get the extracted version to render as expected - I'm hopeful those changes are small and unobtrusive enough.