### PR TITLE
fix(LineDiagram): give `<StopCard />` alerts for that stop

### DIFF
--- a/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
@@ -14,6 +14,7 @@ import { branchPosition, diagramWidth } from "./line-diagram-helpers";
 import { StopRefContext } from "./LineDiagramWithStops";
 import StopCard from "./StopCard";
 import { LiveDataByStop } from "./__line-diagram";
+import { alertsByStop } from "../../../models/alert";
 
 interface Props {
   stopTree: StopTree;
@@ -100,7 +101,7 @@ const ExpandableBranch = ({
               key={stopId}
               stopTree={stopTree}
               stopId={stopId}
-              alerts={alerts}
+              alerts={alertsByStop(alerts, stopId)}
               onClick={handleStopClick}
               liveData={liveData?.[stopId]}
             />

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -12,6 +12,7 @@ import { RouteStop, SelectedOrigin, StopTree } from "../__schedule";
 import { createStopTreeCoordStore } from "./graphics/useTreeStopPositions";
 import LineDiagramWithStops from "./LineDiagramWithStops";
 import StopCard from "./StopCard";
+import { alertsByStop } from "../../../models/alert";
 
 interface Props {
   stopTree: StopTree;
@@ -96,7 +97,7 @@ const LineDiagram = ({
                 key={stop.id}
                 stopTree={stopTree}
                 stopId={stop.id}
-                alerts={alerts}
+                alerts={alertsByStop(alerts, stop.id)}
                 onClick={handleStopClick}
                 liveData={liveData?.[stop.id]}
                 searchQuery={query}

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
@@ -14,6 +14,7 @@ import useTreeStopPositions, { RefMap } from "./graphics/useTreeStopPositions";
 import ExpandableBranch from "./ExpandableBranch";
 import StopCard from "./StopCard";
 import { LiveDataByStop } from "./__line-diagram";
+import { alertsByStop } from "../../../models/alert";
 
 interface Props {
   stopTree: StopTree;
@@ -93,7 +94,7 @@ const NextStopOrBranch = ({
         key={`stop-card-${terminalStopId}`}
         stopTree={stopTree}
         stopId={terminalStopId}
-        alerts={alerts}
+        alerts={alertsByStop(alerts, terminalStopId)}
         onClick={handleStopClick}
         liveData={liveData?.[terminalStopId]}
       />,
@@ -146,7 +147,7 @@ const NextStopOrBranch = ({
         key={`stop-card-${startingId}`}
         stopTree={stopTree}
         stopId={startingId}
-        alerts={alerts}
+        alerts={alertsByStop(alerts, startingId)}
         onClick={handleStopClick}
         liveData={liveData?.[startingId]}
       />,
@@ -181,7 +182,7 @@ const NextStopOrBranch = ({
           key={stopId}
           stopTree={stopTree}
           stopId={stopId}
-          alerts={alerts}
+          alerts={alertsByStop(alerts, stopId)}
           onClick={handleStopClick}
           liveData={liveData?.[stopId]}
         />,
@@ -210,7 +211,7 @@ const NextStopOrBranch = ({
         key={stopId}
         stopTree={stopTree}
         stopId={stopId}
-        alerts={alerts}
+        alerts={alertsByStop(alerts, stopId)}
         onClick={handleStopClick}
         liveData={liveData?.[stopId]}
       />,
@@ -234,7 +235,7 @@ const NextStopOrBranch = ({
       key={stopId}
       stopTree={stopTree}
       stopId={stopId}
-      alerts={alerts}
+      alerts={alertsByStop(alerts, stopId)}
       onClick={handleStopClick}
       liveData={liveData?.[stopId]}
     />


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Line diagrams showing "shuttle" where regular service is running](https://app.asana.com/0/385363666817452/1203533488121919/f)

It turns out we were passing the entire route's alerts to every stop's `<StopCard />`, which led to some erroneous determinations. Most notably, certain stops would be labeled with a "Shuttle" or other diversion when that actually only applied to other stops along the route.

I haven't included any test changes in this because..well, technically the components and functions were working as designed, and it was a bit of a user error on our part to give each stop component more alerts than relevant. And maybe there's a more elegant approach to this, but I didn't want to overhaul things.

### Before

<img width="767" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/1145651d-5356-4b57-8aa5-4cf3bf0e6a2d">


### After

![image](https://github.com/mbta/dotcom/assets/2136286/7e621823-c8b0-48ba-80d0-478f10db820c)
