### PR TITLE
cleanup: remove unused plugs

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/core.ex
+++ b/apps/site/lib/site_web/controllers/schedule/core.ex
@@ -11,8 +11,6 @@ defmodule SiteWeb.ScheduleController.Core do
   plug(SiteWeb.ScheduleController.ExcludedStops)
   plug(SiteWeb.ScheduleController.PreSelect)
   plug(SiteWeb.ScheduleController.VehicleLocations)
-  plug(SiteWeb.ScheduleController.Predictions)
-  plug(SiteWeb.ScheduleController.VehicleTooltips)
 
   defp schedule_pipeline_setup(conn, _opts) do
     conn

--- a/apps/site/lib/site_web/controllers/schedule/green.ex
+++ b/apps/site/lib/site_web/controllers/schedule/green.ex
@@ -26,7 +26,6 @@ defmodule SiteWeb.ScheduleController.Green do
   plug(SiteWeb.ScheduleController.ExcludedStops)
   plug(SiteWeb.ScheduleController.Journeys)
   plug(:validate_journeys)
-  plug(SiteWeb.ScheduleController.TripInfo)
   plug(SiteWeb.ScheduleController.RouteBreadcrumbs)
   plug(SiteWeb.ScheduleController.ScheduleError)
   plug(:require_map)

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -23,8 +23,6 @@ defmodule SiteWeb.ScheduleController.LineController do
   plug(SiteWeb.ScheduleController.HoursOfOperation)
   plug(SiteWeb.ScheduleController.Holidays)
   plug(SiteWeb.ScheduleController.VehicleLocations)
-  plug(SiteWeb.ScheduleController.Predictions)
-  plug(SiteWeb.ScheduleController.VehicleTooltips)
   plug(SiteWeb.ScheduleController.Line)
   plug(SiteWeb.ScheduleController.CMS)
   plug(:channel_id)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Document the State of Predictions in Dotcom](https://app.asana.com/0/385363666817452/1202432733748699/f)

[The documentation is over on Notion](https://www.notion.so/mbta-downtown-crossing/Predictions-WIP-4a6f64cb1fa04b84a50813c8decd8a14), go review and/or comment on that. :) 

To be honest I didn't expect to open a PR for this but I found a few places where we were including plugs but no longer using the associated data. So here those are!