### PR TITLE
Fetch Schedule PDFs from new endpoint

### DIFF
--- a/apps/cms/lib/api/static.ex
+++ b/apps/cms/lib/api/static.ex
@@ -36,6 +36,10 @@ defmodule CMS.API.Static do
     parse_json("cms/route-pdfs.json")
   end
 
+  def schedule_pdfs_response do
+    parse_json("cms/schedule-pdfs.json")
+  end
+
   # Teaser responses from CMS API (minimal data)
 
   def teaser_response do
@@ -377,6 +381,10 @@ defmodule CMS.API.Static do
 
   def view("/cms/route-pdfs/87", _) do
     {:ok, route_pdfs_response()}
+  end
+
+  def view("/cms/schedules/87", _) do
+    {:ok, schedule_pdfs_response()}
   end
 
   def view("/cms/route-pdfs/error", _) do

--- a/apps/cms/priv/cms/schedule-pdfs.json
+++ b/apps/cms/priv/cms/schedule-pdfs.json
@@ -1,0 +1,118 @@
+[
+  {
+    "mid": [
+      {
+        "value": 3811
+      }
+    ],
+    "uuid": [
+      {
+        "value": "96d1dadc-9bbc-436e-becf-b0bdf817df3e"
+      }
+    ],
+    "vid": [
+      {
+        "value": 6129
+      }
+    ],
+    "langcode": [
+      {
+        "value": "en"
+      }
+    ],
+    "bundle": [
+      {
+        "target_id": "schedule",
+        "target_type": "media_type",
+        "target_uuid": "cf7fb1e9-5939-424f-b773-cab79031e70f"
+      }
+    ],
+    "revision_created": [
+      {
+        "value": 1659387643
+      }
+    ],
+    "revision_user": [],
+    "revision_log_message": [],
+    "status": [
+      {
+        "value": true
+      }
+    ],
+    "uid": [
+      {
+        "target_id": 29,
+        "target_type": "user",
+        "target_uuid": "9f40de48-dc44-49d9-a207-4a55a2c8546e",
+        "url": "/user/29"
+      }
+    ],
+    "name": [
+      {
+        "value": "110-01.22.3.pdf"
+      }
+    ],
+    "thumbnail": [
+      {
+        "target_id": 7201,
+        "alt": "",
+        "title": null,
+        "width": 180,
+        "height": 180,
+        "target_type": "file",
+        "target_uuid": "93cdf192-1e76-4091-89cd-b9093cef9394",
+        "url": "https://pr-390-mbta.pantheonsite.io/sites/default/files/media-icons/generic/generic.png",
+        "mime_type": "image/png"
+      }
+    ],
+    "created": [
+      {
+        "value": 1659387643
+      }
+    ],
+    "changed": [
+      {
+        "value": 1659387656
+      }
+    ],
+    "default_langcode": [
+      {
+        "value": true
+      }
+    ],
+    "revision_translation_affected": [
+      {
+        "value": true
+      }
+    ],
+    "path": [
+      {
+        "alias": null,
+        "pid": null,
+        "langcode": "en"
+      }
+    ],
+    "field_link_text_override": [],
+    "field_pdf_date_end": [
+      {
+        "value": "2022-08-31"
+      }
+    ],
+    "field_pdf_date_start": [
+      {
+        "value": "2022-08-01"
+      }
+    ],
+    "field_route_pdf": [
+      {
+        "target_id": 12219,
+        "display": true,
+        "description": "",
+        "target_type": "file",
+        "target_uuid": "b8724a29-125a-4699-a9b4-00c8ef1a20b6",
+        "url": "https://dev-mbta.pantheonsite.io/sites/default/files/route_pdfs/2022-winter/110-01.22.3.pdf",
+        "mime_type": "application/pdf"
+      }
+    ]
+  }
+]

