### PR TITLE
fix(Routes.Route): add the ride to type_atom

### DIFF
--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -51,7 +51,7 @@ defmodule Routes.Route do
   @silver_line ~w(741 742 743 746 749 751)
   @silver_line_set MapSet.new(@silver_line)
 
-  @spec type_atom(t | type_int | String.t()) :: gtfs_route_type
+  @spec type_atom(t | type_int | String.t()) :: route_type
   def type_atom(%__MODULE__{type: type}), do: type_atom(type)
   def type_atom(0), do: :subway
   def type_atom(1), do: :subway
@@ -66,6 +66,7 @@ defmodule Routes.Route do
   def type_atom("909"), do: :logan_express
   def type_atom("983"), do: :massport_shuttle
   def type_atom("Massport-" <> _), do: :massport_shuttle
+  def type_atom("the_ride"), do: :the_ride
 
   @spec types_for_mode(gtfs_route_type | subway_lines_type) :: [0..4]
   def types_for_mode(:subway), do: [0, 1]

--- a/apps/routes/test/route_test.exs
+++ b/apps/routes/test/route_test.exs
@@ -13,7 +13,8 @@ defmodule Routes.RouteTest do
             {4, :ferry},
             {"909", :logan_express},
             {"983", :massport_shuttle},
-            {"Massport-1", :massport_shuttle}
+            {"Massport-1", :massport_shuttle},
+            {"the_ride", :the_ride}
           ] do
         assert type_atom(int) == atom
       end


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Rendering news entries with related transit of "the ride" break things](https://app.asana.com/0/385363666817452/1203353754294449/f)

When processing a CMS news entry tagged with "The RIDE" under related transit, the homepage would break with the following error:

```
** (FunctionClauseError) no function clause matching in Routes.Route.type_atom/1
        (routes 0.0.1) lib/route.ex:55: Routes.Route.type_atom("the_ride")
        (site 0.0.1) lib/site_web/views/partial_view.ex:72: SiteWeb.PartialView.news_entry/2
        (elixir 1.10.4) lib/enum.ex:1396: Enum."-map/2-lists^map/1-0-"/2
        (site 0.0.1) lib/site_web/views/page_view.ex:248: SiteWeb.PageView.do_render_news_entries/1
```

This PR adds an entry to handle `Routes.Route.type_atom("the_ride")`. This ultimately renders the correct icon for the news entry, tested locally after I created Test News Entry on test-mbta (the CMS instance behind our dev environment):

<img width="539" alt="image" src="https://user-images.githubusercontent.com/2136286/201396910-c0007989-de00-4529-8842-bea7ddf23da6.png">

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

