### PR TITLE
feat(AmenityCard): add badge prop, improve styles

### DIFF
--- a/apps/site/assets/css/_stop-page.scss
+++ b/apps/site/assets/css/_stop-page.scss
@@ -317,6 +317,12 @@
     @include media-breakpoint-down(sm) {
       margin-bottom: 1rem;
     }
+
+    &[disabled] {
+      background-color: $gray-lightest;
+      border-color: $gray-light;
+      color: $body-color;
+    }
   }
 
   .c-descriptive-link__caret-wrapper {

--- a/apps/site/assets/css/_stop-page.scss
+++ b/apps/site/assets/css/_stop-page.scss
@@ -322,7 +322,33 @@
       background-color: $gray-lightest;
       border-color: $gray-light;
       color: $body-color;
+
+      // override set .c-descriptive-link title
+      .c-descriptive-link__title,
+      // override SVG components that have a hard-coded fill
+      [class*='c-svg__icon'] :where(path, rect)[fill] {
+        color: inherit;
+        fill: currentColor;
+      }
     }
+  }
+
+  .c-descriptive-link__header {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+  }
+
+  .c-descriptive-link__title,
+  .c-descriptive-link__badge {
+    font-family: $font-family-sans-serif;
+    white-space: nowrap;
+  }
+
+  .c-descriptive-link__text {
+    padding: 1rem;
+    text-align: left;
   }
 
   .c-descriptive-link__caret-wrapper {

--- a/apps/site/assets/css/_utilities.scss
+++ b/apps/site/assets/css/_utilities.scss
@@ -84,6 +84,10 @@
   background-color: $gray;
 }
 
