### PR TITLE
[Spike] Using the predictions refactor work in departures

### DIFF
--- a/apps/site/assets/ts/app/__tests__/channels-test.ts
+++ b/apps/site/assets/ts/app/__tests__/channels-test.ts
@@ -1,5 +1,5 @@
 import { Channel, Socket } from "phoenix";
-import setupChannels from "../channels";
+import setupChannels, { joinChannel } from "../channels";
 
 const mockOnLoadEventListener = () => {
   // because the turbolinks:load event doesn't fire outside the browser, run in manually here
@@ -90,5 +90,17 @@ describe("setupChannels", () => {
     expect(console.log).toHaveBeenCalledWith("success joining vehicles:Red:0");
 
     consoleMock.mockRestore();
+  });
+});
+
+describe("joinChannel", () => {
+  it("can handle data dispatched on join", () => {
+    const mockHandleJoin = jest.fn();
+    const channelName = "some:channel";
+    window.channels[channelName] = window.socket.channel(channelName, {});
+    joinChannel(channelName, mockHandleJoin);
+    // @ts-ignore
+    window.channels[channelName].joinPush.trigger("ok", { some: "data" });
+    expect(mockHandleJoin).toHaveBeenCalledWith({ some: "data" });
   });
 });

--- a/apps/site/assets/ts/app/channels.ts
+++ b/apps/site/assets/ts/app/channels.ts
@@ -24,7 +24,11 @@ export type SocketEvent<DataType> = UpdateEvent<DataType> | RemoveEvent;
 const isVehicleChannel = (channelId: string): boolean =>
   channelId.includes("vehicles:") && channelId !== "vehicles:remove";
 
