### PR TITLE
Inject alerts section after first image

### DIFF
--- a/apps/site/assets/css/_project.scss
+++ b/apps/site/assets/css/_project.scss
@@ -90,4 +90,9 @@
       content: fa-content($fa-var-angle-up);
     }
   }
+
+  details {
+    border-bottom: 2px solid $gray-lightest;
+    margin-bottom: 1em;
+  }
 }

--- a/apps/site/lib/site_web/templates/cms/page/_project.html.eex
+++ b/apps/site/lib/site_web/templates/cms/page/_project.html.eex
@@ -8,15 +8,8 @@
   </div>
 <% end %>
 
-<%= render(
-  "_alerts.html",
-  alerts: @conn.assigns.alerts,
-  date_time: @conn.assigns.date_time,
-  page: @page
-) %>
-
 <div class="page-section">
-  <%= Site.ContentRewriter.rewrite(@page.body, @conn) %>
+  <%= body_with_alerts_section(@conn, @page) %>
 
   <%= for paragraph <- @page.paragraphs do %>
     <%= SiteWeb.CMS.ParagraphView.render_paragraph(paragraph, @conn) %>

--- a/apps/site/test/site_web/views/page_content_view_test.exs
+++ b/apps/site/test/site_web/views/page_content_view_test.exs
@@ -120,4 +120,39 @@ defmodule SiteWeb.CMS.PageViewTest do
       assert rendered =~ "Related Service Alerts"
     end
   end
+
+  describe "body_with_alerts_section/2" do
+    test "injects alerts section after figure if present" do
+      conn = %{assigns: %{alerts: [], date_time: DateTime.utc_now()}}
+
+      page = %{
+        body: {:safe, "<figure><img></img></figure><p></p>"},
+        path_alias: "/test",
+        redirects: []
+      }
+
+      {:safe, content} = body_with_alerts_section(conn, page)
+      content = Enum.join(content, "")
+
+      [{figure_index, _}] = Regex.run(~r/<figure>/, content, return: :index)
+      [{alerts_section_index, _}] = Regex.run(~r/alerts-section/, content, return: :index)
+      [{p_tag_index, _}] = Regex.run(~r/<p>/, content, return: :index)
+
+      assert figure_index < alerts_section_index
+      assert alerts_section_index < p_tag_index
+    end
+
+    test "renders alerts section first if figure not present" do
+      conn = %{assigns: %{alerts: [], date_time: DateTime.utc_now()}}
+      page = %{body: {:safe, "<p></p><div></div>"}, path_alias: "/test", redirects: []}
+
+      {:safe, content} = body_with_alerts_section(conn, page)
+      content = Enum.join(content, "")
+
+      [{alerts_section_index, _}] = Regex.run(~r/alerts-section/, content, return: :index)
+      [{p_tag_index, _}] = Regex.run(~r/<p>/, content, return: :index)
+
+      assert alerts_section_index < p_tag_index
+    end
+  end
 end


### PR DESCRIPTION
### Summary of Changes

![2022-05-25_11-58](https://user-images.githubusercontent.com/5061820/170305954-95801274-de73-434a-baea-445286fec1ad.png)

This injects the alerts section after the first `<figure>` tag present in the `body` of a project page. If a `<figure>` tag is not the first tag, the alerts section is injected before the first element.

I believe this should be (reasonably) robust if for some reason the `<figure>` tag is missing, but let me know if I'm missing anything.

