### PR TITLE
HTML displaying in title of vehicle icon

### DIFF
--- a/apps/site/assets/ts/helpers/icon.tsx
+++ b/apps/site/assets/ts/helpers/icon.tsx
@@ -161,7 +161,6 @@ export const TooltipWrapper: React.FC<{
       data-html={options.html}
       data-selector="true"
       data-original-title={tooltipText}
-      title={tooltipText}
     >
       {children}
     </Tag>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -25,14 +25,14 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
             <VehicleIcons stop={{...}} vehicles={{...}}>
               <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
                 <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 1 at stop 1</div>\\" tooltipOptions={{...}}>
-                  <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 1 at stop 1</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 1 at stop 1</div>\\">
+                  <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 1 at stop 1</div>\\">
                     <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </TooltipWrapper>
               </div>
               <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
                 <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 2 at stop 1</div>\\" tooltipOptions={{...}}>
-                  <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 2 at stop 1</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 2 at stop 1</div>\\">
+                  <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 2 at stop 1</div>\\">
                     <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </TooltipWrapper>
@@ -43,7 +43,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
             <VehicleIcons stop={{...}} vehicles={{...}}>
               <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
                 <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 3 at stop 2</div>\\" tooltipOptions={{...}}>
-                  <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 3 at stop 2</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 3 at stop 2</div>\\">
+                  <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 3 at stop 2</div>\\">
                     <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                   </span>
                 </TooltipWrapper>
@@ -105,12 +105,12 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                   </h4>
                   <div className=\\"m-schedule-diagram__features\\">
                     <TooltipWrapper tooltipText=\\"Parking\\" tooltipOptions={{...}}>
-                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
+                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\">
                         <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       </span>
                     </TooltipWrapper>
                     <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                         <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       </span>
                     </TooltipWrapper>
@@ -151,7 +151,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                   </h4>
                   <div className=\\"m-schedule-diagram__features\\">
                     <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                         <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       </span>
                     </TooltipWrapper>
@@ -160,14 +160,14 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                 <div className=\\"m-schedule-diagram__stop-details\\">
                   <div className=\\"m-schedule-diagram__connections\\">
                     <TooltipWrapper href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
-                      <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Orange Line\\" title=\\"Orange Line\\">
+                      <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Orange Line\\">
                         <span className=\\"m-schedule-diagram__connection\\">
                           <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                         </span>
                       </a>
                     </TooltipWrapper>
                     <TooltipWrapper href=\\"/schedules/Green-C/line\\" tooltipText=\\"Green Line C\\" tooltipOptions={{...}}>
-                      <a href=\\"/schedules/Green-C/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Green Line C\\" title=\\"Green Line C\\">
+                      <a href=\\"/schedules/Green-C/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Green Line C\\">
                         <span className=\\"m-schedule-diagram__connection\\">
                           <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                         </span>
@@ -234,7 +234,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                   </h4>
                   <div className=\\"m-schedule-diagram__features\\">
                     <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                         <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       </span>
                     </TooltipWrapper>
@@ -243,14 +243,14 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                 <div className=\\"m-schedule-diagram__stop-details\\">
                   <div className=\\"m-schedule-diagram__connections\\">
                     <TooltipWrapper href=\\"/schedules/62/line\\" tooltipText=\\"Route 62\\" tooltipOptions={{...}}>
-                      <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Route 62\\" title=\\"Route 62\\">
+                      <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Route 62\\">
                         <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                           62
                         </span>
                       </a>
                     </TooltipWrapper>
                     <TooltipWrapper href=\\"/schedules/67/line\\" tooltipText=\\"Route 67\\" tooltipOptions={{...}}>
-                      <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Route 67\\" title=\\"Route 67\\">
+                      <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Route 67\\">
                         <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                           67
                         </span>
@@ -299,12 +299,12 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                   </h4>
                   <div className=\\"m-schedule-diagram__features\\">
                     <TooltipWrapper tooltipText=\\"Parking\\" tooltipOptions={{...}}>
-                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
+                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\">
                         <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       </span>
                     </TooltipWrapper>
                     <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                         <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       </span>
                     </TooltipWrapper>
@@ -313,7 +313,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                 <div className=\\"m-schedule-diagram__stop-details\\">
                   <div className=\\"m-schedule-diagram__connections\\">
                     <TooltipWrapper href=\\"/schedules/BOAT-A/line\\" tooltipText=\\"Atlantis\\" tooltipOptions={{...}}>
-                      <a href=\\"/schedules/BOAT-A/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Atlantis\\" title=\\"Atlantis\\">
+                      <a href=\\"/schedules/BOAT-A/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Atlantis\\">
                         <span className=\\"m-schedule-diagram__connection\\">
                           <span className=\\"notranslate c-svg__icon-bus-small\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                         </span>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -10,14 +10,14 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
           <VehicleIcons stop={{...}} vehicles={{...}}>
             <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
               <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 1 at stop 1</div>\\" tooltipOptions={{...}}>
-                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 1 at stop 1</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 1 at stop 1</div>\\">
+                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 1 at stop 1</div>\\">
                   <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                 </span>
               </TooltipWrapper>
             </div>
             <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
               <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 2 at stop 1</div>\\" tooltipOptions={{...}}>
-                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 2 at stop 1</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 2 at stop 1</div>\\">
+                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 2 at stop 1</div>\\">
                   <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                 </span>
               </TooltipWrapper>
@@ -28,7 +28,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
           <VehicleIcons stop={{...}} vehicles={{...}}>
             <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
               <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 3 at stop 2</div>\\" tooltipOptions={{...}}>
-                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 3 at stop 2</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 3 at stop 2</div>\\">
+                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">tooltip for vehicle 3 at stop 2</div>\\">
                   <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                 </span>
               </TooltipWrapper>
@@ -90,12 +90,12 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                 </h4>
                 <div className=\\"m-schedule-diagram__features\\">
                   <TooltipWrapper tooltipText=\\"Parking\\" tooltipOptions={{...}}>
-                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
+                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\">
                       <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                     </span>
                   </TooltipWrapper>
                   <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                       <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                     </span>
                   </TooltipWrapper>
@@ -136,7 +136,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                 </h4>
                 <div className=\\"m-schedule-diagram__features\\">
                   <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                       <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                     </span>
                   </TooltipWrapper>
@@ -145,14 +145,14 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
               <div className=\\"m-schedule-diagram__stop-details\\">
                 <div className=\\"m-schedule-diagram__connections\\">
                   <TooltipWrapper href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
-                    <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Orange Line\\" title=\\"Orange Line\\">
+                    <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Orange Line\\">
                       <span className=\\"m-schedule-diagram__connection\\">
                         <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       </span>
                     </a>
                   </TooltipWrapper>
                   <TooltipWrapper href=\\"/schedules/Green-C/line\\" tooltipText=\\"Green Line C\\" tooltipOptions={{...}}>
-                    <a href=\\"/schedules/Green-C/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Green Line C\\" title=\\"Green Line C\\">
+                    <a href=\\"/schedules/Green-C/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Green Line C\\">
                       <span className=\\"m-schedule-diagram__connection\\">
                         <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       </span>
@@ -219,7 +219,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                 </h4>
                 <div className=\\"m-schedule-diagram__features\\">
                   <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                       <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                     </span>
                   </TooltipWrapper>
@@ -228,14 +228,14 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
               <div className=\\"m-schedule-diagram__stop-details\\">
                 <div className=\\"m-schedule-diagram__connections\\">
                   <TooltipWrapper href=\\"/schedules/62/line\\" tooltipText=\\"Route 62\\" tooltipOptions={{...}}>
-                    <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Route 62\\" title=\\"Route 62\\">
+                    <a href=\\"/schedules/62/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Route 62\\">
                       <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                         62
                       </span>
                     </a>
                   </TooltipWrapper>
                   <TooltipWrapper href=\\"/schedules/67/line\\" tooltipText=\\"Route 67\\" tooltipOptions={{...}}>
-                    <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Route 67\\" title=\\"Route 67\\">
+                    <a href=\\"/schedules/67/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Route 67\\">
                       <span className=\\"c-icon__bus-pill--small m-schedule-diagram__connection u-bg--bus\\">
                         67
                       </span>
@@ -284,12 +284,12 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                 </h4>
                 <div className=\\"m-schedule-diagram__features\\">
                   <TooltipWrapper tooltipText=\\"Parking\\" tooltipOptions={{...}}>
-                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\" title=\\"Parking\\">
+                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\">
                       <span className=\\"notranslate c-svg__icon-parking-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                     </span>
                   </TooltipWrapper>
                   <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\" title=\\"Accessible\\">
+                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                       <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                     </span>
                   </TooltipWrapper>
@@ -298,7 +298,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
               <div className=\\"m-schedule-diagram__stop-details\\">
                 <div className=\\"m-schedule-diagram__connections\\">
                   <TooltipWrapper href=\\"/schedules/BOAT-A/line\\" tooltipText=\\"Atlantis\\" tooltipOptions={{...}}>
-                    <a href=\\"/schedules/BOAT-A/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Atlantis\\" title=\\"Atlantis\\">
+                    <a href=\\"/schedules/BOAT-A/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Atlantis\\">
                       <span className=\\"m-schedule-diagram__connection\\">
                         <span className=\\"notranslate c-svg__icon-bus-small\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                       </span>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LiveCrowdingIconTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LiveCrowdingIconTest.tsx.snap
@@ -4,7 +4,7 @@ exports[`LiveCrowdingIcon with crowded renders and matches snapshot 1`] = `
 "<LiveCrowdingIcon crowding=\\"crowded\\">
   <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <TooltipWrapper tooltipText=\\"Currently <strong>crowded</strong>\\" tooltipOptions={{...}}>
-      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>crowded</strong>\\" title=\\"Currently <strong>crowded</strong>\\">
+      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>crowded</strong>\\">
         <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowded \\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
       </span>
     </TooltipWrapper>
@@ -16,7 +16,7 @@ exports[`LiveCrowdingIcon with not_crowded renders and matches snapshot 1`] = `
 "<LiveCrowdingIcon crowding=\\"not_crowded\\">
   <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <TooltipWrapper tooltipText=\\"Currently <strong>not crowded</strong>\\" tooltipOptions={{...}}>
-      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>not crowded</strong>\\" title=\\"Currently <strong>not crowded</strong>\\">
+      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>not crowded</strong>\\">
         <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--not_crowded \\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
       </span>
     </TooltipWrapper>
@@ -28,7 +28,7 @@ exports[`LiveCrowdingIcon with some_crowding renders and matches snapshot 1`] = 
 "<LiveCrowdingIcon crowding=\\"some_crowding\\">
   <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <TooltipWrapper tooltipText=\\"Currently <strong>some crowding</strong>\\" tooltipOptions={{...}}>
-      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>some crowding</strong>\\" title=\\"Currently <strong>some crowding</strong>\\">
+      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>some crowding</strong>\\">
         <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--some_crowding \\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
       </span>
     </TooltipWrapper>

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/VehicleIconsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/VehicleIconsTest.tsx.snap
@@ -5,21 +5,21 @@ exports[`VehicleIcons with vehicles renders and matches snapshot 1`] = `
   <VehicleIcons stop={{...}} vehicles={{...}}>
     <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
       <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 1 tooltip text</div>\\" tooltipOptions={{...}}>
-        <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 1 tooltip text</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 1 tooltip text</div>\\">
+        <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 1 tooltip text</div>\\">
           <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
         </span>
       </TooltipWrapper>
     </div>
     <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
       <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 2 tooltip text</div>\\" tooltipOptions={{...}}>
-        <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 2 tooltip text</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 2 tooltip text</div>\\">
+        <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 2 tooltip text</div>\\">
           <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
         </span>
       </TooltipWrapper>
     </div>
     <div className=\\"m-schedule-diagram__vehicle\\" style={{...}}>
       <TooltipWrapper tooltipText=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 3 tooltip text</div>\\" tooltipOptions={{...}}>
-        <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 3 tooltip text</div>\\" title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 3 tooltip text</div>\\">
+        <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"right\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"<div class=\\"m-schedule-diagram__vehicle-tooltip\\">vehicle 3 tooltip text</div>\\">
           <span className=\\"notranslate m-schedule-diagram__vehicle--icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
         </span>
       </TooltipWrapper>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [HTML displaying in title of vehicle icon](https://app.asana.com/0/385363666817452/1202074066973267/f)

removed title text from icons so that only the custom tooltips are displayed.

![image](https://user-images.githubusercontent.com/526017/164249106-6491634d-2a2c-44cd-903e-c0ee0d2fb976.png)
