### PR TITLE
feat(StopRedesign): Add map of stop to page

### DIFF
--- a/apps/site/assets/css/_stop-page.scss
+++ b/apps/site/assets/css/_stop-page.scss
@@ -298,11 +298,6 @@
   padding: $base-spacing * .75;
 }
 
-.map-container {
-  background-color: gray;
-  width: 100%;
-}
-
 .station-amenities {
   display: grid;
   grid-gap: 1rem;

--- a/apps/site/assets/ts/hooks/__tests__/useMapConfigTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/useMapConfigTest.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { SWRConfig } from "swr";
+import useMapConfig from "../useMapConfig";
+
+const unmockedFetch = global.fetch;
+const HookWrapper: React.FC = ({ children }) => (
+  <SWRConfig value={{ dedupingInterval: 0 }}>{children}</SWRConfig>
+);
+
+const testMapConfig = {
+  tile_server_url: "Test URL"
+};
+
+describe("useMapConfig", () => {
+  beforeAll(() => {
+    // provide mocked network response
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve: Function) =>
+          resolve({
+            json: () => testMapConfig,
+            ok: true,
+            status: 200,
+            statusText: "OK"
+          })
+        )
+    );
+  });
+
+  it("should return a map config", async () => {
+    const { result, waitFor } = renderHook(() => useMapConfig(), {
+      wrapper: HookWrapper
+    });
+    await waitFor(() => expect(result.current).toEqual(testMapConfig));
+  });
+
+  afterAll(() => {
+    global.fetch = unmockedFetch;
+  });
+});

--- a/apps/site/assets/ts/hooks/useMapConfig.ts
+++ b/apps/site/assets/ts/hooks/useMapConfig.ts
@@ -1,0 +1,16 @@
+import useSWR from "swr";
+import { fetchJsonOrThrow } from "../helpers/fetch-json";
+
+const fetchData = async (url: string): Promise<MapConfig> =>
+  fetchJsonOrThrow(url);
+
+export interface MapConfig {
+  tile_server_url: string;
+}
+
+const useMapConfig = (): MapConfig | undefined => {
+  const { data } = useSWR<MapConfig>(`/api/map-config`, fetchData);
+  return data;
+};
+
+export default useMapConfig;

--- a/apps/site/assets/ts/leaflet/components/__mapdata.d.ts
+++ b/apps/site/assets/ts/leaflet/components/__mapdata.d.ts
@@ -42,12 +42,12 @@ export interface MapData {
     longitude: number;
     latitude: number;
   };
-  height: number;
+  height?: number;
   markers: MapMarker[];
   stop_markers?: MapMarker[];
   polylines: Polyline[];
   tile_server_url: TileServerUrl;
-  width: number;
+  width?: number;
   zoom: number | null;
 }
 

--- a/apps/site/assets/ts/stop/__tests__/StopMapRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopMapRedesignTest.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MapData } from "../../leaflet/components/__mapdata";
+import { Stop } from "../../__v3api";
+import StopMapRedesign from "../components/StopMapRedesign";
+
+jest.mock("../../leaflet/components/Map", () => ({
+  __esModule: true,
+  default: (props: { mapData: MapData }) => {
+    expect(props.mapData.markers.length).toBe(1);
+    return <div>Map Component</div>;
+  }
+}));
+
+describe("StopMapRedesign", () => {
+  it("should render the map", () => {
+    render(<StopMapRedesign stop={{ id: "Test Stop ID" } as Stop} />);
+    expect(screen.queryByText("Map Component"));
+  });
+});

