### PR TITLE
Add East Boston ferry fare

### DIFF
--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -211,6 +211,7 @@ defmodule Fares.FareInfo do
       inner_harbor_month_price: "90.00",
       inner_harbor_month_price_reduced: "30.00",
       cross_harbor_price: "9.75",
+      east_boston_price: "2.40",
       commuter_ferry_price: "9.75",
       commuter_ferry_month_price: "329.00",
       commuter_ferry_logan_price: "9.75",
@@ -460,6 +461,7 @@ defmodule Fares.FareInfo do
         inner_harbor_month_price: inner_harbor_month_price,
         inner_harbor_month_price_reduced: inner_harbor_month_price_reduced,
         cross_harbor_price: cross_harbor_price,
+        east_boston_price: east_boston_price,
         commuter_ferry_price: commuter_ferry_price,
         commuter_ferry_month_price: commuter_ferry_month_price,
         commuter_ferry_logan_price: commuter_ferry_logan_price
@@ -522,6 +524,22 @@ defmodule Fares.FareInfo do
         media: [:mticket, :paper_ferry, :cash],
         reduced: nil,
         cents: dollars_to_cents(cross_harbor_price) * 2
+      },
+      %Fare{
+        mode: :ferry,
+        name: :ferry_east_boston,
+        duration: :single_trip,
+        media: [:mticket, :paper_ferry, :cash],
+        reduced: nil,
+        cents: dollars_to_cents(east_boston_price)
+      },
+      %Fare{
+        mode: :ferry,
+        name: :ferry_east_boston,
+        duration: :round_trip,
+        media: [:mticket, :paper_ferry, :cash],
+        reduced: nil,
+        cents: dollars_to_cents(east_boston_price) * 2
       },
       %Fare{
         mode: :ferry,

--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -529,7 +529,7 @@ defmodule Fares.FareInfo do
         mode: :ferry,
         name: :ferry_east_boston,
         duration: :single_trip,
-        media: [:mticket, :paper_ferry, :cash],
+        media: [:mticket, :paper_ferry],
         reduced: nil,
         cents: dollars_to_cents(east_boston_price)
       },
@@ -537,7 +537,7 @@ defmodule Fares.FareInfo do
         mode: :ferry,
         name: :ferry_east_boston,
         duration: :round_trip,
-        media: [:mticket, :paper_ferry, :cash],
+        media: [:mticket, :paper_ferry],
         reduced: nil,
         cents: dollars_to_cents(east_boston_price) * 2
       },

--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -671,7 +671,8 @@ defmodule Fares.FareInfo do
 
   defp floor_to_ten_cents(fare), do: Float.floor(fare / 10) * 10
 
-  defp compute_reduced_fare(%Fare{name: :ferry_east_boston}), do: 110
+  defp compute_reduced_fare(%Fare{name: :ferry_east_boston, duration: :single_trip}), do: 110
+  defp compute_reduced_fare(%Fare{name: :ferry_east_boston, duration: :round_trip}), do: 220
   defp compute_reduced_fare(%Fare{cents: cents}), do: floor_to_ten_cents(cents) / 2
 
   # Student and Senior fare prices are always the same.

--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -596,7 +596,7 @@ defmodule Fares.FareInfo do
       fares
       |> Enum.filter(&(&1.duration in [:single_trip, :round_trip]))
       |> Enum.flat_map(fn fare ->
-        reduced_price = floor_to_ten_cents(fare.cents) / 2
+        reduced_price = compute_reduced_fare(fare)
         [%{fare | cents: reduced_price, media: [:senior_card, :student_card], reduced: :any}]
       end)
 
@@ -670,6 +670,9 @@ defmodule Fares.FareInfo do
   end
 
   defp floor_to_ten_cents(fare), do: Float.floor(fare / 10) * 10
