### PR TITLE
Adjust route pattern filtering on backend (again)

### DIFF
--- a/apps/site/assets/ts/helpers/__tests__/stop-tree-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/stop-tree-test.ts
@@ -24,7 +24,8 @@ import {
   sliceSizeForId,
   startingNodes,
   stopForId,
-  stopIds
+  stopIds,
+  isEmptyTree
 } from "../stop-tree";
 
 const routeStopA: RouteStop = { id: "a" } as RouteStop;
@@ -89,6 +90,12 @@ const branchingStopTree: StopTree = {
     y1: { next: [], previous: ["m3"] }
   },
   startingNodes: ["a1", "b1", "c1"]
+};
+
+const emptyStopTree: StopTree = {
+  byId: {},
+  edges: {},
+  startingNodes: []
 };
 
 describe("nodeForId", () => {
@@ -276,5 +283,19 @@ describe("newBranchesStartingInSlice", () => {
     expect(newBranchesStartingInSlice(branchingStopTree, "b1")).toEqual([]);
     expect(newBranchesStartingInSlice(branchingStopTree, "b2")).toEqual(["a1"]);
     expect(newBranchesStartingInSlice(branchingStopTree, "b3")).toEqual(["c1"]);
+  });
+});
+
+describe("isEmptyTree", () => {
+  test("returns true for stop trees with empty data", () => {
+    expect(isEmptyTree(emptyStopTree)).toBe(true);
+    expect(isEmptyTree({ ...simpleStopTree, edges: {} })).toBe(true);
+    expect(isEmptyTree({ ...simpleStopTree, byId: {} })).toBe(true);
+    expect(isEmptyTree({ ...simpleStopTree, startingNodes: [] })).toBe(true);
+  });
+
+  test("returns false when tree has complete data", () => {
+    expect(isEmptyTree(simpleStopTree)).toBe(false);
+    expect(isEmptyTree(branchingStopTree)).toBe(false);
   });
 });

--- a/apps/site/assets/ts/helpers/stop-tree.ts
+++ b/apps/site/assets/ts/helpers/stop-tree.ts
@@ -1,3 +1,4 @@
+import { isEmpty } from "lodash";
 import {
   RouteStop,
   StopId,
@@ -137,3 +138,6 @@ export const newBranchesStartingInSlice = (
   (sliceForId(stopTree, stopId) || []).filter(
     id => id !== stopId && isStartNode(stopTree, id)
   );
+
+export const isEmptyTree = (stopTree: StopTree): boolean =>
+  Object.values(stopTree).some(isEmpty);

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../models/route";
 import LineDiagram from "./line-diagram/LineDiagram";
 import { fromStopTreeData } from "./ScheduleLoader";
+import { isEmptyTree } from "../../helpers/stop-tree";
 
 export interface Props {
   route: EnhancedRoute;
@@ -199,6 +200,7 @@ const ScheduleDirection = ({
     );
   }, [route, state.directionId, busVariantId, currentRoutePatternIdForData]);
 
+  const hasValidTree = lineState.data && !isEmptyTree(lineState.data.stopTree);
   return (
     <>
       <div className="m-schedule-direction">
@@ -219,7 +221,7 @@ const ScheduleDirection = ({
           <ScheduleDirectionButton dispatch={dispatch} />
         ) : null}
       </div>
-      {isSubwayRoute(route) && lineState.data && lineState.data.stopTree && (
+      {isSubwayRoute(route) && hasValidTree && (
         <LineDiagram
           stopTree={lineState.data.stopTree}
           route={route}
@@ -253,7 +255,7 @@ const ScheduleDirection = ({
           </a>
         </>
       )}
-      {!isSubwayRoute(route) && lineState.data && lineState.data.stopTree && (
+      {!isSubwayRoute(route) && hasValidTree && (
         <LineDiagram
           stopTree={lineState.data.stopTree}
           route={route}

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -234,7 +234,12 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
   def filtered_by_typicality(route_patterns) do
     route_patterns
     |> filter_by_min_typicality()
-    |> Enum.filter(fn x -> x.shape_priority > 0 end)
+    |> Enum.filter(fn x ->
+      # TODO: Deprecate our use of shape priority entirely,
+      # because it's no longer supported in the V3 API
+      # For now, be less strict if using the most typical route pattern
+      if x.typicality == 1, do: true, else: x.shape_priority > 0
+    end)
   end
 
   # Filters route patterns by the smallest typicality found in the array


### PR DESCRIPTION
**Asana ticket:** [Bus Schedules/Maps Not Showing for Select Routes](https://app.asana.com/0/385363666817452/1203554997501355/f)

* Adds a front-end check to avoid creating errors if the stop tree data that populates the line diagram is empty (before it was only checking if it was _defined_)
* Loosen the filtering of route patterns on the backend

This function is something we have to fiddle with a lot... I've added a comment, but basically we should stop using shape priority. I think we implemented this in the past to avoid issues with conflicting branches on light or heavy rail routes. Doing a cursory check with this change, it doesn't seem to adversely affect rail lines.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

