### PR TITLE
Add alerts to project pages

### DIFF
--- a/apps/site/assets/css/_project.scss
+++ b/apps/site/assets/css/_project.scss
@@ -62,3 +62,32 @@
 .m-project-updates__title {
   margin-top: 0;
 }
+
+.alerts-section {
+  summary {
+    &::marker, &::-webkit-details-marker {
+      display: none;
+    }
+    list-style: none;
+
+    display: inline-block;
+    color: $brand-primary;
+    padding: 0.5em 0;
+
+    &::after {
+      @extend %fa-icon;
+      @extend .fa-solid;
+      margin-left: 0.5em;
+
+      content: fa-content($fa-var-angle-down);
+    }
+
+    cursor: pointer;
+  }
+
+  details[open] {
+    summary::after {
+      content: fa-content($fa-var-angle-up);
+    }
+  }
+}

--- a/apps/site/lib/site_web/controllers/cms_controller.ex
+++ b/apps/site/lib/site_web/controllers/cms_controller.ex
@@ -107,11 +107,14 @@ defmodule SiteWeb.CMSController do
       Breadcrumb.build(project.title)
     ]
 
+    conn = assign(conn, :alerts, Alerts.Repo.all(conn.assigns.date_time))
+
     render_generic(conn, project, breadcrumbs)
   end
 
   defp render_page(conn, %Page.ProjectUpdate{} = update) do
     base = ProjectController.get_breadcrumb_base()
+    conn = assign(conn, :alerts, Alerts.Repo.all(conn.assigns.date_time))
 
     case Repo.get_page(update.project_url) do
       %Page.Project{} = project ->

--- a/apps/site/lib/site_web/templates/alert/_item.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_item.html.eex
@@ -18,7 +18,7 @@
       </div>
       <div>
         <%= replace_urls_with_links(@alert.header) %>
-        <%= if @alert.url != nil && @alert.url != "" do %>
+        <%= if @alert.url != nil && @alert.url != "" && !@hide_url do %>
           <span>&nbsp;</span>
           <%= replace_urls_with_links(@alert.url) %>
         <% end %>

--- a/apps/site/lib/site_web/templates/alert/group.html.eex
+++ b/apps/site/lib/site_web/templates/alert/group.html.eex
@@ -1,5 +1,5 @@
 <ul class="c-alert-group">
   <%= for alert <- @alerts do %>
-    <%= render "_item.html", alert: alert, extra_id: @route.id, date_time: @date_time %>
+    <%= render "_item.html", alert: alert, date_time: @date_time, hide_url: assigns[:hide_urls] %>
   <% end %>
 </ul>

--- a/apps/site/lib/site_web/templates/cms/page/_alerts.html.eex
+++ b/apps/site/lib/site_web/templates/cms/page/_alerts.html.eex
@@ -1,8 +1,5 @@
 <div class="alerts-section">
-  <%
-    paths = MapSet.new([@page.path_alias | @page.redirects])
-    alerts = Enum.filter(@alerts, & alert_related?(paths, &1))
-  %>
+  <% alerts = alerts_for_project(@page, @alerts) %>
   <%= if !Enum.empty?(alerts) do %>
     <h2>Related Service Alerts</h2>
     <details>

--- a/apps/site/lib/site_web/templates/cms/page/_alerts.html.eex
+++ b/apps/site/lib/site_web/templates/cms/page/_alerts.html.eex
@@ -1,0 +1,13 @@
+<div class="alerts-section">
+  <%
+    paths = MapSet.new([@page.path_alias | @page.redirects])
+    alerts = Enum.filter(@alerts, & alert_related?(paths, &1))
+  %>
+  <%= if !Enum.empty?(alerts) do %>
+    <h2>Related Service Alerts</h2>
+    <details>
+      <summary>Details</summary>
+      <%= render(SiteWeb.AlertView, "group.html", alerts: alerts, date_time: @date_time, hide_urls: true) %>
+    </details>
+  <% end %>
+</div>

--- a/apps/site/lib/site_web/templates/cms/page/_project.html.eex
+++ b/apps/site/lib/site_web/templates/cms/page/_project.html.eex
@@ -8,6 +8,13 @@
   </div>
 <% end %>
 
+<%= render(
+  "_alerts.html",
+  alerts: @conn.assigns.alerts,
+  date_time: @conn.assigns.date_time,
+  page: @page
+) %>
+
 <div class="page-section">
   <%= Site.ContentRewriter.rewrite(@page.body, @conn) %>
 

--- a/apps/site/lib/site_web/views/page_content_view.ex
+++ b/apps/site/lib/site_web/views/page_content_view.ex
@@ -121,4 +121,11 @@ defmodule SiteWeb.CMS.PageView do
         Enum.any?(alert_project_paths, &MapSet.member?(project_paths, &1))
     end
   end
