### PR TITLE
fix(test): Update E-line test to match suspension data

### DIFF
--- a/apps/routes/lib/parser.ex
+++ b/apps/routes/lib/parser.ex
@@ -83,11 +83,15 @@ defmodule Routes.Parser do
       %Shape{
         id: id,
         name: attributes["name"],
-        stop_ids: Enum.map(relationships["stops"], & &1.id),
+        stop_ids: stop_ids(relationships),
         direction_id: attributes["direction_id"],
         polyline: attributes["polyline"],
         priority: attributes["priority"]
       }
     ]
   end
+
+  @spec stop_ids(%{String.t() => list(JsonApi.Item.t())}) :: [Stops.Stop.id_t()]
+  defp stop_ids(%{"stops" => stops}), do: Enum.map(stops, & &1.id)
+  defp stop_ids(_), do: []
 end

--- a/apps/routes/test/parser_test.exs
+++ b/apps/routes/test/parser_test.exs
@@ -181,5 +181,29 @@ defmodule Routes.ParserTest do
                }
              ]
     end
+
+    test "handles a response with no stops" do
+      item = %Item{
+        id: "shape_id",
+        attributes: %{
+          "name" => "name",
+          "direction_id" => 1,
+          "polyline" => "polyline",
+          "priority" => -1
+        },
+        relationships: %{}
+      }
+
+      assert parse_shape(item) == [
+               %Shape{
+                 id: "shape_id",
+                 name: "name",
+                 stop_ids: [],
+                 direction_id: 1,
+                 polyline: "polyline",
+                 priority: -1
+               }
+             ]
+    end
   end
 end

--- a/apps/site/lib/site_web/templates/customer_support/_form.html.eex
+++ b/apps/site/lib/site_web/templates/customer_support/_form.html.eex
@@ -69,7 +69,7 @@
               </span>
             </span>
           </div>
-          <%= text_input(f, :vehicle, id: "vehicle", placeholder: placeholder_text("vehicle"), class: "support-form-input form-control", value: assigns[:vehicle], maxlength: 8, ) %>
+          <%= text_input(f, :vehicle, id: "vehicle", placeholder: placeholder_text("vehicle"), class: "support-form-input form-control", value: assigns[:vehicle], maxlength: 8 ) %>
         </div>
       </div>
     </div>

--- a/apps/site/test/green_line_test.exs
+++ b/apps/site/test/green_line_test.exs
@@ -17,12 +17,14 @@ defmodule GreenLineTest do
       refute "place-unsqu" in route_id_stop_map["Green-B"]
       refute "place-unsqu" in route_id_stop_map["Green-C"]
       refute "place-unsqu" in route_id_stop_map["Green-D"]
-      assert "place-unsqu" in route_id_stop_map["Green-E"]
+      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # assert "place-unsqu" in route_id_stop_map["Green-E"]
 
       refute "place-lech" in route_id_stop_map["Green-B"]
       refute "place-lech" in route_id_stop_map["Green-C"]
       refute "place-lech" in route_id_stop_map["Green-D"]
-      assert "place-lech" in route_id_stop_map["Green-E"]
+      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # assert "place-lech" in route_id_stop_map["Green-E"]
 
       assert "place-coecl" in route_id_stop_map["Green-B"]
       assert "place-coecl" in route_id_stop_map["Green-C"]
@@ -88,8 +90,11 @@ defmodule GreenLineTest do
       # be terminating at North Station for now.
       # assert stop_map["Green-E"] ==
       #          MapSet.new(["place-hsmnl", "place-gover", "place-north", "place-lech"])
+      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # assert stop_map["Green-E"] ==
+      #          MapSet.new(["place-hsmnl", "place-gover", "place-north"])
       assert stop_map["Green-E"] ==
-               MapSet.new(["place-hsmnl", "place-gover", "place-north"])
+               MapSet.new(["place-hsmnl", "place-gover"])
     end
 
     test "a list of stops without duplicates is returned" do
@@ -137,7 +142,9 @@ defmodule GreenLineTest do
       assert terminus?(stop_id, "Green-D")
     end
 
-    for stop_id <- ["place-unsqu", "place-hsmnl"] do
+    # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+    # for stop_id <- ["place-unsqu", "place-hsmnl"] do
+    for stop_id <- ["place-gover", "place-hsmnl"] do
       assert terminus?(stop_id, "Green-E")
     end
   end
@@ -145,8 +152,11 @@ defmodule GreenLineTest do
   test "terminus?/3" do
     assert terminus?("place-lake", "Green-B", 0)
     refute terminus?("place-lake", "Green-B", 1)
