### PR TITLE
hotfix(Trip Planner): parse new Massport GTFS

### DIFF
--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -64,7 +64,9 @@ defmodule Routes.Route do
   def type_atom("bus"), do: :bus
   def type_atom("ferry"), do: :ferry
   def type_atom("909"), do: :logan_express
+  def type_atom("2274"), do: :logan_express
   def type_atom("983"), do: :massport_shuttle
+  def type_atom("2272"), do: :massport_shuttle
   def type_atom("Massport-" <> _), do: :massport_shuttle
   def type_atom("the_ride"), do: :the_ride
 

--- a/apps/site/lib/site_web/views/helpers.ex
+++ b/apps/site/lib/site_web/views/helpers.ex
@@ -181,9 +181,9 @@ defmodule SiteWeb.ViewHelpers do
   def mode_name(type) when type in [2, :commuter_rail], do: "Commuter Rail"
   def mode_name(type) when type in [3, :bus], do: "Bus"
   def mode_name(type) when type in [4, :ferry], do: "Ferry"
-  def mode_name(type) when type in ["909", :logan_express], do: "Logan Express"
+  def mode_name(type) when type in ["2274", "909", :logan_express], do: "Logan Express"
 
-  def mode_name(type) when type in ["983", :massport_shuttle],
+  def mode_name(type) when type in ["2272", "983", :massport_shuttle],
     do: "Massport Shuttle"
 
   def mode_name("Massport-" <> _route), do: "Massport Shuttle"

--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
@@ -166,7 +166,7 @@ defmodule TripPlan.Api.OpenTripPlanner.Parser do
     # agency is either 1 (MBTA) or 2 (Massport)
     case agency do
       "1" -> id
-      "2" -> "Massport-" <> id
+      "2" <> _ -> "Massport-" <> id
     end
   end
 end


### PR DESCRIPTION
Lets us use new Massport GTFS with agency IDs 2274 and 2272, adds these to the relevant helpers so that we can parse and display itineraries in our Trip Planner without crashing. :) Will test on dev-green (which has OTP with the relevant GTFS set up via [chore: Use Trillium-hosted GTFS file for Massport](https://github.com/mbta/OpenTripPlanner/pull/48)).

<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Suggested trips do not include Massport shuttles](https://app.asana.com/0/385363666817452/1203244406551664/f)


