### PR TITLE
Subscribe to streaming updates by routeId and stopId

### DIFF
--- a/apps/predictions/lib/parser.ex
+++ b/apps/predictions/lib/parser.ex
@@ -1,9 +1,10 @@
 defmodule Predictions.Parser do
-  alias Predictions.Prediction
-
   @moduledoc """
   Functions for parsing predictions from their JSON:API format.
   """
+
+  alias JsonApi.Item
+  alias Predictions.Prediction
 
   @type record :: {
           Prediction.id_t() | nil,
@@ -13,30 +14,83 @@ defmodule Predictions.Parser do
           0 | 1,
           DateTime.t() | nil,
           non_neg_integer,
-          Prediction.schedule_relationship(),
+          Prediction.schedule_relationship() | nil,
           String.t() | nil,
           String.t() | nil,
           boolean
         }
 
-  @spec parse(JsonApi.Item.t()) :: record
-  def parse(%JsonApi.Item{attributes: attributes} = item) do
+  @spec parse(Item.t()) :: record
+  def parse(%Item{} = item) do
     {
       item.id,
       trip_id(item),
       stop_id(item),
       route_id(item),
-      attributes["direction_id"],
-      [attributes["arrival_time"], attributes["departure_time"]] |> first_time,
-      attributes["stop_sequence"] || 0,
-      schedule_relationship(attributes["schedule_relationship"]),
+      direction_id(item),
+      first_time(item),
+      stop_sequence(item),
+      schedule_relationship(item),
       track(item),
-      attributes["status"],
-      departing?(attributes)
+      status(item),
+      departing?(item)
     }
   end
 
-  defp first_time(times) do
+  @spec departing?(Item.t()) :: boolean()
+  def departing?(%Item{attributes: %{"departure_time" => binary}}) when is_binary(binary),
+    do: true
+
+  def departing?(%Item{attributes: %{"status" => binary}}) when is_binary(binary),
+    do: upcoming_status?(binary)
+
+  def departing?(_), do: false
+
+  @spec direction_id(Item.t()) :: 0 | 1
+  def direction_id(%Item{attributes: %{"direction_id" => direction_id}}), do: direction_id
+
+  @spec first_time(Item.t()) :: DateTime.t() | nil
+  def first_time(%Item{
+        attributes: %{"arrival_time" => arrival_time, "departure_time" => departure_time}
+      }),
+      do: first_time_from_arrival_departure([arrival_time, departure_time])
+
+  def first_time(_), do: nil
+
+  @spec schedule_relationship(Item.t()) :: Prediction.schedule_relationship() | nil
+  def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "ADDED"}}), do: :added
+
+  def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "UNSCHEDULED"}}),
+    do: :unscheduled
+
+  def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "CANCELLED"}}),
+    do: :cancelled
+
+  def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "SKIPPED"}}),
+    do: :skipped
+
+  def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "NO_DATA"}}),
+    do: :no_data
+
+  def schedule_relationship(_), do: nil
+
+  @spec status(Item.t()) :: String.t() | nil
+  def status(%Item{attributes: %{"status" => status}}), do: status
+  def status(_), do: nil
+
+  @spec stop_sequence(Item.t()) :: non_neg_integer()
+  def stop_sequence(%Item{attributes: %{"stop_sequence" => stop_sequence}}), do: stop_sequence
+  def stop_sequence(_), do: 0
+
+  @spec track(Item.t()) :: String.t() | nil
+  def track(%{attributes: %{"track" => track}}), do: track
+
+  def track(%{relationships: %{"stop" => [%{attributes: %{"platform_code" => track}} | _]}}),
+    do: track
+
+  def track(_), do: nil
+
+  defp first_time_from_arrival_departure(times) do
     case times
          |> Enum.reject(&is_nil/1)
          |> List.first()
@@ -46,56 +100,28 @@ defmodule Predictions.Parser do
     end
   end
 
-  @spec track(JsonApi.Item.t()) :: String.t() | nil
-  defp track(%{attributes: %{"track" => track}}), do: track
-
-  defp track(%{relationships: %{"stop" => [%{attributes: %{"platform_code" => track}} | _]}}),
-    do: track
-
-  defp track(_), do: nil
-
-  defp departing?(%{"departure_time" => binary}) when is_binary(binary) do
-    true
-  end
-
-  defp departing?(%{"status" => binary}) when is_binary(binary) do
-    upcoming_status?(binary)
-  end
-
-  defp departing?(_) do
-    false
-  end
-
   @spec upcoming_status?(String.t()) :: boolean
   defp upcoming_status?("Approaching"), do: true
   defp upcoming_status?("Boarding"), do: true
   defp upcoming_status?(status), do: String.ends_with?(status, "away")
 
-  @spec schedule_relationship(String.t()) :: Prediction.schedule_relationship()
-  defp schedule_relationship("ADDED"), do: :added
-  defp schedule_relationship("UNSCHEDULED"), do: :unscheduled
-  defp schedule_relationship("CANCELLED"), do: :cancelled
-  defp schedule_relationship("SKIPPED"), do: :skipped
-  defp schedule_relationship("NO_DATA"), do: :no_data
-  defp schedule_relationship(_), do: nil
-
-  defp stop_id(%JsonApi.Item{relationships: %{"stop" => [%{id: id} | _]}}) do
+  defp stop_id(%Item{relationships: %{"stop" => [%{id: id} | _]}}) do
     id
   end
 
-  defp stop_id(%JsonApi.Item{relationships: %{"stop" => []}}) do
+  defp stop_id(%Item{relationships: %{"stop" => []}}) do
     nil
   end
 
-  defp trip_id(%JsonApi.Item{relationships: %{"trip" => [%{id: id} | _]}}) do
+  defp trip_id(%Item{relationships: %{"trip" => [%{id: id} | _]}}) do
     id
   end
 
-  defp trip_id(%JsonApi.Item{relationships: %{"trip" => []}}) do
+  defp trip_id(%Item{relationships: %{"trip" => []}}) do
     nil
   end
 
-  defp route_id(%JsonApi.Item{relationships: %{"route" => [%{id: id} | _]}}) do
+  defp route_id(%Item{relationships: %{"route" => [%{id: id} | _]}}) do
     id
   end
 end

--- a/apps/predictions/lib/parser.ex
+++ b/apps/predictions/lib/parser.ex
@@ -50,10 +50,13 @@ defmodule Predictions.Parser do
   def direction_id(%Item{attributes: %{"direction_id" => direction_id}}), do: direction_id
 
   @spec first_time(Item.t()) :: DateTime.t() | nil
-  def first_time(%Item{
-        attributes: %{"arrival_time" => arrival_time, "departure_time" => departure_time}
-      }),
-      do: first_time_from_arrival_departure([arrival_time, departure_time])
+  def first_time(%Item{attributes: %{"departure_time" => departure_time}})
+      when not is_nil(departure_time),
+      do: parse_time(departure_time)
+
+  def first_time(%Item{attributes: %{"arrival_time" => arrival_time}})
+      when not is_nil(arrival_time),
+      do: parse_time(arrival_time)
 
   def first_time(_), do: nil
 
@@ -90,13 +93,13 @@ defmodule Predictions.Parser do
 
   def track(_), do: nil
 
-  defp first_time_from_arrival_departure(times) do
-    case times
-         |> Enum.reject(&is_nil/1)
-         |> List.first()
-         |> Timex.parse("{ISO:Extended}") do
-      {:ok, time} -> time
-      _ -> nil
+  defp parse_time(prediction_time) do
+    case Timex.parse(prediction_time, "{ISO:Extended}") do
+      {:ok, time} ->
+        time
+
+      _ ->
+        nil
     end
   end
 

