### PR TITLE
fix(TripPlanner): stop subtracting fares with transfers

### DIFF
--- a/apps/site/lib/site_web/views/trip_plan_view.ex
+++ b/apps/site/lib/site_web/views/trip_plan_view.ex
@@ -558,21 +558,8 @@ defmodule SiteWeb.TripPlanView do
       |> Stream.filter(fn leg -> Fares.get_fare_by_type(leg, fare_type) != nil end)
 
     transit_legs
-    |> Stream.with_index()
-    |> Enum.reduce(0, fn {leg, leg_index}, acc ->
-      if leg_index < 1 do
-        acc + (leg |> Fares.get_fare_by_type(fare_type) |> fare_cents())
-      else
-        # Look at this transit leg and previous transit leg(s)
-        two_legs = transit_legs |> Enum.slice(leg_index - 1, 2)
-        three_legs = transit_legs |> Enum.slice(leg_index - 2, 3)
-        # If this is part of a free transfer, don't add fare
-        cond do
-          Transfer.is_maybe_transfer?(three_legs) -> acc
-          Transfer.is_maybe_transfer?(two_legs) -> acc
-          true -> acc + (leg |> Fares.get_fare_by_type(fare_type) |> fare_cents())
-        end
-      end
+    |> Enum.reduce(0, fn leg, acc ->
+      acc + (leg |> Fares.get_fare_by_type(fare_type) |> fare_cents())
     end)
   end
 

--- a/apps/site/test/site_web/views/trip_plan_view_test.exs
+++ b/apps/site/test/site_web/views/trip_plan_view_test.exs
@@ -1252,6 +1252,7 @@ closest arrival to 12:00 AM, Thursday, January 1st."
       assert format_mode(subway) == "Subway"
     end
 
+    @tag skip: "Stopped supporting Trip Planner transfer fares for now."
     test "gets the highest one-way fare correctly with subway -> subway xfer" do
       subway_leg_for_route =
         &%Leg{


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [🗺 Trip Planner | Bus -> Subway Returning Only Bus Fare](https://app.asana.com/0/385363666817452/1204444184386032/f)

A quick change to stop accounting for transfers when showing fares in Trip Planner. Deploying to dev-blue.