### PR TITLE
Predictions Refactor | Flexible Subscription IDs

### DIFF
--- a/apps/predictions/test/stream_supervisor_test.exs
+++ b/apps/predictions/test/stream_supervisor_test.exs
@@ -34,12 +34,12 @@ defmodule Predictions.StreamSupervisorTest do
 
   describe "ensure_stream_is_started/1" do
     test "starts a stream if not already started" do
-      prediction_key = "Purple:awesome-station:1"
+      prediction_key = "route=Purple:stop=awesome-station:direction=1"
       assert {:ok, _pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
     end
 
     test "returns existing stream from registry" do
-      prediction_key = "Pink:place:1"
+      prediction_key = "route=Pink:stop=place:direction=0"
       {:ok, pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
       assert {:ok, ^pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
     end

--- a/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
@@ -60,7 +60,9 @@ describe("usePredictionsChannel hook", () => {
     );
     expect(result.current).toEqual({});
     expect(
-      window.channels["predictions:Purple:place-somewhere:0"]
+      window.channels[
+        "predictions:route=Purple:stop=place-somewhere:direction_id=0"
+      ]
     ).toBeTruthy();
   });
 
@@ -73,7 +75,7 @@ describe("usePredictionsChannel hook", () => {
     act(() => {
       const event = new CustomEvent<{
         predictions: StreamPrediction[];
-      }>("predictions:Purple:place-somewhere:0", {
+      }>("predictions:route=Purple:stop=place-somewhere:direction_id=0", {
         detail: {
           predictions: predictionsFromStream
         }
@@ -96,7 +98,7 @@ describe("usePredictionsChannel hook", () => {
     act(() => {
       const event = new CustomEvent<{
         predictions: StreamPrediction[];
-      }>("predictions:Purple:place-somewhere:0", {
+      }>("predictions:route=Purple:stop=place-somewhere:direction_id=0", {
         detail: {
           predictions: predictionsFromStream
         }
@@ -111,7 +113,7 @@ describe("usePredictionsChannel hook", () => {
     act(() => {
       const event = new CustomEvent<{
         predictions: StreamPrediction[];
-      }>("predictions:Purple:place-somewhere:0", {
+      }>("predictions:route=Purple:stop=place-somewhere:direction_id=0", {
         detail: {
           predictions: predictionsFromStream
         }

--- a/apps/site/assets/ts/hooks/usePredictionsChannel.ts
+++ b/apps/site/assets/ts/hooks/usePredictionsChannel.ts
@@ -91,7 +91,7 @@ const usePredictionsChannel = (
   stopId: string,
   directionId: 0 | 1
 ): PredictionsByHeadsign => {
-  const channelName = `predictions:${routeId}:${stopId}:${directionId}`;
+  const channelName = `predictions:route=${routeId}:stop=${stopId}:direction_id=${directionId}`;
   const reducer: Reducer<PredictionsByHeadsign, ChannelPredictionResponse> = (
     oldGroupedPredictions,
     { predictions }

--- a/apps/site/lib/site_web/channels/predictions_channel.ex
+++ b/apps/site/lib/site_web/channels/predictions_channel.ex
@@ -10,16 +10,15 @@ defmodule SiteWeb.PredictionsChannel do
   @impl Channel
   @spec join(topic :: binary(), payload :: Channel.payload(), socket :: Socket.t()) ::
           {:ok, %{predictions: [Prediction.t()]}, Socket.t()}
-  def join("predictions:" <> route_stop_direction, _message, socket) do
+  def join("predictions:" <> opts, _message, socket) do
     predictions_subscribe_fn =
       Application.get_env(
         :site,
         :predictions_subscribe_fn,
-        &PredictionsPubSub.subscribe/3
+        &PredictionsPubSub.subscribe/1
       )
 
-    [route_id, stop_id, direction_id] = String.split(route_stop_direction, ":")
-    predictions = predictions_subscribe_fn.(route_id, stop_id, direction_id)
+    predictions = predictions_subscribe_fn.(opts)
     {:ok, %{predictions: filter_new(predictions)}, socket}
   end
 

--- a/apps/site/test/site_web/channels/predictions_channel_test.exs
+++ b/apps/site/test/site_web/channels/predictions_channel_test.exs
@@ -23,15 +23,11 @@ defmodule SiteWeb.PredictionsChannelTest do
     departure_time: Timex.shift(Util.now(), hours: 2)
   }
 
-  setup do
-    reassign_env(:site, :predictions_subscribe_fn, fn route_id, _, _ ->
-      case route_id do
-        @route_39 ->
-          [@prediction39]
+  @channel_name "predictions:route=#{@route_39}:stop=#{@stop_fh}:direction_id=#{@direction}"
 
-        _ ->
-          []
-      end
+  setup do
+    reassign_env(:site, :predictions_subscribe_fn, fn _ ->
+      [@prediction39]
     end)
 
     socket = socket(UserSocket, "", %{})
@@ -48,7 +44,7 @@ defmodule SiteWeb.PredictionsChannelTest do
                subscribe_and_join(
                  socket,
                  PredictionsChannel,
-                 "predictions:#{@route_39}:#{@stop_fh}:#{@direction}"
+                 @channel_name
                )
     end
   end
@@ -59,7 +55,7 @@ defmodule SiteWeb.PredictionsChannelTest do
         subscribe_and_join(
           socket,
           PredictionsChannel,
-          "predictions:#{@route_39}:#{@stop_fh}:#{@direction}"
+          @channel_name
         )
 
       assert {:noreply, _socket} =


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Predictions Refactor | Flexible Subscription IDs](https://app.asana.com/0/1204716173461809/1204668141429887/f)

The goal of this PR was to make the backend changes needed to enable predictions streaming for more than a route-direction-stop triad. In total,

- Instead of managing lists of predictions in a `Map` keyed by `route:stop:direction`, predictions are put into an ETS table. The single ETS table is created on startup and each new subscription starts a new streaming connection to the API (same as before), each connection having the ability to remove/update/add entries to the table. Each entry is a tuple of `{prediction ID, route ID, stop ID, direction ID, trip ID, vehicle ID, prediction (the whole object)}` - making it easy to fetch predictions by any and all of those keys.
- The frontend update was just to make this change non-breaking. This will have to be followed up by a PR that makes `usePredictionsChannel` take more flexible arguments, so that we can, say, subscribe to all predictions for a stop.
- I don't love the channel naming scheme I came up with to enable this. Here the format is `predictions:<key>=<value>:<key2>=<value2>` and so on. The other idea I have is to just make it more constrained: `predictions:stop:<stopid>`, `predictions:route:<routeid>-<directionid>`, `predictions:trip:<tripid>` and so forth.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
