### PR TITLE
Use heading elements instead of div for desktop nav sections

### DIFF
--- a/apps/site/lib/site_web/templates/layout/_new_nav_contact_numbers.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_contact_numbers.html.eex
@@ -1,5 +1,5 @@
 <div class="m-menu__feature top-section">
-  <div class="m-menu__section-heading">Information & Support</div>
+  <h3 class="m-menu__section-heading">Information & Support</h3>
   <small>Monday thru Friday: 6:30 AM - 8 PM</small>
   <small>Saturday thru Sunday: 8 AM - 4 PM</small>
   <div class="m-menu__feature_phone">
@@ -10,7 +10,7 @@
   </div>
 </div>
 <div class="m-menu__feature emergency-contacts mobile">
-  <div class="m-menu__section-heading">Emergency Contacts</div>
+  <h3 class="m-menu__section-heading">Emergency Contacts</h3>
   <small>24 hours, 7 days a week</small>
   <div class="m-menu__feature_phone">
     <strong>Transit Police:</strong> <%= tel_link "617-222-1212" %>
@@ -20,6 +20,6 @@
   </div>
 </div>
 <div class="m-menu__feature bottom-section">
-  <div class="m-menu__section-heading">Report a Railroad Crossing Gate Issue</div>
+  <h3 class="m-menu__section-heading">Report a Railroad Crossing Gate Issue</h3>
   <div class="m-menu__feature_phone">To report a problem or emergency with a railroad crossing, call <%= tel_link "1-800-522-8236" %></div>
 </div>

--- a/apps/site/lib/site_web/templates/layout/_new_nav_desktop.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_desktop.html.eex
@@ -19,9 +19,9 @@
           <div class="collapse" id="<%= to_camelcase(name) %>" role="tabpanel">
             <div class="m-menu-desktop__section <%= to_camelcase(name) %>">
               <%= for %{links: links, sub_menu_section: section_name} <- sub_menus do %>
-                <div class="m-menu__section-heading">
+                <h3 class="m-menu__section-heading">
                   <%= section_name %>
-                </div>
+                </h3>
                 <nav class="m-menu-desktop__submenu-section" aria-label="<%= section_name %>">
                   <%= Enum.map(links, &SiteWeb.LayoutView.render_nav_link/1) %>
                 </nav>
@@ -35,7 +35,7 @@
 
                 <%= if special_section == "Emergency Contacts" do %>
                   <div class="m-menu__feature emergency-contacts desktop">
-                    <div class="m-menu__section-heading">Emergency Contacts</div>
+                    <h3 class="m-menu__section-heading">Emergency Contacts</h3>
                     <small>24 hours, 7 days a week</small>
                     <div class="m-menu__feature_phone">
                       <strong>Transit Police:</strong> <%= tel_link "617-222-1212" %>

--- a/apps/site/lib/site_web/templates/layout/_new_nav_popular_fares.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_popular_fares.html.eex
@@ -1,5 +1,5 @@
 <div class="m-menu__feature">
-  <div class="m-menu__section-heading">Most popular fares</div>
+  <h3 class="m-menu__section-heading">Most popular fares</h3>
   <dl title="Most popular fares">
     <dt>Subway One-Way</dt>
     <dd>$2.40</dd>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Make the desktop column headings into heading elements ](https://app.asana.com/0/385363666817452/1202308344478711/f)

changed divs into h3 elements for desktop nav section headers.
