### PR TITLE
feat: Streaming predictions proof-of-concept

### DIFF
--- a/apps/predictions/lib/parser.ex
+++ b/apps/predictions/lib/parser.ex
@@ -1,9 +1,10 @@
 defmodule Predictions.Parser do
-  alias Predictions.Prediction
-
   @moduledoc """
   Functions for parsing predictions from their JSON:API format.
   """
+
+  alias JsonApi.Item
+  alias Predictions.Prediction
 
   @type record :: {
           Prediction.id_t() | nil,
@@ -13,30 +14,83 @@ defmodule Predictions.Parser do
           0 | 1,
           DateTime.t() | nil,
           non_neg_integer,
-          Prediction.schedule_relationship(),
+          Prediction.schedule_relationship() | nil,
           String.t() | nil,
           String.t() | nil,
           boolean
         }
 
-  @spec parse(JsonApi.Item.t()) :: record
-  def parse(%JsonApi.Item{attributes: attributes} = item) do
+  @spec parse(Item.t()) :: record
+  def parse(%Item{} = item) do
     {
       item.id,
       trip_id(item),
       stop_id(item),
       route_id(item),
-      attributes["direction_id"],
-      [attributes["arrival_time"], attributes["departure_time"]] |> first_time,
-      attributes["stop_sequence"] || 0,
-      schedule_relationship(attributes["schedule_relationship"]),
+      direction_id(item),
+      first_time(item),
+      stop_sequence(item),
+      schedule_relationship(item),
       track(item),
-      attributes["status"],
-      departing?(attributes)
+      status(item),
+      departing?(item)
     }
   end
 
-  defp first_time(times) do
+  @spec departing?(Item.t()) :: boolean()
+  def departing?(%Item{attributes: %{"departure_time" => binary}}) when is_binary(binary),
+    do: true
+
+  def departing?(%Item{attributes: %{"status" => binary}}) when is_binary(binary),
+    do: upcoming_status?(binary)
+
+  def departing?(_), do: false
+
+  @spec direction_id(Item.t()) :: 0 | 1
+  def direction_id(%Item{attributes: %{"direction_id" => direction_id}}), do: direction_id
+
+  @spec first_time(Item.t()) :: DateTime.t() | nil
+  def first_time(%Item{
+        attributes: %{"arrival_time" => arrival_time, "departure_time" => departure_time}
+      }),
+      do: first_time_from_arrival_departure([arrival_time, departure_time])
+
+  def first_time(_), do: nil
+
+  @spec schedule_relationship(Item.t()) :: Prediction.schedule_relationship() | nil
+  def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "ADDED"}}), do: :added
+
+  def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "UNSCHEDULED"}}),
+    do: :unscheduled
+
+  def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "CANCELLED"}}),
+    do: :cancelled
+
+  def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "SKIPPED"}}),
+    do: :skipped
+
+  def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "NO_DATA"}}),
+    do: :no_data
+
+  def schedule_relationship(_), do: nil
+
+  @spec status(Item.t()) :: String.t() | nil
+  def status(%Item{attributes: %{"status" => status}}), do: status
+  def status(_), do: nil
+
+  @spec stop_sequence(Item.t()) :: non_neg_integer()
+  def stop_sequence(%Item{attributes: %{"stop_sequence" => stop_sequence}}), do: stop_sequence
+  def stop_sequence(_), do: 0
+
+  @spec track(Item.t()) :: String.t() | nil
+  def track(%{attributes: %{"track" => track}}), do: track
+
+  def track(%{relationships: %{"stop" => [%{attributes: %{"platform_code" => track}} | _]}}),
+    do: track
+
+  def track(_), do: nil
+
+  defp first_time_from_arrival_departure(times) do
     case times
          |> Enum.reject(&is_nil/1)
          |> List.first()
@@ -46,56 +100,28 @@ defmodule Predictions.Parser do
     end
   end
 
-  @spec track(JsonApi.Item.t()) :: String.t() | nil
-  defp track(%{attributes: %{"track" => track}}), do: track
-
-  defp track(%{relationships: %{"stop" => [%{attributes: %{"platform_code" => track}} | _]}}),
-    do: track
-
-  defp track(_), do: nil
-
-  defp departing?(%{"departure_time" => binary}) when is_binary(binary) do
-    true
-  end
-
-  defp departing?(%{"status" => binary}) when is_binary(binary) do
-    upcoming_status?(binary)
-  end
-
-  defp departing?(_) do
-    false
-  end
-
   @spec upcoming_status?(String.t()) :: boolean
   defp upcoming_status?("Approaching"), do: true
   defp upcoming_status?("Boarding"), do: true
   defp upcoming_status?(status), do: String.ends_with?(status, "away")
 
-  @spec schedule_relationship(String.t()) :: Prediction.schedule_relationship()
-  defp schedule_relationship("ADDED"), do: :added
-  defp schedule_relationship("UNSCHEDULED"), do: :unscheduled
-  defp schedule_relationship("CANCELLED"), do: :cancelled
-  defp schedule_relationship("SKIPPED"), do: :skipped
-  defp schedule_relationship("NO_DATA"), do: :no_data
-  defp schedule_relationship(_), do: nil
-
-  defp stop_id(%JsonApi.Item{relationships: %{"stop" => [%{id: id} | _]}}) do
+  defp stop_id(%Item{relationships: %{"stop" => [%{id: id} | _]}}) do
     id
   end
 
-  defp stop_id(%JsonApi.Item{relationships: %{"stop" => []}}) do
+  defp stop_id(%Item{relationships: %{"stop" => []}}) do
     nil
   end
 
-  defp trip_id(%JsonApi.Item{relationships: %{"trip" => [%{id: id} | _]}}) do
+  defp trip_id(%Item{relationships: %{"trip" => [%{id: id} | _]}}) do
     id
   end
 
-  defp trip_id(%JsonApi.Item{relationships: %{"trip" => []}}) do
+  defp trip_id(%Item{relationships: %{"trip" => []}}) do
     nil
   end
 
-  defp route_id(%JsonApi.Item{relationships: %{"route" => [%{id: id} | _]}}) do
+  defp route_id(%Item{relationships: %{"route" => [%{id: id} | _]}}) do
     id
   end
 end

