### PR TITLE
Setup bus change page feature flag + initial WIP

### DIFF
--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -26,6 +26,8 @@ config :site, SiteWeb.ViewHelpers, google_tag_manager_id: System.get_env("GOOGLE
 
 config :laboratory,
   features: [
+    {:bus_changes, "Bus Change Page (~ Feb 2023)",
+     "Adding a page listing past and present stop changes."},
     {:stops_redesign, "Stops Page Redesign (Jan ~ April 2023)",
      "Revamping of the Stop pages as part of the 🚉 Website - Stops Page Redesign epic"}
   ],

--- a/apps/site/lib/site_web/controllers/bus_stop_change_controller.ex
+++ b/apps/site/lib/site_web/controllers/bus_stop_change_controller.ex
@@ -1,0 +1,56 @@
+defmodule SiteWeb.BusStopChangeController do
+  use SiteWeb, :controller
+
+  alias Alerts.Alert
+
+  def index(conn, _params) do
+    if Laboratory.enabled?(conn, :bus_changes) do
+      conn
+      # Don't let Google crawl this page
+      |> put_resp_header("x-robots-tag", "noindex")
+      # |> assign(:meta_description, "TBA")
+      |> assign(:alerts, bus_stop_alerts(conn.assigns.date_time))
+      |> render("index.html", %{})
+    else
+      redirect(conn, to: alert_path(conn, :index))
+    end
+  end
+
+  """
+  Identify the set of alerts most indicative of bus stop relocations and closures.
+  This is a WIP.
+  """
+
+  defp bus_stop_alerts(date_time) do
+    Alerts.Repo.all(date_time)
+    |> Enum.filter(fn %Alert{
+                        active_period: _active_period,
+                        effect: effect,
+                        lifecycle: _lifecycle
+                      } = alert ->
+      is_closed? = effect in [:stop_closure, :stop_moved, :service_change]
+
+      other_adverse_effects? =
+        effect in [
+          :snow_route,
+          :schedule_change,
+          :dock_closure,
+          :detour,
+          :cancellation,
+          :access_issue,
+          :station_issue,
+          :stop_shoveling,
+          :station_closure,
+          :suspension,
+          :shuttle,
+          :no_service,
+          :facility_issue
+        ]
+
+      stop_set = Alert.get_entity(alert, :stop) |> MapSet.delete(nil)
+      affects_stop? = MapSet.size(stop_set) > 0
+      # if affects_stop?, do: IO.inspect(stop_set, label: alert.id)
+      is_closed? || (affects_stop? && other_adverse_effects?)
+    end)
+  end
+end

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -192,6 +192,7 @@ defmodule SiteWeb.Router do
     get("/search", SearchController, :index)
     post("/search/query", SearchController, :query)
     post("/search/click", SearchController, :click)
+    get("/bus-stop-changes", BusStopChangeController, :index)
 
     for static_page <- StaticPage.static_pages() do
       get("/#{StaticPage.convert_path(static_page)}", StaticPageController, static_page)

--- a/apps/site/lib/site_web/templates/bus_stop_change/index.html.eex
+++ b/apps/site/lib/site_web/templates/bus_stop_change/index.html.eex
@@ -1,0 +1,24 @@
+<div class="container">
+  <div class="page-section">
+    <div class="page-header">
+      <h1>Bus Stop Changes</h1>
+    </div>
+    <div class="callout bg-warning lead">This page is under construction. Please use for testing and research purposes only at this time.</div>
+    <div class="row">
+      <div class="col-lg-3">
+        <%= SiteWeb.PartialView.alert_time_filters(nil, [
+          method: :alert_path,
+          item: :subway
+        ]) %>
+      </div>
+      <div class="col-lg-8 col-lg-offset-1">
+        <%= for alert <- @alerts do %>
+        <section>
+          <%= SiteWeb.AlertView.render "_item.html", alert: alert, date_time: @conn.assigns.date_time %>
+          <hr />
+        </section>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/site/lib/site_web/templates/bus_stop_change/index.html.eex
+++ b/apps/site/lib/site_web/templates/bus_stop_change/index.html.eex
@@ -15,6 +15,14 @@
         <%= for alert <- @alerts do %>
         <section>
           <%= SiteWeb.AlertView.render "_item.html", alert: alert, date_time: @conn.assigns.date_time %>
+          <%= if length(related_stops(alert)) > 0 do %>
+          <strong>Affected Stops</strong>
+          <ul>
+          <%= for stop <- related_stops(alert) do %>
+            <li><a href="<%= stop_path(@conn, :show, stop.id) %>"><%= stop.name %></a></li>
+          <% end %>
+          </ul>
+          <% end %>
           <hr />
         </section>
         <% end %>

--- a/apps/site/lib/site_web/views/bus_stop_change_view.ex
+++ b/apps/site/lib/site_web/views/bus_stop_change_view.ex
@@ -1,3 +1,12 @@
 defmodule SiteWeb.BusStopChangeView do
   use SiteWeb, :view
+  alias Alerts.Alert
+
+  def related_stops(%Alert{} = alert) do
+    Alert.get_entity(alert, :stop)
+    |> MapSet.delete(nil)
+    |> MapSet.to_list()
+    |> Enum.map(&Stops.Repo.get_parent(&1))
+    |> Enum.uniq()
+  end
 end

--- a/apps/site/lib/site_web/views/bus_stop_change_view.ex
+++ b/apps/site/lib/site_web/views/bus_stop_change_view.ex
@@ -1,0 +1,3 @@
+defmodule SiteWeb.BusStopChangeView do
+  use SiteWeb, :view
+end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Set up initial page structure](https://app.asana.com/0/385363666817452/1203811157466553/f)

The new draft  page is set up at `/bus-stop-changes`, hidden behind a new feature flag accessible at `/_flags` (will redirect to /alerts if the flag is not enabled).