+
+  defp compute_reduced_fare(%Fare{name: :ferry_east_boston}), do: 110
+  defp compute_reduced_fare(%Fare{cents: cents}), do: floor_to_ten_cents(cents) / 2
 
   # Student and Senior fare prices are always the same.
   # For every generic reduced fare, add in two discreet

--- a/apps/fares/lib/fares.ex
+++ b/apps/fares/lib/fares.ex
@@ -24,6 +24,7 @@ defmodule Fares do
   @type ferry_name ::
           :ferry_cross_harbor
           | :ferry_inner_harbor
+          | :ferry_east_boston
           | :commuter_ferry_logan
           | :commuter_ferry
           | :ferry_george
@@ -131,6 +132,11 @@ defmodule Fares do
   defp calculate_ferry(origin, destination)
        when "Boat-Long" in [origin, destination] and "Boat-Logan" in [origin, destination] do
     :ferry_cross_harbor
+  end
+
+  defp calculate_ferry(origin, destination)
+       when "Boat-Long" in [origin, destination] and "Boat-Lewis" in [origin, destination] do
+    :ferry_east_boston
   end
 
   defp calculate_ferry(origin, destination)

--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -80,6 +80,7 @@ defmodule Fares.Format do
   def name(:express_bus), do: "Express Bus"
   def name(:ferry_inner_harbor), do: "Charlestown Ferry"
   def name(:ferry_cross_harbor), do: "Cross Harbor Ferry"
+  def name(:ferry_east_boston), do: "East Boston Ferry"
   def name(:ferry_george), do: "Georges Island"
   def name(:commuter_ferry), do: "Hingham/Hull Ferry"
   def name(:commuter_ferry_logan), do: "Commuter Ferry to Logan Airport"

--- a/apps/fares/test/fares_test.exs
+++ b/apps/fares/test/fares_test.exs
@@ -19,7 +19,7 @@ defmodule FaresTest do
 
   describe "fare_for_stops/3" do
     # a subset of possible ferry stops
-    @ferries ~w(Boat-Hingham Boat-Charlestown Boat-Logan Boat-Long-South)
+    @ferries ~w(Boat-Hingham Boat-Charlestown Boat-Logan Boat-Long-South Boat-Lewis)
 
     test "returns the name of the commuter rail fare given the origin and destination" do
       zone_1a = "place-north"
@@ -43,6 +43,7 @@ defmodule FaresTest do
         has_charlestown? = "Boat-Charlestown" in both
         has_long? = "Boat-Long" in both
         has_long_south? = "Boat-Long-South" in both
+        has_east_boston? = "Boat-Lewis" in both
 
         expected_name =
           cond do
@@ -50,6 +51,7 @@ defmodule FaresTest do
             has_long? and has_logan? -> :ferry_cross_harbor
             has_long_south? and has_charlestown? -> :ferry_inner_harbor
             has_logan? -> :commuter_ferry_logan
+            has_long? and has_east_boston? -> :ferry_east_boston
             true -> :commuter_ferry
           end
 

--- a/apps/fares/test/format_test.exs
+++ b/apps/fares/test/format_test.exs
@@ -52,6 +52,7 @@ defmodule Fares.FormatTest do
     test "gives a descriptive name for ferry fares" do
       assert name(%Fare{name: :ferry_inner_harbor}) == "Charlestown Ferry"
       assert name(%Fare{name: :ferry_cross_harbor}) == "Cross Harbor Ferry"
+      assert name(%Fare{name: :east_boston_ferry}) == "East Boston Ferry"
       assert name(%Fare{name: :commuter_ferry}) == "Hingham/Hull Ferry"
     end
 

--- a/apps/site/lib/site/content_rewriters/liquid_objects/fare.ex
+++ b/apps/site/lib/site/content_rewriters/liquid_objects/fare.ex
@@ -27,6 +27,7 @@ defmodule Site.ContentRewriters.LiquidObjects.Fare do
           | :commuter_ferry
           | :ferry_cross_harbor
           | :ferry_inner_harbor
