### PR TITLE
a11y: remove inappropriate tab roles

### DIFF
--- a/apps/site/lib/site_web/templates/layout/_new_nav_desktop.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_desktop.html.eex
@@ -1,4 +1,4 @@
-<nav id="navmenu-desktop" class="m-menu--desktop">
+<nav id="navmenu-desktop" class="m-menu--desktop" aria-label="Main navigation">
   <%= for %{menu_section: name, link: href, sub_menus: sub_menus} <- SiteWeb.LayoutView.nav_link_content_redesign(@conn) do %>
 
     <a class="m-menu--desktop__toggle collapsed"

--- a/apps/site/lib/site_web/templates/layout/_new_nav_desktop.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_desktop.html.eex
@@ -1,9 +1,9 @@
-<nav id="navmenu-desktop" class="m-menu--desktop" role="tablist">
+<nav id="navmenu-desktop" class="m-menu--desktop">
   <%= for %{menu_section: name, link: href, sub_menus: sub_menus} <- SiteWeb.LayoutView.nav_link_content_redesign(@conn) do %>
 
     <a class="m-menu--desktop__toggle collapsed"
       href="<%= href %>"
-      role="tab"
+      role="button"
       data-toggle="collapse"
       data-parent="#navmenu-desktop"
       data-target="#<%= to_camelcase(name) %>"
@@ -16,7 +16,7 @@
     <div class="m-menu--desktop__menu">
       <div class="container">
         <div class="panel">
-          <div class="collapse" id="<%= to_camelcase(name) %>" role="tabpanel">
+          <div class="collapse" id="<%= to_camelcase(name) %>">
             <div class="m-menu-desktop__section <%= to_camelcase(name) %>">
               <%= for %{links: links, sub_menu_section: section_name} <- sub_menus do %>
                 <div class="m-menu__section-heading">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Replace "tabpanel" role with disclosure pattern](https://app.asana.com/0/385363666817452/1202299919599010/f)

Turns out we pretty much had the disclosure pattern established!

The one thing I didn't do was replace the links with buttons - I really wanted to keep them as links with `href` attributes because these are what's used for navigation when a user doesn't have JavaScript enabled. So for those I added `role="button"`, which I think should suffice.