### PR TITLE
Stops Page Redesign | Prevent page scrolling on mobile in realtime tracking view

### DIFF
--- a/apps/site/assets/css/_stop-card.scss
+++ b/apps/site/assets/css/_stop-card.scss
@@ -166,7 +166,7 @@ $radius: 4px;
 
   @include media-breakpoint-down(sm) {
     height: unset;
-    max-height: 350px;
+    max-height: 425px;
   }
 
   .departure-card {

--- a/apps/site/assets/css/_stop-card.scss
+++ b/apps/site/assets/css/_stop-card.scss
@@ -63,20 +63,58 @@ $radius: 4px;
   background-color: $gray-bordered-background;
   border: .25px solid $gray-lighter;
   border-radius: $radius;
+  display: grid;
   gap: .5rem;
+  grid-template-columns: 5fr 7fr;
   padding: .75rem;
 
+  .back-to-routes {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+  }
+
   .stop-routes {
-    display: grid;
-    grid-template-columns: 5fr 7fr;
+    grid-column: 1 / 2;
+    grid-row: 1 / 3;
+  }
+
+  .back-to-routes + .stop-routes {
+    grid-row: 2 / 3;
+  }
+
+  .stop-map {
+    grid-column: 2 / 3;
+    grid-row: 1 / 3;
+  }
+
+  &.selected-departure {
+    z-index: 2;
+    // on mobile, adopt a full-screen "app" view,
+    // with map above departure list
     @include media-breakpoint-down(sm) {
-      grid-template-columns: 1fr;
+      bottom: 0;
+      grid-template-rows: min-content 1fr 1fr;
+      left: 0;
+      padding-bottom: 0;
+      padding-top: 0;
+      position: fixed;
+      right: 0;
+      top: 0;
+
+      .stop-map {
+        grid-column: 1 / 2;
+        grid-row: 2 / 3;
+      }
+
+      .stop-routes {
+        grid-row: 3 / 4;
+      }
     }
   }
 
   @include media-breakpoint-down(sm) {
     border-radius: 0;
-    display: block;
+    grid-template-columns: 1fr;
     margin-left: -$base-spacing;
     margin-right: -$base-spacing;
   }

--- a/apps/site/assets/css/_stop-card.scss
+++ b/apps/site/assets/css/_stop-card.scss
@@ -66,7 +66,7 @@ $radius: 4px;
   gap: .5rem;
   padding: .75rem;
 
-  .stop-routes__all {
+  .stop-routes {
     display: grid;
     grid-template-columns: 5fr 7fr;
     @include media-breakpoint-down(sm) {
@@ -261,49 +261,6 @@ $radius: 4px;
   .leaflet-popup-close-button {
     right: calc(#{$base-spacing} / 4);
     top: calc(#{$base-spacing} / 4);
-  }
-}
-
-.departures-container {
-  background-color: $white;
-  display: grid;
-  grid-template-areas: 'back-button map'
-    'departures map'
-    'departures map';
-  grid-template-columns: 5fr 7fr;
-  grid-template-rows: min-content 1fr 1.5 fr;
-  left: 0;
-  margin: 0;
-  top: 0;
-  width: 100%;
-  z-index: 2;
-  .back-to-routes {
-    grid-area: back-button;
-  }
-
-  .stop-routes__map.stop-routes__map--selected-route {
-    grid-area: map;
-    height: 100%;
-  }
-
-  .stop-routes__departures--selected-route {
-    grid-area: departures;
-  }
-
-  @include media-breakpoint-down(sm) {
-    box-shadow: 0 0 $space-4 $space-2 $drop-shadow-color;
-    grid-template: 'back-button'
-      'map'
-      'departures';
-    grid-template-columns: 1fr;
-    grid-template-rows: min-content 1fr 1fr;
-    height: 100vh;
-    max-height: 100%;
-    -webkit-overflow-scrolling: touch;
-    overflow-y: auto;
-    padding: 0;
-    position: fixed;
-    width: 100%;
   }
 }
 

--- a/apps/site/assets/ts/helpers/media-breakpoints.ts
+++ b/apps/site/assets/ts/helpers/media-breakpoints.ts
@@ -11,6 +11,4 @@ export const isLGDown = (): boolean =>
   window.matchMedia(`(max-width: ${mediaBreakpoints.lg}px)`).matches;
 
 export const isSMDown = (): boolean =>
-  typeof document !== "undefined"
-    ? window.matchMedia(`(max-width: ${mediaBreakpoints.sm}px)`).matches
-    : false;
+  window?.matchMedia(`(max-width: ${mediaBreakpoints.sm}px)`)?.matches;

--- a/apps/site/assets/ts/stop/components/DepartureCard.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureCard.tsx
@@ -23,7 +23,7 @@ const DepartureCard = ({
   onClick: (
     route: Route,
     directionId: DirectionId,
-    departures: ScheduleWithTimestamp[] | null | undefined
+    departures: ScheduleWithTimestamp[] | undefined
   ) => void;
   alertsForRoute: Alert[];
 }): ReactElement<HTMLElement> => {

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -174,7 +174,7 @@ interface DepartureTimesProps {
   onClick: (
     route: Route,
     directionId: DirectionId,
-    departures: ScheduleWithTimestamp[] | null | undefined
+    departures: ScheduleWithTimestamp[] | undefined
   ) => void;
 }
 

--- a/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
@@ -106,7 +106,11 @@ const DeparturesAndMap = ({
   );
 
   return (
-    <div className="stop-routes-and-map">
+    <div
+      className={`stop-routes-and-map ${
+        viewSelectedDeparture ? "selected-departure" : ""
+      }`}
+    >
       {viewSelectedDeparture && BackToRoutes}
       <div className="stop-routes">
         {viewSelectedDeparture ? (

--- a/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from "react";
-import { chain } from "lodash";
+import { chain, isUndefined, some } from "lodash";
 import { Alert, DirectionId, Route, Stop } from "../../__v3api";
 import { ScheduleWithTimestamp } from "../../models/schedules";
 import StopPageDepartures from "./StopPageDepartures";
@@ -13,7 +13,6 @@ import {
   isACommuterRailRoute
 } from "../../models/route";
 import useVehiclesChannel from "../../hooks/useVehiclesChannel";
-import { Polyline } from "../../leaflet/components/__mapdata";
 
 interface DeparturesAndMapProps {
   routes: Route[];
@@ -31,19 +30,19 @@ const DeparturesAndMap = ({
   alerts
 }: DeparturesAndMapProps): ReactElement<HTMLElement> => {
   const [departureInfo, setDepartureInfo] = useState<{
-    departureRoute: Route | null;
-    departureDirectionId: DirectionId | null;
-    departureSchedules: ScheduleWithTimestamp[] | null | undefined;
+    departureRoute: Route | undefined;
+    departureDirectionId: DirectionId | undefined;
+    departureSchedules: ScheduleWithTimestamp[] | undefined;
   }>({
-    departureRoute: null,
-    departureDirectionId: null,
-    departureSchedules: null
+    departureRoute: undefined,
+    departureDirectionId: undefined,
+    departureSchedules: undefined
   });
 
   const setDepartureVariables: (
     route: Route,
     directionId: DirectionId,
-    departures: ScheduleWithTimestamp[] | null | undefined
+    departures: ScheduleWithTimestamp[] | undefined
   ) => void = (route, directionId, allDepartures) => {
     setDepartureInfo({
       departureRoute: route,
@@ -52,16 +51,10 @@ const DeparturesAndMap = ({
     });
   };
 
-  const viewAllRoutes: () => boolean = () => {
-    if (
-      !departureInfo.departureRoute &&
-      !departureInfo.departureDirectionId &&
-      !departureInfo.departureSchedules
-    ) {
-      return true;
-    }
-    return false;
-  };
+  const viewSelectedDeparture = !some(
+    Object.values(departureInfo),
+    isUndefined
+  );
 
   const defaultPolylines = chain(routesWithPolylines)
     .filter(
@@ -75,61 +68,58 @@ const DeparturesAndMap = ({
     .uniqBy("id")
     .value();
 
-  const findShapeForSelection = (): Polyline | undefined => {
-    if (
-      departureInfo.departureRoute === null ||
-      departureInfo.departureDirectionId === null ||
-      !departureInfo.departureSchedules
-    ) {
-      return undefined;
-    }
-
-    const selectedRoute = routesWithPolylines.find(
-      route => route.id === departureInfo.departureRoute!.id
+  const shapeForSelection = routesWithPolylines
+    .find(route => route.id === departureInfo.departureRoute?.id)
+    ?.polylines.find(
+      line => line.id === departureInfo.departureSchedules?.[0]?.trip.shape_id
     );
 
-    const shapeIdForSelection =
-      departureInfo.departureSchedules[0]?.trip.shape_id;
+  const vehiclesForSelectedRoute = useVehiclesChannel(
+    departureInfo.departureRoute &&
+      departureInfo.departureDirectionId !== undefined
+      ? {
+          routeId: departureInfo.departureRoute.id,
+          directionId: departureInfo.departureDirectionId
+        }
+      : null
+  );
 
-    if (selectedRoute && shapeIdForSelection) {
-      return selectedRoute.polylines.find(
-        line => line.id === shapeIdForSelection
-      );
-    }
-    return undefined;
-  };
+  const unsetDepartureInfo = (): void =>
+    setDepartureInfo({
+      departureRoute: undefined,
+      departureDirectionId: undefined,
+      departureSchedules: undefined
+    });
 
-  const DefaultRoutesMap = (): JSX.Element => {
-    return (
-      <StopMapRedesign stop={stop} lines={defaultPolylines} vehicles={[]} />
-    );
-  };
-
-  const SelectedRoutePatternMap = (): JSX.Element => {
-    const vehiclesForSelectedRoute = useVehiclesChannel(
-      departureInfo.departureRoute &&
-        departureInfo.departureDirectionId !== null
-        ? {
-            routeId: departureInfo.departureRoute.id,
-            directionId: departureInfo.departureDirectionId
-          }
-        : null
-    );
-
-    const shapeForSelection = findShapeForSelection();
-    return (
-      <StopMapRedesign
-        stop={stop}
-        lines={shapeForSelection ? [shapeForSelection] : []}
-        vehicles={vehiclesForSelectedRoute}
-      />
-    );
-  };
+  const BackToRoutes = (
+    <div className="back-to-routes">
+      <div
+        onClick={unsetDepartureInfo}
+        onKeyDown={unsetDepartureInfo}
+        aria-label={`Back to all ${stop.name} routes`}
+        role="presentation"
+      >
+        {renderFa("", "fa-angle-left")}
+        {`Back to all ${stop.name} routes`}
+      </div>
+    </div>
+  );
 
   return (
     <div className="stop-routes-and-map">
-      {viewAllRoutes() ? (
-        <div className="stop-routes__all">
+      {viewSelectedDeparture && BackToRoutes}
+      <div className="stop-routes">
+        {viewSelectedDeparture ? (
+          <div className="stop-departures">
+            <DepartureList
+              route={departureInfo.departureRoute!}
+              stop={stop}
+              schedules={departureInfo.departureSchedules!}
+              directionId={departureInfo.departureDirectionId!}
+              alerts={alerts}
+            />
+          </div>
+        ) : (
           <StopPageDepartures
             routes={routes}
             stop={stop}
@@ -137,55 +127,21 @@ const DeparturesAndMap = ({
             onClick={setDepartureVariables}
             alerts={alerts}
           />
-          <div className="hidden-sm-down">
-            <DefaultRoutesMap />
-          </div>
-        </div>
-      ) : (
-        <div className="departures-container">
-          <div className="back-to-routes">
-            <div
-              onClick={() =>
-                setDepartureInfo({
-                  departureRoute: null,
-                  departureDirectionId: null,
-                  departureSchedules: null
-                })
-              }
-              onKeyDown={() =>
-                setDepartureInfo({
-                  departureRoute: null,
-                  departureDirectionId: null,
-                  departureSchedules: null
-                })
-              }
-              aria-label={`Back to all ${stop.name} routes`}
-              role="presentation"
-            >
-              {renderFa("", "fa-angle-left")}
-              {`Back to all ${stop.name} routes`}
-            </div>
-          </div>
-          <div className="stop-routes__map stop-routes__map--selected-route">
-            <SelectedRoutePatternMap />
-          </div>
-          <div className="stop-routes__departures stop-routes__departures--selected-route">
-            {departureInfo.departureDirectionId != null &&
-            departureInfo.departureSchedules &&
-            departureInfo.departureRoute ? (
-              <DepartureList
-                route={departureInfo.departureRoute}
-                stop={stop}
-                schedules={departureInfo.departureSchedules}
-                directionId={departureInfo.departureDirectionId}
-                alerts={alerts}
-              />
-            ) : (
-              <div />
-            )}
-          </div>
-        </div>
-      )}
+        )}
+      </div>
+      <div
+        className={`stop-map ${viewSelectedDeparture ? "" : "hidden-sm-down"}`}
+      >
+        <StopMapRedesign
+          stop={stop}
+          lines={
+            viewSelectedDeparture && shapeForSelection
+              ? [shapeForSelection]
+              : defaultPolylines
+          }
+          vehicles={viewSelectedDeparture ? vehiclesForSelectedRoute : []}
+        />
+      </div>
     </div>
   );
 };

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -14,7 +14,7 @@ interface StopPageDeparturesProps {
   onClick: (
     route: Route,
     directionId: DirectionId,
-    departures: ScheduleWithTimestamp[] | null | undefined
+    departures: ScheduleWithTimestamp[] | undefined
   ) => void;
   alerts: Alert[];
 }


### PR DESCRIPTION

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Bug: stop page mobile view realtime tracking body of page still scrolls](https://app.asana.com/0/385363666817452/1204770533473925/f)

Isza's `z-index` addition made the bug more bearable, but this PR implements some additional code to prevent scrolling on the background.

## Highlighted changes
- via a `useEffect` hook, disable/enable body scrolling when toggling between the landing page and realtime tracking view
- Adjusted layout: When toggling between the landing page and realtime tracking view, we keep the same HTML layout and swap out inner components as needed, instead of constructing an alternate layout. Some CSS is used to toggle further layout changes when the `.selected-departure` class name is present.
- Change viewAllRoutes function to a simpler viewSelectedDeparture variable.
- Extract function for resetting the selected departure info
- A few other minor JS variable simplifications and tweaks

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
