### PR TITLE
Homepage Alert Icon fixes

### DIFF
--- a/apps/site/assets/js/sticky-tooltip.js
+++ b/apps/site/assets/js/sticky-tooltip.js
@@ -61,6 +61,21 @@ export default function($) {
 
       hideTooltip($this);
     });
+    $(document).on("focus", selector, function(e) {
+      const $this = $(this);
+      if (wasTouchedRecently($this)) {
+        return;
+      }
+      $this.tooltip("show");
+    });
+    $(document).on("focusout", selector, function(e) {
+      const $this = $(this);
+      if (wasTouchedRecently($this)) {
+        return;
+      }
+
+      hideTooltip($this);
+    });
 
     $(document).on("touchend", "body", () => {
       hideTooltip($('[data-toggle="tooltip"]'));
@@ -69,6 +84,7 @@ export default function($) {
 
   function clearTooltips() {
     $(selector).tooltip("dispose");
+    $(".tooltip").remove();
   }
 
   document.addEventListener("turbolinks:before-cache", clearTooltips, {

--- a/apps/site/lib/site/components/icons/svg_icon/component.html.eex
+++ b/apps/site/lib/site/components/icons/svg_icon/component.html.eex
@@ -3,7 +3,7 @@
   hyphenated_class = "icon-#{CSSHelpers.atom_to_class(icon)}"
   data_toggle = if args.show_tooltip?, do: "data-toggle=tooltip", else: ""
   title = if args.show_tooltip?, do: icon_title(icon), else: ""
-  %><svg version="1.1" width="30" height="30" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="icon <%= hyphenated_class %> <%= args.class %>" viewbox="<%= viewbox(icon) %>" preserveAspectRatio="xMidYMid meet" <%= data_toggle %> title="<%= title %>">
+  %><svg tabindex="0" version="1.1" width="30" height="30" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="icon <%= hyphenated_class %> <%= args.class %>" viewbox="<%= viewbox(icon) %>" preserveAspectRatio="xMidYMid meet" <%= data_toggle %> title="<%= title %>">
   <g fill-rule="evenodd" class="notranslate icon-image <%= hyphenated_class %>-image">
     <%= get_path(icon) %>
   </g>

--- a/apps/site/lib/site/components/icons/svg_icon/component.html.eex
+++ b/apps/site/lib/site/components/icons/svg_icon/component.html.eex
@@ -3,7 +3,21 @@
   hyphenated_class = "icon-#{CSSHelpers.atom_to_class(icon)}"
   data_toggle = if args.show_tooltip?, do: "data-toggle=tooltip", else: ""
   title = if args.show_tooltip?, do: icon_title(icon), else: ""
-  %><svg tabindex="0" version="1.1" width="30" height="30" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="icon <%= hyphenated_class %> <%= args.class %>" viewbox="<%= viewbox(icon) %>" preserveAspectRatio="xMidYMid meet" <%= data_toggle %> title="<%= title %>">
+  %><svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  version="1.1"
+  width="30"
+  height="30"
+  viewbox="<%= viewbox(icon) %>"
+  preserveAspectRatio="xMidYMid meet"
+  role="img"
+  tabindex="0"
+  aria-label="<%= title %>"
+  class="icon <%= hyphenated_class %> <%= args.class %>"
+  <%= data_toggle %>
+  title="<%= title %>"
+  >
   <g fill-rule="evenodd" class="notranslate icon-image <%= hyphenated_class %>-image">
     <%= get_path(icon) %>
   </g>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Recently Visited Routes alert tooltip issues](https://app.asana.com/0/555089885850811/1202570650180355/f)

- [x] Screen reader users can't see alert tooltip
- [x] Keyboard users can't access/see alert tooltip 
- [x] Should be able to tab to alert icon and open tooltip when it gets focus, then close tooltip when tabbing away and focus is lost
- [x] Recently visited schedules buttons with alert tooltip cannot be closed and is not contained by landmarks (resolved by removing old tooltips when navigating back to page)
![image](https://user-images.githubusercontent.com/526017/178556028-28f17b89-da4f-48ac-9acb-8630c58e08ba.png)

![image](https://user-images.githubusercontent.com/526017/178556149-73d8de70-c5f8-41a7-b352-70ac3c73c540.png)
