### PR TITLE
fix: Move Union Square to the end of the line diagram

### DIFF
--- a/apps/site/test/site_web/controllers/schedule/green_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/green_test.exs
@@ -73,9 +73,7 @@ defmodule SiteWeb.ScheduleController.GreenTest do
        %{conn: conn} do
     conn = get(conn, green_path(conn, :line, %{"schedule_direction[direction_id]": 0}))
 
-    # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
-    # assert [{_, %{id: "place-unsqu"}} | all_stops] = conn.assigns.all_stops
-    assert [{_, %{id: "place-lech"}} | all_stops] = conn.assigns.all_stops
+    assert [{_, %{id: "place-unsqu"}} | all_stops] = conn.assigns.all_stops
 
     fenway = Enum.find(all_stops, fn {_, stop} -> stop.id == "place-fenwy" end)
     assert elem(fenway, 0) == [{"Green-B", :line}, {"Green-C", :line}, {"Green-D", :stop}]

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
@@ -638,15 +638,15 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
       assert [
                {
                  [nil: :stop],
+                 %Stops.RouteStop{id: "place-gover"}
+               },
+               {
+                 [nil: :stop],
                  %RouteStop{id: "place-north"}
                },
                {
                  [nil: :stop],
                  %RouteStop{id: "place-haecl"}
-               },
-               {
-                 [nil: :stop],
-                 %Stops.RouteStop{id: "place-gover"}
                },
                {
                  [nil: :stop],
@@ -1018,23 +1018,13 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
         |> DiagramHelpers.build_stop_list(0)
         |> Enum.map(fn {branches, stop} -> {branches, stop.id} end)
 
-      # As of June 2020, Lechmere has been closed so the commented line will make the test fail.
-      # We are temporarily adding the fix but this will need to be undone later on.
       for {id, idx} <- [
-            # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
-            # {"place-unsqu", 0},
-            # {"place-north", 3},
-            # {"place-gover", 5},
-            # {"place-pktrm", 6},
-            # {"place-coecl", 9},
-            # {"place-hsmnl", 20},
-            # {"place-river", 35},
-            # {"place-clmnl", 48},
-            # {"place-lake", 64}
-            {"place-lech", 0},
-            {"place-pktrm", 5},
-            {"place-coecl", 8},
-            {"place-hsmnl", 19},
+            {"place-unsqu", 0},
+            {"place-north", 3},
+            {"place-gover", 5},
+            {"place-pktrm", 6},
+            {"place-coecl", 9},
+            {"place-hsmnl", 20},
             {"place-river", 35},
             {"place-clmnl", 48},
             {"place-lake", 64}
@@ -1408,11 +1398,11 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
       branches = {nil, GreenLine.branch_ids()}
 
       assert DiagramHelpers.build_branched_stop(unsqu, [], branches) == [
-               {[{"Green-E", :terminus}], unsqu}
+               {[{"Green-D", :terminus}], unsqu}
              ]
 
       assert DiagramHelpers.build_branched_stop(lech, [], branches) == [
-               {[{"Green-E", :stop}], lech}
+               {[{"Green-E", :terminus}], lech}
              ]
 
       assert DiagramHelpers.build_branched_stop(spmnl, [], branches) == [

--- a/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/diagram_helpers_test.exs
@@ -1057,10 +1057,7 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
         Enum.chunk_by(stops, fn {branches, _stop} -> Enum.count(branches) end)
 
       assert Enum.all?(trunk, &(&1 |> branches() |> length() == 1))
-
-      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
-      # assert trunk |> List.first() |> stop_id() == "place-unsqu"
-      assert trunk |> List.first() |> stop_id() == "place-lech"
+      assert trunk |> List.first() |> stop_id() == "place-unsqu"
       assert trunk |> List.last() |> stop_id() == "place-armnl"
 
       # E branch + merge
@@ -1068,12 +1065,9 @@ defmodule SiteWeb.ScheduleController.Line.DiagramHelpersTest do
       assert e |> List.first() |> stop_id() == "place-coecl"
       assert e |> List.last() |> stop_id() == "place-hsmnl"
 
-      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
-      # assert Enum.all?(hynes, &(&1 |> branches() |> length() == 1))
-      # assert length(hynes) == 1
-      assert length(hynes) == 2
-      # assert hynes |> List.first() |> stop_id() == "place-hymnl"
-      assert hynes |> List.first() |> stop_id() == "place-unsqu"
+      assert Enum.all?(hynes, &(&1 |> branches() |> length() == 1))
+      assert length(hynes) == 1
+      assert hynes |> List.first() |> stop_id() == "place-hymnl"
 
       assert Enum.all?(bcd_combined, &(&1 |> branches() |> length() == 3))
       assert bcd_combined |> List.first() |> stop_id() == "place-kencl"

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -174,13 +174,12 @@ defmodule SiteWeb.ScheduleControllerTest do
       {_, first_stop} = List.first(conn.assigns.all_stops)
       {_, last_stop} = List.last(conn.assigns.all_stops)
 
-      # As of Aug 2022, the Green Line Union Square branch is temporarily suspended.
-      assert first_stop.id == "place-lech"
+      assert first_stop.id == "place-unsqu"
 
       assert last_stop.id == "place-lake"
 
       # includes the stop features
-      assert first_stop.stop_features == [:green_line_d, :bus, :access]
+      assert first_stop.stop_features == [:access]
 
       # spider map
       assert conn.assigns.map_img_src =~ "maps.googleapis.com"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Union Square displayed in middle of line diagram](https://app.asana.com/0/555089885850811/1203005769296541)

fix: Move Union Square to the end of the line diagram

<img width="574" alt="Screen Shot 2022-09-22 at 16 27 45" src="https://user-images.githubusercontent.com/42339/191845331-e86d2daf-f9da-4b6c-a5d8-6aecae8e9e34.png">

---

Before getting review, please check the following:

* [x] Does frontend functionality render and work correctly in IE?
* [x] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [x] Are interactive elements accessible to screen readers?
* [x] Have you checked for tech debt you can address in the area you're working in?
* [x] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [x] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
