### PR TITLE
feat: Transfers from a shuttle should not be free

### DIFF
--- a/apps/trip_plan/lib/trip_plan/transfer.ex
+++ b/apps/trip_plan/lib/trip_plan/transfer.ex
@@ -38,8 +38,16 @@ defmodule TripPlan.Transfer do
 
   def is_subway_transfer?(_), do: false
 
-  @doc "Takes a set of legs and returns true if there might be a transfer between the legs, based on the lists in @single_ride_transfers and @multi_ride_transfers. Exception: no transfers from bus route to same bus route."
+  @doc """
+  Takes a set of legs and returns true if there might be a transfer between the legs, based on the lists in @single_ride_transfers and @multi_ride_transfers.
+
+  Exceptions:
+  - no transfers from bus route to same bus route
+  - no transfers from a shuttle to any other mode
+  """
   @spec is_maybe_transfer?([Leg.t()]) :: boolean
+  def is_maybe_transfer?([%Leg{mode: %TransitDetail{route_id: "Shuttle-" <> _}} | _]), do: false
+
   def is_maybe_transfer?([
         first_leg = %Leg{mode: %TransitDetail{route_id: first_route}},
         middle_leg = %Leg{mode: %TransitDetail{route_id: middle_route}},
@@ -60,7 +68,8 @@ defmodule TripPlan.Transfer do
          Enum.all?([from_route, to_route], &is_bus?/1) do
       false
     else
-      Map.get(@single_ride_transfers, Fares.to_fare_atom(from_route), [])
+      @single_ride_transfers
+      |> Map.get(Fares.to_fare_atom(from_route), [])
       |> Enum.member?(Fares.to_fare_atom(to_route))
     end
   end

--- a/apps/trip_plan/test/transfer_test.exs
+++ b/apps/trip_plan/test/transfer_test.exs
@@ -19,6 +19,7 @@ defmodule TransferTest do
     @other_outerxp_leg leg_for_route.("352")
     @sl_rapid_leg leg_for_route.("741")
     @sl_bus_leg leg_for_route.("751")
+    @shuttle_leg leg_for_route.("Shuttle-GovernmentCenterOakGrove")
 
     test "if from or to is nil" do
       refute [nil, nil] |> is_maybe_transfer?
@@ -96,6 +97,11 @@ defmodule TransferTest do
       refute [@ferry_leg, @outerxp_leg] |> is_maybe_transfer?
       refute [@ferry_leg, @sl_bus_leg] |> is_maybe_transfer?
       refute [@ferry_leg, @sl_rapid_leg] |> is_maybe_transfer?
+    end
+
+    test "shuttle -> subway or bus" do
+      refute is_maybe_transfer?([@shuttle_leg, @bus_leg])
+      refute is_maybe_transfer?([@shuttle_leg, @subway_leg])
     end
 
     test "bus -> bus -> subway" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate making OL/GL shuttle to subway transfer not free](https://app.asana.com/0/555089885850811/1202824647488182)

Shuttles have free fares, but if a rider then transfers to a subway or
bus line they have to pay the normal fare for that route.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
