### PR TITLE
fix: use bus name instead of id in meta description

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -277,8 +277,8 @@ defmodule SiteWeb.ScheduleController.LineController do
     end
   end
 
-  defp bus_description(%{id: route_number} = route) do
-    "MBTA #{bus_type(route)} route #{route_number} stops and schedules, including maps, real-time updates, " <>
+  defp bus_description(route) do
+    "MBTA #{bus_type(route)} route #{route.name} stops and schedules, including maps, real-time updates, " <>
       "parking and accessibility information, and connections."
   end
 

--- a/apps/site/test/site_web/controllers/schedule/line_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_controller_test.exs
@@ -4,6 +4,22 @@ defmodule SiteWeb.Schedule.LineControllerTest do
   alias SiteWeb.ScheduleController.LineController
   import Mock
 
+  describe "show/2" do
+    test "sets a custom meta description", %{conn: conn} do
+      conn = get(conn, line_path(conn, :show, "1"))
+
+      assert conn.assigns.meta_description ==
+               "MBTA bus route 1 stops and schedules, including maps, real-time updates, parking and accessibility information, and connections."
+    end
+
+    test "sets a good meta description for buses with names", %{conn: conn} do
+      conn = get(conn, line_path(conn, :show, "747"))
+      assert "MBTA bus route CT2" <> _ = conn.assigns.meta_description
+      conn = get(conn, line_path(conn, :show, "751"))
+      assert "MBTA Silver Line route SL4" <> _ = conn.assigns.meta_description
+    end
+  end
+
   describe "services/3" do
     test "omits services in the past" do
       service_date = ~D[2019-05-01]


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Google results should show short names instead of route IDs](https://app.asana.com/0/385363666817452/1202793084291449/f)

Just going through old tickets in the icebox.... this adjusts the description seen when searching Google or somesuch for certain routes that are better known by name rather than route id: CT2, SL4, etc.