### PR TITLE
fix(LocationService.Utils): compile with unmatched parenthesis

### DIFF
--- a/apps/location_service/lib/utils.ex
+++ b/apps/location_service/lib/utils.ex
@@ -29,7 +29,7 @@ defmodule LocationService.Utils do
       # p       -- Match the current part
       # \\w*    -- Match any number of word characters
       # )       -- Close `t`
-      src = "(^|\\W)(?<t>" <> p <> "\\w*)"
+      src = "(^|\\W)(?<t>" <> Regex.escape(p) <> "\\w*)"
       {:ok, re} = Regex.compile(src, "i")
 
       Regex.scan(re, text, return: :index, capture: :all_names)

--- a/apps/location_service/test/utils_test.exs
+++ b/apps/location_service/test/utils_test.exs
@@ -57,5 +57,15 @@ defmodule LocationService.UtilsTest do
 
       assert ["Sesame"] = spans
     end
+
+    test "can handle text with brackets" do
+      spans =
+        get_highlighted_spans_text(%{
+          search: "Great Harvest Bread Co. (great harvest bread)",
+          text: "Great Harvest Bread Co."
+        })
+
+      assert ["Great", "Harvest", "Bread", "Co."] = spans
+    end
   end
 end


### PR DESCRIPTION
Make sure to escape any necessary characters in the text when creating the regex expression. From Sentry reports this was most often text containing parentheses or brackets.

Added a test using a search term from one of our error reports.

#### Summary of changes
**Asana Ticket:** [LocationService | Elixir.MatchError: no match of right hand side value: {:error, {'missing )', 17}}](https://app.asana.com/0/385363666817452/1202185936565802/f)