### PR TITLE
feat(StopAlerts): Fixed endpoint for getting all the alerts at a stop

### DIFF
--- a/apps/alerts/lib/cache/store.ex
+++ b/apps/alerts/lib/cache/store.ex
@@ -121,6 +121,7 @@ defmodule Alerts.Cache.Store do
         read_concurrency: true
       ])
 
+    # no cover
     _ = :ets.new(:stop_id_to_alert_ids, [:bag, :protected, :named_table, read_concurrency: true])
 
     # no cover
@@ -142,12 +143,7 @@ defmodule Alerts.Cache.Store do
 
     stop_inserts =
       Enum.flat_map(alerts, fn alert ->
-        non_nil_stops =
-          Enum.filter(alert.informed_entity, fn %Alerts.InformedEntity{stop: stop_id} ->
-            stop_id != nil
-          end)
-
-        Enum.map(non_nil_stops, fn stop_id ->
+        Enum.map(alert.informed_entity.stop, fn stop_id ->
           {
             stop_id,
             alert.id

--- a/apps/alerts/test/cache/store_test.exs
+++ b/apps/alerts/test/cache/store_test.exs
@@ -56,4 +56,29 @@ defmodule Alerts.Cache.StoreTest do
     assert Store.all_alerts(@now) == [alert1, alert2]
     assert Store.alerts(["123", "456"], @now) == [alert1, alert2]
   end
+
+  test "gets the alerts by the stop" do
+    alert1 = %Alerts.Alert{
+      id: "123",
+      effect: :station_closure,
+      informed_entity: %Alerts.InformedEntitySet{stop: MapSet.new(["543", "654"])}
+    }
+
+    alert2 = %Alerts.Alert{
+      id: "124",
+      effect: :station_closure,
+      informed_entity: %Alerts.InformedEntitySet{stop: MapSet.new(["543"])}
+    }
+
+    alert3 = %Alerts.Alert{
+      id: "125",
+      effect: :station_closure,
+      informed_entity: %Alerts.InformedEntitySet{stop: MapSet.new(["987", "333"])}
+    }
+
+    alert4 = %Alerts.Alert{id: "126", effect: :cancellation}
+
+    Store.update([alert1, alert2, alert3, alert4], nil)
+    assert Store.alert_ids_for_stop_id("543") == ["123", "124"]
+  end
 end

--- a/apps/alerts/test/cache/store_test.exs
+++ b/apps/alerts/test/cache/store_test.exs
@@ -57,7 +57,7 @@ defmodule Alerts.Cache.StoreTest do
     assert Store.alerts(["123", "456"], @now) == [alert1, alert2]
   end
 
-  test "gets the alerts by the stop" do
+  test "gets the alerts by the stop id" do
     alert1 = %Alerts.Alert{
       id: "123",
       effect: :station_closure,
@@ -79,6 +79,6 @@ defmodule Alerts.Cache.StoreTest do
     alert4 = %Alerts.Alert{id: "126", effect: :cancellation}
 
     Store.update([alert1, alert2, alert3, alert4], nil)
-    assert Store.alert_ids_for_stop_id("543") == ["123", "124"]
+    assert Store.alert_ids_for_stop_id("543") == ["124", "123"]
   end
 end

--- a/apps/alerts/test/repo_test.exs
+++ b/apps/alerts/test/repo_test.exs
@@ -1,6 +1,6 @@
 defmodule Alerts.RepoTest do
   use ExUnit.Case
-  alias Alerts.{Alert, Banner, Cache.Store, InformedEntity, Repo}
+  alias Alerts.{Alert, Banner, Cache.Store, InformedEntity, Repo, InformedEntitySet}
 
   @now Timex.parse!("2017-06-08T10:00:00-05:00", "{ISO:Extended}")
 
@@ -64,11 +64,16 @@ defmodule Alerts.RepoTest do
     test "returns the list of alerts from the store with the given types" do
       commuter_rail_alert = %Alert{
         id: "commuter_rail_alert",
-        informed_entity: [@commuter_rail_entity]
+        informed_entity: InformedEntitySet.new([@commuter_rail_entity])
       }
 
-      bus_alert = %Alert{id: "bus_alert", informed_entity: [@bus_entity]}
-      subway_alert = %Alert{id: "subway_alert", informed_entity: [@subway_entity]}
+      bus_alert = %Alert{id: "bus_alert", informed_entity: InformedEntitySet.new([@bus_entity])}
+
+      subway_alert = %Alert{
+        id: "subway_alert",
+        informed_entity: InformedEntitySet.new([@subway_entity])
+      }
+
       Store.update([commuter_rail_alert, bus_alert, subway_alert], nil)
       alerts = Repo.by_route_types([2, 0], @now)
 
@@ -86,13 +91,13 @@ defmodule Alerts.RepoTest do
     @subway_entity2 %InformedEntity{route_type: 0}
 
     test "returns all alerts with given route_id, or route_type when route_id is nil" do
-      cr_alert1 = %Alert{id: "cr1", informed_entity: [@cr_entity1]}
-      cr_alert2 = %Alert{id: "cr2", informed_entity: [@cr_entity2]}
-      bus_alert = %Alert{id: "bus", informed_entity: [@bus_entity]}
+      cr_alert1 = %Alert{id: "cr1", informed_entity: InformedEntitySet.new([@cr_entity1])}
+      cr_alert2 = %Alert{id: "cr2", informed_entity: InformedEntitySet.new([@cr_entity2])}
+      bus_alert = %Alert{id: "bus", informed_entity: InformedEntitySet.new([@bus_entity])}
 
       subway_alert = %Alert{
         id: "subway",
-        informed_entity: [@subway_entity, @subway_entity2]
+        informed_entity: InformedEntitySet.new([@subway_entity, @subway_entity2])
       }
 
       Store.update([cr_alert1, cr_alert2, bus_alert, subway_alert], nil)

--- a/apps/site/assets/ts/hooks/__tests__/useAlertsForStopTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/useAlertsForStopTest.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { SWRConfig } from "swr";
+import useAlertsForStop from "../useAlertsForStop";
+
+const unmockedFetch = global.fetch;
+const HookWrapper: React.FC = ({ children }) => (
+  <SWRConfig value={{ dedupingInterval: 0 }}>{children}</SWRConfig>
+);
+
+const testAlert = {
+  id: "0"
+};
+
+describe("useAlertsForStop", () => {
+  beforeAll(() => {
+    // provide mocked network response
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve: Function) =>
+          resolve({
+            json: () => testAlert,
+            ok: true,
+            status: 200,
+            statusText: "OK"
+          })
+        )
+    );
+  });
+
+  it("should return an alert", async () => {
+    const { result, waitFor } = renderHook(() => useAlertsForStop("stop-id"), {
+      wrapper: HookWrapper
+    });
+    await waitFor(() => expect(result.current).toEqual(testAlert));
+  });
+
+  afterAll(() => {
+    global.fetch = unmockedFetch;
+  });
+});

--- a/apps/site/assets/ts/hooks/useAlertsForStop.ts
+++ b/apps/site/assets/ts/hooks/useAlertsForStop.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { fetchJsonOrThrow } from "../helpers/fetch-json";
+import { Alert } from "../__v3api";
+
+const fetchData = async (url: string): Promise<Alert[]> =>
+  fetchJsonOrThrow(url);
+
+const useAlertsForStop = (stopId: string): Alert[] | undefined => {
+  const { data } = useSWR<Alert[]>(`/api/stops/${stopId}/alerts`, fetchData);
+  return data;
+};
+
+export default useAlertsForStop;

--- a/apps/site/lib/site_web/controllers/alert_controller.ex
+++ b/apps/site/lib/site_web/controllers/alert_controller.ex
@@ -30,7 +30,6 @@ defmodule SiteWeb.AlertController do
     check_cms_or_404(conn)
   end
 
-  # TODO revisit this later to see if it is used/needed
   @spec show_by_stop(Plug.Conn.t(), map) :: Plug.Conn.t()
   def show_by_stop(conn, %{"stop_id" => stop_id}) do
     alerts = Repo.by_stop_id(stop_id)

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -137,7 +137,6 @@ defmodule SiteWeb.Router do
     get("/stops/place-dudly", Redirector, to: "/stops/place-nubn")
 
     get("/stops/api", StopController, :api)
-    get("/stops/:stop_id/alerts", AlertController, :show_by_stop)
     resources("/stops", StopController, only: [:index, :show])
     get("/stops/*path", StopController, :stop_with_slash_redirect)
 
@@ -207,6 +206,7 @@ defmodule SiteWeb.Router do
     pipe_through([:secure, :browser])
 
     get("/alerts", AlertController, :show_by_routes)
+    get("/stops/:stop_id/alerts", AlertController, :show_by_stop)
   end
 
   scope "/api", SiteWeb do


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

The alerts are first sorted into a table that stores which stop_ids map to which alert_ids
Create an endpoint that returns all the alerts for the given stop.
The bones of the logic was there this pull request fixes it.

**Asana Ticket:** [Departure Cards | Departure Display | Alerts Data](https://app.asana.com/0/home/1201123880594717/1204340687791888)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

