### PR TITLE
feat: Keep original stop_id on prediction & schedule records

### DIFF
--- a/apps/predictions/lib/prediction.ex
+++ b/apps/predictions/lib/prediction.ex
@@ -24,7 +24,7 @@ defmodule Predictions.Prediction do
   @type id_t :: String.t()
   @type schedule_relationship :: nil | :added | :unscheduled | :cancelled | :skipped | :no_data
 
-  @typedoc "Stop may be the child stop (platform) of the prediction or the parent stop (station) of that child stop. The unmodified stop_id for the prediction can be found in the raw_stop_id field."
+  @typedoc "If the predicted stop has a parent stop (station), then that *may* be the stop set on the `stop` field. In some cases, it may contain a platform stop when the stop has a parent. The unmodified stop_id for the prediction can be found in the raw_stop_id field."
   @type stop :: Stops.Stop.t() | nil
 
   @type t :: %__MODULE__{

--- a/apps/predictions/lib/prediction.ex
+++ b/apps/predictions/lib/prediction.ex
@@ -8,7 +8,7 @@ defmodule Predictions.Prediction do
   defstruct id: nil,
             trip: nil,
             stop: nil,
-            raw_stop_id: nil,
+            platform_stop_id: nil,
             route: nil,
             vehicle_id: nil,
             direction_id: nil,
@@ -24,14 +24,14 @@ defmodule Predictions.Prediction do
   @type id_t :: String.t()
   @type schedule_relationship :: nil | :added | :unscheduled | :cancelled | :skipped | :no_data
 
-  @typedoc "If the predicted stop has a parent stop (station), then that *may* be the stop set on the `stop` field. In some cases, it may contain a platform stop when the stop has a parent. The unmodified stop_id for the prediction can be found in the raw_stop_id field."
+  @typedoc "If the predicted stop has a parent stop (station), then that *may* be the stop set on the `stop` field. In some cases, it may contain a platform stop when the stop has a parent. The unmodified stop_id for the prediction can be found in the platform_stop_id field."
   @type stop :: Stops.Stop.t() | nil
 
   @type t :: %__MODULE__{
           id: id_t,
           trip: Schedules.Trip.t() | nil,
           stop: stop,
-          raw_stop_id: Stops.Stop.id_t() | nil,
+          platform_stop_id: Stops.Stop.id_t() | nil,
           route: Routes.Route.t(),
           vehicle_id: Vehicles.Vehicle.id_t() | nil,
           direction_id: 0 | 1,

--- a/apps/predictions/lib/prediction.ex
+++ b/apps/predictions/lib/prediction.ex
@@ -8,6 +8,7 @@ defmodule Predictions.Prediction do
   defstruct id: nil,
             trip: nil,
             stop: nil,
+            raw_stop_id: nil,
             route: nil,
             vehicle_id: nil,
             direction_id: nil,
@@ -22,10 +23,15 @@ defmodule Predictions.Prediction do
 
   @type id_t :: String.t()
   @type schedule_relationship :: nil | :added | :unscheduled | :cancelled | :skipped | :no_data
+
+  @typedoc "Stop may be the child stop (platform) of the prediction or the parent stop (station) of that child stop. The unmodified stop_id for the prediction can be found in the raw_stop_id field."
+  @type stop :: Stops.Stop.t() | nil
+
   @type t :: %__MODULE__{
           id: id_t,
           trip: Schedules.Trip.t() | nil,
-          stop: Stops.Stop.t() | nil,
+          stop: stop,
+          raw_stop_id: Stops.Stop.id_t() | nil,
           route: Routes.Route.t(),
           vehicle_id: Vehicles.Vehicle.id_t() | nil,
           direction_id: 0 | 1,

--- a/apps/predictions/lib/repo.ex
+++ b/apps/predictions/lib/repo.ex
@@ -179,7 +179,7 @@ defmodule Predictions.Repo do
 
   defp do_record_to_structs(
          %Stop{} = stop,
-         {id, trip_id, _stop_id, route_id, direction_id, time, stop_sequence,
+         {id, trip_id, raw_stop_id, route_id, direction_id, time, stop_sequence,
           schedule_relationship, track, status, departing?, vehicle_id}
        ) do
     trip =
@@ -194,6 +194,7 @@ defmodule Predictions.Repo do
         id: id,
         trip: trip,
         stop: stop,
+        raw_stop_id: raw_stop_id,
         route: route,
         direction_id: direction_id,
         time: time,

--- a/apps/predictions/lib/repo.ex
+++ b/apps/predictions/lib/repo.ex
@@ -179,7 +179,7 @@ defmodule Predictions.Repo do
 
   defp do_record_to_structs(
          %Stop{} = stop,
-         {id, trip_id, raw_stop_id, route_id, direction_id, time, stop_sequence,
+         {id, trip_id, platform_stop_id, route_id, direction_id, time, stop_sequence,
           schedule_relationship, track, status, departing?, vehicle_id}
        ) do
     trip =
@@ -194,7 +194,7 @@ defmodule Predictions.Repo do
         id: id,
         trip: trip,
         stop: stop,
-        raw_stop_id: raw_stop_id,
+        platform_stop_id: platform_stop_id,
         route: route,
         direction_id: direction_id,
         time: time,

--- a/apps/predictions/lib/stream_parser.ex
+++ b/apps/predictions/lib/stream_parser.ex
@@ -35,6 +35,7 @@ defmodule Predictions.StreamParser do
       time: Parser.first_time(item),
       route: route,
       stop: Stops.Repo.get_parent(stop),
+      raw_stop_id: stop_id(item),
       trip: trip,
       schedule_relationship: Parser.schedule_relationship(item),
       status: Parser.status(item),
@@ -77,6 +78,11 @@ defmodule Predictions.StreamParser do
     do: Schedules.Repo.trip(id)
 
   defp included_trip(_), do: nil
+
+  @spec stop_id(Item.t()) :: Stops.Stop.id_t() | nil
+  defp stop_id(%Item{relationships: %{"stop" => [%Item{id: id}]}}), do: id
+
+  defp stop_id(_), do: nil
 
   # note: likely to be a child stop
   @spec included_stop(Item.t()) :: Stops.Stop.t() | nil

--- a/apps/predictions/lib/stream_parser.ex
+++ b/apps/predictions/lib/stream_parser.ex
@@ -35,7 +35,7 @@ defmodule Predictions.StreamParser do
       time: Parser.first_time(item),
       route: route,
       stop: Stops.Repo.get_parent(stop),
-      raw_stop_id: stop_id(item),
+      platform_stop_id: stop_id(item),
       trip: trip,
       schedule_relationship: Parser.schedule_relationship(item),
       status: Parser.status(item),

--- a/apps/predictions/test/repo_test.exs
+++ b/apps/predictions/test/repo_test.exs
@@ -276,7 +276,7 @@ defmodule Predictions.RepoTest do
                  id: "prediction_id",
                  trip: nil,
                  stop: %Stop{id: "place-sstat"},
-                 raw_stop_id: "70079",
+                 platform_stop_id: "70079",
                  route: %Route{id: "Red"},
                  direction_id: 0,
                  time: %DateTime{},

--- a/apps/predictions/test/repo_test.exs
+++ b/apps/predictions/test/repo_test.exs
@@ -259,7 +259,7 @@ defmodule Predictions.RepoTest do
       prediction = {
         "prediction_id",
         "trip_id",
-        "place-sstat",
+        "70079",
         "Red",
         0,
         Util.now() |> Timex.shift(minutes: 5),
@@ -276,6 +276,7 @@ defmodule Predictions.RepoTest do
                  id: "prediction_id",
                  trip: nil,
                  stop: %Stop{id: "place-sstat"},
+                 raw_stop_id: "70079",
                  route: %Route{id: "Red"},
                  direction_id: 0,
                  time: %DateTime{},

--- a/apps/predictions/test/stream_parser_test.exs
+++ b/apps/predictions/test/stream_parser_test.exs
@@ -58,7 +58,7 @@ defmodule Predictions.StreamParserTest do
                route: route,
                status: "On Time",
                stop: stop,
-               raw_stop_id: "place-pktrm",
+               platform_stop_id: "place-pktrm",
                stop_sequence: 0,
                time: time,
                track: track,

--- a/apps/predictions/test/stream_parser_test.exs
+++ b/apps/predictions/test/stream_parser_test.exs
@@ -58,6 +58,7 @@ defmodule Predictions.StreamParserTest do
                route: route,
                status: "On Time",
                stop: stop,
+               raw_stop_id: "place-pktrm",
                stop_sequence: 0,
                time: time,
                track: track,

--- a/apps/schedules/lib/repo.ex
+++ b/apps/schedules/lib/repo.ex
@@ -238,7 +238,7 @@ defmodule Schedules.Repo do
         %Schedules.Schedule{
           route: Routes.Repo.get(route_id),
           trip: trip(trip_id),
-          raw_stop_id: stop_id,
+          platform_stop_id: stop_id,
           stop: Stops.Repo.get_parent(stop_id),
           time: time,
           flag?: flag?,

--- a/apps/schedules/lib/repo.ex
+++ b/apps/schedules/lib/repo.ex
@@ -238,7 +238,7 @@ defmodule Schedules.Repo do
         %Schedules.Schedule{
           route: Routes.Repo.get(route_id),
           trip: trip(trip_id),
-          stop_id: stop_id,
+          raw_stop_id: stop_id,
           stop: Stops.Repo.get_parent(stop_id),
           time: time,
           flag?: flag?,

--- a/apps/schedules/lib/repo.ex
+++ b/apps/schedules/lib/repo.ex
@@ -238,6 +238,7 @@ defmodule Schedules.Repo do
         %Schedules.Schedule{
           route: Routes.Repo.get(route_id),
           trip: trip(trip_id),
+          stop_id: stop_id,
           stop: Stops.Repo.get_parent(stop_id),
           time: time,
           flag?: flag?,

--- a/apps/schedules/lib/schedule.ex
+++ b/apps/schedules/lib/schedule.ex
@@ -16,7 +16,7 @@ defmodule Schedules.Schedule do
             pickup_type: 0,
             raw_stop_id: nil
 
-  @typedoc "If the schedule record is for a child (platform) stop, the stop field will contain the parent (station) stop. If the schedule record is for a parent stop, then the stop field is populated with that parent stop record. The unmodified stop_id for the schedule record can be found in the raw_stop_id field."
+  @typedoc "If the scheduled stop has a parent stop (station), then the `stop` field will contain that parent stop. Otherwise it will contain the stop for the scheduled stop_id. The unmodified stop_id for the schedule record can be found in the raw_stop_id field."
   @type stop :: Stops.Stop.t()
 
   @type t :: %Schedules.Schedule{

--- a/apps/schedules/lib/schedule.ex
+++ b/apps/schedules/lib/schedule.ex
@@ -14,9 +14,9 @@ defmodule Schedules.Schedule do
             last_stop?: false,
             stop_sequence: 0,
             pickup_type: 0,
-            raw_stop_id: nil
+            platform_stop_id: nil
 
-  @typedoc "If the scheduled stop has a parent stop (station), then the `stop` field will contain that parent stop. Otherwise it will contain the stop for the scheduled stop_id. The unmodified stop_id for the schedule record can be found in the raw_stop_id field."
+  @typedoc "If the scheduled stop has a parent stop (station), then the `stop` field will contain that parent stop. Otherwise it will contain the scheduled platform stop. Whether or not the stop has a parent, the unmodified stop id can be found in platform_stop_id field."
   @type stop :: Stops.Stop.t()
 
   @type t :: %Schedules.Schedule{
@@ -29,7 +29,7 @@ defmodule Schedules.Schedule do
           last_stop?: boolean,
           stop_sequence: non_neg_integer,
           pickup_type: integer,
-          raw_stop_id: Stops.Stop.id_t()
+          platform_stop_id: Stops.Stop.id_t()
         }
 
   def flag?(%Schedules.Schedule{flag?: value}), do: value

--- a/apps/schedules/lib/schedule.ex
+++ b/apps/schedules/lib/schedule.ex
@@ -16,7 +16,7 @@ defmodule Schedules.Schedule do
             pickup_type: 0,
             raw_stop_id: nil
 
-  @typedoc "The parent stop (station) for the schedule record. If this schedule record is for a child stop (platform/track), then that child stop id can be found on the `raw_stop_id` field."
+  @typedoc "If the schedule record is for a child (platform) stop, the stop field will contain the parent (station) stop. If the schedule record is for a parent stop, then the stop field is populated with that parent stop record. The unmodified stop_id for the schedule record can be found in the raw_stop_id field."
   @type stop :: Stops.Stop.t()
 
   @type t :: %Schedules.Schedule{

--- a/apps/schedules/lib/schedule.ex
+++ b/apps/schedules/lib/schedule.ex
@@ -13,18 +13,23 @@ defmodule Schedules.Schedule do
             early_departure?: false,
             last_stop?: false,
             stop_sequence: 0,
-            pickup_type: 0
+            pickup_type: 0,
+            raw_stop_id: nil
+
+  @typedoc "The parent stop (station) for the schedule record. If this schedule record is for a child stop (platform/track), then that child stop id can be found on the `raw_stop_id` field."
+  @type stop :: Stops.Stop.t()
 
   @type t :: %Schedules.Schedule{
           route: Routes.Route.t(),
           trip: Schedules.Trip.t(),
-          stop: Stops.Stop.t(),
+          stop: stop,
           time: DateTime.t(),
           flag?: boolean,
           early_departure?: boolean,
           last_stop?: boolean,
           stop_sequence: non_neg_integer,
-          pickup_type: integer
+          pickup_type: integer,
+          raw_stop_id: Stops.Stop.id_t()
         }
 
   def flag?(%Schedules.Schedule{flag?: value}), do: value

--- a/apps/schedules/test/repo_test.exs
+++ b/apps/schedules/test/repo_test.exs
@@ -43,10 +43,10 @@ defmodule Schedules.RepoTest do
 
       assert response != []
 
-      assert %{stop: %{id: "place-alfcl", name: "Alewife"}, raw_stop_id: raw_stop_id} =
+      assert %{stop: %{id: "place-alfcl", name: "Alewife"}, platform_stop_id: platform_stop_id} =
                first_schedule
 
-      assert "place-alfcl" != raw_stop_id
+      assert "place-alfcl" != platform_stop_id
     end
 
     test "filters by min_time when provided" do

--- a/apps/schedules/test/repo_test.exs
+++ b/apps/schedules/test/repo_test.exs
@@ -31,8 +31,9 @@ defmodule Schedules.RepoTest do
       assert Enum.any?(response, &(&1.route.id == "9"))
     end
 
-    test "returns the parent station as the stop" do
-      response =
+    test "returns the parent station as the stop and keeps raw stop id" do
+      [first_schedule | _rest] =
+        response =
         by_route_ids(
           ["Red"],
           date: Util.service_date(),
@@ -41,7 +42,11 @@ defmodule Schedules.RepoTest do
         )
 
       assert response != []
-      assert %{id: "place-alfcl", name: "Alewife"} = List.first(response).stop
+
+      assert %{stop: %{id: "place-alfcl", name: "Alewife"}, raw_stop_id: raw_stop_id} =
+               first_schedule
+
+      assert "place-alfcl" != raw_stop_id
     end
 
     test "filters by min_time when provided" do

--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -92,6 +92,7 @@ defmodule Site.RealtimeScheduleTest do
       status: nil,
       stop: @stop,
       stop_sequence: 190,
+      platform_stop_id: "70036",
       arrival_time: @now,
       departure_time: @now_departure,
       time: @now,
@@ -116,6 +117,7 @@ defmodule Site.RealtimeScheduleTest do
       status: nil,
       stop_sequence: 190,
       stop: @stop,
+      platform_stop_id: "70036",
       arrival_time: @now,
       departure_time: @now_departure,
       time: @now,
@@ -133,6 +135,7 @@ defmodule Site.RealtimeScheduleTest do
       pickup_type: 0,
       route: @route,
       stop: @stop,
+      platform_stop_id: "70036",
       stop_sequence: 1,
       time: @now,
       trip: @trip
@@ -196,7 +199,8 @@ defmodule Site.RealtimeScheduleTest do
                   time: ["arriving"],
                   track: nil,
                   headsign: "Oak Grove",
-                  vehicle_id: "vehicle_id"
+                  vehicle_id: "vehicle_id",
+                  platform_stop_id: "70036"
                 },
                 schedule: nil
               },
@@ -214,7 +218,8 @@ defmodule Site.RealtimeScheduleTest do
                   time: ["arriving"],
                   track: nil,
                   headsign: "Oak Grove",
-                  vehicle_id: nil
+                  vehicle_id: nil,
+                  platform_stop_id: "70036"
                 },
                 schedule: nil
               }
@@ -237,7 +242,8 @@ defmodule Site.RealtimeScheduleTest do
                   time: ["arriving"],
                   track: nil,
                   headsign: "Oak Grove",
-                  vehicle_id: "vehicle_id"
+                  vehicle_id: "vehicle_id",
+                  platform_stop_id: "70036"
                 },
                 schedule: nil
               },
@@ -255,7 +261,8 @@ defmodule Site.RealtimeScheduleTest do
                   time: ["arriving"],
                   track: nil,
                   headsign: "Oak Grove",
-                  vehicle_id: nil
+                  vehicle_id: nil,
+                  platform_stop_id: "70036"
                 },
                 schedule: nil
               }


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Support comparing scheduled and predicted platform stops](https://app.asana.com/0/555089885850811/1204552579091683/f)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

This PR includes the original stop_id for predictions and schedules as `platform_stop_id` so that we are able to compare the  scheduled vs. predicted stop. 

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

