### PR TITLE
feat: add referrer to Algolia API request

### DIFF
--- a/apps/algolia/lib/algolia/update.ex
+++ b/apps/algolia/lib/algolia/update.ex
@@ -44,6 +44,7 @@ defmodule Algolia.Update do
   defp send_update({:ok, request}, base_url, index_module) do
     opts = %Api{
       host: base_url,
+      referrer: nil,
       index: index_module.index_name(),
       action: "batch",
       body: request

--- a/apps/algolia/test/api_test.exs
+++ b/apps/algolia/test/api_test.exs
@@ -22,6 +22,7 @@ defmodule Algolia.ApiTest do
 
       opts = %Algolia.Api{
         host: "http://localhost:#{bypass.port}",
+        referrer: nil,
         index: "*",
         action: "queries",
         body: @request
@@ -36,6 +37,7 @@ defmodule Algolia.ApiTest do
 
       opts = %Algolia.Api{
         host: "http://localhost:#{bypass.port}",
+        referrer: nil,
         index: "*",
         action: "queries",
         body: @request
@@ -47,6 +49,26 @@ defmodule Algolia.ApiTest do
         end)
 
       assert log =~ "missing Algolia config keys"
+    end
+
+    test "uses the referrer in the POST request header" do
+      bypass = Bypass.open()
+
+      referrer = "something.somewhere.com"
+
+      Bypass.expect(bypass, "POST", "/1/indexes/*/queries", fn conn ->
+        assert [referrer] = Plug.Conn.get_req_header(conn, "referrer")
+        Plug.Conn.send_resp(conn, 200, "")
+      end)
+
+      %Algolia.Api{
+        host: "http://localhost:#{bypass.port}",
+        referrer: referrer,
+        index: "*",
+        action: "queries",
+        body: @request
+      }
+      |> Algolia.Api.post()
     end
   end
 end

--- a/apps/site/lib/site_web/controllers/search_controller.ex
+++ b/apps/site/lib/site_web/controllers/search_controller.ex
@@ -55,6 +55,7 @@ defmodule SiteWeb.SearchController do
   def query(%Conn{} = conn, params) do
     %Api{
       host: conn.assigns[:algolia_host],
+      referrer: Conn.get_req_header(conn, "referrer") |> List.first(),
       index: "*",
       action: "queries",
       body: Query.build(params)

--- a/apps/site/test/site_web/controllers/search_controller_test.exs
+++ b/apps/site/test/site_web/controllers/search_controller_test.exs
@@ -14,11 +14,18 @@ defmodule SiteWeb.SearchControllerTest do
   end
 
   describe "query" do
+    setup %{conn: conn} do
+      conn = Plug.Conn.put_req_header(conn, "referrer", "something.somewhere.com")
+      %{conn: conn}
+    end
+
     @tag :capture_log
-    test "sends a POST to Algolia and returns the results", %{conn: conn} do
+    test "sends a POST with referrer to Algolia and returns the results", %{conn: conn} do
       bypass = Bypass.open()
 
       Bypass.expect(bypass, fn conn ->
+        assert ["something.somewhere.com"] = Plug.Conn.get_req_header(conn, "referrer")
+
         {status, resp} =
           case Plug.Conn.read_body(conn) do
             {:ok, ~s({"requests":[]}), %Plug.Conn{}} -> {200, ~s({"results": []})}


### PR DESCRIPTION
I was experimenting with adding some restrictions on the Algolia keys we use in our deployed applications. I'd added write and search keys to dev-blue that limit requests to those having (URL of dev-blue) as the referrer. It worked for other Algolia requests, but not this POST query.

This PR updates our request to include the `referrer` header value present on the `conn`. I will deploy it to dev-blue to see if my idea works!