### PR TITLE
feat(DepartureTimes): Add an alert badge to the departure row

### DIFF
--- a/apps/site/assets/css/_spacing.scss
+++ b/apps/site/assets/css/_spacing.scss
@@ -65,6 +65,10 @@
   padding-left: .313rem;
 }
 
+.ps-8 {
+  padding-left: .5rem;
+}
+
 .ps-16 {
   padding-left: 1rem;
 }
@@ -73,6 +77,10 @@
 // End
 .pe-5 {
   padding-right: .313rem;
+}
+
+.pe-8 {
+  padding-right: .5rem;
 }
 
 .pe-16 {

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -213,6 +213,10 @@
   color: $gray;
 }
 
+.u-display-none {
+  display: none;
+}
+
 // quick margin utilities loosely based off Bootstrap v4
 /* stylelint-disable declaration-no-important */
 .mb-0 {

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -213,10 +213,6 @@
   color: $gray;
 }
 
-.u-display-none {
-  display: none;
-}
-
 // quick margin utilities loosely based off Bootstrap v4
 /* stylelint-disable declaration-no-important */
 .mb-0 {

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -125,6 +125,10 @@
   padding: calc(#{$base-spacing} / 2);
 }
 
+.u-error-background {
+  background-color: $form-error-message;
+}
+
 .u-full-bleed {
   // Disable upper margin collapse since we want the bg color here.
   @include margin-clearance;

--- a/apps/site/assets/ts/components/Badge.tsx
+++ b/apps/site/assets/ts/components/Badge.tsx
@@ -1,11 +1,19 @@
 import React from "react";
 
-const Badge = ({ text }: { text: string }): JSX.Element => {
+const Badge = ({
+  text,
+  contextText
+}: {
+  text: string;
+  contextText?: string;
+}): JSX.Element => {
   return (
     <div
       className="u-error-background font-weight-bold ps-8 pe-8 fs-14"
       style={{ borderRadius: "0.75rem" }}
     >
+      {/* The purpose of this block is to have invisble text for screen readers*/}
+      {contextText && <span className="u-display-none">{contextText}</span>}
       {text}
     </div>
   );

--- a/apps/site/assets/ts/components/Badge.tsx
+++ b/apps/site/assets/ts/components/Badge.tsx
@@ -3,7 +3,7 @@ import React from "react";
 const Badge = ({ text }: { text: string }): JSX.Element => {
   return (
     <div
-      className="u-error-background font-weight-bold ps-5 pe-5"
+      className="u-error-background font-weight-bold ps-8 pe-8 fs-14"
       style={{ borderRadius: "0.75rem" }}
     >
       {text}

--- a/apps/site/assets/ts/components/Badge.tsx
+++ b/apps/site/assets/ts/components/Badge.tsx
@@ -13,7 +13,7 @@ const Badge = ({
       style={{ borderRadius: "0.75rem" }}
     >
       {/* The purpose of this block is to have invisble text for screen readers*/}
-      {contextText && <span className="u-display-none">{contextText}</span>}
+      {contextText && <span className="sr-only">{contextText}</span>}
       {text}
     </div>
   );

--- a/apps/site/assets/ts/components/Badge.tsx
+++ b/apps/site/assets/ts/components/Badge.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+const Badge = ({ text }: { text: string }): JSX.Element => {
+  return (
+    <div
+      className="u-error-background font-weight-bold ps-5 pe-5"
+      style={{ borderRadius: "0.75rem" }}
+    >
+      {text}
+    </div>
+  );
+};
+
+export default Badge;

--- a/apps/site/assets/ts/components/Badge.tsx
+++ b/apps/site/assets/ts/components/Badge.tsx
@@ -12,7 +12,7 @@ const Badge = ({
       className="u-error-background font-weight-bold ps-8 pe-8 fs-14"
       style={{ borderRadius: "0.75rem" }}
     >
-      {/* The purpose of this block is to have invisble text for screen readers*/}
+      {/* The purpose of this block is to have invisble text for screen readers */}
       {contextText && <span className="sr-only">{contextText}</span>}
       {text}
     </div>

--- a/apps/site/assets/ts/components/__tests__/BadgeTest.tsx
+++ b/apps/site/assets/ts/components/__tests__/BadgeTest.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Badge from "../Badge";
+
+describe("Badge", () => {
+  it("should display the text", () => {
+    render(<Badge text="Test Text" />);
+
+    expect(screen.queryByText("Test Text")).toBeDefined();
+  });
+});

--- a/apps/site/assets/ts/hooks/usePredictionsChannel.ts
+++ b/apps/site/assets/ts/hooks/usePredictionsChannel.ts
@@ -36,7 +36,7 @@ interface ChannelPredictionResponse {
   predictions: StreamPrediction[];
 }
 
-interface PredictionsByHeadsign {
+export interface PredictionsByHeadsign {
   [headsign: string]: PredictionWithTimestamp[];
 }
 

--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -9,7 +9,8 @@ import {
   isActiveDiversion,
   hasAnActiveDiversion,
   alertsByRoute,
-  alertsByDirectionId
+  alertsByDirectionId,
+  alertsAffectingBothDirections
 } from "../alert";
 
 const zeroPadded = (num: number): string => `${num}`.padStart(2, "0");
@@ -275,7 +276,7 @@ describe("alertsByRoute", () => {
 });
 
 describe("alertsByDirectionId", () => {
-  test("it should group alerts by directionId", () => {
+  test("it should group alerts by directionId, filtering out both directions", () => {
     const alerts = [
       {
         id: "1234",
@@ -300,5 +301,47 @@ describe("alertsByDirectionId", () => {
     expect(Object.keys(result).length).toBe(2);
     expect(result[1].length).toBe(1);
     expect(result[0].length).toBe(1);
+  });
+});
+
+describe("alertsAffectingBothDirections", () => {
+  test("should return only the alerts that affect both directions", () => {
+    const alerts = [
+      {
+        id: "1234",
+        informed_entity: {
+          direction_id: [0]
+        }
+      },
+      {
+        id: "3333",
+        informed_entity: {
+          direction_id: [null]
+        }
+      },
+      {
+        id: "0987",
+        informed_entity: {
+          direction_id: [1]
+        }
+      },
+      {
+        id: "4444",
+        informed_entity: {
+          direction_id: []
+        }
+      },
+      {
+        id: "5555",
+        informed_entity: {
+          direction_id: null
+        }
+      }
+    ] as Alert[];
+    const result = alertsAffectingBothDirections(alerts);
+    expect(result.length).toBe(3);
+    expect(result[0].id).toBe("3333");
+    expect(result[1].id).toBe("4444");
+    expect(result[2].id).toBe("5555");
   });
 });

--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -7,7 +7,9 @@ import {
   uniqueByEffect,
   isDiversion,
   isActiveDiversion,
-  hasAnActiveDiversion
+  hasAnActiveDiversion,
+  alertsByRoute,
+  alertsByDirectionId
 } from "../alert";
 
 const zeroPadded = (num: number): string => `${num}`.padStart(2, "0");
@@ -245,5 +247,58 @@ describe("hasAnActiveDiversion", () => {
       ])
     ).toBeTruthy();
     expect(hasAnActiveDiversion(stopId, [nonActiveDiversionAlert])).toBeFalsy();
+  });
+});
+
+describe("alertsByRoute", () => {
+  test("it should group alerts across multiple routes", () => {
+    const alerts = [
+      {
+        id: "1234",
+        informed_entity: {
+          route: ["441442", "442"]
+        }
+      },
+      {
+        id: "4321",
+        informed_entity: {
+          route: ["442", "53"]
+        }
+      }
+    ] as Alert[];
+    const result = alertsByRoute(alerts);
+    expect(Object.keys(result).length).toBe(3);
+    expect(result["442"].length).toBe(2);
+    expect(result["441442"].length).toBe(1);
+    expect(result["53"].length).toBe(1);
+  });
+});
+
+describe("alertsByDirectionId", () => {
+  test("it should group alerts by directionId", () => {
+    const alerts = [
+      {
+        id: "1234",
+        informed_entity: {
+          direction_id: [0]
+        }
+      },
+      {
+        id: "4321",
+        informed_entity: {
+          direction_id: [null]
+        }
+      },
+      {
+        id: "0987",
+        informed_entity: {
+          direction_id: [1]
+        }
+      }
+    ] as Alert[];
+    const result = alertsByDirectionId(alerts);
+    expect(Object.keys(result).length).toBe(2);
+    expect(result[1].length).toBe(1);
+    expect(result[0].length).toBe(1);
   });
 });

--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -293,14 +293,14 @@ describe("alertsByDirectionId", () => {
       {
         id: "0987",
         informed_entity: {
-          direction_id: [1]
+          direction_id: [0, 1]
         }
       }
     ] as Alert[];
     const result = alertsByDirectionId(alerts);
     expect(Object.keys(result).length).toBe(2);
     expect(result[1].length).toBe(1);
-    expect(result[0].length).toBe(1);
+    expect(result[0].length).toBe(2);
   });
 });
 

--- a/apps/site/assets/ts/models/__tests__/schedule-test.ts
+++ b/apps/site/assets/ts/models/__tests__/schedule-test.ts
@@ -1,0 +1,26 @@
+import { Schedule } from "../../__v3api";
+import { schedulesByHeadsign } from "../schedule";
+
+describe("schedulesByHeadsign", () => {
+  it("should return schedules grouped by headsign", () => {
+    const schedules = [
+      {
+        trip: { headsign: "Sign 1" }
+      },
+      {
+        trip: { headsign: "Sign 2" }
+      },
+      {
+        trip: { headsign: "Sign 3" }
+      },
+      {
+        trip: { headsign: "Sign 1" }
+      }
+    ] as Schedule[];
+
+    const groupedSchedules = schedulesByHeadsign(schedules);
+    expect(groupedSchedules["Sign 1"].length).toBe(2);
+    expect(groupedSchedules["Sign 2"].length).toBe(1);
+    expect(groupedSchedules["Sign 3"].length).toBe(1);
+  });
+});

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -23,13 +23,13 @@ export const alertsByStop = (alerts: Alert[], stopId: StopId): Alert[] =>
 const hasEffect = (alerts: Alert[], effect: string): boolean =>
   some(alerts, alert => alert.effect === effect);
 
-export const isSuspension = (alerts: Alert[]): boolean =>
+export const hasSuspension = (alerts: Alert[]): boolean =>
   hasEffect(alerts, "suspension");
 
-export const isShuttleService = (alerts: Alert[]): boolean =>
+export const hasShuttleService = (alerts: Alert[]): boolean =>
   hasEffect(alerts, "shuttle");
 
-export const isDetour = (alerts: Alert[]): boolean =>
+export const hasDetour = (alerts: Alert[]): boolean =>
   hasEffect(alerts, "detour");
 
 export const alertsWithStop = (alerts: Alert[]): Alert[] =>

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -42,7 +42,6 @@ export const routeWideAlerts = (alerts: Alert[]): Alert[] =>
     entities.some(entity => !entity.stop && !entity.trip)
   );
 
-// Can there be alerts that don't affect routes
 export const alertsByRoute = (alerts: Alert[]): { [key: string]: Alert[] } => {
   return reduce(
     alerts,

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -1,4 +1,5 @@
 import { isValid, parseISO } from "date-fns";
+import { isArray, mergeWith, reduce, some } from "lodash";
 import { StopId } from "../schedule/components/__schedule";
 import { Alert, TimePeriodPairs } from "../__v3api";
 
@@ -18,6 +19,93 @@ export const alertsByStop = (alerts: Alert[], stopId: StopId): Alert[] =>
     ({ informed_entity: entities }: Alert): boolean =>
       !!entities.stop && entities.stop!.some((id: StopId) => id === stopId)
   );
+
+const hasEffect = (alerts: Alert[], effect: string): boolean =>
+  some(alerts, alert => alert.effect === effect);
+
+export const isSuspension = (alerts: Alert[]): boolean =>
+  hasEffect(alerts, "suspension");
+
+export const isShuttleService = (alerts: Alert[]): boolean =>
+  hasEffect(alerts, "shuttle");
+
+export const isDetour = (alerts: Alert[]): boolean =>
+  hasEffect(alerts, "detour");
+
+export const alertsWithStop = (alerts: Alert[]): Alert[] =>
+  alerts.filter(
+    ({ informed_entity: entites }: Alert): boolean => !!entites.stop
+  );
+
+export const routeWideAlerts = (alerts: Alert[]): Alert[] =>
+  alerts.filter(({ informed_entity: { entities } }: Alert): boolean =>
+    entities.some(entity => !entity.stop && !entity.trip)
+  );
+
+// Can there be alerts that don't affect routes
+export const alertsByRoute = (alerts: Alert[]): { [key: string]: Alert[] } => {
+  return reduce(
+    alerts,
+    (acc, alert) => {
+      // create a map of every route id to the alert
+      const explodedAlerts = reduce(
+        alert.informed_entity.route,
+        (innerAcc, routeId) => {
+          return { ...innerAcc, [routeId]: [alert] };
+        },
+        {}
+      );
+
+      return mergeWith(acc, explodedAlerts, (objValue, srcValue) => {
+        if (isArray(objValue)) {
+          return objValue.concat(srcValue);
+        }
+        return srcValue;
+      });
+    },
+    {}
+  );
+};
+
+// This will only return alerts with direction id specified (aka affecting a single direction)
+export const alertsByDirectionId = (
+  alerts: Alert[]
+): { [key: number]: Alert[] } => {
+  return reduce(
+    alerts,
+    (acc, alert) => {
+      const explodedAlerts = reduce(
+        alert.informed_entity.direction_id,
+        (innerAcc, directionId) => {
+          // only include specified directions
+          if (directionId !== null) {
+            return { ...innerAcc, [directionId]: [alert] };
+          }
+          return innerAcc;
+        },
+        {}
+      );
+
+      return mergeWith(acc, explodedAlerts, (objValue, srcValue) => {
+        if (isArray(objValue)) {
+          return objValue.concat(srcValue);
+        }
+        return srcValue;
+      });
+    },
+    {}
+  );
+};
+
+export const alertsAffectingBothDirections = (alerts: Alert[]): Alert[] => {
+  return alerts.filter(alert => {
+    return (
+      alert.informed_entity.direction_id === null ||
+      alert.informed_entity.direction_id.length === 0 ||
+      alert.informed_entity.direction_id[0] === null
+    );
+  });
+};
 
 export const uniqueByEffect = (
   alert: Alert,

--- a/apps/site/assets/ts/models/schedule.ts
+++ b/apps/site/assets/ts/models/schedule.ts
@@ -1,0 +1,14 @@
+import { Dictionary, groupBy } from "lodash";
+import { Schedule } from "../__v3api";
+import { ScheduleWithTimestamp } from "./schedules";
+
+const schedulesByHeadsign = <T extends Schedule | ScheduleWithTimestamp>(
+  schedules: T[] | undefined
+): Dictionary<T[]> => {
+  return groupBy<T>(schedules, (sch: T) => {
+    return sch.trip.headsign;
+  });
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { schedulesByHeadsign };

--- a/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import DepartureCard from "../components/DepartureCard";
-import * as DepartureTimes from "../components/DepartureTimes";
 import { Alert, RouteType, Stop } from "../../__v3api";
 import { baseRoute } from "./helpers";
 import { ScheduleWithTimestamp } from "../../models/schedules";
@@ -31,6 +30,7 @@ describe("DepartureCard", () => {
         route={baseRoute("749", 3)}
         stop={stop}
         schedulesForRoute={[]}
+        alertsForRoute={[]}
         onClick={() => {}}
       />
     );
@@ -128,6 +128,7 @@ describe("DepartureCard", () => {
         stop={stop}
         schedulesForRoute={schedules}
         alertsForRoute={alerts}
+        onClick={() => {}}
       />
     );
 

--- a/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -131,7 +131,7 @@ describe("DepartureCard", () => {
       />
     );
 
-    const suspensionBadges = screen.getAllByText("Suspension");
+    const suspensionBadges = screen.getAllByText("Stop Closed");
     expect(suspensionBadges.length).toBe(2);
     expect(screen.queryByText("Shuttle Service")).toBeNull();
     expect(screen.queryByText("Detour")).toBeNull();

--- a/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import DepartureCard from "../components/DepartureCard";
-import { RouteType, Stop } from "../../__v3api";
+import * as DepartureTimes from "../components/DepartureTimes";
+import { Alert, RouteType, Stop } from "../../__v3api";
 import { baseRoute } from "./helpers";
+import { ScheduleWithTimestamp } from "../../models/schedules";
 
 const stop = {} as Stop;
 const mockClickAction = jest.fn();
@@ -15,6 +17,7 @@ describe("DepartureCard", () => {
         stop={stop}
         schedulesForRoute={[]}
         onClick={mockClickAction}
+        alertsForRoute={[]}
       />
     );
     const listItem = screen.getByRole("listitem");
@@ -45,6 +48,7 @@ describe("DepartureCard", () => {
             stop={stop}
             schedulesForRoute={[]}
             onClick={mockClickAction}
+            alertsForRoute={[]}
           />
         )
       )
@@ -72,8 +76,64 @@ describe("DepartureCard", () => {
         stop={stop}
         schedulesForRoute={[]}
         onClick={mockClickAction}
+        alertsForRoute={[]}
       />
     );
     expect(container.querySelector(expectedClass)).toBeInTheDocument();
+  });
+
+  it("passes alerts for both directions to the departure times", () => {
+    // Suspension Alerts show up before Shuttle Service and Detour Alerts
+    // If the alert that affects that affects both directions is a Suspension alert
+    // then it should take any priority over the Shuttle Service Alerts which
+    // are both direction specific.  By the Suspension alert showing up
+    // This test validates that alerts affecting both directions are passed
+    // to the child components
+    const alerts = [
+      {
+        id: "1234",
+        informed_entity: {
+          direction_id: [0]
+        },
+        effect: "shuttle"
+      },
+      {
+        id: "4321",
+        informed_entity: {
+          direction_id: [null]
+        },
+        effect: "suspension"
+      },
+      {
+        id: "0987",
+        informed_entity: {
+          direction_id: [1]
+        },
+        effect: "detour"
+      }
+    ] as Alert[];
+
+    const schedules = [
+      {
+        trip: { direction_id: 0 }
+      },
+      {
+        trip: { direction_id: 1 }
+      }
+    ] as ScheduleWithTimestamp[];
+
+    render(
+      <DepartureCard
+        route={baseRoute("749", 3)}
+        stop={stop}
+        schedulesForRoute={schedules}
+        alertsForRoute={alerts}
+      />
+    );
+
+    const suspensionBadges = screen.getAllByText("Suspension");
+    expect(suspensionBadges.length).toBe(2);
+    expect(screen.queryByText("Shuttle Service")).toBeNull();
+    expect(screen.queryByText("Detour")).toBeNull();
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/DeparturesAndMapTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DeparturesAndMapTest.tsx
@@ -52,6 +52,7 @@ describe("DeparturesAndMap", () => {
         stop={stop}
         schedules={[]}
         routesWithPolylines={testRoutesWithPolylines}
+        alerts={[]}
       />
     );
 
@@ -68,6 +69,7 @@ describe("DeparturesAndMap", () => {
         stop={stop}
         schedules={schedules}
         routesWithPolylines={testRoutesWithPolylines}
+        alerts={[]}
       />
     );
 
@@ -93,6 +95,7 @@ describe("DeparturesAndMap", () => {
         stop={stop}
         schedules={schedules}
         routesWithPolylines={testRoutesWithPolylines}
+        alerts={[]}
       />
     );
 

--- a/apps/site/assets/ts/stop/__tests__/StopPageDeparturesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageDeparturesTest.tsx
@@ -24,6 +24,7 @@ describe("StopPageDepartures", () => {
         stop={stop}
         schedules={[]}
         onClick={mockClickAction}
+        alerts={[]}
       />
     );
     expect(asFragment()).toMatchSnapshot();
@@ -37,6 +38,7 @@ describe("StopPageDepartures", () => {
         stop={stop}
         schedules={scheduleData}
         onClick={mockClickAction}
+        alerts={[]}
       />
     );
     expect(asFragment()).toMatchSnapshot();
@@ -46,5 +48,20 @@ describe("StopPageDepartures", () => {
         screen.getByRole("button", { name: new RegExp(name) })
       ).toBeDefined();
     });
+  });
+
+  it("doesn't show the filters if there is 1 mode present", () => {
+    render(
+      <StopPageDepartures
+        routes={[routeData[0]]}
+        stop={stop}
+        schedules={scheduleData}
+        onClick={() => {}}
+        alerts={[]}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: new RegExp("All") })
+    ).toBeNull();
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
@@ -217,4 +217,31 @@ describe("StopPageRedesign", () => {
     expect(screen.queryByText("The Walkway has spillage")).toBeNull();
     expect(screen.queryByText("Elevator is Malfunctioning")).toBeDefined();
   });
+
+  it("should not render past alerts", () => {
+    const now = new Date();
+    const past1 = add(now, { days: -1 });
+    const past2 = add(now, { days: -3 });
+
+    const alertsForStop: Alert[] = [
+      {
+        informed_entity: {
+          entities: [{ stop: "Test 1" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(past2), dateFormatter(past1)]],
+        lifecycle: "new",
+        id: "000001",
+        header: "Test Alert The Road Is Closed",
+        effect: "1"
+      }
+    ] as Alert[];
+
+    jest
+      .spyOn(useAlerts, "useAlertsByStop")
+      .mockImplementation(() => alertsForStop);
+
+    render(<StopPageRedesign stopId="Test 1" />);
+
+    expect(screen.queryByText("Road Is Closed")).toBeNull();
+  });
 });

--- a/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { screen, within } from "@testing-library/dom";
+import {
+  screen,
+  waitForElementToBeRemoved,
+  within
+} from "@testing-library/dom";
 import { render } from "@testing-library/react";
 import StopPageRedesign from "../components/StopPageRedesign";
 import * as useStop from "../../hooks/useStop";
@@ -9,31 +13,32 @@ import { newLatOrLon, routeWithPolylines } from "./helpers";
 import { RouteWithPolylines } from "../../hooks/useRoute";
 import * as useSchedules from "../../hooks/useSchedules";
 import * as useAlerts from "../../hooks/useAlerts";
-
-test("StopPageRedesign shows Loading without stop or routes", () => {
-  jest.spyOn(useRoute, "useRoutesByStop").mockImplementation(() => {
-    return undefined;
-  });
-  jest.spyOn(useStop, "default").mockImplementation(() => {
-    return undefined;
-  });
-
-  render(<StopPageRedesign stopId="123" />);
-  expect(screen.queryByText("Loading...")).toBeDefined();
-});
+import { ScheduleWithTimestamp } from "../../models/schedules";
+import { add, format } from "date-fns";
 
 describe("StopPageRedesign", () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    // Empty arrays need be defined outsite the mocks
+    // putting these directly inside the mocks led to maximum
+    // update depth errors
+    const routesByStopArray: RouteWithPolylines[] = [];
+    const alertsArray: Alert[] = [];
+    const schedulesArray: ScheduleWithTimestamp[] = [];
+
     jest.spyOn(useRoute, "useRoutesByStop").mockImplementation(() => {
-      return [];
+      return routesByStopArray;
     });
 
     jest.spyOn(useSchedules, "useSchedulesByStop").mockImplementation(() => {
-      return [];
+      return schedulesArray;
     });
 
     jest.spyOn(useAlerts, "useAlertsByStop").mockImplementation(() => {
-      return [];
+      return alertsArray;
+    });
+
+    jest.spyOn(useAlerts, "useAlertsByRoute").mockImplementation(() => {
+      return alertsArray;
     });
 
     jest.spyOn(useStop, "default").mockImplementation(() => {
@@ -48,9 +53,37 @@ describe("StopPageRedesign", () => {
     });
   });
 
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it("should render", () => {
     render(<StopPageRedesign stopId="123" />);
     expect(screen.queryByText("Test Stop")).not.toBeNull();
+  });
+
+  it("shows Loading without stop or routes", () => {
+    jest.spyOn(useRoute, "useRoutesByStop").mockImplementation(() => {
+      return undefined;
+    });
+    jest.spyOn(useStop, "default").mockImplementation(() => {
+      return undefined;
+    });
+
+    render(<StopPageRedesign stopId="123" />);
+    expect(screen.queryByText("Loading...")).toBeDefined();
+  });
+
+  it("shows Loading without alerts", () => {
+    jest
+      .spyOn(useAlerts, "useAlertsByStop")
+      .mockImplementation(() => undefined);
+    jest
+      .spyOn(useAlerts, "useAlertsByRoute")
+      .mockImplementation(() => undefined);
+
+    render(<StopPageRedesign stopId="123" />);
+    expect(screen.queryByText("Loading...")).toBeDefined();
   });
 
   it("gets lines to show on the map", () => {
@@ -85,28 +118,103 @@ describe("StopPageRedesign", () => {
     expect(mapPolylines).toHaveLength(10);
   });
 
+  const dateFormatter = (date: Date): string => {
+    return format(date, "yyyy-M-d HH:mm");
+  };
+
   it("should render alerts", () => {
-    const lowAlert: Alert = {
-      updated_at: "Updated: 4/11/2019 09:33A",
-      severity: 7,
-      priority: "low",
-      lifecycle: "upcoming",
-      active_period: [],
-      informed_entity: {} as InformedEntitySet,
-      id: "00005",
-      header: "There is construction at this station.",
-      effect: "other",
-      description: "",
-      url: "https://www.mbta.com"
-    };
+    const now = new Date();
+    const future1 = add(now, { days: 1 });
+    const lowAlerts: Alert[] = [
+      {
+        updated_at: "Updated: 4/11/2019 09:33A",
+        severity: 7,
+        priority: "low",
+        lifecycle: "new",
+        active_period: [[dateFormatter(now), dateFormatter(future1)]],
+        informed_entity: {} as InformedEntitySet,
+        id: "00005",
+        header: "There is construction at this station.",
+        effect: "other",
+        description: "",
+        url: "https://www.mbta.com"
+      }
+    ];
 
     jest
       .spyOn(useAlerts, "useAlertsByStop")
-      .mockImplementation(() => [lowAlert]);
+      .mockImplementation(() => lowAlerts);
 
     render(<StopPageRedesign stopId="123" />);
     expect(
       screen.queryByText("There is construction at this station.")
     ).not.toBeNull();
+  });
+
+  it("should only render current alerts and not future alerts", () => {
+    const now = new Date();
+    const future1 = add(now, { days: 1 });
+    const future2 = add(now, { days: 3 });
+
+    const alertsForStop: Alert[] = [
+      {
+        informed_entity: {
+          entities: [{ stop: "Test 1" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(now), dateFormatter(future1)]],
+        lifecycle: "new",
+        id: "000001",
+        header: "Test Alert The Road Is Closed",
+        effect: "1"
+      },
+      {
+        informed_entity: {
+          entities: [{ stop: "Test 1" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(future1), dateFormatter(future2)]],
+        lifecycle: "new",
+        id: "000002",
+        header: "Test Alert The Road Is Open",
+        effect: "2"
+      }
+    ] as Alert[];
+
+    const alertsForRoute: Alert[] = [
+      {
+        informed_entity: {
+          entities: [{ route: "Test Route 2" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(future1), dateFormatter(future2)]],
+        lifecycle: "new",
+        id: "000003",
+        header: "Test Alert The Walkway has spillage",
+        effect: "3"
+      },
+      {
+        informed_entity: {
+          entities: [{ route: "Test Route 3" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(now), dateFormatter(future2)]],
+        lifecycle: "new",
+        id: "000004",
+        header: "Test Alert The Elevator is Malfunctioning",
+        effect: "4"
+      }
+    ] as Alert[];
+
+    jest
+      .spyOn(useAlerts, "useAlertsByStop")
+      .mockImplementation(() => alertsForStop);
+
+    jest
+      .spyOn(useAlerts, "useAlertsByRoute")
+      .mockImplementation(() => alertsForRoute);
+
+    render(<StopPageRedesign stopId="Test 1" />);
+
+    expect(screen.queryByText("Road Is Closed")).toBeDefined();
+    expect(screen.queryByText("Road Is Open")).toBeNull();
+    expect(screen.queryByText("The Walkway has spillage")).toBeNull();
+    expect(screen.queryByText("Elevator is Malfunctioning")).toBeDefined();
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -122,6 +122,7 @@ describe("DepartureTimes", () => {
           directionId={0}
           schedulesForDirection={schedules}
           alertsForDirection={alerts}
+          onClick={() => {}}
         />
       );
       expect(screen.getByText(expectedBadge)).toBeDefined();
@@ -467,6 +468,7 @@ describe("DepartureTimes", () => {
         directionId={0}
         schedulesForDirection={schedules}
         onClick={mockClickAction}
+        alertsForDirection={[]}
       />
     );
 

--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -5,7 +5,7 @@ import DepartureTimes, {
   infoToDisplayTime
 } from "../../components/DepartureTimes";
 import { baseRoute } from "../helpers";
-import { Stop } from "../../../__v3api";
+import { Alert, Stop } from "../../../__v3api";
 import { DepartureInfo } from "../../../models/departureInfo";
 import * as predictionsChannel from "../../../hooks/usePredictionsChannel";
 import { ScheduleWithTimestamp } from "../../../models/schedules";
@@ -17,7 +17,6 @@ const destinationText = route.direction_destinations[0]!;
 const mockClickAction = jest.fn();
 
 describe("DepartureTimes", () => {
-  describe("DepartureTimes component", () => {});
   it("should display a default", () => {
     render(
       <DepartureTimes
@@ -26,6 +25,7 @@ describe("DepartureTimes", () => {
         directionId={0}
         schedulesForDirection={[]}
         onClick={mockClickAction}
+        alertsForDirection={[]}
       />
     );
     expect(screen.findByText(destinationText)).toBeDefined();
@@ -80,6 +80,7 @@ describe("DepartureTimes", () => {
         schedulesForDirection={schedules}
         overrideDate={dateToCompare}
         onClick={mockClickAction}
+        alertsForDirection={[]}
       />
     );
     expect(screen.getByText("Test 1"));
@@ -91,6 +92,41 @@ describe("DepartureTimes", () => {
     // expect(screen.getByText("Test 3"))
     // expect(screen.getByText("11:45 AM"))
   });
+
+  it.each`
+    alertEffect     | expectedBadge
+    ${"suspension"} | ${"Suspension"}
+    ${"shuttle"}    | ${"Shuttle Service"}
+    ${"detour"}     | ${"Detour"}
+  `(
+    `displays $expectedBadge when alert has effect $alertEffect`,
+    ({ alertEffect, expectedBadge }) => {
+      const schedules = [
+        { trip: { direction_id: 0 } }
+      ] as ScheduleWithTimestamp[];
+
+      const alerts = [
+        {
+          id: "1234",
+          informed_entity: {
+            direction_id: [0]
+          },
+          effect: alertEffect
+        }
+      ] as Alert[];
+
+      render(
+        <DepartureTimes
+          route={route}
+          stop={stop}
+          directionId={0}
+          schedulesForDirection={schedules}
+          alertsForDirection={alerts}
+        />
+      );
+      expect(screen.getByText(expectedBadge)).toBeDefined();
+    }
+  );
 
   describe("getNextTwoTimes", () => {
     it("should return the next 2 departure infos times", () => {

--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -95,7 +95,7 @@ describe("DepartureTimes", () => {
 
   it.each`
     alertEffect     | expectedBadge
-    ${"suspension"} | ${"Suspension"}
+    ${"suspension"} | ${"Stop Closed"}
     ${"shuttle"}    | ${"Shuttle Service"}
     ${"detour"}     | ${"Detour"}
   `(

--- a/apps/site/assets/ts/stop/components/DepartureCard.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureCard.tsx
@@ -1,9 +1,9 @@
 import React, { ReactElement } from "react";
-import { groupBy } from "lodash";
+import { concat, groupBy } from "lodash";
 import { routeBgClass, busClass } from "../../helpers/css";
 import { breakTextAtSlash } from "../../helpers/text";
 import { isASilverLineRoute } from "../../models/route";
-import { DirectionId, Route, Stop } from "../../__v3api";
+import { Alert, DirectionId, Route, Stop } from "../../__v3api";
 import CRsvg from "../../../static/images/icon-commuter-rail-default.svg";
 import Bussvg from "../../../static/images/icon-bus-default.svg";
 import SubwaySvg from "../../../static/images/icon-subway-default.svg";
@@ -11,6 +11,10 @@ import FerrySvg from "../../../static/images/icon-ferry-default.svg";
 import renderSvg from "../../helpers/render-svg";
 import DepartureTimes from "./DepartureTimes";
 import { ScheduleWithTimestamp } from "../../models/schedules";
+import {
+  alertsAffectingBothDirections,
+  alertsByDirectionId
+} from "../../models/alert";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const routeToModeIcon = (route: Route): any => {
@@ -37,7 +41,8 @@ const DepartureCard = ({
   route,
   stop,
   schedulesForRoute,
-  onClick
+  onClick,
+  alertsForRoute = []
 }: {
   route: Route;
   schedulesForRoute: ScheduleWithTimestamp[];
@@ -47,6 +52,7 @@ const DepartureCard = ({
     directionId: DirectionId,
     departures: ScheduleWithTimestamp[] | null | undefined
   ) => void;
+  alertsForRoute: Alert[];
 }): ReactElement<HTMLElement> => {
   const routeName = (
     <span className={busClass(route)}>
@@ -59,6 +65,18 @@ const DepartureCard = ({
     schedulesForRoute,
     (sch: ScheduleWithTimestamp) => sch.trip.direction_id
   );
+
+  const alertsByDirectionObj = alertsByDirectionId(alertsForRoute);
+  const alertsAffectingBothDirectionsArray = alertsAffectingBothDirections(
+    alertsForRoute
+  );
+
+  const alertsZeroDirectionArray = alertsByDirectionObj[0]
+    ? alertsByDirectionObj[0]
+    : [];
+  const alertsOneDirectionArray = alertsByDirectionObj[1]
+    ? alertsByDirectionObj[1]
+    : [];
 
   return (
     <li className="departure-card">
@@ -76,6 +94,10 @@ const DepartureCard = ({
         directionId={0}
         schedulesForDirection={schedulesByDirection[0]}
         onClick={onClick}
+        alertsForDirection={concat(
+          alertsAffectingBothDirectionsArray,
+          alertsZeroDirectionArray
+        )}
       />
       <DepartureTimes
         key={`${route.id}-1`}
@@ -84,6 +106,10 @@ const DepartureCard = ({
         directionId={1}
         schedulesForDirection={schedulesByDirection[1]}
         onClick={onClick}
+        alertsForDirection={concat(
+          alertsAffectingBothDirectionsArray,
+          alertsOneDirectionArray
+        )}
       />
     </li>
   );

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -11,7 +11,11 @@ import {
   mergeIntoDepartureInfo
 } from "../../helpers/departureInfo";
 import { DepartureInfo } from "../../models/departureInfo";
-import { isDetour, isShuttleService, isSuspension } from "../../models/alert";
+import {
+  hasDetour,
+  hasShuttleService,
+  hasSuspension
+} from "../../models/alert";
 import Badge from "../../components/Badge";
 import {
   DisplayTimeConfig,
@@ -32,15 +36,15 @@ const getNextTwoTimes = (
 };
 
 const toAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
-  if (isSuspension(alerts)) {
+  if (hasSuspension(alerts)) {
     return <Badge text="Stop Closed" contextText="Route Status" />;
   }
 
-  if (isShuttleService(alerts)) {
+  if (hasShuttleService(alerts)) {
     return <Badge text="Shuttle Service" contextText="Route Status" />;
   }
 
-  if (isDetour(alerts)) {
+  if (hasDetour(alerts)) {
     return <Badge text="Detour" contextText="Route Status" />;
   }
   return undefined;

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -33,7 +33,7 @@ const getNextTwoTimes = (
 
 const toAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
   if (isSuspension(alerts)) {
-    return <Badge text="Suspension" />;
+    return <Badge text="Stop Closed" />;
   }
 
   if (isShuttleService(alerts)) {
@@ -182,9 +182,7 @@ const DepartureTimes = ({
   return (
     <>
       {Object.entries(schedules).map(([headsign, schs]) => {
-        const predictions = predictionsByHeadsign[headsign]
-          ? predictionsByHeadsign[headsign]
-          : [];
+        const predictions = predictionsByHeadsign[headsign] || [];
         const formattedTimes = toDisplayTime(schs, predictions, overrideDate);
         return (
           <div

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -182,10 +182,10 @@ const DepartureTimes = ({
     directionId
   );
 
-  const schedules = schedulesByHeadsign(schedulesForDirection);
+  const groupedSchedules = schedulesByHeadsign(schedulesForDirection);
   return (
     <>
-      {Object.entries(schedules).map(([headsign, schedules]) => {
+      {Object.entries(groupedSchedules).map(([headsign, schedules]) => {
         const predictions = predictionsByHeadsign[headsign] || [];
         return (
           <div

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -33,15 +33,15 @@ const getNextTwoTimes = (
 
 const toAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
   if (isSuspension(alerts)) {
-    return <Badge text="Stop Closed" />;
+    return <Badge text="Stop Closed" contextText="Route Status" />;
   }
 
   if (isShuttleService(alerts)) {
-    return <Badge text="Shuttle Service" />;
+    return <Badge text="Shuttle Service" contextText="Route Status" />;
   }
 
   if (isDetour(alerts)) {
-    return <Badge text="Detour" />;
+    return <Badge text="Detour" contextText="Route Status" />;
   }
   return undefined;
 };

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -181,23 +181,24 @@ const DepartureTimes = ({
   const schedules = schedulesByHeadsign(schedulesForDirection);
   return (
     <>
-      {Object.entries(schedules).map(([headsign, schs]) => {
+      {Object.entries(schedules).map(([headsign, schedules]) => {
         const predictions = predictionsByHeadsign[headsign] || [];
-        const formattedTimes = toDisplayTime(schs, predictions, overrideDate);
         return (
           <div
+            // TODO remove this class name in favor of test ids
             className="departure-row-click-test"
             key={`${headsign}-${route.id}`}
-            onClick={() => onClick(route, directionId, schs)}
-            onKeyDown={() => onClick(route, directionId, schs)}
+            onClick={() => onClick(route, directionId, schedules)}
+            onKeyDown={() => onClick(route, directionId, schedules)}
             role="presentation"
           >
             {getRow(
-          headsign,
-          schs,
-          predictions,
-          alertsForDirection,
-          overrideDate)}
+              headsign,
+              schedules,
+              predictions,
+              alertsForDirection,
+              overrideDate
+            )}
           </div>
         );
       })}

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -1,38 +1,24 @@
 import React, { ReactElement } from "react";
-import { Dictionary, groupBy, slice } from "lodash";
-import {
-  differenceInSeconds,
-  isSameDay,
-  secondsInDay,
-  secondsInHour,
-  secondsInMinute
-} from "date-fns";
+import { slice } from "lodash";
 import usePredictionsChannel from "../../hooks/usePredictionsChannel";
-import { DirectionId, Route, Stop } from "../../__v3api";
+import { Alert, DirectionId, Route, Stop } from "../../__v3api";
 import renderFa from "../../helpers/render-fa";
-import { formatToBostonTime } from "../../helpers/date";
 import realtimeIcon from "../../../static/images/icon-realtime-tracking.svg";
 import SVGIcon from "../../helpers/render-svg";
 import { ScheduleWithTimestamp } from "../../models/schedules";
-import { PredictionWithTimestamp } from "../../models/perdictions";
 import {
-  departureInfoToTime,
-  displayInfoContainsPrediction,
   getNextUnCancelledDeparture,
   mergeIntoDepartureInfo
 } from "../../helpers/departureInfo";
 import { DepartureInfo } from "../../models/departureInfo";
-
-// This interface is used to tell the front end
-// how to display the ScheduleInfoModel data
-interface DisplayTimeConfig {
-  isPrediction?: boolean;
-  displayString: string;
-  trackName?: string | null;
-  isTomorrow?: boolean;
-  isBolded?: boolean;
-  isStikethrough?: boolean;
-}
+import { isDetour, isShuttleService, isSuspension } from "../../models/alert";
+import Badge from "../../components/Badge";
+import {
+  DisplayTimeConfig,
+  infoToDisplayTime
+} from "../models/displayTimeConfig";
+import { schedulesByHeadsign } from "../../models/schedule";
+import { PredictionWithTimestamp } from "../../models/perdictions";
 
 // Returns 2 times from the departureInfo array
 // ensuring that upto one returned time is cancelled
@@ -45,152 +31,19 @@ const getNextTwoTimes = (
   return [departure1, departure2];
 };
 
-const infoToDisplayTime = (
-  time1: DepartureInfo | undefined,
-  time2: DepartureInfo | undefined,
-  targetDate: Date = new Date()
-): DisplayTimeConfig[] => {
-  const defaultState = [{ displayString: "Updates unavailable" }];
-  // If there is not input time1 then a schedule or prediction could not be found
-  if (!time1) {
-    return defaultState;
+const toAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
+  if (isSuspension(alerts)) {
+    return <Badge text="Suspension" />;
   }
 
-  const departure1Time = departureInfoToTime(time1);
-  const formatOverride = "h:mm aa";
-
-  if (time1.isDelayed) {
-    // is delayed can only be true if both a prediction and schedule exist
-    const scheduleTime = time1.schedule!.time;
-    const predictionTime = time1.prediction!.time;
-    return [
-      {
-        displayString: `${formatToBostonTime(predictionTime, formatOverride)}`,
-        isBolded: true,
-        // only predictions can be delayed
-        isPrediction: true
-      },
-      {
-        displayString: `${formatToBostonTime(scheduleTime, formatOverride)}`,
-        isStikethrough: true,
-        trackName: time1.prediction!.track
-      }
-    ];
+  if (isShuttleService(alerts)) {
+    return <Badge text="Shuttle Service" />;
   }
 
-  if (time2 && time1.isCancelled) {
-    const departure2Time = departureInfoToTime(time2);
-    // State 7
-    // State 8
-    // If trip1 is cancelled, then trip2 should not be cancelled
-    // Display trip2 in the first time spot (and its track info in the second)
-    return [
-      {
-        displayString: `${formatToBostonTime(departure2Time, formatOverride)}`,
-        isBolded: true,
-        isPrediction: displayInfoContainsPrediction(time2)
-      },
-      {
-        displayString: `${formatToBostonTime(departure1Time, formatOverride)}`,
-        isStikethrough: true,
-        trackName: time2.prediction?.track
-      }
-    ];
+  if (isDetour(alerts)) {
+    return <Badge text="Detour" />;
   }
-
-  const diffInSeconds1 = differenceInSeconds(departure1Time, targetDate);
-  const diffInSeconds2 = time2
-    ? differenceInSeconds(departureInfoToTime(time2), targetDate)
-    : -1;
-
-  if (diffInSeconds1 <= secondsInMinute) {
-    // State 9
-    return [
-      {
-        displayString: "Arriving",
-        isPrediction: displayInfoContainsPrediction(time1),
-        isBolded: true
-      }
-    ];
-  }
-
-  if (
-    diffInSeconds1 < secondsInHour &&
-    diffInSeconds1 > secondsInMinute &&
-    diffInSeconds2 < secondsInHour &&
-    diffInSeconds2 > secondsInMinute
-  ) {
-    // State 1
-    return [
-      {
-        displayString: `${Math.floor(diffInSeconds1 / secondsInMinute)} min`,
-        isPrediction: displayInfoContainsPrediction(time1),
-        isBolded: true
-      },
-      { displayString: `${Math.floor(diffInSeconds2 / secondsInMinute)} min` }
-    ];
-  }
-
-  if (
-    diffInSeconds1 < secondsInHour &&
-    diffInSeconds1 > secondsInMinute &&
-    diffInSeconds2 >= secondsInHour
-  ) {
-    // State 2
-    return [
-      {
-        displayString: `${Math.floor(diffInSeconds1 / secondsInMinute)} min`,
-        isBolded: true,
-        isPrediction: displayInfoContainsPrediction(time1)
-      }
-    ];
-  }
-
-  if (diffInSeconds1 >= secondsInHour && diffInSeconds1 < secondsInDay) {
-    // State 3
-    // State 4
-    // State 5
-    // State 6
-    return [
-      {
-        displayString: `${formatToBostonTime(departure1Time, formatOverride)}`,
-        // If the days are not the same, then one must be tomorrow
-        isTomorrow: !isSameDay(departure1Time, targetDate),
-        isPrediction: displayInfoContainsPrediction(time1),
-        isBolded: true,
-        trackName: time1.prediction?.track
-      }
-    ];
-  }
-
-  if (diffInSeconds1 >= secondsInDay) {
-    // State 11
-    return [{ displayString: "No upcoming trips" }];
-  }
-
-  // Default state is error
-  // State 10
-  return defaultState;
-};
-
-const toDisplayTime = (
-  schedules: ScheduleWithTimestamp[],
-  predictions: PredictionWithTimestamp[],
-  targetDate = new Date()
-): DisplayTimeConfig[] => {
-  // TODO this should be short cutted by alerts
-  const departureInfos = mergeIntoDepartureInfo(schedules, predictions);
-  const [time1, time2] = getNextTwoTimes(departureInfos);
-
-  return infoToDisplayTime(time1, time2, targetDate);
-};
-
-const schedulesByHeadsign = (
-  schedules: ScheduleWithTimestamp[] | undefined
-): Dictionary<ScheduleWithTimestamp[]> => {
-  return groupBy(schedules, (sch: ScheduleWithTimestamp) => {
-    return sch.trip.headsign;
-  });
+  return undefined;
 };
 
 const departureTimeClasses = (
@@ -212,9 +65,39 @@ const departureTimeClasses = (
   return customClasses;
 };
 
+const displayFormattedTimes = (
+  formattedTimes: DisplayTimeConfig[]
+): JSX.Element => {
+  return (
+    <div className="d-flex justify-content-space-between">
+      {formattedTimes.map((time, index) => {
+        const classes = departureTimeClasses(time, index);
+        return (
+          <>
+            {time.isPrediction && (
+              <div className="me-4">
+                {SVGIcon("c-svg__icon--realtime fs-10", realtimeIcon)}
+              </div>
+            )}
+            <div key={`${time.displayString}-departure-times`} className="me-8">
+              <div className={`${classes} u-nowrap`}>{time.displayString}</div>
+              <div className="fs-12">
+                {/* Prioritize displaying Tomorrow over track name if both are present */}
+                {time.isTomorrow && "Tomorrow"}
+                {!time.isTomorrow && !!time.trackName && time.trackName}
+              </div>
+            </div>
+          </>
+        );
+      })}
+    </div>
+  );
+};
+
 const departureTimeRow = (
   headsignName: string,
-  formattedTimes: DisplayTimeConfig[]
+  formattedTimes: DisplayTimeConfig[],
+  alertBadge?: JSX.Element
 ): JSX.Element => {
   return (
     <div
@@ -223,33 +106,8 @@ const departureTimeRow = (
     >
       <div className="departure-card__headsign-name">{headsignName}</div>
       <div className="d-flex align-items-center">
-        <div className="d-flex justify-content-space-between">
-          {formattedTimes.map((time, index) => {
-            const classes = departureTimeClasses(time, index);
-            return (
-              <>
-                {time.isPrediction && (
-                  <div className="me-4">
-                    {SVGIcon("c-svg__icon--realtime fs-10", realtimeIcon)}
-                  </div>
-                )}
-                <div
-                  key={`${time.displayString}-departure-times`}
-                  className="me-8"
-                >
-                  <div className={`${classes} u-nowrap`}>
-                    {time.displayString}
-                  </div>
-                  <div className="fs-12">
-                    {/* Prioritize displaying Tomorrow over track name if both are present */}
-                    {time.isTomorrow && "Tomorrow"}
-                    {!time.isTomorrow && !!time.trackName && time.trackName}
-                  </div>
-                </div>
-              </>
-            );
-          })}
-        </div>
+        {formattedTimes.length > 0 && displayFormattedTimes(formattedTimes)}
+        {alertBadge}
         {/* TODO: Navigate to Realtime Tracking view (whole row should be clickable) */}
         <button
           type="button"
@@ -262,11 +120,34 @@ const departureTimeRow = (
   );
 };
 
+const getRow = (
+  headsign: string,
+  schedules: ScheduleWithTimestamp[],
+  predictions: PredictionWithTimestamp[],
+  alerts: Alert[],
+  overrideDate?: Date
+): JSX.Element => {
+  const alertBadge = toAlertBadge(alerts);
+  if (alertBadge) {
+    return departureTimeRow(headsign, [], alertBadge);
+  }
+
+  // Merging should happen after alert processing incase a route is cancelled
+  const departureInfos = mergeIntoDepartureInfo(schedules, predictions);
+
+  const [time1, time2] = getNextTwoTimes(departureInfos);
+  const formattedTimes = infoToDisplayTime(time1, time2, overrideDate);
+
+  return departureTimeRow(headsign, formattedTimes);
+};
+
 interface DepartureTimesProps {
   route: Route;
   stop: Stop;
   directionId: DirectionId;
   schedulesForDirection: ScheduleWithTimestamp[] | undefined;
+  alertsForDirection: Alert[];
+  // override date primarily used for testing
   overrideDate?: Date;
   onClick: (
     route: Route,
@@ -287,8 +168,9 @@ const DepartureTimes = ({
   stop,
   directionId,
   schedulesForDirection,
-  overrideDate,
-  onClick
+  onClick,
+  alertsForDirection,
+  overrideDate
 }: DepartureTimesProps): ReactElement<HTMLElement> => {
   const predictionsByHeadsign = usePredictionsChannel(
     route.id,
@@ -300,10 +182,10 @@ const DepartureTimes = ({
   return (
     <>
       {Object.entries(schedules).map(([headsign, schs]) => {
-        const preds = predictionsByHeadsign[headsign]
+        const predictions = predictionsByHeadsign[headsign]
           ? predictionsByHeadsign[headsign]
           : [];
-        const formattedTimes = toDisplayTime(schs, preds, overrideDate);
+        const formattedTimes = toDisplayTime(schs, predictions, overrideDate);
         return (
           <div
             className="departure-row-click-test"
@@ -312,7 +194,12 @@ const DepartureTimes = ({
             onKeyDown={() => onClick(route, directionId, schs)}
             role="presentation"
           >
-            {departureTimeRow(headsign, formattedTimes)}
+            {getRow(
+          headsign,
+          schs,
+          predictions,
+          alertsForDirection,
+          overrideDate)}
           </div>
         );
       })}

--- a/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from "react";
 import { chain } from "lodash";
-import { DirectionId, Route, Stop } from "../../__v3api";
+import { Alert, DirectionId, Route, Stop } from "../../__v3api";
 import { ScheduleWithTimestamp } from "../../models/schedules";
 import StopPageDepartures from "./StopPageDepartures";
 import StopMapRedesign from "./StopMapRedesign";
@@ -13,13 +13,15 @@ interface DeparturesAndMapProps {
   stop: Stop;
   schedules: ScheduleWithTimestamp[];
   routesWithPolylines: RouteWithPolylines[];
+  alerts: Alert[];
 }
 
 const DeparturesAndMap = ({
   routes,
   stop,
   schedules,
-  routesWithPolylines
+  routesWithPolylines,
+  alerts
 }: DeparturesAndMapProps): ReactElement<HTMLElement> => {
   const [departureInfo, setDepartureInfo] = useState<{
     departureRoute: Route | null;
@@ -68,6 +70,7 @@ const DeparturesAndMap = ({
           stop={stop}
           schedules={schedules}
           onClick={setDepartureVariables}
+          alerts={alerts}
         />
       ) : (
         <div className="departures-container">

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -1,11 +1,12 @@
 import { filter, groupBy, sortBy } from "lodash";
 import { isPast } from "date-fns";
 import React, { ReactElement, useState } from "react";
-import { DirectionId, Route, Stop } from "../../__v3api";
+import { Alert, DirectionId, Route, Stop } from "../../__v3api";
 import DeparturesFilters, { ModeChoice } from "./DeparturesFilters";
 import { modeForRoute } from "../../models/route";
 import DepartureCard from "./DepartureCard";
 import { ScheduleWithTimestamp } from "../../models/schedules";
+import { alertsByRoute } from "../../models/alert";
 
 interface StopPageDeparturesProps {
   routes: Route[];
@@ -16,6 +17,7 @@ interface StopPageDeparturesProps {
     directionId: DirectionId,
     departures: ScheduleWithTimestamp[] | null | undefined
   ) => void;
+  alerts: Alert[];
 }
 
 // Commuter Rail, then Subway, then Bus
@@ -33,7 +35,8 @@ const StopPageDepartures = ({
   routes,
   stop,
   schedules,
-  onClick
+  onClick,
+  alerts
 }: StopPageDeparturesProps): ReactElement<HTMLElement> => {
   // default to show all modes.
   const [selectedMode, setSelectedMode] = useState<ModeChoice>("all");
@@ -47,6 +50,7 @@ const StopPageDepartures = ({
   const modesList = Object.keys(groupedRoutes) as ModeChoice[];
   const filteredRoutes =
     selectedMode === "all" ? routes : groupedRoutes[selectedMode];
+  const groupedAlerts = alertsByRoute(alerts);
 
   return (
     <div className="routes">
@@ -66,6 +70,7 @@ const StopPageDepartures = ({
             schedulesForRoute={groupedSchedules[route.id]}
             onClick={onClick}
             // This list should only have one value, is there another way to do this?
+            alertsForRoute={groupedAlerts[route.id]}
           />
         ))}
       </ul>

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -6,7 +6,7 @@ import { useRoutesByStop } from "../../hooks/useRoute";
 import StopPageHeaderRedesign from "./StopPageHeaderRedesign";
 import Loading from "../../components/Loading";
 import Alerts from "../../components/Alerts";
-import { Alert, Route } from "../../__v3api";
+import { Route } from "../../__v3api";
 import { useSchedulesByStop } from "../../hooks/useSchedules";
 import { useAlertsByRoute, useAlertsByStop } from "../../hooks/useAlerts";
 import DeparturesAndMap from "./DeparturesAndMap";
@@ -19,7 +19,6 @@ const StopPageRedesign = ({
 }): ReactElement<HTMLElement> => {
   const [routeIdState, setRouteIdState] = useState<string[]>([]);
   const [routeState, setRouteState] = useState<Route[]>([]);
-  const [alertState, setAlertState] = useState<Alert[]>([]);
 
   const stop = useStop(stopId);
   const routesWithPolylines = useRoutesByStop(stopId);
@@ -30,41 +29,30 @@ const StopPageRedesign = ({
   //
 
   useEffect(() => {
-    setRouteState(
-      routesWithPolylines
-        ? routesWithPolylines.map(rwp => omit(rwp, "polylines"))
-        : []
-    );
+    const routes = routesWithPolylines
+      ? routesWithPolylines.map(rwp => omit(rwp, "polylines"))
+      : [];
+    setRouteState(routes);
   }, [routesWithPolylines]);
 
   useEffect(() => {
     setRouteIdState(routeState.map(route => route.id));
   }, [routeState]);
 
-  useEffect(() => {
-    // alerts contains all the alerts affecting the stop in question
-    const alertsArray = alerts !== undefined ? alerts : [];
-    const alertsRouteArray =
-      alertsForRoutes !== undefined ? alertsForRoutes : [];
-    // routeWideAlertsArray are all the alerts that affect the whole route
-    // not just specific stops
-    const routeWideAlertsArray = routeWideAlerts(alertsRouteArray);
-    // Get only alerts that are current
-    const currentAlerts = filter(
-      alertsArray.concat(routeWideAlertsArray),
-      alert => isCurrentAlert(alert)
-    );
-    setAlertState(currentAlerts);
-  }, [alerts, alertsForRoutes]);
+  // alerts contains all the alerts affecting the stop in question
+  const alertsArray = alerts !== undefined ? alerts : [];
+  const alertsRouteArray = alertsForRoutes !== undefined ? alertsForRoutes : [];
+  // routeWideAlertsArray are all the alerts that affect the whole route
+  // not just specific stops
+  const routeWideAlertsArray = routeWideAlerts(alertsRouteArray);
+  // Get only alerts that are current
+  const currentAlerts = filter(
+    alertsArray.concat(routeWideAlertsArray),
+    alert => isCurrentAlert(alert)
+  );
 
   // Return loading indicator while waiting on data fetch
-  if (
-    !stop ||
-    !routesWithPolylines ||
-    !schedules ||
-    !alerts ||
-    !alertsForRoutes
-  ) {
+  if (!stop || !routesWithPolylines || !schedules) {
     return <Loading />;
   }
 
@@ -72,13 +60,13 @@ const StopPageRedesign = ({
     <article>
       <StopPageHeaderRedesign stop={stop} routes={routeState} />
       <div className="container">
-        <Alerts alerts={alertState} />
+        <Alerts alerts={currentAlerts} />
         <DeparturesAndMap
           routes={routeState}
           stop={stop}
           schedules={schedules}
           routesWithPolylines={routesWithPolylines}
-          alerts={alertState}
+          alerts={currentAlerts}
         />
         <footer>
           <StationInformation stop={stop} />

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -1,46 +1,84 @@
-import React, { ReactElement } from "react";
-import { omit } from "lodash";
+import React, { ReactElement, useEffect, useState } from "react";
+import { filter, omit } from "lodash";
 import useStop from "../../hooks/useStop";
 import StationInformation from "./StationInformation";
 import { useRoutesByStop } from "../../hooks/useRoute";
 import StopPageHeaderRedesign from "./StopPageHeaderRedesign";
 import Loading from "../../components/Loading";
 import Alerts from "../../components/Alerts";
-import { Route } from "../../__v3api";
+import { Alert, Route } from "../../__v3api";
 import { useSchedulesByStop } from "../../hooks/useSchedules";
-import { useAlertsByStop } from "../../hooks/useAlerts";
+import { useAlertsByRoute, useAlertsByStop } from "../../hooks/useAlerts";
 import DeparturesAndMap from "./DeparturesAndMap";
+import { isCurrentAlert, routeWideAlerts } from "../../models/alert";
 
 const StopPageRedesign = ({
   stopId
 }: {
   stopId: string;
 }): ReactElement<HTMLElement> => {
+  const [routeIdState, setRouteIdState] = useState<string[]>([]);
+  const [routeState, setRouteState] = useState<Route[]>([]);
+  const [alertState, setAlertState] = useState<Alert[]>([]);
+
   const stop = useStop(stopId);
   const routesWithPolylines = useRoutesByStop(stopId);
   // TODO maybe move to the StopDeparturesPage (or keep it here for loading indicator)
   const schedules = useSchedulesByStop(stopId);
   const alerts = useAlertsByStop(stopId);
+  const alertsForRoutes = useAlertsByRoute(routeIdState);
   //
 
+  useEffect(() => {
+    setRouteState(
+      routesWithPolylines
+        ? routesWithPolylines.map(rwp => omit(rwp, "polylines"))
+        : []
+    );
+  }, [routesWithPolylines]);
+
+  useEffect(() => {
+    setRouteIdState(routeState.map(route => route.id));
+  }, [routeState]);
+
+  useEffect(() => {
+    // alerts contains all the alerts affecting the stop in question
+    const alertsArray = alerts !== undefined ? alerts : [];
+    const alertsRouteArray =
+      alertsForRoutes !== undefined ? alertsForRoutes : [];
+    // routeWideAlertsArray are all the alerts that affect the whole route
+    // not just specific stops
+    const routeWideAlertsArray = routeWideAlerts(alertsRouteArray);
+    // Get only alerts that are current
+    const currentAlerts = filter(
+      alertsArray.concat(routeWideAlertsArray),
+      alert => isCurrentAlert(alert)
+    );
+    setAlertState(currentAlerts);
+  }, [alerts, alertsForRoutes]);
+
   // Return loading indicator while waiting on data fetch
-  if (!stop || !routesWithPolylines || !schedules || !alerts) {
+  if (
+    !stop ||
+    !routesWithPolylines ||
+    !schedules ||
+    !alerts ||
+    !alertsForRoutes
+  ) {
     return <Loading />;
   }
-  const routes: Route[] = routesWithPolylines.map(rwp =>
-    omit(rwp, "polylines")
-  );
 
   return (
     <article>
-      <StopPageHeaderRedesign stop={stop} routes={routes} />
+      <StopPageHeaderRedesign stop={stop} routes={routeState} />
       <div className="container">
-        <Alerts alerts={alerts} />
+        <Alerts alerts={alertState} />
         <DeparturesAndMap
-          routes={routes}
+          routes={routeState}
           stop={stop}
           schedules={schedules}
           routesWithPolylines={routesWithPolylines}
+          alerts={alertState}
         />
         <footer>
           <StationInformation stop={stop} />

--- a/apps/site/assets/ts/stop/models/displayTimeConfig.ts
+++ b/apps/site/assets/ts/stop/models/displayTimeConfig.ts
@@ -1,0 +1,154 @@
+import {
+  differenceInSeconds,
+  isSameDay,
+  secondsInDay,
+  secondsInHour,
+  secondsInMinute
+} from "date-fns";
+import {
+  departureInfoToTime,
+  displayInfoContainsPrediction
+} from "../../helpers/departureInfo";
+import { formatToBostonTime } from "../../helpers/date";
+import { DepartureInfo } from "../../models/departureInfo";
+
+// This interface is used to tell the front end
+// how to display the ScheduleInfoModel data
+interface DisplayTimeConfig {
+  isPrediction?: boolean;
+  displayString: string;
+  trackName?: string | null;
+  isTomorrow?: boolean;
+  isBolded?: boolean;
+  isStikethrough?: boolean;
+}
+
+const infoToDisplayTime = (
+  time1: DepartureInfo | undefined,
+  time2: DepartureInfo | undefined,
+  targetDate: Date = new Date()
+): DisplayTimeConfig[] => {
+  const defaultState = [{ displayString: "Updates unavailable" }];
+  // If there is not input time1 then a schedule or prediction could not be found
+  if (!time1) {
+    return defaultState;
+  }
+
+  const departure1Time = departureInfoToTime(time1);
+  const formatOverride = "h:mm aa";
+
+  if (time1.isDelayed) {
+    // is delayed can only be true if both a prediction and schedule exist
+    const scheduleTime = time1.schedule!.time;
+    const predictionTime = time1.prediction!.time;
+    return [
+      {
+        displayString: `${formatToBostonTime(predictionTime, formatOverride)}`,
+        isBolded: true,
+        // only predictions can be delayed
+        isPrediction: true
+      },
+      {
+        displayString: `${formatToBostonTime(scheduleTime, formatOverride)}`,
+        isStikethrough: true,
+        trackName: time1.prediction!.track
+      }
+    ];
+  }
+
+  if (time2 && time1.isCancelled) {
+    const departure2Time = departureInfoToTime(time2);
+    // State 7
+    // State 8
+    // If trip1 is cancelled, then trip2 should not be cancelled
+    // Display trip2 in the first time spot (and its track info in the second)
+    return [
+      {
+        displayString: `${formatToBostonTime(departure2Time, formatOverride)}`,
+        isBolded: true,
+        isPrediction: displayInfoContainsPrediction(time2)
+      },
+      {
+        displayString: `${formatToBostonTime(departure1Time, formatOverride)}`,
+        isStikethrough: true,
+        trackName: time2.prediction?.track
+      }
+    ];
+  }
+
+  const diffInSeconds1 = differenceInSeconds(departure1Time, targetDate);
+  const diffInSeconds2 = time2
+    ? differenceInSeconds(departureInfoToTime(time2), targetDate)
+    : -1;
+
+  if (diffInSeconds1 <= secondsInMinute) {
+    // State 9
+    return [
+      {
+        displayString: "Arriving",
+        isPrediction: displayInfoContainsPrediction(time1),
+        isBolded: true
+      }
+    ];
+  }
+
+  if (
+    diffInSeconds1 < secondsInHour &&
+    diffInSeconds1 > secondsInMinute &&
+    diffInSeconds2 < secondsInHour &&
+    diffInSeconds2 > secondsInMinute
+  ) {
+    // State 1
+    return [
+      {
+        displayString: `${Math.floor(diffInSeconds1 / secondsInMinute)} min`,
+        isPrediction: displayInfoContainsPrediction(time1),
+        isBolded: true
+      },
+      { displayString: `${Math.floor(diffInSeconds2 / secondsInMinute)} min` }
+    ];
+  }
+
+  if (
+    diffInSeconds1 < secondsInHour &&
+    diffInSeconds1 > secondsInMinute &&
+    diffInSeconds2 >= secondsInHour
+  ) {
+    // State 2
+    return [
+      {
+        displayString: `${Math.floor(diffInSeconds1 / secondsInMinute)} min`,
+        isBolded: true,
+        isPrediction: displayInfoContainsPrediction(time1)
+      }
+    ];
+  }
+
+  if (diffInSeconds1 >= secondsInHour && diffInSeconds1 < secondsInDay) {
+    // State 3
+    // State 4
+    // State 5
+    // State 6
+    return [
+      {
+        displayString: `${formatToBostonTime(departure1Time, formatOverride)}`,
+        // If the days are not the same, then one must be tomorrow
+        isTomorrow: !isSameDay(departure1Time, targetDate),
+        isPrediction: displayInfoContainsPrediction(time1),
+        isBolded: true,
+        trackName: time1.prediction?.track
+      }
+    ];
+  }
+
+  if (diffInSeconds1 >= secondsInDay) {
+    // State 11
+    return [{ displayString: "No upcoming trips" }];
+  }
+
+  // Default state is error
+  // State 10
+  return defaultState;
+};
+
+export { DisplayTimeConfig, infoToDisplayTime };


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
Adds a Badge to display alerts in the departure cards instead of the times if an alert is present.

![Screen Shot 2023-05-16 at 5 15 41 PM](https://github.com/mbta/dotcom/assets/2679229/81fcf68b-c22d-43e5-a9e3-b4aec046d809)

The alerts effect types this works for are Suspensions, Shuttle Service, and Detours.

This pull request fetches route wide alerts for the new stop redesign page, merges them with the stop specific routes.
The alerts are then divided up by route, and then direction.  To be passed to the corresponding `DepartureTimes` component for the direction.  This is then processed to display the corresponding badge if eligible.

This also breaks out `DepartureInfo` into its own file to help readability.

NOTE: This pull request needs the alert date parsing pull request merged for the badges to display

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Alerts | Route Specific Badges on Departure Cards](https://app.asana.com/0/555089885850811/1204305469426565)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

