### PR TITLE
GA4 click event clean-up

### DIFF
--- a/apps/site/assets/css/_accordion-ui.scss
+++ b/apps/site/assets/css/_accordion-ui.scss
@@ -123,7 +123,7 @@
     margin: 0;
   }
 
-  :not([data-accordion-expanded]) + .c-accordion-ui__content {
+  [data-accordion-expanded='false'] + .c-accordion-ui__content {
     display: none; // start hidden
   }
 
@@ -131,7 +131,7 @@
     @include fa-icon-solid($fa-var-angle-down);
   }
 
-  [data-accordion-expanded] .c-indicator__content--angle {
+  [data-accordion-expanded='true'] .c-indicator__content--angle {
     @include fa-icon-solid($fa-var-angle-up);
   }
 }

--- a/apps/site/assets/css/_svg.scss
+++ b/apps/site/assets/css/_svg.scss
@@ -14,4 +14,5 @@
 
 [class*=c-svg__icon] {
   display: inline-block;
+  pointer-events: none; // prevents click events on SVG paths or shapes
 }

--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -315,11 +315,6 @@ export function setup(rootElement: HTMLElement): void {
     .querySelector("[data-nav='veil']")
     ?.addEventListener("click", closeAllMenus);
 
-  const transitDiv = rootElement.querySelector("#Transit-accordion");
-  if (transitDiv) {
-    transitDiv.getElementsByTagName("button")[0].click();
-  }
-
   // Closes veil before navigating to search result
   document.addEventListener("autocomplete:selected", closeAllMenus);
 }

--- a/apps/site/assets/ts/ui/__tests__/accordion-test.ts
+++ b/apps/site/assets/ts/ui/__tests__/accordion-test.ts
@@ -5,7 +5,7 @@ const body = `
 <div class="c-accordion-ui c-accordion-ui--no-bootstrap" role="presentation" data-accordion>
 ${[1, 2, 3].map(
   (_, i) => `
-  <h3 class="c-accordion-ui__heading">
+  <h3 class="c-accordion-ui__heading" data-accordion-expanded="false">
     <button class="c-accordion-ui__trigger c-accordion-ui__title"
       id="${i}-title"
       aria-expanded="false"
@@ -35,9 +35,9 @@ describe("accordion", () => {
   test("toggles aria-expanded on click", async () => {
     const btn = document.querySelector("button")!;
     expect(btn.getAttribute("aria-expanded")).toBe("false");
-    expect(
-      btn.parentElement!.getAttribute("data-accordion-expanded")
-    ).toBeFalsy();
+    expect(btn.parentElement!.getAttribute("data-accordion-expanded")).toBe(
+      "false"
+    );
 
     fireEvent.click(btn);
     await waitFor(() => {
@@ -50,9 +50,9 @@ describe("accordion", () => {
     fireEvent.click(btn);
     await waitFor(() => {
       expect(btn.getAttribute("aria-expanded")).toBe("false");
-      expect(
-        btn.parentElement!.getAttribute("data-accordion-expanded")
-      ).toBeFalsy();
+      expect(btn.parentElement!.getAttribute("data-accordion-expanded")).toBe(
+        "false"
+      );
     });
   });
 

--- a/apps/site/assets/ts/ui/accordion.ts
+++ b/apps/site/assets/ts/ui/accordion.ts
@@ -12,10 +12,10 @@ const addAccordionToggleObserver = (btn: Element): void =>
       if (newValue === oldValue) return;
       const wrapperEl = target.parentElement!;
       if (
-        wrapperEl.getAttribute("data-accordion-expanded") &&
+        wrapperEl.getAttribute("data-accordion-expanded") === "true" &&
         newValue === "false"
       ) {
-        wrapperEl.removeAttribute("data-accordion-expanded");
+        wrapperEl.setAttribute("data-accordion-expanded", "false");
       } else if (newValue === "true") {
         wrapperEl.setAttribute("data-accordion-expanded", "true");
       }

--- a/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.eex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.eex
@@ -1,7 +1,7 @@
 <nav class="m-menu--mobile" id="navmenu" aria-label="Navigation Menu">
   <div class="m-menu__content" data-nav="mobile-content">
     <h1 class="m-menu__title heading-2">Main Menu</h1>
-    <%= for %{menu_section: menu_section, sub_menus: sub_menus} <- nav_link_content_redesign(@conn) do %>
+    <%= for {%{menu_section: menu_section, sub_menus: sub_menus}, index} <- Enum.with_index(nav_link_content_redesign(@conn)) do %>
       <nav aria-labelledby="section-heading-<%= menu_section %>" class="m-menu__section">
         <h2 id="section-heading-<%= menu_section %>" class="m-menu__section-heading"><%= menu_section %></h2>
         <%= SiteWeb.PartialView.render("_accordion_ui_no_bootstrap.html",
@@ -9,11 +9,12 @@
               id: menu_section,
               multiselectable: false,
               sections:
-                for %{links: links} = sub_menu <- sub_menus do
+                for {%{links: links} = sub_menu, sub_index} <- Enum.with_index(sub_menus) do
                   %{
                     content: Enum.map(links, &render_nav_link/1),
                     title: sub_menu.sub_menu_section,
-                    prefix: String.replace(sub_menu.sub_menu_section, " ", "-")
+                    prefix: String.replace(sub_menu.sub_menu_section, " ", "-"),
+                    expanded?: index === 0 && sub_index === 0
                   }
                 end
             })

--- a/apps/site/lib/site_web/templates/partial/_accordion_ui_no_bootstrap.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_accordion_ui_no_bootstrap.html.eex
@@ -2,10 +2,11 @@
 
 <div class="c-accordion-ui c-accordion-ui--no-bootstrap" id="<%= id %>" data-accordion role="presentation" <%= if @multiselectable do %> aria-multiselectable="true"<% end %>>
   <%= for section <- @sections do %>
-    <h3 class="c-accordion-ui__heading<%= if assigns[:sticky] do %> fixedsticky sticky-top<% end %>">
+    <% expanded = Map.get(section, :expanded?, false) |> to_string() %>
+    <h3 class="c-accordion-ui__heading<%= if assigns[:sticky] do %> fixedsticky sticky-top<% end %>" data-accordion-expanded="<%= expanded %>">
       <button class="c-accordion-ui__trigger c-accordion-ui__title"
         id="<%= section.prefix %>-title"
-        aria-expanded="false"
+        aria-expanded="<%= expanded %>"
         aria-controls="<%= section.prefix %>-section">
         <%= section.title |> Site.ContentRewriter.rewrite(@conn) |> raw() %>
         <span class="c-accordion-ui__indicator">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [GA4 click event clean-up](https://app.asana.com/0/385363666817452/1203009465850182/f)

* Adjusted the accordion code to support explicitly defining expanded state on each section, and refactors our mobile menu to use that instead of relying on a `click()` with JavaScript.
* Adds `pointer-events: none` to all SVG icons.