### PR TITLE
Upcoming Public Meetings section cropped

### DIFF
--- a/apps/site/assets/css/_homepage.scss
+++ b/apps/site/assets/css/_homepage.scss
@@ -304,6 +304,7 @@
     border-left: 0;
     border-right: 0;
     border-bottom: 0;
+    overflow: auto;
   }
 
   .m-event__date-circle {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Upcoming Public Meetings section cropped](https://app.asana.com/0/555089885850811/1202522864391322/f)

Added overflow: auto styling so that event info doesn't crop.
Note: pasted text using dev tools to increase characters in event description
<img width="1267" alt="Screen Shot 2022-07-12 at 3 02 50 PM" src="https://user-images.githubusercontent.com/91911166/178577714-47ab18d9-4039-44da-a14b-1954ac964caa.png">

