### PR TITLE
refactor(LineDiagram): extract useRealtime

### DIFF
--- a/apps/site/assets/js/app.js
+++ b/apps/site/assets/js/app.js
@@ -53,7 +53,7 @@ if (window.sentry) {
     dsn: window.sentry.dsn,
     environment: window.sentry.environment,
     autoSessionTracking: false,
-    sampleRate: 0.10, // error sampling - might increase later
+    sampleRate: 0.1, // error sampling - might increase later
     initialScope: {
       tags: { "dotcom.application": "frontend" }
     },

--- a/apps/site/assets/ts/hooks/__tests__/useRealtimeTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/useRealtimeTest.tsx
@@ -1,0 +1,75 @@
+import { renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { SWRConfig } from "swr";
+import { LiveDataByStop } from "../../schedule/components/line-diagram/__line-diagram";
+import { LineDiagramVehicle } from "../../schedule/components/__schedule";
+import { HeadsignWithCrowding, Route } from "../../__v3api";
+import useRealtime from "../useRealtime";
+
+const unmockedFetch = global.fetch;
+const testRoute = { id: "Red", type: 1 } as Route;
+const testRouteFerry = { id: "Boat", type: 4 } as Route;
+const testRequestURL = `/schedules/line_api/realtime?id=${testRoute.id}&direction_id=0`;
+const HookWrapper: React.FC = ({ children }) => (
+  <SWRConfig value={{ dedupingInterval: 0 }}>{children}</SWRConfig>
+);
+const testResponse: LiveDataByStop = {
+  "place-north": {
+    vehicles: [{} as LineDiagramVehicle],
+    headsigns: [{} as HeadsignWithCrowding]
+  },
+  "place-bbsta": { vehicles: [], headsigns: [] }
+};
+
+describe("useRealtime", () => {
+  beforeAll(() => {
+    // provide mocked network response
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve: Function) =>
+          resolve({
+            json: () => testResponse,
+            ok: true,
+            status: 200,
+            statusText: "OK"
+          })
+        )
+    );
+  });
+
+  test("should do nothing when enabled value is false", async () => {
+    const { result, waitFor } = renderHook(
+      () => useRealtime(testRoute, 0, false),
+      {
+        wrapper: HookWrapper
+      }
+    );
+    await waitFor(() => expect(result.current).toBe(undefined));
+  });
+
+  test("should do nothing when route is ferry", async () => {
+    const { result, waitFor } = renderHook(
+      () => useRealtime(testRouteFerry, 0, false),
+      {
+        wrapper: HookWrapper
+      }
+    );
+    await waitFor(() => expect(result.current).toBe(undefined));
+  });
+
+  test("should make fetch request", async () => {
+    const { result, waitFor } = renderHook(
+      () => useRealtime(testRoute, 0, true),
+      {
+        wrapper: HookWrapper
+      }
+    );
+
+    await waitFor(() => expect(result.current).toMatchObject(testResponse));
+    expect(global.fetch).toHaveBeenCalledWith(testRequestURL);
+  });
+
+  afterAll(() => {
+    global.fetch = unmockedFetch;
+  });
+});

--- a/apps/site/assets/ts/hooks/useRealtime.ts
+++ b/apps/site/assets/ts/hooks/useRealtime.ts
@@ -1,0 +1,28 @@
+import useSWR, { Fetcher } from "swr";
+import { LiveDataByStop } from "../schedule/components/line-diagram/__line-diagram";
+import { DirectionId, Route } from "../__v3api";
+
+/**
+ * Live data, including realtime vehicle locations and predictions
+ * Available on all modes except ferry (route.type 4)
+ */
+const fetcher: Fetcher<LiveDataByStop, string> = (url: string) =>
+  fetch(url).then(response => response.json());
+
+const useRealtime = (
+  route: Route,
+  directionId: DirectionId,
+  enabled: boolean = true
+): LiveDataByStop | undefined => {
+  const liveUrl = `/schedules/line_api/realtime?id=${route.id}&direction_id=${directionId}`;
+  const { data } = useSWR<LiveDataByStop>(
+    enabled && route.type !== 4 ? liveUrl : null,
+    fetcher,
+    {
+      refreshInterval: 15000
+    }
+  );
+  return data;
+};
+
+export default useRealtime;

--- a/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
@@ -85,7 +85,7 @@ const ExpandableBranch = (
               key={stop.route_stop.id}
               stop={stop}
               onClick={handleStopClick}
-              liveData={liveData[stop.route_stop.id]}
+              liveData={liveData ? liveData[stop.route_stop.id] : undefined}
             />
           ))}
         </>

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -1,17 +1,16 @@
 import React, { ReactElement } from "react";
 import { Provider } from "react-redux";
 import { updateInLocation } from "use-query-params";
-import useSWR from "swr";
 import useFilteredList from "../../../hooks/useFilteredList";
 import SearchBox from "../../../components/SearchBox";
 import { LineDiagramStop, SelectedOrigin, RouteStop } from "../__schedule";
 import { DirectionId, Route } from "../../../__v3api";
 import { createLineDiagramCoordStore } from "./graphics/graphic-helpers";
