### PR TITLE
Make AWS Location Service place index configurable

### DIFF
--- a/apps/location_service/config/config.exs
+++ b/apps/location_service/config/config.exs
@@ -1,24 +1,14 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-# TODO: add aws keys and host(https://places.geo.us-east-1.amazonaws.com)
 use Mix.Config
 
 config :location_service, :http_pool, :google_http_pool
 
-if Mix.env() == :prod do
-  config :location_service,
-    google_api_key: "${GOOGLE_API_KEY}",
-    google_client_id: "${GOOGLE_MAPS_CLIENT_ID}",
-    google_signing_key: "${GOOGLE_MAPS_SIGNING_KEY}",
-    geocode: {:system, "LOCATION_SERVICE", :google},
-    reverse_geocode: {:system, "LOCATION_SERVICE", :google},
-    autocomplete: {:system, "LOCATION_SERVICE", :google}
-else
-  config :location_service,
-    google_api_key: System.get_env("GOOGLE_API_KEY"),
-    google_client_id: System.get_env("GOOGLE_MAPS_CLIENT_ID") || "",
-    google_signing_key: System.get_env("GOOGLE_MAPS_SIGNING_KEY") || "",
-    geocode: {:system, "LOCATION_SERVICE", :aws},
-    reverse_geocode: {:system, "LOCATION_SERVICE", :aws},
-    autocomplete: {:system, "LOCATION_SERVICE", :aws}
-end
+config :location_service,
+  google_api_key: System.get_env("GOOGLE_API_KEY"),
+  google_client_id: System.get_env("GOOGLE_MAPS_CLIENT_ID") || "",
+  google_signing_key: System.get_env("GOOGLE_MAPS_SIGNING_KEY") || "",
+  geocode: {:system, "LOCATION_SERVICE", :aws},
+  reverse_geocode: {:system, "LOCATION_SERVICE", :aws},
+  autocomplete: {:system, "LOCATION_SERVICE", :aws},
+  aws_index_prefix: {:system, "AWS_PLACE_INDEX_PREFIX", "dotcom-dev"}
+
+import_config "#{Mix.env()}.exs"

--- a/apps/location_service/config/dev.exs
+++ b/apps/location_service/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/apps/location_service/config/prod.exs
+++ b/apps/location_service/config/prod.exs
@@ -1,0 +1,10 @@
+use Mix.Config
+
+config :location_service,
+  google_api_key: "${GOOGLE_API_KEY}",
+  google_client_id: "${GOOGLE_MAPS_CLIENT_ID}",
+  google_signing_key: "${GOOGLE_MAPS_SIGNING_KEY}",
+  geocode: {:system, "LOCATION_SERVICE", :google},
+  reverse_geocode: {:system, "LOCATION_SERVICE", :google},
+  autocomplete: {:system, "LOCATION_SERVICE", :google},
+  aws_index_prefix: {:system, "AWS_PLACE_INDEX_PREFIX", "dotcom-prod"}

--- a/apps/location_service/config/test.exs
+++ b/apps/location_service/config/test.exs
@@ -1,0 +1,1 @@
+use Mix.Config


### PR DESCRIPTION
Requests to AWS Location Service are made to a specific place index. This PR stops hardcoding those index names (`dotcom-dev-here` and `dotcom-dev-esri`). 

It does assume that we'll keep naming place indexes in a "`prefix`-esri" and  "`prefix`-here" format. We already have `dotcom-prod-here` and `dotcom-prod-esri` set up with intended use for our production website. And we likely won't be making more place indexes anyway....