### PR TITLE
Change project alerts related alerts logic

### DIFF
--- a/apps/site/lib/site_web/views/page_content_view.ex
+++ b/apps/site/lib/site_web/views/page_content_view.ex
@@ -107,12 +107,8 @@ defmodule SiteWeb.CMS.PageView do
   end
 
   @spec trim_and_downcase(String.t() | nil) :: String.t()
-  defp trim_and_downcase(s) do
-    case s do
-      nil -> nil
-      s -> String.downcase(String.trim(s))
-    end
-  end
+  defp trim_and_downcase(nil), do: nil
+  defp trim_and_downcase(s), do: String.downcase(String.trim(s))
 
   @spec alert_related?(MapSet.t(), Alerts.Alert.t()) :: boolean()
   defp alert_related?(project_paths, alert) do

--- a/apps/site/lib/site_web/views/page_content_view.ex
+++ b/apps/site/lib/site_web/views/page_content_view.ex
@@ -118,9 +118,9 @@ defmodule SiteWeb.CMS.PageView do
 
       alert_path ->
         alert_path
-        |> get_project_url_paths(alert_path)
+        |> get_project_url_paths()
         |> Enum.map(&trim_and_downcase/1)
-        |> Enum.any(&MapSet.member?(project_paths, &1))
+        |> Enum.any?(&MapSet.member?(project_paths, &1))
     end
   end
 

--- a/apps/site/lib/site_web/views/page_content_view.ex
+++ b/apps/site/lib/site_web/views/page_content_view.ex
@@ -117,17 +117,19 @@ defmodule SiteWeb.CMS.PageView do
         false
 
       alert_path ->
-        alert_project_paths = get_project_url_paths(alert_path)
-        alert_project_paths = Enum.map(alert_project_paths, &trim_and_downcase/1)
-
-        Enum.any?(alert_project_paths, &MapSet.member?(project_paths, &1))
+        alert_path
+        |> get_project_url_paths(alert_path)
+        |> Enum.map(&trim_and_downcase/1)
+        |> Enum.any(&MapSet.member?(project_paths, &1))
     end
   end
 
   @spec alerts_for_project(Page.Project.t(), [Alerts.Alert]) :: [Alerts.Alert]
   defp alerts_for_project(project, alerts) do
-    paths = [project.path_alias | project.redirects]
-    paths = MapSet.new(Enum.map(paths, &trim_and_downcase/1))
+    paths =
+      [project.path_alias | project.redirects]
+      |> Enum.map(&trim_and_downcase/1)
+      |> MapSet.new()
 
     Enum.filter(alerts, &alert_related?(paths, &1))
   end

--- a/apps/site/test/site_web/views/page_content_view_test.exs
+++ b/apps/site/test/site_web/views/page_content_view_test.exs
@@ -119,6 +119,30 @@ defmodule SiteWeb.CMS.PageViewTest do
       assert rendered =~ "alerts-section"
       assert rendered =~ "Related Service Alerts"
     end
+
+    test "renders project with alerts, redirect with different casing" do
+      conn = %{
+        assigns: %{
+          alerts: [
+            %Alerts.Alert{
+              url: "http://mbta.com/NorthQuincy"
+            }
+          ],
+          date_time: DateTime.utc_now()
+        }
+      }
+
+      project = %Project{id: 0, path_alias: "/projects/test", redirects: ["/northquincy"]}
+
+      rendered =
+        project
+        |> render_page(conn)
+        |> HTML.safe_to_string()
+
+      assert rendered =~ "page-section"
+      assert rendered =~ "alerts-section"
+      assert rendered =~ "Related Service Alerts"
+    end
   end
 
   describe "body_with_alerts_section/2" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Linked alerts not displaying on project pages](https://app.asana.com/0/555089885850811/1202368368463960/f)

- Ignore casing in paths
- No longer ignore URLs that don't have `/project` in them. We sometimes
  create "vanity URLs" which link to project pages, so this accounts for
  them