--- a/apps/predictions/lib/prediction.ex
+++ b/apps/predictions/lib/prediction.ex
@@ -22,7 +22,7 @@ defmodule Predictions.Prediction do
   @type t :: %__MODULE__{
           id: id_t,
           trip: Schedules.Trip.t() | nil,
-          stop: Stops.Stop.t(),
+          stop: Stops.Stop.t() | nil,
           route: Routes.Route.t(),
           direction_id: 0 | 1,
           time: DateTime.t() | nil,

--- a/apps/predictions/lib/prediction.ex
+++ b/apps/predictions/lib/prediction.ex
@@ -10,6 +10,8 @@ defmodule Predictions.Prediction do
             stop: nil,
             route: nil,
             direction_id: nil,
+            arrival_time: nil,
+            departure_time: nil,
             time: nil,
             stop_sequence: 0,
             schedule_relationship: nil,
@@ -25,6 +27,9 @@ defmodule Predictions.Prediction do
           stop: Stops.Stop.t() | nil,
           route: Routes.Route.t(),
           direction_id: 0 | 1,
+          arrival_time: DateTime.t() | nil,
+          departure_time: DateTime.t() | nil,
+          # TODO: Deprecated, should be removed in favor of arrival_time and departure_time -- MSS 2022-09-22
           time: DateTime.t() | nil,
           stop_sequence: non_neg_integer,
           schedule_relationship: schedule_relationship,

--- a/apps/predictions/lib/predictions.ex
+++ b/apps/predictions/lib/predictions.ex
@@ -1,4 +1,12 @@
 defmodule Predictions do
+  @moduledoc """
+  Supervisor for the Predictions application.
+
+  Children include:
+  - StreamSupervisor: Dynamically sets up per-route streams of predictions from the API.
+  - Repo: Manages ad-hoc API requests.
+  """
+
   use Application
 
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
@@ -8,6 +16,11 @@ defmodule Predictions do
 
     # Define workers and child supervisors to be supervised
     children = [
+      supervisor(Phoenix.PubSub.PG2, [Predictions.PubSub, []]),
+      {Registry, keys: :unique, name: :prediction_streams_registry},
+      {Registry, keys: :duplicate, name: :prediction_subscriptions_registry},
+      Predictions.StreamSupervisor,
+      Predictions.PredictionsPubSub,
       Predictions.Repo
     ]
 

--- a/apps/predictions/lib/predictions_pub_sub.ex
+++ b/apps/predictions/lib/predictions_pub_sub.ex
@@ -1,0 +1,183 @@
+defmodule Predictions.PredictionsPubSub do
+  @moduledoc """
+  Allow channels to subscribe to prediction streams.
+  """
+
+  use GenServer
+
+  alias Predictions.{Prediction, StreamSupervisor}
+  alias Routes.Route
+
+  defstruct predictions_by_route_id: %{}
+
+  @type t :: %__MODULE__{
+          predictions_by_route_id: predictions_by_route_id()
+        }
+
+  @type predictions_by_route_id :: %{Route.id_t() => [Prediction.t()]}
+
+  @type broadcast_message :: {:new_predictions, [Prediction.t()]}
+
+  # Client
+
+  @spec start_link() :: GenServer.on_start()
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+
+    GenServer.start_link(
+      __MODULE__,
+      opts,
+      name: name
+    )
+  end
+
+  @spec subscribe(Route.id_t()) :: [Prediction.t()]
+  @spec subscribe(Route.id_t(), GenServer.server()) :: [Prediction.t()]
+  def subscribe(route_id, server \\ __MODULE__) do
+    StreamSupervisor.ensure_stream_is_started(route_id)
+    {registry_key, predictions} = GenServer.call(server, {:subscribe, route_id})
+    Registry.register(:prediction_subscriptions_registry, registry_key, route_id)
+    predictions
+  end
+
+  # Server
+
+  @impl GenServer
+  @spec init(keyword) :: {:ok, t()}
+  def init(opts) do
+    subscribe_fn = Keyword.get(opts, :subscribe_fn, &Phoenix.PubSub.subscribe/2)
+    subscribe_fn.(Predictions.PubSub, "predictions")
+    {:ok, %__MODULE__{}}
+  end
+
+  @impl GenServer
+  def handle_call(
+        {:subscribe, route_id},
+        _from,
+        %__MODULE__{predictions_by_route_id: predictions_by_route_id} = state
+      ) do
+    registry_key = self()
+    predictions = predictions_for_route_id(predictions_by_route_id, route_id)
+
+    {:reply, {registry_key, predictions}, state}
+  end
+
+  @impl GenServer
+  def handle_info(
+        {:reset, [%Predictions.Prediction{route: %Routes.Route{id: route_id}} | _] = predictions},
+        %__MODULE__{predictions_by_route_id: predictions_by_route_id} = state
+      ) do
+    new_state = %__MODULE__{
+      state
+      | predictions_by_route_id: Map.put(predictions_by_route_id, route_id, predictions)
+    }
+
+    broadcast(new_state)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info(
+        {:add,
+         [%Predictions.Prediction{route: %Routes.Route{id: route_id}} | _] = new_predictions},
+        %__MODULE__{predictions_by_route_id: predictions_by_route_id} = state
+      ) do
+    new_predictions_by_route_id =
+      Map.put(
+        predictions_by_route_id,
+        route_id,
+        predictions_for_route_id(predictions_by_route_id, route_id) ++ new_predictions
+      )
+
+    new_state = %__MODULE__{
+      state
+      | predictions_by_route_id: new_predictions_by_route_id
+    }
+
+    broadcast(new_state)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info(
+        {:update,
+         [%Predictions.Prediction{route: %Routes.Route{id: route_id}} | _] = updated_predictions},
+        %__MODULE__{predictions_by_route_id: predictions_by_route_id} = state
+      ) do
+    updated_prediction_ids = Enum.map(updated_predictions, & &1.id)
+
+    predictions_sans_old =
+      predictions_by_route_id
+      |> predictions_for_route_id(route_id)
+      |> Enum.reject(&Enum.member?(updated_prediction_ids, &1.id))
+
+    new_predictions_by_route_id =
+      Map.put(
+        predictions_by_route_id,
+        route_id,
+        predictions_sans_old ++ updated_predictions
+      )
+
+    new_state = %__MODULE__{
+      state
+      | predictions_by_route_id: new_predictions_by_route_id
+    }
+
+    broadcast(new_state)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info(
+        {:remove,
+         [%Predictions.Prediction{route: %Routes.Route{id: route_id}} | _] = predictions_to_remove},
+        %__MODULE__{predictions_by_route_id: predictions_by_route_id} = state
+      ) do
+    prediction_ids_to_remove = Enum.map(predictions_to_remove, & &1.id)
+
+    predictions_sans_removed =
+      predictions_by_route_id
+      |> predictions_for_route_id(route_id)
+      |> Enum.reject(&Enum.member?(prediction_ids_to_remove, &1.id))
+
+    new_predictions_by_route_id =
+      Map.put(
+        predictions_by_route_id,
+        route_id,
+        predictions_sans_removed
+      )
+
+    new_state = %__MODULE__{
+      state
+      | predictions_by_route_id: new_predictions_by_route_id
+    }
+
+    broadcast(new_state)
+
+    {:noreply, new_state}
+  end
+
+  @spec predictions_for_route_id(predictions_by_route_id(), Route.id_t()) :: [Prediction.t()]
+  defp predictions_for_route_id(predictions_by_route_id, route_id),
+    do: Map.get(predictions_by_route_id, route_id, [])
+
+  @spec broadcast(t()) :: :ok
+  defp broadcast(state) do
+    registry_key = self()
+
+    Registry.dispatch(:prediction_subscriptions_registry, registry_key, fn entries ->
+      Enum.each(entries, &send_data(&1, state))
+    end)
+  end
+
+  @spec send_data({pid, Route.id()}, t()) :: broadcast_message()
+  defp send_data({pid, route_id}, %__MODULE__{
+         predictions_by_route_id: predictions_by_route_id
+       }) do
+    send(
+      pid,
+      {:new_predictions, predictions_for_route_id(predictions_by_route_id, route_id)}
+    )
+  end
+end

--- a/apps/predictions/lib/stream.ex
+++ b/apps/predictions/lib/stream.ex
@@ -1,0 +1,64 @@
+defmodule Predictions.Stream do
+  @moduledoc """
+  Uses V3Api.Stream to subscribe to the V3Api and receive prediction events.
+  """
+
+  use GenStage
+  require Logger
+
+  alias V3Api.Stream.Event
+  alias Phoenix.PubSub
+  alias Predictions.{Prediction, Repo, StreamParser}
+
+  @type event_type :: :reset | :add | :update | :remove
+
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+
+    GenStage.start_link(
+      __MODULE__,
+      opts,
+      name: name
+    )
+  end
+
+  def init(opts) do
+    producer_consumer = Keyword.fetch!(opts, :subscribe_to)
+    broadcast_fn = Keyword.get(opts, :broadcast_fn, &PubSub.broadcast/3)
+    {:consumer, %{broadcast_fn: broadcast_fn}, subscribe_to: [producer_consumer]}
+  end
+
+  def handle_events(events, _from, state) do
+    :ok = Enum.each(events, &send_event(&1, state.broadcast_fn))
+    {:noreply, [], state}
+  end
+
+  defp send_event(
+         %Event{
+           event: type,
+           data: %JsonApi{data: data}
+         },
+         broadcast_fn
+       ) do
+    data
+    |> Enum.filter(&Repo.has_trip?/1)
+    |> Enum.map(&StreamParser.parse/1)
+    |> broadcast(type, broadcast_fn)
+  end
+
+  @typep broadcast_fn :: (atom, String.t(), any -> :ok | {:error, any})
+  @spec broadcast([Prediction.t() | String.t()], event_type, broadcast_fn) :: :ok
+  defp broadcast([], _type, _broadcast_fn), do: :ok
+
+  defp broadcast(data, type, broadcast_fn) do
+    Predictions.PubSub
+    |> broadcast_fn.("predictions", {type, data})
+    |> log_errors()
+  end
+
+  @spec log_errors(:ok | {:error, any}) :: :ok
+  defp log_errors(:ok), do: :ok
+
+  defp log_errors({:error, error}),
+    do: Logger.error("module=#{__MODULE__} error=#{inspect(error)}")
+end

--- a/apps/predictions/lib/stream.ex
+++ b/apps/predictions/lib/stream.ex
@@ -43,8 +43,15 @@ defmodule Predictions.Stream do
     data
     |> Enum.filter(&Repo.has_trip?/1)
     |> Enum.map(&StreamParser.parse/1)
+    |> Enum.filter(&by_min_time/1)
     |> broadcast(type, broadcast_fn)
   end
+
+  @spec by_min_time(Prediction.t()) :: boolean()
+  @spec by_min_time(Prediction.t(), DateTime.t()) :: boolean()
+  defp by_min_time(prediction, now \\ Util.now())
+  defp by_min_time(%Prediction{time: nil}, _), do: false
+  defp by_min_time(%Prediction{time: time}, now), do: Util.time_is_greater_or_equal?(time, now)
 
   @typep broadcast_fn :: (atom, String.t(), any -> :ok | {:error, any})
   @spec broadcast([Prediction.t() | String.t()], event_type, broadcast_fn) :: :ok

--- a/apps/predictions/lib/stream_parser.ex
+++ b/apps/predictions/lib/stream_parser.ex
@@ -10,10 +10,12 @@ defmodule Predictions.StreamParser do
   alias Stops.Stop
 
   @spec parse(Item.t()) :: Prediction.t()
-  def parse(%JsonApi.Item{} = item) do
+  def parse(%Item{} = item) do
     %Prediction{
       id: item.id,
+      arrival_time: arrival_time(item),
       departing?: Parser.departing?(item),
+      departure_time: departure_time(item),
       direction_id: Parser.direction_id(item),
       route: route(item),
       stop: stop(item),
@@ -24,6 +26,24 @@ defmodule Predictions.StreamParser do
       status: Parser.status(item),
       track: Parser.track(item)
     }
+  end
+
+  @spec arrival_time(Item.t()) :: DateTime.t() | nil
+  defp arrival_time(%Item{attributes: %{"arrival_time" => time}}) when is_binary(time),
+    do: parse_time(time)
+
+  defp arrival_time(_), do: nil
+
+  @spec departure_time(Item.t()) :: DateTime.t() | nil
+  defp departure_time(%Item{attributes: %{"departure_time" => time}}) when is_binary(time),
+    do: parse_time(time)
+
+  defp departure_time(_), do: nil
+
+  @spec parse_time(String.t()) :: DateTime.t()
+  defp parse_time(time) do
+    {:ok, dt, _} = DateTime.from_iso8601(time)
+    dt
   end
 
   @spec route(Item.t()) :: Route.t() | nil

--- a/apps/predictions/lib/stream_supervisor.ex
+++ b/apps/predictions/lib/stream_supervisor.ex
@@ -65,7 +65,7 @@ defmodule Predictions.StreamSupervisor do
   @spec sses_opts(Route.id_t()) :: Keyword.t()
   defp sses_opts(route_id) do
     path =
-      "/predictions?filter[route]=#{route_id}&fields[prediction]=status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence&include=route,trip,trip.occupancies,stop&fields[route]=direction_destinations,direction_names,long_name,short_name,type&fields[trip]=direction_id,headsign,name,bikes_allowed&fields[stop]=platform_code"
+      "/predictions?filter[route]=#{route_id}&fields[prediction]=status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence&include=route,trip,trip.occupancies,stop&fields[route]=long_name,short_name,type&fields[trip]=direction_id,headsign,name,bikes_allowed&fields[stop]=platform_code"
 
     sses_opts =
       V3Api.Stream.build_options(

--- a/apps/predictions/lib/stream_supervisor.ex
+++ b/apps/predictions/lib/stream_supervisor.ex
@@ -1,0 +1,84 @@
+defmodule Predictions.StreamSupervisor do
+  @moduledoc """
+  DynamicSupervisor managing per-route streams of predictions from the API.
+  """
+
+  use DynamicSupervisor
+
+  alias Routes.Route
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts), do: DynamicSupervisor.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl DynamicSupervisor
+  def init(_) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  @spec ensure_stream_is_started(Route.id_t()) :: {:ok, pid()} | :bypassed
+  def ensure_stream_is_started(route_id),
+    do: ensure_stream_is_started(route_id, System.get_env("USE_SERVER_SENT_EVENTS"))
+
+  defp ensure_stream_is_started(_route_id, "false"), do: :bypassed
+
+  defp ensure_stream_is_started(route_id, _) do
+    case lookup(route_id) do
+      nil ->
+        start_stream(route_id)
+
+      pid ->
+        {:ok, pid}
+    end
+  end
+
+  @spec lookup(Route.id_t()) :: pid() | nil
+  defp lookup(route_id) do
+    case Registry.lookup(:prediction_streams_registry, route_id) do
+      [{pid, _}] -> if Process.alive?(pid), do: pid
+      _ -> nil
+    end
+  end
+
+  @spec start_stream(Route.id_t()) :: {:ok, pid()}
+  defp start_stream(route_id) do
+    with {:ok, sses_pid} <-
+           DynamicSupervisor.start_child(__MODULE__, {ServerSentEventStage, sses_opts(route_id)}),
+         {:ok, _api_stream_pid} <-
+           DynamicSupervisor.start_child(
+             __MODULE__,
+             {V3Api.Stream,
+              name: api_stream_name(route_id), subscribe_to: sses_stream_name(route_id)}
+           ),
+         {:ok, _predictions_stream_pid} <-
+           DynamicSupervisor.start_child(
+             __MODULE__,
+             {Predictions.Stream, subscribe_to: api_stream_name(route_id)}
+           ) do
+      Registry.register(:prediction_streams_registry, route_id, sses_pid)
+      {:ok, sses_pid}
+    else
+      {:error, {:already_started, pid}} ->
+        {:ok, pid}
+    end
+  end
+
+  @spec sses_opts(Route.id_t()) :: Keyword.t()
+  defp sses_opts(route_id) do
+    path =
+      "/predictions?filter[route]=#{route_id}&fields[prediction]=status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence&include=route,trip,trip.occupancies,stop&fields[route]=direction_destinations,direction_names,long_name,short_name,type&fields[trip]=direction_id,headsign,name,bikes_allowed&fields[stop]=platform_code"
+
+    sses_opts =
+      V3Api.Stream.build_options(
+        name: sses_stream_name(route_id),
+        path: path
+      )
+
+    sses_opts
+  end
+
+  @spec sses_stream_name(Route.id_t()) :: atom()
+  defp sses_stream_name(route_id), do: :"predictions_sses_stream_#{route_id}"
+
+  @spec api_stream_name(Route.id_t()) :: atom()
+  defp api_stream_name(route_id), do: :"predictions_api_stream_#{route_id}"
+end

--- a/apps/predictions/mix.exs
+++ b/apps/predictions/mix.exs
@@ -38,6 +38,8 @@ defmodule Predictions.Mixfile do
       {:timex, ">= 0.0.0"},
       {:bypass, "~> 1.0", only: :test},
       {:repo_cache, in_umbrella: true},
+      {:phoenix_pubsub, "~> 1.0"},
+      {:server_sent_event_stage, "~> 1.0"},
       {:schedules, in_umbrella: true},
       {:stops, in_umbrella: true},
       {:routes, in_umbrella: true},

--- a/apps/predictions/test/predictions_pub_sub_test.exs
+++ b/apps/predictions/test/predictions_pub_sub_test.exs
@@ -1,0 +1,168 @@
+defmodule Predictions.PredictionsPubSubTest do
+  use ExUnit.Case
+
+  alias Predictions.{Prediction, PredictionsPubSub}
+  alias Routes.Route
+
+  @route_39 "39"
+  @route_66 "66"
+  @prediction39 %Prediction{id: "prediction39", route: %Route{id: @route_39}}
+  @prediction66 %Prediction{id: "prediction66", route: %Route{id: @route_66}}
+
+  describe "start_link/1" do
+    test "starts the server" do
+      subscribe_fn = fn _, _ -> :ok end
+
+      assert {:ok, _pid} =
+               PredictionsPubSub.start_link(name: :start_link, subscribe_fn: subscribe_fn)
+    end
+  end
+
+  describe "subscribe/2" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = PredictionsPubSub.start_link(name: :subscribe, subscribe_fn: subscribe_fn)
+
+      {:ok, pid: pid}
+    end
+
+    test "clients get existing predictions upon subscribing", %{pid: pid} do
+      predictions = [@prediction39]
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :predictions_by_route_id, %{@route_39 => predictions})
+      end)
+
+      assert PredictionsPubSub.subscribe(@route_39, pid) == predictions
+    end
+  end
+
+  describe "handle_info/2 - {:reset, predictions}" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = PredictionsPubSub.start_link(name: :subscribe, subscribe_fn: subscribe_fn)
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :predictions_by_route_id, %{@route_39 => [1, 2, 3]})
+      end)
+
+      {:ok, pid: pid}
+    end
+
+    test "resets the predictions", %{pid: pid} do
+      send(pid, {:reset, [@prediction39]})
+
+      assert pid |> :sys.get_state() |> Map.get(:predictions_by_route_id) |> Map.get(@route_39) ==
+               [
+                 @prediction39
+               ]
+    end
+
+    test "broadcasts new predictions lists to subscribers", %{pid: pid} do
+      PredictionsPubSub.subscribe(@route_39, pid)
+
+      send(pid, {:reset, [@prediction66]})
+      send(pid, {:reset, [@prediction39]})
+
+      assert_receive {:new_predictions, [@prediction39]}
+      refute_receive {:new_predictions, [@prediction66]}
+    end
+  end
+
+  describe "handle_info/2 - {:add, predictions}" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = PredictionsPubSub.start_link(name: :subscribe, subscribe_fn: subscribe_fn)
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :predictions_by_route_id, %{})
+      end)
+
+      {:ok, pid: pid}
+    end
+
+    test "adds the new predictions by route ID", %{pid: pid} do
+      send(pid, {:add, [@prediction39]})
+
+      assert pid |> :sys.get_state() |> Map.get(:predictions_by_route_id) ==
+               %{@route_39 => [@prediction39]}
+    end
+
+    test "broadcasts new predictions lists to subscribers", %{pid: pid} do
+      PredictionsPubSub.subscribe(@route_39, pid)
+
+      send(pid, {:add, [@prediction66]})
+      send(pid, {:add, [@prediction39]})
+
+      assert_receive {:new_predictions, [@prediction39]}
+      refute_receive {:new_predictions, [@prediction66]}
+    end
+  end
+
+  describe "handle_info/2 - {:update, predictions}" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = PredictionsPubSub.start_link(name: :subscribe, subscribe_fn: subscribe_fn)
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :predictions_by_route_id, %{@route_39 => [@prediction39]})
+      end)
+
+      {:ok, pid: pid}
+    end
+
+    test "updates the predictions", %{pid: pid} do
+      send(pid, {:update, [@prediction39]})
+
+      assert pid |> :sys.get_state() |> Map.get(:predictions_by_route_id) ==
+               %{@route_39 => [@prediction39]}
+    end
+
+    test "broadcasts new predictions lists to subscribers", %{pid: pid} do
+      PredictionsPubSub.subscribe(@route_39, pid)
+
+      send(pid, {:update, [@prediction66]})
+      send(pid, {:update, [@prediction39]})
+
+      assert_receive {:new_predictions, [@prediction39]}
+      refute_receive {:new_predictions, [@prediction66]}
+    end
+  end
+
+  describe "handle_info/2 - {:remove, prediction_ids}" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = PredictionsPubSub.start_link(name: :subscribe, subscribe_fn: subscribe_fn)
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :predictions_by_route_id, %{@route_39 => [@prediction39]})
+      end)
+
+      {:ok, pid: pid}
+    end
+
+    test "removes the given predictions", %{pid: pid} do
+      send(pid, {:remove, [@prediction39]})
+
+      assert pid |> :sys.get_state() |> Map.get(:predictions_by_route_id) == %{@route_39 => []}
+    end
+
+    test "broadcasts new predictions lists to subscribers", %{pid: pid} do
+      PredictionsPubSub.subscribe(@route_39, pid)
+
+      send(pid, {:remove, [@prediction39]})
+
+      assert_receive {:new_predictions, []}
+    end
+  end
+end