+
+  @spec alerts_for_project(Page.Project.t(), [Alerts.Alert]) :: [Alerts.Alert]
+  defp alerts_for_project(project, alerts) do
+    paths = MapSet.new([project.path_alias | project.redirects])
+
+    Enum.filter(alerts, & alert_related?(paths, &1))
+  end
 end

--- a/apps/site/lib/site_web/views/page_content_view.ex
+++ b/apps/site/lib/site_web/views/page_content_view.ex
@@ -81,4 +81,44 @@ defmodule SiteWeb.CMS.PageView do
       false
     end
   end
+
+  # TODO(Nick): once we move away from linking to project update URLs, we can
+  # most likely delete this function
+  @spec get_project_url_paths(String.t()) :: [String.t()]
+  def get_project_url_paths(s) do
+    if String.contains?(s, "/projects") do
+      if String.contains?(s, "/update") do
+        [s, Regex.replace(~r/\/update.*/, s, "")]
+      else
+        [s]
+      end
+    else
+      []
+    end
+  end
+
+  @spec get_mbta_url_path(String.t() | nil) :: String.t() | nil
+  defp get_mbta_url_path(nil), do: nil
+
+  defp get_mbta_url_path(path) do
+    uri = URI.parse(path)
+
+    if uri.host != nil and String.contains?(uri.host, "mbta.com") do
+      uri.path
+    else
+      nil
+    end
+  end
+
+  @spec alert_related?(MapSet.t(), Alerts.Alert.t()) :: boolean()
+  defp alert_related?(project_paths, alert) do
+    case get_mbta_url_path(alert.url) do
+      nil ->
+        false
+
+      alert_path ->
+        alert_project_paths = get_project_url_paths(alert_path)
+        Enum.any?(alert_project_paths, &MapSet.member?(project_paths, &1))
+    end
+  end
 end

--- a/apps/site/lib/site_web/views/page_content_view.ex
+++ b/apps/site/lib/site_web/views/page_content_view.ex
@@ -126,6 +126,6 @@ defmodule SiteWeb.CMS.PageView do
   defp alerts_for_project(project, alerts) do
     paths = MapSet.new([project.path_alias | project.redirects])
 
-    Enum.filter(alerts, & alert_related?(paths, &1))
+    Enum.filter(alerts, &alert_related?(paths, &1))
   end
 end

--- a/apps/site/test/site_web/views/page_content_view_test.exs
+++ b/apps/site/test/site_web/views/page_content_view_test.exs
@@ -78,10 +78,13 @@ defmodule SiteWeb.CMS.PageViewTest do
 
   describe "project alerts" do
     test "renders project with no alerts" do
-      conn = %{ assigns: %{
-        alerts: [],
-        date_time: DateTime.utc_now(),
-      } }
+      conn = %{
+        assigns: %{
+          alerts: [],
+          date_time: DateTime.utc_now()
+        }
+      }
+
       project = %Project{id: 0}
 
       rendered =
@@ -94,13 +97,18 @@ defmodule SiteWeb.CMS.PageViewTest do
     end
 
     test "renders project with alerts" do
-      conn = %{ assigns: %{
-        alerts: [%Alerts.Alert {
-          url: "http://mbta.com/projects/test",
-        }],
-        date_time: DateTime.utc_now(),
-      } }
-      project = %Project{id: 0, path_alias: "/projects/test", }
+      conn = %{
+        assigns: %{
+          alerts: [
+            %Alerts.Alert{
+              url: "http://mbta.com/projects/test"
+            }
+          ],
+          date_time: DateTime.utc_now()
+        }
+      }
+
+      project = %Project{id: 0, path_alias: "/projects/test"}
 
       rendered =
         project

--- a/apps/site/test/site_web/views/page_content_view_test.exs
+++ b/apps/site/test/site_web/views/page_content_view_test.exs
@@ -3,7 +3,7 @@ defmodule SiteWeb.CMS.PageViewTest do
 
   import SiteWeb.CMS.PageView
 
-  alias CMS.Page.Basic
+  alias CMS.Page.{Basic, Project}
   alias CMS.Partial.Paragraph.{ContentList, CustomHTML}
   alias Phoenix.HTML
 
@@ -73,6 +73,43 @@ defmodule SiteWeb.CMS.PageViewTest do
       }
 
       refute has_right_rail?(page)
