### PR TITLE
Homepage | Show six events at large breakpoints

### DIFF
--- a/apps/site/lib/site_web/templates/event/_event_teaser.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_teaser.html.eex
@@ -4,8 +4,8 @@
   path_fn = fn -> cms_static_page_path(@conn, @event_teaser.path) end
 
   event_is_hidden = if @check_event_ended do
-    day_today = @conn.assigns.date
-    @event_teaser.date < day_today
+    today = @conn.assigns.date
+    @event_teaser.date.day < today.day and @event_teaser.date.month <= today.month
   else
     false
   end

--- a/apps/site/lib/site_web/templates/event/_event_teaser.html.eex
+++ b/apps/site/lib/site_web/templates/event/_event_teaser.html.eex
@@ -3,11 +3,9 @@
   event_stop = @event_teaser.date_end
   path_fn = fn -> cms_static_page_path(@conn, @event_teaser.path) end
 
-  # this hiding logic will only run for the current month of the current year
-  # so we only need to evaluate the day:
   event_is_hidden = if @check_event_ended do
-    day_today = @conn.assigns.date.day
-    @event_teaser.date.day < day_today
+    day_today = @conn.assigns.date
+    @event_teaser.date < day_today
   else
     false
   end

--- a/apps/site/lib/site_web/templates/page/_homepage-events.html.eex
+++ b/apps/site/lib/site_web/templates/page/_homepage-events.html.eex
@@ -11,10 +11,10 @@
       <%= for event_teaser <- @event_teasers do %>
         <%= render(SiteWeb.EventView, "_event_teaser.html",
             event_teaser: event_teaser,
-            check_event_ended: true,
+            check_event_ended: false,
             conn: @conn,
-            month_number: DateTime.utc_now.month,
-            year: DateTime.utc_now.year) %>
+            month_number: event_teaser.date.month,
+            year: event_teaser.date.year) %>
       <% end %>
     </ul>
   </div>

--- a/apps/site/lib/site_web/templates/page/_homepage-events.html.eex
+++ b/apps/site/lib/site_web/templates/page/_homepage-events.html.eex
@@ -11,7 +11,7 @@
       <%= for event_teaser <- @event_teasers do %>
         <%= render(SiteWeb.EventView, "_event_teaser.html",
             event_teaser: event_teaser,
-            check_event_ended: false,
+            check_event_ended: true,
             conn: @conn,
             month_number: event_teaser.date.month,
             year: event_teaser.date.year) %>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Homepage | Show six events at large breakpoints](https://app.asana.com/0/385363666817452/1202641648100462/f)

Show next six events. Updated event ended check to check date rather than just the day.
<img width="1142" alt="Screen Shot 2022-07-27 at 12 09 36 PM" src="https://user-images.githubusercontent.com/91911166/181297083-97f0b4cf-89c6-4cd9-ab9a-908944c976c5.png">