### PR TITLE
Add more explicit handling for feed_id

### DIFF
--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
@@ -161,12 +161,14 @@ defmodule TripPlan.Api.OpenTripPlanner.Parser do
 
   defp parse_absolute_direction(nil), do: nil
 
-  defp id_after_colon(agency_colon_id) do
-    [agency, id] = String.split(agency_colon_id, ":", parts: 2)
-    # agency is either 1 (MBTA) or 2 (Massport)
-    case agency do
-      "1" -> id
-      "2" <> _ -> "Massport-" <> id
+  defp id_after_colon(feed_colon_id) do
+    [feed, id] = String.split(feed_colon_id, ":", parts: 2)
+
+    # feed id is either mbta-ma-us (MBTA) or 22722274 (Massport), if it's neither, assume it's MBTA
+    case feed do
+      "mbta-ma-us" -> id
+      "22722274" -> "Massport-" <> id
+      _ -> id
     end
   end
 end


### PR DESCRIPTION
All IDs coming from OTP are prefixed with the feed_id as specified in feed_info.txt, this updates the values in the case statement to reflect the exact values, along with a wildcard match that treats any other IDs as MBTA ones (if this is deployed before the ID is added to GTFS, it will continue to function with the auto-generated ID of 1).


#### Summary of changes

**Asana Ticket:** [Fix leg icons and colors](https://app.asana.com/0/1204355099788517/1204505865009728)

All IDs coming from OTP are prefixed with the feed_id as specified in feed_info.txt, this updates the values in the case statement to reflect the exact values, along with a wildcard match that treats any other IDs as MBTA ones (if this is deployed before the ID is added to GTFS, it will continue to function with the auto-generated ID of 1).

⚠️ This must be merged before https://github.com/mbta/gtfs_creator/pull/1927 or the trip planner will break.

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

