### PR TITLE
chore: add Lynn & Winthrop ferry fare info

### DIFF
--- a/apps/cms/test/repo_test.exs
+++ b/apps/cms/test/repo_test.exs
@@ -1,5 +1,5 @@
 defmodule CMS.RepoTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog, only: [capture_log: 1]
   import Phoenix.HTML, only: [safe_to_string: 1]

--- a/apps/fares/lib/fare_info.ex
+++ b/apps/fares/lib/fare_info.ex
@@ -212,6 +212,8 @@ defmodule Fares.FareInfo do
       inner_harbor_month_price_reduced: "30.00",
       cross_harbor_price: "9.75",
       east_boston_price: "2.40",
+      lynn_price: "2.40",
+      winthrop_price: "2.40",
       commuter_ferry_price: "9.75",
       commuter_ferry_month_price: "329.00",
       commuter_ferry_month_price_reduced: "164.00",
@@ -483,6 +485,8 @@ defmodule Fares.FareInfo do
         inner_harbor_month_price_reduced: inner_harbor_month_price_reduced,
         cross_harbor_price: cross_harbor_price,
         east_boston_price: east_boston_price,
+        lynn_price: lynn_price,
+        winthrop_price: winthrop_price,
         commuter_ferry_price: commuter_ferry_price,
         commuter_ferry_month_price_reduced: commuter_ferry_month_price_reduced,
         commuter_ferry_month_price: commuter_ferry_month_price,
@@ -562,6 +566,38 @@ defmodule Fares.FareInfo do
         media: [:mticket],
         reduced: nil,
         cents: dollars_to_cents(east_boston_price) * 2
