### PR TITLE
experiment: alternate chromedriver source

### DIFF
--- a/.github/workflows/algolia-update.yml
+++ b/.github/workflows/algolia-update.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   algolia:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/build-app

--- a/.github/workflows/changed-files.yml
+++ b/.github/workflows/changed-files.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   files:
     name: List changed files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       js: ${{ steps.changes.outputs.js }}
       ts: ${{ steps.changes.outputs.ts }}

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   crawler:
     name: Website Crawler
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
     - uses: erlef/setup-beam@v1

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -41,7 +41,7 @@ jobs:
         PR#${{ github.event.pull_request.number }} failed to deploy to ${{ contains(github.event.pull_request.labels.*.name, 'dev-green') && 'dev-green' || 'dev-blue' }}
 
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [pr]
     steps:
       - name: Unlabel other PRs (if needed)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   docker:
     name: Build Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - run: docker build .

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   shellcheck:
     name: Shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: reviewdog/action-shellcheck@v1.3.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,6 +158,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/build-app
+    - run:
+        # Install Chromedriver version that corresponds with the version of Chrome that is installed here.
+        bash ./scripts/setup_chromedriver.sh
     - env:
         RECAPTCHA_PUBLIC_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
         RECAPTCHA_PRIVATE_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
 
   tslint:
     name: Linting / TypeScript
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.ts }}
     steps:
@@ -42,7 +42,7 @@ jobs:
 
   jslint:
     name: Linting / JavaScript
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.js }}
     steps:
@@ -52,7 +52,7 @@ jobs:
 
   stylelint:
     name: Linting / CSS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.scss }}
     steps:
@@ -62,7 +62,7 @@ jobs:
 
   elixirlint:
     name: Linting / Elixir
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.ex }}
     steps:
@@ -72,7 +72,7 @@ jobs:
 
   elixir_unit:
     name: Unit tests / Elixir / --exclude wallaby --cover
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.ex }}
     steps:
@@ -92,7 +92,7 @@ jobs:
 
   js_unit_1:
     name: Unit tests / JavaScript / Mocha
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.js }}
     steps:
@@ -102,7 +102,7 @@ jobs:
 
   js_unit_2:
     name: Unit tests / JavaScript & TypeScript / Jest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.ts || needs.file_changes.outputs.js }}
     steps:
@@ -112,7 +112,7 @@ jobs:
 
   type_dialyzer:
     name: Type checks / Elixir
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.ex }}
     steps:
@@ -122,7 +122,7 @@ jobs:
 
   type_typescript:
     name: Type checks / TypeScript
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.ts }}
     steps:
@@ -132,7 +132,7 @@ jobs:
 
   elixir_format_check:
     name: Formatting / Elixir
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.ex }}
     steps:
@@ -142,7 +142,7 @@ jobs:
 
   js_format_check:
     name: Formatting / JavaScript & TypeScript
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.js || needs.file_changes.outputs.ts }}
     steps:
@@ -152,7 +152,7 @@ jobs:
 
   elixir_wallaby:
     name: Integration tests / Elixir
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.ex }}
     steps:
@@ -171,7 +171,7 @@ jobs:
 
   cypress:
     name: Integration tests / Cypress
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: file_changes
     if: ${{ needs.file_changes.outputs.ex || needs.file_changes.outputs.js || needs.file_changes.outputs.ts }}
     steps:

--- a/.github/workflows/use-deploy-ecs.yml
+++ b/.github/workflows/use-deploy-ecs.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment:
       name: ${{ inputs.deployment-env }}
       url: ${{ inputs.deployment-env == 'prod' && 'https://www.mbta.com' || format('https://{0}.mbtace.com', inputs.deployment-env) }}

--- a/.github/workflows/use-notify-slack.yml
+++ b/.github/workflows/use-notify-slack.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   slack:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: inputs.job-status != 'cancelled'
     steps:
     - uses: mbta/actions/notify-slack-deploy@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,3 @@
 nodejs 14.20.0
 erlang 22.3.4.26
 elixir 1.10.4-otp-22
-chromedriver 106.0.5249.21

