### PR TITLE
Prevent screen readers from reading multiple elements

### DIFF
--- a/apps/site/lib/site_web/templates/mode/_grid_button.html.eex
+++ b/apps/site/lib/site_web/templates/mode/_grid_button.html.eex
@@ -1,7 +1,7 @@
 <%= link [to: @link_path, class: "c-grid-button c-grid-button--#{grid_button_class_modifier(@route)}", id: grid_button_id(assigns)] do %>
   <div class="c-grid-button__content">
     <%= if show_icon?(@route, @show_icon?) do %>
-      <span class="c-grid-button__icon">
+      <span class="c-grid-button__icon" aria-hidden="true">
         <%= line_icon(@route, :default) %>
       </span>
     <% end %>

--- a/apps/site/lib/site_web/templates/mode/_grid_button_condensed.html.eex
+++ b/apps/site/lib/site_web/templates/mode/_grid_button_condensed.html.eex
@@ -1,6 +1,6 @@
 <%= link [to: @link_path, class: "c-grid-button__condensed", id: grid_button_id(assigns)] do %>
   <div class="c-grid-button__content">
-      <span class="c-grid-button__icon c-grid-button__icon--condensed">
+      <span class="c-grid-button__icon c-grid-button__icon--condensed" aria-hidden="true">
         <%= line_icon(@route, :default) %>
         <span class="c-grid-button__alert--condensed">
           <%= if @has_alert? do

--- a/apps/site/lib/site_web/templates/page/_find_a_location.html.eex
+++ b/apps/site/lib/site_web/templates/page/_find_a_location.html.eex
@@ -7,7 +7,7 @@
   <div class="c-home-grid-buttons-container">
     <%= link to: cms_static_page_path(@conn, "/stops"), class: "c-home-grid-button" do %>
       <div class="c-grid-button__content">
-        <span class="c-grid-button__icon">
+        <span class="c-grid-button__icon" aria-hidden="true">
           <%= svg("stations-parking.svg") %>
         </span>
         <span class="c-grid-button__name">
@@ -17,7 +17,7 @@
     <% end %>
     <%= link to: cms_static_page_path(@conn, "/transit-near-me"), class: "c-home-grid-button" do %>
       <div class="c-grid-button__content">
-        <span class="c-grid-button__icon">
+        <span class="c-grid-button__icon" aria-hidden="true">
           <%= fa "map-location-dot", class: "c-grid-button__icon" %>
         </span>
         <span class="c-grid-button__name">

--- a/apps/site/lib/site_web/templates/page/_tabbed_nav.html.eex
+++ b/apps/site/lib/site_web/templates/page/_tabbed_nav.html.eex
@@ -2,19 +2,25 @@
   <div class="nav m-tabbed-nav__items" role="tablist">
     <div class="m-tabbed-nav__item-container">
       <a tabindex="0" class="nav-link m-tabbed-nav__item active" role="tab" data-toggle="tab" data-tab-type="schedules" aria-controls="schedules-content" aria-selected="true">
-        <%= svg("icon-map-default.svg") %>
+        <span aria-hidden="true">
+          <%= svg("icon-map-default.svg") %>
+        </span>
         <span href="/schedules" class="m-tabbed-nav__icon-text">Schedules</span>
       </a>
     </div>
     <div class="m-tabbed-nav__item-container">
       <a tabindex="0" class="nav-link m-tabbed-nav__item" role="tab" data-toggle="tab" data-tab-type="trip-planner" aria-controls="trip-planner-content" aria-selected="false">
-        <%= svg("icon-trip-planner-default.svg") %>
+        <span aria-hidden="true">
+          <%= svg("icon-trip-planner-default.svg") %>
+        </span>
         <span href="/trip-planner" class="m-tabbed-nav__icon-text">Trip Planner</span>
       </a>
     </div>
     <div class="m-tabbed-nav__item-container">
       <a tabindex="0" class="nav-link m-tabbed-nav__item" role="tab" data-toggle="tab" data-tab-type="alerts" aria-controls="alerts-content" aria-selected="false">
-        <%= svg("icon-alerts-default.svg") %>
+        <span aria-hidden="true">
+          <%= svg("icon-alerts-default.svg") %>
+        </span>
         <span href="/alerts" class="m-tabbed-nav__icon-text">Alerts</span>
       </a>
     </div>

--- a/apps/site/lib/site_web/templates/trip_compare/_to_from_inputs.html.eex
+++ b/apps/site/lib/site_web/templates/trip_compare/_to_from_inputs.html.eex
@@ -10,7 +10,7 @@
   </label>
   <div id="trip-plan__search--from" class="c-search-bar">
     <div id="trip-plan__container--from" class="c-trip-plan-widget__from c-form__input-container<%= if @from_error === "" do "" else " c-form__input-container--error" end %>">
-      <span class="c-trip-plan-widget__input-label">A</span>
+      <span class="c-trip-plan-widget__input-label" aria-hidden="true">A</span>
       <input type="text"
             id="from"
             data-label="A"
@@ -45,7 +45,7 @@
 
   <div id="trip-plan__search--to" class="c-search-bar">
     <div id="trip-plan__container--to" class="c-form__input-container<%= if @to_error === "" do "" else " c-form__input-container--error" end %>">
-      <span class="c-trip-plan-widget__input-label">B</span>
+      <span class="c-trip-plan-widget__input-label" aria-hidden="true">B</span>
       <input type="text"
             id="to"
             data-label="B"

--- a/apps/site/lib/site_web/templates/trip_plan/_to_from_inputs.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_to_from_inputs.html.eex
@@ -12,7 +12,7 @@
 
   <div id="trip-plan__search--from" class="c-search-bar">
     <div id="trip-plan__container--from" class="c-trip-plan-widget__from c-form__input-container<%= if @from_error === "" do "" else " c-form__input-container--error" end %>">
-      <span class="c-trip-plan-widget__input-label">A</span>
+      <span class="c-trip-plan-widget__input-label" aria-hidden="true">A</span>
       <input type="text"
             id="from"
             data-label="A"
@@ -46,7 +46,7 @@
 
   <div id="trip-plan__search--to" class="c-search-bar">
     <div id="trip-plan__container--to" class="c-form__input-container<%= if @to_error === "" do "" else " c-form__input-container--error" end %>">
-      <span class="c-trip-plan-widget__input-label">B</span>
+      <span class="c-trip-plan-widget__input-label" aria-hidden="true">B</span>
       <input type="text"
             id="to"
             data-label="B"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Prevent screen readers from reading multiple elements](https://app.asana.com/0/555089885850811/1202570650180350/f)

Added aria-hidden="true" label to following sections to prevent them from being read.

- [x] Tabs: the title of the icon (only the label text)
- [x] Schedules > Shortcut icons: the title of the SVG (only the label text)
- [x] Trip Planner: "A" and "B" labels on input fields (From and To suffice)
- [x] Find a Location: the title of "Stations and Parking" button icon (e.g., "Stations and Parking Icon, Stations and Parking")