### PR TITLE
Disable background data fetching processes during tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ###
 
 # 1.) Get the Elixir dependencies within an Elixir container
-FROM hexpm/elixir:1.10.4-erlang-22.3.4.26-debian-buster-20210902 as elixir-builder
+FROM hexpm/elixir:1.12.3-erlang-22.3.4.26-debian-buster-20210902 as elixir-builder
 
 ENV LANG="C.UTF-8" MIX_ENV="prod"
 

--- a/apps/alerts/lib/supervisor.ex
+++ b/apps/alerts/lib/supervisor.ex
@@ -18,10 +18,17 @@ defmodule Alerts.Supervisor do
 
   @impl Supervisor
   def init(_arg) do
-    children = [
-      Alerts.Cache.Store,
-      {Alerts.Cache.Fetcher, api_mfa: @api_mfa}
-    ]
+    children =
+      [
+        Alerts.Cache.Store
+      ] ++
+        if Application.get_env(:elixir, :start_data_processes) do
+          [
+            {Alerts.Cache.Fetcher, api_mfa: @api_mfa}
+          ]
+        else
+          []
+        end
 
     Supervisor.init(children, strategy: :rest_for_one)
   end

--- a/apps/routes/lib/routes.ex
+++ b/apps/routes/lib/routes.ex
@@ -13,7 +13,8 @@ defmodule Routes do
     ]
 
     children =
-      if Application.get_env(:routes, :populate_caches?) do
+      if Application.get_env(:routes, :populate_caches?) and
+           Application.get_env(:elixir, :start_data_processes) do
         children ++
           [
             Routes.PopulateCaches

--- a/apps/routes/test/populate_caches_test.exs
+++ b/apps/routes/test/populate_caches_test.exs
@@ -26,7 +26,7 @@ defmodule Routes.PopulateCachesTest do
   alias __MODULE__.FakeRepo
 
   setup do
-    {:ok, _} = Agent.start_link(&MapSet.new/0, name: FakeRepo)
+    _ = Agent.start_link(&MapSet.new/0, name: FakeRepo)
     :ok
   end
 

--- a/apps/site/lib/site/application.ex
+++ b/apps/site/lib/site/application.ex
@@ -19,27 +19,36 @@ defmodule Site.Application do
       update_static_url(Application.get_env(:site, SiteWeb.Endpoint))
     )
 