--- a/apps/predictions/test/stream_parser_test.exs
+++ b/apps/predictions/test/stream_parser_test.exs
@@ -1,0 +1,98 @@
+defmodule Predictions.StreamParserTest do
+  use ExUnit.Case, async: true
+
+  alias JsonApi.Item
+  alias Predictions.{Prediction, StreamParser}
+  alias Routes.Route
+  alias Schedules.Trip
+  alias Stops.Stop
+  alias Timex.Timezone
+
+  describe "parse/1" do
+    test "parses a %JsonApi.Item{} into a Prediction record" do
+      item = %Item{
+        id: "TEST-ID",
+        attributes: %{
+          "arrival_time" => "2016-01-01T00:00:00-04:00",
+          "bikes_allowed" => 1,
+          "departure_time" => "2016-09-15T15:40:00-04:00",
+          "direction_id" => 1,
+          "headsign" => "Back Bay",
+          "name" => "",
+          "status" => "On Time"
+        },
+        relationships: %{
+          "facilities" => [],
+          "parent_station" => [],
+          "route" => [
+            %Item{
+              id: "route_id",
+              attributes: %{
+                "long_name" => "Route",
+                "short_name" => "Route",
+                "type" => 5
+              }
+            },
+            %Item{id: "wrong"}
+          ],
+          "stop" => [
+            %Item{id: "place-pktrm", attributes: %{"name" => "Stop"}},
+            %Item{id: "wrong"}
+          ],
+          "trip" => [
+            %Item{
+              id: "trip_id",
+              attributes: %{
+                "name" => "trip_name",
+                "direction_id" => "0",
+                "headsign" => "trip_headsign"
+              }
+            },
+            %Item{
+              id: "wrong",
+              attributes: %{
+                "name" => "trip_name",
+                "direction_id" => "0",
+                "headsign" => "trip_headsign"
+              }
+            }
+          ],
+          "zone" => [
+            %JsonApi.Item{
+              attributes: nil,
+              id: "LocalBus",
+              relationships: nil,
+              type: "zone"
+            }
+          ]
+        },
+        type: "stop"
+      }
+
+      expected = %Prediction{
+        id: "TEST-ID",
+        departing?: true,
+        direction_id: 1,
+        route: %Route{
+          id: "route_id",
+          type: 5
+        },
+        status: "On Time",
+        stop: %Stop{
+          id: "place-pktrm",
+          name: "Stop"
+        },
+        stop_sequence: 0,
+        time: ~N[2016-01-01T04:00:00] |> Timezone.convert("Etc/GMT+4"),
+        trip: %Trip{
+          id: "trip_id",
+          name: "trip_name",
+          direction_id: "0",
+          headsign: "trip_headsign"
+        }
+      }
+
+      assert StreamParser.parse(item) == expected
+    end
+  end
+end

