### PR TITLE
cleanup: remove code from earlier line diagram workarounds

### DIFF
--- a/apps/stops/lib/route_stop.ex
+++ b/apps/stops/lib/route_stop.ex
@@ -85,14 +85,13 @@ defmodule Stops.RouteStop do
   def list_from_route_patterns(
         [route_pattern_with_stops],
         route,
-        direction_id,
+        _direction_id,
         use_route_id_for_branch_name?
       ) do
     # If there is only one route pattern, we know that we won't need to deal with merging branches so we just return whatever the list of stops is without calling &merge_branch_list/2.
     list_from_route_pattern(
       route_pattern_with_stops,
       route,
-      direction_id,
       use_route_id_for_branch_name?
     )
   end
@@ -104,67 +103,41 @@ defmodule Stops.RouteStop do
         use_route_id_for_branch_name?
       ) do
     route_patterns_with_stops
-    |> Enum.map(&list_from_route_pattern(&1, route, direction_id, use_route_id_for_branch_name?))
+    |> Enum.map(&list_from_route_pattern(&1, route, use_route_id_for_branch_name?))
     |> maybe_stitch_chunks()
     |> merge_branch_list(reverse_direction_for_ferry(route.id, direction_id))
-    |> maybe_correct_for_lechmere_shuttle()
   end
 
-  @lechmere_shuttle_route_pattern_ids ["602-1-0", "602-1-1"]
   @spec list_from_route_pattern(
           {RoutePattern.t(), [Stop.t()]},
           Route.t(),
-          direction_id_t(),
           boolean()
         ) :: [t()]
   def list_from_route_pattern(
         route_patterns_with_stops,
         route,
-        direction_id,
         use_route_id_for_branch_name? \\ false
       )
 
   def list_from_route_pattern(
         {route_pattern, stops},
         route,
-        direction_id,
         use_route_id_for_branch_name?
       ) do
-    if String.starts_with?(route.id, "Green") and
-         route_pattern.id in @lechmere_shuttle_route_pattern_ids do
-      # Special-case the Lechmere shuttle
-      stops
-      # Filter out the bus stop at North Station
-      |> Enum.reject(fn %Stop{id: id} -> id == "21458" end)
-      |> Util.EnumHelpers.with_first_last()
-      |> Enum.with_index()
-      |> Enum.map(fn {{stop, first_or_last?}, idx} ->
-        branch = shuttle_branch_name(route, direction_id, use_route_id_for_branch_name?)
-        first? = idx == 0
-        last? = first_or_last? and idx > 0
+    stops
+    |> Util.EnumHelpers.with_first_last()
+    |> Enum.with_index()
+    |> Enum.map(fn {{stop, first_or_last?}, idx} ->
+      branch = branch_name(route_pattern, use_route_id_for_branch_name?)
+      first? = idx == 0
+      last? = first_or_last? and idx > 0
 
-        stop
-        |> build_route_stop(route, branch: branch, first?: first?, last?: last?)
-        |> fetch_zone()
-        |> fetch_connections()
-        |> fetch_stop_features()
-      end)
-    else
-      stops
-      |> Util.EnumHelpers.with_first_last()
-      |> Enum.with_index()
-      |> Enum.map(fn {{stop, first_or_last?}, idx} ->
-        branch = branch_name(route_pattern, use_route_id_for_branch_name?)
-        first? = idx == 0
-        last? = first_or_last? and idx > 0
-
-        stop
-        |> build_route_stop(route, branch: branch, first?: first?, last?: last?)
-        |> fetch_zone()
-        |> fetch_connections()
-        |> fetch_stop_features()
-      end)
-    end
+      stop
+      |> build_route_stop(route, branch: branch, first?: first?, last?: last?)
+      |> fetch_zone()
+      |> fetch_connections()
+      |> fetch_stop_features()
+    end)
   end
 
   @doc """
@@ -175,49 +148,9 @@ defmodule Stops.RouteStop do
   def reverse_direction_for_ferry("Boat-F1", direction), do: 1 - direction
   def reverse_direction_for_ferry(_route_id, direction), do: direction
 
-  # Special-case the Lechmere shuttle
-  @spec maybe_correct_for_lechmere_shuttle([t()]) :: [t()]
-  defp maybe_correct_for_lechmere_shuttle([
-         %__MODULE__{id: "place-lech"} = lechmere,
-         %__MODULE__{} = second,
-         %__MODULE__{id: "place-north"} = north
-         | rest
-       ]) do
-    [
-      lechmere,
-      %__MODULE__{
-        second
-        | is_terminus?: false,
-          is_beginning?: false
-      },
-      %__MODULE__{
-        north
-        | is_terminus?: false,
-          is_beginning?: false
-      }
-    ] ++ rest
-  end
-
-  defp maybe_correct_for_lechmere_shuttle(route_stops) do
-    if List.last(route_stops).id == "place-lech" do
-      route_stops
-      |> Enum.reverse()
-      |> maybe_correct_for_lechmere_shuttle()
-      |> Enum.reverse()
-    else
-      route_stops
-    end
-  end
-
   @spec branch_name(RoutePattern.t(), boolean()) :: String.t()
   defp branch_name(%RoutePattern{route_id: route_id}, true), do: route_id
   defp branch_name(%RoutePattern{name: name}, false), do: name
-
-  @spec shuttle_branch_name(Route.t(), direction_id_t(), boolean()) :: String.t()
-  defp shuttle_branch_name(_, _, true), do: nil
-  defp shuttle_branch_name(%Route{id: "Green"}, _, false), do: "Green-E"
-  defp shuttle_branch_name(%Route{id: "Green-E"}, 0, false), do: "North Station - Heath Street"
-  defp shuttle_branch_name(%Route{id: "Green-E"}, 1, false), do: "Heath Street - North Station"
 
   @doc """
   Given a route and a list of that route's shapes, generates a list of RouteStops representing all stops on that route. If the route has branches,

