### PR TITLE
fix(nav): remove veil after clicking search result

### DIFF
--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -290,6 +290,9 @@ export function setup(): void {
   if (transitDiv) {
     transitDiv.getElementsByTagName("button")[0].click();
   }
+
+  // Closes veil before navigating to search result
+  document.addEventListener("autocomplete:selected", closeAllMenus);
 }
 
 export default function setupGlobalNavigation(): void {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Header | Veil does not disappear after completing search](https://app.asana.com/0/385363666817452/1202668336235923/f)

Adds an event listener to the dropdown's `autocomplete:selected` event and runs `closeAllMenus()`, which might be kinda overkill given the only thing left open was the veil, but this striked me as more readable and clear.