### PR TITLE
fix(test): Fix test assertions for Green Line suspension data

### DIFF
--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -362,9 +362,7 @@ defmodule SiteWeb.ScheduleView do
     "/fares/" <> route_type <> "-fares"
   end
 
-  @spec single_trip_fares(Route.t() | Route.type_int() | String.t()) :: [
-          {String.t(), String.t() | iolist}
-        ]
+  @spec single_trip_fares(Route.t()) :: [{String.t(), String.t() | iolist}]
   def single_trip_fares(route) do
     summary =
       route
@@ -379,7 +377,7 @@ defmodule SiteWeb.ScheduleView do
     end
   end
 
-  @spec to_fare_summary_atom(Route.t() | Route.type_int() | String.t()) :: atom()
+  @spec to_fare_summary_atom(Route.t()) :: atom
   def to_fare_summary_atom(%Route{type: 3, id: id}) do
     cond do
       Fares.silver_line_rapid_transit?(id) -> :subway

--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -362,7 +362,9 @@ defmodule SiteWeb.ScheduleView do
     "/fares/" <> route_type <> "-fares"
   end
 
-  @spec single_trip_fares(Route.t()) :: [{String.t(), String.t() | iolist}]
+  @spec single_trip_fares(Route.t() | Route.type_int() | String.t()) :: [
+          {String.t(), String.t() | iolist}
+        ]
   def single_trip_fares(route) do
     summary =
       route
@@ -370,14 +372,14 @@ defmodule SiteWeb.ScheduleView do
       |> mode_summaries()
       |> Enum.find(fn summary -> summary.duration == :single_trip end)
 
-    if route.name == "Orange Line Shuttle" do
+    if match?(%Route{name: "Orange Line Shuttle"}, route) do
       [Tuple.append(Tuple.delete_at(Enum.at(summary.fares, 0), 1), "0.00")]
     else
       summary.fares
     end
   end
 
-  @spec to_fare_summary_atom(Route.t()) :: atom
+  @spec to_fare_summary_atom(Route.t() | Route.type_int() | String.t()) :: atom()
   def to_fare_summary_atom(%Route{type: 3, id: id}) do
     cond do
       Fares.silver_line_rapid_transit?(id) -> :subway

--- a/apps/site/test/green_line_test.exs
+++ b/apps/site/test/green_line_test.exs
@@ -89,12 +89,12 @@ defmodule GreenLineTest do
       # As of June 2020, Lechmere is closed for construction and the E-line will
       # be terminating at North Station for now.
       # assert stop_map["Green-E"] ==
-      #          MapSet.new(["place-hsmnl", "place-gover", "place-north", "place-lech"])
-      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      #  MapSet.new(["place-hsmnl", "place-gover", "place-north", "place-lech"])
+      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
       # assert stop_map["Green-E"] ==
       #          MapSet.new(["place-hsmnl", "place-gover", "place-north"])
       assert stop_map["Green-E"] ==
-               MapSet.new(["place-hsmnl", "place-gover"])
+               MapSet.new(["place-gover", "place-hsmnl", "place-north"])
     end
 
     test "a list of stops without duplicates is returned" do
@@ -142,9 +142,9 @@ defmodule GreenLineTest do
       assert terminus?(stop_id, "Green-D")
     end
 
-    # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+    # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
     # for stop_id <- ["place-unsqu", "place-hsmnl"] do
-    for stop_id <- ["place-gover", "place-hsmnl"] do
+    for stop_id <- ["place-lech", "place-hsmnl"] do
       assert terminus?(stop_id, "Green-E")
     end
   end
@@ -152,11 +152,11 @@ defmodule GreenLineTest do
   test "terminus?/3" do
     assert terminus?("place-lake", "Green-B", 0)
     refute terminus?("place-lake", "Green-B", 1)
-    # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+    # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
     # refute terminus?("place-unsqu", "Green-E", 0)
     # assert terminus?("place-unsqu", "Green-E", 1)