+      },
+      %Fare{
+        mode: :ferry,
+        name: :ferry_lynn,
+        duration: :single_trip,
+        media: [:mticket],
+        reduced: nil,
+        cents: dollars_to_cents(lynn_price)
+      },
+      %Fare{
+        mode: :ferry,
+        name: :ferry_lynn,
+        duration: :round_trip,
+        media: [:mticket],
+        reduced: nil,
+        cents: dollars_to_cents(lynn_price) * 2
+      },
+      %Fare{
+        mode: :ferry,
+        name: :ferry_winthrop,
+        duration: :single_trip,
+        media: [:mticket],
+        reduced: nil,
+        cents: dollars_to_cents(winthrop_price)
+      },
+      %Fare{
+        mode: :ferry,
+        name: :ferry_winthrop,
+        duration: :round_trip,
+        media: [:mticket],
+        reduced: nil,
+        cents: dollars_to_cents(winthrop_price) * 2
       },
       %Fare{
         mode: :ferry,

--- a/apps/fares/lib/fares.ex
+++ b/apps/fares/lib/fares.ex
@@ -21,10 +21,15 @@ defmodule Fares do
 
   @terminus_stops ["place-sstat", "place-north", "North Station", "South Station"]
 
+  # For the time being, these stops are ONLY served by the Winthrop Ferry
+  @winthrop_ferry_stops ["Boat-Aquarium", "Boat-Fan", "Boat-Quincy", "Boat-Winthrop"]
+
   @type ferry_name ::
           :ferry_cross_harbor
           | :ferry_inner_harbor
           | :ferry_east_boston
+          | :ferry_lynn
+          | :ferry_winthrop
           | :commuter_ferry_logan
           | :commuter_ferry
           | :ferry_george
@@ -122,6 +127,16 @@ defmodule Fares do
   defp calculate_ferry(origin, destination)
        when "Boat-George" in [origin, destination] do
     :ferry_george
+  end
+
+  defp calculate_ferry(origin, destination)
+       when "Boat-Blossom" in [origin, destination] do
+    :ferry_lynn
+  end
+
+  defp calculate_ferry(origin, destination)
+       when origin in @winthrop_ferry_stops or destination in @winthrop_ferry_stops do
+    :ferry_winthrop
   end
 
   defp calculate_ferry(origin, destination)

--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -81,6 +81,8 @@ defmodule Fares.Format do
   def name(:ferry_inner_harbor), do: "Charlestown Ferry"
   def name(:ferry_cross_harbor), do: "Cross Harbor Ferry"
   def name(:ferry_east_boston), do: "East Boston Ferry"
+  def name(:ferry_lynn), do: "Lynn Ferry"
+  def name(:ferry_winthrop), do: "Winthrop Ferry"
   def name(:ferry_george), do: "Georges Island"
   def name(:commuter_ferry), do: "Hingham/Hull Ferry"
   def name(:commuter_ferry_logan), do: "Commuter Ferry to Logan Airport"

--- a/apps/fares/test/fares_test.exs
+++ b/apps/fares/test/fares_test.exs
@@ -19,7 +19,7 @@ defmodule FaresTest do
 
   describe "fare_for_stops/3" do
     # a subset of possible ferry stops
-    @ferries ~w(Boat-Hingham Boat-Charlestown Boat-Logan Boat-Long-South Boat-Lewis)
+    @ferries ~w(Boat-Hingham Boat-Charlestown Boat-Logan Boat-Long-South Boat-Lewis Boat-Blossom Boat-Winthrop)
 
     test "returns the name of the commuter rail fare given the origin and destination" do
       zone_1a = "place-north"
@@ -44,18 +44,23 @@ defmodule FaresTest do
         has_long? = "Boat-Long" in both
         has_long_south? = "Boat-Long-South" in both
         has_east_boston? = "Boat-Lewis" in both
+        has_lynn? = "Boat-Blossom" in both
+        has_winthrop? = "Boat-Winthrop" in both
 
         expected_name =
           cond do
             has_logan? and has_charlestown? -> :ferry_cross_harbor
             has_long? and has_logan? -> :ferry_cross_harbor
             has_long_south? and has_charlestown? -> :ferry_inner_harbor
-            has_logan? -> :commuter_ferry_logan
             has_long? and has_east_boston? -> :ferry_east_boston
+            has_lynn? -> :ferry_lynn
+            has_winthrop? -> :ferry_winthrop
+            has_logan? -> :commuter_ferry_logan
             true -> :commuter_ferry
           end
 
-        assert Fares.fare_for_stops(:ferry, origin_id, destination_id) == {:ok, expected_name}
+        assert Fares.fare_for_stops(:ferry, origin_id, destination_id) == {:ok, expected_name},
+               "Unexpected result for #{origin_id} to #{destination_id}"
       end
     end
 

--- a/apps/fares/test/format_test.exs
+++ b/apps/fares/test/format_test.exs
@@ -53,6 +53,8 @@ defmodule Fares.FormatTest do
       assert name(%Fare{name: :ferry_inner_harbor}) == "Charlestown Ferry"
       assert name(%Fare{name: :ferry_cross_harbor}) == "Cross Harbor Ferry"
       assert name(%Fare{name: :ferry_east_boston}) == "East Boston Ferry"
+      assert name(%Fare{name: :ferry_lynn}) == "Lynn Ferry"
+      assert name(%Fare{name: :ferry_winthrop}) == "Winthrop Ferry"
       assert name(%Fare{name: :commuter_ferry}) == "Hingham/Hull Ferry"
     end
 

--- a/apps/location_service/test/aws_location/request_test.exs
+++ b/apps/location_service/test/aws_location/request_test.exs
@@ -1,6 +1,6 @@
 defmodule AWSLocation.RequestTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Mock
   import AWSLocation.Request
 

--- a/apps/location_service/test/wrappers_test.exs
+++ b/apps/location_service/test/wrappers_test.exs
@@ -1,5 +1,5 @@
 defmodule LocationService.WrappersTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import LocationService.Wrappers
   import Mock

--- a/apps/routes/lib/mock_repo_api.ex
+++ b/apps/routes/lib/mock_repo_api.ex
@@ -120,6 +120,19 @@ defmodule Routes.MockRepoApi do
   end
 
   @impl Routes.RepoApi
+  def get("Massport-TEST") do
+    %Routes.Route{
+      description: "Massport Generated Route",
+      id: "Massport-TEST",
+      long_name: "Massport-TEST",
+      name: "Massport-TEST",
+      type: "Massport-TEST",
+      custom_route?: true,
+      color: "000000"
+    }
+  end
+
+  @impl Routes.RepoApi
   def get("Red") do
     %Routes.Route{
       id: "Red",

--- a/apps/routes/test/repo_test.exs
+++ b/apps/routes/test/repo_test.exs
@@ -113,7 +113,7 @@ defmodule Routes.RepoTest do
                type: "Massport-TEST",
                custom_route?: true,
                color: "000000"
-             } = Repo.get("Massport-TEST")
+             } = @routes_repo_api.get("Massport-TEST")
     end
 
     test "returns nil for an unknown route" do
@@ -276,14 +276,14 @@ defmodule Routes.RepoTest do
   describe "get_shape/1" do
     shape =
       "903_0018"
-      |> Repo.get_shape()
+      |> @routes_repo_api.get_shape()
       |> List.first()
 
     assert shape.id == "903_0018"
   end
 
   describe "green_line" do
-    green_line = Repo.green_line()
+    green_line = @routes_repo_api.green_line()
     assert green_line.id == "Green"
     assert green_line.name == "Green Line"
   end

--- a/apps/schedules/test/hours_of_operation_test.exs
+++ b/apps/schedules/test/hours_of_operation_test.exs
@@ -1,6 +1,6 @@
 defmodule Schedules.HoursOfOperationTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Mock
   import Schedules.HoursOfOperation
   alias Schedules.{HoursOfOperation, Departures}

--- a/apps/services/test/service_test.exs
+++ b/apps/services/test/service_test.exs
@@ -1,5 +1,5 @@
 defmodule Services.ServiceTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Mock
   alias JsonApi.Item
   alias Services.Service

--- a/apps/site/lib/site/content_rewriters/liquid_objects/fare.ex
+++ b/apps/site/lib/site/content_rewriters/liquid_objects/fare.ex
@@ -28,6 +28,8 @@ defmodule Site.ContentRewriters.LiquidObjects.Fare do
           | :ferry_cross_harbor
           | :ferry_inner_harbor
           | :ferry_east_boston