-import { LiveDataByStop } from "./__line-diagram";
 import StopCard from "./StopCard";
 import LineDiagramWithStops from "./LineDiagramWithStops";
 import { getCurrentState, storeHandler } from "../../store/ScheduleStore";
 import { changeOrigin } from "../ScheduleLoader";
+import useRealtime from "../../../hooks/useRealtime";
 
 interface LineDiagramProps {
   lineDiagram: LineDiagramStop[];
@@ -70,20 +69,7 @@ const LineDiagramAndStopListPage = ({
     "route_stop.name"
   );
 
-  /**
-   * Live data, including realtime vehicle locations and predictions
-   * Available on all modes except ferry (route.type 4)
-   */
-  const liveUrl =
-    route.type !== 4
-      ? `/schedules/line_api/realtime?id=${route.id}&direction_id=${directionId}`
-      : "";
-  const { data: maybeLiveData } = useSWR(
-    liveUrl,
-    url => fetch(url).then(response => response.json()),
-    { refreshInterval: 15000 }
-  );
-  const liveData = (maybeLiveData || {}) as LiveDataByStop;
+  const liveData = useRealtime(route, directionId, true);
 
   /**
    * Putting it all together
@@ -110,7 +96,7 @@ const LineDiagramAndStopListPage = ({
                   key={stop.route_stop.id}
                   stop={stop}
                   onClick={handleStopClick}
-                  liveData={liveData[stop.route_stop.id]}
+                  liveData={liveData ? liveData[stop.route_stop.id] : undefined}
                   searchQuery={stopQuery}
                 />
               )

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
@@ -20,7 +20,9 @@ const LineDiagramWithStops = (
   // create a ref for each stop - we will use this to track the location of the stop so we can place the line diagram bubbles
   const [stopRefsMap, updateAllStopCoords] = useStopPositions(stops);
 
-  const anyCrowding = Object.values(liveData).some(({ headsigns }): boolean =>
+  const anyCrowding = Object.values(
+    liveData || {}
+  ).some(({ headsigns }): boolean =>
     headsigns
       ? headsigns
           .filter(hasPredictionTime)
@@ -48,7 +50,7 @@ const LineDiagramWithStops = (
                 key={stop.route_stop.id}
                 stop={stop}
                 onClick={handleStopClick}
-                liveData={liveData[stop.route_stop.id]}
+                liveData={liveData ? liveData[stop.route_stop.id] : undefined}
               />
             ))}
           </ol>

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopListWithBranches.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopListWithBranches.tsx
@@ -61,7 +61,7 @@ export const Branch = (props: CommonLineDiagramProps): React.ReactElement => {
               key={stop.route_stop.id}
               stop={stop}
               onClick={handleStopClick}
-              liveData={liveData[stop.route_stop.id]}
+              liveData={liveData ? liveData[stop.route_stop.id] : undefined}
             />
           ))}
         </ol>
@@ -94,7 +94,11 @@ const StopListWithBranches = (
             key={stopOrStops.route_stop.id}
             stop={stopOrStops}
             onClick={props.handleStopClick}
-            liveData={props.liveData[stopOrStops.route_stop.id]}
+            liveData={
+              props.liveData
+                ? props.liveData[stopOrStops.route_stop.id]
+                : undefined
+            }
           />
         );
       })}

--- a/apps/site/assets/ts/schedule/components/line-diagram/__line-diagram.d.ts
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__line-diagram.d.ts
@@ -4,7 +4,7 @@ import { LineDiagramVehicle, LineDiagramStop, RouteStop } from "../__schedule";
 export interface CommonLineDiagramProps {
   stops: LineDiagramStop[];
   handleStopClick: (stop: RouteStop) => void;
-  liveData: LiveDataByStop;
+  liveData: LiveDataByStop | undefined;
 }
 
 export interface LiveData {

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramTest.tsx
@@ -220,7 +220,7 @@ it.each`
     } else {
       // will not ping the realtime endpoint
       expect(useSWRSpy).toHaveBeenCalledWith(
-        "",
+        null,
         expect.any(Function),
         expect.objectContaining({
           refreshInterval: expect.any(Number)

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Diagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Diagram.tsx
@@ -21,7 +21,7 @@ import { BASE_LINE_WIDTH, DiagonalHatchPattern } from "./graphic-helpers";
 
 interface DiagramProps {
   lineDiagram: LineDiagramStop[];
-  liveData: LiveDataByStop | null;
+  liveData: LiveDataByStop | undefined;
 }
 
 const branchingDescription = (lineDiagram: LineDiagramStop[]): string => {
@@ -54,7 +54,7 @@ const diagramDescription = (
 
 interface VehicleIconSetProps {
   stop: LineDiagramStop;
-  liveData: LiveDataByStop | null;
+  liveData: LiveDataByStop | undefined;
 }
 
 const LiveVehicleIconSet = ({


### PR DESCRIPTION
Also changes `liveData` prop slightly to represent absent data as `undefined` rather than `null`.

no ticket, just a thing I tried to clean up while tinkering with the line diagram. This PR also adds conditional logic, so we can easily turn the line diagram's live data "off" by specifying `false` as the third argument in `useRealtime()`. This is hardcoded to true right now and thus doesn't change anything about the current line diagram state.