### PR TITLE
fix: Use the direction_id param on the line page

### DIFF
--- a/apps/site/assets/ts/schedule/components/ScheduleLoader.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleLoader.tsx
@@ -52,6 +52,7 @@ export const ScheduleLoader = ({
   const [query] = useQueryParams({
     // eslint-disable-next-line camelcase
     "schedule_finder[direction_id]": StringParam,
+    "schedule_direction[direction_id]": StringParam,
     "schedule_finder[origin]": StringParam
   });
 
@@ -81,14 +82,15 @@ export const ScheduleLoader = ({
     let { modalOpen, modalMode } = currentState;
 
     let newDirection: DirectionId | undefined;
-    let newOrigin: SelectedOrigin | undefined;
+    const newOrigin: SelectedOrigin | undefined =
+      query["schedule_finder[origin]"];
 
     // modify the store values in case URL has parameters:
-    if (query["schedule_finder[direction_id]"] !== undefined) {
-      newDirection = query["schedule_finder[direction_id]"] === "0" ? 0 : 1;
-    }
-    if (query["schedule_finder[origin]"] !== undefined) {
-      newOrigin = query["schedule_finder[origin]"];
+    const queryDirectionId =
+      query["schedule_finder[direction_id]"] ||
+      query["schedule_direction[direction_id]"];
+    if (queryDirectionId !== undefined) {
+      newDirection = queryDirectionId === "0" ? 0 : 1;
     }
 
     if (newDirection !== undefined && newOrigin !== undefined) {


### PR DESCRIPTION
Asana ticket: [Schedule | Investigate direction_id url parameter](https://app.asana.com/0/385363666817452/1200154423941953)

#### Summary of changes
Fixes an existing bug. Steps to reproduce:

1. Go to a line page, e.g. https://www.mbta.com/schedules/1/line
2. See that it defaults to direction 0, showing "Nubian" as the first stop
3. Click "Change Direction"
4. See that direction 1 is specified in the URL query, and the page correctly shows direction 1, with "Massachusetts Ave @ Holyoke St" as the first stop
5. Refresh the page

**Expected behavior:**
The page loads based on the URL query, showing direction 1, with "Nubian" as the first stop.

**Observed behavior:**
The page displays direction 0, with "Massachusetts Ave @ Holyoke St" as the first stop.

I couldn't find an existing ticket for this issue, but please let me know if I've missed one.

---

Before getting review, please check the following:

* [ ] Does frontend functionality render and work correctly in IE?
* [ ] Have we load-tested any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] Are interactive elements accessible to screen readers?
* [ ] Have you checked for tech debt you can address in the area you're working in?
* [ ] If this change involves routes, does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?
* [ ] Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?
