### PR TITLE
feat: Remove paper ticket option for East Boston Ferry

### DIFF
--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -529,7 +529,7 @@ defmodule Fares.FareInfo do
         mode: :ferry,
         name: :ferry_east_boston,
         duration: :single_trip,
-        media: [:mticket, :paper_ferry],
+        media: [:mticket],
         reduced: nil,
         cents: dollars_to_cents(east_boston_price)
       },
@@ -537,7 +537,7 @@ defmodule Fares.FareInfo do
         mode: :ferry,
         name: :ferry_east_boston,
         duration: :round_trip,
-        media: [:mticket, :paper_ferry],
+        media: [:mticket],
         reduced: nil,
         cents: dollars_to_cents(east_boston_price) * 2
       },

--- a/apps/fares/test/format_test.exs
+++ b/apps/fares/test/format_test.exs
@@ -52,7 +52,7 @@ defmodule Fares.FormatTest do
     test "gives a descriptive name for ferry fares" do
       assert name(%Fare{name: :ferry_inner_harbor}) == "Charlestown Ferry"
       assert name(%Fare{name: :ferry_cross_harbor}) == "Cross Harbor Ferry"
-      assert name(%Fare{name: :east_boston_ferry}) == "East Boston Ferry"
+      assert name(%Fare{name: :ferry_east_boston}) == "East Boston Ferry"
       assert name(%Fare{name: :commuter_ferry}) == "Hingham/Hull Ferry"
     end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Remove "or Paper Ferry Ticket" from East Boston Ferry card](https://app.asana.com/0/385363666817452/1202964593147464/f)

Unlike the other ferries, the East Boston ferry fare cannot be purchased with cash nor with a paper ferry ticket. mTicket is the only way to pay the fare.

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
