### PR TITLE
Calculate some CR legs as $0 during OL shutdown

### DIFF
--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -6,31 +6,62 @@ defmodule Fares.FareInfo do
   alias Fares.Fare
 
   now = DateTime.utc_now()
-  surge_start =  ~U[2022-08-11 04:55:00Z] # TEMP VALUE FOR TESTING UPDATE BEFORE  MERGE
-  surge_end =  ~U[2022-09-19 04:55:00Z]
+  # TEMP VALUE FOR TESTING UPDATE BEFORE  MERGE
+  surge_start = ~U[2022-08-11 04:55:00Z]
+  surge_end = ~U[2022-09-19 04:55:00Z]
 
   @fare_data [
     %{
       mode: :commuter,
       zone: "1A",
-      single_trip: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "2.40" end,
-      single_trip_reduced: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "1.10" end,
+      single_trip:
+        if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do
+          "0.00"
+        else
+          "2.40"
+        end,
+      single_trip_reduced:
+        if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do
+          "0.00"
+        else
+          "1.10"
+        end,
       monthly: "90.00",
       monthly_reduced: "30.00"
     },
     %{
       mode: :commuter,
       zone: "1",
-      single_trip: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "6.50" end,
-      single_trip_reduced: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "3.25" end,
+      single_trip:
+        if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do
+          "0.00"
+        else
+          "6.50"
+        end,
+      single_trip_reduced:
+        if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do
+          "0.00"
+        else
+          "3.25"
+        end,
       monthly: "214.00",
       monthly_reduced: "107.00"
     },
     %{
       mode: :commuter,
       zone: "2",
-      single_trip: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "7.00" end,
-      single_trip_reduced: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "3.50" end,
+      single_trip:
+        if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do
+          "0.00"
+        else
+          "7.00"
+        end,
+      single_trip_reduced:
+        if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do
+          "0.00"
+        else
+          "3.50"
+        end,
       monthly: "232.00",
       monthly_reduced: "116.00"
     },

--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -6,9 +6,8 @@ defmodule Fares.FareInfo do
   alias Fares.Fare
 
   now = DateTime.utc_now()
-  # TEMP VALUE FOR TESTING UPDATE BEFORE  MERGE
-  surge_start = ~U[2022-08-11 04:55:00Z]
-  surge_end = ~U[2022-09-19 04:55:00Z]
+  surge_start = ~U[2022-08-20 01:00:00Z]
+  surge_end = ~U[2022-09-19 06:00:00Z]
 
   @fare_data [
     %{

--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -6,13 +6,8 @@ defmodule Fares.FareInfo do
   alias Fares.Fare
 
   now = DateTime.utc_now()
-  surge_start =  ~U[2022-08-11 04:55:00Z] # TEMP VALUE FOR TESTING
+  surge_start =  ~U[2022-08-11 04:55:00Z] # TEMP VALUE FOR TESTING UPDATE BEFORE  MERGE
   surge_end =  ~U[2022-09-19 04:55:00Z]
-
-  # def is_surge(date) do
-  #   DateTime.compare(date, surge_start) == :gt and DateTime.compare(date, surge_end) == :lt
-  # end
-
 
   @fare_data [
     %{

--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -5,28 +5,37 @@ defmodule Fares.FareInfo do
 
   alias Fares.Fare
 
+  now = DateTime.utc_now()
+  surge_start =  ~U[2022-08-11 04:55:00Z] # TEMP VALUE FOR TESTING
+  surge_end =  ~U[2022-09-19 04:55:00Z]
+
+  # def is_surge(date) do
+  #   DateTime.compare(date, surge_start) == :gt and DateTime.compare(date, surge_end) == :lt
+  # end
+
+
   @fare_data [
     %{
       mode: :commuter,
       zone: "1A",
-      single_trip: "2.40",
-      single_trip_reduced: "1.10",
+      single_trip: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "2.40" end,
+      single_trip_reduced: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "1.10" end,
       monthly: "90.00",
       monthly_reduced: "30.00"
     },
     %{
       mode: :commuter,
       zone: "1",
-      single_trip: "6.50",
-      single_trip_reduced: "3.25",
+      single_trip: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "6.50" end,
+      single_trip_reduced: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "3.25" end,
       monthly: "214.00",
       monthly_reduced: "107.00"
     },
     %{
       mode: :commuter,
       zone: "2",
-      single_trip: "7.00",
-      single_trip_reduced: "3.50",
+      single_trip: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "7.00" end,
+      single_trip_reduced: if DateTime.compare(now, surge_start) == :gt and DateTime.compare(now, surge_end) == :lt do "0.00" else "3.50" end,
       monthly: "232.00",
       monthly_reduced: "116.00"
     },

--- a/apps/site/lib/site_web/templates/trip_compare/_fare_calculator.html.eex
+++ b/apps/site/lib/site_web/templates/trip_compare/_fare_calculator.html.eex
@@ -82,6 +82,10 @@
   </div>
 <% end %>
 
+<div class="m-trip-plan-farecalc__notes-block">
+  During the Orange Line shutdown, riders can show their CharlieCard or CharlieTicket to conductors to ride the Commuter Rail in Zones 1A, 1 and 2 at no charge.
+</div>
+
 <%= if @itinerary_is_from_or_to_airport do %>
   <div class="m-trip-plan-farecalc__notes-block">
     <span class="m-trip-plan-farecalc__title">Logan Airport:</span> Silver Line service from Logan Airport is always free. If you are headed to Logan Airport, transfers from the Red Line to the SL1 are also free.

--- a/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_fare_calculator.html.eex
@@ -82,6 +82,10 @@
   </div>
 <% end %>
 
+<div class="m-trip-plan-farecalc__notes-block">
+  During the Orange Line shutdown, riders can show their CharlieCard or CharlieTicket to conductors to ride the Commuter Rail in Zones 1A, 1 and 2 at no charge.
+</div>
+
 <%= if @itinerary_is_from_or_to_airport do %>
   <div class="m-trip-plan-farecalc__notes-block">
     <span class="m-trip-plan-farecalc__title">Logan Airport:</span> Silver Line service from Logan Airport is always free. If you are headed to Logan Airport, transfers from the Red Line to the SL1 are also free.


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Calculate some CR legs as $0 during OL shutdown](https://app.asana.com/0/555089885850811/1202802897881991/f)

If leg in itinerary is 1A,1, or 2 don't charge for that section.