### PR TITLE
feat(StopRedesign): Schedule endpoint to return schedules by stop

### DIFF
--- a/apps/schedules/lib/repo.ex
+++ b/apps/schedules/lib/repo.ex
@@ -55,8 +55,8 @@ defmodule Schedules.Repo do
     |> load_from_other_repos
   end
 
-  @spec schedule_for_stop(Stop.id_t(), Keyword.t()) :: [Schedule.t()] | {:error, any}
-  def schedule_for_stop(stop_id, opts) do
+  @spec schedules_for_stop(Stop.id_t(), Keyword.t()) :: [Schedule.t()] | {:error, any}
+  def schedules_for_stop(stop_id, opts) do
     @default_params
     |> Keyword.merge(opts |> Keyword.delete(:min_time))
     |> Keyword.put(:stop, stop_id)

--- a/apps/schedules/test/repo_test.exs
+++ b/apps/schedules/test/repo_test.exs
@@ -91,7 +91,7 @@ defmodule Schedules.RepoTest do
 
   describe "schedule_for_trip/2" do
     @trip_id "place-WML-0442"
-             |> schedule_for_stop(direction_id: 1)
+             |> schedules_for_stop(direction_id: 1)
              |> List.first()
              |> Map.get(:trip)
              |> Map.get(:id)

--- a/apps/site/lib/site/transit_near_me.ex
+++ b/apps/site/lib/site/transit_near_me.ex
@@ -75,7 +75,7 @@ defmodule Site.TransitNearMe do
 
   @default_opts [
     stops_nearby_fn: &Nearby.nearby_with_varying_radius_by_mode/1,
-    schedules_fn: &Schedules.Repo.schedule_for_stop/2
+    schedules_fn: &Schedules.Repo.schedules_for_stop/2
   ]
 
   @stops_without_predictions [

--- a/apps/site/lib/site_web/controllers/schedule_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule_controller.ex
@@ -2,7 +2,7 @@ defmodule SiteWeb.ScheduleController do
   use SiteWeb, :controller
   alias Routes.Route
 
-  plug(SiteWeb.Plugs.Route)
+  plug(SiteWeb.Plugs.Route when action not in [:schedules_for_stop])
 
   @spec show(Plug.Conn.t(), map) :: Phoenix.HTML.Safe.t()
   def show(%{query_params: %{"tab" => "timetable"} = query_params} = conn, _params) do
@@ -42,5 +42,11 @@ defmodule SiteWeb.ScheduleController do
     conn
     |> redirect(to: path)
     |> halt()
+  end
+
+  @spec schedules_for_stop(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def schedules_for_stop(conn, %{"stop_id" => stop_id}) do
+    schedules = Schedules.Repo.schedules_for_stop(stop_id, [])
+    json(conn, schedules)
   end
 end

--- a/apps/site/lib/site_web/controllers/stop_controller.ex
+++ b/apps/site/lib/site_web/controllers/stop_controller.ex
@@ -69,14 +69,6 @@ defmodule SiteWeb.StopController do
     end
   end
 
-  def schedules_for_stop(conn, %{"stop_id" => stop_id}) do
-    # we should only cache figure out what, and how long to cache
-    # Real time should be a separate request (this is only scheduled)
-    # Should not return past schedules by default
-    schedules = Schedules.ByStop.SchedulesByStopRepo.departures_for_stop(stop_id, [])
-    json(conn, schedules)
-  end
-
   @spec show_old(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show_old(%Plug.Conn{query_params: query_params} = conn, %{"id" => stop}) do
     stop =

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -143,7 +143,6 @@ defmodule SiteWeb.Router do
     get("/api/realtime/stops", RealtimeScheduleApi, :stops)
 
     get("/schedules", ModeController, :index)
-    get("/schedules/at_stop/:stop_id", StopController, :schedules_for_stop)
     get("/schedules/schedule_api", ScheduleController.ScheduleApi, :show)
     get("/schedules/map_api", ScheduleController.MapApi, :show)
     get("/schedules/line_api", ScheduleController.LineApi, :show)
@@ -207,6 +206,7 @@ defmodule SiteWeb.Router do
 
     get("/alerts", AlertController, :show_by_routes)
     get("/stops/:stop_id/alerts", AlertController, :show_by_stop)
+    get("/stops/:stop_id/schedules", ScheduleController, :schedules_for_stop)
   end
 
   scope "/api", SiteWeb do

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -6,6 +6,9 @@ defmodule SiteWeb.ScheduleControllerTest do
   alias RoutePatterns.RoutePattern
   alias Schedules.Sort
   alias Stops.RouteStops
+  alias SiteWeb.ScheduleController
+
+  import Mock
 
   @moduletag :external
 
@@ -296,5 +299,21 @@ defmodule SiteWeb.ScheduleControllerTest do
 
     assert first_route_pattern_0.direction_id == 0
     assert first_route_pattern_1.direction_id == 1
+  end
+
+  describe "schedules_for_stop/2" do
+    test "should return an array of schedules", %{conn: conn} do
+      with_mock(Schedules.Repo,
+        schedules_for_stop: fn
+          "TEST 1234", [] -> [%Schedules.Schedule{stop: %Stops.Stop{id: "TEST 1234"}}]
+          _, _ -> nil
+        end
+      ) do
+        conn = ScheduleController.schedules_for_stop(conn, %{"stop_id" => "TEST 1234"})
+        body = json_response(conn, 200)
+        assert Kernel.length(body) == 1
+        assert %{"stop" => %{"id" => "TEST 1234"}} = Enum.at(body, 0)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
Broke out the stop redesign departure times into a backend only ticket.
I believe all of the feedback from the previous pull request has been addressed.

Basic idea create an endpoint to get all the schedules for a given stop for the new stop page to consume.

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Departure Card Times](https://app.asana.com/0/home/1201123880594717/1204305469426579)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

