### PR TITLE
Access :hide_url via assigns map

### DIFF
--- a/apps/site/lib/site_web/templates/alert/_item.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_item.html.eex
@@ -18,7 +18,7 @@
       </div>
       <div>
         <%= replace_urls_with_links(@alert.header) %>
-        <%= if @alert.url != nil && @alert.url != "" && !@hide_url do %>
+        <%= if @alert.url != nil && @alert.url != "" && !Map.get(assigns, :hide_url, false) do %>
           <span>&nbsp;</span>
           <%= replace_urls_with_links(@alert.url) %>
         <% end %>


### PR DESCRIPTION
This prevents a page rendering error when the assign isn't present (e.g.
for trip planner alerts)
