### PR TITLE
feat(AlertBanner): Parse URL out of alert text and got to url on bann…

### DIFF
--- a/apps/alerts/lib/banner.ex
+++ b/apps/alerts/lib/banner.ex
@@ -5,6 +5,7 @@ defmodule Alerts.Banner do
   defstruct id: "",
             title: "",
             url: nil,
+            url_parsed_out_of_title: false,
             effect: :unknown,
             severity: 5,
             informed_entity_set: %InformedEntitySet{}
@@ -17,6 +18,7 @@ defmodule Alerts.Banner do
           id: String.t(),
           title: String.t(),
           url: String.t() | nil,
+          url_parsed_out_of_title: boolean(),
           effect: Alert.effect(),
           severity: Alert.severity(),
           informed_entity_set: InformedEntitySet.t()

--- a/apps/alerts/lib/parser.ex
+++ b/apps/alerts/lib/parser.ex
@@ -199,12 +199,13 @@ defmodule Alerts.Parser do
               "informed_entity" => informed_entity
             } = attributes
         })
-        when title != nil do
+        when title != nil and url != nil do
       [
         %Banner{
           id: id,
           title: title,
           url: url,
+          url_parsed_out_of_title: false,
           effect: Alert.effect(attributes),
           severity: Alert.severity(severity),
           informed_entity_set:
@@ -212,6 +213,33 @@ defmodule Alerts.Parser do
         }
       ]
     end
+
+    def parse(%JsonApi.Item{
+      id: id,
+      attributes:
+        %{
+          "url" => url,
+          "banner" => title,
+          "severity" => severity,
+          "informed_entity" => informed_entity
+        } = attributes
+    })
+    when title != nil and url == nil do
+
+    parsed_url = SiteWeb.Views.Helpers.URLParsingHelpers.get_full_url(title)
+  [
+    %Banner{
+      id: id,
+      title: title,
+      url: parsed_url,
+      url_parsed_out_of_title: true,
+      effect: Alert.effect(attributes),
+      severity: Alert.severity(severity),
+      informed_entity_set:
+        informed_entity |> Alert.parse_informed_entity() |> InformedEntitySet.new()
+    }
+  ]
+end
 
     def parse(%JsonApi.Item{}) do
       []

--- a/apps/alerts/lib/parser.ex
+++ b/apps/alerts/lib/parser.ex
@@ -232,7 +232,7 @@ defmodule Alerts.Parser do
           id: id,
           title: title,
           url: parsed_url,
-          url_parsed_out_of_title: true,
+          url_parsed_out_of_title: parsed_url != nil,
           effect: Alert.effect(attributes),
           severity: Alert.severity(severity),
           informed_entity_set:

--- a/apps/alerts/lib/parser.ex
+++ b/apps/alerts/lib/parser.ex
@@ -215,31 +215,31 @@ defmodule Alerts.Parser do
     end
 
     def parse(%JsonApi.Item{
-      id: id,
-      attributes:
-        %{
-          "url" => url,
-          "banner" => title,
-          "severity" => severity,
-          "informed_entity" => informed_entity
-        } = attributes
-    })
-    when title != nil and url == nil do
+          id: id,
+          attributes:
+            %{
+              "url" => url,
+              "banner" => title,
+              "severity" => severity,
+              "informed_entity" => informed_entity
+            } = attributes
+        })
+        when title != nil and url == nil do
+      parsed_url = SiteWeb.Views.Helpers.URLParsingHelpers.get_full_url(title)
 
-    parsed_url = SiteWeb.Views.Helpers.URLParsingHelpers.get_full_url(title)
-  [
-    %Banner{
-      id: id,
-      title: title,
-      url: parsed_url,
-      url_parsed_out_of_title: true,
-      effect: Alert.effect(attributes),
-      severity: Alert.severity(severity),
-      informed_entity_set:
-        informed_entity |> Alert.parse_informed_entity() |> InformedEntitySet.new()
-    }
-  ]
-end
+      [
+        %Banner{
+          id: id,
+          title: title,
+          url: parsed_url,
+          url_parsed_out_of_title: true,
+          effect: Alert.effect(attributes),
+          severity: Alert.severity(severity),
+          informed_entity_set:
+            informed_entity |> Alert.parse_informed_entity() |> InformedEntitySet.new()
+        }
+      ]
+    end
 
     def parse(%JsonApi.Item{}) do
       []

--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -72,9 +72,11 @@ defmodule SiteWeb.ScheduleController.TimetableController do
   @spec timetable_schedules(Plug.Conn.t()) :: [Schedules.Schedule.t()]
   defp timetable_schedules(%{assigns: %{date: date, route: route, direction_id: direction_id}}) do
     if route.id == "Orange" do
