### PR TITLE
feat: Populate trip planner origin stops from URL param

### DIFF
--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -177,6 +177,8 @@ defmodule SiteWeb.Router do
     get("/transit-near-me", TransitNearMeController, :index)
     resources("/alerts", AlertController, only: [:index, :show])
     get("/trip-planner", TripPlanController, :index)
+    get("/trip-planner/from/", Redirector, to: "/trip-planner")
+    get("/trip-planner/from/:address", TripPlanController, :from)
     get("/trip-planner/to/", Redirector, to: "/trip-planner")
     get("/trip-planner/to/:address", TripPlanController, :to)
     get("/vote", TripPlanController, :vote)


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [/from links: Pre-populate origin stop for trip planner from URL](https://app.asana.com/0/555089885850811/1203192939356021)

Populate trip planner origin stops from the URL path. Parallels how the existing "to" field works. Supports both lat-lon and geocoding addresses.

lat-lon:
<img width="337" alt="Screenshot 2022-11-17 at 11 00 39" src="https://user-images.githubusercontent.com/42339/202538048-f1bb956c-a7b7-4404-99b9-7d92e44bfc4e.png">

geocoding:
<img width="329" alt="Screenshot 2022-11-17 at 11 03 07" src="https://user-images.githubusercontent.com/42339/202538065-c198d6c4-93b5-4d7b-a491-622e38c6abbf.png">


---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