-    refute terminus?("place-unsqu", "Green-E", 0)
-    assert terminus?("place-unsqu", "Green-E", 1)
+    # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+    # refute terminus?("place-unsqu", "Green-E", 0)
+    # assert terminus?("place-unsqu", "Green-E", 1)
+    refute terminus?("place-gover", "Green-E", 0)
+    assert terminus?("place-gover", "Green-E", 1)
   end
 
   describe "naive_headsign/2" do
@@ -159,7 +169,9 @@ defmodule GreenLineTest do
       assert naive_headsign("Green-D", 0) == "Riverside"
       assert naive_headsign("Green-D", 1) == "North Station"
       assert naive_headsign("Green-E", 0) == "Heath Street"
-      assert naive_headsign("Green-E", 1) == "Union Square"
+      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # assert naive_headsign("Green-E", 1) == "Union Square"
+      assert naive_headsign("Green-E", 1) == "Government Center"
     end
   end
 

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -257,10 +257,16 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
     end
 
     test "handles green line trips from the generic Green page", %{conn: conn} do
+      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # params = %{
+      #   id: "Green",
+      #   direction: "0",
+      #   stop: "place-north"
+      # }
       params = %{
         id: "Green",
         direction: "0",
-        stop: "place-north"
+        stop: "place-gover"
       }
 
       params_for_trip = get_valid_trip_params(params, conn)

--- a/apps/site/test/site_web/controllers/schedule/green_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/green_test.exs
@@ -73,7 +73,9 @@ defmodule SiteWeb.ScheduleController.GreenTest do
        %{conn: conn} do
     conn = get(conn, green_path(conn, :line, %{"schedule_direction[direction_id]": 0}))
 
-    assert [{_, %{id: "place-unsqu"}} | all_stops] = conn.assigns.all_stops
+    # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+    # assert [{_, %{id: "place-unsqu"}} | all_stops] = conn.assigns.all_stops
+    assert [{_, %{id: "place-gover"}} | all_stops] = conn.assigns.all_stops
 
     fenway = Enum.find(all_stops, fn {_, stop} -> stop.id == "place-fenwy" end)
     assert elem(fenway, 0) == [{"Green-B", :line}, {"Green-C", :line}, {"Green-D", :stop}]

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
@@ -644,7 +644,9 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
                  %Stops.RouteStop{id: "place-haecl"}
                },
                {
-                 [nil: :stop],
+                 # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+                 #  [nil: :stop],
+                 [nil: :terminus],
                  %Stops.RouteStop{id: "place-gover"}
                },
                {
@@ -996,7 +998,9 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
                  %Stops.RouteStop{id: "place-pktrm"}
                },
                {
-                 [nil: :stop],
+                 # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+                 #  [nil: :stop],
+                 [nil: :terminus],
                  %Stops.RouteStop{id: "place-gover"}
                }
              ] = DiagramHelpers.build_stop_list(branches, 1)

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -304,15 +304,23 @@ defmodule SiteWeb.ScheduleController.LineTest do
       # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
       # We are temporarily adding the fix but this will need to be undone later on.
       for {id, idx} <- [
-            {"place-unsqu", 0},
-            {"place-north", 3},
-            {"place-gover", 5},
-            {"place-pktrm", 6},
-            {"place-coecl", 9},
-            {"place-hsmnl", 20},
-            {"place-river", 35},
-            {"place-clmnl", 48},
-            {"place-lake", 64}
+            # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+            # {"place-unsqu", 0},
+            # {"place-north", 3},
+            # {"place-gover", 5},
+            # {"place-pktrm", 6},
+            # {"place-coecl", 9},
+            # {"place-hsmnl", 20},
+            # {"place-river", 35},
+            # {"place-clmnl", 48},
+            # {"place-lake", 64}
+            {"place-gover", 0},
+            {"place-pktrm", 1},
+            {"place-coecl", 4},
+            {"place-hsmnl", 15},
+            {"place-river", 32},
+            {"place-clmnl", 45},
+            {"place-lake", 61}
           ] do
         assert stops |> Enum.at(idx) |> elem(1) == id
       end
@@ -333,7 +341,9 @@ defmodule SiteWeb.ScheduleController.LineTest do
 
       assert Enum.all?(trunk, &(&1 |> branches() |> length() == 1))
 
-      assert trunk |> List.first() |> stop_id() == "place-unsqu"
+      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # assert trunk |> List.first() |> stop_id() == "place-unsqu"
+      assert trunk |> List.first() |> stop_id() == "place-gover"
       assert trunk |> List.last() |> stop_id() == "place-armnl"
 
       # E branch + merge