-    refute terminus?("place-gover", "Green-E", 0)
-    assert terminus?("place-gover", "Green-E", 1)
+    refute terminus?("place-lech", "Green-E", 0)
+    assert terminus?("place-lech", "Green-E", 1)
   end
 
   describe "naive_headsign/2" do
@@ -169,9 +169,9 @@ defmodule GreenLineTest do
       assert naive_headsign("Green-D", 0) == "Riverside"
       assert naive_headsign("Green-D", 1) == "North Station"
       assert naive_headsign("Green-E", 0) == "Heath Street"
-      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
       # assert naive_headsign("Green-E", 1) == "Union Square"
-      assert naive_headsign("Green-E", 1) == "Government Center"
+      assert naive_headsign("Green-E", 1) == "Lechmere"
     end
   end
 

--- a/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/finder_api_test.exs
@@ -277,7 +277,7 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
       |> json_response(200)
     end
 
-    test "only shows times starting at selected origin onward - outbound", %{conn: conn} do
+    test "only shows times starting at selected origin onward - direction 0", %{conn: conn} do
       origin_stop = "place-sstat"
 
       params = %{
@@ -295,12 +295,14 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
         |> json_response(200)
 
       assert %{"times" => times} = trip
-      assert length(times) == 8
+      destination_stop_ids = Enum.map(times, &get_in(&1, ["schedule", "stop", "id"]))
+
+      refute Enum.member?(destination_stop_ids, "place-dwnxg")
 
       assert origin_stop = times |> List.first() |> get_in(["schedule", "stop", "id"])
     end
 
-    test "only shows times starting at selected origin onward - inbound", %{conn: conn} do
+    test "only shows times starting at selected origin onward - direction 1", %{conn: conn} do
       origin_stop = "place-sstat"
 
       params = %{
@@ -318,7 +320,10 @@ defmodule SiteWeb.ScheduleController.FinderApiTest do
         |> json_response(200)
 
       assert %{"times" => times} = trip
-      assert length(times) == 10
+
+      destination_stop_ids = Enum.map(times, &get_in(&1, ["schedule", "stop", "id"]))
+
+      refute Enum.member?(destination_stop_ids, "place-brdwy")
 
       assert origin_stop = times |> List.first() |> get_in(["schedule", "stop", "id"])
     end

--- a/apps/site/test/site_web/controllers/schedule/green_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/green_test.exs
@@ -73,9 +73,9 @@ defmodule SiteWeb.ScheduleController.GreenTest do
        %{conn: conn} do
     conn = get(conn, green_path(conn, :line, %{"schedule_direction[direction_id]": 0}))
 
-    # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+    # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
     # assert [{_, %{id: "place-unsqu"}} | all_stops] = conn.assigns.all_stops
-    assert [{_, %{id: "place-gover"}} | all_stops] = conn.assigns.all_stops
+    assert [{_, %{id: "place-lech"}} | all_stops] = conn.assigns.all_stops
 
     fenway = Enum.find(all_stops, fn {_, stop} -> stop.id == "place-fenwy" end)
     assert elem(fenway, 0) == [{"Green-B", :line}, {"Green-C", :line}, {"Green-D", :stop}]

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
@@ -644,9 +644,7 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
                  %Stops.RouteStop{id: "place-haecl"}
                },
                {
-                 # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
-                 #  [nil: :stop],
-                 [nil: :terminus],
+                 [nil: :stop],
                  %Stops.RouteStop{id: "place-gover"}
                },
                {
@@ -998,9 +996,7 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
                  %Stops.RouteStop{id: "place-pktrm"}
                },
                {
-                 # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
-                 #  [nil: :stop],
-                 [nil: :terminus],
+                 [nil: :stop],
                  %Stops.RouteStop{id: "place-gover"}
                }
              ] = DiagramHelpers.build_stop_list(branches, 1)

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -138,7 +138,8 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
       assert Enum.map(e_stops, & &1.branch) ==
                [
-                 "Green-E",
+                 # As of 8/2022, the E line running to Union Square has been suspended
+                 #  "Green-E",
                  "Green-E",
                  "Green-E",
                  nil,
@@ -162,7 +163,8 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                ]
 
       assert_stop_ids(e_stops, [
-        "place-unsqu",
+        # As of 8/2022, the E line running to Union Square has been suspended
+        # "place-unsqu",
         "place-lech",
         "place-spmnl",
         "place-north",
@@ -188,7 +190,8 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
       assert Enum.map(e_stops, & &1.is_terminus?) ==
                [
                  true,
-                 false,
+                 # As of 8/2022, the E line running to Union Square has been suspended
+                 #  false,
                  false,
                  false,
                  false,
@@ -213,7 +216,8 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
       assert Enum.map(e_stops, & &1.is_beginning?) ==
                [
                  true,
-                 false,
+                 # As of 8/2022, the E line running to Union Square has been suspended
+                 #  false,
                  false,
                  false,
                  false,
@@ -605,15 +609,20 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
     test "handles the E line" do
       assert [
-               %RouteStops{branch: "Union Square - Heath Street", stops: stops}
+               # As of 8/2022, the E line running to Union Square has been suspended
+               #  %RouteStops{branch: "Union Square - Heath Street", stops: stops}
+               %RouteStops{branch: "Lechmere - Heath Street", stops: stops}
              ] = Helpers.get_branch_route_stops(%Route{id: "Green-E"}, 0)
 
-      assert Enum.all?(stops, &(&1.branch == "Union Square - Heath Street"))
+      # As of 8/2022, the E line running to Union Square has been suspended
+      # assert Enum.all?(stops, &(&1.branch == "Union Square - Heath Street"))
+      assert Enum.all?(stops, &(&1.branch == "Lechmere - Heath Street"))
 
       assert Enum.map(stops, & &1.is_terminus?) ==
                [
                  true,
-                 false,
+                 # As of 8/2022, the E line running to Union Square has been suspended
+                 #  false,
                  false,
                  false,
                  false,
@@ -638,7 +647,8 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
       assert Enum.map(stops, & &1.is_beginning?) ==
                [
                  true,
-                 false,
+                 # As of 8/2022, the E line running to Union Square has been suspended
+                 #  false,
                  false,
                  false,
                  false,

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -304,7 +304,7 @@ defmodule SiteWeb.ScheduleController.LineTest do
       # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
       # We are temporarily adding the fix but this will need to be undone later on.
       for {id, idx} <- [
-            # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+            # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
             # {"place-unsqu", 0},
             # {"place-north", 3},
             # {"place-gover", 5},
@@ -314,13 +314,13 @@ defmodule SiteWeb.ScheduleController.LineTest do
             # {"place-river", 35},
             # {"place-clmnl", 48},
             # {"place-lake", 64}
-            {"place-gover", 0},
-            {"place-pktrm", 1},
-            {"place-coecl", 4},
-            {"place-hsmnl", 15},
-            {"place-river", 32},
-            {"place-clmnl", 45},
-            {"place-lake", 61}
+            {"place-lech", 0},
+            {"place-pktrm", 5},
+            {"place-coecl", 8},
+            {"place-hsmnl", 19},
+            {"place-river", 35},
+            {"place-clmnl", 48},
+            {"place-lake", 64}
           ] do
         assert stops |> Enum.at(idx) |> elem(1) == id
       end

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -341,9 +341,9 @@ defmodule SiteWeb.ScheduleController.LineTest do
 
       assert Enum.all?(trunk, &(&1 |> branches() |> length() == 1))
 
-      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
       # assert trunk |> List.first() |> stop_id() == "place-unsqu"
-      assert trunk |> List.first() |> stop_id() == "place-gover"
+      assert trunk |> List.first() |> stop_id() == "place-lech"
       assert trunk |> List.last() |> stop_id() == "place-armnl"
 
       # E branch + merge

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -351,9 +351,12 @@ defmodule SiteWeb.ScheduleController.LineTest do
       assert e |> List.first() |> stop_id() == "place-coecl"
       assert e |> List.last() |> stop_id() == "place-hsmnl"
 
-      assert Enum.all?(hynes, &(&1 |> branches() |> length() == 1))
-      assert length(hynes) == 1
-      assert hynes |> List.first() |> stop_id() == "place-hymnl"
+      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
+      # assert Enum.all?(hynes, &(&1 |> branches() |> length() == 1))
+      # assert length(hynes) == 1
+      assert length(hynes) == 2
+      # assert hynes |> List.first() |> stop_id() == "place-hymnl"
+      assert hynes |> List.first() |> stop_id() == "place-unsqu"
 
       assert Enum.all?(bcd_combined, &(&1 |> branches() |> length() == 3))
       assert bcd_combined |> List.first() |> stop_id() == "place-kencl"
@@ -423,7 +426,9 @@ defmodule SiteWeb.ScheduleController.LineTest do
 
       chunked = Enum.chunk_by(stops, fn {branches, _stop} -> Enum.count(branches) end)
 
-      assert [b, bc_combined, bcd_combined, hynes, e, trunk] = chunked
+      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
+      # assert [b, bc_combined, bcd_combined, hynes, e, trunk] = chunked
+      assert [b, bc_combined, bcd_combined, e, trunk] = chunked
 
       assert Enum.all?(b, &(&1 |> branches() |> length() == 1))
       assert b |> List.first() |> stop_id() == "place-lake"
@@ -437,20 +442,25 @@ defmodule SiteWeb.ScheduleController.LineTest do
       assert bcd_combined |> List.first() |> stop_id() == "place-river"
       assert bcd_combined |> List.last() |> stop_id() == "place-kencl"
 
-      assert Enum.all?(hynes, &(&1 |> branches() |> length() == 1))
-      assert length(hynes) == 1
-      assert hynes |> List.first() |> stop_id() == "place-hymnl"
+      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
+      # assert Enum.all?(hynes, &(&1 |> branches() |> length() == 1))
+      # assert length(hynes) == 1
+      # assert hynes |> List.first() |> stop_id() == "place-hymnl"
 
       # E branch + merge
-      assert Enum.all?(e, &(&1 |> branches() |> length() == 2))
-      assert e |> List.first() |> stop_id() == "place-hsmnl"
-      assert e |> List.last() |> stop_id() == "place-coecl"
+      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
+      # assert Enum.all?(e, &(&1 |> branches() |> length() == 2))
+      # assert e |> List.first() |> stop_id() == "place-hsmnl"
+      # assert e |> List.last() |> stop_id() == "place-coecl"
+      assert e |> List.first() |> stop_id() == "place-hymnl"
+      assert e |> List.last() |> stop_id() == "place-armnl"
 
-      assert Enum.all?(trunk, &(&1 |> branches() |> length() == 1))
-      assert trunk |> List.first() |> stop_id() == "place-armnl"
-      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
+      # assert Enum.all?(trunk, &(&1 |> branches() |> length() == 1))
+      # assert trunk |> List.first() |> stop_id() == "place-armnl"
       # assert trunk |> List.last() |> stop_id() == "place-unsqu"
-      assert trunk |> List.last() |> stop_id() == "place-gover"
+      assert trunk |> List.first() |> stop_id() == "place-coecl"
+      assert trunk |> List.last() |> stop_id() == "place-hsmnl"
     end
   end
 

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -174,19 +174,13 @@ defmodule SiteWeb.ScheduleControllerTest do
       {_, first_stop} = List.first(conn.assigns.all_stops)
       {_, last_stop} = List.last(conn.assigns.all_stops)
 
-      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
-      assert first_stop.id == "place-gover"
+      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
+      assert first_stop.id == "place-lech"
 
       assert last_stop.id == "place-lake"
 
       # includes the stop features
-      assert first_stop.stop_features == [
-               :green_line_b,
-               :green_line_c,
-               :green_line_d,
-               :blue_line,
-               :access
-             ]
+      assert first_stop.stop_features == [:bus, :access]
 
       # spider map
       assert conn.assigns.map_img_src =~ "maps.googleapis.com"

--- a/apps/site/test/site_web/excluded_stops_test.exs
+++ b/apps/site/test/site_web/excluded_stops_test.exs
@@ -38,9 +38,9 @@ defmodule ExcludedStopsTest do
         |> GreenLine.stops_on_routes()
         |> GreenLine.all_stops()
 
-      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
       # assert excluded_origin_stops(1, "Green", all_stops) == ["place-unsqu"]
-      assert excluded_origin_stops(1, "Green", all_stops) == ["place-north"]
+      assert excluded_origin_stops(1, "Green", all_stops) == ["place-lech"]
     end
   end
 

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -446,7 +446,9 @@ defmodule SiteWeb.ScheduleViewTest do
 
   describe "single_trip_fares/1" do
     test "only return summary for single_trip fares" do
-      assert single_trip_fares("commuter_rail") == [{"Zones 1A-10", ["$2.40", " – ", "$13.25"]}]
+      assert single_trip_fares(%Route{type: 2, name: "Fitchburg"}) == [
+               {"Zones 1A-10", ["$2.40", " – ", "$13.25"]}
+             ]
     end
   end
 

--- a/apps/stops/test/nearby_test.exs
+++ b/apps/stops/test/nearby_test.exs
@@ -187,6 +187,7 @@ defmodule Stops.NearbyTest do
         {"65", 1},
         {"8", 0},
         {"8", 1},
+        {"9", 1},
         {"Green-B", 0},
         {"Green-B", 1},
         {"Green-C", 0},

--- a/apps/stops/test/repo_test.exs
+++ b/apps/stops/test/repo_test.exs
@@ -183,10 +183,10 @@ defmodule Stops.RepoTest do
     test "includes specific green_line branches if specified" do
       # when green line isn't expanded, keep it in GTFS order
       features = stop_features(%Stop{id: "place-pktrm"})
-      assert features == [:red_line, :green_line_b, :green_line_c, :green_line_d]
+      assert features == [:red_line, :green_line_b, :green_line_c, :green_line_d, :green_line_e]
       # when green line is expanded, put the branches first
       features = stop_features(%Stop{id: "place-pktrm"}, expand_branches?: true)
-      assert features == [:"Green-B", :"Green-C", :"Green-D", :red_line]
+      assert features == [:"Green-B", :"Green-C", :"Green-D", :"Green-E", :red_line]
     end
   end
 end

--- a/apps/stops/test/route_stops_test.exs
+++ b/apps/stops/test/route_stops_test.exs
@@ -164,7 +164,7 @@ defmodule Stops.RouteStopsTest do
       #            stops: [%RouteStop{id: "place-lech", is_terminus?: true} | _]
       #          }
       #        ] = stops
-      # As of Aug 2022, the Green Line past Government Center is temporarily suspended.
+      # As of Aug 2022, the Green Line past North Station is temporarily suspended.
       # assert [
       #          %RouteStops{
       #            stops: [%RouteStop{id: "place-north", is_terminus?: true} | _]
@@ -172,7 +172,7 @@ defmodule Stops.RouteStopsTest do
       #        ] = stops
       assert [
                %RouteStops{
-                 stops: [%RouteStop{id: "place-gover", is_terminus?: true} | _]
+                 stops: [%RouteStop{id: "place-north", is_terminus?: true} | _]
                }
              ] = stops
     end


### PR DESCRIPTION
#### Summary of changes
No ticket, fixes currently failing tests

- fix: Properly handle different valid input types
- fix(test): Improve tests to match descriptions
- fix(test): Fix test assertions for Green Line suspension data
- fix(test): Fix more test data

~~Note: I left that last commit separate because those failures seem more suspicious to me. I'm going to keep looking into them as I work through the GL diagram issues.~~
Given that the line diagram is working better with the latest GTFS data, I'm actually probably less worried about those failures than I was at first glance.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
