### PR TITLE
fix: adjust mobile menu placement on mobile after click

### DIFF
--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -88,6 +88,7 @@ export function setup(rootElement: HTMLElement): void {
     .forEach(toggle => {
       toggle.addEventListener("click", event => {
         event.preventDefault(); // don't navigate the <a>
+        setHeaderElementPositions(header, rootElement);
         toggleMenu(event.currentTarget as Element);
       });
     });


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Mobile menu placement affected by scrolling](https://app.asana.com/0/385363666817452/1204109811265850/f)

This PR sets the menu's CSS positioning right after clicking, before the menu is displayed, thereby circumventing the issue captured in the Asana ticket's video.

---
