### PR TITLE
Update "Use my location" label in header search and schedule hubs

### DIFF
--- a/apps/site/assets/js/algolia-autocomplete-with-geo.js
+++ b/apps/site/assets/js/algolia-autocomplete-with-geo.js
@@ -1,4 +1,5 @@
 import AlgoliaAutocomplete from "./algolia-autocomplete";
+import { TEMPLATES } from "./algolia-result";
 import * as GoogleMapsHelpers from "./google-maps-helpers";
 // eslint-disable-next-line
 import * as QueryHelpers from "../ts/helpers/query";
@@ -34,9 +35,10 @@ class AlgoliaAutocompleteWithGeo extends AlgoliaAutocomplete {
     locationParams,
     popular,
     parent,
-    containerEl = null
+    containerEl = null,
+    templates = TEMPLATES
   }) {
-    super({ id, selectors, indices, parent, containerEl });
+    super({ id, selectors, indices, parent, containerEl, templates });
     this.debounceInterval = 250;
     if (!this._parent.getParams) {
       this._parent.getParams = () => ({});

--- a/apps/site/assets/js/algolia-autocomplete.js
+++ b/apps/site/assets/js/algolia-autocomplete.js
@@ -6,7 +6,16 @@ import * as QueryHelpers from "../ts/helpers/query";
 /* eslint-disable class-methods-use-this */
 
 export default class AlgoliaAutocomplete {
-  constructor({ id, selectors, indices, parent, containerEl = null }) {
+  #templates;
+
+  constructor({
+    id,
+    selectors,
+    indices,
+    parent,
+    containerEl = null,
+    templates = AlgoliaResult.TEMPLATES
+  }) {
     if (typeof id !== "string") {
       throw new window.Error("autocomplete must have an id");
     }
@@ -27,6 +36,9 @@ export default class AlgoliaAutocomplete {
     this._results = {};
     this._highlightedHit = null;
     this._autocomplete = null;
+
+    this.#templates = templates;
+
     this.bind();
   }
 
@@ -375,7 +387,7 @@ export default class AlgoliaAutocomplete {
   }
 
   renderResult(index) {
-    return hit => AlgoliaResult.renderResult(hit, index);
+    return hit => AlgoliaResult.renderResult(hit, index, this.#templates);
   }
 
   setValue(value) {

--- a/apps/site/assets/js/algolia-embedded-search.js
+++ b/apps/site/assets/js/algolia-embedded-search.js
@@ -14,13 +14,16 @@ import {
 } from "./algolia-embedded-search-options";
 
 export class AlgoliaEmbeddedSearch {
+  #templates;
+
   constructor({
     pageId,
     withGoogle,
     selectors,
     params,
     indices,
-    locationParams
+    locationParams,
+    templates = AlgoliaResult.TEMPLATES
   }) {
     this.withGoogle = withGoogle;
     this.pageId = pageId;
@@ -35,6 +38,8 @@ export class AlgoliaEmbeddedSearch {
     this.controller = null;
     this.autocomplete = null;
     this.goBtn = document.getElementById(selectors.goBtn);
+    this.#templates = templates;
+
     this.bind();
     if (this.input) {
       this.init();
@@ -55,6 +60,7 @@ export class AlgoliaEmbeddedSearch {
           indices: Object.keys(this.indices),
           locationParams: this.locationParams,
           popular: [],
+          templates: this.#templates,
           parent: this
         })
       : new AlgoliaAutocomplete({
@@ -63,6 +69,7 @@ export class AlgoliaEmbeddedSearch {
           indices: Object.keys(this.indices),
           locationParams: this.locationParams,
           popular: [],
+          templates: this.#templates,
           parent: this
         });
     this.autocomplete.renderFooterTemplate =
@@ -142,6 +149,7 @@ export const init = () => {
             selectors,
             params,
             indices,
+            templates: AlgoliaResult.TEMPLATES_ALT_USE_MY_LOCATION,
             withGoogle: true
           })
       );

--- a/apps/site/assets/js/algolia-homepage-search.js
+++ b/apps/site/assets/js/algolia-homepage-search.js
@@ -1,4 +1,5 @@
 import { AlgoliaEmbeddedSearch } from "./algolia-embedded-search";
+import { TEMPLATES_ALT_USE_MY_LOCATION } from "./algolia-result";
 // eslint-disable-next-line import/no-unresolved
 import * as QueryHelpers from "../ts/helpers/query";
 
@@ -78,7 +79,8 @@ export const doInit = id => {
     params: PARAMS,
     selectors: selectors,
     locationParams: LOCATION_PARAMS,
-    withGoogle: true
+    withGoogle: true,
+    templates: TEMPLATES_ALT_USE_MY_LOCATION
   });
 
   search.buildSearchParams = () =>

--- a/apps/site/assets/js/algolia-result.js
+++ b/apps/site/assets/js/algolia-result.js
@@ -81,6 +81,17 @@ export const TEMPLATES = {
   `)
 };
 
+export const TEMPLATES_ALT_USE_MY_LOCATION = {
+  ...TEMPLATES,
+  usemylocation: hogan.compile(`
+    <a id="search-bar__my-location" class="c-search-bar__my-location">
+      <i aria-hidden="true" class="fa fa-location-arrow "></i>
+      Use my location to find transit near me
+      <i aria-hidden="true" id="search-result__loading-indicator" class="fa fa-cog fa-spin c-search-result__loading-indicator"></i>
+    </a>
+  `)
+};
+
 function iconsFromGTFSAncestries(ancestries) {
   return ancestries
     .map(anc => anc.toLowerCase())
@@ -537,13 +548,13 @@ export function parseResult(hit, index) {
   });
 }
 
-export function renderResult(hit, index) {
+export function renderResult(hit, index, templates) {
   const parsedResult = parseResult(hit, index);
   if (parsedResult.hitFeatureIcons.length > 2) {
     return TEMPLATES["threePlusIcons"].render(parsedResult);
   }
-  if (TEMPLATES[index]) {
-    return TEMPLATES[index].render(parsedResult);
+  if (templates[index]) {
+    return templates[index].render(parsedResult);
   }
-  return TEMPLATES.default.render(parsedResult);
+  return templates.default.render(parsedResult);
 }

--- a/apps/site/assets/js/algolia-result.js
+++ b/apps/site/assets/js/algolia-result.js
@@ -548,7 +548,7 @@ export function parseResult(hit, index) {
   });
 }
 
-export function renderResult(hit, index, templates) {
+export function renderResult(hit, index, templates = TEMPLATES) {
   const parsedResult = parseResult(hit, index);
   if (parsedResult.hitFeatureIcons.length > 2) {
     return TEMPLATES["threePlusIcons"].render(parsedResult);


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update "Use my location" label](https://app.asana.com/0/385363666817452/1202299919599024/f)

Can't get screenshots, but this updates the "Use my location" text in the header search and on schedule hubs (e.g. `/schedules`) to be "Use my location to find transit near me". Any other locations (including the trip planner widget on the schedule hubs) retain the original text.

To do this, I've parameterized the templates we use for the results.