### PR TITLE
refactor: add stop_id directly to container element

### DIFF
--- a/apps/site/assets/ts/stop/stop-loader-redesign.tsx
+++ b/apps/site/assets/ts/stop/stop-loader-redesign.tsx
@@ -3,13 +3,10 @@ import ReactDOM from "react-dom";
 import StopPageRedesign from "./components/StopPageRedesign";
 
 const render = (): void => {
-  // TODO is there a better way to get this (from the pheonix page perhaps?)
-  const urlTokens = window.location.href.split("/");
-  const stopId = urlTokens[urlTokens.length - 1];
-  ReactDOM.render(
-    <StopPageRedesign stopId={stopId} />,
-    document.getElementById("react-stop-redesign-root")
-  );
+  const rootEl = document.getElementById("react-stop-redesign-root");
+  const stopId = rootEl?.dataset.stopId;
+  if (!stopId) return;
+  ReactDOM.render(<StopPageRedesign stopId={stopId} />, rootEl);
 };
 
 export const onLoad = (): void => {

--- a/apps/site/assets/ts/stop/stop-loader-redesign.tsx
+++ b/apps/site/assets/ts/stop/stop-loader-redesign.tsx
@@ -4,7 +4,7 @@ import StopPageRedesign from "./components/StopPageRedesign";
 
 const render = (): void => {
   const rootEl = document.getElementById("react-stop-redesign-root");
-  const stopId = rootEl?.dataset.stopId;
+  const stopId = rootEl?.dataset.mbtaStopId;
   if (!stopId) return;
   ReactDOM.render(<StopPageRedesign stopId={stopId} />, rootEl);
 };

--- a/apps/site/lib/site_web/templates/stop/show-redesign.html.eex
+++ b/apps/site/lib/site_web/templates/stop/show-redesign.html.eex
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="<%= static_url(@conn, "/css/map.css") %>" data-turbolinks-track="reload">
 <div>
-  <div id="react-stop-redesign-root"></div>
+  <div id="react-stop-redesign-root" data-stop-id="<%= @stop_id %>"></div>
 </div>
 
 <%= if Application.get_env(:site, :dev_server?) do %>

--- a/apps/site/lib/site_web/templates/stop/show-redesign.html.eex
+++ b/apps/site/lib/site_web/templates/stop/show-redesign.html.eex
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="<%= static_url(@conn, "/css/map.css") %>" data-turbolinks-track="reload">
 <div>
-  <div id="react-stop-redesign-root" data-stop-id="<%= @stop_id %>"></div>
+  <div id="react-stop-redesign-root" data-mbta-stop-id="<%= @stop_id %>"></div>
 </div>
 
 <%= if Application.get_env(:site, :dev_server?) do %>


### PR DESCRIPTION
...and stop reading the stop ID from the window location.

The way our current loading worked, whatever URL params are on the page ended up getting captured in the stop ID, e.g. visiting `/stops/place-whatever?something=foo` would result in a `stopId` of `place-whatever?something=foo`, which caused multiple subsequent requests to fail.

This fixes that by passing in the stop ID via the HTML.

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Stop Page | Load page when directed from search result](https://app.asana.com/0/385363666817452/1204659277085822/f)


