### PR TITLE
fix: add custom Street View link for Brockton

### DIFF
--- a/apps/site/lib/site_web/controllers/stop/curated_street_view.ex
+++ b/apps/site/lib/site_web/controllers/stop/curated_street_view.ex
@@ -7,7 +7,10 @@ defmodule SiteWeb.StopController.CuratedStreetView do
 
   @urls %{
     "place-sstat" =>
-      "https://www.google.com/maps/@42.3525788,-71.0553574,3a,75y,163.27h,107.69t/data=!3m6!1e1!3m4!1sanRemqiMAwXSR_cMnct4Og!2e0!7i16384!8i8192"
+      "https://www.google.com/maps/@42.3525788,-71.0553574,3a,75y,163.27h,107.69t/data=!3m6!1e1!3m4!1sanRemqiMAwXSR_cMnct4Og!2e0!7i16384!8i8192",
+    # Brockton: "CR Morning Drop-off" sign
+    "place-MM-0200" =>
+      "https://www.google.com/maps/@42.0844083,-71.0156909,3a,75y,294.34h,89.91t/data=!3m6!1e1!3m4!1sedGNjWy3ih49KuVjbWtgQA!2e0!7i16384!8i8192"
   }
 
   @spec url(Stop.id_t()) :: String.t() | nil


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [GTFS | update street view for Brockton Station](https://app.asana.com/0/385363666817452/1202664751368463/f)

Here's where the new link goes, which I felt was the closest I could get to an accessible station entrance:

![image](https://user-images.githubusercontent.com/2136286/181057812-5ecc904b-cb40-46c6-be1f-b82b56f8fc92.png)