--- a/apps/stops/test/route_stop_test.exs
+++ b/apps/stops/test/route_stop_test.exs
@@ -9,7 +9,6 @@ defmodule Stops.RouteStopTest do
   @stop %Stop{name: "Braintree", id: "place-brntn"}
   @green_route %Route{id: "Green", type: 0}
   @green_b_route %Route{id: "Green-B", type: 1}
-  @green_e_route %Route{id: "Green-E", type: 1}
   @orange_route %Route{id: "Orange", type: 1}
   @red_route %Route{id: "Red", type: 1}
   @newburyport_route %Route{id: "CR-Newburyport", type: 0}
@@ -131,281 +130,7 @@ defmodule Stops.RouteStopTest do
       assert_branch_names(actual, ["Ashmont - Alewife", "Braintree - Alewife", nil, nil])
     end
 
-    test "Green-B, direction 0" do
-      route_pattern = %RoutePattern{
-        direction_id: 0,
-        id: "Green-B-3-0",
-        name: "Park Street - Boston College",
-        representative_trip_id: "45809685",
-        route_id: "Green-B",
-        typicality: 1
-      }
-
-      stops = make_stops(~w(place-pktrm place-bucen place-lake)s)
-
-      route_pattern_with_stops = [{route_pattern, stops}]
-
-      actual = list_from_route_patterns(route_pattern_with_stops, @green_b_route, 0)
-
-      assert_stop_ids(actual, ~w(place-pktrm place-bucen place-lake)s)
-
-      assert_branch_names(actual, [
-        "Park Street - Boston College",
-        "Park Street - Boston College",
-        "Park Street - Boston College"
-      ])
-    end
-
-    test "Green-B, direction 1" do
-      route_pattern = %RoutePattern{
-        direction_id: 0,
-        id: "Green-B-3-1",
-        name: "Boston College - Park Street",
-        representative_trip_id: "45809684",
-        route_id: "Green-B",
-        typicality: 1
-      }
-
-      stops = make_stops(~w(place-lake place-bucen place-pktrm)s)
-
-      route_pattern_with_stops = [{route_pattern, stops}]
-
-      actual = list_from_route_patterns(route_pattern_with_stops, @green_b_route, 1)
-
-      assert_stop_ids(actual, ~w(place-lake place-bucen place-pktrm)s)
-
-      assert_branch_names(actual, [
-        "Boston College - Park Street",
-        "Boston College - Park Street",
-        "Boston College - Park Street"
-      ])
-    end
-
-    test "Green-E, direction 0" do
-      e_route_pattern = %RoutePattern{
-        direction_id: 0,
-        id: "Green-E-1-0",
-        name: "North Station - Heath Street",
-        representative_trip_id: "45803749",
-        route_id: "Green-E",
-        time_desc: nil,
-        typicality: 1
-      }
-
-      e_stops =
-        make_stops(
-          ~w(place-north place-haecl place-gover place-pktrm place-boyls place-armnl place-coecl place-prmnl place-symcl place-nuniv place-mfa place-lngmd place-brmnl place-fenwd place-mispk place-rvrwy place-bckhl place-hsmnl)s
-        )
-
-      lechmere_shuttle_route_pattern = %RoutePattern{
-        direction_id: 0,
-        id: "602-1-0",
-        name: "Lechmere - Nashua St @ North Station",
-        representative_trip_id: "46001155",
-        route_id: "602",
-        time_desc: nil,
-        typicality: 1
-      }
-
-      lechmere_shuttle_stops = make_stops(~w(place-lech 14159 21458)s)
-
-      route_pattern_with_stops = [
-        {e_route_pattern, e_stops},
-        {lechmere_shuttle_route_pattern, lechmere_shuttle_stops}
-      ]
-
-      actual = list_from_route_patterns(route_pattern_with_stops, @green_e_route, 0)
-
-      assert_stop_ids(
-        actual,
-        ~w(place-lech 14159 place-north place-haecl place-gover place-pktrm place-boyls place-armnl place-coecl place-prmnl place-symcl place-nuniv place-mfa place-lngmd place-brmnl place-fenwd place-mispk place-rvrwy place-bckhl place-hsmnl)s
-      )
-
-      assert_branch_names(actual, [
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street",
-        "North Station - Heath Street"
-      ])
-
-      assert Enum.map(actual, & &1.is_terminus?) ==
-               [
-                 true,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 true
-               ]
-
-      assert Enum.map(actual, & &1.is_beginning?) ==
-               [
-                 true,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false
-               ]
-    end
-
-    test "Green-E, direction 1" do
-      e_route_pattern = %RoutePattern{
-        direction_id: 1,
-        id: "Green-E-1-1",
-        name: "Heath Street - North Station",
-        representative_trip_id: "45803750",
-        route_id: "Green-E",
-        time_desc: nil,
-        typicality: 1
-      }
-
-      e_stops =
-        make_stops(
-          ~w(place-hsmnl place-bckhl place-rvrwy place-mispk place-fenwd place-brmnl place-lngmd place-mfa place-nuniv place-symcl place-prmnl place-coecl place-armnl place-boyls place-pktrm place-gover place-haecl place-north)s
-        )
-
-      lechmere_shuttle_route_pattern = %RoutePattern{
-        direction_id: 1,
-        id: "602-1-1",
-        name: "Nashua St @ North Station - Lechmere",
-        representative_trip_id: "46001157",
-        route_id: "602",
-        time_desc: nil,
-        typicality: 1
-      }
-
-      lechmere_shuttle_stops = make_stops(~w(21458 14155 place-lech)s)
-
-      route_pattern_with_stops = [
-        {e_route_pattern, e_stops},
-        {lechmere_shuttle_route_pattern, lechmere_shuttle_stops}
-      ]
-
-      actual = list_from_route_patterns(route_pattern_with_stops, @green_e_route, 1)
-
-      assert_stop_ids(
-        actual,
-        ~w(place-hsmnl place-bckhl place-rvrwy place-mispk place-fenwd place-brmnl place-lngmd place-mfa place-nuniv place-symcl place-prmnl place-coecl place-armnl place-boyls place-pktrm place-gover place-haecl place-north 14155 place-lech)s
-      )
-
-      assert_branch_names(actual, [
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station",
-        "Heath Street - North Station"
-      ])
-
-      assert Enum.map(actual, & &1.is_terminus?) ==
-               [
-                 true,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 true
-               ]
-
-      assert Enum.map(actual, & &1.is_beginning?) ==
-               [
-                 true,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false
-               ]
-    end
-
-    test "Green, direction 0" do
+    test "Green (4 branches), direction 0" do
       b_route_pattern = %RoutePattern{
         direction_id: 0,
         id: "Green-B-3-0",
@@ -434,78 +159,60 @@ defmodule Stops.RouteStopTest do
       d_route_pattern = %RoutePattern{
         direction_id: 0,
         id: "Green-D-2-0",
-        name: "Government Center - Riverside",
+        name: "Union Square - Riverside",
         representative_trip_id: "45809766",
         route_id: "Green-D",
         typicality: 1
       }
 
       d_stops =
-        make_stops(~w(place-gover place-pktrm place-coecl place-kencl place-fenwy place-river)s)
+        make_stops(
+          ~w(place-unsqu place-lech place-north place-gover place-pktrm place-coecl place-kencl place-fenwy place-river)s
+        )
 
       e_route_pattern = %RoutePattern{
         direction_id: 0,
         id: "Green-E-1-0",
-        name: "North Station - Heath Street",
+        name: "Medford/Tufts - Heath Street",
         representative_trip_id: "45809752",
         route_id: "Green-E",
         typicality: 1
       }
 
       e_stops =
-        make_stops(~w(place-north place-gover place-pktrm place-coecl place-prmnl place-hsmnl)s)
-
-      lechmere_shuttle_route_pattern = %RoutePattern{
-        direction_id: 0,
-        id: "602-1-0",
-        name: "Lechmere - Nashua St @ North Station",
-        representative_trip_id: "45171678",
-        route_id: "602",
-        time_desc: nil,
-        typicality: 1
-      }
-
-      lechmere_shuttle_stops = make_stops(~w(place-lech 14159 21458)s)
+        make_stops(
+          ~w(place-mdftf place-lech place-north place-gover place-pktrm place-coecl place-prmnl place-hsmnl)s
+        )
 
       route_patterns_with_stops = [
         {b_route_pattern, b_stops},
         {c_route_pattern, c_stops},
         {d_route_pattern, d_stops},
-        {e_route_pattern, e_stops},
-        {lechmere_shuttle_route_pattern, lechmere_shuttle_stops}
+        {e_route_pattern, e_stops}
       ]
 
       actual = list_from_route_patterns(route_patterns_with_stops, @green_route, 0, true)
 
       assert_stop_ids(
         actual,
-        ~w(place-lech 14159 place-north place-gover place-pktrm place-coecl place-prmnl place-hsmnl place-gover place-pktrm place-coecl place-kencl place-fenwy place-river place-north place-gover place-pktrm place-coecl place-kencl place-smary place-clmnl place-pktrm place-coecl place-kencl place-bland place-lake)s
+        ~w(place-mdftf place-lech place-north place-gover place-pktrm place-coecl place-prmnl place-hsmnl place-kencl place-fenwy place-river place-kencl place-smary place-clmnl place-kencl place-bland place-lake)s
       )
 
       assert_branch_names(actual, [
         nil,
         nil,
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
+        nil,
+        nil,
+        nil,
+        nil,
         "Green-E",
         "Green-E",
         "Green-D",
         "Green-D",
         "Green-D",
-        "Green-D",
-        "Green-D",
-        "Green-D",
         "Green-C",
         "Green-C",
         "Green-C",
-        "Green-C",
-        "Green-C",
-        "Green-C",
-        "Green-C",
-        "Green-B",
-        "Green-B",
         "Green-B",
         "Green-B",
         "Green-B"
@@ -521,21 +228,12 @@ defmodule Stops.RouteStopTest do
                  false,
                  false,
                  true,
-                 true,
-                 false,
-                 false,
                  false,
                  false,
                  true,
-                 true,
-                 false,
-                 false,
-                 false,
                  false,
                  false,
                  true,
-                 true,
-                 false,
                  false,
                  false,
                  true
@@ -544,127 +242,6 @@ defmodule Stops.RouteStopTest do
       assert Enum.map(actual, & &1.is_beginning?) ==
                [
                  true,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 true,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 true,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 true,
-                 false,
-                 false,
-                 false,
-                 false
-               ]
-    end
-
-    test "Green, direction 1" do
-      trunk_route_pattern = %RoutePattern{
-        direction_id: 1,
-        id: "Green-E-1-1",
-        name: "Heath Street - North Station",
-        representative_trip_id: "45803750",
-        route_id: "Green-E",
-        time_desc: nil,
-        typicality: 1
-      }
-
-      trunk_stops =
-        make_stops(
-          ~w(place-hsmnl place-bckhl place-rvrwy place-mispk place-fenwd place-brmnl place-lngmd place-mfa place-nuniv place-symcl place-prmnl place-coecl place-armnl place-boyls place-pktrm place-gover place-haecl place-north)s
-        )
-
-      lechmere_shuttle_route_pattern = %RoutePattern{
-        direction_id: 1,
-        id: "602-1-1",
-        name: "Nashua St @ North Station - Lechmere",
-        representative_trip_id: "46001157",
-        route_id: "602",
-        time_desc: nil,
-        typicality: 1
-      }
-
-      lechmere_shuttle_stops = make_stops(~w(21458 14155 place-lech))
-
-      route_patterns_with_stops = [
-        {trunk_route_pattern, trunk_stops},
-        {lechmere_shuttle_route_pattern, lechmere_shuttle_stops}
-      ]
-
-      actual = list_from_route_patterns(route_patterns_with_stops, @green_route, 1, true)
-
-      assert_stop_ids(
-        actual,
-        ~w(place-hsmnl place-bckhl place-rvrwy place-mispk place-fenwd place-brmnl place-lngmd place-mfa place-nuniv place-symcl place-prmnl place-coecl place-armnl place-boyls place-pktrm place-gover place-haecl place-north 14155 place-lech)s
-      )
-
-      assert_branch_names(actual, [
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        "Green-E",
-        nil,
-        nil
-      ])
-
-      assert Enum.map(actual, & &1.is_terminus?) ==
-               [
-                 true,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 false,
-                 true
-               ]
-
-      assert Enum.map(actual, & &1.is_beginning?) ==
-               [
-                 true,
-                 false,
-                 false,
-                 false,
                  false,
                  false,
                  false,


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** No ticket

Just removing some old line diagram backend code we don't need anymore. This also modifies the list_from_route_pattern function to remove the now-unused `direction_id` argument. The removed code focused on these things:

1. Consolidating overlapping route patterns, covering an edge case on the Kingston/Plymouth Line where one route pattern terminated at Kingston and the other continued one stop further to Plymouth.
2. Manually removing stops that were added during commuter rail replacement bus service, covering an edge case on the Fitchburg Line where rail replacement bus service additionally stopped at Alewife, but "normal" service does not.
3. Manual corrections to the Green Line route during Lechmere shuttle service.

All of these edge cases are over with! So I am removing the workarounds.

**Will these edge cases happen again?** Maybe! I am hoping before that happens, we can improve how we decide which stops show on the line diagram such that these edge cases won't present a problem. Including holding out for canonical routes (https://github.com/mbta/api/pull/523) 😉 .

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