@@ -387,7 +397,8 @@ defmodule SiteWeb.ScheduleController.LineTest do
       # We are temporarily adding the fix but this will need to be undone later on.
       for {id, idx} <- [
             # {"place-lech", 64},
-            {"place-north", 61},
+            # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+            # {"place-north", 61},
             {"place-gover", 59},
             {"place-pktrm", 58},
             {"place-coecl", 55},
@@ -437,7 +448,9 @@ defmodule SiteWeb.ScheduleController.LineTest do
 
       assert Enum.all?(trunk, &(&1 |> branches() |> length() == 1))
       assert trunk |> List.first() |> stop_id() == "place-armnl"
-      assert trunk |> List.last() |> stop_id() == "place-unsqu"
+      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # assert trunk |> List.last() |> stop_id() == "place-unsqu"
+      assert trunk |> List.last() |> stop_id() == "place-gover"
     end
   end
 

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -372,13 +372,15 @@ defmodule SiteWeb.ScheduleController.LineTest do
     end
 
     test "direction 1 returns a list of all stops in order from west to east" do
-      route_stops = get_route_stops("Green", 0, @deps.stops_by_route_fn)
+      direction_id = 1
+
+      route_stops = get_route_stops("Green", direction_id, @deps.stops_by_route_fn)
 
       stops =
         "Green"
-        |> get_shapes_by_direction(0, 1)
-        |> get_branches(route_stops, %Routes.Route{id: "Green"}, 1)
-        |> build_stop_list(1)
+        |> get_shapes_by_direction(0, direction_id)
+        |> get_branches(route_stops, %Routes.Route{id: "Green"}, direction_id)
+        |> build_stop_list(direction_id)
         |> Enum.map(fn {branches, stop} -> {branches, stop.id} end)
 
       # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
@@ -440,14 +442,15 @@ defmodule SiteWeb.ScheduleController.LineTest do
   end
 
   describe "build_stop_list/2 for branched non-Green routes" do
-    test "Red outbound" do
-      route_stops = get_route_stops("Red", 0, @deps.stops_by_route_fn)
+    test "Red direction 0" do
+      direction_id = 0
+      route_stops = get_route_stops("Red", direction_id, @deps.stops_by_route_fn)
 
       stops =
         "Red"
-        |> get_shapes_by_direction(1, 0)
-        |> get_branches(route_stops, %Routes.Route{id: "Red"}, 0)
-        |> build_stop_list(0)
+        |> get_shapes_by_direction(1, direction_id)
+        |> get_branches(route_stops, %Routes.Route{id: "Red"}, direction_id)
+        |> build_stop_list(direction_id)
         |> Enum.map(fn {branches, stop} -> {branches, stop.id} end)
 
       for {id, idx} <- [
@@ -460,14 +463,15 @@ defmodule SiteWeb.ScheduleController.LineTest do
       end
     end
 
-    test "outbound returns the correct number of bubbles for each stop" do
-      route_stops = get_route_stops("Red", 0, @deps.stops_by_route_fn)
+    test "direction 0 returns the correct number of bubbles for each stop" do
+      direction_id = 0
+      route_stops = get_route_stops("Red", direction_id, @deps.stops_by_route_fn)
 
       stops =
         "Red"
-        |> get_shapes_by_direction(1, 0)
-        |> get_branches(route_stops, %Routes.Route{id: "Red"}, 0)
-        |> build_stop_list(0)
+        |> get_shapes_by_direction(1, direction_id)
+        |> get_branches(route_stops, %Routes.Route{id: "Red"}, direction_id)
+        |> build_stop_list(direction_id)
         |> Enum.map(fn {branches, stop} -> {branches, stop.id} end)
 
       [one, two, another_one] =
@@ -486,14 +490,15 @@ defmodule SiteWeb.ScheduleController.LineTest do
       assert stop_id(List.last(another_one)) == "place-asmnl"
     end
 
-    test "Red inbound" do
-      route_stops = get_route_stops("Red", 0, @deps.stops_by_route_fn)
+    test "Red direction 1" do
+      direction_id = 1
+      route_stops = get_route_stops("Red", direction_id, @deps.stops_by_route_fn)
 
       stops =
         "Red"
-        |> get_shapes_by_direction(1, 1)
-        |> get_branches(route_stops, %Routes.Route{id: "Red"}, 1)
-        |> build_stop_list(1)
+        |> get_shapes_by_direction(1, direction_id)
+        |> get_branches(route_stops, %Routes.Route{id: "Red"}, direction_id)
+        |> build_stop_list(direction_id)
         |> Enum.map(fn {branches, stop} -> {branches, stop.id} end)
 
       for {id, idx} <- [
@@ -506,14 +511,15 @@ defmodule SiteWeb.ScheduleController.LineTest do
       end
     end
 
-    test "inbound returns the correct number of bubbles for each stop" do
-      route_stops = get_route_stops("Red", 0, @deps.stops_by_route_fn)
+    test "direction 1 returns the correct number of bubbles for each stop" do
+      direction_id = 1
+      route_stops = get_route_stops("Red", direction_id, @deps.stops_by_route_fn)
 
       stops =
         "Red"
         |> get_shapes_by_direction(1, 1)
-        |> get_branches(route_stops, %Routes.Route{id: "Red"}, 1)
-        |> build_stop_list(1)
+        |> get_branches(route_stops, %Routes.Route{id: "Red"}, direction_id)
+        |> build_stop_list(direction_id)
         |> Enum.map(fn {branches, stop} -> {branches, stop.id} end)
 
       [another_one, two, one] =

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -174,12 +174,19 @@ defmodule SiteWeb.ScheduleControllerTest do
       {_, first_stop} = List.first(conn.assigns.all_stops)
       {_, last_stop} = List.last(conn.assigns.all_stops)
 
-      assert first_stop.id == "place-unsqu"
+      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      assert first_stop.id == "place-gover"
 
       assert last_stop.id == "place-lake"
 
       # includes the stop features
-      assert first_stop.stop_features == [:access]
+      assert first_stop.stop_features == [
+               :green_line_b,
+               :green_line_c,
+               :green_line_d,
+               :blue_line,
+               :access
+             ]
 
       # spider map
       assert conn.assigns.map_img_src =~ "maps.googleapis.com"

--- a/apps/site/test/site_web/excluded_stops_test.exs
+++ b/apps/site/test/site_web/excluded_stops_test.exs
@@ -38,7 +38,9 @@ defmodule ExcludedStopsTest do
         |> GreenLine.stops_on_routes()
         |> GreenLine.all_stops()
 
-      assert excluded_origin_stops(1, "Green", all_stops) == ["place-unsqu"]
+      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # assert excluded_origin_stops(1, "Green", all_stops) == ["place-unsqu"]
+      assert excluded_origin_stops(1, "Green", all_stops) == ["place-north"]
     end
   end
 

--- a/apps/stops/test/repo_test.exs
+++ b/apps/stops/test/repo_test.exs
@@ -183,10 +183,10 @@ defmodule Stops.RepoTest do
     test "includes specific green_line branches if specified" do
       # when green line isn't expanded, keep it in GTFS order
       features = stop_features(%Stop{id: "place-pktrm"})
-      assert features == [:red_line, :green_line_b, :green_line_c, :green_line_d, :green_line_e]
+      assert features == [:red_line, :green_line_b, :green_line_c, :green_line_d]
       # when green line is expanded, put the branches first
       features = stop_features(%Stop{id: "place-pktrm"}, expand_branches?: true)
-      assert features == [:"Green-B", :"Green-C", :"Green-D", :"Green-E", :red_line]
+      assert features == [:"Green-B", :"Green-C", :"Green-D", :red_line]
     end
   end
 end

--- a/apps/stops/test/route_stops_test.exs
+++ b/apps/stops/test/route_stops_test.exs
@@ -164,9 +164,15 @@ defmodule Stops.RouteStopsTest do
       #            stops: [%RouteStop{id: "place-lech", is_terminus?: true} | _]
       #          }
       #        ] = stops
+      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # assert [
+      #          %RouteStops{
+      #            stops: [%RouteStop{id: "place-north", is_terminus?: true} | _]
+      #          }
+      #        ] = stops
       assert [
                %RouteStops{
-                 stops: [%RouteStop{id: "place-north", is_terminus?: true} | _]
+                 stops: [%RouteStop{id: "place-gover", is_terminus?: true} | _]
                }
              ] = stops
     end

--- a/apps/v3_api/test/routes_test.exs
+++ b/apps/v3_api/test/routes_test.exs
@@ -25,7 +25,8 @@ defmodule V3Api.RoutesTest do
 
   describe "by_stop/2" do
     test "gets routes by stop ID" do
-      assert %JsonApi{data: [%JsonApi.Item{id: "131"}]} = Routes.by_stop("place-ogmnl", @opts)
+      assert %JsonApi{data: [%JsonApi.Item{id: "CR-Haverhill"}]} =
+               Routes.by_stop("place-ogmnl", @opts)
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
No ticket, fixes a [failing test in CI](https://github.com/mbta/dotcom/runs/7865831703?check_suite_focus=true).

The train isn't running past Government Center starting in a few days.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
