### PR TITLE
Destination header in Schedule Finder should be left-aligned

### DIFF
--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -400,7 +400,7 @@
   vertical-align: top;
 
   &:last-child:not(:first-child) {
-    text-align: right;
+    text-align: left;
   }
 
   &--expanded {

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -430,6 +430,10 @@
   &--tiny {
     width: 1ch;
   }
+
+  .pull-left {
+    float: left;
+  }
 }
 
 .trip-details-table {
@@ -562,8 +566,4 @@
       flex: none;
     }
   }
-}
-
-.pull-left {
-  float: left;
 }

--- a/apps/site/assets/css/_schedule-page.scss
+++ b/apps/site/assets/css/_schedule-page.scss
@@ -400,7 +400,7 @@
   vertical-align: top;
 
   &:last-child:not(:first-child) {
-    text-align: left;
+    text-align: right;
   }
 
   &--expanded {
@@ -562,4 +562,8 @@
       flex: none;
     }
   }
+}
+
+.pull-left {
+  float: left;
 }


### PR DESCRIPTION
**Asana Ticket:** [Destination header in Schedule Finder should be left-aligned](https://app.asana.com/0/555089885850811/1203117266516157/f)

left align header in modal
<img width="480" alt="Screen Shot 2022-11-29 at 2 06 36 PM" src="https://user-images.githubusercontent.com/91911166/204622861-90639ce9-5b5c-433e-9e86-17465a439c91.png">