-    children = [
-      # Start the endpoint when the application starts
-      %{
-        id: ConCache,
-        start:
-          {ConCache, :start_link,
-           [
+    children =
+      [
+        # Start the endpoint when the application starts
+        %{
+          id: ConCache,
+          start:
+            {ConCache, :start_link,
              [
-               ttl: :timer.seconds(60),
-               ttl_check: :timer.seconds(5),
-               ets_options: [read_concurrency: true]
-             ],
-             [name: :line_diagram_realtime_cache]
-           ]}
-      },
-      {Site.Stream.Vehicles, name: Site.Stream.Vehicles},
-      {Site.GreenLine.Supervisor, name: Site.GreenLine.Supervisor},
-      {Site.React, name: Site.React},
-      {Site.RealtimeSchedule, name: Site.RealtimeSchedule},
-      {SiteWeb.Endpoint, name: SiteWeb.Endpoint}
-    ]
+               [
+                 ttl: :timer.seconds(60),
+                 ttl_check: :timer.seconds(5),
+                 ets_options: [read_concurrency: true]
+               ],
+               [name: :line_diagram_realtime_cache]
+             ]}
+        }
+      ] ++
+        if Application.get_env(:elixir, :start_data_processes) do
+          [
+            {Site.Stream.Vehicles, name: Site.Stream.Vehicles},
+            {Site.GreenLine.Supervisor, name: Site.GreenLine.Supervisor}
+          ]
+        else
+          []
+        end ++
+        [
+          {Site.React, name: Site.React},
+          {Site.RealtimeSchedule, name: Site.RealtimeSchedule},
+          {SiteWeb.Endpoint, name: SiteWeb.Endpoint}
+        ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options

--- a/apps/site/test/green_line_test.exs
+++ b/apps/site/test/green_line_test.exs
@@ -3,6 +3,12 @@ defmodule GreenLineTest do
 
   import GreenLine
 
+  setup_all do
+    # Start parent supervisor
+    {:ok, _pid} = Site.GreenLine.Supervisor.start_link([])
+    :ok
+  end
+
   describe "stops_on_routes/1" do
     test "returns ordered stops on the green line by direction ID" do
       {stops, _} = stops_on_routes(0)

--- a/apps/site/test/site/lib/green_line/cache_test.exs
+++ b/apps/site/test/site/lib/green_line/cache_test.exs
@@ -5,6 +5,8 @@ defmodule Site.GreenLine.CacheTest do
 
   setup_all do
     System.put_env("WARM_CACHES", "true")
+    # start parent supervisor
+    {:ok, _pid} = Site.GreenLine.Supervisor.start_link([])
 
     on_exit(fn ->
       System.put_env("WARM_CACHES", "false")

--- a/apps/site/test/site/lib/green_line/supervisor_test.exs
+++ b/apps/site/test/site/lib/green_line/supervisor_test.exs
@@ -4,6 +4,12 @@ defmodule Site.GreenLine.CacheSupervisorTest do
 
   import Site.GreenLine.CacheSupervisor
 
+  setup_all do
+    # Start parent supervisor
+    {:ok, _pid} = Site.GreenLine.Supervisor.start_link([])
+    :ok
+  end
+
   test "CacheSupervisor is started along with registry" do
     assert {:error, {:already_started, _}} = start_link([])
 

--- a/apps/site/test/site/trip_plan/itinerary_row_list_test.exs
+++ b/apps/site/test/site/trip_plan/itinerary_row_list_test.exs
@@ -7,6 +7,12 @@ defmodule Site.TripPlan.ItineraryRowListTest do
   @to TripPlan.Api.MockPlanner.random_stop(stop_id: nil)
   @date_time ~N[2017-06-27T11:43:00]
 
+  setup_all do
+    # Start parent supervisor - Site.TripPlan.ItineraryRow.get_additional_routes/5 needs this to be running.
+    {:ok, _pid} = Site.GreenLine.Supervisor.start_link([])
+    :ok
+  end
+
   describe "from_itinerary" do
     setup do
       {:ok, [itinerary]} = TripPlan.plan(@from, @to, depart_at: @date_time)

--- a/apps/site/test/site_web/controllers/schedule/green_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/green_test.exs
@@ -9,6 +9,12 @@ defmodule SiteWeb.ScheduleController.GreenTest do
 
   @green_line @routes_repo_api.green_line()
 
+  setup_all do
+    # Start parent supervisor
+    {:ok, _pid} = Site.GreenLine.Supervisor.start_link([])
+    :ok
+  end
+
   describe "schedule_path/3" do
     test "renders line tab without redirect when query_params doesn't include :tab", %{conn: conn} do
       conn = get(conn, schedule_path(conn, :show, "Green"))

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -11,6 +11,12 @@ defmodule SiteWeb.ScheduleControllerTest do
 
   @routes_repo_api Application.get_env(:routes, :routes_repo_api)
 
+  setup_all do
+    # Start parent supervisor
+    {:ok, _pid} = Site.GreenLine.Supervisor.start_link([])
+    :ok
+  end
+
   describe "Bus" do
     test "uses a direction id to determine which stops to show", %{conn: conn} do
       conn = get(conn, line_path(conn, :show, "1", "schedule_direction[direction_id]": 0))

--- a/apps/vehicles/lib/vehicles.ex
+++ b/apps/vehicles/lib/vehicles.ex
@@ -12,9 +12,13 @@ defmodule Vehicles do
 
   defp children do
     streams =
-      "USE_SERVER_SENT_EVENTS"
-      |> System.get_env()
-      |> stream_children()
+      if Application.get_env(:elixir, :start_data_processes) do
+        "USE_SERVER_SENT_EVENTS"
+        |> System.get_env()
+        |> stream_children()
+      else
+        []
+      end
 
     [
       {Phoenix.PubSub.PG2, name: Vehicles.PubSub},

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,17 +1,23 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # Enable colorization in terminal
 # https://github.com/rrrene/bunt/issues/4#issuecomment-301350784
 config :elixir, ansi_enabled: true
+
+# Used by several applications to turn off a subset of child processes in the
+# test environment.
+config :elixir, start_data_processes: config_env() != :test
 
 # By default, the umbrella project as well as each child
 # application will require this configuration file, ensuring
 # they all use the same configuration. While one could
 # configure all applications here, we prefer to delegate
 # back to each application for organization purposes.
-import_config "../apps/*/config/config.exs"
+for config <- "../apps/*/config/config.exs" |> Path.expand(__DIR__) |> Path.wildcard() do
+  import_config config
+end
 
 # Sample configuration (overrides the imported configuration above):
 #


### PR DESCRIPTION
This is a bit of a behind-the-scenes change I made while working on a different thing.

**Issue:** Dotcom runs lots of different processes in the background, mostly fetching and parsing data. But these processes always run, even during CI, producing occasional error messages such as this one:

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/2136286/225742389-67b5f011-3e94-4461-8575-4ec6ed2f8652.png">

Not technically failing test, but kind of annoying, intermittent, and unnecessary.

I eventually came across a pattern used in other projects, where we can configure certain processes to not be automatically started in every environment. [Skate uses it here](https://github.com/mbta/skate/blob/master/lib/skate/application.ex#L17) to omit certain modules from being added to the supervision tree in the test environment. So I decided to do something similar here!

**Approach:** 
* Set a single configuration variable. The name and placement are a bit arbitrary, I just wanted every app in `apps/` to be able to access it. 
* Read that variable and use it to add child processes to various `Supervisor`s across the website
* Adjust tests that were written in a way that assumes those child processes were always running.... well in this case instead of rewriting the tests, I manually start whatever required process is needed for the test. I believe it gets torn down when the test is complete.

Going to deploy and make sure it works as expected.