### PR TITLE
miscellaneous set-up updates

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -14,6 +14,7 @@ export RECAPTCHA_PRIVATE_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 # export SUPPORT_TICKET_REPLY_EMAIL=
 # export SUPPORT_TICKET_TO_EMAIL=
 # export V3_API_KEY=
+export V3_API_VERSION=2019-07-01
 export V3_URL=https://api-dev.mbtace.com
 # export WIREMOCK_PATH=
 export WIREMOCK_PROXY_URL=https://api-dev.mbtace.com

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 nodejs 14.20.0
 erlang 22.3.4.26
 elixir 1.10.4-otp-22
+chromedriver 106.0.5249.21

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ From a development standpoint, polyfills and code transforms are implemented via
 
 Welcome to [Dotcom](https://www.notion.so/mbta-downtown-crossing/Dotcom-6aa7b0f0258446a197d35b1f05d90e96). There are more [details and background information in this Notion document](https://www.notion.so/mbta-downtown-crossing/Engineering-db62977f905347bab6fe94a2249a8a05), but read on to get started on your setup!
 
-1. Request a V3 API key at https://api-dev.mbtace.com/. Note that, at
-any given time, the site may not be compatible with the very latest API version - as of Jan 2021 the site is using API version `2019-07-01`. After receiving an API key, you may need to edit the version of your key to match the site's API version.
+1. Request a V3 API key at https://api-dev.mbtace.com/. After getting an API key, it's customary to click "request increase" for your key's 'Per-Minute Limit'.
 
 1. Install [Homebrew](https://docs.brew.sh/Installation.html):
     ```

--- a/README.md
+++ b/README.md
@@ -44,61 +44,34 @@ any given time, the site may not be compatible with the very latest API version 
 
 1. Install [asdf package version manager](https://github.com/asdf-vm/asdf)
    * Follow the instructions on https://github.com/asdf-vm/asdf
+     
+     ```shell
+     brew install asdf
+     ```
    * Install the necessary tools to set up asdf plugins:
 
-     ```
-     brew install coreutils automake autoconf openssl libyaml readline libxslt libtool unixodbc gpg
+     ```shell
+     brew install gpg gawk # for nodejs plugin
+     brew install autoconf openssl@1.1 # for erlang plugin
+     brew install wxwidgets # optional for erlang for building with wxWidgets (start observer or debugger!)
+     brew install libxslt fop # optional for erlang for building documentation and elixir reference builds
      ```
 
    * Add asdf plugins
 
      ```
-     asdf plugin-add erlang
-     asdf plugin-add elixir
-     asdf plugin-add nodejs
+     asdf plugin add erlang
+     asdf plugin add elixir
+     asdf plugin add nodejs
+     asdf plugin add chromedriver
      ```
-     You can verify the plugins were installed with `asdf plugin-list`
+     You can verify the plugins were installed with `asdf plugin list`.
 
-   * Import the Node.js release team's OpenPGP keys to install 'nodejs' plugin:
+     While Erlang, Elixir, and NodeJS are essential for any development on Dotcom, Chromedriver is only needed for Elixir acceptance tests using Wallaby.
 
-     ```
-     bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
-     ```
+     You're welcome to add more plugins for personal use! But these four are the ones set up in `.tool-versions` and invoked in the next step:
 
-     If you run into problems, you might have to update the `import-release-team-keyring` script.
-
-   * If running OSX 10.15 Catalina, run `export MACOSX_DEPLOYMENT_TARGET=10.14`.
-     This works around a [known issue](https://github.com/asdf-vm/asdf-erlang/issues/116)
-     with compiling versions of Erlang prior to 22.1.4.
-
-   * If running OSX 11 Big Sur, you will need to modify the source directly.
-     ([This comment captures the issue/solution](https://github.com/asdf-vm/asdf-erlang/issues/161#issuecomment-731558207)). As of Jan 2021, we use erlang 22.3.3, and the filenames below reflect this.
-
-     First, run the install. Navigate to the erlang directory and unzip the source.
-
-     ```
-     asdf install
-     cd ~/.asdf/plugins/erlang/kerl-home/archives
-     tar zxvf OTP-22.3.3.tar.gz
-     ```
-     Modify ~/.asdf/plugins/erlang/kerl-home/archives/otp-OTP-23.1.4/make/configure.in line 415 to read:
-     ```
-     #if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version && false
-     ```
-     Re-tar the directory:
-     ```
-     rm OTP-22.3.3.tar.gz
-     tar czvf OTP-22.3.3.tar.gz otp-OTP-22.3.3
-     rm -rf otp-OTP-22.3.3
-     ```
-     Then re-run the erlang install:
-     ```
-     asdf install erlang 22.3.3
-     ```
-   
-   * _Note on Erlang version:  while v24 resolves the compilation issue, we still need to use v22 as of Jan 2021._
-
-   * Now, (if you haven't already in the OSX11 instructions above) run the install:
+   * Now run the install:
 
      ```
      asdf install
@@ -116,31 +89,16 @@ any given time, the site may not be compatible with the very latest API version 
       elixir         <version> (set by ~/dotcom/.tool-versions)
       erlang         <version> (set by ~/dotcom/.tool-versions)
       nodejs         <version> (set by ~/dotcom/.tool-versions)
+      chromedriver   <version> (set by ~/dotcom/.tool-versions)
       ...
      ```
 
-     If you are missing any versions, you should re-run `asdf install`. Related [Github issue about asdf-erlang](https://github.com/asdf-vm/asdf-erlang/issues/57)
+     If you are missing any versions, you should re-run `asdf install`.
 
      You may have to individually install each version
      ```
      asdf install plugin_name <version> (set by ~/dotcom/.tool-versions)
      ```
-
-     If erlang is still missing you can run the following commands
-     ```
-      brew install openssl@1.1
-      export KERL_CONFIGURE_OPTIONS="--without-javac --with-ssl=/usr/local/opt/openssl@1.1"
-      brew install autoconf@2.69 && \
-      brew link --overwrite autoconf@2.69 && \
-      autoconf -V
-     ```
-
-1. Install chromedriver (for Elixir acceptance tests using Wallaby)
-    ```
-    brew install chromedriver
-    ```
-   Note: `chromedriver` requires Chrome to be installed. If you don't already
-   have it, `brew install --cask google-chrome` is an easy way to install it.
 
 1. Install our Elixir dependencies. From the root of this repo:
     ```

--- a/apps/v3_api/config/config.exs
+++ b/apps/v3_api/config/config.exs
@@ -5,6 +5,7 @@ use Mix.Config
 config :v3_api,
   base_url: {:system, "V3_URL"},
   api_key: {:system, "V3_API_KEY"},
+  api_version: {:system, "V3_API_VERSION", "2019-07-01"},
   wiremock_proxy_url: {:system, "WIREMOCK_PROXY_URL"},
   wiremock_proxy: {:system, "WIREMOCK_PROXY", "false"},
   default_timeout: 5_000,

--- a/apps/v3_api/lib/headers.ex
+++ b/apps/v3_api/lib/headers.ex
@@ -21,7 +21,9 @@ defmodule V3Api.Headers do
 
   @spec api_key_header(header_list, String.t() | nil) :: header_list
   defp api_key_header(headers, nil), do: headers
-  defp api_key_header(headers, <<key::binary>>), do: [{"x-api-key", key} | headers]
+
+  defp api_key_header(headers, <<key::binary>>),
+    do: [{"x-api-key", key}, {"MBTA-Version", "2019-07-01"} | headers]
 
   @spec proxy_headers(header_list) :: header_list
   defp proxy_headers(headers) do

--- a/apps/v3_api/lib/headers.ex
+++ b/apps/v3_api/lib/headers.ex
@@ -22,8 +22,10 @@ defmodule V3Api.Headers do
   @spec api_key_header(header_list, String.t() | nil) :: header_list
   defp api_key_header(headers, nil), do: headers
 
-  defp api_key_header(headers, <<key::binary>>),
-    do: [{"x-api-key", key}, {"MBTA-Version", "2019-07-01"} | headers]
+  defp api_key_header(headers, <<key::binary>>) do
+    api_version = Util.config(:v3_api, :api_version)
+    [{"x-api-key", key}, {"MBTA-Version", api_version} | headers]
+  end
 
   @spec proxy_headers(header_list) :: header_list
   defp proxy_headers(headers) do

--- a/apps/v3_api/lib/stream.ex
+++ b/apps/v3_api/lib/stream.ex
@@ -64,7 +64,7 @@ defmodule V3Api.Stream do
       ]
     else
       _ ->
-        raise ArgumentError, "Missing valid V3_URL and/or V3_API_KEY (2019-07-01 version)"
+        raise ArgumentError, "Missing valid V3_URL and/or V3_API_KEY"
     end
   end
 

--- a/apps/v3_api/lib/stream.ex
+++ b/apps/v3_api/lib/stream.ex
@@ -56,10 +56,16 @@ defmodule V3Api.Stream do
 
   @spec default_options :: Keyword.t()
   defp default_options do
-    [
-      base_url: config(:base_url),
-      api_key: config(:api_key)
-    ]
+    with base_url when not is_nil(base_url) <- config(:base_url),
+         api_key when not is_nil(api_key) <- config(:api_key) do
+      [
+        base_url: base_url,
+        api_key: api_key
+      ]
+    else
+      _ ->
+        raise ArgumentError, "Missing valid V3_URL and/or V3_API_KEY (2019-07-01 version)"
+    end
   end
 
   @spec config(atom) :: any


### PR DESCRIPTION
No ticket, but am setting up Dotcom on my new laptop and saw some opportunities to clarify the docs a bit and make some improvements.
- Some of the install guidance was out of date, so removed some of the parts we won't be likely to need.
- I also noticed there's a chromedriver asdf plugin now, so I updated the docs to use that instead of having devs install chromedriver+chrome separately
- The error when running Dotcom when I forgot to set up my environment variables wasn't very helpful! So the second commit adds an error message for this scenario.
- The third commit adds a header to every API request according to the guidance in https://www.mbta.com/developers/v3-api/versioning -- I want this to take precedence when the API key is a different version than the one we support, but I haven't confirmed that this change actually will work that way. So I left untouched our existing documentation encouraging devs to set the correct API key version. Asana ticket: [Set API version for all requests](https://app.asana.com/0/1203354074531980/1189283639595009/f)