-      route_ids = ["CR-Needham", "CR-Providence","CR-Franklin"]
-      Enum.flat_map(route_ids, fn route_id -> Schedules.Repo.by_route_ids([route_id], date: date, direction_id: direction_id) end)
+      route_ids = ["CR-Needham", "CR-Providence", "CR-Franklin"]
 
+      Enum.flat_map(route_ids, fn route_id ->
+        Schedules.Repo.by_route_ids([route_id], date: date, direction_id: direction_id)
+      end)
     else
       case Schedules.Repo.by_route_ids([route.id], date: date, direction_id: direction_id) do
         {:error, _} -> []
@@ -115,20 +117,21 @@ defmodule SiteWeb.ScheduleController.TimetableController do
   defp all_stops(conn, _) do
     # we override the default fetch of all_stops to not use the date. We will
     # use the date to fetch the actual schedule data.
-    all_stops = if conn.assigns.route.id == "Orange" do
-
-      if conn.assigns.direction_id == 0 do
-        stop_ids = ["place-sstat", "place-bbsta", "place-rugg", "place-forhl"]
-        for stop_id <- stop_ids, do: Stops.Repo.get(stop_id)
+    all_stops =
+      if conn.assigns.route.id == "Orange" do
+        if conn.assigns.direction_id == 0 do
+          stop_ids = ["place-sstat", "place-bbsta", "place-rugg", "place-forhl"]
+          for stop_id <- stop_ids, do: Stops.Repo.get(stop_id)
+        else
+          stop_ids = ["place-forhl", "place-rugg", "place-bbsta", "place-sstat"]
+          for stop_id <- stop_ids, do: Stops.Repo.get(stop_id)
+        end
       else
-        stop_ids = ["place-forhl","place-rugg", "place-bbsta", "place-sstat"]
-        for stop_id <- stop_ids, do: Stops.Repo.get(stop_id)
+        Stops.Repo.by_route(conn.assigns.route.id, conn.assigns.direction_id,
+          date: conn.assigns.date
+        )
       end
-    else
-      Stops.Repo.by_route(conn.assigns.route.id, conn.assigns.direction_id,
-        date: conn.assigns.date
-      )
-    end
+
     assign(conn, :all_stops, all_stops)
   end
 

--- a/apps/site/lib/site_web/templates/alert/_banner.html.eex
+++ b/apps/site/lib/site_web/templates/alert/_banner.html.eex
@@ -13,7 +13,7 @@
       </div>
       <div>
         <%= replace_urls_with_links(BannerAlert.header(@alert)) %>
-        <%= if @alert.url != nil && @alert.url != "" do %>
+        <%= if @alert.url != nil && @alert.url != "" && @alert.url_parsed_out_of_title == false do %>
           <span>&nbsp;</span>
           <%= replace_urls_with_links(@alert.url) %>
         <% end %>

--- a/apps/site/lib/site_web/views/helpers/url_parsing_helpers.ex
+++ b/apps/site/lib/site_web/views/helpers/url_parsing_helpers.ex
@@ -25,7 +25,7 @@ defmodule SiteWeb.Views.Helpers.URLParsingHelpers do
   def replace_urls_with_links(text) do
     @url_regex
     |> Regex.replace(text, &create_url/1)
-    |> Phoenix.HTML.raw
+    |> Phoenix.HTML.raw()
   end
 
   defp create_url(url) do