+          | :ferry_east_boston
           | :foxboro
           | :express_bus
           | :local_bus
@@ -62,6 +63,7 @@ defmodule Site.ContentRewriters.LiquidObjects.Fare do
     "commuter_ferry",
     "ferry_cross_harbor",
     "ferry_inner_harbor",
+    "ferry_east_boston",
     "foxboro",
     "express_bus",
     "local_bus",

--- a/apps/site/test/site/content_rewriters/liquid_objects/fare_test.exs
+++ b/apps/site/test/site/content_rewriters/liquid_objects/fare_test.exs
@@ -126,12 +126,12 @@ defmodule Site.ContentRewriters.LiquidObjects.FareTest do
                duration: :single_trip
              ]
              |> Repo.all()
-             |> fare_result(:ferry) == "$3.70 – $9.75"
+             |> fare_result(:ferry) == "$2.40 – $9.75"
 
-      assert fare_request("ferry") == {:ok, "$3.70 – $9.75"}
+      assert fare_request("ferry") == {:ok, "$2.40 – $9.75"}
 
       # mticket single-ride fares are not reduced
-      assert fare_request("ferry:mticket") == {:ok, "$3.70 – $9.75"}
+      assert fare_request("ferry:mticket") == {:ok, "$2.40 – $9.75"}
     end
 
     test "handles :ferry:month" do
@@ -158,6 +158,21 @@ defmodule Site.ContentRewriters.LiquidObjects.FareTest do
       assert fare_request("ferry_inner_harbor:month:reduced") == {:ok, "$30.00"}
       refute fare_request("ferry_cross_harbor:month:reduced") == {:ok, "$30.00"}
       assert fare_request("ferry:month:reduced") == {:ok, "$30.00"}
+    end
+
+    test "handles ferry:reduced" do
+      assert [
+               mode: :ferry,
+               reduced: :any,
+               duration: :single_trip
+             ]
+             |> Repo.all()
+             |> fare_result(:ferry) == "$1.20 – $4.85"
+
+      assert fare_request("ferry_inner_harbor:reduced") == {:ok, "$1.85"}
+      assert fare_request("ferry_east_boston:reduced") == {:ok, "$1.20"}
+      assert fare_request("ferry_cross_harbor:reduced") == {:ok, "$4.85"}
+      assert fare_request("ferry:reduced") == {:ok, "$1.20 – $4.85"}
     end
 
     test "handles subway:week:reduced" do

--- a/apps/site/test/site/content_rewriters/liquid_objects/fare_test.exs
+++ b/apps/site/test/site/content_rewriters/liquid_objects/fare_test.exs
@@ -167,12 +167,12 @@ defmodule Site.ContentRewriters.LiquidObjects.FareTest do
                duration: :single_trip
              ]
              |> Repo.all()
-             |> fare_result(:ferry) == "$1.20 – $4.85"
+             |> fare_result(:ferry) == "$1.10 – $4.85"
 
       assert fare_request("ferry_inner_harbor:reduced") == {:ok, "$1.85"}
-      assert fare_request("ferry_east_boston:reduced") == {:ok, "$1.20"}
+      assert fare_request("ferry_east_boston:reduced") == {:ok, "$1.10"}
       assert fare_request("ferry_cross_harbor:reduced") == {:ok, "$4.85"}
-      assert fare_request("ferry:reduced") == {:ok, "$1.20 – $4.85"}
+      assert fare_request("ferry:reduced") == {:ok, "$1.10 – $4.85"}
     end
 
     test "handles subway:week:reduced" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add East Boston ferry fare](https://app.asana.com/0/385363666817452/1202953235045313/f)

Adds the one-way fare of $2.40, payable via mTicket, paper ticket, or cash, for the upcoming East Boston ferry service between the `Boat-Long` and `Boat-Lewis` stops. The tests updated here confirm the new ferry fare ranges of $2.40 - $9.75 and $1.10 - $4.85 (reduced).