-const joinChannel = <T>(channelId: string, handleJoin?: Function): void => {
+const joinChannel = <T>(
+  channelId: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handleJoin?: (event: any) => void
+): void => {
   if (!window.socket) return;
 
   if (!window.channels[channelId]) {

--- a/apps/site/assets/ts/app/channels.ts
+++ b/apps/site/assets/ts/app/channels.ts
@@ -24,7 +24,7 @@ export type SocketEvent<DataType> = UpdateEvent<DataType> | RemoveEvent;
 const isVehicleChannel = (channelId: string): boolean =>
   channelId.includes("vehicles:") && channelId !== "vehicles:remove";
 
-const joinChannel = <T>(channelId: string): void => {
+const joinChannel = <T>(channelId: string, handleJoin?: Function): void => {
   if (!window.socket) return;
 
   if (!window.channels[channelId]) {
@@ -40,8 +40,11 @@ const joinChannel = <T>(channelId: string): void => {
         /* eslint-disable no-console */
         console.error(`failed to join ${channelId}`, reason)
       )
-      .receive("ok", () => {
+      .receive("ok", event => {
         console.log(`success joining ${channelId}`);
+        if (handleJoin) {
+          handleJoin(event);
+        }
         /* eslint-enable no-console */
         if (isVehicleChannel(channelId)) {
           const [, route_id, direction_id] = channelId.split(":");

--- a/apps/site/assets/ts/helpers/__tests__/date-test.ts
+++ b/apps/site/assets/ts/helpers/__tests__/date-test.ts
@@ -1,4 +1,9 @@
-import { compareStringTimes, formatToBostonTime } from "../date";
+import endOfHour from "date-fns/endOfHour";
+import {
+  compareStringTimes,
+  formatDepartureTime,
+  formatToBostonTime
+} from "../date";
 
 describe("compareStringTimes", () => {
   it.each`
@@ -20,5 +25,16 @@ describe("compareStringTimes", () => {
 describe("formatToBostonTime", () => {
   it("should format the string in the same timezone as Boston", () => {
     expect(formatToBostonTime("2022-10-28T15:25:00-04:00")).toBe("3:25 PM");
+  });
+});
+
+describe("formatDepartureTime", () => {
+  it("(WIP) should format to friendly format", () => {
+    const now = new Date();
+    const time = endOfHour(now);
+    expect(formatDepartureTime(time, true)).toMatch(
+      /^\d{1,2}:\d{2}:\d{2} (AM|PM)$/
+    );
+    expect(formatDepartureTime(time, false)).toMatch(/(minute|hour)/);
   });
 });

--- a/apps/site/assets/ts/helpers/date.ts
+++ b/apps/site/assets/ts/helpers/date.ts
@@ -1,4 +1,4 @@
-import { getMinutes, parseISO } from "date-fns";
+import { formatDistanceToNow, getMinutes, parseISO } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 
 // this returns a Date() in the browser time zone, unlike new Date(unformatted)
@@ -68,6 +68,14 @@ export const formatToBostonTime = (dateTimeString: string): string => {
     formatString = "h aa"; // 5 AM
   }
   return formatInTimeZone(dateTime, "America/New_York", formatString);
+};
+
+/** WIP human-readable predicted or scheduled time on the stop page */
+export const formatDepartureTime = (date: Date, isCR: boolean): string => {
+  if (isCR) {
+    return date.toLocaleTimeString();
+  }
+  return formatDistanceToNow(date, { addSuffix: true });
 };
 
 export default formattedDate;

--- a/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
@@ -1,0 +1,145 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import usePredictionsChannel, {
+  StreamPrediction
+} from "../usePredictionsChannel";
+import {
+  makeMockChannel,
+  makeMockSocket
+} from "../../helpers/socketTestHelpers";
+import { Stop, Trip } from "../../__v3api";
+
+describe("usePredictionsChannel", () => {
+  beforeAll(() => {
+    const mockSocket = makeMockSocket();
+    const mockChannel = makeMockChannel("ok");
+    mockSocket.channel.mockImplementationOnce(() => mockChannel);
+
+    // mock setup global variables on page load
+    window.socket = mockSocket;
+    window.channels = {};
+  });
+
+  test("initializes connection to appropriate channel", () => {
+    const { result } = renderHook(() =>
+      usePredictionsChannel("Purple", "place-somewhere", 0)
+    );
+    expect(result.current).toEqual({});
+    expect(
+      window.channels["predictions:Purple:place-somewhere:0"]
+    ).toBeTruthy();
+  });
+
+  test("gets and outputs data", () => {
+    const { result } = renderHook(() =>
+      usePredictionsChannel("Purple", "place-somewhere", 0)
+    );
+
+    /* pretend this is the channel emitting new predictions */
+    act(() => {
+      const event = new CustomEvent<{
+        predictions: StreamPrediction[];
+      }>("predictions:Purple:place-somewhere:0", {
+        detail: {
+          predictions: [
+            {
+              id: "1",
+              "departing?": true,
+              direction_id: 0,
+              stop: { id: "place-somewhere" } as Stop,
+              time: "2022-12-15 00:46:04.576744Z",
+              track: "7",
+              trip: { id: "123", headsign: "Destination One" } as Trip
+            } as StreamPrediction,
+            {
+              id: "2",
+              "departing?": true,
+              direction_id: 0,
+              stop: { id: "place-somewhere" } as Stop,
+              time: "2022-12-15 00:48:04.576744Z",
+              track: "2",
+              trip: { id: "600", headsign: "Destination Two" } as Trip
+            } as StreamPrediction,
+            {
+              id: "3",
+              "departing?": false,
+              direction_id: 0,
+              stop: { id: "place-somewhere" } as Stop,
+              time: "2022-12-15 00:55:04.576744Z",
+              trip: { id: "20", headsign: "Destination One" } as Trip
+            } as StreamPrediction
+          ]
+        }
+      });
+      document.dispatchEvent(event);
+    });
+
+    expect(result.current).toHaveProperty("Destination One");
+    expect(result.current).toHaveProperty("Destination Two");
+    expect(result.current["Destination One"]).toHaveLength(2);
+    expect(result.current["Destination Two"]).toHaveLength(1);
+  });
+
+  test("doesn't output data if same as new data", () => {
+    const { result } = renderHook(() =>
+      usePredictionsChannel("Purple", "place-somewhere", 0)
+    );
+
+    const initialPredictions = [
+      {
+        id: "1",
+        "departing?": true,
+        direction_id: 0,
+        stop: { id: "place-somewhere" } as Stop,
+        time: "2022-12-15 00:46:04.576744Z",
+        track: "7",
+        trip: { id: "123", headsign: "Destination One" } as Trip
+      } as StreamPrediction,
+      {
+        id: "2",
+        "departing?": true,
+        direction_id: 0,
+        stop: { id: "place-somewhere" } as Stop,
+        time: "2022-12-15 00:48:04.576744Z",
+        track: "2",
+        trip: { id: "600", headsign: "Destination Two" } as Trip
+      } as StreamPrediction,
+      {
+        id: "3",
+        "departing?": false,
+        direction_id: 0,
+        stop: { id: "place-somewhere" } as Stop,
+        time: "2022-12-15 00:55:04.576744Z",
+        trip: { id: "20", headsign: "Destination One" } as Trip
+      } as StreamPrediction
+    ];
+
+    /* pretend this is the channel emitting new predictions */
+    act(() => {
+      const event = new CustomEvent<{
+        predictions: StreamPrediction[];
+      }>("predictions:Purple:place-somewhere:0", {
+        detail: {
+          predictions: initialPredictions
+        }
+      });
+      document.dispatchEvent(event);
+    });
+
+    const results = result.current;
+    expect(results).toBeTruthy();
+
+    /* again! */
+    act(() => {
+      const event = new CustomEvent<{
+        predictions: StreamPrediction[];
+      }>("predictions:Purple:place-somewhere:0", {
+        detail: {
+          predictions: initialPredictions
+        }
+      });
+      document.dispatchEvent(event);
+    });
+    expect(result.current).toBeTruthy();
+    expect(result.current).toEqual(results);
+  });
+});

--- a/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
@@ -1,14 +1,46 @@
 import { act, renderHook } from "@testing-library/react-hooks";
 import usePredictionsChannel, {
-  StreamPrediction
+  Prediction,
+  StreamPrediction,
+  groupByHeadsigns,
+  parsePrediction
 } from "../usePredictionsChannel";
 import {
   makeMockChannel,
   makeMockSocket
 } from "../../helpers/socketTestHelpers";
-import { Stop, Trip } from "../../__v3api";
+import { Route, Stop, Trip } from "../../__v3api";
 
-describe("usePredictionsChannel", () => {
+const predictionsFromStream = [
+  {
+    id: "1",
+    "departing?": true,
+    direction_id: 0,
+    stop: { id: "place-somewhere" } as Stop,
+    departure_time: "2022-12-15 00:46:04.576744Z",
+    track: "7",
+    trip: { id: "123", headsign: "Destination One" } as Trip
+  } as StreamPrediction,
+  {
+    id: "2",
+    "departing?": true,
+    direction_id: 0,
+    stop: { id: "place-somewhere" } as Stop,
+    departure_time: "2022-12-15 00:48:04.576744Z",
+    track: "2",
+    trip: { id: "600", headsign: "Destination Two" } as Trip
+  } as StreamPrediction,
+  {
+    id: "3",
+    "departing?": false,
+    direction_id: 0,
+    stop: { id: "place-somewhere" } as Stop,
+    departure_time: "2022-12-15 00:55:04.576744Z",
+    trip: { id: "20", headsign: "Destination One" } as Trip
+  } as StreamPrediction
+];
+
+describe("usePredictionsChannel hook", () => {
   beforeAll(() => {
     const mockSocket = makeMockSocket();
     const mockChannel = makeMockChannel("ok");
@@ -40,34 +72,7 @@ describe("usePredictionsChannel", () => {
         predictions: StreamPrediction[];
       }>("predictions:Purple:place-somewhere:0", {
         detail: {
-          predictions: [
-            {
-              id: "1",
-              "departing?": true,
-              direction_id: 0,
-              stop: { id: "place-somewhere" } as Stop,
-              time: "2022-12-15 00:46:04.576744Z",
-              track: "7",
-              trip: { id: "123", headsign: "Destination One" } as Trip
-            } as StreamPrediction,
-            {
-              id: "2",
-              "departing?": true,
-              direction_id: 0,
-              stop: { id: "place-somewhere" } as Stop,
-              time: "2022-12-15 00:48:04.576744Z",
-              track: "2",
-              trip: { id: "600", headsign: "Destination Two" } as Trip
-            } as StreamPrediction,
-            {
-              id: "3",
-              "departing?": false,
-              direction_id: 0,
-              stop: { id: "place-somewhere" } as Stop,
-              time: "2022-12-15 00:55:04.576744Z",
-              trip: { id: "20", headsign: "Destination One" } as Trip
-            } as StreamPrediction
-          ]
+          predictions: predictionsFromStream
         }
       });
       document.dispatchEvent(event);
@@ -84,42 +89,13 @@ describe("usePredictionsChannel", () => {
       usePredictionsChannel("Purple", "place-somewhere", 0)
     );
 
-    const initialPredictions = [
-      {
-        id: "1",
-        "departing?": true,
-        direction_id: 0,
-        stop: { id: "place-somewhere" } as Stop,
-        time: "2022-12-15 00:46:04.576744Z",
-        track: "7",
-        trip: { id: "123", headsign: "Destination One" } as Trip
-      } as StreamPrediction,
-      {
-        id: "2",
-        "departing?": true,
-        direction_id: 0,
-        stop: { id: "place-somewhere" } as Stop,
-        time: "2022-12-15 00:48:04.576744Z",
-        track: "2",
-        trip: { id: "600", headsign: "Destination Two" } as Trip
-      } as StreamPrediction,
-      {
-        id: "3",
-        "departing?": false,
-        direction_id: 0,
-        stop: { id: "place-somewhere" } as Stop,
-        time: "2022-12-15 00:55:04.576744Z",
-        trip: { id: "20", headsign: "Destination One" } as Trip
-      } as StreamPrediction
-    ];
-
     /* pretend this is the channel emitting new predictions */
     act(() => {
       const event = new CustomEvent<{
         predictions: StreamPrediction[];
       }>("predictions:Purple:place-somewhere:0", {
         detail: {
-          predictions: initialPredictions
+          predictions: predictionsFromStream
         }
       });
       document.dispatchEvent(event);
@@ -134,7 +110,7 @@ describe("usePredictionsChannel", () => {
         predictions: StreamPrediction[];
       }>("predictions:Purple:place-somewhere:0", {
         detail: {
-          predictions: initialPredictions
+          predictions: predictionsFromStream
         }
       });
       document.dispatchEvent(event);
@@ -142,4 +118,72 @@ describe("usePredictionsChannel", () => {
     expect(result.current).toBeTruthy();
     expect(result.current).toEqual(results);
   });
+});
+
+test("usePredictionsChannel parsePrediction modifies the streamed prediction", () => {
+  const streamPrediction = {
+    id: "1",
+    direction_id: 0,
+    route: { id: "Silver" } as Route,
+    stop: { id: "place-somewhere" } as Stop,
+    schedule_relationship: "added",
+    track: null,
+    arrival_time: "2022-12-15 00:54:59.576744Z",
+    departure_time: "2022-12-15 00:55:04.576744Z",
+    time: "2022-12-15 00:54:59.576744Z",
+    trip: { id: "999", headsign: "Final Destination" } as Trip
+  } as StreamPrediction;
+  const parsed = parsePrediction(streamPrediction);
+
+  expect(parsed).toBeTruthy();
+  expect(parsed.time).toEqual(new Date(streamPrediction.departure_time!));
+  expect(parsed.time).not.toEqual(new Date(streamPrediction.arrival_time!));
+  expect(parsed.time).not.toEqual(new Date(streamPrediction.time!));
+});
+
+test("usePredictionsChannel groupByHeadsigns groups and sorts", () => {
+  const predictions = [
+    {
+      trip: { headsign: "A" },
+      time: new Date("2023-04-17T10:10:00")
+    } as Prediction,
+    {
+      trip: { headsign: "B" },
+      time: new Date("2023-04-17T09:14:00")
+    } as Prediction,
+    {
+      trip: { headsign: "A" },
+      time: new Date("2023-04-17T08:54:00")
+    } as Prediction,
+    {
+      trip: { headsign: "B" },
+      time: new Date("2023-04-17T09:00:00")
+    } as Prediction,
+    {
+      trip: { headsign: "A" },
+      time: new Date("2023-04-17T07:33:00")
+    } as Prediction,
+    {
+      trip: { headsign: "C" },
+      time: new Date("2023-04-17T09:25:00")
+    } as Prediction,
+    {
+      trip: { headsign: "C" },
+      time: new Date("2023-04-17T09:24:00")
+    } as Prediction,
+    {
+      trip: { headsign: "A" },
+      time: new Date("2023-04-17T09:24:00")
+    } as Prediction
+  ];
+  const grouped = groupByHeadsigns(predictions);
+  expect(Object.keys(grouped)).toContain("A");
+  expect(Object.keys(grouped)).toContain("B");
+  expect(Object.keys(grouped)).toContain("C");
+  expect(grouped["A"].map(p => p.time.toLocaleTimeString())).toEqual([
+    "7:33:00 AM",
+    "8:54:00 AM",
+    "9:24:00 AM",
+    "10:10:00 AM"
+  ]);
 });

--- a/apps/site/assets/ts/hooks/useChannel.ts
+++ b/apps/site/assets/ts/hooks/useChannel.ts
@@ -35,7 +35,7 @@ function useChannel<
   const [state, dispatch] = useReducer<OnDataReducerType>(reducer, initialData);
 
   useEffect(() => {
-    joinChannel<OnDataEventType[]>(channelId);
+    joinChannel<OnDataEventType[]>(channelId, dispatch);
 
     return () => {
       leaveChannel(channelId);

--- a/apps/site/assets/ts/hooks/usePredictionsChannel.ts
+++ b/apps/site/assets/ts/hooks/usePredictionsChannel.ts
@@ -1,0 +1,93 @@
+import { chain } from "lodash";
+import deepEqual from "fast-deep-equal/react";
+import { Reducer, useCallback } from "react";
+import {
+  DirectionId,
+  Route,
+  ScheduleRelationship,
+  Stop,
+  Trip
+} from "../__v3api";
+import useChannel from "./useChannel";
+
+/**
+ * The format of a prediction emitted via websockets from
+ * SiteWeb.PredictionsChannel.
+ */
+export interface StreamPrediction {
+  id: string;
+  arrival_time: string | null;
+  departure_time: string | null;
+  time: string | null;
+  route: Route;
+  stop: Stop;
+  trip: Trip;
+  stop_sequence: number;
+  direction_id: DirectionId;
+  schedule_relationship: ScheduleRelationship;
+  track: string | null;
+  status: string | null;
+  "departing?": boolean;
+}
+
+interface ChannelPredictionResponse {
+  predictions: StreamPrediction[];
+}
+
+interface PredictionsByHeadsign {
+  [headsign: string]: StreamPrediction[];
+}
+
+const groupByHeadsignFunc = (numPredictions?: number) => {
+  return (predictions: StreamPrediction[]): PredictionsByHeadsign =>
+    chain(predictions)
+      .groupBy("trip.headsign")
+      .mapValues(headsignPredictions =>
+        chain(headsignPredictions)
+          .sortBy("time", Date)
+          .uniqBy("id")
+          .value()
+          .slice(0, numPredictions)
+      )
+      .value();
+};
+
+/**
+ * Subscribes to updates on predictions for a specific route/stop/direction via
+ * websockets + Phoenix channels. The channel updates very frequently, so this
+ * function takes care to only emit updated predictions if they are different
+ * from the previous set of predictions.
+ * - Transforms the predictions via a reducer function that groups the
+ *   predictions by trip headsign, sorting the lists of predictions by time.
+ * - Default behavior will keep all predictions, but `numPredictions` can be
+ *   used to truncate to a certain number of predictions per headsign.
+ */
+const usePredictionsChannel = (
+  routeId: string,
+  stopId: string,
+  directionId: 0 | 1,
+  numPredictions?: number
+): PredictionsByHeadsign => {
+  const channelName = `predictions:${routeId}:${stopId}:${directionId}`;
+  const reducer: Reducer<
+    PredictionsByHeadsign,
+    ChannelPredictionResponse
+  > = useCallback(
+    (oldGroupedPredictions, newStreamedPredictions) => {
+      const newGroupedPredictions = groupByHeadsignFunc(numPredictions)(
+        newStreamedPredictions.predictions
+      );
+      // don't attempt to reconcile with prior predictions, just replace state with
+      // all the new predictions from the channel if there are any changes.
+      return deepEqual(oldGroupedPredictions, newGroupedPredictions)
+        ? oldGroupedPredictions
+        : newGroupedPredictions;
+    },
+    [numPredictions]
+  );
+  const initialState: PredictionsByHeadsign = {};
+  const state = useChannel(channelName, reducer, initialState);
+  return state;
+};
+
+export default usePredictionsChannel;

--- a/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import DepartureCard from "../components/DepartureCard";
-import { Route, RouteType } from "../../__v3api";
+import { Route, RouteType, Stop } from "../../__v3api";
 
 const baseRoute = (name: string, type: RouteType): Route =>
   ({
@@ -11,10 +10,11 @@ const baseRoute = (name: string, type: RouteType): Route =>
     name: `${name} Route`,
     type
   } as Route);
+const stop = {} as Stop;
 
 describe("DepartureCard", () => {
   it("renders a list item with route name", () => {
-    render(<DepartureCard route={baseRoute("749", 3)} />);
+    render(<DepartureCard route={baseRoute("749", 3)} stop={stop} />);
     const listItem = screen.getByRole("listitem");
     expect(listItem).toBeDefined();
     expect(within(listItem).getByText("Silver Line 749 Route")).toBeDefined();
@@ -23,7 +23,9 @@ describe("DepartureCard", () => {
   it("renders icons for modes", () => {
     const iconElements = [0, 1, 2, 3, 4]
       .map(type =>
-        render(<DepartureCard route={baseRoute("", type as RouteType)} />)
+        render(
+          <DepartureCard route={baseRoute("", type as RouteType)} stop={stop} />
+        )
       )
       .map(({ container }) => container.querySelector(".c-svg__icon"));
     iconElements.forEach(el => expect(el).toBeDefined());
@@ -43,7 +45,7 @@ describe("DepartureCard", () => {
     ${baseRoute("", 3)}         | ${".u-bg--bus"}
     ${baseRoute("", 4)}         | ${".u-bg--ferry"}
   `("renders different colors for routes/modes", ({ route, expectedClass }) => {
-    const { container } = render(<DepartureCard route={route} />);
+    const { container } = render(<DepartureCard route={route} stop={stop} />);
     expect(container.querySelector(expectedClass)).toBeInTheDocument();
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -3,7 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import DepartureCard from "../components/DepartureCard";
 import { Route, RouteType, Stop } from "../../__v3api";
 
-const baseRoute = (name: string, type: RouteType): Route =>
+export const baseRoute = (name: string, type: RouteType): Route =>
   ({
     id: name,
     direction_destinations: { 0: "Somewhere there", 1: "Over yonder" },

--- a/apps/site/assets/ts/stop/__tests__/StopPageDeparturesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageDeparturesTest.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import StopPageDepartures from "../components/StopPageDepartures";
-import { Route, RouteType } from "../../__v3api";
+import { Route, RouteType, Stop } from "../../__v3api";
 
 const baseRoute = (name: string, type: RouteType): Route =>
   ({
@@ -10,23 +10,27 @@ const baseRoute = (name: string, type: RouteType): Route =>
     name: `${name} Route`,
     type
   } as Route);
-
+const stop = {} as Stop;
 const routeData: Route[] = [baseRoute("4B", 3), baseRoute("Magenta", 1)];
 
 describe("StopPageDepartures", () => {
   it("renders with no data", () => {
-    const { asFragment } = render(<StopPageDepartures routes={[]} />);
+    const { asFragment } = render(
+      <StopPageDepartures routes={[]} stop={stop} />
+    );
     expect(asFragment()).toMatchSnapshot();
     expect(screen.getByRole("list")).toBeEmptyDOMElement();
   });
 
   it("renders with data", () => {
-    const { asFragment } = render(<StopPageDepartures routes={routeData} />);
+    const { asFragment } = render(
+      <StopPageDepartures routes={routeData} stop={stop} />
+    );
     expect(asFragment()).toMatchSnapshot();
     expect(screen.getAllByRole("list")[0]).not.toBeEmptyDOMElement();
     ["All", "Bus", "Subway"].forEach(name => {
       expect(
-        screen.getByRole("button", { name: new RegExp(name, "g") })
+        screen.getByRole("button", { name: new RegExp(name) })
       ).toBeDefined();
     });
   });

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
@@ -76,7 +76,7 @@ exports[`StopPageDepartures renders with data 1`] = `
             Somewhere there
           </div>
           <div>
-            No predictions.
+            No times.
           </div>
           <button
             aria-label="Open upcoming departures to Somewhere there"
@@ -97,7 +97,7 @@ exports[`StopPageDepartures renders with data 1`] = `
             Over yonder
           </div>
           <div>
-            No predictions.
+            No times.
           </div>
           <button
             aria-label="Open upcoming departures to Over yonder"
@@ -138,7 +138,7 @@ exports[`StopPageDepartures renders with data 1`] = `
             Somewhere there
           </div>
           <div>
-            No predictions.
+            No times.
           </div>
           <button
             aria-label="Open upcoming departures to Somewhere there"
@@ -159,7 +159,7 @@ exports[`StopPageDepartures renders with data 1`] = `
             Over yonder
           </div>
           <div>
-            No predictions.
+            No times.
           </div>
           <button
             aria-label="Open upcoming departures to Over yonder"

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
@@ -75,10 +75,8 @@ exports[`StopPageDepartures renders with data 1`] = `
           >
             Somewhere there
           </div>
-          <div
-            class="departure-card__times"
-          >
-            [Times here]
+          <div>
+            No predictions.
           </div>
           <button
             aria-label="Open upcoming departures to Somewhere there"
@@ -98,10 +96,8 @@ exports[`StopPageDepartures renders with data 1`] = `
           >
             Over yonder
           </div>
-          <div
-            class="departure-card__times"
-          >
-            [Times here]
+          <div>
+            No predictions.
           </div>
           <button
             aria-label="Open upcoming departures to Over yonder"
@@ -141,10 +137,8 @@ exports[`StopPageDepartures renders with data 1`] = `
           >
             Somewhere there
           </div>
-          <div
-            class="departure-card__times"
-          >
-            [Times here]
+          <div>
+            No predictions.
           </div>
           <button
             aria-label="Open upcoming departures to Somewhere there"
@@ -164,10 +158,8 @@ exports[`StopPageDepartures renders with data 1`] = `
           >
             Over yonder
           </div>
-          <div
-            class="departure-card__times"
-          >
-            [Times here]
+          <div>
+            No predictions.
           </div>
           <button
             aria-label="Open upcoming departures to Over yonder"

--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import DepartureTimes from "../../components/DepartureTimes";
+import { baseRoute } from "../DepartureCardTest";
+import { Stop } from "../../../__v3api";
+
+const route = baseRoute("TestRoute", 1);
+const stop = {} as Stop;
+const destinationText = route.direction_destinations[0]!;
+
+describe("(WIP) DepartureTimes", () => {
+  it("should display a default", () => {
+    render(<DepartureTimes route={route} stop={stop} directionId={0} />);
+    expect(screen.findByText(destinationText)).toBeDefined();
+    expect(
+      screen.queryByRole("button", {
+        name: `Open upcoming departures to ${destinationText}`
+      })
+    ).toBeDefined();
+  });
+});

--- a/apps/site/assets/ts/stop/components/DepartureCard.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureCard.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from "react";
 import { routeBgClass, busClass } from "../../helpers/css";
 import { breakTextAtSlash } from "../../helpers/text";
 import { isASilverLineRoute } from "../../models/route";
-import { DirectionId, Route, Stop } from "../../__v3api";
+import { Route, Stop } from "../../__v3api";
 import CRsvg from "../../../static/images/icon-commuter-rail-default.svg";
 import Bussvg from "../../../static/images/icon-bus-default.svg";
 import SubwaySvg from "../../../static/images/icon-subway-default.svg";
@@ -50,14 +50,18 @@ const DepartureCard = ({
       <div className={`departure-card__route ${routeBgClass(route)}`}>
         {renderSvg("c-svg__icon", routeToModeIcon(route), true)} {routeName}
       </div>
-      {Object.entries(route.direction_destinations).map(([direction_id]) => (
-        <DepartureTimes
-          key={`${route.id}-${direction_id}`}
-          route={route}
-          stop={stop}
-          directionId={(direction_id as unknown) as DirectionId}
-        />
-      ))}
+      <DepartureTimes
+        key={`${route.id}-0`}
+        route={route}
+        stop={stop}
+        directionId={0}
+      />
+      <DepartureTimes
+        key={`${route.id}-1`}
+        route={route}
+        stop={stop}
+        directionId={1}
+      />
     </li>
   );
 };

--- a/apps/site/assets/ts/stop/components/DepartureCard.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureCard.tsx
@@ -1,14 +1,14 @@
 import React, { ReactElement } from "react";
 import { routeBgClass, busClass } from "../../helpers/css";
-import renderFa from "../../helpers/render-fa";
 import { breakTextAtSlash } from "../../helpers/text";
 import { isASilverLineRoute } from "../../models/route";
-import { Route } from "../../__v3api";
+import { DirectionId, Route, Stop } from "../../__v3api";
 import CRsvg from "../../../static/images/icon-commuter-rail-default.svg";
 import Bussvg from "../../../static/images/icon-bus-default.svg";
 import SubwaySvg from "../../../static/images/icon-subway-default.svg";
 import FerrySvg from "../../../static/images/icon-ferry-default.svg";
 import renderSvg from "../../helpers/render-svg";
+import DepartureTimes from "./DepartureTimes";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const routeToModeIcon = (route: Route): any => {
@@ -32,9 +32,11 @@ const routeToModeIcon = (route: Route): any => {
 };
 
 const DepartureCard = ({
-  route
+  route,
+  stop
 }: {
   route: Route;
+  stop: Stop;
 }): ReactElement<HTMLElement> => {
   const routeName = (
     <span className={busClass(route)}>
@@ -48,23 +50,14 @@ const DepartureCard = ({
       <div className={`departure-card__route ${routeBgClass(route)}`}>
         {renderSvg("c-svg__icon", routeToModeIcon(route), true)} {routeName}
       </div>
-      {Object.entries(route.direction_destinations).map(
-        ([direction_id, headsign]) => (
-          <div
-            key={`${route.id}-${direction_id}-${headsign}`}
-            className="departure-card__headsign"
-          >
-            <div className="departure-card__headsign-name">{headsign}</div>
-            <div className="departure-card__times">[Times here]</div>
-            <button
-              type="button"
-              aria-label={`Open upcoming departures to ${headsign}`}
-            >
-              {renderFa("", "fa-angle-right")}
-            </button>
-          </div>
-        )
-      )}
+      {Object.entries(route.direction_destinations).map(([direction_id]) => (
+        <DepartureTimes
+          key={`${route.id}-${direction_id}`}
+          route={route}
+          stop={stop}
+          directionId={(direction_id as unknown) as DirectionId}
+        />
+      ))}
     </li>
   );
 };

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -1,23 +1,15 @@
-import formatDistanceToNow from "date-fns/formatDistanceToNow";
 import React, { ReactElement } from "react";
 import usePredictionsChannel from "../../hooks/usePredictionsChannel";
 import { isACommuterRailRoute } from "../../models/route";
 import { DirectionId, Route, Stop } from "../../__v3api";
 import renderFa from "../../helpers/render-fa";
+import { formatDepartureTime } from "../../helpers/date";
 
 interface DepartureTimesProps {
   route: Route;
   stop: Stop;
   directionId: DirectionId;
 }
-
-const formatTime = (timeString: string, isCR: boolean): string => {
-  const d = new Date(timeString);
-  if (isCR) {
-    return d.toLocaleTimeString();
-  }
-  return formatDistanceToNow(d, { addSuffix: true });
-};
 
 /* istanbul ignore next */
 /**
@@ -63,7 +55,9 @@ const DepartureTimes = (
             <div>
               {predictions.length ? (
                 predictions.map(p => {
-                  return <div key={p.id}>{formatTime(p.time!, isCR)}</div>;
+                  return (
+                    <div key={p.id}>{formatDepartureTime(p.time!, isCR)}</div>
+                  );
                 })
               ) : (
                 <div>No predictions.</div>

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -1,0 +1,85 @@
+import formatDistanceToNow from "date-fns/formatDistanceToNow";
+import React, { ReactElement } from "react";
+import usePredictionsChannel from "../../hooks/usePredictionsChannel";
+import { isACommuterRailRoute } from "../../models/route";
+import { DirectionId, Route, Stop } from "../../__v3api";
+import renderFa from "../../helpers/render-fa";
+
+interface DepartureTimesProps {
+  route: Route;
+  stop: Stop;
+  directionId: DirectionId;
+}
+
+const formatTime = (timeString: string, isCR: boolean): string => {
+  const d = new Date(timeString);
+  if (isCR) {
+    return d.toLocaleTimeString();
+  }
+  return formatDistanceToNow(d, { addSuffix: true });
+};
+
+/* istanbul ignore next */
+/**
+ * A proof-of-concept component illustrating a usage of the
+ * usePredictionsChannel hook to fetch live predictions for a specific
+ * route/stop/direction, sorted by date.
+ *
+ */
+const DepartureTimes = (
+  props: DepartureTimesProps
+): ReactElement<HTMLElement> => {
+  const { route, stop, directionId } = props;
+  const isCR = isACommuterRailRoute(route);
+  const predictionsByHeadsign = usePredictionsChannel(
+    route.id,
+    stop.id,
+    directionId,
+    isCR ? 1 : 2
+  );
+
+  if (!Object.keys(predictionsByHeadsign).length) {
+    return (
+      <div className="departure-card__headsign">
+        <div className="departure-card__headsign-name">
+          {route.direction_destinations[directionId]}
+        </div>
+        <div>No predictions.</div>
+        <button
+          type="button"
+          aria-label={`Open upcoming departures to ${route.direction_destinations[directionId]}`}
+        >
+          {renderFa("", "fa-angle-right")}
+        </button>
+      </div>
+    );
+  }
+  return (
+    <>
+      {Object.entries(predictionsByHeadsign).map(([headsign, predictions]) => {
+        return (
+          <div key={headsign} className="departure-card__headsign">
+            <div className="departure-card__headsign-name">{headsign}</div>
+            <div>
+              {predictions.length ? (
+                predictions.map(p => {
+                  return <div key={p.id}>{formatTime(p.time!, isCR)}</div>;
+                })
+              ) : (
+                <div>No predictions.</div>
+              )}
+            </div>
+            <button
+              type="button"
+              aria-label={`Open upcoming departures to ${headsign}`}
+            >
+              {renderFa("", "fa-angle-right")}
+            </button>
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+export default DepartureTimes;

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -11,6 +11,29 @@ interface DepartureTimesProps {
   directionId: DirectionId;
 }
 
+const departureTimeRow = (
+  headsignName: string,
+  formattedTimes?: string[]
+): JSX.Element => {
+  return (
+    <div key={headsignName} className="departure-card__headsign">
+      <div className="departure-card__headsign-name">{headsignName}</div>
+      <div>
+        {formattedTimes && formattedTimes.length > 0
+          ? formattedTimes.map(t => <div key={t}>{t}</div>)
+          : "No times."}
+      </div>
+      {/* TODO: Navigate to Realtime Tracking view */}
+      <button
+        type="button"
+        aria-label={`Open upcoming departures to ${headsignName}`}
+      >
+        {renderFa("", "fa-angle-right")}
+      </button>
+    </div>
+  );
+};
+
 /* istanbul ignore next */
 /**
  * A proof-of-concept component illustrating a usage of the
@@ -30,46 +53,18 @@ const DepartureTimes = (
     isCR ? 1 : 2
   );
 
+  // TODO: Show schedules when we don't have predictions, and implement logic
+  // for various states of next departute time.
+
   if (!Object.keys(predictionsByHeadsign).length) {
-    return (
-      <div className="departure-card__headsign">
-        <div className="departure-card__headsign-name">
-          {route.direction_destinations[directionId]}
-        </div>
-        <div>No predictions.</div>
-        <button
-          type="button"
-          aria-label={`Open upcoming departures to ${route.direction_destinations[directionId]}`}
-        >
-          {renderFa("", "fa-angle-right")}
-        </button>
-      </div>
-    );
+    return departureTimeRow(route.direction_destinations[directionId]!);
   }
   return (
     <>
       {Object.entries(predictionsByHeadsign).map(([headsign, predictions]) => {
-        return (
-          <div key={headsign} className="departure-card__headsign">
-            <div className="departure-card__headsign-name">{headsign}</div>
-            <div>
-              {predictions.length ? (
-                predictions.map(p => {
-                  return (
-                    <div key={p.id}>{formatDepartureTime(p.time!, isCR)}</div>
-                  );
-                })
-              ) : (
-                <div>No predictions.</div>
-              )}
-            </div>
-            <button
-              type="button"
-              aria-label={`Open upcoming departures to ${headsign}`}
-            >
-              {renderFa("", "fa-angle-right")}
-            </button>
-          </div>
+        return departureTimeRow(
+          headsign,
+          predictions.map(p => formatDepartureTime(p.time, isCR))
         );
       })}
     </>

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -1,12 +1,13 @@
 import { groupBy, sortBy } from "lodash";
 import React, { ReactElement, useState } from "react";
-import { Route } from "../../__v3api";
+import { Route, Stop } from "../../__v3api";
 import DeparturesFilters, { ModeChoice } from "./DeparturesFilters";
 import { modeForRoute } from "../../models/route";
 import DepartureCard from "./DepartureCard";
 
 interface StopPageDeparturesProps {
   routes: Route[];
+  stop: Stop;
 }
 
 // Commuter Rail, then Subway, then Bus
@@ -21,7 +22,8 @@ const modeSortFn = ({ type }: Route): number => {
 };
 
 const StopPageDepartures = ({
-  routes
+  routes,
+  stop
 }: StopPageDeparturesProps): ReactElement<HTMLElement> => {
   // default to show all modes.
   const [selectedMode, setSelectedMode] = useState<ModeChoice>("all");
@@ -41,7 +43,7 @@ const StopPageDepartures = ({
       )}
       <ul className="stop-departures list-unstyled">
         {sortBy(filteredRoutes, [modeSortFn, "sort_order"]).map(route => (
-          <DepartureCard key={route.id} route={route} />
+          <DepartureCard key={route.id} route={route} stop={stop} />
         ))}
       </ul>
     </div>

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -26,7 +26,7 @@ const StopPageRedesign = ({
       {/* Route and Map Div */}
       <div className="container">
         <div className="stop-routes-and-map">
-          <StopPageDepartures routes={routes} />
+          <StopPageDepartures routes={routes} stop={stop} />
           <StopMapRedesign stop={stop} />
         </div>
         {/* Station Information Div */}


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [[Spike] Using the predictions refactor work in departures](https://app.asana.com/0/385363666817452/1204099052193042/f)

> **Note**
> Dotcom is working on a redesign of the stops pages ([random example page](https://dev.mbtace.com/stops/1112)). As with the current version, the new version will show upcoming departures using data we get from the V3 API's predictions. This WIP can be viewed by enabling the feature flag to turn on the stops page redesign. You can enable the feature flag appending `active_flag=stops_redesign` to the URL, or by visiting `/_flags` and clicking the checkbox.

A few months ago the Dotcom team had put in substantial effort into reconsidering how we fetch and serve prediction data site-wide, culminating in **#1476 feat(Predictions): Subscribe to streaming updates by routeId and stopId**. The work done in **#1481 Consolidate channel handling**  was also essential to simplify how we interact with channels. Finally, #1566 helped establish the structure that makes this PR simpler to implement. The goal of this spike was to understand whether the prior streaming predictions work could be leveraged to display live departures for the new stops page. Turns out it can! 

(All the PRs in that last paragraph were worked on and merged as part of this spike task! What's left in this PR is all that remains, the relatively small task of displaying the predictions on the page).

**This PR:**

* Creates a new React hook, `usePredictionsChannel`, which subscribes to our backend streaming predictions channel for a specified route/stop/direction, and outputs sets of predictions grouped by headway.
* Adds a feature/bugfix? to our current `joinChannel` function, to add the ability to handle any data that might be immediately sent by the channel on joining.
* Adds upcoming departure times to the redesigned stop page, using this channel. The messages sent from the channel are inspectable in most browser devtools. Live updates as quickly as the stream and frontend will let us!  🚀 

**Next**

I haven't load tested any this. What happens when tens of thousands of visitors try to view predictions on the North Station page at the same time? Since the stops page redesign work is still a WIP, I'm ok leaving this question for a future investigation.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
