### PR TITLE
fix: only run Algolia update in MBTA org

### DIFF
--- a/.github/workflows/algolia-update.yml
+++ b/.github/workflows/algolia-update.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   algolia:
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'mbta'
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/build-app


### PR DESCRIPTION
#### Summary of changes

The Algolia indexing job does not need to run on forks (and in fact, breaks).

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.