### PR TITLE
fix(TripPlanner): Remove the header from the accordion on the trip pl…

### DIFF
--- a/apps/site/assets/js/app.js
+++ b/apps/site/assets/js/app.js
@@ -53,7 +53,7 @@ if (window.sentry) {
     dsn: window.sentry.dsn,
     environment: window.sentry.environment,
     autoSessionTracking: false,
-    sampleRate: 0.10, // error sampling - might increase later
+    sampleRate: 0.1, // error sampling - might increase later
     initialScope: {
       tags: { "dotcom.application": "frontend" }
     },

--- a/apps/site/assets/ts/components/Accordion.tsx
+++ b/apps/site/assets/ts/components/Accordion.tsx
@@ -15,7 +15,7 @@ interface Props {
 export const AccordionNoJS = ({
   id,
   children,
-  headingRole = true,
+  headingRole = true
 }: {
   id: string;
   children: ReactElement<HTMLElement>;

--- a/apps/site/assets/ts/components/Accordion.tsx
+++ b/apps/site/assets/ts/components/Accordion.tsx
@@ -9,17 +9,20 @@ interface Props {
     expanded: string;
   };
   children: ReactElement<HTMLElement>;
+  headingRole?: boolean;
 }
 
 export const AccordionNoJS = ({
   id,
-  children
+  children,
+  headingRole = true,
 }: {
   id: string;
   children: ReactElement<HTMLElement>;
+  headingRole?: boolean;
 }): ReactElement<HTMLElement> => (
   <div className="c-accordion-ui">
-    <div role="heading" aria-level={3}>
+    <div role={headingRole ? "heading" : ""} aria-level={3}>
       <div
         className="c-accordion-ui__target"
         id={`${id}-section`}
@@ -33,12 +36,12 @@ export const AccordionNoJS = ({
 );
 
 const Accordion = (props: Props): ReactElement<HTMLElement> => {
-  const { id, title, children } = props;
+  const { id, title, children, headingRole = true } = props;
   const [isExpanded, toggleExpanded] = useState(false);
   const onClick = (): void => toggleExpanded(expanded => !expanded);
   return (
     <div className="c-accordion-ui">
-      <div className="panel" role="heading" aria-level={3}>
+      <div className="panel" role={headingRole ? "heading" : ""} aria-level={3}>
         <div className="c-accordion-ui__heading">
           <button
             className={`c-accordion-ui__trigger ${!isExpanded && "collapsed"}`}

--- a/apps/site/assets/ts/components/Accordion.tsx
+++ b/apps/site/assets/ts/components/Accordion.tsx
@@ -9,40 +9,35 @@ interface Props {
     expanded: string;
   };
   children: ReactElement<HTMLElement>;
-  headingRole?: boolean;
 }
 
 export const AccordionNoJS = ({
   id,
-  children,
-  headingRole = true
+  children
 }: {
   id: string;
   children: ReactElement<HTMLElement>;
-  headingRole?: boolean;
 }): ReactElement<HTMLElement> => (
   <div className="c-accordion-ui">
-    <div role={headingRole ? "heading" : ""} aria-level={3}>
-      <div
-        className="c-accordion-ui__target"
-        id={`${id}-section`}
-        role="region"
-        aria-labelledby={`${id}-title`}
-      >
-        <div className="c-accordion-ui__content">{children}</div>
-      </div>
+    <div
+      className="c-accordion-ui__target"
+      id={`${id}-section`}
+      role="region"
+      aria-labelledby={`${id}-title`}
+    >
+      <div className="c-accordion-ui__content">{children}</div>
     </div>
   </div>
 );
 
 const Accordion = (props: Props): ReactElement<HTMLElement> => {
-  const { id, title, children, headingRole = true } = props;
+  const { id, title, children } = props;
   const [isExpanded, toggleExpanded] = useState(false);
   const onClick = (): void => toggleExpanded(expanded => !expanded);
   return (
     <div className="c-accordion-ui">
-      <div className="panel" role={headingRole ? "heading" : ""} aria-level={3}>
-        <div className="c-accordion-ui__heading">
+      <div className="panel">
+        <div className="c-accordion-ui__heading" role="heading" aria-level={3}>
           <button
             className={`c-accordion-ui__trigger ${!isExpanded && "collapsed"}`}
             aria-expanded={isExpanded}

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/AccordionTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/AccordionTest.tsx.snap
@@ -5,12 +5,12 @@ exports[`Accordion component renders 1`] = `
   className="c-accordion-ui"
 >
   <div
-    aria-level={3}
     className="panel"
-    role="heading"
   >
     <div
+      aria-level={3}
       className="c-accordion-ui__heading"
+      role="heading"
     >
       <button
         aria-controls="test-accordion-section"

--- a/apps/site/assets/ts/trip-compare-results/__tests__/__snapshots__/TripCompareResultsTest.tsx.snap
+++ b/apps/site/assets/ts/trip-compare-results/__tests__/__snapshots__/TripCompareResultsTest.tsx.snap
@@ -87,12 +87,12 @@ Array [
         className="c-accordion-ui"
       >
         <div
-          aria-level={3}
           className="panel"
-          role="heading"
         >
           <div
+            aria-level={3}
             className="c-accordion-ui__heading"
+            role="heading"
           >
             <button
               aria-controls="itinerary-1-section"
@@ -129,32 +129,27 @@ Array [
           className="c-accordion-ui"
         >
           <div
-            aria-level={3}
-            role="heading"
+            aria-labelledby="itinerary-1-title"
+            className="c-accordion-ui__target"
+            id="itinerary-1-section"
+            role="region"
           >
             <div
-              aria-labelledby="itinerary-1-title"
-              className="c-accordion-ui__target"
-              id="itinerary-1-section"
-              role="region"
+              className="c-accordion-ui__content"
             >
               <div
-                className="c-accordion-ui__content"
+                className="m-trip-plan-results__itinerary-body"
               >
                 <div
-                  className="m-trip-plan-results__itinerary-body"
-                >
-                  <div
-                    className="trip-plan-map map"
-                  />
-                  <div
-                    dangerouslySetInnerHTML={
-                      Object {
-                        "__html": "<div>Lots of content about the itinerary</div>",
-                      }
+                  className="trip-plan-map map"
+                />
+                <div
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<div>Lots of content about the itinerary</div>",
                     }
-                  />
-                </div>
+                  }
+                />
               </div>
             </div>
           </div>

--- a/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
+++ b/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
@@ -40,12 +40,12 @@ exports[`it renders 1`] = `
     className="c-accordion-ui"
   >
     <div
-      aria-level={3}
       className="panel"
-      role=""
     >
       <div
+        aria-level={3}
         className="c-accordion-ui__heading"
+        role="heading"
       >
         <button
           aria-controls="itinerary-1-section"
@@ -82,32 +82,27 @@ exports[`it renders 1`] = `
       className="c-accordion-ui"
     >
       <div
-        aria-level={3}
-        role=""
+        aria-labelledby="itinerary-1-title"
+        className="c-accordion-ui__target"
+        id="itinerary-1-section"
+        role="region"
       >
         <div
-          aria-labelledby="itinerary-1-title"
-          className="c-accordion-ui__target"
-          id="itinerary-1-section"
-          role="region"
+          className="c-accordion-ui__content"
         >
           <div
-            className="c-accordion-ui__content"
+            className="m-trip-plan-results__itinerary-body"
           >
             <div
-              className="m-trip-plan-results__itinerary-body"
-            >
-              <div
-                className="trip-plan-map map"
-              />
-              <div
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<div>Lots of content about the itinerary</div>",
-                  }
+              className="trip-plan-map map"
+            />
+            <div
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "<div>Lots of content about the itinerary</div>",
                 }
-              />
-            </div>
+              }
+            />
           </div>
         </div>
       </div>
@@ -117,12 +112,12 @@ exports[`it renders 1`] = `
     className="c-accordion-ui"
   >
     <div
-      aria-level={3}
       className="panel"
-      role="heading"
     >
       <div
+        aria-level={3}
         className="c-accordion-ui__heading"
+        role="heading"
       >
         <button
           aria-controls="itinerary-1-fare-calculator-section"
@@ -159,26 +154,21 @@ exports[`it renders 1`] = `
       className="c-accordion-ui"
     >
       <div
-        aria-level={3}
-        role="heading"
+        aria-labelledby="itinerary-1-fare-calculator-title"
+        className="c-accordion-ui__target"
+        id="itinerary-1-fare-calculator-section"
+        role="region"
       >
         <div
-          aria-labelledby="itinerary-1-fare-calculator-title"
-          className="c-accordion-ui__target"
-          id="itinerary-1-fare-calculator-section"
-          role="region"
+          className="c-accordion-ui__content"
         >
           <div
-            className="c-accordion-ui__content"
-          >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<div>HTML content for fare calculator</div>",
-                }
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<div>HTML content for fare calculator</div>",
               }
-            />
-          </div>
+            }
+          />
         </div>
       </div>
     </div>

--- a/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
+++ b/apps/site/assets/ts/trip-plan-results/__tests__/__snapshots__/TripPlannerResultsTest.tsx.snap
@@ -42,7 +42,7 @@ exports[`it renders 1`] = `
     <div
       aria-level={3}
       className="panel"
-      role="heading"
+      role=""
     >
       <div
         className="c-accordion-ui__heading"
@@ -83,7 +83,7 @@ exports[`it renders 1`] = `
     >
       <div
         aria-level={3}
-        role="heading"
+        role=""
       >
         <div
           aria-labelledby="itinerary-1-title"

--- a/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
+++ b/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
@@ -92,7 +92,6 @@ const ItineraryAccordion = ({
     </div>
     <Accordion
       id={`itinerary-${itinerary.id}`}
-      headingRole={false}
       title={{
         collapsed: "Show map and trip details",
         expanded: "Hide map and trip details"
@@ -101,7 +100,7 @@ const ItineraryAccordion = ({
       <ItineraryBody {...itinerary} />
     </Accordion>
     <noscript>
-      <AccordionNoJS id={`itinerary-${itinerary.id}`} headingRole={false}>
+      <AccordionNoJS id={`itinerary-${itinerary.id}`}>
         <ItineraryBody {...itinerary} />
       </AccordionNoJS>
     </noscript>

--- a/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
+++ b/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
@@ -101,7 +101,7 @@ const ItineraryAccordion = ({
       <ItineraryBody {...itinerary} />
     </Accordion>
     <noscript>
-      <AccordionNoJS id={`itinerary-${itinerary.id}`}>
+      <AccordionNoJS id={`itinerary-${itinerary.id}`} headingRole={false}>
         <ItineraryBody {...itinerary} />
       </AccordionNoJS>
     </noscript>

--- a/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
+++ b/apps/site/assets/ts/trip-plan-results/components/Itinerary.tsx
@@ -92,6 +92,7 @@ const ItineraryAccordion = ({
     </div>
     <Accordion
       id={`itinerary-${itinerary.id}`}
+      headingRole={false}
       title={{
         collapsed: "Show map and trip details",
         expanded: "Hide map and trip details"

--- a/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
@@ -1,10 +1,9 @@
 <% id = if Map.get(assigns, :id), do: "#{Map.get(assigns, :id)}-accordion", else: "accordion" %>
-<% headerRole = Map.get(assigns, :headerRole, true) %>
 
 <div class="c-accordion-ui" id="<%= id %>" role="presentation" <%= if @multiselectable do %> aria-multiselectable="true"<% end %>>
   <%= for section <- @sections do %>
-    <div class="panel" <%= if headerRole do %>role="heading"<% end %> aria-level="3">
-      <div class="c-accordion-ui__heading<%= if assigns[:sticky] do %> fixedsticky sticky-top<% end %>">
+    <div class="panel">
+      <div class="c-accordion-ui__heading<%= if assigns[:sticky] do %> fixedsticky sticky-top<% end %>" role="heading" aria-level="3">
         <button class="c-accordion-ui__trigger collapsed"
             data-target="#<%= section.prefix %>-section"
             aria-expanded="false"

--- a/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_accordion_ui.html.eex
@@ -1,8 +1,9 @@
 <% id = if Map.get(assigns, :id), do: "#{Map.get(assigns, :id)}-accordion", else: "accordion" %>
+<% headerRole = Map.get(assigns, :headerRole, true) %>
 
 <div class="c-accordion-ui" id="<%= id %>" role="presentation" <%= if @multiselectable do %> aria-multiselectable="true"<% end %>>
   <%= for section <- @sections do %>
-    <div class="panel" role="heading" aria-level="3">
+    <div class="panel" <%= if headerRole do %>role="heading"<% end %> aria-level="3">
       <div class="c-accordion-ui__heading<%= if assigns[:sticky] do %> fixedsticky sticky-top<% end %>">
         <button class="c-accordion-ui__trigger collapsed"
             data-target="#<%= section.prefix %>-section"


### PR DESCRIPTION
…anner

#### Summary of changes
**Asana Ticket:** [Repeated heading 3 label for itinerary and content](https://app.asana.com/0/555089885850811/1202300116369146)

The `aria-role=header` attribute has been set as optional for the `Accordion` component.
This is to stop the screen read from reading each part of the trip with header title

Note: The role is optional, but it needs to be deliberately opted out of, as it defaults to setting the header given no information

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] Are interactive elements accessible to screen readers?
* [ ] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [ ] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
