### PR TITLE
fix(RoutePatterns.Repo): Don't filter out canonical route patterns by default

### DIFF
--- a/apps/route_patterns/lib/repo.ex
+++ b/apps/route_patterns/lib/repo.ex
@@ -35,10 +35,7 @@ defmodule RoutePatterns.Repo do
   end
 
   def by_route_id(route_id, opts) do
-    default_opts = [{:canonical, false}]
-
-    default_opts
-    |> Keyword.merge(opts)
+    opts
     |> Keyword.put(:route, route_id)
     |> Keyword.put(:sort, "typicality,sort_order")
     |> Keyword.put(:include, "representative_trip.shape")

--- a/apps/route_patterns/test/repo_test.exs
+++ b/apps/route_patterns/test/repo_test.exs
@@ -35,35 +35,5 @@ defmodule RoutePatterns.RepoTest do
       alewife_patterns = Repo.by_route_id("Red", direction_id: 1)
       assert alewife_patterns |> Enum.map(& &1.direction_id) |> Enum.uniq() == [1]
     end
-
-    test "API request includes canonical route filter by default" do
-      with_mock(V3Api.RoutePatterns, all: fn params -> %JsonApi{data: []} end) do
-        Repo.by_route_id("CR-Franklin")
-
-        assert_called(
-          V3Api.RoutePatterns.all(
-            include: "representative_trip.shape",
-            sort: "typicality,sort_order",
-            route: "CR-Franklin",
-            canonical: false
-          )
-        )
-      end
-    end
-
-    test "API request includes canonical routes when parameter explicitly passed" do
-      with_mock(V3Api.RoutePatterns, all: fn params -> %JsonApi{data: []} end) do
-        Repo.by_route_id("CR-Franklin", canonical: true)
-
-        assert_called(
-          V3Api.RoutePatterns.all(
-            include: "representative_trip.shape",
-            sort: "typicality,sort_order",
-            route: "CR-Franklin",
-            canonical: true
-          )
-        )
-      end
-    end
   end
 end

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -40,7 +40,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
       assert [
                %RouteStops{branch: "Alewife - Ashmont", stops: ashmont_route_stops},
                %RouteStops{branch: "Alewife - Braintree", stops: braintree_route_stops}
-             ] = Helpers.get_branch_route_stops(%Route{id: "Red"}, 0)
+             ] = Enum.sort_by(Helpers.get_branch_route_stops(%Route{id: "Red"}, 0), & &1.branch)
 
       assert Enum.all?(ashmont_route_stops, &(&1.branch == "Alewife - Ashmont"))
 

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -142,9 +142,9 @@ defmodule SiteWeb.ScheduleControllerTest do
 
       assert [
                %RouteStops{branch: nil, stops: unbranched_stops},
-               %RouteStops{branch: "Alewife - Braintree", stops: braintree},
-               %RouteStops{branch: "Alewife - Ashmont", stops: ashmont}
-             ] = branches
+               %RouteStops{branch: "Alewife - Ashmont", stops: ashmont},
+               %RouteStops{branch: "Alewife - Braintree", stops: braintree}
+             ] = Enum.sort_by(branches, & &1.branch)
 
       # stops are in southbound order
       assert List.first(unbranched_stops).id == "place-alfcl"


### PR DESCRIPTION
… 

<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
Fix to https://github.com/mbta/dotcom/pull/1590. Canonical route patterns aren't always separate reference patterns not scheduled to operate; they can be scheduled to operate, so we shouldn't filter them out by default.

Some 
<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

