### PR TITLE
Fix line diagram / map crash when spam clicking "Change Direction"

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
@@ -3,12 +3,12 @@ import { hasBranchLines } from "./line-diagram-helpers";
 import Diagram from "./graphics/Diagram";
 import StopListWithBranches from "./StopListWithBranches";
 import { CommonLineDiagramProps } from "./__line-diagram";
-import useStopPositions, { RefList } from "./graphics/useStopPositions";
+import useStopPositions, { RefMap } from "./graphics/useStopPositions";
 import StopCard from "./StopCard";
 import { hasPredictionTime } from "../../../models/prediction";
 
-export const StopRefContext = React.createContext<[RefList, () => void]>([
-  {},
+export const StopRefContext = React.createContext<[RefMap, () => void]>([
+  new Map(),
   () => {}
 ]);
 

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -90,7 +90,7 @@ const StopCard = (props: StopCardProps): ReactElement<HTMLElement> => {
         )}
         <header
           className="m-schedule-diagram__stop-heading"
-          ref={refs[routeStop.id]}
+          ref={(el) => refs.set(routeStop.id, el)}
         >
           <h4 className="m-schedule-diagram__stop-link notranslate">
             <a href={`/stops/${routeStop.id}`}>

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/useStopPositions.ts
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/useStopPositions.ts
@@ -4,16 +4,7 @@ import { LineDiagramStop } from "../../__schedule";
 import { isMergeStop } from "../line-diagram-helpers";
 import { BASE_LINE_WIDTH, BRANCH_SPACING } from "./graphic-helpers";
 
-export interface RefList {
-  [key: string]: React.MutableRefObject<HTMLElement | null>;
-}
-
-function useStopRef(prev: RefList, stop: LineDiagramStop): RefList {
-  return {
-    ...prev,
-    [stop.route_stop.id]: useRef<HTMLElement>(null)
-  };
-}
+export type RefMap = Map<string, HTMLElement | null>;
 
 const stopById = (stopId: string): ((stop: LineDiagramStop) => boolean) =>
   // eslint-disable-next-line camelcase
@@ -29,15 +20,20 @@ const xCoordForStop = (stop: LineDiagramStop): number => {
 
 export default function useStopPositions(
   stops: LineDiagramStop[]
-): [RefList, () => void] {
-  const stopRefsMap: RefList = stops.reduce(useStopRef, {});
+): [RefMap, () => void] {
+  const stopRefsMap = useRef(new Map() as RefMap);
   const dispatchStopCoords = useDispatch();
   const updateAllStops = useCallback((): void => {
-    Object.entries(stopRefsMap).forEach(([stopId, ref]) => {
-      const x = xCoordForStop(stops.find(stopById(stopId))!);
+    stopRefsMap.current.forEach((el, stopId) => {
+      const stop = stops.find(stopById(stopId));
+      if (!stop) {
+        return;
+      }
+
+      const x = xCoordForStop(stop);
       let coordinates = null;
-      if (ref && ref.current) {
-        const { offsetTop, offsetHeight } = ref.current;
+      if (el) {
+        const { offsetTop, offsetHeight } = el;
         const y = offsetTop + offsetHeight / 2;
         coordinates = [x, y];
       }
@@ -55,5 +51,5 @@ export default function useStopPositions(
     return () => window.removeEventListener("resize", updateAllStops);
   }, [updateAllStops]);
 
-  return [stopRefsMap, updateAllStops];
+  return [stopRefsMap.current, updateAllStops];
 }


### PR DESCRIPTION
For some lines (noticed on bus routes), the number of stops we get back differs when reversing directions. Previously, we were looping over these stops and calling `useRef` for each one. This breaks one of the rules of hooks: https://reactjs.org/docs/hooks-rules.html

When rapidly clicking the "change directions" button, occasionally the line diagram and map would blow up with a message about calling hooks out of order, which is a symptom of the above issue. This change addresses this by instead using a single ref with `Map` from `stopId`s to `HTMLElement`s, rather creating a `ref` for each stop.

While I have not been able to reproduce the page crash locally after applying these changes, I have a feeling this does not address the "true" root cause (some sort of race condition / stale data? I'm still not 100% sure).

The original reason for digging into this was to address an issue that appears
to only manifest on iOS where clicking the change direction button _once_ would break the page. Since the effects of both (i.e. the line diagram and map disappear) are the same, I _hope_ that this will also fix that issue, but I'm not 100% certain that it will.
