### PR TITLE
Validate that a vehicle number is between 1 and 8 digits

### DIFF
--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -364,7 +364,7 @@ const validators = {
   },
   vehicle: function($) {
     const value = $("#vehicle").val();
-    return value.length == 0 || /^[0-9]{1,8}$/.test(value);
+    return /^[0-9]{0,8}$/.test(value);
   }
 };
 

--- a/apps/site/assets/js/support-form.js
+++ b/apps/site/assets/js/support-form.js
@@ -364,7 +364,7 @@ const validators = {
   },
   vehicle: function($) {
     const value = $("#vehicle").val();
-    return /^[0-9]*$/.test(value);
+    return value.length == 0 || /^[0-9]{1,8}$/.test(value);
   }
 };
 

--- a/apps/site/assets/js/test/support-form_test.js
+++ b/apps/site/assets/js/test/support-form_test.js
@@ -345,6 +345,21 @@ describe("support form", () => {
       );
     });
 
+    it("errors when vehicle number longer than 8 digits", () => {
+      $("#vehicle").val("Not a number");
+      $("#support-submit").click();
+      assert.isFalse(
+        $(".support-vehicle-error-container").hasClass("hidden-xs-up"),
+        "not false"
+      );
+      $("#vehicle").val("1".repeat(9));
+      $("#support-submit").click();
+      assert.isFalse(
+        $(".support-vehicle-error-container").hasClass("hidden-xs-up"),
+        "not false"
+      );
+    });
+
     it("requires a service to be selected", () => {
       $("#support-submit").click();
       assert.isFalse($(".support-form-expanded").hasClass("hidden-xs-up"));

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -278,7 +278,9 @@ defmodule SiteWeb.CustomerSupportController do
 
   @spec validate_vehicle(map) :: :ok | String.t()
   defp validate_vehicle(%{"vehicle" => vehicle_number}) do
-    if Regex.match?(~r/^[0-9]*$/, vehicle_number), do: :ok, else: "vehicle"
+    if vehicle_number == "" || Regex.match?(~r/^[0-9]{1,8}$/, vehicle_number),
+      do: :ok,
+      else: "vehicle"
   end
 
   defp validate_vehicle(_), do: :ok

--- a/apps/site/lib/site_web/controllers/customer_support_controller.ex
+++ b/apps/site/lib/site_web/controllers/customer_support_controller.ex
@@ -278,7 +278,7 @@ defmodule SiteWeb.CustomerSupportController do
 
   @spec validate_vehicle(map) :: :ok | String.t()
   defp validate_vehicle(%{"vehicle" => vehicle_number}) do
-    if vehicle_number == "" || Regex.match?(~r/^[0-9]{1,8}$/, vehicle_number),
+    if Regex.match?(~r/^[0-9]{0,8}$/, vehicle_number),
       do: :ok,
       else: "vehicle"
   end

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -69,7 +69,7 @@
               </span>
             </span>
           </div>
-          <%= text_input(f, :vehicle, id: "vehicle", placeholder: placeholder_text("vehicle"), class: "support-form-input form-control", value: assigns[:vehicle] ) %>
+          <%= text_input(f, :vehicle, id: "vehicle", placeholder: placeholder_text("vehicle"), class: "support-form-input form-control", value: assigns[:vehicle], maxlength: 8, ) %>
         </div>
       </div>
     </div>

--- a/apps/site/test/site_web/controllers/customer_support_controller_test.exs
+++ b/apps/site/test/site_web/controllers/customer_support_controller_test.exs
@@ -188,6 +188,15 @@ defmodule SiteWeb.CustomerSupportControllerTest do
         post(
           conn,
           customer_support_path(conn, :submit),
+          put_in(valid_request_response_data(), ["support", "vehicle"], String.duplicate("0", 9))
+        )
+
+      assert "vehicle" in conn.assigns.errors
+
+      conn =
+        post(
+          conn,
+          customer_support_path(conn, :submit),
           put_in(valid_request_response_data(), ["support", "vehicle"], "01243")
         )
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Limit vehicle number input to 8 digits](https://app.asana.com/0/385363666817452/1201613685853937/f)

This also maintains the existing (but perhaps unintended?) behavior of successfully validating empty strings in the `vehicle` input