### PR TITLE
increase max walk distance

### DIFF
--- a/apps/trip_plan/lib/trip_plan.ex
+++ b/apps/trip_plan/lib/trip_plan.ex
@@ -6,8 +6,8 @@ defmodule TripPlan do
 
   # Default options for the plans
   @default_opts [
-    # ~0.5 miles
-    max_walk_distance: 805
+    # ~0.7 miles in meters (was .5)
+    max_walk_distance: 1100
   ]
 
   @doc """


### PR DESCRIPTION
No ticket increase max walk distance to .7 miles to reveal some commuter rail suggestions.