### PR TITLE
fix: lay out datepicker buttons as expected

### DIFF
--- a/apps/site/assets/css/_datepicker.scss
+++ b/apps/site/assets/css/_datepicker.scss
@@ -44,10 +44,16 @@
 .datepicker-month-wrap {
   background: $brand-primary-darkest;
   color: $white;
-  // duplicate property required because IE doesn't support `initial`
-  height: auto;
   height: initial;
   padding: $base-spacing-sm;
+
+  .pull-left {
+    float: left;
+  }
+
+  .pull-right {
+    float: right;
+  }
 }
 
 .datepicker-month::after {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Trip Planner | Datepicker buttons misaligned](https://app.asana.com/0/385363666817452/1202407129112905/f)

I have no idea why the `pull-right` and `pull-left` CSS classes (very common Bootstrap utility classes) were not doing their job now....

Before:
![image](https://user-images.githubusercontent.com/2136286/176752697-511836b3-a77d-40d7-962d-7ff0ed74efae.png)


Updated:
<img width="433" alt="image" src="https://user-images.githubusercontent.com/2136286/176752967-e6e20aee-33f7-43a4-b6df-1ef958500ece.png">
