### PR TITLE
feat(Routes.Repo): use stop.connecting_stops relation

### DIFF
--- a/apps/routes/lib/repo.ex
+++ b/apps/routes/lib/repo.ex
@@ -165,8 +165,8 @@ defmodule Routes.Repo do
      data
      |> Enum.flat_map(&fetch_connecting_routes_via_stop/1)
      |> Enum.reject(&Route.hidden?/1)
-     |> Enum.uniq()
      |> Enum.map(&parse_route/1)
+     |> Enum.uniq()
      |> Enum.sort_by(& &1.sort_order)}
   end
 

--- a/apps/routes/test/repo_test.exs
+++ b/apps/routes/test/repo_test.exs
@@ -1,5 +1,6 @@
 defmodule Routes.RepoTest do
   use ExUnit.Case, async: true
+  import Mock
   alias Routes.{Repo, Route}
 
   @routes_repo_api Application.get_env(:routes, :routes_repo_api)
@@ -134,6 +135,19 @@ defmodule Routes.RepoTest do
     test "returns no routes on nonexistant station" do
       assert [] = @routes_repo_api.by_stop("thisstopdoesntexist")
     end
+
+    test "can include additional routes via stop connections" do
+      with_mock V3Api.Routes, [],
+        by_stop: &mock_routes_by_stop/1,
+        by_stop: &mock_routes_by_stop/2 do
+        routes = Routes.Repo.by_stop("initial-stop-id")
+        more_routes = Routes.Repo.by_stop("initial-stop-id", include: "stop.connecting_stops")
+        assert ["initial-route-id"] = Enum.map(routes, & &1.id)
+
+        assert ["connecting-route-id-1", "connecting-route-id-2", "initial-route-id"] =
+                 Enum.map(more_routes, & &1.id)
+      end
+    end
   end
 
   describe "by_stop_and_direction/2" do
@@ -260,5 +274,69 @@ defmodule Routes.RepoTest do
     green_line = Repo.green_line()
     assert green_line.id == "Green"
     assert green_line.name == "Green Line"
