### PR TITLE
refactor(StopPageDepartures): filter schedules in backend

### DIFF
--- a/apps/site/assets/ts/hooks/useSchedules.ts
+++ b/apps/site/assets/ts/hooks/useSchedules.ts
@@ -37,7 +37,7 @@ const useSchedulesByStop = (
   stopId: string
 ): FetchState<ScheduleWithTimestamp[]> => {
   const { data, error } = useSWR<ScheduleData[]>(
-    `/api/stops/${stopId}/schedules`,
+    `/api/stops/${stopId}/schedules?last_stop_departures=false&future_departures=true`,
     fetchData
   );
   if (error) {

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -1,5 +1,4 @@
-import { filter, groupBy, sortBy } from "lodash";
-import { isPast } from "date-fns";
+import { groupBy, sortBy } from "lodash";
 import React, { ReactElement, useState } from "react";
 import { Alert, DirectionId, Route, Stop } from "../../__v3api";
 import DeparturesFilters, { ModeChoice } from "./DeparturesFilters";
@@ -41,12 +40,7 @@ const StopPageDepartures = ({
   // default to show all modes.
   const [selectedMode, setSelectedMode] = useState<ModeChoice>("all");
   const groupedRoutes = groupBy(routes, modeForRoute);
-  // This filtering should be done on the backend
-  const currentSchedules = filter(
-    schedules,
-    (s: ScheduleWithTimestamp) => !isPast(s.time)
-  );
-  const groupedSchedules = groupBy(currentSchedules, s => s.route.id);
+  const groupedSchedules = groupBy(schedules, s => s.route.id);
   const modesList = Object.keys(groupedRoutes) as ModeChoice[];
   const filteredRoutes =
     selectedMode === "all" ? routes : groupedRoutes[selectedMode];

--- a/apps/site/lib/site_web/controllers/schedule_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule_controller.ex
@@ -46,7 +46,15 @@ defmodule SiteWeb.ScheduleController do
 
   @spec schedules_for_stop(Plug.Conn.t(), map) :: Plug.Conn.t()
   def schedules_for_stop(conn, %{"stop_id" => stop_id}) do
-    schedules = Schedules.Repo.schedules_for_stop(stop_id, [])
+    schedules =
+      Schedules.Repo.schedules_for_stop(stop_id, [])
+      # Only list schedules with departure_time in the future
+      |> Enum.filter(fn %Schedules.Schedule{departure_time: dt} ->
+        dt && Util.time_is_greater_or_equal?(dt, Util.now())
+      end)
+      # Don't list schedules departing from the last stop
+      |> Enum.reject(fn %Schedules.Schedule{last_stop?: is_last_stop} -> is_last_stop end)
+
     json(conn, schedules)
   end
 end

--- a/apps/site/lib/site_web/controllers/schedule_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule_controller.ex
@@ -1,6 +1,7 @@
 defmodule SiteWeb.ScheduleController do
   use SiteWeb, :controller
   alias Routes.Route
+  alias Schedules.Schedule
 
   plug(SiteWeb.Plugs.Route when action not in [:schedules_for_stop])
 
@@ -45,16 +46,38 @@ defmodule SiteWeb.ScheduleController do
   end
 
   @spec schedules_for_stop(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def schedules_for_stop(conn, %{"stop_id" => stop_id}) do
+  def schedules_for_stop(conn, %{"stop_id" => stop_id} = params) do
     schedules =
       Schedules.Repo.schedules_for_stop(stop_id, [])
-      # Only list schedules with departure_time in the future
-      |> Enum.filter(fn %Schedules.Schedule{departure_time: dt} ->
-        dt && Util.time_is_greater_or_equal?(dt, Util.now())
-      end)
-      # Don't list schedules departing from the last stop
-      |> Enum.reject(fn %Schedules.Schedule{last_stop?: is_last_stop} -> is_last_stop end)
+      |> future_departures(conn, params)
+      |> omit_last_stop_departures(params)
 
     json(conn, schedules)
   end
+
+  defp future_departures(schedules, conn, %{"future_departures" => "true"}) do
+    now =
+      case conn.assigns do
+        %{"date_time" => date_time} -> date_time
+        _ -> Util.now()
+      end
+
+    # Only list schedules with departure_time in the future
+    schedules
+    |> Enum.filter(fn %Schedule{departure_time: dt} ->
+      dt && Util.time_is_greater_or_equal?(dt, now)
+    end)
+  end
+
+  defp future_departures(schedules, _, _), do: schedules
+
+  defp omit_last_stop_departures(schedules, %{"last_stop_departures" => "false"}) do
+    # Don't list schedules departing from the last stop
+    schedules
+    |> Enum.reject(fn %Schedule{departure_time: dt, last_stop?: is_last_stop} ->
+      dt && is_last_stop
+    end)
+  end
+
+  defp omit_last_stop_departures(schedules, _), do: schedules
 end

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -347,7 +347,12 @@ defmodule SiteWeb.ScheduleControllerTest do
             nil
         end
       ) do
-        conn = ScheduleController.schedules_for_stop(conn, %{"stop_id" => "TEST 1234"})
+        conn =
+          ScheduleController.schedules_for_stop(conn, %{
+            "stop_id" => "TEST 1234",
+            "future_departures" => "true"
+          })
+
         body = json_response(conn, 200)
         assert Kernel.length(body) == 2
         assert %{"stop" => %{"id" => "TEST 1234"}} = Enum.at(body, 0)
@@ -381,7 +386,13 @@ defmodule SiteWeb.ScheduleControllerTest do
             nil
         end
       ) do
-        conn = ScheduleController.schedules_for_stop(conn, %{"stop_id" => "TEST 1234"})
+        conn =
+          ScheduleController.schedules_for_stop(conn, %{
+            "stop_id" => "TEST 1234",
+            "future_departures" => "true",
+            "last_stop_departures" => "false"
+          })
+
         body = json_response(conn, 200)
         assert Kernel.length(body) == 2
       end


### PR DESCRIPTION
I saw the comment `// This filtering should be done on the backend` for the listing current schedules, so I went ahead and did that, and added a condition to remove schedules with a `last_stop?` value of `true`.

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [For terminal stops, don't list routes that end at that stop](https://app.asana.com/0/385363666817452/1204678909646879/f)

### Wonderland station:

| Before      | After |
| ----------- | ----------- |
|  ![dev mbtace com_stops_place-wondl](https://github.com/mbta/dotcom/assets/2136286/43d4c9aa-f049-4c54-9e06-1537d8846b5c)   |  ![localhost_4001_stops_place-wondl (3)](https://github.com/mbta/dotcom/assets/2136286/bee2a1b0-be2b-4a84-aa50-02f5f7b4755d)   |

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
