### PR TITLE
feat: add plug for listing active line suspensions

### DIFF
--- a/apps/site/lib/site_web/plugs/line_suspensions.ex
+++ b/apps/site/lib/site_web/plugs/line_suspensions.ex
@@ -1,0 +1,46 @@
+defmodule SiteWeb.Plugs.LineSuspensions do
+  @moduledoc """
+    assigns line_suspensions map based on hard-coded values into @suspensions
+    Could potentially add more detail e.g. which stops are served by shuttle,
+    which alternative modes are available, etc.
+  """
+
+  @suspensions %{"Orange" => [~N[2022-08-19T21:00:00], ~N[2022-09-19T04:55:00]]}
+
+  @behaviour Plug
+  import Plug.Conn, only: [assign: 3]
+
+  @impl true
+  def init([]), do: [suspensions_fn: &__MODULE__.get_suspensions/0]
+
+  @impl true
+  def call(conn, suspensions_fn: suspensions_fn) do
+    now = Map.get(conn.assigns, :date_time)
+
+    unless now do
+      raise RuntimeError, message: "Please use this Plug after assigning :date_time"
+      conn
+    else
+      current_suspensions =
+        Enum.filter(
+          suspensions_fn.(),
+          &is_active_suspension?(now, elem(&1, 1))
+        )
+
+      if !Enum.empty?(current_suspensions) do
+        assign(conn, :line_suspensions, current_suspensions |> Enum.map(&Tuple.to_list(&1)))
+      else
+        conn
+      end
+    end
+  end
+
+  def get_suspensions, do: @suspensions
+
+  defp is_active_suspension?(now, date_range) do
+    [start_date, end_date] =
+      Enum.map(date_range, &Util.convert_using_timezone(&1, "America/New_York"))
+
+    Timex.between?(now, start_date, end_date)
+  end
+end

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -31,6 +31,7 @@ defmodule SiteWeb.Router do
     plug(:optional_disable_indexing)
     plug(:activate_flag)
     plug(SiteWeb.Plugs.GlxNowOpen)
+    plug(SiteWeb.Plugs.LineSuspensions)
   end
 
   pipeline :api do

--- a/apps/site/lib/site_web/templates/layout/app.html.eex
+++ b/apps/site/lib/site_web/templates/layout/app.html.eex
@@ -96,6 +96,11 @@
       <%= if assigns[:glx_stations_open] do %>
         <div class="glx-stations-open" style="display: none;" data-opening='<%= assigns[:glx_opening_date] %>' data-stations='<%= assigns[:glx_stations_open] %>' />
       <% end %>
+      <%= if assigns[:line_suspensions] do %>
+        <div data-line-suspensions>
+          <%= raw Jason.encode!(@line_suspensions) %>
+        </div>
+      <% end %>
     </div>
 
     <%# Load polyfills only if needed %>

--- a/apps/site/test/site_web/plugs/line_suspensions_test.exs
+++ b/apps/site/test/site_web/plugs/line_suspensions_test.exs
@@ -1,0 +1,30 @@
+defmodule SiteWeb.Plugs.LineSuspensionsTest do
+  use SiteWeb.ConnCase
+  import SiteWeb.Plugs.LineSuspensions
+
+  defp mock_suspensions_fn do
+    %{
+      "route1" => [~N[2016-01-01T00:00:00], ~N[2016-02-01T00:00:00]],
+      "route2" => [~N[2019-01-01T00:00:00], ~N[2019-02-01T00:00:00]],
+      "route3" => [~N[2023-01-01T00:00:00], ~N[2023-02-01T00:00:00]]
+    }
+  end
+
+  describe "call/2" do
+    test "with no date_time, raises error", %{conn: conn} do
+      assert_raise RuntimeError, "Please use this Plug after assigning :date_time", fn ->
+        _updated_conn = call(conn, suspensions_fn: &mock_suspensions_fn/0)
+      end
+    end
+
+    test "with a valid date_time assigned, uses that to assign line suspensions", %{conn: conn} do
+      updated_conn =
+        conn
+        |> assign(:date_time, ~N[2016-01-22T00:00:00])
+        |> call(suspensions_fn: &mock_suspensions_fn/0)
+
+      assert updated_conn.assigns.line_suspensions
+      assert Enum.count(updated_conn.assigns.line_suspensions) == 1
+    end
+  end
+end


### PR DESCRIPTION
no ticket, another intermediary step on the way to an adjusted line diagram.

This heavily follows our recent example for handling the GLX opening, by [adding a plug that can interpret the current date to determine relevance](https://github.com/mbta/dotcom/pull/1219/files), and [adding a DOM element to the application template](https://github.com/mbta/dotcom/pull/1223/files#diff-6f96a0b2dce5094d2afb1aaa067dc5181bec30ad7a76013d19989fed805f6702) that we can read from in other components. 

After this we can read the suspension-related values in our React components and create logic around it.

This uses the `date_time` URL parameter to determine "now"-ness - e.g. there'll be no extra DOM element now, but if you append `?date_time=2022-08-20T00:00:00` to the URL (or any other valid ISO-formatted datetime within range), you should see the extra element appear. I'll deploy it to dev-blue.