### PR TITLE
501 and 505 do not display scheduled trips in Schedule Finder

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -127,21 +127,13 @@ defmodule SiteWeb.ScheduleController.LineController do
   def services(route_id, service_date, services_by_route_id_fn \\ &ServicesRepo.by_route_id/1) do
     route_id
     |> services_by_route_id_fn.()
-    |> IO.inspect(label: "initial 501 services")
     |> dedup_identical_services()
-    |> IO.inspect(label: "dedup ident")
     |> dedup_similar_services()
-    |> IO.inspect(label: "dedup similar")
     |> Enum.reject(&(&1.name == "Weekday (no school)"))
     |> Enum.reject(&(Date.compare(&1.end_date, service_date) == :lt))
-    |> IO.inspect(label: "one")
     |> Enum.sort_by(&sort_services_by_date/1)
-    |> IO.inspect(label: "two")
-    # seems to wrap each service in __struct__:
     |> Enum.map(&Map.put(&1, :service_date, service_date))
-    |> IO.inspect(label: "three")
     |> tag_default_service()
-    |> IO.inspect(label: "end result 501")
   end
 
   # Some routes have no services (ie, "Green")

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -98,6 +98,7 @@ defmodule SiteWeb.ScheduleController.LineController do
   @spec dedup_similar_services([Service.t()]) :: [Service.t()]
   def dedup_similar_services(services) do
     services
+    |> Enum.reject(&(&1.valid_days == [5] || &1.valid_days == [1, 2, 3, 4]))
     |> Enum.group_by(&{&1.type, &1.typicality, &1.valid_days})
     |> Enum.flat_map(fn {_, service_group} ->
       Enum.reject(service_group, &service_completely_overlapped?(&1, service_group))

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -99,7 +99,7 @@ defmodule SiteWeb.ScheduleController.LineController do
   def dedup_similar_services(services) do
     services
     |> Enum.reject(&(&1.valid_days == [5] || &1.valid_days == [1, 2, 3, 4]))
-    |> Enum.group_by(&{&1.type, &1.typicality, &1.valid_days})
+    |> Enum.group_by(&{&1.type, &1.typicality})
     |> Enum.flat_map(fn {_, service_group} ->
       Enum.reject(service_group, &service_completely_overlapped?(&1, service_group))
     end)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [501 and 505 do not display scheduled trips in Schedule Finder](https://app.asana.com/0/385363666817452/1203082825839704/f)

Group services with additional field of `valid_dates`. Currently up on green.