### PR TITLE
Trip Planner design updates

### DIFF
--- a/apps/site/assets/css/_trip-plan-form.scss
+++ b/apps/site/assets/css/_trip-plan-form.scss
@@ -5,15 +5,6 @@
     }
   }
 
-  .c-trip-plan-widget__inputs {
-    flex: none;
-    flex-direction: column;
-
-    .c-trip-plan-widget__from {
-      margin-right: 0;
-    }
-  }
-
   .c-trip-plan-widget__submit {
     width: 100%;
   }

--- a/apps/site/assets/css/_trip-plan-widget.scss
+++ b/apps/site/assets/css/_trip-plan-widget.scss
@@ -1,15 +1,3 @@
-@mixin trip-planner-widget($vertical:true) {
-  @if $vertical == true {
-    .c-trip-plan-widget__reverse-control {
-      display: none;
-  }
-  } @else {
-    .c-trip-plan-widget__reverse-control-vert {
-      display: none;
-    }
-  }
-}
-
 .c-trip-plan-widget {
   background-color: $gray-bordered-background;
   border: solid 1px $gray-lightest;
@@ -26,7 +14,7 @@
     margin-top: 0;
   }
 
-  .c-trip-plan-widget__reverse-control-vert {
+  .c-trip-plan-widget__reverse-control {
     display: none;
   }
 
@@ -116,23 +104,14 @@
   justify-content: flex-start;
 }
 
-.c-trip-plan-widget__reverse-control-vert {
+.c-trip-plan-widget__reverse-control {
   color: $brand-primary;
   cursor: pointer;
   margin-left: auto;
   user-select: none;
 }
 
-.m-trip-plan__form-container {
-  @include trip-planner-widget(true);
-}
-
-.col-xs-12 {
-  @include trip-planner-widget(true);
-}
-
 .m-tabbed-nav__content-item {
-  @include trip-planner-widget(false);
 
   .c-trip-plan-widget {
     border: solid 1px transparent;

--- a/apps/site/assets/css/_trip-plan-widget.scss
+++ b/apps/site/assets/css/_trip-plan-widget.scss
@@ -30,43 +30,21 @@
       margin-top: .5rem;
     }
   }
-
-  @include media-breakpoint-only(md) {
-    .c-trip-plan-widget__inputs {
-      flex-direction: column;
-
-      .c-trip-plan-widget__from {
-        margin-right: 0;
-      }
-    }
-  }
 }
 
 .c-trip-plan-widget__inputs {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template:
+    "a a" auto
+    "b b" auto
+    "c x" auto
+    "d d" auto / 1fr auto;
 
-  @include media-breakpoint-between(sm, md) {
-    flex-direction: row;
-
-    .c-trip-plan-widget__from {
-      margin-right: $base-spacing;
-    }
-
-    .c-search-bar {
-      flex-basis: 50%;
-    }
-  }
-}
-
-.c-trip-plan-widget__submit {
-  display: inline-flex;
-  justify-content: center;
-  width: 65%;
-
-  @include media-breakpoint-between(sm, md) {
-    width: 40%;
-  }
+  #trip-plan__label--from { grid-area: a; }
+  #trip-plan__search--from { grid-area: b; }
+  #trip-plan__label--to { grid-area: c; }
+  #trip-plan__search--to { grid-area: d; }
+  #trip-plan-reverse-control { grid-area: x; }
 }
 
 .c-trip-plan-widget__submit-container {
@@ -99,84 +77,41 @@
   padding-top: $base-spacing * .75;
 }
 
-.c-trip-plan-widget__label--to {
-  display: flex;
-  justify-content: flex-start;
-}
-
 .c-trip-plan-widget__reverse-control {
   color: $brand-primary;
   cursor: pointer;
-  margin-left: auto;
   user-select: none;
 }
 