--- a/apps/predictions/lib/prediction.ex
+++ b/apps/predictions/lib/prediction.ex
@@ -22,7 +22,7 @@ defmodule Predictions.Prediction do
   @type t :: %__MODULE__{
           id: id_t,
           trip: Schedules.Trip.t() | nil,
-          stop: Stops.Stop.t(),
+          stop: Stops.Stop.t() | nil,
           route: Routes.Route.t(),
           direction_id: 0 | 1,
           time: DateTime.t() | nil,

--- a/apps/predictions/lib/prediction.ex
+++ b/apps/predictions/lib/prediction.ex
@@ -10,6 +10,8 @@ defmodule Predictions.Prediction do
             stop: nil,
             route: nil,
             direction_id: nil,
+            arrival_time: nil,
+            departure_time: nil,
             time: nil,
             stop_sequence: 0,
             schedule_relationship: nil,
@@ -25,6 +27,9 @@ defmodule Predictions.Prediction do
           stop: Stops.Stop.t() | nil,
           route: Routes.Route.t(),
           direction_id: 0 | 1,
+          arrival_time: DateTime.t() | nil,
+          departure_time: DateTime.t() | nil,
+          # TODO: Deprecated, should be removed in favor of arrival_time and departure_time -- MSS 2022-09-22
           time: DateTime.t() | nil,
           stop_sequence: non_neg_integer,
           schedule_relationship: schedule_relationship,

--- a/apps/predictions/lib/predictions.ex
+++ b/apps/predictions/lib/predictions.ex
@@ -1,4 +1,12 @@
 defmodule Predictions do
+  @moduledoc """
+  Supervisor for the Predictions application.
+
+  Children include:
+  - StreamSupervisor: Dynamically sets up per-route streams of predictions from the API.
+  - Repo: Manages ad-hoc API requests.
+  """
+
   use Application
 
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
@@ -8,6 +16,11 @@ defmodule Predictions do
 
     # Define workers and child supervisors to be supervised
     children = [
+      supervisor(Phoenix.PubSub.PG2, [Predictions.PubSub, []]),
+      {Registry, keys: :unique, name: :prediction_streams_registry},
+      {Registry, keys: :duplicate, name: :prediction_subscriptions_registry},
+      Predictions.StreamSupervisor,
+      Predictions.PredictionsPubSub,
       Predictions.Repo
     ]
 

--- a/apps/predictions/lib/predictions.ex
+++ b/apps/predictions/lib/predictions.ex
@@ -16,7 +16,14 @@ defmodule Predictions do
 
     # Define workers and child supervisors to be supervised
     children = [
-      supervisor(Phoenix.PubSub.PG2, [Predictions.PubSub, []]),
+      # can update to this syntax after upgrading Phoenix to 1.5+
+      # {Phoenix.PubSub, [name: Predictions.PubSub, adapter: Phoenix.PubSub.PG2]},
+      %{
+        id: Predictions.PubSub,
+        start:
+          {Phoenix.PubSub.PG2, :start_link,
+           [[name: Predictions.PubSub, adapter: Phoenix.PubSub.PG2]]}
+      },
       {Registry, keys: :unique, name: :prediction_streams_registry},
       {Registry, keys: :duplicate, name: :prediction_subscriptions_registry},
       Predictions.StreamSupervisor,

--- a/apps/predictions/lib/predictions_pub_sub.ex
+++ b/apps/predictions/lib/predictions_pub_sub.ex
@@ -68,7 +68,13 @@ defmodule Predictions.PredictionsPubSub do
 
     predictions = predictions_for_key(predictions_by_key, route_stop_direction)
 
-    {:reply, {registry_key, predictions}, state}
+    # add new subscription to state
+    new_state = %__MODULE__{
+      state
+      | predictions_by_key: Map.put(predictions_by_key, route_stop_direction, predictions)
+    }
+
+    {:reply, {registry_key, predictions}, new_state}
   end
 
   @impl GenServer

--- a/apps/predictions/lib/predictions_pub_sub.ex
+++ b/apps/predictions/lib/predictions_pub_sub.ex
@@ -1,0 +1,183 @@
+defmodule Predictions.PredictionsPubSub do
+  @moduledoc """
+  Allow channels to subscribe to prediction streams.
+  """
+
+  use GenServer
+
+  alias Predictions.{Prediction, StreamSupervisor}
+  alias Routes.Route
+
+  defstruct predictions_by_route_id: %{}
+
+  @type t :: %__MODULE__{
+          predictions_by_route_id: predictions_by_route_id()
+        }
+
+  @type predictions_by_route_id :: %{Route.id_t() => [Prediction.t()]}
+
+  @type broadcast_message :: {:new_predictions, [Prediction.t()]}
+
+  # Client
+
+  @spec start_link() :: GenServer.on_start()
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+
+    GenServer.start_link(
+      __MODULE__,
+      opts,
+      name: name
+    )
+  end
+
+  @spec subscribe(Route.id_t()) :: [Prediction.t()]
+  @spec subscribe(Route.id_t(), GenServer.server()) :: [Prediction.t()]
+  def subscribe(route_id, server \\ __MODULE__) do
+    StreamSupervisor.ensure_stream_is_started(route_id)
+    {registry_key, predictions} = GenServer.call(server, {:subscribe, route_id})
+    Registry.register(:prediction_subscriptions_registry, registry_key, route_id)
+    predictions
+  end
+
+  # Server
+
+  @impl GenServer
+  @spec init(keyword) :: {:ok, t()}
+  def init(opts) do
+    subscribe_fn = Keyword.get(opts, :subscribe_fn, &Phoenix.PubSub.subscribe/2)
+    subscribe_fn.(Predictions.PubSub, "predictions")
+    {:ok, %__MODULE__{}}
+  end
+
+  @impl GenServer
+  def handle_call(
+        {:subscribe, route_id},
+        _from,
+        %__MODULE__{predictions_by_route_id: predictions_by_route_id} = state
+      ) do
+    registry_key = self()
+    predictions = predictions_for_route_id(predictions_by_route_id, route_id)
+
+    {:reply, {registry_key, predictions}, state}
+  end
+
+  @impl GenServer
+  def handle_info(
+        {:reset, [%Predictions.Prediction{route: %Routes.Route{id: route_id}} | _] = predictions},
+        %__MODULE__{predictions_by_route_id: predictions_by_route_id} = state
+      ) do
+    new_state = %__MODULE__{
+      state
+      | predictions_by_route_id: Map.put(predictions_by_route_id, route_id, predictions)
+    }
+
+    broadcast(new_state)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info(
+        {:add,
+         [%Predictions.Prediction{route: %Routes.Route{id: route_id}} | _] = new_predictions},
+        %__MODULE__{predictions_by_route_id: predictions_by_route_id} = state
+      ) do
+    new_predictions_by_route_id =
+      Map.put(
+        predictions_by_route_id,
+        route_id,
+        predictions_for_route_id(predictions_by_route_id, route_id) ++ new_predictions
+      )
+
+    new_state = %__MODULE__{
+      state
+      | predictions_by_route_id: new_predictions_by_route_id
+    }
+
+    broadcast(new_state)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info(
+        {:update,
+         [%Predictions.Prediction{route: %Routes.Route{id: route_id}} | _] = updated_predictions},
+        %__MODULE__{predictions_by_route_id: predictions_by_route_id} = state
+      ) do
+    updated_prediction_ids = Enum.map(updated_predictions, & &1.id)
+
+    predictions_sans_old =
+      predictions_by_route_id
+      |> predictions_for_route_id(route_id)
+      |> Enum.reject(&Enum.member?(updated_prediction_ids, &1.id))
+
+    new_predictions_by_route_id =
+      Map.put(
+        predictions_by_route_id,
+        route_id,
+        predictions_sans_old ++ updated_predictions
+      )
+
+    new_state = %__MODULE__{
+      state
+      | predictions_by_route_id: new_predictions_by_route_id
+    }
+
+    broadcast(new_state)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info(
+        {:remove,
+         [%Predictions.Prediction{route: %Routes.Route{id: route_id}} | _] = predictions_to_remove},
+        %__MODULE__{predictions_by_route_id: predictions_by_route_id} = state
+      ) do
+    prediction_ids_to_remove = Enum.map(predictions_to_remove, & &1.id)
+
+    predictions_sans_removed =
+      predictions_by_route_id
+      |> predictions_for_route_id(route_id)
+      |> Enum.reject(&Enum.member?(prediction_ids_to_remove, &1.id))
+
+    new_predictions_by_route_id =
+      Map.put(
+        predictions_by_route_id,
+        route_id,
+        predictions_sans_removed
+      )
+
+    new_state = %__MODULE__{
+      state
+      | predictions_by_route_id: new_predictions_by_route_id
+    }
+
+    broadcast(new_state)
+
+    {:noreply, new_state}
+  end
+
+  @spec predictions_for_route_id(predictions_by_route_id(), Route.id_t()) :: [Prediction.t()]
+  defp predictions_for_route_id(predictions_by_route_id, route_id),
+    do: Map.get(predictions_by_route_id, route_id, [])
+
+  @spec broadcast(t()) :: :ok
+  defp broadcast(state) do
+    registry_key = self()
+
+    Registry.dispatch(:prediction_subscriptions_registry, registry_key, fn entries ->
+      Enum.each(entries, &send_data(&1, state))
+    end)
+  end
+
+  @spec send_data({pid, Route.id()}, t()) :: broadcast_message()
+  defp send_data({pid, route_id}, %__MODULE__{
+         predictions_by_route_id: predictions_by_route_id
+       }) do
+    send(
+      pid,
+      {:new_predictions, predictions_for_route_id(predictions_by_route_id, route_id)}
+    )
+  end
+end

--- a/apps/predictions/lib/predictions_pub_sub.ex
+++ b/apps/predictions/lib/predictions_pub_sub.ex
@@ -2,7 +2,7 @@ defmodule Predictions.PredictionsPubSub do
   @moduledoc """
   Allow channels to subscribe to prediction streams, which are collected into a
   Map with keys representing route-stop-direction triads as
-  "<route-id>-<parent-stop-id>-<direction-id>"
+  "<route-id>:<parent-stop-id>:<direction-id>"
   """
 
   use GenServer

--- a/apps/predictions/lib/predictions_pub_sub.ex
+++ b/apps/predictions/lib/predictions_pub_sub.ex
@@ -1,7 +1,8 @@
 defmodule Predictions.PredictionsPubSub do
   @moduledoc """
   Allow channels to subscribe to prediction streams, which are collected into a
-  Map with keys representing route-stop pairs as "<route-id>@<parent-stop-id>"
+  Map with keys representing route-stop-direction triads as
+  "<route-id>-<parent-stop-id>-<direction-id>"
   """
 
   use GenServer

--- a/apps/predictions/lib/stream.ex
+++ b/apps/predictions/lib/stream.ex
@@ -1,0 +1,64 @@
+defmodule Predictions.Stream do
+  @moduledoc """
+  Uses V3Api.Stream to subscribe to the V3Api and receive prediction events.
+  """
+
+  use GenStage
+  require Logger
+
+  alias V3Api.Stream.Event
+  alias Phoenix.PubSub
+  alias Predictions.{Prediction, Repo, StreamParser}
+
+  @type event_type :: :reset | :add | :update | :remove
+
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+
+    GenStage.start_link(
+      __MODULE__,
+      opts,
+      name: name
+    )
+  end
+
+  def init(opts) do
+    producer_consumer = Keyword.fetch!(opts, :subscribe_to)
+    broadcast_fn = Keyword.get(opts, :broadcast_fn, &PubSub.broadcast/3)
+    {:consumer, %{broadcast_fn: broadcast_fn}, subscribe_to: [producer_consumer]}
+  end
+
+  def handle_events(events, _from, state) do
+    :ok = Enum.each(events, &send_event(&1, state.broadcast_fn))
+    {:noreply, [], state}
+  end
+
+  defp send_event(
+         %Event{
+           event: type,
+           data: %JsonApi{data: data}
+         },
+         broadcast_fn
+       ) do
+    data
+    |> Enum.filter(&Repo.has_trip?/1)
+    |> Enum.map(&StreamParser.parse/1)
+    |> broadcast(type, broadcast_fn)
+  end
+
+  @typep broadcast_fn :: (atom, String.t(), any -> :ok | {:error, any})
+  @spec broadcast([Prediction.t() | String.t()], event_type, broadcast_fn) :: :ok
+  defp broadcast([], _type, _broadcast_fn), do: :ok
+
+  defp broadcast(data, type, broadcast_fn) do
+    Predictions.PubSub
+    |> broadcast_fn.("predictions", {type, data})
+    |> log_errors()
+  end
+
+  @spec log_errors(:ok | {:error, any}) :: :ok
+  defp log_errors(:ok), do: :ok
+
+  defp log_errors({:error, error}),
+    do: Logger.error("module=#{__MODULE__} error=#{inspect(error)}")
+end

--- a/apps/predictions/lib/stream_parser.ex
+++ b/apps/predictions/lib/stream_parser.ex
@@ -68,10 +68,18 @@ defmodule Predictions.StreamParser do
 
   defp trip(_), do: nil
 
+  # Predictions are generally associated in the API with child stops. Find the
+  # parent stop and store that ID.
   @spec stop(Item.t()) :: Stops.Stop.t() | nil
-  defp stop(%Item{relationships: %{"stop" => [%Item{id: id, attributes: attributes} | _]}}) do
+  defp stop(%Item{relationships: %{"stop" => [%Item{id: id, attributes: attributes}]}}) do
+    stop_id =
+      case Stops.Repo.get_parent(id) do
+        %Stop{id: parent_id} -> parent_id
+        nil -> id
+      end
+
     %Stop{
-      id: id,
+      id: stop_id,
       name: attributes["name"]
     }
   end

--- a/apps/predictions/lib/stream_parser.ex
+++ b/apps/predictions/lib/stream_parser.ex
@@ -10,10 +10,12 @@ defmodule Predictions.StreamParser do
   alias Stops.Stop
 
   @spec parse(Item.t()) :: Prediction.t()
-  def parse(%JsonApi.Item{} = item) do
+  def parse(%Item{} = item) do
     %Prediction{
       id: item.id,
+      arrival_time: arrival_time(item),
       departing?: Parser.departing?(item),
+      departure_time: departure_time(item),
       direction_id: Parser.direction_id(item),
       route: route(item),
       stop: stop(item),
@@ -24,6 +26,24 @@ defmodule Predictions.StreamParser do
       status: Parser.status(item),
       track: Parser.track(item)
     }
+  end
+
+  @spec arrival_time(Item.t()) :: DateTime.t() | nil
+  defp arrival_time(%Item{attributes: %{"arrival_time" => time}}) when is_binary(time),
+    do: parse_time(time)
+
+  defp arrival_time(_), do: nil
+
+  @spec departure_time(Item.t()) :: DateTime.t() | nil
+  defp departure_time(%Item{attributes: %{"departure_time" => time}}) when is_binary(time),
+    do: parse_time(time)
+
+  defp departure_time(_), do: nil
+
+  @spec parse_time(String.t()) :: DateTime.t()
+  defp parse_time(time) do
+    {:ok, dt, _} = DateTime.from_iso8601(time)
+    dt
   end
 
   @spec route(Item.t()) :: Route.t() | nil

--- a/apps/predictions/lib/stream_parser.ex
+++ b/apps/predictions/lib/stream_parser.ex
@@ -66,8 +66,6 @@ defmodule Predictions.StreamParser do
 
   defp included_route(_), do: nil
 
-
-
   @spec included_trip(Item.t()) :: Trip.t() | nil
   defp included_trip(%Item{relationships: %{"trip" => [%Item{id: id} | _]}}),
     do: Schedules.Repo.trip(id)

--- a/apps/predictions/lib/stream_supervisor.ex
+++ b/apps/predictions/lib/stream_supervisor.ex
@@ -1,11 +1,11 @@
 defmodule Predictions.StreamSupervisor do
   @moduledoc """
-  DynamicSupervisor managing per-route streams of predictions from the API.
+  DynamicSupervisor managing streams of predictions from the API.
   """
 
   use DynamicSupervisor
 
-  alias Routes.Route
+  alias Predictions.PredictionsPubSub
 
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts), do: DynamicSupervisor.start_link(__MODULE__, opts, name: __MODULE__)
@@ -15,46 +15,51 @@ defmodule Predictions.StreamSupervisor do
     DynamicSupervisor.init(strategy: :one_for_one)
   end
 
-  @spec ensure_stream_is_started(Route.id_t()) :: {:ok, pid()} | :bypassed
-  def ensure_stream_is_started(route_id),
-    do: ensure_stream_is_started(route_id, System.get_env("USE_SERVER_SENT_EVENTS"))
+  @spec ensure_stream_is_started(PredictionsPubSub.prediction_key()) :: {:ok, pid()} | :bypassed
+  def ensure_stream_is_started(route_stop_direction),
+    do: ensure_stream_is_started(route_stop_direction, System.get_env("USE_SERVER_SENT_EVENTS"))
 
-  defp ensure_stream_is_started(_route_id, "false"), do: :bypassed
+  defp ensure_stream_is_started(_route_stop_direction, "false"), do: :bypassed
 
-  defp ensure_stream_is_started(route_id, _) do
-    case lookup(route_id) do
+  defp ensure_stream_is_started(route_stop_direction, _) do
+    case lookup(route_stop_direction) do
       nil ->
-        start_stream(route_id)
+        start_stream(route_stop_direction)
 
       pid ->
         {:ok, pid}
     end
   end
 
-  @spec lookup(Route.id_t()) :: pid() | nil
-  defp lookup(route_id) do
-    case Registry.lookup(:prediction_streams_registry, route_id) do
+  @spec lookup(PredictionsPubSub.prediction_key()) :: pid() | nil
+  defp lookup(route_stop_direction) do
+    case Registry.lookup(:prediction_streams_registry, route_stop_direction) do
       [{pid, _}] -> if Process.alive?(pid), do: pid
       _ -> nil
     end
   end
 
-  @spec start_stream(Route.id_t()) :: {:ok, pid()}
-  defp start_stream(route_id) do
+  @spec start_stream(PredictionsPubSub.prediction_key()) :: {:ok, pid()}
+  defp start_stream(route_stop_direction) do
     with {:ok, sses_pid} <-
-           DynamicSupervisor.start_child(__MODULE__, {ServerSentEventStage, sses_opts(route_id)}),
+           DynamicSupervisor.start_child(
+             __MODULE__,
+             {ServerSentEventStage, sses_opts(route_stop_direction)}
+           ),
+         api_stream_name <- api_stream_name(route_stop_direction),
+         sses_stream_name <- sses_stream_name(route_stop_direction),
+         prediction_stream_name <- prediction_stream_name(route_stop_direction),
          {:ok, _api_stream_pid} <-
            DynamicSupervisor.start_child(
              __MODULE__,
-             {V3Api.Stream,
-              name: api_stream_name(route_id), subscribe_to: sses_stream_name(route_id)}
+             {V3Api.Stream, name: api_stream_name, subscribe_to: sses_stream_name}
            ),
          {:ok, _predictions_stream_pid} <-
            DynamicSupervisor.start_child(
              __MODULE__,
-             {Predictions.Stream, subscribe_to: api_stream_name(route_id)}
+             {Predictions.Stream, name: prediction_stream_name, subscribe_to: api_stream_name}
            ) do
-      Registry.register(:prediction_streams_registry, route_id, sses_pid)
+      Registry.register(:prediction_streams_registry, route_stop_direction, sses_pid)
       {:ok, sses_pid}
     else
       {:error, {:already_started, pid}} ->
@@ -62,23 +67,34 @@ defmodule Predictions.StreamSupervisor do
     end
   end
 
-  @spec sses_opts(Route.id_t()) :: Keyword.t()
-  defp sses_opts(route_id) do
+  @spec sses_opts(PredictionsPubSub.prediction_key()) :: Keyword.t()
+  defp sses_opts(route_stop_direction) do
+    [route_id, stop_id, direction_id] = String.split(route_stop_direction, ":")
+
+    filters =
+      "filter[route]=#{route_id}&filter[stop]=#{stop_id}&filter[direction_id]=#{direction_id}"
+
     path =
-      "/predictions?filter[route]=#{route_id}&fields[prediction]=status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence&include=route,trip,trip.occupancies,stop&fields[route]=direction_destinations,direction_names,long_name,short_name,type&fields[trip]=direction_id,headsign,name,bikes_allowed&fields[stop]=platform_code"
+      "/predictions?#{filters}&fields[prediction]=status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence&include=route,trip,trip.occupancies,stop&fields[route]=long_name,short_name,type&fields[trip]=direction_id,headsign,name,bikes_allowed&fields[stop]=platform_code"
 
     sses_opts =
       V3Api.Stream.build_options(
-        name: sses_stream_name(route_id),
+        name: sses_stream_name(route_stop_direction),
         path: path
       )
 
     sses_opts
   end
 
-  @spec sses_stream_name(Route.id_t()) :: atom()
-  defp sses_stream_name(route_id), do: :"predictions_sses_stream_#{route_id}"
+  @spec sses_stream_name(PredictionsPubSub.prediction_key()) :: atom()
+  defp sses_stream_name(route_stop_direction),
+    do: :"predictions_sses_stream_#{route_stop_direction}"
 
-  @spec api_stream_name(Route.id_t()) :: atom()
-  defp api_stream_name(route_id), do: :"predictions_api_stream_#{route_id}"
+  @spec api_stream_name(PredictionsPubSub.prediction_key()) :: atom()
+  defp api_stream_name(route_stop_direction),
+    do: :"predictions_api_stream_#{route_stop_direction}"
+
+  @spec prediction_stream_name(PredictionsPubSub.prediction_key()) :: atom()
+  defp prediction_stream_name(route_stop_direction),
+    do: :"predictions_data_stream_#{route_stop_direction}"
 end

--- a/apps/predictions/lib/stream_supervisor.ex
+++ b/apps/predictions/lib/stream_supervisor.ex
@@ -1,0 +1,84 @@
+defmodule Predictions.StreamSupervisor do
+  @moduledoc """
+  DynamicSupervisor managing per-route streams of predictions from the API.
+  """
+
+  use DynamicSupervisor
+
+  alias Routes.Route
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts), do: DynamicSupervisor.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl DynamicSupervisor
+  def init(_) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  @spec ensure_stream_is_started(Route.id_t()) :: {:ok, pid()} | :bypassed
+  def ensure_stream_is_started(route_id),
+    do: ensure_stream_is_started(route_id, System.get_env("USE_SERVER_SENT_EVENTS"))
+
+  defp ensure_stream_is_started(_route_id, "false"), do: :bypassed
+
+  defp ensure_stream_is_started(route_id, _) do
+    case lookup(route_id) do
+      nil ->
+        start_stream(route_id)
+
+      pid ->
+        {:ok, pid}
+    end
+  end
+
+  @spec lookup(Route.id_t()) :: pid() | nil
+  defp lookup(route_id) do
+    case Registry.lookup(:prediction_streams_registry, route_id) do
+      [{pid, _}] -> if Process.alive?(pid), do: pid
+      _ -> nil
+    end
+  end
+
+  @spec start_stream(Route.id_t()) :: {:ok, pid()}
+  defp start_stream(route_id) do
+    with {:ok, sses_pid} <-
+           DynamicSupervisor.start_child(__MODULE__, {ServerSentEventStage, sses_opts(route_id)}),
+         {:ok, _api_stream_pid} <-
+           DynamicSupervisor.start_child(
+             __MODULE__,
+             {V3Api.Stream,
+              name: api_stream_name(route_id), subscribe_to: sses_stream_name(route_id)}
+           ),
+         {:ok, _predictions_stream_pid} <-
+           DynamicSupervisor.start_child(
+             __MODULE__,
+             {Predictions.Stream, subscribe_to: api_stream_name(route_id)}
+           ) do
+      Registry.register(:prediction_streams_registry, route_id, sses_pid)
+      {:ok, sses_pid}
+    else
+      {:error, {:already_started, pid}} ->
+        {:ok, pid}
+    end
+  end
+
+  @spec sses_opts(Route.id_t()) :: Keyword.t()
+  defp sses_opts(route_id) do
+    path =
+      "/predictions?filter[route]=#{route_id}&fields[prediction]=status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence&include=route,trip,trip.occupancies,stop&fields[route]=direction_destinations,direction_names,long_name,short_name,type&fields[trip]=direction_id,headsign,name,bikes_allowed&fields[stop]=platform_code"
+
+    sses_opts =
+      V3Api.Stream.build_options(
+        name: sses_stream_name(route_id),
+        path: path
+      )
+
+    sses_opts
+  end
+
+  @spec sses_stream_name(Route.id_t()) :: atom()
+  defp sses_stream_name(route_id), do: :"predictions_sses_stream_#{route_id}"
+
+  @spec api_stream_name(Route.id_t()) :: atom()
+  defp api_stream_name(route_id), do: :"predictions_api_stream_#{route_id}"
+end

