### PR TITLE
Stop Page Redesign Landing Page | Map should show subway and commuter rail routes

### DIFF
--- a/apps/route_patterns/lib/repo.ex
+++ b/apps/route_patterns/lib/repo.ex
@@ -36,11 +36,7 @@ defmodule RoutePatterns.Repo do
 
   def by_route_id(route_id, opts) do
     opts
-    |> Keyword.get(:direction_id)
-    |> case do
-      nil -> [route: route_id]
-      direction_id -> [route: route_id, direction_id: direction_id]
-    end
+    |> Keyword.put(:route, route_id)
     |> Keyword.put(:sort, "typicality,sort_order")
     |> Keyword.put(:include, "representative_trip.shape")
     |> cache(&api_all/1)

--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -235,8 +235,8 @@ defmodule Routes.Route do
   def combined_route?(%{id: "627"}), do: true
   def combined_route?(_), do: false
 
-  @spec is_rail_route?(t()) :: boolean
-  def is_rail_route?(route) do
+  @spec rail?(t()) :: boolean
+  def rail?(route) do
     type_atom(route) in [:subway, :commuter_rail]
   end
 

--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -235,6 +235,11 @@ defmodule Routes.Route do
   def combined_route?(%{id: "627"}), do: true
   def combined_route?(_), do: false
 