+    end
+  end
+
+  describe "project alerts" do
+    test "renders project with no alerts" do
+      conn = %{ assigns: %{
+        alerts: [],
+        date_time: DateTime.utc_now(),
+      } }
+      project = %Project{id: 0}
+
+      rendered =
+        project
+        |> render_page(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "page-section"
+      assert rendered =~ "alerts-section"
+    end
+
+    test "renders project with alerts" do
+      conn = %{ assigns: %{
+        alerts: [%Alerts.Alert {
+          url: "http://mbta.com/projects/test",
+        }],
+        date_time: DateTime.utc_now(),
+      } }
+      project = %Project{id: 0, path_alias: "/projects/test", }
+
+      rendered =
+        project
+        |> render_page(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "page-section"
+      assert rendered =~ "alerts-section"
+      assert rendered =~ "Related Service Alerts"
     end
   end
 end

--- a/apps/site/test/site_web/views/project_contact_test.exs
+++ b/apps/site/test/site_web/views/project_contact_test.exs
@@ -11,10 +11,9 @@ defmodule SiteWeb.CMS.Page.ProjectContactTest do
     assigns: %{
       alerts: [],
       date_time: DateTime.utc_now(),
-      page: %{redirects: [], page_alias: 'n/a'}
     }
   }
-  @project %Project{id: 1}
+  @project %Project{id: 1, path_alias: "/projects/test"}
 
   describe "_contact.html" do
     test ".project-contact is not rendered if no data is available" do
@@ -123,6 +122,24 @@ defmodule SiteWeb.CMS.Page.ProjectContactTest do
         |> HTML.safe_to_string()
 
       assert output =~ "contact-element-phone"
+    end
+
+    test ".contact-element-email is rendered with alerts" do
+      project = %{@project | media_email: "present"}
+      conn = %{@conn | assigns: %{ @conn.assigns | alerts: [%Alerts.Alert{
+        url: "http://mbta.com/projects/test",
+        priority: :high,
+        description: "Test Alert",
+        effect: :cancellation,
+      }]}}
+
+      output =
+        project
+        |> render_page_content(conn)
+        |> HTML.safe_to_string()
+
+      assert output =~ "contact-element-email"
+      assert output =~ "Related Service Alerts"
     end
   end
 end

--- a/apps/site/test/site_web/views/project_contact_test.exs
+++ b/apps/site/test/site_web/views/project_contact_test.exs
@@ -10,7 +10,7 @@ defmodule SiteWeb.CMS.Page.ProjectContactTest do
   @conn %Conn{
     assigns: %{
       alerts: [],
-      date_time: DateTime.utc_now(),
+      date_time: DateTime.utc_now()
     }
   }
   @project %Project{id: 1, path_alias: "/projects/test"}
@@ -126,12 +126,21 @@ defmodule SiteWeb.CMS.Page.ProjectContactTest do
 
     test ".contact-element-email is rendered with alerts" do
       project = %{@project | media_email: "present"}
-      conn = %{@conn | assigns: %{ @conn.assigns | alerts: [%Alerts.Alert{
-        url: "http://mbta.com/projects/test",
-        priority: :high,
-        description: "Test Alert",
-        effect: :cancellation,
-      }]}}
+
+      conn = %{
+        @conn
+        | assigns: %{
+            @conn.assigns
+            | alerts: [
+                %Alerts.Alert{
+                  url: "http://mbta.com/projects/test",
+                  priority: :high,
+                  description: "Test Alert",
+                  effect: :cancellation
+                }
+              ]
+          }
+      }
 
       output =
         project

--- a/apps/site/test/site_web/views/project_contact_test.exs
+++ b/apps/site/test/site_web/views/project_contact_test.exs
@@ -7,7 +7,13 @@ defmodule SiteWeb.CMS.Page.ProjectContactTest do
   alias Phoenix.HTML
   alias Plug.Conn
 
-  @conn %Conn{}
+  @conn %Conn{
+    assigns: %{
+      alerts: [],
+      date_time: DateTime.utc_now(),
+      page: %{redirects: [], page_alias: 'n/a'}
+    }
+  }
   @project %Project{id: 1}
 
   describe "_contact.html" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Display alerts list on project page](https://app.asana.com/0/385363666817452/1200671244979944/f)

**NOTE**: This also closes [this ticket](https://app.asana.com/0/385363666817452/1200311487753031/f)

![2022-05-23_13-34](https://user-images.githubusercontent.com/5061820/169875852-75a437e1-0745-41a5-b9d1-496bc8544c8e.png)
![2022-05-23_13-34_2](https://user-images.githubusercontent.com/5061820/169875866-ffed4500-fbad-42dd-a22c-d0a23058fd23.png)

Some changes from the design:
- The design calls for this section to be below the header image on the page. However, the header image comes back to us as a "section" of the content we get from the CMS. We could probably do some smarts to properly split the image from the rest of the sections and inject this section, but I think it'll be relatively tricky. Steve gave the go-ahead for keeping it at the top for now, and we can circle back to this later if need be.
- I changed the "Show / Hide Alerts" text to be a static "Details". The switch between "Show Alerts" and "Hide Alerts" was causing annoying visual shifting of the dropdown indicator, and I'm not aware of a good solution to set the width of the element to the greater of the two. If anyone has any ideas here, let me know.