--- a/apps/predictions/lib/stream_supervisor.ex
+++ b/apps/predictions/lib/stream_supervisor.ex
@@ -34,8 +34,11 @@ defmodule Predictions.StreamSupervisor do
   @spec lookup(PredictionsPubSub.prediction_key()) :: pid() | nil
   defp lookup(route_stop_direction) do
     case Registry.lookup(:prediction_streams_registry, route_stop_direction) do
-      [{pid, _}] -> if Process.alive?(pid), do: pid
-      _ -> nil
+      [{_pid, sses_pid}] ->
+        if Process.alive?(sses_pid), do: sses_pid
+
+      _ ->
+        nil
     end
   end
 

--- a/apps/predictions/mix.exs
+++ b/apps/predictions/mix.exs
@@ -38,6 +38,8 @@ defmodule Predictions.Mixfile do
       {:timex, ">= 0.0.0"},
       {:bypass, "~> 1.0", only: :test},
       {:repo_cache, in_umbrella: true},
+      {:phoenix_pubsub, "~> 1.0"},
+      {:server_sent_event_stage, "~> 1.0"},
       {:schedules, in_umbrella: true},
       {:stops, in_umbrella: true},
       {:routes, in_umbrella: true}

--- a/apps/predictions/test/parser_test.exs
+++ b/apps/predictions/test/parser_test.exs
@@ -59,7 +59,7 @@ defmodule Predictions.ParserTest do
         "place-pktrm",
         "route_id",
         0,
