### PR TITLE
feat(RouteCardHeader): Add copy that makes the card header look clickable

### DIFF
--- a/apps/site/assets/css/_link-block.scss
+++ b/apps/site/assets/css/_link-block.scss
@@ -34,10 +34,11 @@
   }
 
   &__view-schedule {
+    font-size: 1rem;
     position: relative;
-    bottom: 2px;
+    bottom: 0.125rem;
     font-weight: 500;
-    font-size: 14px;
-    margin-left: 25px;
+    margin-left: 0.75rem;
+    border-bottom: 0.063rem solid;
   }
 }

--- a/apps/site/assets/css/_link-block.scss
+++ b/apps/site/assets/css/_link-block.scss
@@ -32,4 +32,12 @@
   &__inner-link {
     pointer-events: all;
   }
+
+  &__view-schedule {
+    position: relative;
+    bottom: 2px;
+    font-weight: 500;
+    font-size: 14px;
+    margin-left: 25px;
+  }
 }

--- a/apps/site/assets/css/_transit-near-me.scss
+++ b/apps/site/assets/css/_transit-near-me.scss
@@ -217,7 +217,6 @@ $xxl-map-height: map-get($container-max-widths, xxl) * math.div(9, 16);
   justify-content: space-between;
   margin: 0;
   padding: calc(#{$base-spacing} / 2);
-  text-transform: uppercase;
 
   // adjust icon colors and sizing based on background color
   @each $line in map-keys($mbta-line-colors) {

--- a/apps/site/assets/ts/components/RouteCardHeader.tsx
+++ b/apps/site/assets/ts/components/RouteCardHeader.tsx
@@ -27,7 +27,7 @@ const RouteCardHeader = ({
             ? `Silver Line ${route.name}`
             : breakTextAtSlash(route.name)}
         </span>
-        <u className="c-link-block__view-schedule">View Schedule</u>
+        <span className="c-link-block__view-schedule">View Schedule</span>
       </span>
       {hasAlert && (
         <a

--- a/apps/site/assets/ts/components/RouteCardHeader.tsx
+++ b/apps/site/assets/ts/components/RouteCardHeader.tsx
@@ -27,7 +27,7 @@ const RouteCardHeader = ({
             ? `Silver Line ${route.name}`
             : breakTextAtSlash(route.name)}
         </span>
-        <span className="c-link-block__view-schedule">View Schedule</span>
+        <span className="c-link-block__view-schedule">View schedule</span>
       </span>
       {hasAlert && (
         <a

--- a/apps/site/assets/ts/components/RouteCardHeader.tsx
+++ b/apps/site/assets/ts/components/RouteCardHeader.tsx
@@ -21,10 +21,13 @@ const RouteCardHeader = ({
       <span className="sr-only">Go to route</span>
     </a>
     <div className="c-link-block__inner">
-      <span className={busClass(route)}>
-        {isASilverLineRoute(route.id)
-          ? `Silver Line ${route.name}`
-          : breakTextAtSlash(route.name)}
+      <span>
+        <span className={busClass(route)}>
+          {isASilverLineRoute(route.id)
+            ? `Silver Line ${route.name}`
+            : breakTextAtSlash(route.name)}
+        </span>
+        <u className="c-link-block__view-schedule">View Schedule</u>
       </span>
       {hasAlert && (
         <a

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/RouteCardHeaderTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/RouteCardHeaderTest.tsx.snap
@@ -8,7 +8,12 @@ exports[`RouteCardHeader component renders 1`] = `
     </span>
   </a>
   <div className=\\"c-link-block__inner\\">
-    <span className=\\"bus-route-sign\\" />
+    <span>
+      <span className=\\"bus-route-sign\\" />
+      <u className=\\"c-link-block__view-schedule\\">
+        View Schedule
+      </u>
+    </span>
   </div>
 </div>"
 `;

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/RouteCardHeaderTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/RouteCardHeaderTest.tsx.snap
@@ -10,9 +10,9 @@ exports[`RouteCardHeader component renders 1`] = `
   <div className=\\"c-link-block__inner\\">
     <span>
       <span className=\\"bus-route-sign\\" />
-      <u className=\\"c-link-block__view-schedule\\">
+      <span className=\\"c-link-block__view-schedule\\">
         View Schedule
-      </u>
+      </span>
     </span>
   </div>
 </div>"

--- a/apps/site/assets/ts/components/__tests__/__snapshots__/RouteCardHeaderTest.tsx.snap
+++ b/apps/site/assets/ts/components/__tests__/__snapshots__/RouteCardHeaderTest.tsx.snap
@@ -11,7 +11,7 @@ exports[`RouteCardHeader component renders 1`] = `
     <span>
       <span className=\\"bus-route-sign\\" />
       <span className=\\"c-link-block__view-schedule\\">
-        View Schedule
+        View schedule
       </span>
     </span>
   </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/DeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/DeparturesTest.tsx.snap
@@ -103,11 +103,11 @@ exports[`it renders 1`] = `
             >
               Red Line
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -322,11 +322,11 @@ exports[`it renders 1`] = `
             >
               Silver Line SL1
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -492,11 +492,11 @@ exports[`it renders 1`] = `
             >
               Silver Line SL2
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -662,11 +662,11 @@ exports[`it renders 1`] = `
             >
               Silver Line SL3
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -832,11 +832,11 @@ exports[`it renders 1`] = `
             >
               Fairmount Line
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -972,11 +972,11 @@ exports[`it renders 1`] = `
             >
               Framingham/​Worcester Line
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -1192,11 +1192,11 @@ exports[`it renders 1`] = `
             >
               Franklin Line
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -1412,11 +1412,11 @@ exports[`it renders 1`] = `
             >
               Greenbush Line
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -1552,11 +1552,11 @@ exports[`it renders 1`] = `
             >
               Kingston/​Plymouth Line
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -1732,11 +1732,11 @@ exports[`it renders 1`] = `
             >
               Middleborough/​Lakeville Line
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -1872,11 +1872,11 @@ exports[`it renders 1`] = `
             >
               Needham Line
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -2012,11 +2012,11 @@ exports[`it renders 1`] = `
             >
               Providence/​Stoughton Line
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>
@@ -2314,11 +2314,11 @@ exports[`it renders filtered data 1`] = `
             >
               Red Line
             </span>
-            <u
+            <span
               className="c-link-block__view-schedule"
             >
               View Schedule
-            </u>
+            </span>
           </span>
         </div>
       </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/DeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/DeparturesTest.tsx.snap
@@ -97,10 +97,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Red Line
+          <span>
+            <span
+              className=""
+            >
+              Red Line
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -309,10 +316,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Silver Line SL1
+          <span>
+            <span
+              className=""
+            >
+              Silver Line SL1
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -472,10 +486,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Silver Line SL2
+          <span>
+            <span
+              className=""
+            >
+              Silver Line SL2
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -635,10 +656,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Silver Line SL3
+          <span>
+            <span
+              className=""
+            >
+              Silver Line SL3
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -798,10 +826,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Fairmount Line
+          <span>
+            <span
+              className=""
+            >
+              Fairmount Line
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -931,10 +966,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Framingham/​Worcester Line
+          <span>
+            <span
+              className=""
+            >
+              Framingham/​Worcester Line
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -1144,10 +1186,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Franklin Line
+          <span>
+            <span
+              className=""
+            >
+              Franklin Line
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -1357,10 +1406,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Greenbush Line
+          <span>
+            <span
+              className=""
+            >
+              Greenbush Line
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -1490,10 +1546,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Kingston/​Plymouth Line
+          <span>
+            <span
+              className=""
+            >
+              Kingston/​Plymouth Line
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -1663,10 +1726,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Middleborough/​Lakeville Line
+          <span>
+            <span
+              className=""
+            >
+              Middleborough/​Lakeville Line
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -1796,10 +1866,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Needham Line
+          <span>
+            <span
+              className=""
+            >
+              Needham Line
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -1929,10 +2006,17 @@ exports[`it renders 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Providence/​Stoughton Line
+          <span>
+            <span
+              className=""
+            >
+              Providence/​Stoughton Line
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>
@@ -2224,10 +2308,17 @@ exports[`it renders filtered data 1`] = `
         <div
           className="c-link-block__inner"
         >
-          <span
-            className=""
-          >
-            Red Line
+          <span>
+            <span
+              className=""
+            >
+              Red Line
+            </span>
+            <u
+              className="c-link-block__view-schedule"
+            >
+              View Schedule
+            </u>
           </span>
         </div>
       </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/DeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/DeparturesTest.tsx.snap
@@ -106,7 +106,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -325,7 +325,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -495,7 +495,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -665,7 +665,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -835,7 +835,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -975,7 +975,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -1195,7 +1195,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -1415,7 +1415,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -1555,7 +1555,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -1735,7 +1735,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -1875,7 +1875,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -2015,7 +2015,7 @@ exports[`it renders 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>
@@ -2317,7 +2317,7 @@ exports[`it renders filtered data 1`] = `
             <span
               className="c-link-block__view-schedule"
             >
-              View Schedule
+              View schedule
             </span>
           </span>
         </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/RouteCardTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/RouteCardTest.tsx.snap
@@ -26,11 +26,11 @@ exports[`it renders 1`] = `
         >
           Red Line
         </span>
-        <u
+        <span
           className="c-link-block__view-schedule"
         >
           View Schedule
-        </u>
+        </span>
       </span>
     </div>
   </div>
@@ -248,11 +248,11 @@ exports[`renders blue line routes 1`] = `
         >
           Blue Line
         </span>
-        <u
+        <span
           className="c-link-block__view-schedule"
         >
           View Schedule
-        </u>
+        </span>
       </span>
     </div>
   </div>
@@ -302,11 +302,11 @@ exports[`renders bus routes 1`] = `
         >
           Bus
         </span>
-        <u
+        <span
           className="c-link-block__view-schedule"
         >
           View Schedule
-        </u>
+        </span>
       </span>
     </div>
   </div>
@@ -356,11 +356,11 @@ exports[`renders ferry routes 1`] = `
         >
           Charlestown Ferry
         </span>
-        <u
+        <span
           className="c-link-block__view-schedule"
         >
           View Schedule
-        </u>
+        </span>
       </span>
     </div>
   </div>
@@ -410,11 +410,11 @@ exports[`renders green line routes 1`] = `
         >
           B Line
         </span>
-        <u
+        <span
           className="c-link-block__view-schedule"
         >
           View Schedule
-        </u>
+        </span>
       </span>
     </div>
   </div>
@@ -464,11 +464,11 @@ exports[`renders orange line routes 1`] = `
         >
           Orange Line
         </span>
-        <u
+        <span
           className="c-link-block__view-schedule"
         >
           View Schedule
-        </u>
+        </span>
       </span>
     </div>
   </div>
@@ -518,11 +518,11 @@ exports[`renders red line routes 1`] = `
         >
           Red Line
         </span>
-        <u
+        <span
           className="c-link-block__view-schedule"
         >
           View Schedule
-        </u>
+        </span>
       </span>
     </div>
   </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/RouteCardTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/RouteCardTest.tsx.snap
@@ -29,7 +29,7 @@ exports[`it renders 1`] = `
         <span
           className="c-link-block__view-schedule"
         >
-          View Schedule
+          View schedule
         </span>
       </span>
     </div>
@@ -251,7 +251,7 @@ exports[`renders blue line routes 1`] = `
         <span
           className="c-link-block__view-schedule"
         >
-          View Schedule
+          View schedule
         </span>
       </span>
     </div>
@@ -305,7 +305,7 @@ exports[`renders bus routes 1`] = `
         <span
           className="c-link-block__view-schedule"
         >
-          View Schedule
+          View schedule
         </span>
       </span>
     </div>
@@ -359,7 +359,7 @@ exports[`renders ferry routes 1`] = `
         <span
           className="c-link-block__view-schedule"
         >
-          View Schedule
+          View schedule
         </span>
       </span>
     </div>
@@ -413,7 +413,7 @@ exports[`renders green line routes 1`] = `
         <span
           className="c-link-block__view-schedule"
         >
-          View Schedule
+          View schedule
         </span>
       </span>
     </div>
@@ -467,7 +467,7 @@ exports[`renders orange line routes 1`] = `
         <span
           className="c-link-block__view-schedule"
         >
-          View Schedule
+          View schedule
         </span>
       </span>
     </div>
@@ -521,7 +521,7 @@ exports[`renders red line routes 1`] = `
         <span
           className="c-link-block__view-schedule"
         >
-          View Schedule
+          View schedule
         </span>
       </span>
     </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/RouteCardTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/RouteCardTest.tsx.snap
@@ -20,10 +20,17 @@ exports[`it renders 1`] = `
     <div
       className="c-link-block__inner"
     >
-      <span
-        className=""
-      >
-        Red Line
+      <span>
+        <span
+          className=""
+        >
+          Red Line
+        </span>
+        <u
+          className="c-link-block__view-schedule"
+        >
+          View Schedule
+        </u>
       </span>
     </div>
   </div>
@@ -235,10 +242,17 @@ exports[`renders blue line routes 1`] = `
     <div
       className="c-link-block__inner"
     >
-      <span
-        className=""
-      >
-        Blue Line
+      <span>
+        <span
+          className=""
+        >
+          Blue Line
+        </span>
+        <u
+          className="c-link-block__view-schedule"
+        >
+          View Schedule
+        </u>
       </span>
     </div>
   </div>
@@ -282,10 +296,17 @@ exports[`renders bus routes 1`] = `
     <div
       className="c-link-block__inner"
     >
-      <span
-        className="bus-route-sign"
-      >
-        Bus
+      <span>
+        <span
+          className="bus-route-sign"
+        >
+          Bus
+        </span>
+        <u
+          className="c-link-block__view-schedule"
+        >
+          View Schedule
+        </u>
       </span>
     </div>
   </div>
@@ -329,10 +350,17 @@ exports[`renders ferry routes 1`] = `
     <div
       className="c-link-block__inner"
     >
-      <span
-        className=""
-      >
-        Charlestown Ferry
+      <span>
+        <span
+          className=""
+        >
+          Charlestown Ferry
+        </span>
+        <u
+          className="c-link-block__view-schedule"
+        >
+          View Schedule
+        </u>
       </span>
     </div>
   </div>
@@ -376,10 +404,17 @@ exports[`renders green line routes 1`] = `
     <div
       className="c-link-block__inner"
     >
-      <span
-        className=""
-      >
-        B Line
+      <span>
+        <span
+          className=""
+        >
+          B Line
+        </span>
+        <u
+          className="c-link-block__view-schedule"
+        >
+          View Schedule
+        </u>
       </span>
     </div>
   </div>
@@ -423,10 +458,17 @@ exports[`renders orange line routes 1`] = `
     <div
       className="c-link-block__inner"
     >
-      <span
-        className=""
-      >
-        Orange Line
+      <span>
+        <span
+          className=""
+        >
+          Orange Line
+        </span>
+        <u
+          className="c-link-block__view-schedule"
+        >
+          View Schedule
+        </u>
       </span>
     </div>
   </div>
@@ -470,10 +512,17 @@ exports[`renders red line routes 1`] = `
     <div
       className="c-link-block__inner"
     >
-      <span
-        className=""
-      >
-        Red Line
+      <span>
+        <span
+          className=""
+        >
+          Red Line
+        </span>
+        <u
+          className="c-link-block__view-schedule"
+        >
+          View Schedule
+        </u>
       </span>
     </div>
   </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
@@ -621,11 +621,11 @@ Array [
                       >
                         Red Line
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -840,11 +840,11 @@ Array [
                       >
                         Silver Line SL1
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -1010,11 +1010,11 @@ Array [
                       >
                         Silver Line SL2
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -1180,11 +1180,11 @@ Array [
                       >
                         Silver Line SL3
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -1350,11 +1350,11 @@ Array [
                       >
                         Fairmount Line
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -1490,11 +1490,11 @@ Array [
                       >
                         Framingham/​Worcester Line
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -1710,11 +1710,11 @@ Array [
                       >
                         Franklin Line
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -1930,11 +1930,11 @@ Array [
                       >
                         Greenbush Line
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -2070,11 +2070,11 @@ Array [
                       >
                         Kingston/​Plymouth Line
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -2250,11 +2250,11 @@ Array [
                       >
                         Middleborough/​Lakeville Line
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -2390,11 +2390,11 @@ Array [
                       >
                         Needham Line
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>
@@ -2530,11 +2530,11 @@ Array [
                       >
                         Providence/​Stoughton Line
                       </span>
-                      <u
+                      <span
                         className="c-link-block__view-schedule"
                       >
                         View Schedule
-                      </u>
+                      </span>
                     </span>
                   </div>
                 </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
@@ -624,7 +624,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -843,7 +843,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -1013,7 +1013,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -1183,7 +1183,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -1353,7 +1353,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -1493,7 +1493,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -1713,7 +1713,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -1933,7 +1933,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -2073,7 +2073,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -2253,7 +2253,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -2393,7 +2393,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>
@@ -2533,7 +2533,7 @@ Array [
                       <span
                         className="c-link-block__view-schedule"
                       >
-                        View Schedule
+                        View schedule
                       </span>
                     </span>
                   </div>

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageTest.tsx.snap
@@ -615,10 +615,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Red Line
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Red Line
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -827,10 +834,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Silver Line SL1
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Silver Line SL1
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -990,10 +1004,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Silver Line SL2
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Silver Line SL2
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -1153,10 +1174,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Silver Line SL3
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Silver Line SL3
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -1316,10 +1344,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Fairmount Line
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Fairmount Line
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -1449,10 +1484,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Framingham/​Worcester Line
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Framingham/​Worcester Line
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -1662,10 +1704,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Franklin Line
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Franklin Line
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -1875,10 +1924,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Greenbush Line
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Greenbush Line
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -2008,10 +2064,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Kingston/​Plymouth Line
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Kingston/​Plymouth Line
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -2181,10 +2244,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Middleborough/​Lakeville Line
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Middleborough/​Lakeville Line
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -2314,10 +2384,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Needham Line
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Needham Line
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>
@@ -2447,10 +2524,17 @@ Array [
                   <div
                     className="c-link-block__inner"
                   >
-                    <span
-                      className=""
-                    >
-                      Providence/​Stoughton Line
+                    <span>
+                      <span
+                        className=""
+                      >
+                        Providence/​Stoughton Line
+                      </span>
+                      <u
+                        className="c-link-block__view-schedule"
+                      >
+                        View Schedule
+                      </u>
                     </span>
                   </div>
                 </div>

--- a/apps/site/assets/ts/tnm/__tests__/__snapshots__/RouteCardTest.tsx.snap
+++ b/apps/site/assets/ts/tnm/__tests__/__snapshots__/RouteCardTest.tsx.snap
@@ -30,7 +30,7 @@ exports[`it renders a stop card 1`] = `
         <span
           className="c-link-block__view-schedule"
         >
-          View Schedule
+          View schedule
         </span>
       </span>
       <a
@@ -177,7 +177,7 @@ exports[`it renders a stop card for the silver line 1`] = `
         <span
           className="c-link-block__view-schedule"
         >
-          View Schedule
+          View schedule
         </span>
       </span>
       <a

--- a/apps/site/assets/ts/tnm/__tests__/__snapshots__/RouteCardTest.tsx.snap
+++ b/apps/site/assets/ts/tnm/__tests__/__snapshots__/RouteCardTest.tsx.snap
@@ -27,11 +27,11 @@ exports[`it renders a stop card 1`] = `
         >
           Route Name
         </span>
-        <u
+        <span
           className="c-link-block__view-schedule"
         >
           View Schedule
-        </u>
+        </span>
       </span>
       <a
         className="c-link-block__inner-link"
@@ -174,11 +174,11 @@ exports[`it renders a stop card for the silver line 1`] = `
         >
           Silver Line Route Name
         </span>
-        <u
+        <span
           className="c-link-block__view-schedule"
         >
           View Schedule
-        </u>
+        </span>
       </span>
       <a
         className="c-link-block__inner-link"

--- a/apps/site/assets/ts/tnm/__tests__/__snapshots__/RouteCardTest.tsx.snap
+++ b/apps/site/assets/ts/tnm/__tests__/__snapshots__/RouteCardTest.tsx.snap
@@ -21,10 +21,17 @@ exports[`it renders a stop card 1`] = `
     <div
       className="c-link-block__inner"
     >
-      <span
-        className="bus-route-sign"
-      >
-        Route Name
+      <span>
+        <span
+          className="bus-route-sign"
+        >
+          Route Name
+        </span>
+        <u
+          className="c-link-block__view-schedule"
+        >
+          View Schedule
+        </u>
       </span>
       <a
         className="c-link-block__inner-link"
@@ -161,10 +168,17 @@ exports[`it renders a stop card for the silver line 1`] = `
     <div
       className="c-link-block__inner"
     >
-      <span
-        className=""
-      >
-        Silver Line Route Name
+      <span>
+        <span
+          className=""
+        >
+          Silver Line Route Name
+        </span>
+        <u
+          className="c-link-block__view-schedule"
+        >
+          View Schedule
+        </u>
       </span>
       <a
         className="c-link-block__inner-link"

--- a/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
+++ b/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
@@ -132,11 +132,11 @@ exports[`render it renders 1`] = `
               >
                 Orange Line
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
             <a
               className="c-link-block__inner-link"
@@ -350,11 +350,11 @@ exports[`render it renders 1`] = `
               >
                 Haverhill Line
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -527,11 +527,11 @@ exports[`render it renders 1`] = `
               >
                 97
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -730,11 +730,11 @@ exports[`render it renders 1`] = `
               >
                 99
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -933,11 +933,11 @@ exports[`render it renders 1`] = `
               >
                 101
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -1134,11 +1134,11 @@ exports[`render it renders 1`] = `
               >
                 104
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
             <a
               className="c-link-block__inner-link"
@@ -1352,11 +1352,11 @@ exports[`render it renders 1`] = `
               >
                 105
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
             <a
               className="c-link-block__inner-link"
@@ -1570,11 +1570,11 @@ exports[`render it renders 1`] = `
               >
                 106
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -1871,11 +1871,11 @@ exports[`render it renders 1`] = `
               >
                 108
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -2074,11 +2074,11 @@ exports[`render it renders 1`] = `
               >
                 131
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -2211,11 +2211,11 @@ exports[`render it renders 1`] = `
               >
                 132
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -2414,11 +2414,11 @@ exports[`render it renders 1`] = `
               >
                 136
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -2599,11 +2599,11 @@ exports[`render it renders 1`] = `
               >
                 137
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -2802,11 +2802,11 @@ exports[`render it renders 1`] = `
               >
                 411
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>
@@ -3063,11 +3063,11 @@ exports[`render it renders 1`] = `
               >
                 430
               </span>
-              <u
+              <span
                 className="c-link-block__view-schedule"
               >
                 View Schedule
-              </u>
+              </span>
             </span>
           </div>
         </div>

--- a/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
+++ b/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
@@ -135,7 +135,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
             <a
@@ -353,7 +353,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -530,7 +530,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -733,7 +733,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -936,7 +936,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -1137,7 +1137,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
             <a
@@ -1355,7 +1355,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
             <a
@@ -1573,7 +1573,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -1874,7 +1874,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -2077,7 +2077,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -2214,7 +2214,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -2417,7 +2417,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -2602,7 +2602,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -2805,7 +2805,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>
@@ -3066,7 +3066,7 @@ exports[`render it renders 1`] = `
               <span
                 className="c-link-block__view-schedule"
               >
-                View Schedule
+                View schedule
               </span>
             </span>
           </div>

--- a/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
+++ b/apps/site/assets/ts/tnm/__tests__/__snapshots__/RoutesSidebarTest.tsx.snap
@@ -126,10 +126,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className=""
-            >
-              Orange Line
+            <span>
+              <span
+                className=""
+              >
+                Orange Line
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
             <a
               className="c-link-block__inner-link"
@@ -337,10 +344,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className=""
-            >
-              Haverhill Line
+            <span>
+              <span
+                className=""
+              >
+                Haverhill Line
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -507,10 +521,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              97
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                97
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -703,10 +724,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              99
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                99
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -899,10 +927,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              101
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                101
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -1093,10 +1128,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              104
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                104
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
             <a
               className="c-link-block__inner-link"
@@ -1304,10 +1346,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              105
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                105
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
             <a
               className="c-link-block__inner-link"
@@ -1515,10 +1564,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              106
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                106
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -1809,10 +1865,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              108
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                108
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -2005,10 +2068,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              131
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                131
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -2135,10 +2205,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              132
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                132
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -2331,10 +2408,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              136
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                136
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -2509,10 +2593,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              137
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                137
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -2705,10 +2796,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              411
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                411
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>
@@ -2959,10 +3057,17 @@ exports[`render it renders 1`] = `
           <div
             className="c-link-block__inner"
           >
-            <span
-              className="bus-route-sign"
-            >
-              430
+            <span>
+              <span
+                className="bus-route-sign"
+              >
+                430
+              </span>
+              <u
+                className="c-link-block__view-schedule"
+              >
+                View Schedule
+              </u>
             </span>
           </div>
         </div>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add clearer link to schedule page in Departures](https://app.asana.com/0/home/1201123880594717/1202908385566824)
**Follow Up Ticket:** [Design Fixes](https://app.asana.com/0/555089885850811/1202967204475095/f)

Added the text - View Schedule to the card header, and removed the upper casing from the card header as well.

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] Are interactive elements accessible to screen readers?
* [ ] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [ ] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
