### PR TITLE
fix for Map and line diagram disappear when changing direction

### DIFF
--- a/apps/site/assets/css/leaflet.scss
+++ b/apps/site/assets/css/leaflet.scss
@@ -1,4 +1,3 @@
-@import 'node_modules/react-leaflet-fullscreen/dist/styles';
 @import 'variables';
 @import 'colors';
 

--- a/apps/site/assets/package-lock.json
+++ b/apps/site/assets/package-lock.json
@@ -35,7 +35,6 @@
         "react": "^16.8.6",
         "react-dom": "^16.8.6",
         "react-leaflet": "^2.7.0",
-        "react-leaflet-fullscreen": "^1.0.2",
         "react-redux": "^7.2.0",
         "redux": "^4.0.5",
         "smoothscroll-polyfill": "^0.4.4",
@@ -12532,11 +12531,6 @@
       "resolved": "https://registry.npmjs.org/leaflet-rotatedmarker/-/leaflet-rotatedmarker-0.2.0.tgz",
       "integrity": "sha1-RGf0n5jRv9VpWb2cZwUgPdJgEnc="
     },
-    "node_modules/leaflet.fullscreen": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/leaflet.fullscreen/-/leaflet.fullscreen-1.6.0.tgz",
-      "integrity": "sha512-Mr6STMeyKSfJ1CsKFcPZOm425LOe0c/6EHh0AK93GiTvteTAMFmO/oFDNe+0p1mk4+8yeGLcYgaXTSzPveEGhA=="
-    },
     "node_modules/left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -16603,18 +16597,6 @@
         "leaflet": "^1.6.0",
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0  || ^17.0.0"
-      }
-    },
-    "node_modules/react-leaflet-fullscreen": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-leaflet-fullscreen/-/react-leaflet-fullscreen-1.0.2.tgz",
-      "integrity": "sha512-SU7Bs5pokR3UEj8K6MEKcHCbCNEKqN39Z3ad78i1nUqLb0MRymf+8Oy69l8AkKnRN4KOcOcatDsAA1L3ifev9Q==",
-      "dependencies": {
-        "leaflet.fullscreen": "1.6.0",
-        "prop-types": "^15.6.x"
-      },
-      "peerDependencies": {
-        "react-leaflet": "^2.x"
       }
     },
     "node_modules/react-redux": {
@@ -30241,11 +30223,6 @@
       "resolved": "https://registry.npmjs.org/leaflet-rotatedmarker/-/leaflet-rotatedmarker-0.2.0.tgz",
       "integrity": "sha1-RGf0n5jRv9VpWb2cZwUgPdJgEnc="
     },
-    "leaflet.fullscreen": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/leaflet.fullscreen/-/leaflet.fullscreen-1.6.0.tgz",
-      "integrity": "sha512-Mr6STMeyKSfJ1CsKFcPZOm425LOe0c/6EHh0AK93GiTvteTAMFmO/oFDNe+0p1mk4+8yeGLcYgaXTSzPveEGhA=="
-    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -33256,15 +33233,6 @@
         "fast-deep-equal": "^3.1.3",
         "hoist-non-react-statics": "^3.3.2",
         "warning": "^4.0.3"
-      }
-    },
-    "react-leaflet-fullscreen": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-leaflet-fullscreen/-/react-leaflet-fullscreen-1.0.2.tgz",
-      "integrity": "sha512-SU7Bs5pokR3UEj8K6MEKcHCbCNEKqN39Z3ad78i1nUqLb0MRymf+8Oy69l8AkKnRN4KOcOcatDsAA1L3ifev9Q==",
-      "requires": {
-        "leaflet.fullscreen": "1.6.0",
-        "prop-types": "^15.6.x"
       }
     },
     "react-redux": {

--- a/apps/site/assets/package.json
+++ b/apps/site/assets/package.json
@@ -31,7 +31,6 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-leaflet": "^2.7.0",
-    "react-leaflet-fullscreen": "^1.0.2",
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "smoothscroll-polyfill": "^0.4.4",

--- a/apps/site/assets/ts/leaflet/components/Map.tsx
+++ b/apps/site/assets/ts/leaflet/components/Map.tsx
@@ -66,7 +66,6 @@ const Component = ({
       opts?: IconOpts
     ) => Icon | undefined = require("../icon").default;
     require("leaflet-rotatedmarker");
-    const FullscreenControl = require("react-leaflet-fullscreen");
     const getBounds = require("../bounds").default;
     /* eslint-enable */
     const { Map, Marker, Polyline, Popup, TileLayer } = leaflet;
@@ -126,7 +125,6 @@ const Component = ({
             {marker.tooltip && <Popup maxHeight={175}>{marker.tooltip}</Popup>}
           </Marker>
         ))}
-        <FullscreenControl />
       </Map>
     );
   }

--- a/apps/site/assets/ts/tnm/components/leaflet/MapWrapper.tsx
+++ b/apps/site/assets/ts/tnm/components/leaflet/MapWrapper.tsx
@@ -65,7 +65,6 @@ const LeafletMap = ({
 }: Props): ReactElement<HTMLElement> => {
   /* eslint-disable */
   const leaflet: typeof Leaflet = require("react-leaflet");
-  const FullscreenControl = require("react-leaflet-fullscreen");
   const { Map, TileLayer } = leaflet;
   /* eslint-enable */
 
@@ -111,7 +110,6 @@ const LeafletMap = ({
           dispatch={dispatch}
         />
       ))}
-      <FullscreenControl />
     </Map>
   );
 };


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Map and line diagram disappear when changing direction](https://app.asana.com/0/385363666817452/1202368368463934/f)

This bug happened on mobile when changing direction after clicking on the map. Seemed to be some weird React state thing. We don't know when this started and can't quite pinpoint a conclusive cause. However, removing this minor Leaflet plugin (`<FullscreenControl />`) seems to fix it (at the price of losing our ability to make a map full screen).

The main other approach I looked into was upgrading `react-leaflet`, which required a whole slew of dependency upgrades (React 16 to 17 and related), and required a bit of refactoring that was starting to take a bit too long. Though I think one day it might be nice to re-implement our `<Map />` with a more modern take.
