### PR TITLE
Section header should be hidden when there's no content available

### DIFF
--- a/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
+++ b/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
@@ -5,7 +5,7 @@
       <h2 class="sr-only">Featured MBTA Updates and Projects</h2>
     <% end %>
     <div class="container page-section">
-      <%= unless @promoted == false do %>
+      <%= unless Enum.empty?(@whats_happening_items) do %>
         <h2>What's Happening at the MBTA</h2>
       <% end %>
       <div id="whats-happening-<%= tag %>" class="row m-whats-happening__row m-whats-happening__row--<%= tag %>">

--- a/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
+++ b/apps/site/lib/site_web/templates/page/_whats_happening.html.eex
@@ -5,7 +5,7 @@
       <h2 class="sr-only">Featured MBTA Updates and Projects</h2>
     <% end %>
     <div class="container page-section">
-      <%= unless @promoted do %>
+      <%= unless @promoted == false do %>
         <h2>What's Happening at the MBTA</h2>
       <% end %>
       <div id="whats-happening-<%= tag %>" class="row m-whats-happening__row m-whats-happening__row--<%= tag %>">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Section header should be hidden when there's no content available](https://app.asana.com/0/555089885850811/1202532801799502/f)

Hide what's happening header if no content. Note there is already a check for events section
`<%= unless Enum.empty?(@event_teasers) do %>`