### PR TITLE
fix(ServiceOptGroup): improve (now) logic

### DIFF
--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
@@ -4,7 +4,8 @@ import { shortDate, stringToDateObject } from "../../../../helpers/date";
 import {
   ServiceGroupNames,
   serviceDays,
-  dedupeServices
+  dedupeServices,
+  isInCurrentService
 } from "../../../../helpers/service";
 
 interface Props {
@@ -67,7 +68,19 @@ const ServiceOptGroup = ({
         }
 
         if (service.id === todayServiceId) {
-          optionText += " (now)";
+          // if it's the only service this rating, this service might not
+          // technically be now - adjust text for that
+          const now = Date.now();
+          if (isInCurrentService(service, new Date(now))) {
+            optionText += " (now)";
+          } else {
+            optionText += ` (Starting ${startDate.toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+              timeZone: "UTC"
+            })})`;
+          }
         }
 
         return (

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from "react";
+import { format } from "date-fns";
 import { Service } from "../../../../__v3api";
 import { shortDate, stringToDateObject } from "../../../../helpers/date";
 import {
@@ -13,13 +14,15 @@ interface Props {
   services: Service[];
   multipleWeekdays: boolean;
   todayServiceId: string;
+  nowDate?: Date;
 }
 
 const ServiceOptGroup = ({
   label,
   services,
   multipleWeekdays,
-  todayServiceId
+  todayServiceId,
+  nowDate = new Date()
 }: Props): ReactElement<HTMLElement> | null =>
   services.length === 0 ? null : (
     <optgroup label={label}>
@@ -70,16 +73,10 @@ const ServiceOptGroup = ({
         if (service.id === todayServiceId) {
           // if it's the only service this rating, this service might not
           // technically be now - adjust text for that
-          const now = Date.now();
-          if (isInCurrentService(service, new Date(now))) {
+          if (isInCurrentService(service, nowDate)) {
             optionText += " (now)";
           } else {
-            optionText += ` (Starting ${startDate.toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-              timeZone: "UTC"
-            })})`;
+            optionText += ` (Starting ${format(startDate, "MMMM d, y")})`;
           }
         }
 

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/ServiceOptGroupTest.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/ServiceOptGroupTest.tsx
@@ -80,6 +80,31 @@ describe("ServiceOptGroup", () => {
   ];
 
   it("adds (now) to today's service based on todayServiceId prop", () => {
+    jest
+      .spyOn(Date, "now")
+      .mockImplementation(() => new Date("2019-09-07").getTime());
+    const wrapper = mount(
+      <ServiceOptGroup
+        label={"Test services"}
+        services={servicesList.concat(
+          makeSimpleService(
+            ["2019-09-06", "2019-10-01"],
+            ["2019-09-01", "2019-11-01"],
+            "Current Summer",
+            "n"
+          )
+        )}
+        multipleWeekdays={false}
+        todayServiceId="n"
+      />
+    );
+    expect(wrapper.text()).toContain(
+      "Current Summer schedule, Test Rating (now)"
+    );
+    jest.resetAllMocks();
+  });
+
+  it("adds (starting date) to today's service based on todayServiceId prop if service hasn't yet started", () => {
     const wrapper = mount(
       <ServiceOptGroup
         label={"Test services"}
@@ -89,7 +114,7 @@ describe("ServiceOptGroup", () => {
       />
     );
     expect(wrapper.text()).toContain(
-      "First Summer schedule, Test Rating (now)"
+      "First Summer schedule, Test Rating (Starting June 1, 2019)"
     );
   });
 

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/ServiceOptGroupTest.tsx
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/ServiceOptGroupTest.tsx
@@ -80,9 +80,6 @@ describe("ServiceOptGroup", () => {
   ];
 
   it("adds (now) to today's service based on todayServiceId prop", () => {
-    jest
-      .spyOn(Date, "now")
-      .mockImplementation(() => new Date("2019-09-07").getTime());
     const wrapper = mount(
       <ServiceOptGroup
         label={"Test services"}
@@ -96,12 +93,12 @@ describe("ServiceOptGroup", () => {
         )}
         multipleWeekdays={false}
         todayServiceId="n"
+        nowDate={new Date("2019-09-07")}
       />
     );
     expect(wrapper.text()).toContain(
       "Current Summer schedule, Test Rating (now)"
     );
-    jest.resetAllMocks();
   });
 
   it("adds (starting date) to today's service based on todayServiceId prop if service hasn't yet started", () => {

--- a/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/__snapshots__/DailyScheduleTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/__snapshots__/DailyScheduleTest.tsx.snap
@@ -49,10 +49,10 @@ Array [
               Friday schedule, Test
             </option>
             <option
-              aria-label="Current Schedules (Test, ends Oct 25) Saturday schedule, Test (now)"
+              aria-label="Current Schedules (Test, ends Oct 25) Saturday schedule, Test (Starting July 6, 2019)"
               value="BUS319-P-Sa-02"
             >
-              Saturday schedule, Test (now)
+              Saturday schedule, Test (Starting July 6, 2019)
             </option>
             <option
               aria-label="Current Schedules (Test, ends Oct 25) Sunday schedule, Test"


### PR DESCRIPTION
Because of the way the backend logic works, if there's only one service available this rating, that service might get labelled as "today's", even if it's not within the valid service dates. To improve this, 

- actually check whether the service is in the current service before labelling with "(now)"
- if it's not in the current service, adjust the text to indicate start date


#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Schedule finder should not present future services as current](https://app.asana.com/0/385363666817452/1204794505976013/f)

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