+.u-bg--gray-lighter {
+  background-color: $gray-lighter;
+}
+
 .u-bg--gray-bordered-background {
   background-color: $gray-bordered-background;
   box-shadow: 0 0 4px rgba(0, 0, 0, .25);

--- a/apps/site/assets/ts/components/Badge.tsx
+++ b/apps/site/assets/ts/components/Badge.tsx
@@ -2,14 +2,17 @@ import React from "react";
 
 const Badge = ({
   text,
-  contextText
+  contextText,
+  bgClass
 }: {
   text: string;
   contextText?: string;
+  bgClass?: string;
 }): JSX.Element => {
   return (
     <div
-      className="u-error-background font-weight-bold ps-8 pe-8 fs-14"
+      className={`${bgClass ||
+        "u-error-background"} font-weight-bold ps-8 pe-8 fs-14`}
       style={{ borderRadius: "0.75rem" }}
     >
       {/* The purpose of this block is to have invisble text for screen readers */}

--- a/apps/site/assets/ts/stop/__tests__/components/amenities/AmenityCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/amenities/AmenityCardTest.tsx
@@ -49,15 +49,7 @@ describe("AmenityCard", () => {
     expect(screen.queryByText("Modal content")).toBeNull();
   });
 
-  it("should support a disabled state if there's no modal", () => {
-    render(
-      <AmenityCard headerText="Card" icon={<span></span>}>
-        Card content
-      </AmenityCard>
-    );
-    expect(
-      screen.getByRole("button", { name: "Card Card content" })
-    ).toBeDisabled();
+  it("should support an enabled state if is a modal", () => {
     render(
       <AmenityCard
         headerText="Card"
@@ -70,5 +62,16 @@ describe("AmenityCard", () => {
     expect(
       screen.getByRole("button", { name: "Card Card content" })
     ).not.toBeDisabled();
+  });
+
+  it("should support a disabled state if there's no modal", () => {
+    render(
+      <AmenityCard headerText="Card" icon={<span></span>}>
+        Card content
+      </AmenityCard>
+    );
+    expect(
+      screen.getByRole("button", { name: "Card Card content" })
+    ).toBeDisabled();
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/components/amenities/AmenityCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/amenities/AmenityCardTest.tsx
@@ -46,4 +46,27 @@ describe("AmenityCard", () => {
     expect(screen.queryByText("Inner header")).toBeNull();
     expect(screen.queryByText("Modal content")).toBeNull();
   });
+
+  it("should support a disabled state if there's no modal", () => {
+    render(
+      <AmenityCard headerText="Card" icon={<span></span>}>
+        Card content
+      </AmenityCard>
+    );
+    expect(
+      screen.getByRole("button", { name: "Card Card content" })
+    ).toBeDisabled();
+    render(
+      <AmenityCard
+        headerText="Card"
+        icon={<span></span>}
+        modalContent={"More to come!"}
+      >
+        Card content
+      </AmenityCard>
+    );
+    expect(
+      screen.getByRole("button", { name: "Card Card content" })
+    ).not.toBeDisabled();
+  });
 });

--- a/apps/site/assets/ts/stop/__tests__/components/amenities/AmenityCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/amenities/AmenityCardTest.tsx
@@ -5,17 +5,19 @@ import AmenityCard, {
 } from "../../../components/amenities/AmenityCard";
 
 describe("AmenityCard", () => {
-  it("should render the icon, title, content", () => {
+  it("should render the icon, title, content, badge", () => {
     render(
       <AmenityCard
         headerText={"Amenity Title"}
         icon={<span data-testid="icon"></span>}
+        badge={<span data-testid="badge"></span>}
       >
         <div>Card content</div>
       </AmenityCard>
     );
     expect(screen.getByText("Amenity Title")).toBeDefined();
     expect(screen.getByTestId("icon")).toBeDefined();
+    expect(screen.getByTestId("badge")).toBeDefined();
     expect(screen.getByText("Card content")).toBeDefined();
   });
 

--- a/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
@@ -11,7 +11,7 @@ export const AmenityModal = ({
   children
 }: {
   headerText: string;
-  children?: JSX.Element[] | JSX.Element;
+  children?: React.ReactNode;
 }): ReactElement => {
   const elementId = headerText.toLowerCase().replace(/[ _]/g, "-");
   const { closeModal } = useContext(AmenityModalContext);
@@ -37,8 +37,8 @@ const AmenityCard = ({
 }: {
   headerText: string;
   icon: JSX.Element;
-  modalContent?: JSX.Element[] | JSX.Element;
-  children?: JSX.Element[] | JSX.Element;
+  modalContent?: React.ReactNode;
+  children?: React.ReactNode;
 }): JSX.Element => {
   const [modalOpen, setModalOpen] = useState(false);
   return (

--- a/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
@@ -32,11 +32,13 @@ export const AmenityModal = ({
 const AmenityCard = ({
   headerText,
   icon,
+  badge,
   modalContent,
   children
 }: {
   headerText: string;
   icon: JSX.Element;
+  badge?: React.ReactNode;
   modalContent?: React.ReactNode;
   children?: React.ReactNode;
 }): JSX.Element => {
@@ -56,6 +58,7 @@ const AmenityCard = ({
               {headerText}
             </div>
           </div>
+          {badge && <div style={{ display: "inline-block" }}>{badge}</div>}
           {children && (
             <div className="c-descriptive-link__text pt-8 hidden-sm-down">
               {children}

--- a/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
@@ -65,19 +65,13 @@ const AmenityCard = ({
         onClick={() => setModalOpen(true)}
         disabled={!modalContent}
       >
-        <div className="p-16">
-          <div className="d-flex text-primary">
+        <div className="c-descriptive-link__text">
+          <div className="c-descriptive-link__header">
             {icon}
-            <div className="c-descriptive-link__title ps-8 mb-0">
-              {headerText}
-            </div>
+            <div className="c-descriptive-link__title mb-0">{headerText}</div>
+            {badge && <div className="c-descriptive-link__badge">{badge}</div>}
           </div>
-          {badge && <div style={{ display: "inline-block" }}>{badge}</div>}
-          {children && (
-            <div className="c-descriptive-link__text pt-8 hidden-sm-down">
-              {children}
-            </div>
-          )}
+          {children && <div className="mt-8 hidden-sm-down">{children}</div>}
         </div>
         {modalContent && (
           <div className="c-descriptive-link__caret-wrapper">

--- a/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
@@ -29,6 +29,20 @@ export const AmenityModal = ({
   );
 };
 
+export const AmenityLink = ({
+  url,
+  text
+}: {
+  url: string;
+  text: string;
+}): JSX.Element => (
+  <p>
+    <a href={url} className="c-call-to-action">
+      {text}
+    </a>
+  </p>
+);
+
 const AmenityCard = ({
   headerText,
   icon,

--- a/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
@@ -47,6 +47,7 @@ const AmenityCard = ({
         type="button"
         className="c-descriptive-link justify-content-space-between"
         onClick={() => setModalOpen(true)}
+        disabled={!modalContent}
       >
         <div className="p-16">
           <div className="d-flex text-primary">
@@ -61,9 +62,11 @@ const AmenityCard = ({
             </div>
           )}
         </div>
-        <div className="c-descriptive-link__caret-wrapper">
-          {renderFa("c-descriptive-link__caret", "fa-angle-right")}
-        </div>
+        {modalContent && (
+          <div className="c-descriptive-link__caret-wrapper">
+            {renderFa("c-descriptive-link__caret", "fa-angle-right")}
+          </div>
+        )}
       </button>
       <AmenityModalContext.Provider
         value={{ closeModal: () => setModalOpen(false) }}


### PR DESCRIPTION
#### Summary of changes

No ticket, just a few improvements on the original `AmenityCard` component we'll all use:

* Some CSS and layout improvements, mostly around the card's heading. This allows the badge to be on the same line as the header text, and wrap nicely without interfering with the width of the right arrow.
* Adds disabled state
  * Grey background and black header text and black icon
  * No click enabled / hides arrow
  * Adjusts badge to support additional CSS class - e.g. you can do `<Badge bgClass="u-bg--gray-lighter" />` to replace the default red background with a grey one
* Added an `<AmenityLink />`, there isn't much to it but just standardizing our rendering of links
* Improves the typing used for children components