+  end
+
+  defp mock_routes_by_stop("connecting-stop-id") do
+    %JsonApi{
+      data: [
+        %JsonApi.Item{
+          id: "connecting-route-id-1",
+          attributes: %{
+            "direction_names" => ["Outbound", "Inbound"],
+            "direction_destinations" => ["Start", "End"],
+            "long_name" => "Connecting route at this stop"
+          }
+        },
+        %JsonApi.Item{
+          id: "connecting-route-id-2",
+          attributes: %{
+            "direction_names" => ["Outbound", "Inbound"],
+            "direction_destinations" => ["Start", "End"],
+            "long_name" => "Another connecting route at this stop"
+          }
+        }
+      ]
+    }
+  end
+
+  defp mock_routes_by_stop("initial-stop-id", include: "stop.connecting_stops") do
+    %JsonApi{
+      data: [
+        %JsonApi.Item{
+          id: "initial-route-id",
+          attributes: %{
+            "direction_names" => ["Outbound", "Inbound"],
+            "direction_destinations" => ["Start", "End"],
+            "long_name" => "Route with stops and connections"
+          },
+          relationships: %{
+            "stop" => [
+              %JsonApi.Item{
+                id: "initial-stop-id",
+                relationships: %{
+                  "connecting_stops" => [%JsonApi.Item{id: "connecting-stop-id"}]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  end
+
+  defp mock_routes_by_stop("initial-stop-id", _opts) do
+    %JsonApi{
+      data: [
+        %JsonApi.Item{
+          id: "initial-route-id",
+          attributes: %{
+            "direction_names" => ["Outbound", "Inbound"],
+            "direction_destinations" => ["Start", "End"],
+            "long_name" => "Route with stops and connections"
+          },
+          relationships: %{}
+        }
+      ]
+    }
   end
 end

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -68,8 +68,6 @@ const showPrediction = (
   liveData?: LiveData
 ): boolean => hasLivePredictions(liveData) && !isEndNode(stopTree, stopId);
 
-const byRouteId = (a: Route, b: Route): number => (a.id < b.id ? -1 : 1);
-
 const connectionsFor = (
   routeStop: RouteStop,
   stopTree: StopTree
@@ -83,7 +81,7 @@ const connectionsFor = (
       ...routeStop.route,
       "custom_route?": false
     };
-    return [routeStopRoute, ...connections].sort(byRouteId);
+    return [routeStopRoute, ...connections];
   }
   return connections;
 };

--- a/apps/site/assets/ts/schedule/components/line-diagram/StopConnections.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/StopConnections.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { sortBy } from "lodash";
 import { RouteStopRoute } from "../__schedule";
 import { TooltipWrapper, modeIcon } from "../../../helpers/icon";
 import { isABusRoute, isACommuterRailRoute } from "../../../models/route";
@@ -6,7 +7,6 @@ import { routeBgClass } from "../../../helpers/css";
 import { Route } from "../../../__v3api";
 
 const filteredConnections = (
-  route_id: string,
   connections: RouteStopRoute[]
 ): RouteStopRoute[] => {
   const firstCRIndex = connections.findIndex(
@@ -16,12 +16,19 @@ const filteredConnections = (
     connection => connection.type === 4
   );
 
-  return connections.filter(
+  // show only 1 CR or Ferry icon
+  const consolidated = connections.filter(
     (connection, index) =>
       (connection.type !== 2 && connection.type !== 4) ||
       (connection.type === 2 && index === firstCRIndex) ||
       (connection.type === 4 && index === firstFerryIndex)
   );
+
+  // sort by type (CR or Ferry icon first), then sort_order
+  return sortBy(consolidated, [
+    ({ type }) => ([2, 4].includes(type) ? -1 : 0),
+    "sort_order"
+  ]);
 };
 
 const connectionName = (connection: Route): string => {
@@ -43,37 +50,35 @@ const StopConnections = (
   connections: RouteStopRoute[]
 ): JSX.Element => (
   <div className="m-schedule-diagram__connections">
-    {filteredConnections(route_id, connections).map(
-      (connectingRoute: Route) => (
-        <TooltipWrapper
-          key={connectingRoute.id}
-          href={`/schedules/${connectingRoute.id}/line`}
-          tooltipText={connectionName(connectingRoute)}
-          tooltipOptions={{
-            placement: "bottom",
-            animation: false
-          }}
-        >
-          {isABusRoute(connectingRoute) ? (
-            <span
-              key={connectingRoute.id}
-              className={`c-icon__bus-pill--small m-schedule-diagram__connection ${routeBgClass(
-                connectingRoute
-              )}`}
-            >
-              {connectingRoute.name}
-            </span>
-          ) : (
-            <span
-              key={connectingRoute.id}
-              className="m-schedule-diagram__connection"
-            >
-              {modeIcon(connectingRoute.id)}
-            </span>
-          )}
-        </TooltipWrapper>
-      )
-    )}
+    {filteredConnections(connections).map((connectingRoute: Route) => (
+      <TooltipWrapper
+        key={connectingRoute.id}
+        href={`/schedules/${connectingRoute.id}/line`}
+        tooltipText={connectionName(connectingRoute)}
+        tooltipOptions={{
+          placement: "bottom",
+          animation: false
+        }}
+      >
+        {isABusRoute(connectingRoute) ? (
+          <span
+            key={connectingRoute.id}
+            className={`c-icon__bus-pill--small m-schedule-diagram__connection ${routeBgClass(
+              connectingRoute
+            )}`}
+          >
+            {connectingRoute.name}
+          </span>
+        ) : (
+          <span
+            key={connectingRoute.id}
+            className="m-schedule-diagram__connection"
+          >
+            {modeIcon(connectingRoute.id)}
+          </span>
+        )}
+      </TooltipWrapper>
+    ))}
   </div>
 );
 

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -257,7 +257,7 @@ defmodule SiteWeb.ScheduleController.LineController do
         group_name: ViewHelpers.mode_name(group),
         routes:
           routes
-          |> Enum.sort_by(&connection_sorter/1)
+          |> Enum.sort_by(& &1.sort_order)
           |> Enum.map(&%{route: Route.to_json_safe(&1), direction_id: nil})
       }
     end)
@@ -289,19 +289,6 @@ defmodule SiteWeb.ScheduleController.LineController do
 
   defp bus_type(route),
     do: if(Route.silver_line?(route), do: "Silver Line", else: "bus")
-
-  defp connection_sorter(%Route{id: id} = route) do
-    # force silver line to top of list
-    if Route.silver_line?(route) do
-      "000" <> id
-    else
-      case Integer.parse(id) do
-        {number, _} when number < 10 -> "00" <> id
-        {number, _} when number < 100 -> "0" <> id
-        _ -> id
-      end
-    end
-  end
 
   defp route_type(route) do
     route

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -89,6 +89,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert List.last(stops).stop_features == [
                :red_line,
                :silver_line,
+               :bus,
                :commuter_rail,
                :access,
                :parking_lot
@@ -175,7 +176,7 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert last_stop.id == "place-lake"
 
       # includes the stop features
-      assert first_stop.stop_features == [:access]
+      assert first_stop.stop_features == [:bus, :access]
 
       # spider map
       assert conn.assigns.map_img_src =~ "maps.googleapis.com"

--- a/apps/stops/lib/route_stop.ex
+++ b/apps/stops/lib/route_stop.ex
@@ -370,7 +370,7 @@ defmodule Stops.RouteStop do
       ) do
     connections =
       route_stop.id
-      |> Routes.Repo.by_stop()
+      |> Routes.Repo.by_stop(include: "stop.connecting_stops")
       |> Enum.reject(&(&1.id == route_stop.route.id))
 
     %{route_stop | connections: connections}


### PR DESCRIPTION
If `connecting_stops` are included in the fetched routes from the API: lookup `V3Api.Routes.by_stop` again for each connecting stop, and merge resulting routes into the response.

This will happen when the `[include: stop.connecting_stops]` option is passed to `Routes.Repo.by_stop`.

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Missing stop connections on line diagram](https://app.asana.com/0/385363666817452/1198864672065648/f)

Going to deploy this somewhere for QA, as I'm not quite sure how many areas of the website this is going to end up affecting!

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