--- a/apps/site/lib/site_web/views/helpers/url_parsing_helpers.ex
+++ b/apps/site/lib/site_web/views/helpers/url_parsing_helpers.ex
@@ -1,0 +1,55 @@
+defmodule SiteWeb.Views.Helpers.URLParsingHelpers do
+  @moduledoc "Helpers to parse out the url from a string and create an html link"
+
+  @url_regex ~r/(https?:\/\/)?([\da-z\.-]+)\.([a-z]{2,6})([\/\w\.-]*)*\/?/i
+
+  @spec get_full_url(String.t()) :: String.t() | nil
+  def get_full_url(text) do
+    with [match | _] <- Regex.run(@url_regex, text) do
+      {url, _suffix} = parse_url_and_suffix(match)
+      ensure_scheme(url)
+    end
+  end
+
+  defp parse_url_and_suffix(url) do
+    # I could probably convince the Regex to match an internal period but not
+    # one at the end, but this is clearer. -ps
+    if String.ends_with?(url, ".") do
+      String.split_at(url, -1)
+    else
+      {url, ""}
+    end
+  end
+
+  @spec replace_urls_with_links(String.t()) :: Phoenix.HTML.safe()
+  def replace_urls_with_links(text) do
+    @url_regex
+    |> Regex.replace(text, &create_url/1)
+    |> Phoenix.HTML.raw
+  end
+
+  defp create_url(url) do
+    {url, suffix} = parse_url_and_suffix(url)
+
+    full_url = ensure_scheme(url)
+
+    # remove [http:// | https:// | www.] from URL:
+    stripped_url = String.replace(full_url, ~r/(https?:\/\/)?(www\.)?/i, "")
+
+    # capitalize 'mbta' (special case):
+    stripped_url =
+      if String.contains?(stripped_url, "mbta") do
+        String.replace(stripped_url, "mbta", "MBTA")
+      else
+        stripped_url
+      end
+
+    ~s(<a target="_blank" href="#{full_url}">#{stripped_url}</a>#{suffix})
+  end
+
+  defp ensure_scheme("http://" <> _ = url), do: url
+  defp ensure_scheme("https://" <> _ = url), do: url
+  defp ensure_scheme("mbta.com" <> _ = url), do: "https://" <> url
+  defp ensure_scheme("MBTA.com" <> _ = url), do: "https://" <> url
+  defp ensure_scheme(url), do: "http://" <> url
+end

--- a/apps/site/test/site_web/views/helpers/url_parsing_helpers_test.exs
+++ b/apps/site/test/site_web/views/helpers/url_parsing_helpers_test.exs
@@ -1,0 +1,16 @@
+defmodule SiteWeb.Views.Helpers.AlertHelpersTest do
+  use SiteWeb.ConnCase, async: true
+  import SiteWeb.Views.Helpers.URLParsingHelpers
+
+  describe "get_full_url/1" do
+    test "should return the url parsed from the text" do
+      text = "The Orange Line shutdown (9 PM, August 19 - September 18) overlaps with Green Line closures. Learn more and see alternative travel options at MBTA.com/BBT2022"
+      assert get_full_url(text) == "https://MBTA.com/BBT2022"
+    end
+
+    test "should return nil if there is no url in the parsed text" do
+      text = "The Orange Line shutdown (9 PM, August 19 - September 18) overlaps with Green Line closures. Learn more and see alternative travel options at"
+      assert get_full_url(text) == nil
+    end
+  end
+end

--- a/apps/site/test/site_web/views/helpers/url_parsing_helpers_test.exs
+++ b/apps/site/test/site_web/views/helpers/url_parsing_helpers_test.exs
@@ -4,12 +4,16 @@ defmodule SiteWeb.Views.Helpers.AlertHelpersTest do
 
   describe "get_full_url/1" do
     test "should return the url parsed from the text" do
-      text = "The Orange Line shutdown (9 PM, August 19 - September 18) overlaps with Green Line closures. Learn more and see alternative travel options at MBTA.com/BBT2022"
+      text =
+        "The Orange Line shutdown (9 PM, August 19 - September 18) overlaps with Green Line closures. Learn more and see alternative travel options at MBTA.com/BBT2022"
+
       assert get_full_url(text) == "https://MBTA.com/BBT2022"
     end
 
     test "should return nil if there is no url in the parsed text" do
-      text = "The Orange Line shutdown (9 PM, August 19 - September 18) overlaps with Green Line closures. Learn more and see alternative travel options at"
+      text =
+        "The Orange Line shutdown (9 PM, August 19 - September 18) overlaps with Green Line closures. Learn more and see alternative travel options at"
+
       assert get_full_url(text) == nil
     end
   end

--- a/apps/site/test/site_web/views/helpers/url_parsing_helpers_test.exs
+++ b/apps/site/test/site_web/views/helpers/url_parsing_helpers_test.exs
@@ -1,4 +1,4 @@
-defmodule SiteWeb.Views.Helpers.AlertHelpersTest do
+defmodule SiteWeb.Views.Helpers.URLParsingHelpersTest do
   use SiteWeb.ConnCase, async: true
   import SiteWeb.Views.Helpers.URLParsingHelpers
 


### PR DESCRIPTION
…er click

#### Summary of changes
**Asana Ticket:** [Navigate to linked URL when user clicks banner alert](https://app.asana.com/0/home/1201123880594717/1202824647488164)

The main goal here was to change to a desired behavior without changing other existing behavior around the banner.

The alert banners already support navigating to a url on click.  The alert banner data just needed to be parsed differently to put the url in the right location.  Adding the parsed url to the alert banner struct caused the URL to be appended to the banner a second time.  The property `url_parsed_out_of_title` was added to stop this behavior so that if we parsed a url out of the title it would not render it again.

If a url is set on the data imported for the banner it should do the same behavior as today.

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] Are interactive elements accessible to screen readers?
* [ ] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [ ] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
