### PR TITLE
fix?: filter by smallest typicality for all routes

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -225,9 +225,13 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
     |> Enum.all?(&MapSet.subset?(&1, MapSet.new(stops)))
   end
 
+  @doc """
+  Filters a list of route patterns down to the route patterns sharing the lowest
+  number for the "typicality" property, additionally removing route patterns
+  associated with a negative shape_priority value.
+  """
   @spec filtered_by_typicality([RoutePattern.t()]) :: [RoutePattern.t()]
-  defp filtered_by_typicality(route_patterns) do
-    # Find route patterns with smallest typicality.
+  def filtered_by_typicality(route_patterns) do
     route_patterns
     |> filter_by_min_typicality()
     |> Enum.filter(fn x -> x.shape_priority > 0 end)

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -2,7 +2,6 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
   use ExUnit.Case, async: true
 
   alias Routes.{Route}
-  alias RoutePatterns.RoutePattern
   alias SiteWeb.ScheduleController.Line.Helpers
   alias Stops.{RouteStops, Stop}
 
@@ -824,20 +823,8 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
     end
   end
 
-  describe "by_typicality/2" do
-    test "without a selected route pattern, allows (returns true) only RoutePattern with a typicality of 1 through the filter" do
-      assert Helpers.by_typicality(%RoutePattern{typicality: 1}, nil)
-      refute Helpers.by_typicality(%RoutePattern{typicality: 2}, nil)
-    end
-
-    test "with a selected route pattern, allows (returns true) all RoutePatterns through the filter" do
-      assert Helpers.by_typicality(%RoutePattern{typicality: 1}, "123")
-      assert Helpers.by_typicality(%RoutePattern{typicality: 2}, "123")
-    end
-  end
-
-  defp assert_stop_ids(actual, stop_ids) do
-    assert stop_ids(actual) == stop_ids
+  def assert_stop_ids(actual, stop_ids) do
+    assert Enum.map(actual, & &1.id) == stop_ids
   end
 
   defp stop_ids(stops), do: Enum.map(stops, & &1.id)

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -823,6 +823,39 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
     end
   end
 
+  describe "filtered_by_typicality/1" do
+    test "finds all most typical route patterns" do
+      assert [%{typicality: 1}] =
+               Helpers.filtered_by_typicality([
+                 %RoutePatterns.RoutePattern{typicality: 1},
+                 %RoutePatterns.RoutePattern{typicality: 2},
+                 %RoutePatterns.RoutePattern{typicality: 3},
+                 %RoutePatterns.RoutePattern{typicality: 4},
+                 %RoutePatterns.RoutePattern{typicality: 5}
+               ])
+
+      assert [%{typicality: 2}, _, _] =
+               Helpers.filtered_by_typicality([
+                 %RoutePatterns.RoutePattern{typicality: 2},
+                 %RoutePatterns.RoutePattern{typicality: 2},
+                 %RoutePatterns.RoutePattern{typicality: 2},
+                 %RoutePatterns.RoutePattern{typicality: 4},
+                 %RoutePatterns.RoutePattern{typicality: 5}
+               ])
+    end
+
+    test "excludes route patterns with negative shape_priority" do
+      assert [%RoutePatterns.RoutePattern{typicality: 2, shape_priority: 1}, _] =
+               Helpers.filtered_by_typicality([
+                 %RoutePatterns.RoutePattern{typicality: 2, shape_priority: -2},
+                 %RoutePatterns.RoutePattern{typicality: 2, shape_priority: 1},
+                 %RoutePatterns.RoutePattern{typicality: 2, shape_priority: 2},
+                 %RoutePatterns.RoutePattern{typicality: 4, shape_priority: 1},
+                 %RoutePatterns.RoutePattern{typicality: 5, shape_priority: 1}
+               ])
+    end
+  end
+
   def assert_stop_ids(actual, stop_ids) do
     assert Enum.map(actual, & &1.id) == stop_ids
   end


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

There've been enough times where the line diagram page has been compromised on occasions where there are no route patterns with a typicality of 1. Currently it's happening on CR-Fitchburg outbound:

<img width="939" alt="image" src="https://user-images.githubusercontent.com/2136286/200943379-da25eeeb-65b4-4bed-a160-00ae6c985d92.png">


This PR is an experiment... it uses whatever available route patterns have the lowest typicality value (e.g. if none have 1 but a route pattern is present with `typicality=2`, use that to build the line diagram). This technique was already in use for one of the ferry routes; this PR simply uses that for _every_ route.

There might be side effects on various routes! So I'd like to deploy this to a staging server for QA.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

