### PR TITLE
Use pre-cached object reference for checking offset

### DIFF
--- a/apps/site/assets/js/algolia-autocomplete.js
+++ b/apps/site/assets/js/algolia-autocomplete.js
@@ -45,6 +45,7 @@ export default class AlgoliaAutocomplete {
     this.onKeyup = this.onKeyup.bind(this);
     this.clear = this.clear.bind(this);
     this._toggleResetButton = this._toggleResetButton.bind(this);
+    this.getById = this.getById.bind(this);
   }
 
   clear() {
@@ -214,7 +215,7 @@ export default class AlgoliaAutocomplete {
     const acDialog = window
       .jQuery(this._resultsContainer)
       .find(".c-search-bar__-dropdown-menu")[0];
-    if (acDialog) {
+    if (acDialog && this._input) {
       this.positionDropdown(acDialog);
       this.announceResults(acDialog);
     }
@@ -225,8 +226,7 @@ export default class AlgoliaAutocomplete {
       $(`#${this._selectors.container}`).css("border-left-width"),
       10
     );
-    const { offsetLeft } = this.getById(this._selectors.input);
-    const { offsetTop } = this.getById(this._selectors.input);
+    const { offsetLeft, offsetTop } = this._input;
 
     /* eslint-disable no-param-reassign */
     acDialog.style.width = `${this._searchContainer.offsetWidth}px`;


### PR DESCRIPTION
When navigating from a 'parent' page for a type of service:
![image](https://user-images.githubusercontent.com/526017/164083287-03cfaacf-311b-46c7-afe0-34786bb990e7.png)
These search boxes are present within the page and an embedded algolia search object is generated for each search input. When a user navigates to a more specific pages, say for the red line only:
![image](https://user-images.githubusercontent.com/526017/164083429-73c0cb0b-b148-467f-a218-26093e72b42f.png)
The from, to, and middle search are no longer present within the dom, but the objects are still loaded in memory. So when the app fires the resize event (sometimes happens on page load, especially on mobile) it kicks off the `onOpen` call which attempts to re-query the dom for the element group which it has already been attached to, but since the 3 fields are no longer 'physically' present, the call returns null and destructuring null throws an error.  

![image](https://user-images.githubusercontent.com/526017/164084515-30d37df8-5244-4dc2-a101-bb3d2e0244eb.png)
![image](https://user-images.githubusercontent.com/526017/164084678-c0ac3264-91df-4bf9-a92a-f32dbdbe1052.png)
