### PR TITLE
Add user guides section to homepage

### DIFF
--- a/apps/site/assets/css/_homepage.scss
+++ b/apps/site/assets/css/_homepage.scss
@@ -238,8 +238,14 @@
     }
 
     @include media-breakpoint-down(xs) {
+      margin-bottom: 1.5rem;
+
       h2 {
         flex: 0 0 100%;
+      }
+
+      a {
+        margin-top: 0.75rem;
       }
     }
   }

--- a/apps/site/assets/css/_homepage.scss
+++ b/apps/site/assets/css/_homepage.scss
@@ -223,3 +223,56 @@
     max-width: 18rem;
   }
 }
+
+.homepage-user-guides {
+  header {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0 1rem;
+    align-items: flex-end;
+    margin: 1rem 0;
+
+    h2 {
+      margin: 0;
+    }
+
+    @include media-breakpoint-down(xs) {
+      h2 {
+        flex: 0 0 100%;
+      }
+    }
+  }
+
+  img {
+    max-width: 100%;
+  }
+
+  .user-guides {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+
+    padding-bottom: 1rem;
+
+    overflow-x: auto;
+    max-width: 100%;
+
+    .guide {
+      display: block;
+      min-width: 230px;
+
+      color: inherit;
+      text-decoration: none;
+
+      h3 {
+        margin: 0;
+        margin-top: 0.5rem;
+      }
+
+      &:hover {
+        color: $brand-primary;
+      }
+    }
+  }
+}

--- a/apps/site/lib/site_web/templates/page/_user_guides.html.eex
+++ b/apps/site/lib/site_web/templates/page/_user_guides.html.eex
@@ -27,7 +27,7 @@
       %>
       <%= for {header, image, link} <- guides do %>
         <a class="guide" href="<%= link %>">
-          <img src="<%= image %>"></img>
+          <img src="<%= image %>" alt='Decorative graphic for "<%= header %>"'></img>
           <h3><%= header %></h3>
         </a>
       <% end %>

--- a/apps/site/lib/site_web/templates/page/_user_guides.html.eex
+++ b/apps/site/lib/site_web/templates/page/_user_guides.html.eex
@@ -15,7 +15,7 @@
           },
           {
             "Subway Beginner's Guide",
-            "http://localhost:4001/sites/default/files/styles/max_2600x2600/public/media/2018-12/Subway-Wordless-for-homepage-revised-2018-12-11.png",
+            "/sites/default/files/styles/max_2600x2600/public/media/2018-12/Subway-Wordless-for-homepage-revised-2018-12-11.png",
             "/guides/subway-guide",
           },
           {

--- a/apps/site/lib/site_web/templates/page/_user_guides.html.eex
+++ b/apps/site/lib/site_web/templates/page/_user_guides.html.eex
@@ -27,7 +27,7 @@
       %>
       <%= for {header, image, link} <- guides do %>
         <a class="guide" href="<%= link %>">
-          <img src="<%= image %>" alt='Decorative graphic for "<%= header %>"'></img>
+          <img src="<%= image %>" alt=""></img>
           <h3><%= header %></h3>
         </a>
       <% end %>

--- a/apps/site/lib/site_web/templates/page/_user_guides.html.eex
+++ b/apps/site/lib/site_web/templates/page/_user_guides.html.eex
@@ -1,0 +1,36 @@
+<section class="homepage-user-guides page-section">
+  <div class="container">
+    <header class="section-header">
+      <h2>MBTA User Guides</h2>
+      <a href="/guides" class="c-call-to-action">See all user guides</a>
+    </header>
+    <div class="user-guides">
+      <%
+        guides = [
+          {
+            # &nbsp; used to prevent orphan `T` wrapping
+            {:safe, "Boston Visitor's Guide to The&nbsp;T"},
+            "/sites/default/files/styles/max_2600x2600/public/media/2018-11/Guides-General-HomepageWordless.png",
+            "/guides/boston-visitor-guide",
+          },
+          {
+            "Subway Beginner's Guide",
+            "http://localhost:4001/sites/default/files/styles/max_2600x2600/public/media/2018-12/Subway-Wordless-for-homepage-revised-2018-12-11.png",
+            "/guides/subway-guide",
+          },
+          {
+            "Bus Beginner's Guide",
+            "/sites/default/files/styles/max_2600x2600/public/media/2018-12/Guides-Bus-Singleword-revised-2018-12-11.png",
+            "/guides/bus-guide",
+          },
+        ]
+      %>
+      <%= for {header, image, link} <- guides do %>
+        <a class="guide" href="<%= link %>">
+          <img src="<%= image %>"></img>
+          <h3><%= header %></h3>
+        </a>
+      <% end %>
+    </div>
+  </container>
+</section>

--- a/apps/site/lib/site_web/templates/page/index.html.eex
+++ b/apps/site/lib/site_web/templates/page/index.html.eex
@@ -19,5 +19,6 @@
   <%= render SiteWeb.PageView, "_news_and_updates.html", conn: @conn, news: @news %>
   <%= render SiteWeb.PageView, "_whats_happening.html", conn: @conn, whats_happening_items: @whats_happening_items, promoted: false %>
   <%= if assigns[:homepage_fares], do: render SiteWeb.PageView, "_fares_passes.html", conn: @conn, homepage_fares: @homepage_fares %>
+  <%= render SiteWeb.PageView, "_user_guides.html", conn: @conn %>
   <%= render SiteWeb.PageView, "_important_links.html", conn: @conn %>
 </div>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ["MBTA User Guides" section](https://app.asana.com/0/555089885850811/1202075661172622/f)

There's probably some unification work that can be done with the "What's Happening" sections, but those need different enough logic to render them that I didn't do it here.

**NOTE**: The Abstract designs linked in the ticket have slightly different properties than the existing "What's Happening" section. For the most part I've opted to match Abstract, so there are slight differences between how these sections look.

![Screen Shot 2022-06-06 at 13 51 32](https://user-images.githubusercontent.com/5061820/172217264-1159a72f-f42b-432b-ac05-bbe174cc2c82.png)
![Screen Shot 2022-06-06 at 13 51 25](https://user-images.githubusercontent.com/5061820/172217266-feee6d0c-5bd4-4249-8967-80cfa1cab4af.png)
![Screen Shot 2022-06-06 at 13 51 15](https://user-images.githubusercontent.com/5061820/172217267-82045df5-1e5c-4948-81af-4387243a3132.png)
![Screen Shot 2022-06-06 at 13 51 09](https://user-images.githubusercontent.com/5061820/172217268-a4d7bd04-142c-4c07-b6d9-4c9fc917c133.png)
![Screen Shot 2022-06-06 at 13 50 59](https://user-images.githubusercontent.com/5061820/172217271-8259f623-b0fe-4b46-b0d3-434d7d5051c3.png)

