### PR TITLE
Fix part of alert icon is blue on line diagrams

### DIFF
--- a/apps/site/assets/css/_schedule-page-line-diagram.scss
+++ b/apps/site/assets/css/_schedule-page-line-diagram.scss
@@ -85,11 +85,6 @@
   a {
     font-weight: bold;
   }
-
-  // renders blue (link color) alert icons instead of black
-  .c-svg__icon-alerts-triangle path:not(:nth-child(1)) {
-    fill: currentColor;
-  }
 }
 
 // Access, parking, commuter rail zone etc. icons


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Part of alert icon is blue on line diagrams](https://app.asana.com/0/385363666817452/1202341293911737/f)

Make ! on alert icon one consistent color.