### PR TITLE
feat: add Sentry support to the front-end

### DIFF
--- a/apps/site/assets/js/app.js
+++ b/apps/site/assets/js/app.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-// import * as Sentry from "@sentry/react";
+import * as Sentry from "@sentry/react";
 import "../vendor/fixedsticky";
 import "../vendor/accessible-date-picker";
 import "bootstrap/dist/js/umd/collapse";
@@ -46,11 +46,40 @@ import eventPageSetup from "./event-page-setup";
 import previousEventsButton from "./view-previous-events";
 import pslPageSetup from "./psl-page-setup.js";
 
-// if (window.sentry) {
-//   Sentry.init({
-//     dsn: window.sentry.dsn,
-//   });
-// }
+if (window.sentry) {
+  Sentry.init({
+    dsn: window.sentry.dsn,
+    environment: window.sentry.environment,
+    sampleRate: 0.005, // error sampling - might increase later
+    tags: { "dotcom.application": "frontend" },
+    beforeBreadcrumb: (breadcrumb, hint) => {
+      // omit breadcrumbs that are just these scripts
+      // making their incessant pinging
+      if (
+        breadcrumb.data?.url?.contains("clarity.ms") ||
+        breadcrumb.data?.url?.contains("doubleclick.net") ||
+        breadcrumb.data?.url?.contains("google-analytics.com")
+      ) {
+        return null;
+      }
+      return breadcrumb;
+    },
+    // ignoreErrors is a list of messages to be filtered out before
+    // being sent to Sentry as either regular expressions or strings.
+    // When using strings, they’ll partially match the messages
+    ignoreErrors: [
+      "removeClass(leaflet/dist/leaflet-src)",
+      "translate_",
+      "ResizeObserver loop limit exceeded",
+      "Non-Error promise rejection captured",
+      "Extension context invalidated",
+      "t._leaflet_id"
+    ],
+    // we don't care about errors from external tools and libraries
+    // so only allow errors from our own domains
+    allowUrls: [/https?:\/\/((cdn|www)\.)?mbta\.com/, /mbtace.com/]
+  });
+}
 
 document.body.className = document.body.className.replace("no-js", "js");
 

--- a/apps/site/assets/js/app.js
+++ b/apps/site/assets/js/app.js
@@ -1,6 +1,5 @@
 /* eslint-disable */
 // import * as Sentry from "@sentry/react";
-import { BrowserTracing } from "@sentry/tracing";
 import "../vendor/fixedsticky";
 import "../vendor/accessible-date-picker";
 import "bootstrap/dist/js/umd/collapse";
@@ -50,7 +49,6 @@ import pslPageSetup from "./psl-page-setup.js";
 // if (window.sentry) {
 //   Sentry.init({
 //     dsn: window.sentry.dsn,
-//     integrations: [new BrowserTracing()]
 //   });
 // }
 

--- a/apps/site/assets/package-lock.json
+++ b/apps/site/assets/package-lock.json
@@ -7,7 +7,6 @@
       "dependencies": {
         "@babel/polyfill": "^7.12.1",
         "@sentry/react": "^6.19.6",
-        "@sentry/tracing": "^6.19.6",
         "@types/dot-prop-immutable": "^1.5.0",
         "a11y-dialog": "^7.0.3",
         "algoliasearch": "^3.25.1",
@@ -132,10 +131,11 @@
       }
     },
     "../../../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.4.1",
+      "license": "MIT"
     },
     "../../../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "2.13.1"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.1.2",
@@ -2900,21 +2900,6 @@
       },
       "peerDependencies": {
         "react": "15.x || 16.x || 17.x || 18.x"
-      }
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.6.tgz",
-      "integrity": "sha512-STZdlEtTBqRmPw6Vjkzi/1kGkGPgiX0zdHaSOhSeA2HXHwx7Wnfu7veMKxtKWdO+0yW9QZGYOYqp0GVf4Swujg==",
-      "dependencies": {
-        "@sentry/hub": "6.19.6",
-        "@sentry/minimal": "6.19.6",
-        "@sentry/types": "6.19.6",
-        "@sentry/utils": "6.19.6",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@sentry/types": {
@@ -22884,18 +22869,6 @@
         "@sentry/types": "6.19.6",
         "@sentry/utils": "6.19.6",
         "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/tracing": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.6.tgz",
-      "integrity": "sha512-STZdlEtTBqRmPw6Vjkzi/1kGkGPgiX0zdHaSOhSeA2HXHwx7Wnfu7veMKxtKWdO+0yW9QZGYOYqp0GVf4Swujg==",
-      "requires": {
-        "@sentry/hub": "6.19.6",
-        "@sentry/minimal": "6.19.6",
-        "@sentry/types": "6.19.6",
-        "@sentry/utils": "6.19.6",
         "tslib": "^1.9.3"
       }
     },

