### PR TITLE
fix: blank to/from trip planner. use address instead of description for trip planner controls 

### DIFF
--- a/apps/site/assets/js/trip-planner-location-controls.js
+++ b/apps/site/assets/js/trip-planner-location-controls.js
@@ -300,7 +300,7 @@ export class TripPlannerLocControls {
             const { latitude, longitude } = res;
             this.setAutocompleteValue(
               ac,
-              hit.description,
+              hit.address,
               lat,
               lng,
               latitude,


### PR DESCRIPTION
Auto complete result no longer populates a 'description' field for 'locations' type of results. Change the input to be populated w/ returned full address instead of leaving blank/null.

![image](https://user-images.githubusercontent.com/526017/164767811-c652b551-a3e1-4779-b610-a9b8a2450719.png)