-.m-tabbed-nav__content-item {
+.m-tabbed-nav__content-item .c-trip-plan-widget {
+  border: none;
+  padding: 0;
 
-  .c-trip-plan-widget {
-    border: solid 1px transparent;
-    padding: 0;
+  h2 {
+    display: none;
   }
-  
-  .c-paragraph--trip-plan-widget .c-trip-plan-widget {
+
+  .c-trip-plan-widget__inputs {
+    // use non-mobile layout at this breakpoint
     @include media-breakpoint-up(sm) {
-      .c-trip-plan-widget__inputs {
-        flex-direction: row;
-      }
+      grid-template:
+        "a . c" auto
+        "b x d" auto / 1fr auto 1fr;
     }
   }
-  
-  .c-trip-plan-widget__inputs {
-    display: flex;
-    flex-direction: column;
+
+  .c-trip-plan-widget__reverse-control {
     @include media-breakpoint-up(sm) {
-      flex-direction: row;
-  
-      .c-trip-plan-widget__from {
-        margin-right: $base-spacing;
-      }
-  
-      .c-search-bar {
-        flex-basis: 50%;
-      }
+      padding: 0 1em;
+      position: relative;
+      top: .75em;
+      transform: rotate(90deg);
     }
   }
   
   .c-trip-plan-widget__submit {
-    width: 100%;
-  
-    @include media-breakpoint-up(sm) {
-      width: 35%;
-    }
-  }
-  
-  .c-trip-plan-widget__submit-container {
-    @include media-breakpoint-down(sm) {
+    @include media-breakpoint-only(xs) {
       width: 100%;
-    }
-  }
-
-  .c-trip-plan-widget__location-error {
-    display: none;
-    padding: 0;
-    margin: 0;
-  }
-
-  %error-message {
-    background-color: $form-error-message;
-    color: $error-text;
-    padding: 0;
-  }
-
-  .c-trip-plan-widget__reverse-control {
-    color: $brand-primary;
-    cursor: pointer;
-    margin-left: auto;
-    user-select: none;
-    @include media-breakpoint-up(sm) {
-      transform: rotate(90deg);
-      display: flex;
-      padding: 36px;
     }
   }
 }

--- a/apps/site/lib/site_web/templates/page/_tabbed_nav.html.eex
+++ b/apps/site/lib/site_web/templates/page/_tabbed_nav.html.eex
@@ -32,9 +32,7 @@
       <%= shortcut_icons() %>
     </div>
      <div role="tabpanel" class="m-tabbed-nav__content-item" data-tab-content-type="trip-planner">
-      <div class="m-mode-hub__trip-plan-widget">
-        <%= SiteWeb.PartialView.render("_trip_planner_widget.html", assigns) %>
-      </div>
+      <%= SiteWeb.PartialView.render("_trip_planner_widget.html", assigns) %>
      </div>
      <div role="tabpanel" class="m-tabbed-nav__content-item" data-tab-content-type="alerts">
        <%= alerts(@conn.assigns.alerts) %>

--- a/apps/site/lib/site_web/templates/trip_compare/_to_from_inputs.html.eex
+++ b/apps/site/lib/site_web/templates/trip_compare/_to_from_inputs.html.eex
@@ -4,11 +4,11 @@
   Touch device users, explore by touch or with swipe gestures.
 </span>
 <div class="c-trip-plan-widget__inputs">
+  <label for="from" class="c-search-bar__header" id="trip-plan__label--from">
+    From
+    <%= content_tag(:span, "(Required)", id: "trip-plan__required--from", class: "m-trip-plan__required#{if @from_error === "", do: " m-trip-plan__hidden"}") %>
+  </label>
   <div id="trip-plan__search--from" class="c-search-bar">
-    <label for="from" class="c-search-bar__header" id="trip-plan__label--from">
-      From
-      <%= content_tag(:span, "(Required)", id: "trip-plan__required--from", class: "m-trip-plan__required#{if @from_error === "", do: " m-trip-plan__hidden"}") %>
-    </label>
     <div id="trip-plan__container--from" class="c-trip-plan-widget__from c-form__input-container<%= if @from_error === "" do "" else " c-form__input-container--error" end %>">
       <span class="c-trip-plan-widget__input-label">A</span>
       <input type="text"
@@ -31,15 +31,19 @@
     <div id="trip-plan__location-error--from" role="alert" aria-live="assertive" tabindex="0" class="c-trip-plan-widget__location-error location-error"><%= @from_error %></div>
   </div>
 
+  <div id="trip-plan-reverse-control">
+    <div class="c-trip-plan-widget__reverse-control">
+      <%= fa "long-arrow-down" %>
+      <%= fa "long-arrow-up" %>
+    </div>
+  </div>
+
+  <label for="to" class="c-search-bar__header c-trip-plan-widget__label--to" id="trip-plan__label--to">
+    To&nbsp;
+    <%= content_tag(:span, "(Required)", id: "trip-plan__required--to", class: "m-trip-plan__required#{if @to_error === "", do: " m-trip-plan__hidden"}") %>
+  </label>
+
   <div id="trip-plan__search--to" class="c-search-bar">
-    <label for="to" class="c-search-bar__header c-trip-plan-widget__label--to" id="trip-plan__label--to">
-      To&nbsp;
-      <%= content_tag(:span, "(Required)", id: "trip-plan__required--to", class: "m-trip-plan__required#{if @to_error === "", do: " m-trip-plan__hidden"}") %>
-      <div id="trip-plan-reverse-control" class="c-trip-plan-widget__reverse-control">
-        <%= fa "long-arrow-down" %>
-        <%= fa "long-arrow-up" %>
-      </div>
-    </label>
     <div id="trip-plan__container--to" class="c-form__input-container<%= if @to_error === "" do "" else " c-form__input-container--error" end %>">
       <span class="c-trip-plan-widget__input-label">B</span>
       <input type="text"

--- a/apps/site/lib/site_web/templates/trip_plan/_to_from_inputs.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_to_from_inputs.html.eex
@@ -3,12 +3,14 @@
   When autocomplete results are available, use up and down arrows to review and enter to select.
   Touch device users, explore by touch or with swipe gestures.
 </span>
+
 <div class="c-trip-plan-widget__inputs">
+  <label for="from" class="c-search-bar__header" id="trip-plan__label--from">
+    From
+    <%= content_tag(:span, "(Required)", id: "trip-plan__required--from", class: "m-trip-plan__required#{if @from_error === "", do: " m-trip-plan__hidden"}") %>
+  </label>
+
   <div id="trip-plan__search--from" class="c-search-bar">
-    <label for="from" class="c-search-bar__header" id="trip-plan__label--from">
-      From
-      <%= content_tag(:span, "(Required)", id: "trip-plan__required--from", class: "m-trip-plan__required#{if @from_error === "", do: " m-trip-plan__hidden"}") %>
-    </label>
     <div id="trip-plan__container--from" class="c-trip-plan-widget__from c-form__input-container<%= if @from_error === "" do "" else " c-form__input-container--error" end %>">
       <span class="c-trip-plan-widget__input-label">A</span>
       <input type="text"
@@ -31,17 +33,19 @@
     <div id="trip-plan__location-error--from" role="alert" aria-live="assertive" tabindex="0" class="c-trip-plan-widget__location-error location-error"><%= @from_error %></div>
   </div>
 
-  <div id="trip-plan__search--to" class="c-search-bar">
-    <div class="u-flex-container">
-      <label for="to" class="c-search-bar__header c-trip-plan-widget__label--to" id="trip-plan__label--to">
-        To&nbsp;
-        <%= content_tag(:span, "(Required)", id: "trip-plan__required--to", class: "m-trip-plan__required#{if @to_error === "", do: " m-trip-plan__hidden"}") %>
-      </label>
-      <div id="trip-plan-reverse-control" class="c-trip-plan-widget__reverse-control">
-        <%= fa "long-arrow-down" %>
-        <%= fa "long-arrow-up" %>
-      </div>
+  <div id="trip-plan-reverse-control">
+    <div class="c-trip-plan-widget__reverse-control">
+      <%= fa "long-arrow-down" %>
+      <%= fa "long-arrow-up" %>
     </div>
+  </div>
+
+  <label for="to" class="c-search-bar__header c-trip-plan-widget__label--to" id="trip-plan__label--to">
+    To&nbsp;
+    <%= content_tag(:span, "(Required)", id: "trip-plan__required--to", class: "m-trip-plan__required#{if @to_error === "", do: " m-trip-plan__hidden"}") %>
+  </label>
+
+  <div id="trip-plan__search--to" class="c-search-bar">
     <div id="trip-plan__container--to" class="c-form__input-container<%= if @to_error === "" do "" else " c-form__input-container--error" end %>">
       <span class="c-trip-plan-widget__input-label">B</span>
       <input type="text"

--- a/apps/site/lib/site_web/templates/trip_plan/_to_from_inputs.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_to_from_inputs.html.eex
@@ -31,20 +31,17 @@
     <div id="trip-plan__location-error--from" role="alert" aria-live="assertive" tabindex="0" class="c-trip-plan-widget__location-error location-error"><%= @from_error %></div>
   </div>
 
-  <div id="trip-plan-reverse-control" class="c-trip-plan-widget__reverse-control">
-    <%= fa "long-arrow-down" %>
-    <%= fa "long-arrow-up" %>
-  </div>
-
   <div id="trip-plan__search--to" class="c-search-bar">
-    <label for="to" class="c-search-bar__header c-trip-plan-widget__label--to" id="trip-plan__label--to">
-      To&nbsp;
-      <%= content_tag(:span, "(Required)", id: "trip-plan__required--to", class: "m-trip-plan__required#{if @to_error === "", do: " m-trip-plan__hidden"}") %>
-      <div id="trip-plan-reverse-control" class="c-trip-plan-widget__reverse-control-vert">
+    <div class="u-flex-container">
+      <label for="to" class="c-search-bar__header c-trip-plan-widget__label--to" id="trip-plan__label--to">
+        To&nbsp;
+        <%= content_tag(:span, "(Required)", id: "trip-plan__required--to", class: "m-trip-plan__required#{if @to_error === "", do: " m-trip-plan__hidden"}") %>
+      </label>
+      <div id="trip-plan-reverse-control" class="c-trip-plan-widget__reverse-control">
         <%= fa "long-arrow-down" %>
         <%= fa "long-arrow-up" %>
       </div>
-    </label>
+    </div>
     <div id="trip-plan__container--to" class="c-form__input-container<%= if @to_error === "" do "" else " c-form__input-container--error" end %>">
       <span class="c-trip-plan-widget__input-label">B</span>
       <input type="text"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trip Planner design updates](https://app.asana.com/0/555089885850811/1202384504606984/f)

I ended up reworking the Trip Planner widget to use CSS grid for its layout rather than Flexbox.  It simplifies a lot!

I considered adjusting the layout using a container query (based on the width of the widget container) rather than a media query (based on size of the window), but we only use the horizontal layout on the homepage - so this code only switches the layout on the homepage and not anywhere else the widget is applied.