+          | :ferry_lynn
+          | :ferry_winthrop
           | :foxboro
           | :express_bus
           | :local_bus
@@ -64,6 +66,8 @@ defmodule Site.ContentRewriters.LiquidObjects.Fare do
     "ferry_cross_harbor",
     "ferry_inner_harbor",
     "ferry_east_boston",
+    "ferry_lynn",
+    "ferry_winthrop",
     "foxboro",
     "express_bus",
     "local_bus",

--- a/apps/site/test/detailed_stop_group_test.exs
+++ b/apps/site/test/detailed_stop_group_test.exs
@@ -1,5 +1,5 @@
 defmodule DetailedStopGroupTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import DetailedStopGroup
   alias Routes.Route
 

--- a/apps/site/test/predicted_schedule_test.exs
+++ b/apps/site/test/predicted_schedule_test.exs
@@ -1,5 +1,5 @@
 defmodule PredictedScheduleTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   alias Schedules.{Schedule, ScheduleCondensed, Trip}
   alias Stops.Stop
   alias Predictions.Prediction

--- a/apps/site/test/site/transit_near_me_test.exs
+++ b/apps/site/test/site/transit_near_me_test.exs
@@ -18,26 +18,17 @@ defmodule Site.TransitNearMeTest do
 
   describe "build/2" do
     test "builds a set of data for a location" do
-      data = TransitNearMe.build(@address, date: @date, now: Util.now())
+      assert %{stops: stops, distances: distances} =
+               TransitNearMe.build(@address, date: @date, now: Util.now())
 
-      assert Enum.map(data.stops, & &1.name) == [
-               "Stuart St @ Charles St S",
-               "Charles St S @ Park Plaza",
-               "285 Tremont St",
-               "Washington St @ Tufts Med Ctr",
-               "Tufts Medical Center",
-               "Washington St @ Tufts Med Ctr",
-               "Tremont St @ Charles St S",
-               "Boylston",
-               "Kneeland St @ Washington St",
-               "Tremont St @ Boylston Station",
-               "Park Street",
-               "South Station"
-             ]
+      for stop_id <- Enum.map(stops, & &1.id) do
+        assert stop_id in Map.keys(distances)
+      end
 
       # stops are in order of distance from location
+      distances = Enum.map(stops, &distances[&1.id])
 
-      assert Enum.map(data.stops, &data.distances[&1.id]) == [
+      assert distances == [
                "238 ft",
                "444 ft",
                "0.1 mi",

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -1,5 +1,5 @@
 defmodule SiteWeb.ScheduleController.Line.HelpersTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Routes.{Route}
   alias SiteWeb.ScheduleController.Line.Helpers

--- a/apps/site/test/site_web/controllers/schedule/line_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line_test.exs
@@ -1,5 +1,5 @@
 defmodule SiteWeb.ScheduleController.LineTest do
-  use SiteWeb.ConnCase, async: true
+  use SiteWeb.ConnCase, async: false
   import Mock
   alias Services.Service
   alias SiteWeb.ScheduleController.Line

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule SiteWeb.ScheduleControllerTest do
-  use SiteWeb.ConnCase
+  use SiteWeb.ConnCase, async: false
 
   alias CMS.Partial.Teaser
   alias Plug.Conn

--- a/apps/site/test/site_web/controllers/stop_controller_test.exs
+++ b/apps/site/test/site_web/controllers/stop_controller_test.exs
@@ -60,12 +60,14 @@ defmodule SiteWeb.StopControllerTest do
   end
 
   test "assigns ferry routes", %{conn: conn} do
-    conn =
-      conn
-      |> get(stop_path(conn, :show, "Boat-Charlestown"))
+    with_mock(Laboratory, [], enabled?: fn _, :stops_redesign -> false end) do
+      conn =
+        conn
+        |> get(stop_path(conn, :show, "Boat-Charlestown"))
 
-    assert [ferry] = conn.assigns.routes
-    assert %{group_name: :ferry, routes: [%{route: %{id: "Boat-F4"}}]} = ferry
+      assert [ferry] = conn.assigns.routes
+      assert %{group_name: :ferry, routes: [%{route: %{id: "Boat-F4"}}]} = ferry
+    end
   end
 
   test "assigns the zone number for the current stop", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Ferry Fares Page | Add fare cards for Lynn and Winthrop](https://app.asana.com/0/385363666817452/1204827964401105/f)

Gonna deploy this to dev-green and leave this as a draft while I test if this change works with the (sandbox-mbta) CMS. (edit: done, it works!)

I mostly followed the code changes used when we added the fares for the East Boston ferry in #1411 

The one missed opportunity for optimization here - East Boston, Lynn, and Winthrop have the same one-way fares, so potentially that code could be more streamlined. But I know one of them is increasing in price at the end of summer, and E Boston has reduced fare that might not be the same as the others... so I didn't want to consolidate those if they're not meant to be identical.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