--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
     "@sentry/react": "^6.19.6",
-    "@sentry/tracing": "^6.19.6",
     "@types/dot-prop-immutable": "^1.5.0",
     "a11y-dialog": "^7.0.3",
     "algoliasearch": "^3.25.1",

--- a/apps/site/assets/webpack.config.prod.js
+++ b/apps/site/assets/webpack.config.prod.js
@@ -36,7 +36,8 @@ module.exports = env =>
     },
     plugins: [
       new webpack.DefinePlugin({
-        SENTRY_DSN: JSON.stringify(env.SENTRY_DSN)
+        SENTRY_DSN: JSON.stringify(env.SENTRY_DSN),
+        __SENTRY_DEBUG__: false
       })
     ]
   });

--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -37,14 +37,10 @@ config :site, Site.BodyTag, mticket_header: "x-mticket"
 # Centralize Error reporting
 config :sentry,
   dsn: System.get_env("SENTRY_DSN") || "",
-  environment_name:
-    (case System.get_env("SENTRY_REPORTING_ENV") do
-       nil -> Mix.env()
-       env -> String.to_existing_atom(env)
-     end),
+  environment_name: System.get_env("SENTRY_ENVIRONMENT"),
   enable_source_code_context: false,
   root_source_code_path: File.cwd!(),
-  included_environments: [:prod],
+  included_environments: ~w(prod dev dev-green dev-blue),
   json_library: Poison,
   filter: Site.SentryFilter
 

--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -42,7 +42,8 @@ config :sentry,
   root_source_code_path: File.cwd!(),
   included_environments: ~w(prod dev dev-green dev-blue),
   json_library: Poison,
-  filter: Site.SentryFilter
+  filter: Site.SentryFilter,
+  tags: %{"dotcom.application" => "backend"}
 
 config :site, :former_mbta_site, host: "https://old.mbta.com"
 config :site, tile_server_url: "https://mbta-map-tiles-dev.s3.amazonaws.com"

--- a/apps/site/config/prod.exs
+++ b/apps/site/config/prod.exs
@@ -116,7 +116,9 @@ config :site, SiteWeb.ViewHelpers, google_tag_manager_id: "${GOOGLE_TAG_MANAGER_
 
 config :ehmon, :report_mf, {:ehmon, :info_report}
 
-config :sentry, dsn: "${SENTRY_DSN}"
+config :sentry,
+  dsn: "${SENTRY_DSN}",
+  environment_name: "${SENTRY_ENVIRONMENT}"
 
 config :site, OldSiteFileController,
   response_fn: {SiteWeb.OldSiteFileController, :redirect_through_cdn}

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -31,7 +31,8 @@
     <%= if Application.get_env(:sentry, :dsn) do %>
       <script>
         window.sentry = {
-          dsn: "<%= Application.get_env(:sentry, :dsn) %>"
+          dsn: "<%= Application.get_env(:sentry, :dsn) %>",
+          environment: "<%= Application.get_env(:sentry, :environment_name) %>"
         }
       </script>
     <% end %>


### PR DESCRIPTION
This is a reworked version of https://github.com/mbta/dotcom/pull/1272

This follows closely with other applications under the CTD umbrella - for example https://github.com/mbta/signs_ui/pull/525

* includes support for multiple environments - this will be an environment variable in our deployed applications set to `prod`, `dev`, `dev-green` or `dev-blue`
* adds a new tag, `dotcom.application` that will let us filter Sentry issues by backend vs frontend
* removed `@sentry/tracing` because I don't think our Sentry plan supports transactions anyway