### PR TITLE
feat(StopsPageRedesign): support arrival and departure times

### DIFF
--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -102,6 +102,11 @@ export interface Prediction {
   status: string | null;
   track: string | null;
   schedule_relationship?: ScheduleRelationship;
+  route?: Route;
+  trip?: Trip | null;
+  stop?: Stop;
+  arrival_time?: Date | null;
+  departure_time?: Date | null;
 }
 
 export interface Route {
@@ -314,6 +319,8 @@ export interface Schedule {
   stop_sequence: number;
   pickup_type: number;
   train_number?: string;
+  arrival_time?: Date | null;
+  departure_time?: Date | null;
 }
 
 export interface Shape {

--- a/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
@@ -123,27 +123,50 @@ describe("usePredictionsChannel hook", () => {
   });
 });
 
-test("usePredictionsChannel parsePrediction modifies the streamed prediction", () => {
-  const streamPrediction = {
-    id: "1",
-    direction_id: 0,
-    route: { id: "Silver" } as Route,
-    stop: { id: "place-somewhere" } as Stop,
-    schedule_relationship: "added",
-    track: null,
-    arrival_time: "2022-12-15 00:54:59.576744Z",
-    departure_time: "2022-12-15 00:55:04.576744Z",
-    time: "2022-12-15 00:54:59.576744Z",
-    trip: { id: "999", headsign: "Final Destination" } as Trip,
-    vehicle_id: "v1"
-  } as StreamPrediction;
-  const parsed = parsePrediction(streamPrediction);
+const streamPrediction = {
+  id: "1",
+  direction_id: 0,
+  route: { id: "Silver" } as Route,
+  stop: { id: "place-somewhere" } as Stop,
+  schedule_relationship: "added",
+  track: null,
+  arrival_time: "2022-12-15 00:54:59.576744Z",
+  departure_time: "2022-12-15 00:55:04.576744Z",
+  time: "2022-12-15 00:54:59.576744Z",
+  trip: { id: "999", headsign: "Final Destination" } as Trip,
+  vehicle_id: "v1"
+} as StreamPrediction;
 
-  expect(parsed).toBeTruthy();
-  expect(parsed.time).toEqual(new Date(streamPrediction.departure_time!));
-  expect(parsed.time).not.toEqual(new Date(streamPrediction.arrival_time!));
-  expect(parsed.time).not.toEqual(new Date(streamPrediction.time!));
-  expect(parsed.vehicle_id).toEqual("v1");
+describe("usePredictionsChannel parsePrediction", () => {
+  test("modifies the streamed prediction", () => {
+    const parsed = parsePrediction(streamPrediction);
+    expect(parsed).toBeTruthy();
+    expect(parsed.time).toEqual(new Date(streamPrediction.departure_time!));
+    expect(parsed.time).not.toEqual(new Date(streamPrediction.arrival_time!));
+    expect(parsed.time).not.toEqual(new Date(streamPrediction.time!));
+    expect(parsed.vehicle_id).toEqual("v1");
+  });
+
+  test("handles no departure", () => {
+    const parsed = parsePrediction({
+      ...streamPrediction,
+      departure_time: null
+    });
+    expect(parsed).toBeTruthy();
+    expect(parsed.departure_time).toBeNull();
+    expect(parsed.arrival_time).toEqual(
+      new Date(streamPrediction.arrival_time!)
+    );
+  });
+
+  test("handles no arrival", () => {
+    const parsed = parsePrediction({ ...streamPrediction, arrival_time: null });
+    expect(parsed).toBeTruthy();
+    expect(parsed.arrival_time).toBeNull();
+    expect(parsed.departure_time).toEqual(
+      new Date(streamPrediction.departure_time!)
+    );
+  });
 });
 
 test("usePredictionsChannel groupByHeadsigns groups and sorts", () => {

--- a/apps/site/assets/ts/hooks/usePredictionsChannel.ts
+++ b/apps/site/assets/ts/hooks/usePredictionsChannel.ts
@@ -55,6 +55,12 @@ export const parsePrediction = (
     "status",
     "vehicle_id"
   ]),
+  arrival_time: prediction.arrival_time
+    ? new Date(prediction.arrival_time)
+    : null,
+  departure_time: prediction.departure_time
+    ? new Date(prediction.departure_time)
+    : null,
   // backend removes all predictions with a null departure_time
   // so this is always populated
   time: new Date(prediction.departure_time!)

--- a/apps/site/assets/ts/hooks/useSchedules.ts
+++ b/apps/site/assets/ts/hooks/useSchedules.ts
@@ -21,7 +21,13 @@ const parse = (schedule: ScheduleData): ScheduleWithTimestamp =>
       "pickup_type: number",
       "train_number?: string"
     ]),
-    time: new Date(schedule.time)
+    time: new Date(schedule.time),
+    arrival_time: schedule.arrival_time
+      ? new Date(schedule.arrival_time)
+      : null,
+    departure_time: schedule.departure_time
+      ? new Date(schedule.departure_time)
+      : null
   } as ScheduleWithTimestamp);
 
 const fetchData = async (url: string): Promise<ScheduleData[]> =>

--- a/apps/site/assets/ts/schedule/components/__trips.d.ts
+++ b/apps/site/assets/ts/schedule/components/__trips.d.ts
@@ -32,7 +32,7 @@ export interface TripDeparture {
 }
 
 export interface TripDepartureWithPrediction extends TripDeparture {
-  prediction: Prediction;
+  prediction: TripPrediction;
 }
 
 export interface TripInfo {

--- a/apps/site/assets/ts/tnm/helpers/process-realtime-data.ts
+++ b/apps/site/assets/ts/tnm/helpers/process-realtime-data.ts
@@ -135,7 +135,7 @@ const buildHeadsign = (
         return {
           prediction: shortPrediction,
           // eslint-disable-next-line camelcase
-          scheduled_time: scheduledTime,
+          scheduled_time: scheduledTime || null,
           delay
         };
       }


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Tech Debt - support arrival and departure times in stops page redesign](https://app.asana.com/0/555089885850811/1204758731107223/f)

This is the frontend complement to the backend work supporting prediction and schedule arrival and departure times from #1620 

Edit to clarify: I haven't implemented any logic around it, or changed how any times are displayed yet. But now when we inspect the schedules or predictions used in these React components, they will have populated `arrival_time` and `departure_time` values.