### PR TITLE
fix: timetable icon alignment

### DIFF
--- a/apps/site/assets/css/_timetable.scss
+++ b/apps/site/assets/css/_timetable.scss
@@ -132,6 +132,7 @@
   align-items: center;
   display: inline-flex;
   font-weight: $font-weight-medium;
+  justify-content: space-between;
 }
 
 .m-timetable__stop-link {
@@ -142,8 +143,9 @@
 }
 
 .m-timetable__stop-icons {
-  flex: 0 0 25%;
-  text-align: right;
+  align-items: center;
+  display: flex;
+  gap: 1px;
 }
 
 .m-timetable__stop-alert,

--- a/apps/site/assets/css/_timetable.scss
+++ b/apps/site/assets/css/_timetable.scss
@@ -143,27 +143,25 @@
 }
 
 .m-timetable__stop-icons {
-  align-items: center;
   display: flex;
-  gap: 1px;
+  gap: .125em;
+  line-height: initial;
+
+  // tweak size to be closer to the non-FA icons
+  .fa {
+    font-size: calc(1em + 1.45px);
+  }
 }
 
 .m-timetable__stop-alert,
 .m-timetable__access-icon,
 .m-timetable__parking-icon {
+  align-self: stretch;
+  display: inline-flex; // better alignment in Edge
+
   @include media-breakpoint-down(sm) {
     font-size: 12px;
   }
-}
-
-.m-timetable__parking-icon .fa-square-parking {
-  font-size: calc(1em + 1.5px);
-  position: relative;
-  top: .04em;
-}
-
-.m-timetable__access-icon {
-  margin-left: .1em; // Forces word split of Stops at small breakpoints
 }
 
 .m-timetable__row,

--- a/apps/site/lib/site_web/templates/schedule/_timetable.html.eex
+++ b/apps/site/lib/site_web/templates/schedule/_timetable.html.eex
@@ -91,7 +91,14 @@
                   <%= stop_parking_icon(stop) %>
                   <%= stop_accessibility_icon(stop) %>
                   <%= if Alerts.Stop.match(@alerts, stop.id, route: @route.id, time: @date, direction_id: @direction_id) != [] do %>
-                    <%= fa "exclamation-triangle", ["data-toggle": "tooltip", title: "Service alert or delay", class: "m-timetable__stop-alert"] %>
+                    <%= content_tag(
+                      :span,
+                      fa("exclamation-triangle"),
+                      aria: [hidden: "true"],
+                      class: "m-timetable__stop-alert",
+                      data: [toggle: "tooltip"],
+                      title: "Service alert or delay"
+                    ) %>
                   <% end %>
                 </div>
               </div>

--- a/apps/site/lib/site_web/views/schedule/timetable.ex
+++ b/apps/site/lib/site_web/views/schedule/timetable.ex
@@ -1,6 +1,7 @@
 defmodule SiteWeb.ScheduleView.Timetable do
   alias Schedules.Schedule
   alias SiteWeb.ViewHelpers, as: Helpers
+  alias SiteWeb.PartialView.SvgIconWithCircle
   alias Stops.Stop
 
   import Phoenix.HTML.Tag, only: [content_tag: 3]
@@ -65,17 +66,7 @@ defmodule SiteWeb.ScheduleView.Timetable do
   def stop_accessibility_icon(stop) do
     cond do
       Stop.accessible?(stop) ->
-        [
-          content_tag(
-            :span,
-            Helpers.svg("icon-accessible-small.svg"),
-            aria: [hidden: "true"],
-            class: "m-timetable__access-icon",
-            data: [toggle: "tooltip"],
-            title: "Accessible"
-          ),
-          content_tag(:span, "Accessible", class: "sr-only")
-        ]
+        SvgIconWithCircle.svg_icon_with_circle(%SvgIconWithCircle{icon: :access})
 
       Stop.accessibility_known?(stop) ->
         [


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Horizontally Align Parking, Handicap, Service Alert Icons on Schedule Pages](https://app.asana.com/0/385363666817452/1203492984939266/f)

Attempting to fix the icon alignment. Will be deploying to dev-green to facilitate testing across different browsers.