+  @spec is_rail_route?(t()) :: boolean
+  def is_rail_route?(route) do
+    type_atom(route) in [:subway, :commuter_rail]
+  end
+
   @spec to_json_safe(t) :: map
   def to_json_safe(%__MODULE__{
         id: id,

--- a/apps/routes/test/repo_test.exs
+++ b/apps/routes/test/repo_test.exs
@@ -1,5 +1,5 @@
 defmodule Routes.RepoTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Mock
   alias Routes.{Repo, Route}
 

--- a/apps/routes/test/route_test.exs
+++ b/apps/routes/test/route_test.exs
@@ -269,13 +269,13 @@ defmodule Routes.RouteTest do
     end
   end
 
-  describe "is_rail_route?/1" do
+  describe "rail?/1" do
     test "returns true if a route is on rails" do
-      assert %Routes.Route{type: 0} |> is_rail_route?()
-      assert %Routes.Route{type: 1} |> is_rail_route?()
-      assert %Routes.Route{type: 2} |> is_rail_route?()
-      refute %Routes.Route{type: 3} |> is_rail_route?()
-      refute %Routes.Route{type: 4} |> is_rail_route?()
+      assert %Routes.Route{type: 0} |> rail?()
+      assert %Routes.Route{type: 1} |> rail?()
+      assert %Routes.Route{type: 2} |> rail?()
+      refute %Routes.Route{type: 3} |> rail?()
+      refute %Routes.Route{type: 4} |> rail?()
     end
   end
 end

--- a/apps/routes/test/route_test.exs
+++ b/apps/routes/test/route_test.exs
@@ -268,4 +268,14 @@ defmodule Routes.RouteTest do
       end
     end
   end
+
+  describe "is_rail_route?/1" do
+    test "returns true if a route is on rails" do
+      assert %Routes.Route{type: 0} |> is_rail_route?()
+      assert %Routes.Route{type: 1} |> is_rail_route?()
+      assert %Routes.Route{type: 2} |> is_rail_route?()
+      refute %Routes.Route{type: 3} |> is_rail_route?()
+      refute %Routes.Route{type: 4} |> is_rail_route?()
+    end
+  end
 end

--- a/apps/site/assets/ts/hooks/__tests__/useRouteTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/useRouteTest.tsx
@@ -1,102 +1,96 @@
 import { renderHook } from "@testing-library/react-hooks";
 import React from "react";
 import { SWRConfig } from "swr";
-import { useRoutesByStop } from "../useRoute";
-import { Polyline } from "../../leaflet/components/__mapdata";
-import { zip } from "lodash";
+import { RouteWithPolylines, useRoutesByStop } from "../useRoute";
 
 const unmockedFetch = global.fetch;
 const HookWrapper: React.FC = ({ children }) => (
   <SWRConfig value={{ dedupingInterval: 0 }}>{children}</SWRConfig>
 );
 
-const testRoutes = [
+const testData = [
   {
     id: "0",
-    type: 0
+    type: 0,
+    polylines: [
+      {
+        id: "0",
+        "dotted?": false,
+        weight: 2,
+        positions: [
+          [1, 2],
+          [3, 4]
+        ],
+        color: "#ABC123"
+      }
+    ]
   },
   {
     id: "1",
-    type: 1
+    type: 1,
+    polylines: [
+      {
+        id: "1",
+        "dotted?": false,
+        weight: 2,
+        positions: [
+          [5, 2],
+          [7, 4]
+        ],
+        color: "#ABC123"
+      }
+    ]
   },
   {
     id: "2",
-    type: 2
+    type: 2,
+    polylines: [
+      {
+        id: "2",
+        "dotted?": false,
+        weight: 2,
+        positions: [
+          [9, 2],
+          [3, 4]
+        ],
+        color: "#ABC123"
+      }
+    ]
   },
   {
     id: "3",
-    type: 3
+    type: 3,
+    polylines: [
+      {
+        id: "3",
+        "dotted?": false,
+        weight: 2,
+        positions: [
+          [2, 2],
+          [8, 4]
+        ],
+        color: "#ABC123"
+      }
+    ]
   },
   {
     id: "4",
-    type: 4
+    type: 4,
+    polylines: [
+      {
+        id: "4",
+        "dotted?": false,
+        weight: 2,
+        positions: [
+          [9, 2],
+          [3, 4]
+        ],
+        color: "#ABC123"
+      }
+    ]
   }
-];
+] as RouteWithPolylines[];
 
-const testPolylines: Polyline[][] = [
-  [
-    {
-      id: "0",
-      "dotted?": false,
-      weight: 2,
-      positions: [
-        [1, 2],
-        [3, 4]
-      ],
-      color: "#ABC123"
-    }
-  ],
-  [
-    {
-      id: "1",
-      "dotted?": false,
-      weight: 2,
-      positions: [
-        [5, 2],
-        [7, 4]
-      ],
-      color: "#ABC123"
-    }
-  ],
-  [
-    {
-      id: "2",
-      "dotted?": false,
-      weight: 2,
-      positions: [
-        [9, 2],
-        [3, 4]
-      ],
-      color: "#ABC123"
-    }
-  ],
-  [
-    {
-      id: "3",
-      "dotted?": false,
-      weight: 2,
-      positions: [
-        [2, 2],
-        [8, 4]
-      ],
-      color: "#ABC123"
-    }
-  ],
-  [
-    {
-      id: "4",
-      "dotted?": false,
-      weight: 2,
-      positions: [
-        [9, 2],
-        [3, 4]
-      ],
-      color: "#ABC123"
-    }
-  ]
-];
-
-const testData = zip(testRoutes, testPolylines);
 describe("useRoute", () => {
   beforeAll(() => {
     // provide mocked network response
@@ -119,11 +113,11 @@ describe("useRoute", () => {
         wrapper: HookWrapper
       });
       await waitFor(() => expect(result.current).toEqual(testData));
-      const [route, lines] = result.current![0];
-      expect(typeof route).toBe("object");
-      expect(lines[0]).toHaveProperty("color");
-      expect(lines[0]).toHaveProperty("weight");
-      expect(lines[0]).toHaveProperty("positions");
+      const routeWithPolylines = result.current![0];
+      expect(typeof routeWithPolylines).toBe("object");
+      expect(routeWithPolylines.polylines[0]).toHaveProperty("color");
+      expect(routeWithPolylines.polylines[0]).toHaveProperty("weight");
+      expect(routeWithPolylines.polylines[0]).toHaveProperty("positions");
     });
   });
 

--- a/apps/site/assets/ts/hooks/__tests__/useRouteTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/useRouteTest.tsx
@@ -2,6 +2,8 @@ import { renderHook } from "@testing-library/react-hooks";
 import React from "react";
 import { SWRConfig } from "swr";
 import { useRoutesByStop } from "../useRoute";
+import { Polyline } from "../../leaflet/components/__mapdata";
+import { zip } from "lodash";
 
 const unmockedFetch = global.fetch;
 const HookWrapper: React.FC = ({ children }) => (
@@ -31,6 +33,70 @@ const testRoutes = [
   }
 ];
 
+const testPolylines: Polyline[][] = [
+  [
+    {
+      id: "0",
+      "dotted?": false,
+      weight: 2,
+      positions: [
+        [1, 2],
+        [3, 4]
+      ],
+      color: "#ABC123"
+    }
+  ],
+  [
+    {
+      id: "1",
+      "dotted?": false,
+      weight: 2,
+      positions: [
+        [5, 2],
+        [7, 4]
+      ],
+      color: "#ABC123"
+    }
+  ],
+  [
+    {
+      id: "2",
+      "dotted?": false,
+      weight: 2,
+      positions: [
+        [9, 2],
+        [3, 4]
+      ],
+      color: "#ABC123"
+    }
+  ],
+  [
+    {
+      id: "3",
+      "dotted?": false,
+      weight: 2,
+      positions: [
+        [2, 2],
+        [8, 4]
+      ],
+      color: "#ABC123"
+    }
+  ],
+  [
+    {
+      id: "4",
+      "dotted?": false,
+      weight: 2,
+      positions: [
+        [9, 2],
+        [3, 4]
+      ],
+      color: "#ABC123"
+    }
+  ]
+];
+
+const testData = zip(testRoutes, testPolylines);
 describe("useRoute", () => {
   beforeAll(() => {
     // provide mocked network response
@@ -38,7 +104,7 @@ describe("useRoute", () => {
       () =>
         new Promise((resolve: Function) =>
           resolve({
-            json: () => testRoutes,
+            json: () => testData,
             ok: true,
             status: 200,
             statusText: "OK"
@@ -48,11 +114,16 @@ describe("useRoute", () => {
   });
 
   describe("useRoutesByStop", () => {
-    it("should return an array of routes", async () => {
+    it("should return an array of routes and lines", async () => {
       const { result, waitFor } = renderHook(() => useRoutesByStop("stop-id"), {
         wrapper: HookWrapper
       });
-      await waitFor(() => expect(result.current).toEqual(testRoutes));
+      await waitFor(() => expect(result.current).toEqual(testData));
+      const [route, lines] = result.current![0];
+      expect(typeof route).toBe("object");
+      expect(lines[0]).toHaveProperty("color");
+      expect(lines[0]).toHaveProperty("weight");
+      expect(lines[0]).toHaveProperty("positions");
     });
   });
 

--- a/apps/site/assets/ts/hooks/useRoute.ts
+++ b/apps/site/assets/ts/hooks/useRoute.ts
@@ -1,12 +1,18 @@
 import useSWR from "swr";
 import { fetchJsonOrThrow } from "../helpers/fetch-json";
 import { Route } from "../__v3api";
+import { Polyline } from "../leaflet/components/__mapdata";
 
-const fetchData = async (url: string): Promise<Route[]> =>
+type RoutesWithPolylines = [Route, Polyline[]];
+
+const fetchData = async (url: string): Promise<RoutesWithPolylines[]> =>
   fetchJsonOrThrow(url);
 
-const useRoutesByStop = (stopId: string): Route[] | undefined => {
-  const { data } = useSWR<Route[]>(`/api/routes/by-stop/${stopId}`, fetchData);
+const useRoutesByStop = (stopId: string): RoutesWithPolylines[] | undefined => {
+  const { data } = useSWR<RoutesWithPolylines[]>(
+    `/api/routes/by-stop/${stopId}`,
+    fetchData
+  );
   return data;
 };
 // eslint-disable-next-line import/prefer-default-export

--- a/apps/site/assets/ts/hooks/useRoute.ts
+++ b/apps/site/assets/ts/hooks/useRoute.ts
@@ -3,13 +3,13 @@ import { fetchJsonOrThrow } from "../helpers/fetch-json";
 import { Route } from "../__v3api";
 import { Polyline } from "../leaflet/components/__mapdata";
 
-export type RoutesWithPolylines = [Route, Polyline[]];
+export type RouteWithPolylines = Route & { polylines: Polyline[] };
 
-const fetchData = async (url: string): Promise<RoutesWithPolylines[]> =>
+const fetchData = async (url: string): Promise<RouteWithPolylines[]> =>
   fetchJsonOrThrow(url);
 
-const useRoutesByStop = (stopId: string): RoutesWithPolylines[] | undefined => {
-  const { data } = useSWR<RoutesWithPolylines[]>(
+const useRoutesByStop = (stopId: string): RouteWithPolylines[] | undefined => {
+  const { data } = useSWR<RouteWithPolylines[]>(
     `/api/routes/by-stop/${stopId}`,
     fetchData
   );

--- a/apps/site/assets/ts/hooks/useRoute.ts
+++ b/apps/site/assets/ts/hooks/useRoute.ts
@@ -3,7 +3,7 @@ import { fetchJsonOrThrow } from "../helpers/fetch-json";
 import { Route } from "../__v3api";
 import { Polyline } from "../leaflet/components/__mapdata";
 
-type RoutesWithPolylines = [Route, Polyline[]];
+export type RoutesWithPolylines = [Route, Polyline[]];
 
 const fetchData = async (url: string): Promise<RoutesWithPolylines[]> =>
   fetchJsonOrThrow(url);

--- a/apps/site/assets/ts/jest.config.js
+++ b/apps/site/assets/ts/jest.config.js
@@ -52,7 +52,7 @@ module.exports = {
     "./ts-build",
     "./tnm/__tests__/setupTests.ts",
     "./tnm/__tests__/helpers",
-    "./stop/__tests__/helpers"
+    "./stop/__tests__/helpers.ts"
   ],
   moduleNameMapper: {
     "\\.svg$": "<rootDir>/tnm/__tests__/helpers/svgStubber.js"

--- a/apps/site/assets/ts/jest.config.js
+++ b/apps/site/assets/ts/jest.config.js
@@ -51,7 +51,8 @@ module.exports = {
     "/node_modules/",
     "./ts-build",
     "./tnm/__tests__/setupTests.ts",
-    "./tnm/__tests__/helpers"
+    "./tnm/__tests__/helpers",
+    "./stop/__tests__/helpers"
   ],
   moduleNameMapper: {
     "\\.svg$": "<rootDir>/tnm/__tests__/helpers/svgStubber.js"

--- a/apps/site/assets/ts/schedule/components/Map.tsx
+++ b/apps/site/assets/ts/schedule/components/Map.tsx
@@ -134,6 +134,7 @@ export const reducer: DataReducerType = (state, action) => {
       };
     default:
       /* istanbul ignore next */
+      // eslint-disable-next-line no-console
       console.error("unexpected event", action);
       return state;
   }

--- a/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -1,15 +1,9 @@
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import DepartureCard from "../components/DepartureCard";
-import { Route, RouteType, Stop } from "../../__v3api";
+import { RouteType, Stop } from "../../__v3api";
+import { baseRoute } from "./helpers";
 
-export const baseRoute = (name: string, type: RouteType): Route =>
-  ({
-    id: name,
-    direction_destinations: { 0: "Somewhere there", 1: "Over yonder" },
-    name: `${name} Route`,
-    type
-  } as Route);
 const stop = {} as Stop;
 
 describe("DepartureCard", () => {

--- a/apps/site/assets/ts/stop/__tests__/StopMapRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopMapRedesignTest.tsx
@@ -1,25 +1,53 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import { MapData, Polyline } from "../../leaflet/components/__mapdata";
+import { faker } from "@faker-js/faker";
+import { Polyline } from "../../leaflet/components/__mapdata";
 import { Stop } from "../../__v3api";
 import StopMapRedesign from "../components/StopMapRedesign";
+import { uniqueId } from "lodash";
 
-jest.mock("../../leaflet/components/Map", () => ({
+jest.mock("../../hooks/useMapConfig", () => ({
   __esModule: true,
-  default: (props: { mapData: MapData }) => {
-    expect(props.mapData.markers.length).toBe(1);
-    return <div>Map Component</div>;
-  }
+  default: () => ({
+    tile_server_url: "https://mbta-map-tiles-dev.s3.amazonaws.com"
+  })
 }));
 
+const newLatOrLon = (): number => +faker.random.numeric(2);
+const newPosition = (): [number, number] => [newLatOrLon(), newLatOrLon()];
+const newPolyline = (): Polyline => ({
+  color: faker.color.rgb({ prefix: "#" }),
+  "dotted?": false,
+  id: uniqueId(),
+  positions: [newPosition(), newPosition(), newPosition()],
+  weight: 2
+});
+
+const testStop = {
+  id: "Test Stop ID",
+  latitude: newLatOrLon(),
+  longitude: newLatOrLon()
+} as Stop;
+
 describe("StopMapRedesign", () => {
-  it("should render the map", () => {
-    render(
-      <StopMapRedesign
-        stop={{ id: "Test Stop ID" } as Stop}
-        lines={[{} as Polyline]}
-      />
+  it("should render the Map component with a marker", () => {
+    const { getByAltText } = render(
+      <StopMapRedesign stop={testStop} lines={[]} />
     );
-    expect(screen.queryByText("Map Component"));
+    expect(screen.queryByLabelText("Map with stop")).not.toBeNull();
+    const image = getByAltText("Marker");
+    expect(image).toHaveAttribute("src", "/images/icon-map-station-marker.svg");
+  });
+
+  it("should display lines", () => {
+    const lines = [newPolyline(), newPolyline(), newPolyline(), newPolyline()];
+    const { container } = render(
+      <StopMapRedesign stop={testStop} lines={lines} />
+    );
+
+    const mapPolylines = container
+      .querySelector("[aria-label='Map with stop']")
+      ?.querySelectorAll(".leaflet-overlay-pane path");
+    expect(mapPolylines).toHaveLength(lines.length);
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/StopMapRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopMapRedesignTest.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import { MapData } from "../../leaflet/components/__mapdata";
+import { MapData, Polyline } from "../../leaflet/components/__mapdata";
 import { Stop } from "../../__v3api";
 import StopMapRedesign from "../components/StopMapRedesign";
 
@@ -14,7 +14,12 @@ jest.mock("../../leaflet/components/Map", () => ({
 
 describe("StopMapRedesign", () => {
   it("should render the map", () => {
-    render(<StopMapRedesign stop={{ id: "Test Stop ID" } as Stop} />);
+    render(
+      <StopMapRedesign
+        stop={{ id: "Test Stop ID" } as Stop}
+        lines={[{} as Polyline]}
+      />
+    );
     expect(screen.queryByText("Map Component"));
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/StopMapRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopMapRedesignTest.tsx
@@ -1,10 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import { faker } from "@faker-js/faker";
-import { Polyline } from "../../leaflet/components/__mapdata";
 import { Stop } from "../../__v3api";
 import StopMapRedesign from "../components/StopMapRedesign";
-import { uniqueId } from "lodash";
+import { newLatOrLon, newPolyline } from "./helpers";
 
 jest.mock("../../hooks/useMapConfig", () => ({
   __esModule: true,
@@ -12,16 +10,6 @@ jest.mock("../../hooks/useMapConfig", () => ({
     tile_server_url: "https://mbta-map-tiles-dev.s3.amazonaws.com"
   })
 }));
-
-const newLatOrLon = (): number => +faker.random.numeric(2);
-const newPosition = (): [number, number] => [newLatOrLon(), newLatOrLon()];
-const newPolyline = (): Polyline => ({
-  color: faker.color.rgb({ prefix: "#" }),
-  "dotted?": false,
-  id: uniqueId(),
-  positions: [newPosition(), newPosition(), newPosition()],
-  weight: 2
-});
 
 const testStop = {
   id: "Test Stop ID",

--- a/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
@@ -3,10 +3,10 @@ import { screen, within } from "@testing-library/dom";
 import { render } from "@testing-library/react";
 import StopPageRedesign from "../components/StopPageRedesign";
 import * as useStop from "../../hooks/useStop";
-import { Stop, ParkingLot, Route } from "../../__v3api";
+import { Stop, ParkingLot } from "../../__v3api";
 import * as useRoute from "../../hooks/useRoute";
-import { baseRoute, newLatOrLon, newPolyline } from "./helpers";
-import { RoutesWithPolylines } from "../../hooks/useRoute";
+import { newLatOrLon, routeWithPolylines } from "./helpers";
+import { RouteWithPolylines } from "../../hooks/useRoute";
 
 test("StopPageRedesign shows Loading without stop or routes", () => {
   jest.spyOn(useRoute, "useRoutesByStop").mockImplementation(() => {
@@ -43,18 +43,15 @@ describe("StopPageRedesign", () => {
     expect(screen.queryByText("Test Stop")).not.toBeNull();
   });
 
-  it("filters lines to show on the map", () => {
-    const testRoutesWithPolylines: RoutesWithPolylines[] = [
-      [baseRoute("SomeBus", 3), [newPolyline(), newPolyline(), newPolyline()]],
-      [baseRoute("741", 3), [newPolyline(), newPolyline()]],
-      [baseRoute("AnotherBus", 3), [newPolyline()]],
-      [baseRoute("Train1", 1), [newPolyline(), newPolyline(), newPolyline()]],
-      [
-        baseRoute("Train2", 1),
-        [newPolyline(), newPolyline(), newPolyline(), newPolyline()]
-      ],
-      [baseRoute("Train3", 1), [newPolyline()]],
-      [baseRoute("FerryRoute", 4), [newPolyline(), newPolyline()]]
+  it("gets lines to show on the map", () => {
+    const testRoutesWithPolylines: RouteWithPolylines[] = [
+      routeWithPolylines("SomeBus", 3, 0),
+      routeWithPolylines("741", 3, 2),
+      routeWithPolylines("AnotherBus", 0, 0),
+      routeWithPolylines("Train1", 1, 3),
+      routeWithPolylines("Train2", 1, 4),
+      routeWithPolylines("Train3", 1),
+      routeWithPolylines("FerryRoute", 4, 0)
     ];
     jest.spyOn(useRoute, "useRoutesByStop").mockImplementation(() => {
       return testRoutesWithPolylines;
@@ -66,7 +63,7 @@ describe("StopPageRedesign", () => {
     const routeList = container.querySelector<HTMLElement>(
       "ul.stop-departures"
     )!;
-    const routeNames = testRoutesWithPolylines.flatMap(([route]) => route.name);
+    const routeNames = testRoutesWithPolylines.map(route => route.name);
     routeNames.forEach(name => {
       expect(within(routeList).getByText(name, { exact: false })).toBeTruthy();
     });

--- a/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
@@ -1,32 +1,80 @@
 import React from "react";
-import { screen } from "@testing-library/dom";
+import { screen, within } from "@testing-library/dom";
 import { render } from "@testing-library/react";
 import StopPageRedesign from "../components/StopPageRedesign";
 import * as useStop from "../../hooks/useStop";
-import { Stop, ParkingLot } from "../../__v3api";
+import { Stop, ParkingLot, Route } from "../../__v3api";
 import * as useRoute from "../../hooks/useRoute";
+import { baseRoute, newLatOrLon, newPolyline } from "./helpers";
+import { RoutesWithPolylines } from "../../hooks/useRoute";
 
-jest.mock("../components/StopMapRedesign", () => ({
-  __esModule: true,
-  default: () => <div>StopMap</div>
-}));
+test("StopPageRedesign shows Loading without stop or routes", () => {
+  jest.spyOn(useRoute, "useRoutesByStop").mockImplementation(() => {
+    return undefined;
+  });
+  jest.spyOn(useStop, "default").mockImplementation(() => {
+    return undefined;
+  });
+
+  render(<StopPageRedesign stopId="123" />);
+  expect(screen.queryByText("Loading...")).toBeDefined();
+});
 
 describe("StopPageRedesign", () => {
-  it("should render", () => {
-    jest.spyOn(useRoute, "useRoutesByStop").mockImplementation(() => {
-      return [];
-    });
-
+  beforeAll(() => {
     jest.spyOn(useStop, "default").mockImplementation(() => {
       return {
         id: "123",
         name: "Test Stop",
         parking_lots: [] as ParkingLot[],
-        accessibility: ["ramp"]
+        accessibility: ["ramp"],
+        latitude: newLatOrLon(),
+        longitude: newLatOrLon()
       } as Stop;
+    });
+  });
+
+  it("should render", () => {
+    jest.spyOn(useRoute, "useRoutesByStop").mockImplementation(() => {
+      return [];
     });
 
     render(<StopPageRedesign stopId="123" />);
     expect(screen.queryByText("Test Stop")).not.toBeNull();
+  });
+
+  it("filters lines to show on the map", () => {
+    const testRoutesWithPolylines: RoutesWithPolylines[] = [
+      [baseRoute("SomeBus", 3), [newPolyline(), newPolyline(), newPolyline()]],
+      [baseRoute("741", 3), [newPolyline(), newPolyline()]],
+      [baseRoute("AnotherBus", 3), [newPolyline()]],
+      [baseRoute("Train1", 1), [newPolyline(), newPolyline(), newPolyline()]],
+      [
+        baseRoute("Train2", 1),
+        [newPolyline(), newPolyline(), newPolyline(), newPolyline()]
+      ],
+      [baseRoute("Train3", 1), [newPolyline()]],
+      [baseRoute("FerryRoute", 4), [newPolyline(), newPolyline()]]
+    ];
+    jest.spyOn(useRoute, "useRoutesByStop").mockImplementation(() => {
+      return testRoutesWithPolylines;
+    });
+
+    const { container } = render(<StopPageRedesign stopId="123" />);
+
+    // All routes appear in departures list
+    const routeList = container.querySelector<HTMLElement>(
+      "ul.stop-departures"
+    )!;
+    const routeNames = testRoutesWithPolylines.flatMap(([route]) => route.name);
+    routeNames.forEach(name => {
+      expect(within(routeList).getByText(name, { exact: false })).toBeTruthy();
+    });
+
+    // only certain routes show in map
+    const mapPolylines = container.querySelectorAll(
+      "[aria-label='Map with stop'] .leaflet-overlay-pane path"
+    );
+    expect(mapPolylines).toHaveLength(10);
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import DepartureTimes from "../../components/DepartureTimes";
-import { baseRoute } from "../DepartureCardTest";
 import { Stop } from "../../../__v3api";
+import { baseRoute } from "../helpers";
 
 const route = baseRoute("TestRoute", 1);
 const stop = {} as Stop;

--- a/apps/site/assets/ts/stop/__tests__/helpers.ts
+++ b/apps/site/assets/ts/stop/__tests__/helpers.ts
@@ -1,0 +1,22 @@
+import { faker } from "@faker-js/faker";
+import { uniqueId } from "lodash";
+import { Polyline } from "../../leaflet/components/__mapdata";
+import { Route, RouteType } from "../../__v3api";
+
+export const newLatOrLon = (): number => +faker.random.numeric(2);
+const newPosition = (): [number, number] => [newLatOrLon(), newLatOrLon()];
+export const newPolyline = (): Polyline => ({
+  color: faker.color.rgb({ prefix: "#" }),
+  "dotted?": false,
+  id: uniqueId(),
+  positions: [newPosition(), newPosition(), newPosition()],
+  weight: 4
+});
+
+export const baseRoute = (name: string, type: RouteType): Route =>
+  ({
+    id: name,
+    direction_destinations: { 0: "Somewhere there", 1: "Over yonder" },
+    name: `${name} Route`,
+    type
+  } as Route);

--- a/apps/site/assets/ts/stop/__tests__/helpers.ts
+++ b/apps/site/assets/ts/stop/__tests__/helpers.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import { uniqueId } from "lodash";
 import { Polyline } from "../../leaflet/components/__mapdata";
 import { Route, RouteType } from "../../__v3api";
+import { RouteWithPolylines } from "../../hooks/useRoute";
 
 export const newLatOrLon = (): number => +faker.random.numeric(2);
 const newPosition = (): [number, number] => [newLatOrLon(), newLatOrLon()];
@@ -20,3 +21,18 @@ export const baseRoute = (name: string, type: RouteType): Route =>
     name: `${name} Route`,
     type
   } as Route);
+
+export const routeWithPolylines = (
+  name: string,
+  type: RouteType,
+  numPolylines: number = 1
+): RouteWithPolylines => {
+  const route = baseRoute(name, type);
+  const polylines = Array.from({ length: numPolylines }, (x, i) =>
+    newPolyline()
+  );
+  return {
+    ...route,
+    polylines
+  };
+};

--- a/apps/site/assets/ts/stop/components/StopMapRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopMapRedesign.tsx
@@ -1,4 +1,3 @@
-import { uniqBy } from "lodash";
 import React, { ReactElement } from "react";
 import Map from "../../leaflet/components/Map";
 import { Stop } from "../../__v3api";
@@ -32,7 +31,7 @@ const StopMapRedesign = ({ stop, lines }: Props): ReactElement<HTMLElement> => {
         tooltip: null
       } as MapMarker
     ],
-    polylines: uniqBy(lines, "id"),
+    polylines: lines,
     tile_server_url: mapConfig?.tile_server_url,
     zoom: 16
   } as MapData;

--- a/apps/site/assets/ts/stop/components/StopMapRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopMapRedesign.tsx
@@ -1,3 +1,4 @@
+import { uniqBy } from "lodash";
 import React, { ReactElement } from "react";
 import Map from "../../leaflet/components/Map";
 import { Stop } from "../../__v3api";
@@ -31,7 +32,7 @@ const StopMapRedesign = ({ stop, lines }: Props): ReactElement<HTMLElement> => {
         tooltip: null
       } as MapMarker
     ],
-    polylines: lines,
+    polylines: uniqBy(lines, "id"),
     tile_server_url: mapConfig?.tile_server_url,
     zoom: 16
   } as MapData;

--- a/apps/site/assets/ts/stop/components/StopMapRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopMapRedesign.tsx
@@ -1,14 +1,19 @@
 import React, { ReactElement } from "react";
 import Map from "../../leaflet/components/Map";
 import { Stop } from "../../__v3api";
-import { MapData, MapMarker } from "../../leaflet/components/__mapdata";
+import {
+  MapData,
+  MapMarker,
+  Polyline
+} from "../../leaflet/components/__mapdata";
 import useMapConfig from "../../hooks/useMapConfig";
 
 interface Props {
   stop: Stop;
+  lines: Polyline[];
 }
 
-const StopMapRedesign = ({ stop }: Props): ReactElement<HTMLElement> => {
+const StopMapRedesign = ({ stop, lines }: Props): ReactElement<HTMLElement> => {
   const mapConfig = useMapConfig();
 
   const mapData = {
@@ -26,7 +31,7 @@ const StopMapRedesign = ({ stop }: Props): ReactElement<HTMLElement> => {
         tooltip: null
       } as MapMarker
     ],
-    polylines: [],
+    polylines: lines,
     tile_server_url: mapConfig?.tile_server_url,
     zoom: 16
   } as MapData;

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from "react";
+import { compact, omit } from "lodash";
 import useStop from "../../hooks/useStop";
 import StationInformation from "./StationInformation";
 import StopMapRedesign from "./StopMapRedesign";
@@ -6,7 +7,7 @@ import { useRoutesByStop } from "../../hooks/useRoute";
 import StopPageHeaderRedesign from "./StopPageHeaderRedesign";
 import Loading from "../../components/Loading";
 import StopPageDepartures from "./StopPageDepartures";
-import { isASilverLineRoute } from "../../models/route";
+import { Route } from "../../__v3api";
 
 const StopPageRedesign = ({
   stopId
@@ -19,23 +20,19 @@ const StopPageRedesign = ({
   if (!stop || !routesWithPolylines) {
     return <Loading />;
   }
-  const routes = routesWithPolylines.map(([route]) => route);
-  const polylines = routesWithPolylines
-    .filter(
-      ([route]) => [0, 1, 2].includes(route.type) || isASilverLineRoute(route)
-    )
-    .flatMap(([, polyline]) => polyline);
+  const routes: Route[] = routesWithPolylines.map(rwp =>
+    omit(rwp, "polylines")
+  );
+  const polylines = compact(routesWithPolylines.flatMap(rwp => rwp.polylines));
 
   return (
     <article>
       <StopPageHeaderRedesign stop={stop} routes={routes} />
-      {/* Route and Map Div */}
       <div className="container">
         <div className="stop-routes-and-map">
           <StopPageDepartures routes={routes} stop={stop} />
           <StopMapRedesign stop={stop} lines={polylines} />
         </div>
-        {/* Station Information Div */}
         <footer>
           <StationInformation stop={stop} />
         </footer>

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { compact, omit } from "lodash";
+import { chain, omit } from "lodash";
 import useStop from "../../hooks/useStop";
 import StationInformation from "./StationInformation";
 import StopMapRedesign from "./StopMapRedesign";
@@ -23,7 +23,11 @@ const StopPageRedesign = ({
   const routes: Route[] = routesWithPolylines.map(rwp =>
     omit(rwp, "polylines")
   );
-  const polylines = compact(routesWithPolylines.flatMap(rwp => rwp.polylines));
+  const polylines = chain(routesWithPolylines)
+    .orderBy("sort_order", "desc")
+    .flatMap("polylines")
+    .uniqBy("id")
+    .value();
 
   return (
     <article>

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -6,6 +6,7 @@ import { useRoutesByStop } from "../../hooks/useRoute";
 import StopPageHeaderRedesign from "./StopPageHeaderRedesign";
 import Loading from "../../components/Loading";
 import StopPageDepartures from "./StopPageDepartures";
+import { isASilverLineRoute } from "../../models/route";
 
 const StopPageRedesign = ({
   stopId
@@ -13,12 +14,17 @@ const StopPageRedesign = ({
   stopId: string;
 }): ReactElement<HTMLElement> => {
   const stop = useStop(stopId);
-  const routes = useRoutesByStop(stopId);
-
+  const routesWithPolylines = useRoutesByStop(stopId);
   // Return loading indicator while waiting on data fetch
-  if (!stop || !routes) {
+  if (!stop || !routesWithPolylines) {
     return <Loading />;
   }
+  const routes = routesWithPolylines.map(([route]) => route);
+  const polylines = routesWithPolylines
+    .filter(
+      ([route]) => [0, 1, 2].includes(route.type) || isASilverLineRoute(route)
+    )
+    .flatMap(([, polyline]) => polyline);
 
   return (
     <article>
@@ -27,7 +33,7 @@ const StopPageRedesign = ({
       <div className="container">
         <div className="stop-routes-and-map">
           <StopPageDepartures routes={routes} stop={stop} />
-          <StopMapRedesign stop={stop} />
+          <StopMapRedesign stop={stop} lines={polylines} />
         </div>
         {/* Station Information Div */}
         <footer>

--- a/apps/site/assets/ts/tnm/__tests__/setupTests.ts
+++ b/apps/site/assets/ts/tnm/__tests__/setupTests.ts
@@ -38,3 +38,34 @@ window.matchMedia = jest.fn().mockImplementation(query => {
 });
 
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+/*
+  Extend JSDOM SVGSVGElement by introducing createSVGRect as an empty function
+
+  This technique allows us to emulate SVG support in JSDOM in order to pass Jest tests
+  for vector overlays such as Polyline
+
+  Found here: https://github.com/bcgov/biohubbc/blob/032710042000df75b21dbdc6170124afc9daf026/app/src/setupTests.ts#L12
+*/
+const createElementNSOrig = global.document.createElementNS;
+
+// @ts-ignore
+global.document.createElementNS = function(namespaceURI, qualifiedName) {
+  if (
+    namespaceURI === "http://www.w3.org/2000/svg" &&
+    qualifiedName === "svg"
+  ) {
+    // eslint-disable-next-line prefer-rest-params
+    // @ts-ignore
+    const element = createElementNSOrig.apply(this, arguments) as SVGSVGElement;
+    // @ts-ignore
+    element.createSVGRect = function() {
+      // This is intentional
+    };
+
+    return element;
+  }
+
+  // eslint-disable-next-line prefer-rest-params
+  return createElementNSOrig.apply(this, arguments as any);
+};

--- a/apps/site/assets/ts/trip-planner/__tests__/__snapshots__/VoteMapTest.tsx.snap
+++ b/apps/site/assets/ts/trip-planner/__tests__/__snapshots__/VoteMapTest.tsx.snap
@@ -106,7 +106,28 @@ exports[`VoteMap renders a Map by default 1`] = `
                 href="https://leafletjs.com"
                 title="A JavaScript library for interactive maps"
               >
-                Leaflet
+                <svg
+                  aria-hidden="true"
+                  class="leaflet-attribution-flag"
+                  height="8"
+                  viewBox="0 0 12 8"
+                  width="12"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h12v4H0z"
+                    fill="#4C7BE1"
+                  />
+                  <path
+                    d="M0 4h12v3H0z"
+                    fill="#FFD500"
+                  />
+                  <path
+                    d="M0 7h12v1H0z"
+                    fill="#E0BC00"
+                  />
+                </svg>
+                 Leaflet
               </a>
                
               <span

--- a/apps/site/lib/site_web/controllers/route_controller.ex
+++ b/apps/site/lib/site_web/controllers/route_controller.ex
@@ -20,7 +20,7 @@ defmodule SiteWeb.RouteController do
   end
 
   defp route_polylines(route, stop_id) do
-    if Route.is_rail_route?(route) or Route.silver_line?(route) do
+    if Route.rail?(route) or Route.silver_line?(route) do
       route.id
       |> RoutePatterns.Repo.by_route_id(stop: stop_id)
       |> Enum.map(fn %RoutePattern{shape_id: id, representative_trip_polyline: polyline} ->

--- a/apps/site/lib/site_web/controllers/route_controller.ex
+++ b/apps/site/lib/site_web/controllers/route_controller.ex
@@ -3,7 +3,8 @@ defmodule SiteWeb.RouteController do
   Endpoints for getting route data.
   """
   use SiteWeb, :controller
-  alias Routes.Repo
+  alias RoutePatterns.RoutePattern
+  alias Routes.{Repo, Route}
 
   def get_by_stop_id(conn, %{"stop_id" => stop_id} = _params) do
     routesWithPolylines =
@@ -14,22 +15,30 @@ defmodule SiteWeb.RouteController do
     json(conn, routesWithPolylines)
   end
 
-  defp route_polylines(route) do
-    route.id
-    |> Routes.Repo.get_shapes([])
-    |> Enum.map(fn %Routes.Shape{id: id, polyline: polyline} ->
-      positions =
-        polyline
-        |> Polyline.decode()
-        |> Enum.map(fn {lng, lat} -> [lat, lng] end)
+  defp route_polylines(route, stop_id) do
+    if is_rail_route?(route) or Route.silver_line?(route) do
+      route.id
+      |> RoutePatterns.Repo.by_route_id(stop: stop_id)
+      |> Enum.map(fn %RoutePattern{shape_id: id, representative_trip_polyline: polyline} ->
+        positions =
+          polyline
+          |> Polyline.decode()
+          |> Enum.map(fn {lng, lat} -> [lat, lng] end)
 
-      %Leaflet.MapData.Polyline{
-        id: id,
-        color: "#" <> route.color,
-        dotted?: false,
-        positions: positions,
-        weight: 4
-      }
-    end)
+        %Leaflet.MapData.Polyline{
+          id: id,
+          color: "#" <> route.color,
+          dotted?: false,
+          positions: positions,
+          weight: 4
+        }
+      end)
+    else
+      []
+    end
+  end
+
+  defp is_rail_route?(route) do
+    Route.type_atom(route) in [:subway, :commuter_rail]
   end
 end

--- a/apps/site/lib/site_web/controllers/route_controller.ex
+++ b/apps/site/lib/site_web/controllers/route_controller.ex
@@ -20,7 +20,7 @@ defmodule SiteWeb.RouteController do
   end
 
   defp route_polylines(route, stop_id) do
-    if is_rail_route?(route) or Route.silver_line?(route) do
+    if Route.is_rail_route?(route) or Route.silver_line?(route) do
       route.id
       |> RoutePatterns.Repo.by_route_id(stop: stop_id)
       |> Enum.map(fn %RoutePattern{shape_id: id, representative_trip_polyline: polyline} ->
@@ -40,9 +40,5 @@ defmodule SiteWeb.RouteController do
     else
       []
     end
-  end
-
-  defp is_rail_route?(route) do
-    Route.type_atom(route) in [:subway, :commuter_rail]
   end
 end

--- a/apps/site/lib/site_web/controllers/route_controller.ex
+++ b/apps/site/lib/site_web/controllers/route_controller.ex
@@ -10,7 +10,11 @@ defmodule SiteWeb.RouteController do
     routesWithPolylines =
       stop_id
       |> Repo.by_stop()
-      |> Enum.map(&[&1, route_polylines(&1)])
+      |> Enum.map(fn route ->
+        route
+        |> Route.to_json_safe()
+        |> Map.put(:polylines, route_polylines(route, stop_id))
+      end)
 
     json(conn, routesWithPolylines)
   end

--- a/apps/site/test/site_web/controllers/route_controller_test.exs
+++ b/apps/site/test/site_web/controllers/route_controller_test.exs
@@ -1,0 +1,36 @@
+defmodule SiteWeb.RouteControllerTest do
+  use SiteWeb.ConnCase, async: false
+  import Mock
+  alias Routes.{Route, Shape}
+
+  setup_with_mocks([
+    {Routes.Repo, [],
+     [
+       by_stop: fn _ -> [%Route{id: "route", color: "ADFF2F"}] end,
+       get_shapes: fn _, _ ->
+         [%Shape{id: "1", polyline: "safsadfasds"}, %Shape{id: "2", polyline: "werwqetrewq"}]
+       end
+     ]},
+    {Polyline, [], [decode: fn _ -> [{1, 2}, {3, 4}, {5, 6}] end]}
+  ]) do
+    :ok
+  end
+
+  describe "get_by_stop_id/2" do
+    test "returns routes with polyline data", %{conn: conn} do
+      conn = get(conn, route_path(conn, :get_by_stop_id, "stop_id"))
+      response = json_response(conn, 200)
+      assert [[route, polylines]] = response
+      assert %{"id" => "route", "color" => "ADFF2F"} = route
+
+      assert [
+               %{
+                 "color" => "#ADFF2F",
+                 "positions" => _,
+                 "weight" => _
+               }
+               | _
+             ] = polylines
+    end
+  end
+end

--- a/apps/site/test/site_web/controllers/route_controller_test.exs
+++ b/apps/site/test/site_web/controllers/route_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule SiteWeb.RouteControllerTest do
   use SiteWeb.ConnCase, async: false
   import Mock
-  alias Routes.{Route, Shape}
   alias RoutePatterns.RoutePattern
+  alias Routes.Route
 
   setup_with_mocks([
     {Routes.Repo, [:passthrough],
@@ -27,8 +27,7 @@ defmodule SiteWeb.RouteControllerTest do
     test "returns routes with polyline data", %{conn: conn} do
       conn = get(conn, route_path(conn, :get_by_stop_id, "stop_id"))
       response = json_response(conn, 200)
-      assert [[route, polylines]] = response
-      assert %{"id" => "route", "color" => "ADFF2F"} = route
+      assert [%{"id" => "route", "color" => "ADFF2F", "polylines" => polylines}] = response
 
       assert [
                %{

--- a/apps/site/test/site_web/controllers/route_controller_test.exs
+++ b/apps/site/test/site_web/controllers/route_controller_test.exs
@@ -2,13 +2,20 @@ defmodule SiteWeb.RouteControllerTest do
   use SiteWeb.ConnCase, async: false
   import Mock
   alias Routes.{Route, Shape}
+  alias RoutePatterns.RoutePattern
 
   setup_with_mocks([
-    {Routes.Repo, [],
+    {Routes.Repo, [:passthrough],
      [
-       by_stop: fn _ -> [%Route{id: "route", color: "ADFF2F"}] end,
-       get_shapes: fn _, _ ->
-         [%Shape{id: "1", polyline: "safsadfasds"}, %Shape{id: "2", polyline: "werwqetrewq"}]
+       by_stop: fn _ -> [%Route{id: "route", color: "ADFF2F"}] end
+     ]},
+    {RoutePatterns.Repo, [],
+     [
+       by_route_id: fn _, _ ->
+         [
+           %RoutePattern{shape_id: "1", representative_trip_polyline: "safsadfasds"},
+           %RoutePattern{shape_id: "2", representative_trip_polyline: "werwqetrewq"}
+         ]
        end
      ]},
     {Polyline, [], [decode: fn _ -> [{1, 2}, {3, 4}, {5, 6}] end]}


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Landing Page | Map should show subway and commuter rail routes](https://app.asana.com/0/385363666817452/1204340687791882/f)

Adds subway/trolley/commuter rail routes to the map.

Since fetching shapes is dependent on the routes, I figured we may as well fetch routes and shapes together, so I added that data to the existing endpoint we have for fetching routes for this page.

> **Note**
> This is behind a feature flag – please visit a stop page via `/stops/:stop_id?active_flag=stops_redesign`

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/2136286/233158895-89a601bf-84b0-43b1-932a-41648ae5f5de.png">

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.