### PR TITLE
Add larger site icons to dotcomchrome export script

### DIFF
--- a/apps/site/assets/webpack.config.export-headerfooter.js
+++ b/apps/site/assets/webpack.config.export-headerfooter.js
@@ -103,7 +103,7 @@ module.exports = (env, argv) => {
       // copy images and fonts
       new CopyWebpackPlugin({ patterns: [
             { from: "static/fonts/*", to: "fonts/[name][ext]" },
-            { from: "static/favicon.ico", to: "favicon.ico" },        
+            { from: "static/favicon.ico", to: "favicon.ico" },
             { from: "static/images/mbta-logo.svg", to: "images/mbta-logo.svg" },
             { from: "static/images/mbta-name-and-logo.svg", to: "images/mbta-name-and-logo.svg" },
             { from: "static/images/mbta-logo-t-180.png", to: "images/mbta-logo-t-180.png" },

--- a/apps/site/assets/webpack.config.export-headerfooter.js
+++ b/apps/site/assets/webpack.config.export-headerfooter.js
@@ -103,9 +103,11 @@ module.exports = (env, argv) => {
       // copy images and fonts
       new CopyWebpackPlugin({ patterns: [
             { from: "static/fonts/*", to: "fonts/[name][ext]" },
-            { from: "static/favicon.ico", to: "favicon.ico" },
+            { from: "static/favicon.ico", to: "favicon.ico" },        
             { from: "static/images/mbta-logo.svg", to: "images/mbta-logo.svg" },
             { from: "static/images/mbta-name-and-logo.svg", to: "images/mbta-name-and-logo.svg" },
+            { from: "static/images/mbta-logo-t-180.png", to: "images/mbta-logo-t-180.png" },
+            { from: "static/images/mbta-logo-t-favicon.png", to: "images/mbta-logo-t-favicon.png" },
           ]}),
 
       // purge CSS based on HTML


### PR DESCRIPTION
#### Summary of changes

Adding the larger site icons to the dotcomchrome script, so that sites using dotcomchrome can mirror the existing icon tags from mbta.com