-        ~N[2016-01-01T04:00:00] |> Timezone.convert("Etc/GMT+4"),
+        ~N[2016-09-15T19:40:00] |> Timezone.convert("Etc/GMT+4"),
         5,
         nil,
         "5",

--- a/apps/predictions/test/predictions_pub_sub_test.exs
+++ b/apps/predictions/test/predictions_pub_sub_test.exs
@@ -1,0 +1,168 @@
+defmodule Predictions.PredictionsPubSubTest do
+  use ExUnit.Case
+
+  alias Predictions.{Prediction, PredictionsPubSub}
+  alias Routes.Route
+
+  @route_39 "39"
+  @route_66 "66"
+  @prediction39 %Prediction{id: "prediction39", route: %Route{id: @route_39}}
+  @prediction66 %Prediction{id: "prediction66", route: %Route{id: @route_66}}
+
+  describe "start_link/1" do
+    test "starts the server" do
+      subscribe_fn = fn _, _ -> :ok end
+
+      assert {:ok, _pid} =
+               PredictionsPubSub.start_link(name: :start_link, subscribe_fn: subscribe_fn)
+    end
+  end
+
+  describe "subscribe/2" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = PredictionsPubSub.start_link(name: :subscribe, subscribe_fn: subscribe_fn)
+
+      {:ok, pid: pid}
+    end
+
+    test "clients get existing predictions upon subscribing", %{pid: pid} do
+      predictions = [@prediction39]
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :predictions_by_route_id, %{@route_39 => predictions})
+      end)
+
+      assert PredictionsPubSub.subscribe(@route_39, pid) == predictions
+    end
+  end
+
+  describe "handle_info/2 - {:reset, predictions}" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = PredictionsPubSub.start_link(name: :subscribe, subscribe_fn: subscribe_fn)
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :predictions_by_route_id, %{@route_39 => [1, 2, 3]})
+      end)
+
+      {:ok, pid: pid}
+    end
+
+    test "resets the predictions", %{pid: pid} do
+      send(pid, {:reset, [@prediction39]})
+
+      assert pid |> :sys.get_state() |> Map.get(:predictions_by_route_id) |> Map.get(@route_39) ==
+               [
+                 @prediction39
+               ]
+    end
+
+    test "broadcasts new predictions lists to subscribers", %{pid: pid} do
+      PredictionsPubSub.subscribe(@route_39, pid)
+
+      send(pid, {:reset, [@prediction66]})
+      send(pid, {:reset, [@prediction39]})
+
+      assert_receive {:new_predictions, [@prediction39]}
+      refute_receive {:new_predictions, [@prediction66]}
+    end
+  end
+
+  describe "handle_info/2 - {:add, predictions}" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = PredictionsPubSub.start_link(name: :subscribe, subscribe_fn: subscribe_fn)
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :predictions_by_route_id, %{})
+      end)
+
+      {:ok, pid: pid}
+    end
+
+    test "adds the new predictions by route ID", %{pid: pid} do
+      send(pid, {:add, [@prediction39]})
+
+      assert pid |> :sys.get_state() |> Map.get(:predictions_by_route_id) ==
+               %{@route_39 => [@prediction39]}
+    end
+
+    test "broadcasts new predictions lists to subscribers", %{pid: pid} do
+      PredictionsPubSub.subscribe(@route_39, pid)
+
+      send(pid, {:add, [@prediction66]})
+      send(pid, {:add, [@prediction39]})
+
+      assert_receive {:new_predictions, [@prediction39]}
+      refute_receive {:new_predictions, [@prediction66]}
+    end
+  end
+
+  describe "handle_info/2 - {:update, predictions}" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = PredictionsPubSub.start_link(name: :subscribe, subscribe_fn: subscribe_fn)
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :predictions_by_route_id, %{@route_39 => [@prediction39]})
+      end)
+
+      {:ok, pid: pid}
+    end
+
+    test "updates the predictions", %{pid: pid} do
+      send(pid, {:update, [@prediction39]})
+
+      assert pid |> :sys.get_state() |> Map.get(:predictions_by_route_id) ==
+               %{@route_39 => [@prediction39]}
+    end
+
+    test "broadcasts new predictions lists to subscribers", %{pid: pid} do
+      PredictionsPubSub.subscribe(@route_39, pid)
+
+      send(pid, {:update, [@prediction66]})
+      send(pid, {:update, [@prediction39]})
+
+      assert_receive {:new_predictions, [@prediction39]}
+      refute_receive {:new_predictions, [@prediction66]}
+    end
+  end
+
+  describe "handle_info/2 - {:remove, prediction_ids}" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = PredictionsPubSub.start_link(name: :subscribe, subscribe_fn: subscribe_fn)
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :predictions_by_route_id, %{@route_39 => [@prediction39]})
+      end)
+
+      {:ok, pid: pid}
+    end
+
+    test "removes the given predictions", %{pid: pid} do
+      send(pid, {:remove, [@prediction39]})
+
+      assert pid |> :sys.get_state() |> Map.get(:predictions_by_route_id) == %{@route_39 => []}
+    end
+
+    test "broadcasts new predictions lists to subscribers", %{pid: pid} do
+      PredictionsPubSub.subscribe(@route_39, pid)
+
+      send(pid, {:remove, [@prediction39]})
+
+      assert_receive {:new_predictions, []}
+    end
+  end
+end

