### PR TITLE
feat(DetourBadge): Display times along with detour status

### DIFF
--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -97,9 +97,8 @@ describe("DepartureTimes", () => {
     alertEffect     | expectedBadge
     ${"suspension"} | ${"Stop Closed"}
     ${"shuttle"}    | ${"Shuttle Service"}
-    ${"detour"}     | ${"Detour"}
   `(
-    `displays $expectedBadge when alert has effect $alertEffect`,
+    `displays $expectedBadge when high priority alert has effect $alertEffect`,
     ({ alertEffect, expectedBadge }) => {
       const schedules = [
         { trip: { direction_id: 0 } }
@@ -128,6 +127,56 @@ describe("DepartureTimes", () => {
       expect(screen.getByText(expectedBadge)).toBeDefined();
     }
   );
+
+  it("should display the detour badge with times if detour alert is present", () => {
+    const dateToCompare = new Date("2022-04-27T10:30:00-04:00");
+    jest.spyOn(predictionsChannel, "default").mockImplementation(() => {
+      return {
+        "Test 1": [
+          {
+            time: new Date("2022-04-27T11:15:00-04:00"),
+            trip: { id: "1", headsign: "Test 1" }
+          },
+          {
+            trip: { id: "2", headsign: "Test 1" },
+            time: new Date("2022-04-27T11:20:00-04:00")
+          }
+        ] as PredictionWithTimestamp[]
+      };
+    });
+    const schedules = [
+      {
+        trip: { id: "1", headsign: "Test 1" },
+        time: new Date("2022-04-27T11:15:00-04:00")
+      },
+      {
+        trip: { id: "2", headsign: "Test 1" },
+        time: new Date("2022-04-27T11:18:00-04:00")
+      }
+    ] as ScheduleWithTimestamp[];
+    const detourAlert = {
+      id: "123",
+      informed_entity: {
+        direction_id: [0]
+      },
+      effect: "detour"
+    };
+
+    render(
+      <DepartureTimes
+        route={route}
+        stop={stop}
+        directionId={0}
+        schedulesForDirection={schedules}
+        alertsForDirection={[detourAlert] as Alert[]}
+        overrideDate={dateToCompare}
+        onClick={() => {}}
+      />
+    );
+
+    expect(screen.getByText("Detour")).toBeDefined();
+    expect(screen.getByText("45 min")).toBeDefined();
+  });
 
   describe("getNextTwoTimes", () => {
     it("should return the next 2 departure infos times", () => {

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -35,7 +35,7 @@ const getNextTwoTimes = (
   return [departure1, departure2];
 };
 
-const toAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
+const toHighPriorityAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
   if (hasSuspension(alerts)) {
     return <Badge text="Stop Closed" contextText="Route Status" />;
   }
@@ -44,9 +44,14 @@ const toAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
     return <Badge text="Shuttle Service" contextText="Route Status" />;
   }
 
+  return undefined;
+};
+
+const toInformativeAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
   if (hasDetour(alerts)) {
     return <Badge text="Detour" contextText="Route Status" />;
   }
+
   return undefined;
 };
 
@@ -110,8 +115,10 @@ const departureTimeRow = (
     >
       <div className="departure-card__headsign-name">{headsignName}</div>
       <div className="d-flex align-items-center">
-        {formattedTimes.length > 0 && displayFormattedTimes(formattedTimes)}
-        {alertBadge}
+        <div>
+          {formattedTimes.length > 0 && displayFormattedTimes(formattedTimes)}
+          <div style={{ float: "right" }}>{alertBadge}</div>
+        </div>
         {/* TODO: Navigate to Realtime Tracking view (whole row should be clickable) */}
         <button
           type="button"
@@ -131,10 +138,14 @@ const getRow = (
   alerts: Alert[],
   overrideDate?: Date
 ): JSX.Element => {
-  const alertBadge = toAlertBadge(alerts);
+  // High priority badges override the displaying of times
+  const alertBadge = toHighPriorityAlertBadge(alerts);
   if (alertBadge) {
     return departureTimeRow(headsign, [], alertBadge);
   }
+
+  // informative badges compliment the times being shown
+  const informativeAlertBadge = toInformativeAlertBadge(alerts);
 
   // Merging should happen after alert processing incase a route is cancelled
   const departureInfos = mergeIntoDepartureInfo(schedules, predictions);
@@ -142,7 +153,7 @@ const getRow = (
   const [time1, time2] = getNextTwoTimes(departureInfos);
   const formattedTimes = infoToDisplayTime(time1, time2, overrideDate);
 
-  return departureTimeRow(headsign, formattedTimes);
+  return departureTimeRow(headsign, formattedTimes, informativeAlertBadge);
 };
 
 interface DepartureTimesProps {


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
This pull request:
 - Breaks out the alert badges into 2 different types
   - High Priority for alerts that override the display of times
   - Informative for alert badges that compliment the display times
 - Display times above the informative alert badge

![image](https://github.com/mbta/dotcom/assets/2679229/8c355bf0-5978-477e-8eeb-2a69f172a50a)


<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Detour Time Display](https://app.asana.com/0/555089885850811/1204663298349538)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