--- a/apps/site/assets/ts/stop/components/StopMapRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopMapRedesign.tsx
@@ -1,0 +1,49 @@
+import React, { ReactElement } from "react";
+import Map from "../../leaflet/components/Map";
+import { Stop } from "../../__v3api";
+import { MapData, MapMarker } from "../../leaflet/components/__mapdata";
+import useMapConfig from "../../hooks/useMapConfig";
+
+interface Props {
+  stop: Stop;
+}
+
+const StopMapRedesign = ({ stop }: Props): ReactElement<HTMLElement> => {
+  const mapConfig = useMapConfig();
+
+  const mapData = {
+    default_center: {
+      longitude: stop.longitude,
+      latitude: stop.latitude
+    },
+    markers: [
+      {
+        icon: "map-station-marker",
+        id: stop.id,
+        longitude: stop.longitude,
+        latitude: stop.latitude,
+        rotation_angle: 0,
+        tooltip: null
+      } as MapMarker
+    ],
+    polylines: [],
+    tile_server_url: mapConfig?.tile_server_url,
+    zoom: 16
+  } as MapData;
+
+  return (
+    <div>
+      <h3 className="sr-only">Map</h3>
+      <div
+        id={stop.id}
+        role="application"
+        aria-label="Map with stop"
+        className="m-stop-page__hero-map-container"
+      >
+        <Map mapData={mapData} />
+      </div>
+    </div>
+  );
+};
+
+export default StopMapRedesign;

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -3,6 +3,7 @@ import { uniqueId } from "lodash";
 import DeparturesFilters from "./DeparturesFilters";
 import useStop from "../../hooks/useStop";
 import StationInformation from "./StationInformation";
+import StopMapRedesign from "./StopMapRedesign";
 
 // TODO replace with real data
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -79,8 +80,8 @@ const StopPageRedesign = ({
           </ul>
           <button type="button">Plan your Trip PLACEHOLDER</button>
         </div>
-        <div className="hidden-sm-down map-container">
-          Map PLACEHOLDER Imageine a pretty map
+        <div className="hidden-sm-down w-100">
+          {stop && <StopMapRedesign stop={stop} />}
         </div>
       </div>
       {/* Station Information Div */}

--- a/apps/site/lib/site_web/controllers/map_config_controller.ex
+++ b/apps/site/lib/site_web/controllers/map_config_controller.ex
@@ -1,0 +1,13 @@
+defmodule SiteWeb.MapConfigController do
+  @moduledoc """
+  Endpoints for getting map config details.
+  """
+  use SiteWeb, :controller
+
+  @spec get(Conn.t(), map) :: Conn.t()
+  def get(conn, _opts) do
+    json(conn, %{
+      tile_server_url: Application.fetch_env!(:site, :tile_server_url)
+    })
+  end
+end

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -204,6 +204,8 @@ defmodule SiteWeb.Router do
     get("/alerts", AlertController, :show_by_routes)
 
     get("/stop/:id", StopController, :get)
+
+    get("/map-config", MapConfigController, :get)
   end
 
   scope "/places", SiteWeb do

--- a/apps/site/lib/site_web/templates/stop/show-redesign.html.eex
+++ b/apps/site/lib/site_web/templates/stop/show-redesign.html.eex
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="<%= static_url(@conn, "/css/map.css") %>" data-turbolinks-track="reload">
 <div class="container">
   <div id="react-stop-redesign-root"></div>
 </div>
@@ -6,5 +7,6 @@
   <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/stopRedesign.js" %>"></script>
 <% else %>
   <script defer src="<%= static_url(@conn, "/js/react.js") %>"></script>
+  <script defer src="<%= static_url(@conn, "/js/leaflet.js") %>"></script>
   <script defer src="<%= static_url(@conn, "/js/stopRedesign.js") %>"></script>
 <% end %>

--- a/apps/site/test/site_web/controllers/map_config_controller_test.exs
+++ b/apps/site/test/site_web/controllers/map_config_controller_test.exs
@@ -1,0 +1,11 @@
+defmodule SiteWeb.MapConfigControllerTest do
+  use SiteWeb.ConnCase, async: false
+
+  describe "GET - map config" do
+    test "returns the json with the map config", %{conn: conn} do
+      conn = get(conn, "/api/map-config")
+      data = json_response(conn, 200)
+      assert %{"tile_server_url" => Application.fetch_env!(:site, :tile_server_url)} == data
+    end
+  end
+end


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
Added the leaflet map to the new stop redesign page.
I decided to reuse the lowest level of wrappers we have for the leaflet map because it seemed really flexible and supportive for future requirements for the map, while having next to zero lift to include it in out page.
![Screen Shot 2023-03-15 at 12 16 24 PM](https://user-images.githubusercontent.com/2679229/225389053-9c520dd4-4a7f-43ad-b8ee-a32cdfdcc7bc.png)


<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Map | Display Map with Marker](https://app.asana.com/0/home/1201123880594717/1204099052193031)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

