### PR TITLE
fix: account for services with empty `valid_days`

### DIFF
--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -74,7 +74,8 @@ export const isCurrentValidService = (
   }
 
   // check on valid_days
-  if (!isOnValidDay(service, currentDate)) {
+  // disregard if empty valid_days value
+  if (service.valid_days.length > 0 && !isOnValidDay(service, currentDate)) {
     return false;
   }
 

--- a/apps/site/assets/ts/helpers/service.ts
+++ b/apps/site/assets/ts/helpers/service.ts
@@ -74,8 +74,7 @@ export const isCurrentValidService = (
   }
 
   // check on valid_days
-  // disregard if empty valid_days value
-  if (service.valid_days.length > 0 && !isOnValidDay(service, currentDate)) {
+  if (!isOnValidDay(service, currentDate)) {
     return false;
   }
 


### PR DESCRIPTION
**Problem:** instead of selecting weekday service as the default on a weekday, we were finding cases where Saturday is selected instead.

This seems to be happening when the typical weekday service that _should_ be selected happens to have an empty value for `valid_days`. One example (typical weekday service for the 1 bus): https://api-v3.mbta.com/services/BUS422-hbc42cl1-Wdy-02

**This PR:** When evaluating whether a given service is "current": for services where `valid_days` is an empty array, skip the valid day check. This falls back to instead checking whether the service is within the rating dates, which should generally produce a favorable result.

