### PR TITLE
Don't use PDF name to render PDF link

### DIFF
--- a/apps/site/lib/site_web/views/schedule_view.ex
+++ b/apps/site/lib/site_web/views/schedule_view.ex
@@ -184,7 +184,6 @@ defmodule SiteWeb.ScheduleView do
     pdf_name =
       cond do
         RoutePdf.custom?(pdf) -> pdf.link_text_override
-        pdf.name != nil && pdf.name != "" -> pdf.name
         true -> [pretty_route_name(route), " schedule"]
       end
 

--- a/apps/site/test/site_web/views/schedule_view_test.exs
+++ b/apps/site/test/site_web/views/schedule_view_test.exs
@@ -136,26 +136,14 @@ defmodule SiteWeb.ScheduleViewTest do
           path: "/custom-url",
           date_start: ~D[2017-12-01],
           link_text_override: "Custom schedule"
-        },
-        %RoutePdf{
-          path: "/cool-url",
-          date_start: ~D[2017-12-01],
-          name: "Cool Name"
-        },
-        %RoutePdf{
-          path: "/cool-url",
-          date_start: ~D[2017-12-01],
-          name: ""
         }
       ]
 
       maps = route_pdfs(pdfs, %Routes.Route{name: "1", type: 3}, ~D[2019-01-29])
       assert List.first(maps).url =~ ~r"http://.*/basic-current-url"
       assert List.first(maps).title =~ "Current Route 1 schedule PDF"
-      assert Enum.at(maps, 3).url =~ ~r"http://.*/cool-url"
-      assert Enum.at(maps, 3).title =~ "Cool Name PDF"
-      assert List.last(maps).url =~ ~r"http://.*/cool-url"
-      assert List.last(maps).title =~ "Current Route 1 schedule PDF"
+      assert List.last(maps).url =~ ~r"http://.*/custom-url"
+      assert List.last(maps).title =~ "Current Custom schedule PDF"
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Apply schedule PDF title logic to files from old and new endpoint](https://app.asana.com/0/385363666817452/1202824647488158/f)

Previously, we made a change to use the `name` field on the PDF data to disambiguate the test data that was uploaded as part of the new schedule process changes. Now that these are ironed out, we can revert that logic