### PR TITLE
a11y: increase color contrast for SL pill

### DIFF
--- a/apps/site/assets/css/_homepage.scss
+++ b/apps/site/assets/css/_homepage.scss
@@ -372,6 +372,11 @@
     height: 24px;
   }
 
+  /* adjusts #7c878e -> #6c777e (4.59 contrast ratio) */
+  .u-bg--silver-line {
+    background-color: darken(saturate($brand-silver-line, 0.32), 6.27);
+  }
+
   .m-homepage__alerts-main {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
No ticket, this should resolve this error message that was failing some of our homepage accessibility tests:

```
Fix any of the following:\n  Element has insufficient color contrast of 3.67 (foreground color: #ffffff, background color: #7c878e, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1
```

# Before

![image](https://user-images.githubusercontent.com/2136286/191989751-b2f325c5-0118-4cdd-b6c6-24d08e79d020.png)

---

# After

<img width="782" alt="image" src="https://user-images.githubusercontent.com/2136286/191989619-5016727c-90cd-4a41-b24f-7b71c5b1049c.png">
