### PR TITLE
feat(SiteWeb.Plugs.CacheControl): cache some endpoints

### DIFF
--- a/apps/site/lib/site_web/plugs/cache_control.ex
+++ b/apps/site/lib/site_web/plugs/cache_control.ex
@@ -1,0 +1,24 @@
+defmodule SiteWeb.Plugs.CacheControl do
+  @moduledoc """
+  If a `max_age` option is specified in number of seconds,
+  adds a `cache-control header` to the response.
+  """
+  @behaviour Plug
+
+  @impl true
+  def init(opts) do
+    opts
+  end
+
+  @impl true
+  def call(conn, opts) do
+    do_cache_control(conn, Keyword.get(opts, :max_age))
+  end
+
+  defp do_cache_control(conn, max_age) when is_number(max_age) do
+    conn
+    |> Plug.Conn.put_resp_header("cache-control", "max-age=#{max_age}, private, must-revalidate")
+  end
+
+  defp do_cache_control(conn, _), do: conn
+end

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -38,6 +38,10 @@ defmodule SiteWeb.Router do
     plug(:accepts, ["json"])
   end
 
+  pipeline :cached_daily do
+    plug(SiteWeb.Plugs.CacheControl, max_age: 86_400)
+  end
+
   scope "/", SiteWeb do
     # no pipe
     get("/_health", HealthController, :index)
@@ -201,12 +205,15 @@ defmodule SiteWeb.Router do
 
   scope "/api", SiteWeb do
     pipe_through([:secure, :browser])
+
     get("/alerts", AlertController, :show_by_routes)
+  end
+
+  scope "/api", SiteWeb do
+    pipe_through([:secure, :browser, :cached_daily])
 
     get("/stop/:id", StopController, :get)
-
     get("/map-config", MapConfigController, :get)
-
     get("/routes/by-stop/:stop_id", RouteController, :get_by_stop_id)
   end
 

--- a/apps/site/test/site_web/plugs/cache_control_test.exs
+++ b/apps/site/test/site_web/plugs/cache_control_test.exs
@@ -1,0 +1,25 @@
+defmodule SiteWeb.Plugs.CacheControlTest do
+  @moduledoc false
+  use SiteWeb.ConnCase, async: true
+  import SiteWeb.Plugs.CacheControl
+
+  describe "call/2" do
+    test "does nothing without max_age", %{conn: conn} do
+      assert conn == call(conn, [])
+    end
+
+    test "does nothing with bad max_age", %{conn: conn} do
+      assert conn == call(conn, max_age: :not_a_number)
+    end
+
+    test "adds cache-control header", %{conn: conn} do
+      age = 1337
+      conn_with_header = call(conn, max_age: age)
+      refute conn_with_header == conn
+
+      assert conn_with_header.resp_headers == [
+               {"cache-control", "max-age=#{age}, private, must-revalidate"}
+             ]
+    end
+  end
+end


### PR DESCRIPTION

#### Summary of changes

No ticket. The loading time of our WIP stops redesign page was bugging me. Then I realized we can have the browser cache backend responses. So I added this to the `api/stop/:id`, `api/map-config` and `api/routes/by-stop/:stop_id` endpoints. These are tiny amounts of static information that we don't expect to change over the course of a day anyway.

- Creates a new plug that adds a specified cache-control max-age header to the response.
- Uses the plug on a few of our more recent endpoints, with a max-age of one day.


---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.