### PR TITLE
feat(Predictions): Hoist up websocket to only open on per page

### DIFF
--- a/apps/site/assets/ts/models/prediction.ts
+++ b/apps/site/assets/ts/models/prediction.ts
@@ -1,5 +1,7 @@
+import { Dictionary, groupBy } from "lodash";
 import { TripPrediction } from "../schedule/components/__trips";
-import { HeadsignWithCrowding } from "../__v3api";
+import { HeadsignWithCrowding, Prediction } from "../__v3api";
+import { PredictionWithTimestamp } from "./perdictions";
 
 // eslint-disable-next-line import/prefer-default-export
 export const isSkippedOrCancelled = (
@@ -20,3 +22,13 @@ export const hasPredictionTime = ({
     timeDataList[0].time_data.prediction &&
     timeDataList[0].time_data.prediction.time
   );
+
+export const predictionsByHeadsign = <
+  T extends Prediction | PredictionWithTimestamp
+>(
+  predictions: T[] | undefined
+): Dictionary<T[]> => {
+  return groupBy<T>(predictions, (p: T) => {
+    return p.trip!.headsign;
+  });
+};

--- a/apps/site/assets/ts/stop/components/DepartureCard.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureCard.tsx
@@ -1,25 +1,26 @@
 import React, { ReactElement } from "react";
 import { groupBy } from "lodash";
-import { Alert, DirectionId, Route, Stop } from "../../__v3api";
+import { Alert, DirectionId, Route } from "../../__v3api";
 import { routeName, routeToModeIcon } from "../../helpers/route-headers";
 import { routeBgClass } from "../../helpers/css";
 import renderSvg from "../../helpers/render-svg";
 import DepartureTimes from "./DepartureTimes";
 import { ScheduleWithTimestamp } from "../../models/schedules";
 import { allAlertsForDirection } from "../../models/alert";
+import { PredictionWithTimestamp } from "../../models/perdictions";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 
 const DepartureCard = ({
   route,
-  stop,
   schedulesForRoute,
+  predictionsForRoute,
   onClick,
   alertsForRoute = []
 }: {
   route: Route;
   schedulesForRoute: ScheduleWithTimestamp[];
-  stop: Stop;
+  predictionsForRoute: PredictionWithTimestamp[];
   onClick: (
     route: Route,
     directionId: DirectionId,
@@ -30,6 +31,10 @@ const DepartureCard = ({
   const schedulesByDirection = groupBy(
     schedulesForRoute,
     (sch: ScheduleWithTimestamp) => sch.trip.direction_id
+  );
+  const predictionsByDirection = groupBy(
+    predictionsForRoute,
+    p => p.trip.direction_id
   );
 
   return (
@@ -45,18 +50,18 @@ const DepartureCard = ({
       <DepartureTimes
         key={`${route.id}-0`}
         route={route}
-        stop={stop}
         directionId={0}
         schedulesForDirection={schedulesByDirection[0]}
+        predictionsForDirection={predictionsByDirection[0]}
         onClick={onClick}
         alertsForDirection={allAlertsForDirection(alertsForRoute, 0)}
       />
       <DepartureTimes
         key={`${route.id}-1`}
         route={route}
-        stop={stop}
         directionId={1}
         schedulesForDirection={schedulesByDirection[1]}
+        predictionsForDirection={predictionsByDirection[1]}
         onClick={onClick}
         alertsForDirection={allAlertsForDirection(alertsForRoute, 1)}
       />

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from "react";
-import usePredictionsChannel from "../../hooks/usePredictionsChannel";
-import { Alert, DirectionId, Route, Stop } from "../../__v3api";
+import { Alert, DirectionId, Route } from "../../__v3api";
 import renderFa from "../../helpers/render-fa";
 import realtimeIcon from "../../../static/images/icon-realtime-tracking.svg";
 import SVGIcon from "../../helpers/render-svg";
@@ -18,6 +17,7 @@ import {
 } from "../models/displayTimeConfig";
 import { schedulesByHeadsign } from "../../models/schedule";
 import { PredictionWithTimestamp } from "../../models/perdictions";
+import { predictionsByHeadsign } from "../../models/prediction";
 
 const toHighPriorityAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
   if (hasSuspension(alerts)) {
@@ -147,9 +147,9 @@ const getRow = (
 
 interface DepartureTimesProps {
   route: Route;
-  stop: Stop;
   directionId: DirectionId;
   schedulesForDirection: ScheduleWithTimestamp[] | undefined;
+  predictionsForDirection: PredictionWithTimestamp[];
   alertsForDirection: Alert[];
   // override date primarily used for testing
   overrideDate?: Date;
@@ -169,24 +169,18 @@ interface DepartureTimesProps {
  */
 const DepartureTimes = ({
   route,
-  stop,
   directionId,
   schedulesForDirection,
+  predictionsForDirection,
   onClick,
   alertsForDirection,
   overrideDate
 }: DepartureTimesProps): ReactElement<HTMLElement> => {
-  const predictionsByHeadsign = usePredictionsChannel(
-    route.id,
-    stop.id,
-    directionId
-  );
-
   const groupedSchedules = schedulesByHeadsign(schedulesForDirection);
+  const groupedPredictions = predictionsByHeadsign(predictionsForDirection);
   return (
     <>
       {Object.entries(groupedSchedules).map(([headsign, schedules]) => {
-        const predictions = predictionsByHeadsign[headsign] || [];
         return (
           <div
             key={`${headsign}-${route.id}`}
@@ -197,7 +191,7 @@ const DepartureTimes = ({
             {getRow(
               headsign,
               schedules,
-              predictions,
+              groupedPredictions[headsign],
               alertsForDirection,
               overrideDate
             )}

--- a/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../models/route";
 import useVehiclesChannel from "../../hooks/useVehiclesChannel";
 import { Polyline } from "../../leaflet/components/__mapdata";
+import usePredictionsChannel from "../../hooks/usePredictionsChannel";
 
 interface DeparturesAndMapProps {
   routes: Route[];
@@ -39,6 +40,8 @@ const DeparturesAndMap = ({
     departureDirectionId: null,
     departureSchedules: null
   });
+
+  const predictions = usePredictionsChannel({ stopId: stop.id });
 
   const setDepartureVariables: (
     route: Route,
@@ -132,8 +135,8 @@ const DeparturesAndMap = ({
         <div className="stop-routes__all">
           <StopPageDepartures
             routes={routes}
-            stop={stop}
             schedules={schedules}
+            predictions={predictions}
             onClick={setDepartureVariables}
             alerts={alerts}
           />
@@ -177,6 +180,7 @@ const DeparturesAndMap = ({
                 route={departureInfo.departureRoute}
                 stop={stop}
                 schedules={departureInfo.departureSchedules}
+                predictions={predictions}
                 directionId={departureInfo.departureDirectionId}
                 alerts={alerts}
               />

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -1,16 +1,17 @@
 import { groupBy, sortBy } from "lodash";
 import React, { ReactElement, useState } from "react";
-import { Alert, DirectionId, Route, Stop } from "../../__v3api";
+import { Alert, DirectionId, Route } from "../../__v3api";
 import DeparturesFilters, { ModeChoice } from "./DeparturesFilters";
 import { modeForRoute } from "../../models/route";
 import DepartureCard from "./DepartureCard";
 import { ScheduleWithTimestamp } from "../../models/schedules";
 import { alertsByRoute } from "../../models/alert";
+import { PredictionWithTimestamp } from "../../models/perdictions";
 
 interface StopPageDeparturesProps {
   routes: Route[];
-  stop: Stop;
   schedules: ScheduleWithTimestamp[];
+  predictions: PredictionWithTimestamp[];
   onClick: (
     route: Route,
     directionId: DirectionId,
@@ -32,8 +33,8 @@ const modeSortFn = ({ type }: Route): number => {
 
 const StopPageDepartures = ({
   routes,
-  stop,
   schedules,
+  predictions,
   onClick,
   alerts
 }: StopPageDeparturesProps): ReactElement<HTMLElement> => {
@@ -41,6 +42,7 @@ const StopPageDepartures = ({
   const [selectedMode, setSelectedMode] = useState<ModeChoice>("all");
   const groupedRoutes = groupBy(routes, modeForRoute);
   const groupedSchedules = groupBy(schedules, s => s.route.id);
+  const groupedPredictions = groupBy(predictions, p => p.route.id);
   const modesList = Object.keys(groupedRoutes) as ModeChoice[];
   const filteredRoutes =
     selectedMode === "all" ? routes : groupedRoutes[selectedMode];
@@ -60,8 +62,8 @@ const StopPageDepartures = ({
           <DepartureCard
             key={route.id}
             route={route}
-            stop={stop}
             schedulesForRoute={groupedSchedules[route.id]}
+            predictionsForRoute={groupedPredictions[route.id]}
             onClick={onClick}
             // This list should only have one value, is there another way to do this?
             alertsForRoute={groupedAlerts[route.id]}


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
This PR is to move the predictions channel up higher in the tree.  This allows reuse on the `DepartureList` component and stops us having to keep open and closing channels by just interacting with the page.

<!-- Link to relevant Asana task; remove if not applicable -->
No Ticket

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

