### PR TITLE
fix(DailyScheduleSubway): fallback to service name

### DIFF
--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/DailyScheduleSubway.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/DailyScheduleSubway.tsx
@@ -65,7 +65,7 @@ const getSpecialServiceMaps = (
       return {
         date: parse(addedDate, "yyyy-MM-dd", new Date()),
         dateString: addedDate,
-        name: service.added_dates_notes[addedDate]
+        name: service.added_dates_notes[addedDate] || service.name
       };
     })
   );

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/DailyScheduleSubwayTest.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/DailyScheduleSubwayTest.tsx
@@ -354,8 +354,8 @@ describe("DailyScheduleSubway", () => {
         "default_service?": false
       },
       {
-        added_dates: ["2022-12-26"],
-        added_dates_notes: { "2022-12-26": "Holiday 1" },
+        added_dates: ["2022-12-26", "2022-12-28"],
+        added_dates_notes: { "2022-12-26": "Holiday 1", "2022-12-28": null },
         description: "descr",
         end_date: "2022-12-31",
         id: "1",
@@ -386,7 +386,8 @@ describe("DailyScheduleSubway", () => {
     );
 
     expect(wrapper.html()).toContain("Special Service");
-    expect(wrapper.html()).toContain("Holiday");
+    expect(wrapper.html()).toContain("Holiday 1, Dec 26");
+    expect(wrapper.html()).toContain("name, Dec 28");
   });
   it("should set special service date as today if date is today", () => {
     const specialServices = [


### PR DESCRIPTION
When the `added_dates_notes` happens to be missing a value for a given date, fall back on the service name.

<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Day of Week Not Showing](https://app.asana.com/0/385363666817452/1204633022300171/f)

**Before:**
<img width="456" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/daafbd98-b61e-4c3d-b3de-1db910421515">

**After:**
<img width="448" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/a26fd3cc-2e84-4692-bd28-51c5d26e3f12">


---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