--- a/apps/cms/priv/cms/schedule-pdfs.json
+++ b/apps/cms/priv/cms/schedule-pdfs.json
@@ -1,25 +1,9 @@
 [
   {
-    "mid": [
-      {
-        "value": 3811
-      }
-    ],
-    "uuid": [
-      {
-        "value": "96d1dadc-9bbc-436e-becf-b0bdf817df3e"
-      }
-    ],
-    "vid": [
-      {
-        "value": 6129
-      }
-    ],
-    "langcode": [
-      {
-        "value": "en"
-      }
-    ],
+    "mid": [{ "value": 3835 }],
+    "uuid": [{ "value": "ff1bd70b-fad6-4147-bbd7-257ed58dd2d8" }],
+    "vid": [{ "value": 6160 }],
+    "langcode": [{ "value": "en" }],
     "bundle": [
       {
         "target_id": "schedule",
@@ -27,18 +11,10 @@
         "target_uuid": "cf7fb1e9-5939-424f-b773-cab79031e70f"
       }
     ],
-    "revision_created": [
-      {
-        "value": 1659387643
-      }
-    ],
+    "revision_created": [{ "value": 1660236438 }],
     "revision_user": [],
     "revision_log_message": [],
-    "status": [
-      {
-        "value": true
-      }
-    ],
+    "status": [{ "value": true }],
     "uid": [
       {
         "target_id": 29,
@@ -47,11 +23,7 @@
         "url": "/user/29"
       }
     ],
-    "name": [
-      {
-        "value": "110-01.22.3.pdf"
-      }
-    ],
+    "name": [{ "value": "Summer 2025 350-351-S2-P4" }],
     "thumbnail": [
       {
         "target_id": 7201,
@@ -61,56 +33,145 @@
         "height": 180,
         "target_type": "file",
         "target_uuid": "93cdf192-1e76-4091-89cd-b9093cef9394",
-        "url": "https://pr-390-mbta.pantheonsite.io/sites/default/files/media-icons/generic/generic.png",
+        "url": "https://sandbox-mbta.pantheonsite.io/sites/default/files/media-icons/generic/generic.png",
         "mime_type": "image/png"
       }
     ],
-    "created": [
-      {
-        "value": 1659387643
-      }
-    ],
-    "changed": [
-      {
-        "value": 1659387656
-      }
-    ],
-    "default_langcode": [
-      {
-        "value": true
-      }
-    ],
-    "revision_translation_affected": [
-      {
-        "value": true
-      }
-    ],
-    "path": [
-      {
-        "alias": null,
-        "pid": null,
-        "langcode": "en"
-      }
-    ],
+    "created": [{ "value": 1660236438 }],
+    "changed": [{ "value": 1660236438 }],
+    "default_langcode": [{ "value": true }],
+    "revision_translation_affected": [{ "value": true }],
+    "path": [{ "alias": null, "pid": null, "langcode": "en" }],
+    "field_batch": [],
     "field_link_text_override": [],
-    "field_pdf_date_end": [
-      {
-        "value": "2022-08-31"
-      }
-    ],
-    "field_pdf_date_start": [
-      {
-        "value": "2022-08-01"
-      }
-    ],
+    "field_pdf_date_end": [],
+    "field_pdf_date_start": [{ "value": "2022-08-11" }],
     "field_route_pdf": [
       {
-        "target_id": 12219,
-        "display": true,
-        "description": "",
+        "target_id": 14437,
+        "display": null,
+        "description": null,
         "target_type": "file",
-        "target_uuid": "b8724a29-125a-4699-a9b4-00c8ef1a20b6",
-        "url": "https://dev-mbta.pantheonsite.io/sites/default/files/route_pdfs/2022-winter/110-01.22.3.pdf",
+        "target_uuid": "c051bfd5-3744-4320-aad3-7ca37822e8e6",
+        "url": "https://sandbox-mbta.pantheonsite.io/sites/default/files/media/route_pdfs/batch_304/350-351-S2-P4.pdf",
+        "mime_type": "application/pdf"
+      }
+    ]
+  },
+  {
+    "mid": [{ "value": 3841 }],
+    "uuid": [{ "value": "f99fa39d-70ba-4051-aab5-d159d20ab3eb" }],
+    "vid": [{ "value": 6166 }],
+    "langcode": [{ "value": "en" }],
+    "bundle": [
+      {
+        "target_id": "schedule",
+        "target_type": "media_type",
+        "target_uuid": "cf7fb1e9-5939-424f-b773-cab79031e70f"
+      }
+    ],
+    "revision_created": [{ "value": 1660250618 }],
+    "revision_user": [],
+    "revision_log_message": [],
+    "status": [{ "value": true }],
+    "uid": [
+      {
+        "target_id": 29,
+        "target_type": "user",
+        "target_uuid": "9f40de48-dc44-49d9-a207-4a55a2c8546e",
+        "url": "/user/29"
+      }
+    ],
+    "name": [{ "value": "Winter 2023 350-351-S2-P4" }],
+    "thumbnail": [
+      {
+        "target_id": 7201,
+        "alt": "",
+        "title": null,
+        "width": 180,
+        "height": 180,
+        "target_type": "file",
+        "target_uuid": "93cdf192-1e76-4091-89cd-b9093cef9394",
+        "url": "https://sandbox-mbta.pantheonsite.io/sites/default/files/media-icons/generic/generic.png",
+        "mime_type": "image/png"
+      }
+    ],
+    "created": [{ "value": 1660250618 }],
+    "changed": [{ "value": 1660250618 }],
+    "default_langcode": [{ "value": true }],
+    "revision_translation_affected": [{ "value": true }],
+    "path": [{ "alias": null, "pid": null, "langcode": "en" }],
+    "field_batch": [],
+    "field_link_text_override": [],
+    "field_pdf_date_end": [{ "value": "2022-09-10" }],
+    "field_pdf_date_start": [{ "value": "2022-08-11" }],
+    "field_route_pdf": [
+      {
+        "target_id": 14444,
+        "display": null,
+        "description": null,
+        "target_type": "file",
+        "target_uuid": "7a24945c-d808-47c7-8e25-6af1b268bf0b",
+        "url": "https://sandbox-mbta.pantheonsite.io/sites/default/files/media/route_pdfs/batch_305/350-351-S2-P4.pdf",
+        "mime_type": "application/pdf"
+      }
+    ]
+  },
+  {
+    "mid": [{ "value": 3847 }],
+    "uuid": [{ "value": "fe352e1c-5272-4236-b11c-f888ce371640" }],
+    "vid": [{ "value": 6172 }],
+    "langcode": [{ "value": "en" }],
+    "bundle": [
+      {
+        "target_id": "schedule",
+        "target_type": "media_type",
+        "target_uuid": "cf7fb1e9-5939-424f-b773-cab79031e70f"
+      }
+    ],
+    "revision_created": [{ "value": 1660315027 }],
+    "revision_user": [],
+    "revision_log_message": [],
+    "status": [{ "value": true }],
+    "uid": [
+      {
+        "target_id": 247,
+        "target_type": "user",
+        "target_uuid": "07c22bc5-5e30-4233-b181-cbf2998d2512",
+        "url": "/user/247"
+      }
+    ],
+    "name": [{ "value": "Summer 2022 350-351-S2-P4" }],
+    "thumbnail": [
+      {
+        "target_id": 7201,
+        "alt": "",
+        "title": null,
+        "width": 180,
+        "height": 180,
+        "target_type": "file",
+        "target_uuid": "93cdf192-1e76-4091-89cd-b9093cef9394",
+        "url": "https://sandbox-mbta.pantheonsite.io/sites/default/files/media-icons/generic/generic.png",
+        "mime_type": "image/png"
+      }
+    ],
+    "created": [{ "value": 1660315027 }],
+    "changed": [{ "value": 1660315027 }],
+    "default_langcode": [{ "value": true }],
+    "revision_translation_affected": [{ "value": true }],
+    "path": [{ "alias": null, "pid": null, "langcode": "en" }],
+    "field_batch": [],
+    "field_link_text_override": [],
+    "field_pdf_date_end": [],
+    "field_pdf_date_start": [{ "value": "2022-06-19" }],
+    "field_route_pdf": [
+      {
+        "target_id": 14451,
+        "display": null,
+        "description": null,
+        "target_type": "file",
+        "target_uuid": "56d697c9-3edb-41dc-94fa-7c2b2e47fb62",
+        "url": "https://sandbox-mbta.pantheonsite.io/sites/default/files/media/route_pdfs/batch_304/350-351-S2-P4.pdf",
         "mime_type": "application/pdf"
       }
     ]

--- a/apps/cms/test/repo_test.exs
+++ b/apps/cms/test/repo_test.exs
@@ -229,6 +229,10 @@ defmodule CMS.RepoTest do
     end
   end
 
+  describe "get_schedule_pdfs/1" do
+    assert [%RoutePdf{} | _] = Repo.get_schedule_pdfs("87")
+  end
+
   describe "teasers/1" do
     test "returns only teasers for a project type" do
       types =

--- a/apps/site/lib/site/route_pdfs.ex
+++ b/apps/site/lib/site/route_pdfs.ex
@@ -9,6 +9,7 @@ defmodule Site.RoutePdfs do
   def fetch_and_choose_pdfs(route_id, date) do
     route_id
     |> Repo.get_route_pdfs()
+    |> Enum.concat(Repo.get_schedule_pdfs(route_id))
     |> choose_pdfs(date)
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Elixir integration](https://app.asana.com/0/385363666817452/1202623240995537/f)

Mostly opening this on behalf of @thecristen since all of the actual work has been done by her :) I just confirmed things worked locally.

One question that came up: From the ticket, it sounds like we are transtioning bus routes fully to this new endpoint ~soon, and other modes later on. The code is currently hitting _both_ endpoints and combining the resulting lists. @amaisano Is there any worry that we'll run into a situation where we have PDFs coming from both endpoints for modes we don't want to support yet? Or can we make the assumption that if the schedules are on the prod CMS we do indeed want to show them?

Thanks!