--- a/apps/predictions/test/predictions_pub_sub_test.exs
+++ b/apps/predictions/test/predictions_pub_sub_test.exs
@@ -142,10 +142,20 @@ defmodule Predictions.PredictionsPubSubTest do
     end
 
     test "updates the predictions", %{pid: pid} do
-      send(pid, {:update, [@prediction39]})
+      modified_prediction = %{
+        @prediction39
+        | status: "Now boarding"
+      }
 
-      assert pid |> :sys.get_state() |> Map.get(:predictions_by_key) ==
-               %{"#{@route_39}:#{@stop_id}:#{@direction_id}" => [@prediction39]}
+      send(pid, {:update, [modified_prediction]})
+
+      [prediction] =
+        pid
+        |> :sys.get_state()
+        |> Map.get(:predictions_by_key)
+        |> Map.get("#{@route_39}:#{@stop_id}:#{@direction_id}")
+
+      assert prediction.status == "Now boarding"
     end
 
     test "broadcasts new predictions lists to subscribers", %{pid: pid} do

--- a/apps/predictions/test/repo_test.exs
+++ b/apps/predictions/test/repo_test.exs
@@ -109,7 +109,8 @@ defmodule Predictions.RepoTest do
                       "type": "prediction",
                       "id": "1",
                       "attributes": {
-                        "arrival_time": "2016-01-01T00:00:00-05:00"
+                        "arrival_time": "2016-01-01T00:00:00-05:00",
+                        "direction_id": 0
                       },
                       "relationships": {
                         "route": {"data": {"type": "route", "id": "Red"}},
@@ -121,7 +122,8 @@ defmodule Predictions.RepoTest do
                       "type": "prediction",
                       "id": "1",
                       "attributes": {
-                        "arrival_time": "#{in_five_mins}"
+                        "arrival_time": "#{in_five_mins}",
+                        "direction_id": 0
                       },
                       "relationships": {
                         "route": {"data": {"type": "route", "id": "Red"}},
@@ -177,7 +179,8 @@ defmodule Predictions.RepoTest do
                   "type": "prediction",
                   "id": "1",
                   "attributes": {
-                    "arrival_time": "2016-01-01T00:00:00-05:00"
+                    "arrival_time": "2016-01-01T00:00:00-05:00",
+                    "direction_id": 0
                   },
                   "relationships": {
                     "route": {"data": {"type": "route", "id": "Red"}},
@@ -188,7 +191,8 @@ defmodule Predictions.RepoTest do
                   "type": "prediction",
                   "id": "2",
                   "attributes": {
-                    "arrival_time": "#{in_five_mins}"
+                    "arrival_time": "#{in_five_mins}",
+                    "direction_id": 0
                   },
                   "relationships": {
                     "route": {"data": {"type": "route", "id": "Red"}},

--- a/apps/predictions/test/stream_parser_test.exs
+++ b/apps/predictions/test/stream_parser_test.exs
@@ -1,0 +1,98 @@
+defmodule Predictions.StreamParserTest do
+  use ExUnit.Case, async: true
+
+  alias JsonApi.Item
+  alias Predictions.{Prediction, StreamParser}
+  alias Routes.Route
+  alias Schedules.Trip
+  alias Stops.Stop
+  alias Timex.Timezone
+
+  describe "parse/1" do
+    test "parses a %JsonApi.Item{} into a Prediction record" do
+      item = %Item{
+        id: "TEST-ID",
+        attributes: %{
+          "arrival_time" => "2016-01-01T00:00:00-04:00",
+          "bikes_allowed" => 1,
+          "departure_time" => "2016-09-15T15:40:00-04:00",
+          "direction_id" => 1,
+          "headsign" => "Back Bay",
+          "name" => "",
+          "status" => "On Time"
+        },
+        relationships: %{
+          "facilities" => [],
+          "parent_station" => [],
+          "route" => [
+            %Item{
+              id: "route_id",
+              attributes: %{
+                "long_name" => "Route",
+                "short_name" => "Route",
+                "type" => 5
+              }
+            },
+            %Item{id: "wrong"}
+          ],
+          "stop" => [
+            %Item{id: "place-pktrm", attributes: %{"name" => "Stop"}},
+            %Item{id: "wrong"}
+          ],
+          "trip" => [
+            %Item{
+              id: "trip_id",
+              attributes: %{
+                "name" => "trip_name",
+                "direction_id" => "0",
+                "headsign" => "trip_headsign"
+              }
+            },
+            %Item{
+              id: "wrong",
+              attributes: %{
+                "name" => "trip_name",
+                "direction_id" => "0",
+                "headsign" => "trip_headsign"
+              }
+            }
+          ],
+          "zone" => [
+            %JsonApi.Item{
+              attributes: nil,
+              id: "LocalBus",
+              relationships: nil,
+              type: "zone"
+            }
+          ]
+        },
+        type: "stop"
+      }
+
+      expected = %Prediction{
+        id: "TEST-ID",
+        departing?: true,
+        direction_id: 1,
+        route: %Route{
+          id: "route_id",
+          type: 5
+        },
+        status: "On Time",
+        stop: %Stop{
+          id: "place-pktrm",
+          name: "Stop"
+        },
+        stop_sequence: 0,
+        time: ~N[2016-01-01T04:00:00] |> Timezone.convert("Etc/GMT+4"),
+        trip: %Trip{
+          id: "trip_id",
+          name: "trip_name",
+          direction_id: "0",
+          headsign: "trip_headsign"
+        }
+      }
+
+      assert StreamParser.parse(item) == expected
+    end
+  end
+end

--- a/apps/predictions/test/stream_parser_test.exs
+++ b/apps/predictions/test/stream_parser_test.exs
@@ -36,8 +36,7 @@ defmodule Predictions.StreamParserTest do
             %Item{id: "wrong"}
           ],
           "stop" => [
-            %Item{id: "place-pktrm", attributes: %{"name" => "Stop"}},
-            %Item{id: "wrong"}
+            %Item{id: "place-pktrm", attributes: %{"name" => "Stop", "platform_code" => 99}}
           ],
           "trip" => [
             %Item{
@@ -86,6 +85,7 @@ defmodule Predictions.StreamParserTest do
         },
         stop_sequence: 0,
         time: ~N[2016-01-01T04:00:00] |> Timezone.convert("Etc/GMT+4"),
+        track: 99,
         trip: %Trip{
           id: "trip_id",
           name: "trip_name",

--- a/apps/predictions/test/stream_parser_test.exs
+++ b/apps/predictions/test/stream_parser_test.exs
@@ -64,7 +64,7 @@ defmodule Predictions.StreamParserTest do
       assert %Route{id: "route_id"} = route
       assert %Stop{id: "place-pktrm"} = stop
       assert %Trip{id: "trip_id"} = trip
-      assert time == ~N[2016-01-01T04:00:00] |> Timezone.convert("Etc/GMT+4")
+      assert time == ~N[2016-09-15 19:40:00] |> Timezone.convert("Etc/GMT+4")
       assert track == stop.platform_code
     end
   end

--- a/apps/predictions/test/stream_parser_test.exs
+++ b/apps/predictions/test/stream_parser_test.exs
@@ -71,7 +71,9 @@ defmodule Predictions.StreamParserTest do
 
       expected = %Prediction{
         id: "TEST-ID",
+        arrival_time: ~U[2016-01-01 04:00:00Z],
         departing?: true,
+        departure_time: ~U[2016-09-15 19:40:00Z],
         direction_id: 1,
         route: %Route{
           id: "route_id",

--- a/apps/predictions/test/stream_parser_test.exs
+++ b/apps/predictions/test/stream_parser_test.exs
@@ -1,5 +1,5 @@
 defmodule Predictions.StreamParserTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   import Mock
   alias JsonApi.Item
   alias Predictions.{Prediction, StreamParser}

--- a/apps/predictions/test/stream_supervisor_test.exs
+++ b/apps/predictions/test/stream_supervisor_test.exs
@@ -1,0 +1,20 @@
+defmodule Predictions.StreamSupervisorTest do
+  use ExUnit.Case
+
+  alias Predictions.StreamSupervisor
+
+  describe "start_link/1" do
+    test "StreamSupervisor is started along with registry" do
+      assert {:error, {:already_started, _}} = StreamSupervisor.start_link([])
+
+      assert {:error, {:already_started, _}} =
+               Registry.start_link(keys: :unique, name: :prediction_streams_registry)
+    end
+  end
+
+  describe "ensure_stream_is_started/1" do
+    test "starts a stream if not already started" do
+      assert {:ok, _pid} = StreamSupervisor.ensure_stream_is_started(1)
+    end
+  end
+end

--- a/apps/predictions/test/stream_supervisor_test.exs
+++ b/apps/predictions/test/stream_supervisor_test.exs
@@ -1,7 +1,21 @@
 defmodule Predictions.StreamSupervisorTest do
   use ExUnit.Case
-
   alias Predictions.StreamSupervisor
+
+  setup_all do
+    old_value = System.get_env("USE_SERVER_SENT_EVENTS")
+    System.put_env("USE_SERVER_SENT_EVENTS", "true")
+
+    on_exit(fn ->
+      if old_value do
+        System.put_env("USE_SERVER_SENT_EVENTS", old_value)
+      else
+        System.delete_env("USE_SERVER_SENT_EVENTS")
+      end
+    end)
+
+    :ok
+  end
 
   describe "start_link/1" do
     test "StreamSupervisor is started along with registry" do
@@ -12,10 +26,22 @@ defmodule Predictions.StreamSupervisorTest do
     end
   end
 
+  describe "init/1" do
+    test "StreamSupervisor runs DynamicSupervisor.init" do
+      {:ok, %{strategy: :one_for_one}} = StreamSupervisor.init([])
+    end
+  end
+
   describe "ensure_stream_is_started/1" do
     test "starts a stream if not already started" do
       prediction_key = "Purple:awesome-station:1"
       assert {:ok, _pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
+    end
+
+    test "returns existing stream from registry" do
+      prediction_key = "Pink:place:1"
+      {:ok, pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
+      assert {:ok, ^pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
     end
   end
 end

--- a/apps/predictions/test/stream_supervisor_test.exs
+++ b/apps/predictions/test/stream_supervisor_test.exs
@@ -14,7 +14,8 @@ defmodule Predictions.StreamSupervisorTest do
 
   describe "ensure_stream_is_started/1" do
     test "starts a stream if not already started" do
-      assert {:ok, _pid} = StreamSupervisor.ensure_stream_is_started(1)
+      prediction_key = "Purple:awesome-station:1"
+      assert {:ok, _pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
     end
   end
 end

--- a/apps/predictions/test/stream_test.exs
+++ b/apps/predictions/test/stream_test.exs
@@ -1,0 +1,110 @@
+defmodule Predictions.StreamTest do
+  use ExUnit.Case
+
+  alias JsonApi.Item
+  alias Predictions.{Prediction, Stream}
+  alias Timex.Timezone
+
+  @predictions_data %JsonApi{
+    data: [
+      %Item{
+        id: "prediction1",
+        attributes: %{
+          "track" => "5",
+          "status" => "On Time",
+          "direction_id" => 0,
+          "departure_time" => "2016-09-15T15:40:00-04:00",
+          "arrival_time" => "2016-01-01T00:00:00-04:00",
+          "stop_sequence" => 5
+        },
+        relationships: %{
+          "route" => [
+            %Item{
+              id: "route_id",
+              attributes: %{
+                "long_name" => "Route",
+                "direction_names" => ["East", "West"],
+                "type" => 5
+              }
+            },
+            %Item{id: "wrong"}
+          ],
+          "stop" => [
+            %Item{id: "place-pktrm", attributes: %{"name" => "Stop"}},
+            %Item{id: "wrong"}
+          ],
+          "trip" => [
+            %Item{
+              id: "trip_id",
+              attributes: %{
+                "name" => "trip_name",
+                "direction_id" => "0",
+                "headsign" => "trip_headsign"
+              }
+            },
+            %Item{
+              id: "wrong",
+              attributes: %{
+                "name" => "trip_name",
+                "direction_id" => "0",
+                "headsign" => "trip_headsign"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+
+  describe "start_link/1" do
+    test "starts a GenServer that publishes predictions it receives from the API" do
+      {:ok, mock_api} =
+        GenStage.from_enumerable([
+          %V3Api.Stream.Event{event: :reset, data: @predictions_data}
+        ])
+
+      test_pid = self()
+
+      broadcast_fn = fn Predictions.PubSub, "predictions", {type, data} ->
+        send(test_pid, {type, data})
+        :ok
+      end
+
+      assert {:ok, _} =
+               Stream.start_link(
+                 name: :start_link_test,
+                 broadcast_fn: broadcast_fn,
+                 subscribe_to: mock_api
+               )
+
+      assert_receive {:reset, data}
+      assert [%Prediction{id: "prediction1"}] = data
+    end
+  end
+
+  describe "handle_events/3" do
+    test "publishes :remove events as a list of Prediction structs" do
+      {:ok, mock_api} =
+        GenStage.from_enumerable([
+          %V3Api.Stream.Event{event: :remove, data: @predictions_data}
+        ])
+
+      test_pid = self()
+
+      broadcast_fn = fn Predictions.PubSub, "predictions", {type, data} ->
+        send(test_pid, {:received_broadcast, {type, data}})
+        :ok
+      end
+
+      assert {:ok, _} =
+               Stream.start_link(
+                 name: :remove_as_ids_test,
+                 broadcast_fn: broadcast_fn,
+                 subscribe_to: mock_api
+               )
+
+      assert_receive {:received_broadcast, {:remove, data}}
+      assert [%Prediction{id: "prediction1"}] = data
+    end
+  end
+end

--- a/apps/predictions/test/stream_test.exs
+++ b/apps/predictions/test/stream_test.exs
@@ -3,7 +3,6 @@ defmodule Predictions.StreamTest do
 
   alias JsonApi.Item
   alias Predictions.{Prediction, Stream}
-  alias Timex.Timezone
 
   @predictions_data %JsonApi{
     data: [

--- a/apps/routes/lib/parser.ex
+++ b/apps/routes/lib/parser.ex
@@ -26,16 +26,16 @@ defmodule Routes.Parser do
     {parse_route(item), parse_route_patterns(relationships)}
   end
 
+  @spec name(map) :: String.t()
+  def name(%{"type" => 3, "short_name" => short_name}) when short_name != "", do: short_name
+  def name(%{"short_name" => short_name, "long_name" => ""}), do: short_name
+  def name(%{"long_name" => long_name}), do: long_name
+
   defp parse_route_patterns(%{"route_patterns" => route_patterns}) do
     Enum.map(route_patterns, &RoutePattern.new(&1))
   end
 
   defp parse_route_patterns(_), do: []
-
-  @spec name(map) :: String.t()
-  defp name(%{"type" => 3, "short_name" => short_name}) when short_name != "", do: short_name
-  defp name(%{"short_name" => short_name, "long_name" => ""}), do: short_name
-  defp name(%{"long_name" => long_name}), do: long_name
 
   @spec direction_attrs([String.t()], [Item.t()]) :: %{
           0 => String.t() | nil,

--- a/apps/site/lib/site_web/channels/predictions_channel.ex
+++ b/apps/site/lib/site_web/channels/predictions_channel.ex
@@ -27,7 +27,7 @@ defmodule SiteWeb.PredictionsChannel do
   @impl Channel
   @spec handle_info({:new_predictions, [Prediction.t()]}, Socket.t()) :: {:noreply, Socket.t()}
   def handle_info({:new_predictions, predictions}, socket) do
-    :ok = push(socket, "predictions", %{predictions: predictions})
+    :ok = push(socket, "data", %{predictions: predictions})
     {:noreply, socket}
   end
 end

--- a/apps/site/lib/site_web/channels/predictions_channel.ex
+++ b/apps/site/lib/site_web/channels/predictions_channel.ex
@@ -1,0 +1,32 @@
+defmodule SiteWeb.PredictionsChannel do
+  @moduledoc """
+  Channel allowing clients to subscribe to streams of predictions.
+  """
+  use SiteWeb, :channel
+
+  alias Phoenix.{Channel, Socket}
+  alias Predictions.{Prediction, PredictionsPubSub}
+
+  @impl Channel
+  @spec join(topic :: binary(), payload :: Channel.payload(), socket :: Socket.t()) ::
+          {:ok, %{predictions: [Prediction.t()]}, Socket.t()}
+  def join("predictions:" <> route_id, _message, socket) do
+    predictions_subscribe_fn =
+      Application.get_env(
+        :site,
+        :predictions_subscribe_fn,
+        &PredictionsPubSub.subscribe/1
+      )
+
+    predictions = predictions_subscribe_fn.(route_id)
+
+    {:ok, %{predictions: predictions}, socket}
+  end
+
+  @impl Channel
+  @spec handle_info({:new_predictions, [Prediction.t()]}, Socket.t()) :: {:noreply, Socket.t()}
+  def handle_info({:new_predictions, predictions}, socket) do
+    :ok = push(socket, "predictions", %{predictions: predictions})
+    {:noreply, socket}
+  end
+end

--- a/apps/site/lib/site_web/channels/predictions_channel.ex
+++ b/apps/site/lib/site_web/channels/predictions_channel.ex
@@ -21,7 +21,11 @@ defmodule SiteWeb.PredictionsChannel do
     [route_id, stop_id, direction_id] = String.split(route_stop_direction, ":")
     predictions = predictions_subscribe_fn.(route_id, stop_id, direction_id)
 
-    {:ok, %{predictions: predictions}, socket}
+    # remove old predictions
+    future_predictions = Enum.filter(predictions, &is_in_future?/1)
+    # immediately push current predictions to socket
+    send(self(), {:new_predictions, future_predictions})
+    {:ok, socket}
   end
 
   @impl Channel
@@ -30,4 +34,9 @@ defmodule SiteWeb.PredictionsChannel do
     :ok = push(socket, "data", %{predictions: predictions})
     {:noreply, socket}
   end
+
+  defp is_in_future?(%Prediction{departure_time: %DateTime{} = d}),
+    do: Util.time_is_greater_or_equal?(d, Util.now())
+
+  defp is_in_future?(_), do: false
 end

--- a/apps/site/lib/site_web/channels/predictions_channel.ex
+++ b/apps/site/lib/site_web/channels/predictions_channel.ex
@@ -10,15 +10,16 @@ defmodule SiteWeb.PredictionsChannel do
   @impl Channel
   @spec join(topic :: binary(), payload :: Channel.payload(), socket :: Socket.t()) ::
           {:ok, %{predictions: [Prediction.t()]}, Socket.t()}
-  def join("predictions:" <> route_id, _message, socket) do
+  def join("predictions:" <> route_stop_direction, _message, socket) do
     predictions_subscribe_fn =
       Application.get_env(
         :site,
         :predictions_subscribe_fn,
-        &PredictionsPubSub.subscribe/1
+        &PredictionsPubSub.subscribe/3
       )
 
-    predictions = predictions_subscribe_fn.(route_id)
+    [route_id, stop_id, direction_id] = String.split(route_stop_direction, ":")
+    predictions = predictions_subscribe_fn.(route_id, stop_id, direction_id)
 
     {:ok, %{predictions: predictions}, socket}
   end

--- a/apps/site/lib/site_web/channels/user_socket.ex
+++ b/apps/site/lib/site_web/channels/user_socket.ex
@@ -3,6 +3,7 @@ defmodule SiteWeb.UserSocket do
 
   ## Channels
   channel("vehicles:*", SiteWeb.VehicleChannel)
+  channel("predictions:*", SiteWeb.PredictionsChannel)
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -13,6 +13,7 @@ defmodule Site.RealtimeScheduleTest do
   alias Stops.Stop
 
   @now DateTime.from_naive!(~N[2030-02-19T12:00:00], "Etc/UTC")
+  @now_departure Timex.shift(@now, minutes: 2)
 
   @stop %Stop{id: "place-ogmnl"}
 
@@ -91,6 +92,8 @@ defmodule Site.RealtimeScheduleTest do
       status: nil,
       stop: @stop,
       stop_sequence: 190,
+      arrival_time: @now,
+      departure_time: @now_departure,
       time: @now,
       track: nil,
       trip: %Schedules.Trip{
@@ -112,6 +115,8 @@ defmodule Site.RealtimeScheduleTest do
       status: nil,
       stop_sequence: 190,
       stop: @stop,
+      arrival_time: @now,
+      departure_time: @now_departure,
       time: @now,
       track: nil,
       trip: @trip
@@ -184,6 +189,8 @@ defmodule Site.RealtimeScheduleTest do
                   schedule_relationship: nil,
                   status: nil,
                   stop_sequence: 190,
+                  arrival_time: @now,
+                  departure_time: @now_departure,
                   time: ["arriving"],
                   track: nil,
                   headsign: "Oak Grove"
@@ -199,6 +206,8 @@ defmodule Site.RealtimeScheduleTest do
                   schedule_relationship: nil,
                   status: nil,
                   stop_sequence: 190,
+                  arrival_time: @now,
+                  departure_time: @now_departure,
                   time: ["arriving"],
                   track: nil,
                   headsign: "Oak Grove"
@@ -219,6 +228,8 @@ defmodule Site.RealtimeScheduleTest do
                   schedule_relationship: nil,
                   status: nil,
                   stop_sequence: 190,
+                  arrival_time: @now,
+                  departure_time: @now_departure,
                   time: ["arriving"],
                   track: nil,
                   headsign: "Oak Grove"
@@ -234,6 +245,8 @@ defmodule Site.RealtimeScheduleTest do
                   schedule_relationship: nil,
                   status: nil,
                   stop_sequence: 190,
+                  arrival_time: @now,
+                  departure_time: @now_departure,
                   time: ["arriving"],
                   track: nil,
                   headsign: "Oak Grove"

--- a/apps/site/test/site_web/channels/predictions_channel_test.exs
+++ b/apps/site/test/site_web/channels/predictions_channel_test.exs
@@ -6,13 +6,22 @@ defmodule SiteWeb.PredictionsChannelTest do
   alias Phoenix.Socket
   alias Predictions.Prediction
   alias Routes.Route
+  alias Stops.Stop
   alias SiteWeb.{PredictionsChannel, UserSocket}
 
   @route_39 "39"
-  @prediction39 %Prediction{id: "prediction39", route: %Route{id: @route_39}}
+  @stop_fh "place-forhl"
+  @direction 1
+
+  @prediction39 %Prediction{
+    id: "prediction39",
+    direction_id: @direction,
+    route: %Route{id: @route_39},
+    stop: %Stop{id: @stop_fh}
+  }
 
   setup do
-    reassign_env(:site, :predictions_subscribe_fn, fn route_id ->
+    reassign_env(:site, :predictions_subscribe_fn, fn route_id, _, _ ->
       case route_id do
         @route_39 ->
           [@prediction39]
@@ -28,12 +37,16 @@ defmodule SiteWeb.PredictionsChannelTest do
   end
 
   describe "join/3" do
-    test "subscribes to predictions for a route ID and returns the current list of predictions",
+    test "subscribes to predictions for a route ID, stop ID, and direction, and returns the current list of predictions",
          %{
            socket: socket
          } do
       assert {:ok, %{predictions: predictions}, %Socket{}} =
-               subscribe_and_join(socket, PredictionsChannel, "predictions:#{@route_39}")
+               subscribe_and_join(
+                 socket,
+                 PredictionsChannel,
+                 "predictions:#{@route_39}:#{@stop_fh}:#{@direction}"
+               )
 
       assert predictions == [@prediction39]
     end
@@ -44,7 +57,11 @@ defmodule SiteWeb.PredictionsChannelTest do
       predictions = [@prediction39]
 
       {:ok, _, socket} =
-        subscribe_and_join(socket, PredictionsChannel, "predictions:#{@route_39}")
+        subscribe_and_join(
+          socket,
+          PredictionsChannel,
+          "predictions:#{@route_39}:#{@stop_fh}:#{@direction}"
+        )
 
       assert {:noreply, _socket} =
                PredictionsChannel.handle_info(

--- a/apps/site/test/site_web/channels/predictions_channel_test.exs
+++ b/apps/site/test/site_web/channels/predictions_channel_test.exs
@@ -1,0 +1,58 @@
+defmodule SiteWeb.PredictionsChannelTest do
+  use SiteWeb.ChannelCase
+
+  import Test.Support.EnvHelpers
+
+  alias Phoenix.Socket
+  alias Predictions.Prediction
+  alias Routes.Route
+  alias SiteWeb.{PredictionsChannel, UserSocket}
+
+  @route_39 "39"
+  @prediction39 %Prediction{id: "prediction39", route: %Route{id: @route_39}}
+
+  setup do
+    reassign_env(:site, :predictions_subscribe_fn, fn route_id ->
+      case route_id do
+        @route_39 ->
+          [@prediction39]
+
+        _ ->
+          []
+      end
+    end)
+
+    socket = socket(UserSocket, "", %{})
+
+    {:ok, socket: socket}
+  end
+
+  describe "join/3" do
+    test "subscribes to predictions for a route ID and returns the current list of predictions",
+         %{
+           socket: socket
+         } do
+      assert {:ok, %{predictions: predictions}, %Socket{}} =
+               subscribe_and_join(socket, PredictionsChannel, "predictions:#{@route_39}")
+
+      assert predictions == [@prediction39]
+    end
+  end
+
+  describe "handle_info/2" do
+    test "pushes new data onto the socket", %{socket: socket} do
+      predictions = [@prediction39]
+
+      {:ok, _, socket} =
+        subscribe_and_join(socket, PredictionsChannel, "predictions:#{@route_39}")
+
+      assert {:noreply, _socket} =
+               PredictionsChannel.handle_info(
+                 {:new_predictions, predictions},
+                 socket
+               )
+
+      assert_push("predictions", %{predictions: predictions})
+    end
+  end
+end

--- a/apps/site/test/site_web/channels/predictions_channel_test.exs
+++ b/apps/site/test/site_web/channels/predictions_channel_test.exs
@@ -69,7 +69,7 @@ defmodule SiteWeb.PredictionsChannelTest do
                  socket
                )
 
-      assert_push("predictions", %{predictions: predictions})
+      assert_push("data", %{predictions: predictions})
     end
   end
 end

--- a/apps/site/test/site_web/channels/predictions_channel_test.exs
+++ b/apps/site/test/site_web/channels/predictions_channel_test.exs
@@ -44,16 +44,12 @@ defmodule SiteWeb.PredictionsChannelTest do
          %{
            socket: socket
          } do
-      # our join doesn't directly reply with predictions, but calls itself with
-      # the list of predictions via handle_info
-      assert {:ok, %{}, %Socket{}} =
+      assert {:ok, %{predictions: [@prediction39]}, %Socket{}} =
                subscribe_and_join(
                  socket,
                  PredictionsChannel,
                  "predictions:#{@route_39}:#{@stop_fh}:#{@direction}"
                )
-
-      assert_push("data", %{predictions: [@prediction39]})
     end
   end
 

--- a/apps/site/test/support/env_helpers.ex
+++ b/apps/site/test/support/env_helpers.ex
@@ -1,0 +1,18 @@
+defmodule Test.Support.EnvHelpers do
+  @moduledoc "Helpers for reassigning env variables"
+
+  defmacro reassign_env(app, var, value) do
+    quote do
+      old_value = Application.get_env(unquote(app), unquote(var))
+      Application.put_env(unquote(app), unquote(var), unquote(value))
+
+      on_exit(fn ->
+        if old_value == nil do
+          Application.delete_env(unquote(app), unquote(var))
+        else
+          Application.put_env(unquote(app), unquote(var), old_value)
+        end
+      end)
+    end
+  end
+end

--- a/apps/v3_api/lib/stream.ex
+++ b/apps/v3_api/lib/stream.ex
@@ -76,7 +76,12 @@ defmodule V3Api.Stream do
     path = Keyword.fetch!(opts, :path)
     base_url = Keyword.fetch!(opts, :base_url)
 
-    Keyword.put(opts, :url, Path.join(base_url, path))
+    encoded_url =
+      base_url
+      |> Path.join(path)
+      |> URI.encode()
+
+    Keyword.put(opts, :url, encoded_url)
   end
 
   @spec set_headers(Keyword.t()) :: Keyword.t()


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Subscribe to streaming updates by routeId and stopId](https://app.asana.com/0/385363666817452/1203082255397801/f)


> **Warning**
> This was substantially reworked Dec 14! Description has been updated below.

This builds upon the work done in #1421. To that end, the first three commits are directly from Matt's branch there. The fourth commit (`fixup: feat: Parse and save prediction arrival and departure times`) conceptually goes with the changes in the third commit. 

So, the fifth commit (`feat: get streaming predictions by route, stop, direction`) contains the bulk of the task to enable subscribing to a stream of predictions for a specified stop on a route, rather than all predictions for an entire route. This was further enhanced to add a direction argument. This mostly involved adding a stop and direction arguments to wherever we were using only route ID.

The code uses a channel name format of `"predictions:routeId:stopId:directionId"` e.g. `predictions:Red:place-sstat:1`.

The last two commits are additional enhancements that I feel complete the implementation. These:
* Ensure we use the _parent_ stop when we're parsing the streamed predictions.
* Push the predictions to the socket using the "data" event name, just for consistency with our other channel.

Note this is a backend-only implementation. I'll post another PR soon for the frontend piece of this, which will also build upon the frontend pieces of #1421 but will be a bit more significant of a change.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