--- a/apps/predictions/test/stream_parser_test.exs
+++ b/apps/predictions/test/stream_parser_test.exs
@@ -71,7 +71,9 @@ defmodule Predictions.StreamParserTest do
 
       expected = %Prediction{
         id: "TEST-ID",
+        arrival_time: ~U[2016-01-01 04:00:00Z],
         departing?: true,
+        departure_time: ~U[2016-09-15 19:40:00Z],
         direction_id: 1,
         route: %Route{
           id: "route_id",

--- a/apps/predictions/test/stream_supervisor_test.exs
+++ b/apps/predictions/test/stream_supervisor_test.exs
@@ -1,0 +1,20 @@
+defmodule Predictions.StreamSupervisorTest do
+  use ExUnit.Case
+
+  alias Predictions.StreamSupervisor
+
+  describe "start_link/1" do
+    test "StreamSupervisor is started along with registry" do
+      assert {:error, {:already_started, _}} = StreamSupervisor.start_link([])
+
+      assert {:error, {:already_started, _}} =
+               Registry.start_link(keys: :unique, name: :prediction_streams_registry)
+    end
+  end
+
+  describe "ensure_stream_is_started/1" do
+    test "starts a stream if not already started" do
+      assert {:ok, _pid} = StreamSupervisor.ensure_stream_is_started(1)
+    end
+  end
+end

--- a/apps/predictions/test/stream_test.exs
+++ b/apps/predictions/test/stream_test.exs
@@ -1,0 +1,110 @@
+defmodule Predictions.StreamTest do
+  use ExUnit.Case
+
+  alias JsonApi.Item
+  alias Predictions.{Prediction, Stream}
+  alias Timex.Timezone
+
+  @predictions_data %JsonApi{
+    data: [
+      %Item{
+        id: "prediction1",
+        attributes: %{
+          "track" => "5",
+          "status" => "On Time",
+          "direction_id" => 0,
+          "departure_time" => "2016-09-15T15:40:00-04:00",
+          "arrival_time" => "2016-01-01T00:00:00-04:00",
+          "stop_sequence" => 5
+        },
+        relationships: %{
+          "route" => [
+            %Item{
+              id: "route_id",
+              attributes: %{
+                "long_name" => "Route",
+                "direction_names" => ["East", "West"],
+                "type" => 5
+              }
+            },
+            %Item{id: "wrong"}
+          ],
+          "stop" => [
+            %Item{id: "place-pktrm", attributes: %{"name" => "Stop"}},
+            %Item{id: "wrong"}
+          ],
+          "trip" => [
+            %Item{
+              id: "trip_id",
+              attributes: %{
+                "name" => "trip_name",
+                "direction_id" => "0",
+                "headsign" => "trip_headsign"
+              }
+            },
+            %Item{
+              id: "wrong",
+              attributes: %{
+                "name" => "trip_name",
+                "direction_id" => "0",
+                "headsign" => "trip_headsign"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+
+  describe "start_link/1" do
+    test "starts a GenServer that publishes predictions it receives from the API" do
+      {:ok, mock_api} =
+        GenStage.from_enumerable([
+          %V3Api.Stream.Event{event: :reset, data: @predictions_data}
+        ])
+
+      test_pid = self()
+
+      broadcast_fn = fn Predictions.PubSub, "predictions", {type, data} ->
+        send(test_pid, {type, data})
+        :ok
+      end
+
+      assert {:ok, _} =
+               Stream.start_link(
+                 name: :start_link_test,
+                 broadcast_fn: broadcast_fn,
+                 subscribe_to: mock_api
+               )
+
+      assert_receive {:reset, data}
+      assert [%Prediction{id: "prediction1"}] = data
+    end
+  end
+
+  describe "handle_events/3" do
+    test "publishes :remove events as a list of Prediction structs" do
+      {:ok, mock_api} =
+        GenStage.from_enumerable([
+          %V3Api.Stream.Event{event: :remove, data: @predictions_data}
+        ])
+
+      test_pid = self()
+
+      broadcast_fn = fn Predictions.PubSub, "predictions", {type, data} ->
+        send(test_pid, {:received_broadcast, {type, data}})
+        :ok
+      end
+
+      assert {:ok, _} =
+               Stream.start_link(
+                 name: :remove_as_ids_test,
+                 broadcast_fn: broadcast_fn,
+                 subscribe_to: mock_api
+               )
+
+      assert_receive {:received_broadcast, {:remove, data}}
+      assert [%Prediction{id: "prediction1"}] = data
+    end
+  end
+end

--- a/apps/predictions/test/stream_test.exs
+++ b/apps/predictions/test/stream_test.exs
@@ -3,7 +3,6 @@ defmodule Predictions.StreamTest do
 
   alias JsonApi.Item
   alias Predictions.{Prediction, Stream}
-  alias Timex.Timezone
 
   @predictions_data %JsonApi{
     data: [

--- a/apps/routes/lib/parser.ex
+++ b/apps/routes/lib/parser.ex
@@ -26,16 +26,16 @@ defmodule Routes.Parser do
     {parse_route(item), parse_route_patterns(relationships)}
   end
 
+  @spec name(map) :: String.t()
+  def name(%{"type" => 3, "short_name" => short_name}) when short_name != "", do: short_name
+  def name(%{"short_name" => short_name, "long_name" => ""}), do: short_name
+  def name(%{"long_name" => long_name}), do: long_name
+
   defp parse_route_patterns(%{"route_patterns" => route_patterns}) do
     Enum.map(route_patterns, &RoutePattern.new(&1))
   end
 
   defp parse_route_patterns(_), do: []
-
-  @spec name(map) :: String.t()
-  defp name(%{"type" => 3, "short_name" => short_name}) when short_name != "", do: short_name
-  defp name(%{"short_name" => short_name, "long_name" => ""}), do: short_name
-  defp name(%{"long_name" => long_name}), do: long_name
 
   @spec direction_attrs([String.t()], [Item.t()]) :: %{
           0 => String.t() | nil,

--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -4,6 +4,7 @@ defmodule Routes.Route do
   alias Routes.Repo
 
   @derive Jason.Encoder
+  @derive {Poison.Encoder, except: [:direction_names, :direction_destinations]}
 
   defstruct id: "",
             type: 0,

--- a/apps/site/assets/ts/contexts/socketContext.tsx
+++ b/apps/site/assets/ts/contexts/socketContext.tsx
@@ -1,0 +1,19 @@
+import React, { createContext, ReactElement } from "react";
+import { ConnectionStatus, SocketStatus } from "../hooks/useSocket";
+
+export const SocketContext = createContext<SocketStatus>({
+  socket: undefined,
+  connectionStatus: ConnectionStatus.Loading
+});
+
+export const SocketProvider = ({
+  socketStatus,
+  children
+}: {
+  socketStatus: SocketStatus;
+  children: ReactElement<HTMLElement>;
+}): JSX.Element => (
+  <SocketContext.Provider value={socketStatus}>
+    {children}
+  </SocketContext.Provider>
+);

--- a/apps/site/assets/ts/helpers/socketTestHelpers.ts
+++ b/apps/site/assets/ts/helpers/socketTestHelpers.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { Socket } from "phoenix";
+
+export const makeMockSocket = (): Socket & { channel: jest.Mock } =>
+  ({
+    channel: jest.fn()
+  } as Socket & { channel: jest.Mock });
+
+export const makeMockChannel = (
+  expectedJoinMessage?: "ok" | "error" | "timeout",
+  expectedJoinData?: any
+) => {
+  const result = {
+    join: jest.fn(),
+    leave: jest.fn(),
+    on: jest.fn(),
+    receive: jest.fn()
+  };
+  result.join.mockImplementation(() => result);
+  result.receive.mockImplementation((message, handler) => {
+    if (message === expectedJoinMessage) {
+      // eslint-disable-next-line default-case
+      switch (message) {
+        case "ok":
+          if (expectedJoinData !== undefined) {
+            handler(expectedJoinData);
+          }
+          return result;
+
+        case "error":
+          handler({ reason: "ERROR_REASON" });
+          break;
+
+        case "timeout":
+          handler();
+      }
+    }
+
+    return result;
+  });
+  return result;
+};
+
+export const makeMockOneShotChannel = (dataOnJoin?: any) => {
+  const result: { join: any; on: any; receive: any; leave: any } = {
+    join: () => result,
+    on: jest.fn(),
+    receive: (event: any, handler: ({ data }: { data: any }) => void) => {
+      if (event === "ok") {
+        handler({ data: dataOnJoin });
+      }
+      return result;
+    },
+    leave: jest.fn()
+  };
+
+  return result;
+};

--- a/apps/site/assets/ts/hooks/__tests__/usePredictionsTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/usePredictionsTest.tsx
@@ -1,0 +1,99 @@
+import React, { ReactNode } from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import usePredictions from "../usePredictions";
+import {
+  makeMockChannel,
+  makeMockSocket
+} from "../../helpers/socketTestHelpers";
+import { Socket } from "phoenix";
+import { SocketProvider } from "../../contexts/socketContext";
+import { ConnectionStatus } from "../useSocket";
+
+const routeId = "39";
+
+const predictionsData = [
+  { id: "prediction1", time: "2022-09-21T15:43:24.692760Z" }
+];
+
+const predictions = [
+  { id: "prediction1", time: new Date("2022-09-21T15:43:24.692760Z") }
+];
+
+describe("usePredictions", () => {
+  test("predictions is empty to start", () => {
+    const { result } = renderHook(() => usePredictions(routeId), {
+      wrapper,
+      initialProps: { socket: undefined }
+    });
+    expect(result.current).toEqual([]);
+  });
+
+  test("subscribes to a channel", () => {
+    const mockSocket = makeMockSocket();
+    const mockChannel = makeMockChannel();
+    mockSocket.channel.mockImplementationOnce(() => mockChannel);
+
+    const { rerender } = renderHook(() => usePredictions(routeId), {
+      wrapper,
+      initialProps: { socket: mockSocket }
+    });
+
+    // Needs to be kicked to do the effects again after the socket initializes
+    rerender();
+
+    expect(mockSocket.channel).toHaveBeenCalledTimes(1);
+    expect(mockSocket.channel).toHaveBeenCalledWith("predictions:39");
+    expect(mockChannel.join).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns initial prediction results from joining a channel", async () => {
+    const mockSocket = makeMockSocket();
+    const mockChannel = makeMockChannel();
+    mockSocket.channel.mockImplementationOnce(() => mockChannel);
+    mockChannel.receive.mockImplementation((event, handler) => {
+      if (event === "ok") {
+        handler({ predictions: predictionsData });
+      }
+      return mockChannel;
+    });
+
+    const { result } = renderHook(() => usePredictions(routeId), {
+      wrapper,
+      initialProps: { socket: mockSocket }
+    });
+
+    expect(result.current).toEqual(predictions);
+  });
+
+  test("returns results pushed to the channel", async () => {
+    const mockSocket = makeMockSocket();
+    const mockChannel = makeMockChannel();
+    mockSocket.channel.mockImplementationOnce(() => mockChannel);
+    mockChannel.on.mockImplementation((event, handler) => {
+      if (event === "predictions") {
+        handler({ predictions: predictionsData });
+      }
+    });
+
+    const { result } = renderHook(() => usePredictions(routeId), {
+      wrapper,
+      initialProps: { socket: mockSocket }
+    });
+
+    expect(result.current).toEqual(predictions);
+  });
+});
+
+const wrapper = ({
+  children,
+  socket
+}: {
+  children?: ReactNode;
+  socket: Socket | undefined;
+}): JSX.Element => (
+  <SocketProvider
+    socketStatus={{ socket, connectionStatus: ConnectionStatus.Connected }}
+  >
+    <> {children} </>
+  </SocketProvider>
+);

--- a/apps/site/assets/ts/hooks/__tests__/useSocketTest.ts
+++ b/apps/site/assets/ts/hooks/__tests__/useSocketTest.ts
@@ -1,0 +1,43 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import useSocket, { ConnectionStatus } from "../useSocket";
+
+jest.mock("phoenix", () => ({
+  Socket: jest.fn(() => ({
+    connect: jest.fn(),
+    onOpen: jest.fn(),
+    onClose: jest.fn()
+  })),
+  __esModule: true
+}));
+
+describe("useSocket", () => {
+  test("initially returns a loading socket", () => {
+    const { result } = renderHook(() => useSocket());
+    const mockSocket = result.current.socket;
+    expect(mockSocket).toBeDefined();
+    expect(mockSocket!.connect).toHaveBeenCalled();
+    expect(result.current.connectionStatus).toEqual(ConnectionStatus.Loading);
+  });
+
+  test("connectionStatus is set to Connected when the socket connects", () => {
+    const { result } = renderHook(() => useSocket());
+    const mockSocket = result.current.socket;
+    const [[onOpenHandler]] = (mockSocket!.onOpen as jest.Mock).mock.calls;
+    act(() => {
+      onOpenHandler();
+    });
+    expect(result.current.connectionStatus).toEqual(ConnectionStatus.Connected);
+  });
+
+  test("connectionStatus is set to Disconnected when the socket closes", () => {
+    const { result } = renderHook(() => useSocket());
+    const mockSocket = result.current.socket;
+    const [[onCloseHandler]] = (mockSocket!.onClose as jest.Mock).mock.calls;
+    act(() => {
+      onCloseHandler();
+    });
+    expect(result.current.connectionStatus).toEqual(
+      ConnectionStatus.Disconnected
+    );
+  });
+});

--- a/apps/site/assets/ts/hooks/usePredictions.ts
+++ b/apps/site/assets/ts/hooks/usePredictions.ts
@@ -1,0 +1,184 @@
+import { Channel, Socket } from "phoenix";
+import {
+  Dispatch as ReactDispatch,
+  useContext,
+  useEffect,
+  useReducer
+} from "react";
+import { SocketContext } from "../contexts/socketContext";
+import { DirectionId } from "../__v3api";
+
+type RouteId = string;
+
+export interface Prediction {
+  id: string;
+  directionId: DirectionId;
+  isDeparting: boolean;
+  stopId: string;
+  time: Date;
+  track?: string;
+  tripId: string;
+}
+
+interface StopData {
+  id: string;
+}
+
+interface TripData {
+  id: string;
+}
+
+interface PredictionData {
+  id: string;
+  "departing?": boolean;
+  direction_id: DirectionId;
+  stop: StopData;
+  time: string;
+  track?: string;
+  trip: TripData;
+}
+
+const predictionFromData = (predictionData: PredictionData): Prediction => ({
+  id: predictionData.id,
+  directionId: predictionData.direction_id,
+  isDeparting: predictionData["departing?"],
+  stopId: predictionData.stop.id,
+  time: new Date(predictionData.time),
+  track: predictionData.track,
+  tripId: predictionData.trip.id
+});
+
+interface State {
+  channel?: Channel;
+  routeId?: RouteId;
+  predictions: Prediction[];
+}
+
+const initialState: State = {
+  channel: undefined,
+  routeId: undefined,
+  predictions: []
+};
+
+interface SetRouteIdAction {
+  type: "SET_ROUTE_ID";
+  payload: {
+    routeId: RouteId;
+  };
+}
+
+const setRouteId = (routeId: RouteId): SetRouteIdAction => ({
+  type: "SET_ROUTE_ID",
+  payload: {
+    routeId
+  }
+});
+
+interface SetChannelAction {
+  type: "SET_CHANNEL";
+  payload: {
+    channel: Channel;
+  };
+}
+
+const setChannel = (channel: Channel): SetChannelAction => ({
+  type: "SET_CHANNEL",
+  payload: {
+    channel
+  }
+});
+
+interface SetPredictionsAction {
+  type: "SET_PREDICTIONS";
+  payload: {
+    predictions: Prediction[];
+  };
+}
+
+const setPredictions = (predictions: Prediction[]): SetPredictionsAction => ({
+  type: "SET_PREDICTIONS",
+  payload: {
+    predictions
+  }
+});
+
+type Action = SetRouteIdAction | SetChannelAction | SetPredictionsAction;
+
+type Dispatch = ReactDispatch<Action>;
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "SET_ROUTE_ID":
+      return {
+        ...state,
+        routeId: action.payload.routeId
+      };
+    case "SET_CHANNEL":
+      return {
+        ...state,
+        channel: action.payload.channel
+      };
+    case "SET_PREDICTIONS":
+      return {
+        ...state,
+        predictions: action.payload.predictions
+      };
+    default:
+      return state;
+  }
+};
+
+const subscribe = (
+  socket: Socket,
+  routeId: RouteId,
+  dispatch: Dispatch
+): Channel => {
+  const handlePredictions = ({
+    predictions: predictionsData
+  }: {
+    predictions: PredictionData[];
+  }): void => {
+    const predictions: Prediction[] = predictionsData.map(predictionFromData);
+    dispatch(setPredictions(predictions));
+  };
+
+  dispatch(setRouteId(routeId));
+
+  const topic = `predictions:${routeId}`;
+  const channel = socket.channel(topic);
+
+  channel.on("predictions", handlePredictions);
+
+  channel
+    .join()
+    .receive("ok", handlePredictions)
+    .receive("error", ({ reason }) =>
+      // eslint-disable-next-line no-console
+      console.error("Predictions join failed", reason)
+    );
+
+  return channel;
+};
+
+const usePredictions = (routeId: RouteId): Prediction[] => {
+  const { socket }: { socket: Socket | undefined } = useContext(SocketContext);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { channel, predictions } = state;
+
+  useEffect(() => {
+    if (socket && !channel) {
+      const newChannel: Channel = subscribe(socket, routeId, dispatch);
+      dispatch(setChannel(newChannel));
+    }
+
+    return () => {
+      if (channel) {
+        channel.leave();
+      }
+    };
+  }, [socket, channel, routeId]);
+
+  return predictions;
+};
+
+export default usePredictions;

--- a/apps/site/assets/ts/hooks/useSocket.ts
+++ b/apps/site/assets/ts/hooks/useSocket.ts
@@ -1,0 +1,39 @@
+import { Socket } from "phoenix";
+import { useEffect, useState } from "react";
+
+export enum ConnectionStatus {
+  Loading = 1,
+  Connected,
+  Disconnected
+}
+
+export interface SocketStatus {
+  socket: Socket | undefined;
+  connectionStatus: ConnectionStatus;
+}
+
+const useSocket = (): SocketStatus => {
+  const [socket, setSocket] = useState<Socket | undefined>(undefined);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>(
+    ConnectionStatus.Loading
+  );
+
+  useEffect(() => {
+    const initialSocket = new Socket("/socket", {});
+    initialSocket.connect();
+    initialSocket.onOpen(() => setConnectionStatus(ConnectionStatus.Connected));
+    initialSocket.onClose(() =>
+      setConnectionStatus(ConnectionStatus.Disconnected)
+    );
+    setSocket(initialSocket);
+
+    return () => {
+      setConnectionStatus(ConnectionStatus.Disconnected);
+      initialSocket.disconnect();
+    };
+  }, []);
+
+  return { socket, connectionStatus };
+};
+
+export default useSocket;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -23,6 +23,9 @@ import {
   isFetchFailed
 } from "../../../helpers/fetch-json";
 import { useAwaitInterval } from "../../../helpers/use-await-interval";
+import usePredictions, { Prediction } from "../../../hooks/usePredictions";
+import { SocketProvider } from "../../../contexts/socketContext";
+import useSocket from "../../../hooks/useSocket";
 
 // exported for testing
 export const fetchData = async (
@@ -103,6 +106,8 @@ const ScheduleModalContent = ({
   ]);
   useAwaitInterval(updateData, 10000);
 
+  const predictions: Prediction[] = usePredictions(routeId);
+
   const serviceToday = services.some(service =>
     isInCurrentService(service, stringToDateObject(today))
   );
@@ -130,6 +135,15 @@ const ScheduleModalContent = ({
         />
       </div>
 
+      <div>
+        <b>Predictions ({predictions.length})</b>
+        {predictions.map(prediction => (
+          <div key={prediction.id}>
+            Stop {prediction.stopId}: {prediction.time.toLocaleString()}
+          </div>
+        ))}
+      </div>
+
       {routeToModeName(route) !== "ferry" && renderUpcomingDepartures()}
 
       {scheduleNote ? (
@@ -151,4 +165,16 @@ const ScheduleModalContent = ({
   );
 };
 
-export default ScheduleModalContent;
+const ScheduleModalContentWrapper = (
+  props: Props
+): ReactElement<HTMLElement> => {
+  const socketStatus = useSocket();
+
+  return (
+    <SocketProvider socketStatus={socketStatus}>
+      <ScheduleModalContent {...props} />
+    </SocketProvider>
+  );
+};
+
+export default ScheduleModalContentWrapper;

--- a/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -114,7 +114,7 @@ const ScheduleModalContent = ({
 
   const renderUpcomingDepartures = (): ReactElement<HTMLElement> =>
     serviceToday ? (
-      <UpcomingDepartures state={state} />
+      <UpcomingDepartures state={state} predictions={predictions} />
     ) : (
       <div className="callout text-center u-bold">
         There are no scheduled trips for {formattedDate(today)}.
@@ -133,15 +133,6 @@ const ScheduleModalContent = ({
           selectedOrigin={selectedOrigin}
           stopsByDirection={stops}
         />
-      </div>
-
-      <div>
-        <b>Predictions ({predictions.length})</b>
-        {predictions.map(prediction => (
-          <div key={prediction.id}>
-            Stop {prediction.stopId}: {prediction.time.toLocaleString()}
-          </div>
-        ))}
       </div>
 
       {routeToModeName(route) !== "ferry" && renderUpcomingDepartures()}

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderModalTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleFinderModalTest.tsx.snap
@@ -162,114 +162,125 @@ exports[`ScheduleFinderModal matches snapshot in schedule mode 1`] = `
                 Close
               </button>
               <div className=\\"c-modal__content\\">
-                <ScheduleModalContent handleChangeDirection={[Function: handleChangeDirection]} handleChangeOrigin={[Function: handleChangeOrigin]} handleOriginSelectClick={[Function: handleOriginSelectClick]} route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} selectedDirection={0} selectedOrigin=\\"place-welln\\" services={{...}} stops={{...}} today=\\"2019-12-05\\">
-                  <div className=\\"schedule-finder schedule-finder--modal\\">
-                    <Component onDirectionChange={[Function: handleChangeDirection]} onOriginChange={[Function: handleChangeOrigin]} onOriginSelectClick={[Function: handleOriginSelectClick]} route={{...}} selectedDirection={0} selectedOrigin=\\"place-welln\\" stopsByDirection={{...}}>
-                      <form onSubmit={[Function: handleSubmit]}>
-                        <h2 className=\\"schedule-finder__heading\\">
-                          <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
-                           Schedule Finder
-                        </h2>
-                        <div className=\\"schedule-finder__prompt\\">
-                          Choose a stop to get schedule information and real-time departure predictions.
-                        </div>
-                        <div className=\\"schedule-finder__inputs\\">
-                          <label className=\\"schedule-finder__label\\">
-                            Choose a direction
-                            <SelectContainer>
-                              <div tabIndex={0} className=\\"c-select-custom__container \\" role=\\"button\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
-                                <select className=\\"c-select-custom notranslate\\" value={0} onChange={[Function: onChange]}>
-                                  <option value={0} aria-label=\\"INBOUND \\\\n  Oak Grove\\">
-                                    INBOUND 
-                                      Oak Grove
-                                  </option>
-                                  <option value={1} aria-label=\\"OUTBOUND \\\\n  Forest Hills\\">
-                                    OUTBOUND 
-                                      Forest Hills
-                                  </option>
-                                </select>
-                                <span className=\\"notranslate c-svg__icon c-select-custom__arrow\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
-                              </div>
-                            </SelectContainer>
-                          </label>
-                          <label className=\\"schedule-finder__label\\">
-                            Choose an origin stop
-                            <SelectContainer error={false} handleClick={[Function: handleOriginClick]}>
-                              <div tabIndex={0} className=\\"c-select-custom__container \\" role=\\"button\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
-                                <select className=\\"c-select-custom c-select-custom--noclick notranslate\\" value=\\"place-welln\\" onChange={[Function: onChange]}>
-                                  <option value=\\"\\">
-                                    Select
-                                  </option>
-                                  <option value=\\"place-welln\\" aria-label=\\"Wellington\\">
-                                    Wellington
-                                  </option>
-                                  <option value=\\"123\\" aria-label=\\"Abc\\">
-                                    Abc
-                                  </option>
-                                  <option value=\\"741\\" aria-label=\\"SL\\">
-                                    SL
-                                  </option>
-                                </select>
-                                <span className=\\"notranslate c-svg__icon c-select-custom__arrow\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
-                              </div>
-                            </SelectContainer>
-                          </label>
-                        </div>
-                        <div className=\\"schedule-finder__submit text-right\\">
-                          <input className=\\"btn btn-primary\\" type=\\"submit\\" value=\\"Get schedules\\" />
-                        </div>
-                      </form>
-                    </Component>
-                  </div>
-                  <div className=\\"callout text-center u-bold\\">
-                    There are no scheduled trips for 
-                    December 5, 2019
-                    .
-                  </div>
-                  <DailySchedule stopId=\\"place-welln\\" services={{...}} routeId=\\"Orange\\" directionId={0} routePatterns={{...}} today=\\"2019-12-05\\">
-                    <h3>
-                      Daily Schedule
-                    </h3>
-                    <SchedulesSelect sortedServices={{...}} todayServiceId=\\"\\" defaultSelectedServiceId=\\"BUS319-J-Wdy-02\\" todayDate={{...}} onSelectService={[Function: onSelectService]}>
-                      <div className=\\"schedule-finder__service-selector\\">
-                        <label>
-                          <span className=\\"sr-only\\">
-                            Choose a schedule type from the available options
-                          </span>
-                          <SelectContainer>
-                            <div tabIndex={0} className=\\"c-select-custom__container \\" role=\\"button\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
-                              <select className=\\"c-select-custom text-center u-bold\\" defaultValue=\\"BUS319-J-Wdy-02\\" onChange={[Function: onChange]} aria-controls=\\"daily-schedule\\">
-                                <ServiceOptGroup label=\\"Other Schedules\\" services={{...}} multipleWeekdays={false} todayServiceId=\\"\\">
-                                  <optgroup label=\\"Other Schedules\\">
-                                    <option value=\\"BUS319-J-Wdy-02\\" aria-label=\\"Other Schedules Weekday schedule, Jul 8 to Aug 30\\">
-                                      Weekday schedule, Jul 8 to Aug 30
-                                    </option>
-                                    <option value=\\"BUS319-K-Sa-02\\" aria-label=\\"Other Schedules Saturday schedule, Jul 13 to Aug 31\\">
-                                      Saturday schedule, Jul 13 to Aug 31
-                                    </option>
-                                    <option value=\\"BUS319-L-Su-02\\" aria-label=\\"Other Schedules Sunday schedule, Jul 14 to Aug 25\\">
-                                      Sunday schedule, Jul 14 to Aug 25
-                                    </option>
-                                  </optgroup>
-                                </ServiceOptGroup>
-                              </select>
-                              <span className=\\"notranslate c-svg__icon c-select-custom__arrow\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+                <ScheduleModalContentWrapper handleChangeDirection={[Function: handleChangeDirection]} handleChangeOrigin={[Function: handleChangeOrigin]} handleOriginSelectClick={[Function: handleOriginSelectClick]} route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} selectedDirection={0} selectedOrigin=\\"place-welln\\" services={{...}} stops={{...}} today=\\"2019-12-05\\">
+                  <SocketProvider socketStatus={{...}}>
+                    <ScheduleModalContent handleChangeDirection={[Function: handleChangeDirection]} handleChangeOrigin={[Function: handleChangeOrigin]} handleOriginSelectClick={[Function: handleOriginSelectClick]} route={{...}} routePatternsByDirection={{...}} scheduleNote={{...}} selectedDirection={0} selectedOrigin=\\"place-welln\\" services={{...}} stops={{...}} today=\\"2019-12-05\\">
+                      <div className=\\"schedule-finder schedule-finder--modal\\">
+                        <Component onDirectionChange={[Function: handleChangeDirection]} onOriginChange={[Function: handleChangeOrigin]} onOriginSelectClick={[Function: handleOriginSelectClick]} route={{...}} selectedDirection={0} selectedOrigin=\\"place-welln\\" stopsByDirection={{...}}>
+                          <form onSubmit={[Function: handleSubmit]}>
+                            <h2 className=\\"schedule-finder__heading\\">
+                              <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+                               Schedule Finder
+                            </h2>
+                            <div className=\\"schedule-finder__prompt\\">
+                              Choose a stop to get schedule information and real-time departure predictions.
                             </div>
-                          </SelectContainer>
-                        </label>
+                            <div className=\\"schedule-finder__inputs\\">
+                              <label className=\\"schedule-finder__label\\">
+                                Choose a direction
+                                <SelectContainer>
+                                  <div tabIndex={0} className=\\"c-select-custom__container \\" role=\\"button\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
+                                    <select className=\\"c-select-custom notranslate\\" value={0} onChange={[Function: onChange]}>
+                                      <option value={0} aria-label=\\"INBOUND \\\\n  Oak Grove\\">
+                                        INBOUND 
+                                          Oak Grove
+                                      </option>
+                                      <option value={1} aria-label=\\"OUTBOUND \\\\n  Forest Hills\\">
+                                        OUTBOUND 
+                                          Forest Hills
+                                      </option>
+                                    </select>
+                                    <span className=\\"notranslate c-svg__icon c-select-custom__arrow\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+                                  </div>
+                                </SelectContainer>
+                              </label>
+                              <label className=\\"schedule-finder__label\\">
+                                Choose an origin stop
+                                <SelectContainer error={false} handleClick={[Function: handleOriginClick]}>
+                                  <div tabIndex={0} className=\\"c-select-custom__container \\" role=\\"button\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
+                                    <select className=\\"c-select-custom c-select-custom--noclick notranslate\\" value=\\"place-welln\\" onChange={[Function: onChange]}>
+                                      <option value=\\"\\">
+                                        Select
+                                      </option>
+                                      <option value=\\"place-welln\\" aria-label=\\"Wellington\\">
+                                        Wellington
+                                      </option>
+                                      <option value=\\"123\\" aria-label=\\"Abc\\">
+                                        Abc
+                                      </option>
+                                      <option value=\\"741\\" aria-label=\\"SL\\">
+                                        SL
+                                      </option>
+                                    </select>
+                                    <span className=\\"notranslate c-svg__icon c-select-custom__arrow\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+                                  </div>
+                                </SelectContainer>
+                              </label>
+                            </div>
+                            <div className=\\"schedule-finder__submit text-right\\">
+                              <input className=\\"btn btn-primary\\" type=\\"submit\\" value=\\"Get schedules\\" />
+                            </div>
+                          </form>
+                        </Component>
                       </div>
-                    </SchedulesSelect>
-                    <div id=\\"daily-schedule\\">
-                      <Loading>
-                        <div className=\\"c-spinner__container\\">
-                          <div className=\\"c-spinner\\">
-                            Loading...
+                      <div>
+                        <b>
+                          Predictions (
+                          0
+                          )
+                        </b>
+                      </div>
+                      <div className=\\"callout text-center u-bold\\">
+                        There are no scheduled trips for 
+                        December 5, 2019
+                        .
+                      </div>
+                      <DailySchedule stopId=\\"place-welln\\" services={{...}} routeId=\\"Orange\\" directionId={0} routePatterns={{...}} today=\\"2019-12-05\\">
+                        <h3>
+                          Daily Schedule
+                        </h3>
+                        <SchedulesSelect sortedServices={{...}} todayServiceId=\\"\\" defaultSelectedServiceId=\\"BUS319-J-Wdy-02\\" todayDate={{...}} onSelectService={[Function: onSelectService]}>
+                          <div className=\\"schedule-finder__service-selector\\">
+                            <label>
+                              <span className=\\"sr-only\\">
+                                Choose a schedule type from the available options
+                              </span>
+                              <SelectContainer>
+                                <div tabIndex={0} className=\\"c-select-custom__container \\" role=\\"button\\" onClick={[Function: onClick]} onKeyUp={[Function: onKeyUp]}>
+                                  <select className=\\"c-select-custom text-center u-bold\\" defaultValue=\\"BUS319-J-Wdy-02\\" onChange={[Function: onChange]} aria-controls=\\"daily-schedule\\">
+                                    <ServiceOptGroup label=\\"Other Schedules\\" services={{...}} multipleWeekdays={false} todayServiceId=\\"\\">
+                                      <optgroup label=\\"Other Schedules\\">
+                                        <option value=\\"BUS319-J-Wdy-02\\" aria-label=\\"Other Schedules Weekday schedule, Jul 8 to Aug 30\\">
+                                          Weekday schedule, Jul 8 to Aug 30
+                                        </option>
+                                        <option value=\\"BUS319-K-Sa-02\\" aria-label=\\"Other Schedules Saturday schedule, Jul 13 to Aug 31\\">
+                                          Saturday schedule, Jul 13 to Aug 31
+                                        </option>
+                                        <option value=\\"BUS319-L-Su-02\\" aria-label=\\"Other Schedules Sunday schedule, Jul 14 to Aug 25\\">
+                                          Sunday schedule, Jul 14 to Aug 25
+                                        </option>
+                                      </optgroup>
+                                    </ServiceOptGroup>
+                                  </select>
+                                  <span className=\\"notranslate c-svg__icon c-select-custom__arrow\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+                                </div>
+                              </SelectContainer>
+                            </label>
                           </div>
+                        </SchedulesSelect>
+                        <div id=\\"daily-schedule\\">
+                          <Loading>
+                            <div className=\\"c-spinner__container\\">
+                              <div className=\\"c-spinner\\">
+                                Loading...
+                              </div>
+                            </div>
+                          </Loading>
                         </div>
-                      </Loading>
-                    </div>
-                  </DailySchedule>
-                </ScheduleModalContent>
+                      </DailySchedule>
+                    </ScheduleModalContent>
+                  </SocketProvider>
+                </ScheduleModalContentWrapper>
               </div>
             </div>
           </aside>

--- a/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleModalContentTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/__tests__/__snapshots__/ScheduleModalContentTest.tsx.snap
@@ -131,6 +131,13 @@ Array [
       </div>
     </form>
   </div>,
+  <div>
+    <b>
+      Predictions (
+      0
+      )
+    </b>
+  </div>,
   <div
     className="callout text-center u-bold"
   >

--- a/apps/site/lib/site_web/channels/predictions_channel.ex
+++ b/apps/site/lib/site_web/channels/predictions_channel.ex
@@ -1,0 +1,32 @@
+defmodule SiteWeb.PredictionsChannel do
+  @moduledoc """
+  Channel allowing clients to subscribe to streams of predictions.
+  """
+  use SiteWeb, :channel
+
+  alias Phoenix.{Channel, Socket}
+  alias Predictions.{Prediction, PredictionsPubSub}
+
+  @impl Channel
+  @spec join(topic :: binary(), payload :: Channel.payload(), socket :: Socket.t()) ::
+          {:ok, %{predictions: [Prediction.t()]}, Socket.t()}
+  def join("predictions:" <> route_id, _message, socket) do
+    predictions_subscribe_fn =
+      Application.get_env(
+        :site,
+        :predictions_subscribe_fn,
+        &PredictionsPubSub.subscribe/1
+      )
+
+    predictions = predictions_subscribe_fn.(route_id)
+
+    {:ok, %{predictions: predictions}, socket}
+  end
+
+  @impl Channel
+  @spec handle_info({:new_predictions, [Prediction.t()]}, Socket.t()) :: {:noreply, Socket.t()}
+  def handle_info({:new_predictions, predictions}, socket) do
+    :ok = push(socket, "predictions", %{predictions: predictions})
+    {:noreply, socket}
+  end
+end

--- a/apps/site/lib/site_web/channels/user_socket.ex
+++ b/apps/site/lib/site_web/channels/user_socket.ex
@@ -3,6 +3,7 @@ defmodule SiteWeb.UserSocket do
 
   ## Channels
   channel("vehicles:*", SiteWeb.VehicleChannel)
+  channel("predictions:*", SiteWeb.PredictionsChannel)
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/apps/site/test/site_web/channels/predictions_channel_test.exs
+++ b/apps/site/test/site_web/channels/predictions_channel_test.exs
@@ -1,0 +1,58 @@
+defmodule SiteWeb.PredictionsChannelTest do
+  use SiteWeb.ChannelCase
+
+  import Test.Support.EnvHelpers
+
+  alias Phoenix.Socket
+  alias Predictions.Prediction
+  alias Routes.Route
+  alias SiteWeb.{PredictionsChannel, UserSocket}
+
+  @route_39 "39"
+  @prediction39 %Prediction{id: "prediction39", route: %Route{id: @route_39}}
+
+  setup do
+    reassign_env(:site, :predictions_subscribe_fn, fn route_id ->
+      case route_id do
+        @route_39 ->
+          [@prediction39]
+
+        _ ->
+          []
+      end
+    end)
+
+    socket = socket(UserSocket, "", %{})
+
+    {:ok, socket: socket}
+  end
+
+  describe "join/3" do
+    test "subscribes to predictions for a route ID and returns the current list of predictions",
+         %{
+           socket: socket
+         } do
+      assert {:ok, %{predictions: predictions}, %Socket{}} =
+               subscribe_and_join(socket, PredictionsChannel, "predictions:#{@route_39}")
+
+      assert predictions == [@prediction39]
+    end
+  end
+
+  describe "handle_info/2" do
+    test "pushes new data onto the socket", %{socket: socket} do
+      predictions = [@prediction39]
+
+      {:ok, _, socket} =
+        subscribe_and_join(socket, PredictionsChannel, "predictions:#{@route_39}")
+
+      assert {:noreply, _socket} =
+               PredictionsChannel.handle_info(
+                 {:new_predictions, predictions},
+                 socket
+               )
+
+      assert_push("predictions", %{predictions: predictions})
+    end
+  end
+end

--- a/apps/site/test/support/env_helpers.ex
+++ b/apps/site/test/support/env_helpers.ex
@@ -1,0 +1,18 @@
+defmodule Test.Support.EnvHelpers do
+  @moduledoc "Helpers for reassigning env variables"
+
+  defmacro reassign_env(app, var, value) do
+    quote do
+      old_value = Application.get_env(unquote(app), unquote(var))
+      Application.put_env(unquote(app), unquote(var), unquote(value))
+
+      on_exit(fn ->
+        if old_value == nil do
+          Application.delete_env(unquote(app), unquote(var))
+        else
+          Application.put_env(unquote(app), unquote(var), old_value)
+        end
+      end)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Finish streaming POC](https://app.asana.com/0/555089885850811/1202995400172235)

- feat: Streaming predictions

Use a DynamicSupervisor for API prediction streams since they need to be
per route—a "firehose" ever everything is not supported by the API.
Start streams when a client subscribes to predictions for a route.
Register streams per route to prevent duplication.

Parse data into pure Prediction structs for the moment. We can think
harder about exactly what data format we want after demonstrating this
proof-of-concept.

- feat: Predictions Phoenix channel

- WIP(DO NOT MERGE): React predictions demo

**NB:** The first 2 commits are intended to be production-ready, but the 3rd is only a quick-and-dirty visual demonstration and is expected to be discarded/transformed.

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] Are interactive elements accessible to screen readers?
* [ ] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [ ] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
