### PR TITLE
Liquid replacements for monthly passes

### DIFF
--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -200,7 +200,7 @@ defmodule Fares.FareInfo do
       charlie_card_price: "4.25",
       day_reduced_price: "2.10",
       week_reduced_price: "10.00",
-      month_reduced_price: "30.00",
+      month_reduced_price: "67.00",
       day_pass_price: "11.00",
       week_pass_price: "22.50",
       month_pass_price: "136.00"
@@ -408,6 +408,7 @@ defmodule Fares.FareInfo do
         charlie_card_price: charlie_card_price,
         day_reduced_price: day_reduced_price,
         week_reduced_price: week_reduced_price,
+        month_reduced_price: month_reduced_price,
         month_pass_price: month_pass_price
       })
       when mode in [:local_bus, :express_bus] do
@@ -452,7 +453,16 @@ defmodule Fares.FareInfo do
         | fares
       ]
     else
-      fares
+      [
+        %{
+          base
+          | duration: :month,
+            media: [:senior_card, :student_card],
+            reduced: :any,
+            cents: dollars_to_cents(month_reduced_price)
+        }
+        | fares
+      ]
     end
   end
 

--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -214,6 +214,7 @@ defmodule Fares.FareInfo do
       east_boston_price: "2.40",
       commuter_ferry_price: "9.75",
       commuter_ferry_month_price: "329.00",
+      commuter_ferry_month_price_reduced: "164.00",
       commuter_ferry_logan_price: "9.75",
       day_pass_price: "11.00",
       week_pass_price: "22.50"
@@ -463,6 +464,7 @@ defmodule Fares.FareInfo do
         cross_harbor_price: cross_harbor_price,
         east_boston_price: east_boston_price,
         commuter_ferry_price: commuter_ferry_price,
+        commuter_ferry_month_price_reduced: commuter_ferry_month_price_reduced,
         commuter_ferry_month_price: commuter_ferry_month_price,
         commuter_ferry_logan_price: commuter_ferry_logan_price
       }) do
@@ -589,6 +591,15 @@ defmodule Fares.FareInfo do
         media: [:mticket],
         reduced: nil,
         cents: dollars_to_cents(commuter_ferry_month_price) - 1000
+      },
+      %Fare{
+        mode: :ferry,
+        name: :commuter_ferry,
+        duration: :month,
+        media: [:senior_card, :student_card],
+        reduced: :any,
+        cents: dollars_to_cents(commuter_ferry_month_price_reduced),
+        additional_valid_modes: [:subway, :bus, :commuter_rail]
       }
     ]
 

--- a/apps/site/test/site/content_rewriters/liquid_objects/fare_test.exs
+++ b/apps/site/test/site/content_rewriters/liquid_objects/fare_test.exs
@@ -155,11 +155,12 @@ defmodule Site.ContentRewriters.LiquidObjects.FareTest do
                duration: :month
              ]
              |> Repo.all()
-             |> fare_result(:ferry) == "$30.00"
+             |> fare_result(:ferry) == "$30.00 – $164.00"
 
       assert fare_request("ferry_inner_harbor:month:reduced") == {:ok, "$30.00"}
       refute fare_request("ferry_cross_harbor:month:reduced") == {:ok, "$30.00"}
-      assert fare_request("ferry:month:reduced") == {:ok, "$30.00"}
+      assert fare_request("commuter_ferry:month:reduced") == {:ok, "$164.00"}
+      assert fare_request("ferry:month:reduced") == {:ok, "$30.00 – $164.00"}
     end
 
     test "handles ferry:reduced" do

--- a/apps/site/test/site/content_rewriters/liquid_objects/fare_test.exs
+++ b/apps/site/test/site/content_rewriters/liquid_objects/fare_test.exs
@@ -68,6 +68,7 @@ defmodule Site.ContentRewriters.LiquidObjects.FareTest do
              |> fare_result(:commuter_rail) == "$30.00 – $209.00"
 
       assert fare_request("commuter_rail:month:reduced") == {:ok, "$30.00 – $209.00"}
+      assert fare_request("commuter_ferry:month:reduced") == {:ok, "$164.00"}
     end
 
     test "it handles weekend rail fare requests" do

--- a/apps/site/test/site/content_rewriters/liquid_objects/fare_test.exs
+++ b/apps/site/test/site/content_rewriters/liquid_objects/fare_test.exs
@@ -69,6 +69,7 @@ defmodule Site.ContentRewriters.LiquidObjects.FareTest do
 
       assert fare_request("commuter_rail:month:reduced") == {:ok, "$30.00 – $209.00"}
       assert fare_request("commuter_ferry:month:reduced") == {:ok, "$164.00"}
+      assert fare_request("express_bus:month:reduced") == {:ok, "$67.00"}
     end
 
     test "it handles weekend rail fare requests" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Liquid replacements for monthly passes](https://app.asana.com/0/385363666817452/1203017920930544/f)

Edited fare info to add some missing information needed to generate the shortcodes used in the CMS to render certain fare information, and added a test case for each:

* Added a monthly reduced price for `:commuter_ferry` fare
* Edited the unused monthly reduced price for express buses, and added this `:express_bus` fare