--- a/README.md
+++ b/README.md
@@ -62,13 +62,12 @@ Welcome to [Dotcom](https://www.notion.so/mbta-downtown-crossing/Dotcom-6aa7b0f0
      asdf plugin add erlang
      asdf plugin add elixir
      asdf plugin add nodejs
-     asdf plugin add chromedriver
      ```
      You can verify the plugins were installed with `asdf plugin list`.
 
-     While Erlang, Elixir, and NodeJS are essential for any development on Dotcom, Chromedriver is only needed for Elixir acceptance tests using Wallaby.
+     While Erlang, Elixir, and NodeJS are essential for any development on Dotcom.
 
-     You're welcome to add more plugins for personal use! But these four are the ones set up in `.tool-versions` and invoked in the next step:
+     You're welcome to add more plugins for personal use! But these are the ones set up in `.tool-versions` and invoked in the next step:
 
    * Now run the install:
 
@@ -88,7 +87,6 @@ Welcome to [Dotcom](https://www.notion.so/mbta-downtown-crossing/Dotcom-6aa7b0f0
       elixir         <version> (set by ~/dotcom/.tool-versions)
       erlang         <version> (set by ~/dotcom/.tool-versions)
       nodejs         <version> (set by ~/dotcom/.tool-versions)
-      chromedriver   <version> (set by ~/dotcom/.tool-versions)
       ...
      ```
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -3,17 +3,10 @@
 Common test suites developers might want to run:
 
 * `mix test` — Elixir tests
+  * `mix test --exclude wallaby` - Excludes the integration tests
+  * `mix test --only wallaby` - Runs only the integration tests. This depends on having chromedriver installed, which can be installed via `bash scripts/setup_chromedriver.sh`
 * `npm run --prefix apps/site/assets mocha && npm run --prefix apps/site/assets jest` — all of the JavaScript tests
 
-IMPORTANT NOTE: As of June 2020, Lechmere is closed for construction and the E line will be terminating at North Station for now. This is the list of files that have been affected (whose changes will need to be reverted at a later time):
-
-- `apps/site/lib/green_line.ex`
-- `apps/site/test/green_line_test.exs`
-- `apps/site/test/site_web/controllers/schedule/line_test.exs`
-- `apps/site/test/site_web/controllers/schedule_controller_test.exs`
-- `apps/site/test/site_web/excluded_stops_test.exs`
-- `apps/site/test/site_web/views/partial_view_test.exs`
-- `apps/stops/test/route_stops_test.exs`
 
 Dotcom runs its test suite automatically using Github Actions, mainly from the [`tests.yml`](../.github/workflows/tests.yml) workflow.
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,18 +28,6 @@ defmodule DotCom.Mixfile do
     ]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options.
-  #
-  # Dependencies listed here are available only for this project
-  # and cannot be accessed from applications inside the apps folder
   defp deps do
     [
       {:credo, "~> 1.5", only: [:dev, :test]},

--- a/scripts/setup_chromedriver.sh
+++ b/scripts/setup_chromedriver.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Credits to https://github.com/nanasess/setup-chromedriver
+# This will download and install the Chromedriver version that
+# corresponds with the version of Chrome that is installed.
+# On Linux it downloads Chrome if it isn't already available.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  ARCH="mac64"
+  CHROMEAPP="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+else
+  # Assume Linux
+  ARCH="linux64"
+  CHROMEAPP=google-chrome
+  if ! type -a google-chrome > /dev/null 2>&1; then
+      sudo apt-get update
+      sudo apt-get install -y google-chrome
+  fi
+fi
+
+CHROME_VERSION=$("$CHROMEAPP" --version | cut -f 3 -d ' ' | cut -d '.' -f 1)
+VERSION=$(curl --location --fail --retry 10 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION})
+
+wget -c -nc --retry-connrefused --tries=0 https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_${ARCH}.zip
+unzip -o -q chromedriver_"${ARCH}".zip
+sudo mv chromedriver /usr/local/bin/chromedriver
+rm chromedriver_"${ARCH}".zip
+echo "chromedriver set up for version ${VERSION}"


### PR DESCRIPTION
Goal is to avoid mismatch between local Chrome version and chromedriver version. Can be used both in CI and locally to download the correct chromedriver version that matches your Google Chrome install.

Ran into that issue while working on #1494.

This doesn't require any changes to a developer's local environment if not running the Elixir integration tests (unit tests with the "wallaby" tag).

We'll see here if CI works!