### PR TITLE
Retrofit Departure Cards + List To Show Arrivals

### DIFF
--- a/apps/alerts/test/cache/store_test.exs
+++ b/apps/alerts/test/cache/store_test.exs
@@ -5,6 +5,11 @@ defmodule Alerts.Cache.StoreTest do
 
   @now Timex.parse!("2017-06-08T10:00:00-05:00", "{ISO:Extended}")
 
+  setup_all do
+    _ = start_supervised(Alerts.Cache.Store)
+    :ok
+  end
+
   test "updating and fetching without a banner" do
     alert1 =
       Alerts.Alert.new(

--- a/apps/predictions/lib/parser.ex
+++ b/apps/predictions/lib/parser.ex
@@ -25,15 +25,19 @@ defmodule Predictions.Parser do
 
   @spec parse(Item.t()) :: record
   def parse(%Item{} = item) do
+    arrival = arrival_time(item)
+    departure = departure_time(item)
+    route_id = route_id(item)
+
     {
       item.id,
       trip_id(item),
       stop_id(item),
-      route_id(item),
+      route_id,
       direction_id(item),
-      arrival_time(item),
-      departure_time(item),
-      first_time(item),
+      arrival,
+      departure,
+      Schedules.Parser.display_time(arrival, departure, route_id),
       stop_sequence(item),
       schedule_relationship(item),
       track(item),
@@ -68,17 +72,6 @@ defmodule Predictions.Parser do
       do: parse_time(arrival_time)
 
   def arrival_time(_), do: nil
-
-  @spec first_time(Item.t()) :: DateTime.t() | nil
-  def first_time(%Item{attributes: %{"departure_time" => departure_time}})
-      when not is_nil(departure_time),
-      do: parse_time(departure_time)
-
-  def first_time(%Item{attributes: %{"arrival_time" => arrival_time}})
-      when not is_nil(arrival_time),
-      do: parse_time(arrival_time)
-
-  def first_time(_), do: nil
 
   @spec schedule_relationship(Item.t()) :: Prediction.schedule_relationship() | nil
   def schedule_relationship(%Item{attributes: %{"schedule_relationship" => "ADDED"}}), do: :added

--- a/apps/predictions/lib/stream_parser.ex
+++ b/apps/predictions/lib/stream_parser.ex
@@ -25,14 +25,17 @@ defmodule Predictions.StreamParser do
         _ -> nil
       end
 
+    arrival = arrival_time(item)
+    departure = departure_time(item)
+
     %Prediction{
       id: item.id,
-      arrival_time: arrival_time(item),
+      arrival_time: arrival,
       departing?: Parser.departing?(item),
-      departure_time: departure_time(item),
+      departure_time: departure,
       direction_id: Parser.direction_id(item),
       stop_sequence: Parser.stop_sequence(item),
-      time: Parser.first_time(item),
+      time: Schedules.Parser.display_time(arrival, departure, route),
       route: route,
       stop: Stops.Repo.get_parent(stop),
       platform_stop_id: stop_id(item),

--- a/apps/predictions/test/stream_parser_test.exs
+++ b/apps/predictions/test/stream_parser_test.exs
@@ -6,7 +6,6 @@ defmodule Predictions.StreamParserTest do
   alias Routes.Route
   alias Schedules.Trip
   alias Stops.Stop
-  alias Timex.Timezone
 
   describe "parse/1" do
     setup_with_mocks([
@@ -69,7 +68,7 @@ defmodule Predictions.StreamParserTest do
       assert %Route{id: "route_id"} = route
       assert %Stop{id: "place-pktrm"} = stop
       assert %Trip{id: "trip_id"} = trip
-      assert time == ~N[2016-09-15 19:40:00] |> Timezone.convert("Etc/GMT+4")
+      assert time == ~U[2016-01-01 04:00:00Z]
       assert track == stop.platform_code
       assert "vehicle_id" = vehicle_id
     end

--- a/apps/route_patterns/test/repo_test.exs
+++ b/apps/route_patterns/test/repo_test.exs
@@ -1,5 +1,4 @@
 defmodule RoutePatterns.RepoTest do
-  import Mock
   use ExUnit.Case, async: true
   alias RoutePatterns.{Repo, RoutePattern}
 

--- a/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
@@ -17,7 +17,7 @@ const predictionsFromStream = [
     "departing?": true,
     direction_id: 0,
     stop: { id: "place-somewhere" } as Stop,
-    departure_time: "2022-12-15 00:46:04.576744Z",
+    time: "2022-12-15 00:46:04.576744Z",
     track: "7",
     trip: { id: "123", headsign: "Destination One" } as Trip,
     vehicle_id: "v1"
@@ -27,7 +27,7 @@ const predictionsFromStream = [
     "departing?": true,
     direction_id: 0,
     stop: { id: "place-somewhere" } as Stop,
-    departure_time: "2022-12-15 00:48:04.576744Z",
+    time: "2022-12-15 00:48:04.576744Z",
     track: "2",
     trip: { id: "600", headsign: "Destination Two" } as Trip,
     vehicle_id: "v2"
@@ -37,7 +37,7 @@ const predictionsFromStream = [
     "departing?": false,
     direction_id: 0,
     stop: { id: "place-somewhere" } as Stop,
-    departure_time: "2022-12-15 00:55:04.576744Z",
+    time: "2022-12-15 00:55:04.576744Z",
     trip: { id: "20", headsign: "Destination One" } as Trip,
     vehicle_id: null
   } as StreamPrediction
@@ -141,9 +141,9 @@ describe("usePredictionsChannel parsePrediction", () => {
   test("modifies the streamed prediction", () => {
     const parsed = parsePrediction(streamPrediction);
     expect(parsed).toBeTruthy();
-    expect(parsed.time).toEqual(new Date(streamPrediction.departure_time!));
-    expect(parsed.time).not.toEqual(new Date(streamPrediction.arrival_time!));
-    expect(parsed.time).not.toEqual(new Date(streamPrediction.time!));
+    expect(parsed.time).toEqual(new Date(streamPrediction.time!));
+    expect(parsed.time).toEqual(new Date(streamPrediction.arrival_time!));
+    expect(parsed.time).not.toEqual(new Date(streamPrediction.departure_time!));
     expect(parsed.vehicle_id).toEqual("v1");
   });
 

--- a/apps/site/assets/ts/hooks/usePredictionsChannel.ts
+++ b/apps/site/assets/ts/hooks/usePredictionsChannel.ts
@@ -63,7 +63,7 @@ export const parsePrediction = (
     : null,
   // backend removes all predictions with a null departure_time
   // so this is always populated
-  time: new Date(prediction.departure_time!)
+  time: new Date(prediction.time!)
 });
 
 export const groupByHeadsigns = (

--- a/apps/site/test/site/lib/green_line/supervisor_test.exs
+++ b/apps/site/test/site/lib/green_line/supervisor_test.exs
@@ -1,12 +1,30 @@
 defmodule Site.GreenLine.CacheSupervisorTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   alias Site.GreenLine.DateAgent
 
   import Site.GreenLine.CacheSupervisor
+  import Mock
 
   setup_all do
     # Start parent supervisor
     {:ok, _pid} = Site.GreenLine.Supervisor.start_link([])
+    :ok
+  end
+
+  setup_with_mocks([
+    {Schedules.Repo, [],
+     [
+       rating_dates: fn ->
+         {Timex.shift(Util.service_date(), days: -2), Timex.shift(Util.service_date(), days: 2)}
+       end,
+       end_of_rating: fn -> Timex.shift(Util.service_date(), days: 2) end
+     ]},
+    {Stops.Repo, [],
+     [
+       by_route: fn _, _ -> [%Stops.Stop{}] end,
+       by_route: fn _, _, _ -> [%Stops.Stop{}] end
+     ]}
+  ]) do
     :ok
   end
 
@@ -27,6 +45,7 @@ defmodule Site.GreenLine.CacheSupervisorTest do
 
     assert lookup(date) == nil
 
+    # this is failing in prod
     assert {:ok, pid} = start_child(date)
     assert pid == lookup(date)
   end

--- a/apps/site/test/site/lib/vehicle_helpers_test.exs
+++ b/apps/site/test/site/lib/vehicle_helpers_test.exs
@@ -1,19 +1,28 @@
 defmodule Site.VehicleHelpersTest do
-  @moduledoc """
-  TODO: Mock the underlying trip fetching
-  """
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import VehicleHelpers
+  import Mock
+
+  @shape %Routes.Shape{id: "9850002", polyline: "polyline"}
+  @station %Stops.Stop{id: "place-sstat", name: "South Station"}
+  @trip %Schedules.Trip{
+    id: "CR-554466-501",
+    name: "501",
+    headsign: "Worcester",
+    shape_id: @shape.id
+  }
+  @route %Routes.Route{id: "CR-Worcester", name: "Framingham/Worcester Line", type: 2}
 
   @locations %{
     {"CR-554466-501", "place-sstat"} => %Vehicles.Vehicle{
       latitude: 1.1,
       longitude: 2.2,
       status: :stopped,
-      stop_id: "place-sstat",
-      trip_id: "CR-554466-501",
-      shape_id: "9850002"
+      route_id: @route.id,
+      stop_id: @station.id,
+      trip_id: @trip.id,
+      shape_id: @shape.id
     }
   }
 
@@ -22,27 +31,47 @@ defmodule Site.VehicleHelpersTest do
       departing?: true,
       time: ~N[2018-05-01T11:00:00],
       status: "On Time",
-      trip: %Schedules.Trip{id: "CR-554466-501", shape_id: "9850002"},
-      stop: %Stops.Stop{id: "place-sstat"}
+      trip: @trip,
+      stop: @station
     }
   ]
 
-  @route %Routes.Route{name: "Framingham/Worcester Line", type: 2}
+  setup_with_mocks([
+    {Routes.Repo, [],
+     [
+       get: fn id -> %Routes.Route{id: id} end,
+       get_shape: fn "9850002" -> [@shape] end
+     ]},
+    {Stops.Repo, [],
+     [
+       get: fn
+         "place-sstat" -> @station
+         id -> %Stops.Stop{id: id}
+       end
+     ]},
+    {Schedules.Repo, [],
+     [
+       trip: fn
+         "CR-554466-501" -> @trip
+         id -> %Schedules.Trip{id: id}
+       end
+     ]}
+  ]) do
+    tooltips = build_tooltip_index(@route, @locations, @predictions)
 
-  @tooltips build_tooltip_index(@route, @locations, @predictions)
-
-  @tooltip_base @tooltips["place-sstat"]
+    {:ok, tooltips: tooltips, tooltip_base: tooltips[@station.id]}
+  end
 
   describe "build_tooltip_index/3" do
-    test "verify the Vehicle tooltip data" do
-      assert length(Map.keys(@tooltips)) == 2
-      assert Map.has_key?(@tooltips, {"CR-554466-501", "place-sstat"})
-      assert Map.has_key?(@tooltips, "place-sstat")
-      assert @tooltip_base.route.type == 2
-      assert @tooltip_base.trip.name == "501"
-      assert @tooltip_base.trip.headsign == "Worcester"
-      assert @tooltip_base.prediction.status == "On Time"
-      assert @tooltip_base.vehicle.status == :stopped
+    test "verify the Vehicle tooltip data", %{tooltips: tooltips, tooltip_base: tooltip_base} do
+      assert length(Map.keys(tooltips)) == 2
+      assert Map.has_key?(tooltips, {"CR-554466-501", "place-sstat"})
+      assert Map.has_key?(tooltips, "place-sstat")
+      assert tooltip_base.route.type == 2
+      assert tooltip_base.trip.name == "501"
+      assert tooltip_base.trip.headsign == "Worcester"
+      assert tooltip_base.prediction.status == "On Time"
+      assert tooltip_base.vehicle.status == :stopped
     end
 
     test "it does not return a tooltip if a vehicle has a null stop_id" do
@@ -110,58 +139,64 @@ defmodule Site.VehicleHelpersTest do
   end
 
   describe "tooltip/1" do
-    test "when a prediction has a track, gives the status and the track" do
+    test "when a prediction has a track, gives the status and the track", %{
+      tooltip_base: tooltip_base
+    } do
       tooltip = %{
-        @tooltip_base
-        | prediction: %{@tooltip_base.prediction | status: "Now Boarding", track: "4"}
+        tooltip_base
+        | prediction: %{tooltip_base.prediction | status: "Now Boarding", track: "4"}
       }
 
       assert tooltip(tooltip) =~ "now boarding on track 4"
     end
 
-    test "when a prediction does not have a track, gives nothing" do
+    test "when a prediction does not have a track, gives nothing", %{tooltip_base: tooltip_base} do
       tooltip = %{
-        @tooltip_base
-        | prediction: %{@tooltip_base.prediction | status: "Now Boarding", track: nil}
+        tooltip_base
+        | prediction: %{tooltip_base.prediction | status: "Now Boarding", track: nil}
       }
 
       refute tooltip(tooltip) =~ "now boarding"
     end
 
-    test "when there is no time or status for the prediction, returns stop name" do
+    test "when there is no time or status for the prediction, returns stop name", %{
+      tooltip_base: tooltip_base
+    } do
       tooltip = %{
-        @tooltip_base
-        | prediction: %{@tooltip_base.prediction | status: nil, time: nil}
+        tooltip_base
+        | prediction: %{tooltip_base.prediction | status: nil, time: nil}
       }
 
       assert tooltip(tooltip) =~ "South Station"
     end
 
-    test "creates a tooltip for the prediction" do
+    test "creates a tooltip for the prediction", %{tooltip_base: tooltip_base} do
       time = ~N[2017-02-17T05:46:28]
 
       result =
         tooltip(%{
-          @tooltip_base
+          tooltip_base
           | prediction: %Predictions.Prediction{time: time, status: "Now Boarding", track: "4"}
         })
 
       assert result =~ "now boarding on track 4"
     end
 
-    test "Displays text based on vehicle status" do
-      tooltip1 = %{@tooltip_base | vehicle: %Vehicles.Vehicle{status: :incoming}}
-      tooltip2 = %{@tooltip_base | vehicle: %Vehicles.Vehicle{status: :stopped}}
-      tooltip3 = %{@tooltip_base | vehicle: %Vehicles.Vehicle{status: :in_transit}}
+    test "Displays text based on vehicle status", %{tooltip_base: tooltip_base} do
+      tooltip1 = %{tooltip_base | vehicle: %Vehicles.Vehicle{status: :incoming}}
+      tooltip2 = %{tooltip_base | vehicle: %Vehicles.Vehicle{status: :stopped}}
+      tooltip3 = %{tooltip_base | vehicle: %Vehicles.Vehicle{status: :in_transit}}
 
       assert tooltip(tooltip1) =~ "Worcester train 501 is arriving at"
       assert tooltip(tooltip2) =~ "Worcester train 501 has arrived"
       assert tooltip(tooltip3) =~ "Worcester train 501 is on the way to"
     end
 
-    test "does not include vehicle status if we don't have the name of the next stop" do
+    test "does not include vehicle status if we don't have the name of the next stop", %{
+      tooltip_base: tooltip_base
+    } do
       tooltip = %{
-        @tooltip_base
+        tooltip_base
         | vehicle: %Vehicles.Vehicle{status: :in_transit},
           stop_name: ""
       }
@@ -170,17 +205,17 @@ defmodule Site.VehicleHelpersTest do
       refute tooltip(tooltip) =~ "is on the way to"
     end
 
-    test "displays the route when there isn't a trip" do
-      actual = tooltip(%{@tooltip_base | prediction: nil, trip: nil})
+    test "displays the route when there isn't a trip", %{tooltip_base: tooltip_base} do
+      actual = tooltip(%{tooltip_base | prediction: nil, trip: nil})
       assert actual =~ "Framingham/Worcester Line"
       assert actual =~ "train has arrived"
       assert actual =~ "South Station"
     end
 
-    test "special message with conflicting statuses" do
+    test "special message with conflicting statuses", %{tooltip_base: tooltip_base} do
       actual =
         %{
-          @tooltip_base
+          tooltip_base
           | vehicle: %Vehicles.Vehicle{status: :stopped},
             prediction: %Predictions.Prediction{
               time: ~N[2021-10-01T11:00:00],

--- a/apps/site/test/site/transit_near_me_test.exs
+++ b/apps/site/test/site/transit_near_me_test.exs
@@ -27,10 +27,10 @@ defmodule Site.TransitNearMeTest do
                "Washington St @ Tufts Med Ctr",
                "Tufts Medical Center",
                "Washington St @ Tufts Med Ctr",
+               "Tremont St @ Charles St S",
                "Boylston",
                "Kneeland St @ Washington St",
                "Tremont St @ Boylston Station",
-               "Washington St @ Essex St",
                "Park Street",
                "South Station"
              ]

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -643,17 +643,23 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
     end
 
     test "handles the Hingham-Hull ferry" do
-      [
-        %RouteStops{
-          branch: "Long Wharf - Hingham via Logan Airport & Hull",
-          stops: long_route_stops
-        },
-        %RouteStops{
-          branch: "Long Wharf - Hingham via Hull",
-          stops: long_hull_route_stops
-        },
-        %RouteStops{branch: "Rowes Wharf - Hingham", stops: rowe_route_stops}
-      ] = Helpers.get_branch_route_stops(%Route{id: "Boat-F1"}, 0)
+      route_stops = Helpers.get_branch_route_stops(%Route{id: "Boat-F1"}, 0)
+
+      assert [
+               %RouteStops{
+                 branch: "Long Wharf - Hingham via Logan Airport & Hull",
+                 stops: long_route_stops
+               },
+               %RouteStops{
+                 branch: "Long Wharf - Hingham via Hull",
+                 stops: long_hull_route_stops
+               },
+               %RouteStops{branch: "Rowes Wharf - Hingham", stops: rowe_route_stops},
+               %RouteStops{
+                 branch: "Long Wharf - Hingham via Georges Island & Hull",
+                 stops: _georges_route_stops
+               }
+             ] = route_stops
 
       assert Enum.all?(
                long_route_stops,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Retrofit Departure Cards + List To Show Arrivals](https://app.asana.com/0/385363666817452/1204795517302694/f)

In our predictions and schedules, we have a field called `time` that was meant to abstract the idea of which of departure or arrival time to send to the frontend, but this became murky so we added `departure_time` and `arrival_time` back into the predictions and schedules so that it was easier to understand what we're displaying. But alas, now came time to implement logic to:

- For subway and bus, prefer arrival times
- For everything else, prefer departure times

So I replaced `Predictions.Parser.first_time/1` with `Schedules.Parser.display_time/3`, which implements this mode-specific logic with a slightly more legible name and comment. And put the result in the `time` field. Ideally, all front-end will just use this `time` value.

This affects schedules, predictions and predictions parsed from the stream.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
