### PR TITLE
feat(FareSalesAmenityCard): add info and modal (backend)

### DIFF
--- a/apps/fares/lib/format.ex
+++ b/apps/fares/lib/format.ex
@@ -178,4 +178,9 @@ defmodule Fares.Format do
 
   defp price_range_summary_name(fare, :commuter_rail), do: "Commuter Rail " <> duration(fare)
   defp price_range_summary_name(fare, :ferry), do: "Ferry " <> duration(fare)
+
+  @spec mode_type_for_fare_class(Routes.Route.gtfs_fare_class()) :: mode_type | :unknown
+  def mode_type_for_fare_class(:ferry_fare), do: :ferry
+  def mode_type_for_fare_class(:commuter_rail_fare), do: :commuter_rail
+  def mode_type_for_fare_class(_), do: :bus_subway
 end

--- a/apps/fares/lib/repo.ex
+++ b/apps/fares/lib/repo.ex
@@ -38,4 +38,24 @@ defmodule Fares.Repo do
       (!media || media in fare.media) && match?(^opts, Map.take(fare, Map.keys(opts)))
     end)
   end
+
+  @spec for_fare_class(Routes.Route.gtfs_fare_class(), Keyword.t()) :: [Fare.t()]
+  def for_fare_class(fare_class, opts \\ []) do
+    opts = Keyword.merge(opts, fare_class_opts(fare_class))
+    all(opts)
+  end
+
+  def fare_class_opts(:free_fare), do: [name: :free_fare]
+
+  def fare_class_opts(:express_bus_fare), do: [name: :express_bus]
+
+  def fare_class_opts(:local_bus_fare), do: [name: :local_bus]
+
+  def fare_class_opts(:rapid_transit_fare), do: [mode: :subway]
+
+  def fare_class_opts(:ferry_fare), do: [mode: :ferry]
+
+  def fare_class_opts(:commuter_rail_fare), do: [mode: :commuter_rail]
+
+  def fare_class_opts(_), do: []
 end

--- a/apps/fares/test/repo_test.exs
+++ b/apps/fares/test/repo_test.exs
@@ -254,4 +254,26 @@ defmodule Fares.RepoTest do
                ]
     end
   end
+
+  describe "for_fare_class/1" do
+    test "sets appropriate opts for each fare class" do
+      rapid_transit_fares = Repo.for_fare_class(:rapid_transit_fare)
+      assert Enum.all?(rapid_transit_fares, &(&1.mode == :subway))
+
+      free_fares = Repo.for_fare_class(:free_fare)
+      assert Enum.all?(free_fares, &(&1.name == :free_fare))
+
+      express_bus_fares = Repo.for_fare_class(:express_bus_fare)
+      assert Enum.all?(express_bus_fares, &(&1.name == :express_bus))
+
+      local_bus_fares = Repo.for_fare_class(:local_bus_fare)
+      assert Enum.all?(local_bus_fares, &(&1.name == :local_bus))
+
+      ferry_fares = Repo.for_fare_class(:ferry_fare)
+      assert Enum.all?(ferry_fares, &(&1.mode == :ferry))
+
+      cr_fares = Repo.for_fare_class(:commuter_rail_fare)
+      assert Enum.all?(cr_fares, &(&1.mode == :commuter_rail))
+    end
+  end
 end

--- a/apps/routes/lib/parser.ex
+++ b/apps/routes/lib/parser.ex
@@ -18,7 +18,8 @@ defmodule Routes.Parser do
         direction_attrs(attributes["direction_names"], parse_route_patterns(relationships)),
       direction_destinations:
         direction_attrs(attributes["direction_destinations"], parse_route_patterns(relationships)),
-      description: parse_gtfs_desc(attributes["description"])
+      description: parse_gtfs_desc(attributes["description"]),
+      fare_class: parse_gtfs_fare_class(attributes["fare_class"])
     }
   end
 
@@ -76,6 +77,18 @@ defmodule Routes.Parser do
   defp parse_gtfs_desc("Commuter Bus"), do: :commuter_bus
   defp parse_gtfs_desc("Community Bus"), do: :community_bus
   defp parse_gtfs_desc(_), do: :unknown
+
+  @spec parse_gtfs_fare_class(String.t()) :: Route.gtfs_fare_class()
+  defp parse_gtfs_fare_class(fare_class) when fare_class in ["Inner Express", "Outer Express"],
+    do: :express_bus_fare
+
+  defp parse_gtfs_fare_class("Local Bus"), do: :local_bus_fare
+  defp parse_gtfs_fare_class("Rapid Transit"), do: :rapid_transit_fare
+  defp parse_gtfs_fare_class("Commuter Rail"), do: :commuter_rail_fare
+  defp parse_gtfs_fare_class("Ferry"), do: :ferry_fare
+  defp parse_gtfs_fare_class("Free"), do: :free_fare
+  defp parse_gtfs_fare_class("Special"), do: :special_fare
+  defp parse_gtfs_fare_class(_), do: :unknown_fare
 
   @spec parse_shape(Item.t()) :: [Shape.t()]
   def parse_shape(%Item{id: id, attributes: attributes, relationships: relationships}) do

--- a/apps/routes/lib/route.ex
+++ b/apps/routes/lib/route.ex
@@ -14,6 +14,7 @@ defmodule Routes.Route do
             direction_names: %{0 => "Outbound", 1 => "Inbound"},
             direction_destinations: :unknown,
             description: :unknown,
+            fare_class: :unknown_fare,
             custom_route?: false
 
   @type id_t :: String.t()
@@ -27,6 +28,7 @@ defmodule Routes.Route do
           direction_names: %{0 => String.t() | nil, 1 => String.t() | nil},
           direction_destinations: %{0 => String.t(), 1 => String.t()} | :unknown,
           description: gtfs_route_desc,
+          fare_class: gtfs_fare_class,
           custom_route?: boolean
         }
   @type gtfs_route_type ::
@@ -43,6 +45,15 @@ defmodule Routes.Route do
           | :commuter_bus
           | :community_bus
           | :unknown
+  @type gtfs_fare_class ::
+          :local_bus_fare
+          | :express_bus_fare
+          | :rapid_transit_fare
+          | :commuter_rail_fare
+          | :ferry_fare
+          | :free_fare
+          | :special_fare
+          | :unknown_fare
   @type route_type :: gtfs_route_type | :the_ride
   @type type_int :: 0..4
   @type subway_lines_type :: :orange_line | :red_line | :green_line | :blue_line | :mattapan_line
@@ -251,6 +262,7 @@ defmodule Routes.Route do
         direction_names: direction_names,
         direction_destinations: direction_destinations,
         description: description,
+        fare_class: fare_class,
         custom_route?: custom_route?
       }) do
     direction_destinations_value =
@@ -274,6 +286,7 @@ defmodule Routes.Route do
       },
       direction_destinations: direction_destinations_value,
       description: description,
+      fare_class: fare_class,
       custom_route?: custom_route?
     }
   end

--- a/apps/routes/test/route_test.exs
+++ b/apps/routes/test/route_test.exs
@@ -210,7 +210,8 @@ defmodule Routes.RouteTest do
         name: "Red Line",
         type: 1,
         color: "DA291C",
-        sort_order: 5
+        sort_order: 5,
+        fare_class: :unknown_fare
       }
 
       assert Route.to_json_safe(route) == expected

--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -109,11 +109,22 @@ export interface Prediction {
   departure_time?: Date | null;
 }
 
+export type FareClassType =
+  | "local_bus_fare"
+  | "express_bus_fare"
+  | "rapid_transit_fare"
+  | "commuter_rail_fare"
+  | "ferry_fare"
+  | "free_fare"
+  | "special_fare"
+  | "unknown_fare";
+
 export interface Route {
   color?: string;
   description: string;
   direction_destinations: DirectionInfo;
   direction_names: DirectionInfo;
+  fare_class?: FareClassType;
   id: string;
   long_name: string;
   name: string;

--- a/apps/site/lib/site_web/controllers/fare_controller.ex
+++ b/apps/site/lib/site_web/controllers/fare_controller.ex
@@ -15,6 +15,14 @@ defmodule SiteWeb.FareController do
     nearby_fn: &Fares.RetailLocations.get_nearby/1
   }
 
+  @display_fare_classes [
+    :local_bus_fare,
+    :express_bus_fare,
+    :rapid_transit_fare,
+    :commuter_rail_fare,
+    :ferry_fare
+  ]
+
   def show(conn, %{"id" => "retail-sales-locations"} = params) do
     search_location(conn, params)
   end
@@ -69,6 +77,63 @@ defmodule SiteWeb.FareController do
   def fare_sales_locations(%{}, _nearby_fn) do
     []
   end
+
+  def one_way_by_stop_id(conn, %{"stop_id" => stop_id} = _params) do
+    one_way_fares =
+      stop_id
+      # Get fare_class for all routes at this stop and at connecting stops
+      |> Routes.Repo.by_stop(include: "stop.connecting_stops")
+      |> Enum.map(&display_fare_class/1)
+      |> Enum.uniq()
+      # Sort in same order as @display_fare_classes
+      |> Enum.sort_by(&Enum.find_index(@display_fare_classes, fn fc -> fc == &1 end))
+      |> Enum.flat_map(fn fare_class ->
+        fare_class
+        |> Fares.Repo.for_fare_class(duration: :single_trip, reduced: nil)
+        |> Fares.Format.summarize(Fares.Format.mode_type_for_fare_class(fare_class))
+        |> Enum.map(fn summary ->
+          name =
+            if is_binary(summary.name) do
+              summary.name
+            else
+              Enum.join(summary.name)
+            end
+
+          {String.capitalize(name), Fares.Summary.price_range(summary)}
+        end)
+      end)
+
+    json(conn, one_way_fares)
+  end
+
+  # Use the route mode to determine the display fare. e.g. instead of the 23 bus
+  # showing the free fare, show the bus fare
+  defp display_fare_class(%Routes.Route{id: id, fare_class: fare_class} = route)
+       when fare_class not in @display_fare_classes do
+    if Fares.express?(id) do
+      :express_bus_fare
+    else
+      case Routes.Route.type_atom(route) do
+        :subway ->
+          :rapid_transit_fare
+
+        :bus ->
+          :local_bus_fare
+
+        :commuter_rail ->
+          :commuter_rail_fare
+
+        :ferry ->
+          :ferry_fare
+
+        # probably a shuttle??
+        _ ->
+          :local_bus_fare
+      end
+    end
+  end
+
+  defp display_fare_class(%Routes.Route{fare_class: fare_class}), do: fare_class
 
   defp meta_description(conn, _) do
     conn

--- a/apps/site/lib/site_web/controllers/route_controller.ex
+++ b/apps/site/lib/site_web/controllers/route_controller.ex
@@ -6,18 +6,42 @@ defmodule SiteWeb.RouteController do
   alias Leaflet.MapData.Polyline
   alias Routes.{Repo, Route}
 
+  @display_fare_classes [
+    :local_bus_fare,
+    :express_bus_fare,
+    :rapid_transit_fare,
+    :commuter_rail_fare,
+    :ferry_fare
+  ]
+
   @spec get_by_stop_id(Plug.Conn.t(), map) :: Plug.Conn.t()
   def get_by_stop_id(conn, %{"stop_id" => stop_id} = _params) do
+    routes = stop_id |> Repo.by_stop()
+
     routesWithPolylines =
-      stop_id
-      |> Repo.by_stop()
+      routes
       |> Enum.map(fn route ->
         route
         |> Route.to_json_safe()
         |> Map.put(:polylines, route_polylines(route, stop_id))
       end)
 
-    json(conn, routesWithPolylines)
+    fares =
+      stop_id
+      # Get fare_class for all routes at this stop and at connecting stops
+      |> Repo.by_stop(include: "stop.connecting_stops")
+      |> Enum.map(&display_fare_class/1)
+      |> Enum.uniq()
+      # Sort in same order as @display_fare_classes
+      |> Enum.sort_by(&Enum.find_index(@display_fare_classes, fn fc -> fc == &1 end))
+      |> Enum.map(&Fares.Repo.for_fare_class(&1, duration: :single_trip, reduced: nil))
+      |> Enum.map(fn fares_for_class ->
+        price = price_range(fares_for_class)
+        name = List.first(fares_for_class) |> fare_name()
+        {name, price}
+      end)
+
+    json(conn, %{routes: routesWithPolylines, fares: fares})
   end
 
   defp route_polylines(route, stop_id) do
@@ -25,5 +49,58 @@ defmodule SiteWeb.RouteController do
     |> RoutePatterns.Repo.by_route_id(stop: stop_id)
     |> Enum.filter(&(!is_nil(&1.representative_trip_polyline)))
     |> Enum.map(&Polyline.new(&1, color: "#" <> route.color, weight: 4))
+  end
+
+  # Use the route mode to determine the display fare. e.g. instead of the 23 bus
+  # showing the free fare, show the bus fare
+  defp display_fare_class(%Route{id: id, fare_class: fare_class} = route)
+       when fare_class not in @display_fare_classes do
+    if Fares.express?(id) do
+      :express_bus_fare
+    else
+      case Route.type_atom(route) do
+        :subway ->
+          :rapid_transit_fare
+
+        :bus ->
+          :local_bus_fare
+
+        :commuter_rail ->
+          :commuter_rail_fare
+
+        :ferry ->
+          :ferry_fare
+
+        # probably a shuttle??
+        _ ->
+          :local_bus_fare
+      end
+    end
+  end
+
+  defp display_fare_class(%Route{fare_class: fare_class}), do: fare_class
+
+  defp price_range(fares) do
+    {min_price, max_price} = Enum.min_max_by(fares, & &1.cents)
+
+    if min_price == max_price do
+      Fares.Format.price(min_price)
+    else
+      "#{Fares.Format.price(min_price)} – #{Fares.Format.price(max_price)}"
+    end
+  end
+
+  defp fare_name(%Fares.Fare{mode: :commuter_rail}) do
+    "Commuter rail one-way"
+  end
+
+  defp fare_name(%Fares.Fare{mode: :ferry}) do
+    "Ferry one-way"
+  end
+
+  defp fare_name(fare) do
+    Fares.Format.name(fare)
+    |> String.capitalize()
+    |> String.replace_suffix("", " one-way")
   end
 end

--- a/apps/site/lib/site_web/controllers/route_controller.ex
+++ b/apps/site/lib/site_web/controllers/route_controller.ex
@@ -6,42 +6,18 @@ defmodule SiteWeb.RouteController do
   alias Leaflet.MapData.Polyline
   alias Routes.{Repo, Route}
 
-  @display_fare_classes [
-    :local_bus_fare,
-    :express_bus_fare,
-    :rapid_transit_fare,
-    :commuter_rail_fare,
-    :ferry_fare
-  ]
-
   @spec get_by_stop_id(Plug.Conn.t(), map) :: Plug.Conn.t()
   def get_by_stop_id(conn, %{"stop_id" => stop_id} = _params) do
-    routes = stop_id |> Repo.by_stop()
-
     routesWithPolylines =
-      routes
+      stop_id
+      |> Repo.by_stop()
       |> Enum.map(fn route ->
         route
         |> Route.to_json_safe()
         |> Map.put(:polylines, route_polylines(route, stop_id))
       end)
 
-    fares =
-      stop_id
-      # Get fare_class for all routes at this stop and at connecting stops
-      |> Repo.by_stop(include: "stop.connecting_stops")
-      |> Enum.map(&display_fare_class/1)
-      |> Enum.uniq()
-      # Sort in same order as @display_fare_classes
-      |> Enum.sort_by(&Enum.find_index(@display_fare_classes, fn fc -> fc == &1 end))
-      |> Enum.map(&Fares.Repo.for_fare_class(&1, duration: :single_trip, reduced: nil))
-      |> Enum.map(fn fares_for_class ->
-        price = price_range(fares_for_class)
-        name = List.first(fares_for_class) |> fare_name()
-        {name, price}
-      end)
-
-    json(conn, %{routes: routesWithPolylines, fares: fares})
+    json(conn, routesWithPolylines)
   end
 
   defp route_polylines(route, stop_id) do
@@ -49,58 +25,5 @@ defmodule SiteWeb.RouteController do
     |> RoutePatterns.Repo.by_route_id(stop: stop_id)
     |> Enum.filter(&(!is_nil(&1.representative_trip_polyline)))
     |> Enum.map(&Polyline.new(&1, color: "#" <> route.color, weight: 4))
-  end
-
-  # Use the route mode to determine the display fare. e.g. instead of the 23 bus
-  # showing the free fare, show the bus fare
-  defp display_fare_class(%Route{id: id, fare_class: fare_class} = route)
-       when fare_class not in @display_fare_classes do
-    if Fares.express?(id) do
-      :express_bus_fare
-    else
-      case Route.type_atom(route) do
-        :subway ->
-          :rapid_transit_fare
-
-        :bus ->
-          :local_bus_fare
-
-        :commuter_rail ->
-          :commuter_rail_fare
-
-        :ferry ->
-          :ferry_fare
-
-        # probably a shuttle??
-        _ ->
-          :local_bus_fare
-      end
-    end
-  end
-
-  defp display_fare_class(%Route{fare_class: fare_class}), do: fare_class
-
-  defp price_range(fares) do
-    {min_price, max_price} = Enum.min_max_by(fares, & &1.cents)
-
-    if min_price == max_price do
-      Fares.Format.price(min_price)
-    else
-      "#{Fares.Format.price(min_price)} – #{Fares.Format.price(max_price)}"
-    end
-  end
-
-  defp fare_name(%Fares.Fare{mode: :commuter_rail}) do
-    "Commuter rail one-way"
-  end
-
-  defp fare_name(%Fares.Fare{mode: :ferry}) do
-    "Ferry one-way"
-  end
-
-  defp fare_name(fare) do
-    Fares.Format.name(fare)
-    |> String.capitalize()
-    |> String.replace_suffix("", " one-way")
   end
 end

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -217,6 +217,7 @@ defmodule SiteWeb.Router do
     get("/stop/:id", StopController, :get)
     get("/map-config", MapConfigController, :get)
     get("/routes/by-stop/:stop_id", RouteController, :get_by_stop_id)
+    get("/fares/one-way/by-stop/:stop_id", FareController, :one_way_by_stop_id)
   end
 
   scope "/places", SiteWeb do

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -217,7 +217,7 @@ defmodule SiteWeb.Router do
     get("/stop/:id", StopController, :get)
     get("/map-config", MapConfigController, :get)
     get("/routes/by-stop/:stop_id", RouteController, :get_by_stop_id)
-    get("/fares/one-way/by-stop/:stop_id", FareController, :one_way_by_stop_id)
+    get("/fares/one-way", FareController, :one_way_by_stop_id)
   end
 
   scope "/places", SiteWeb do

--- a/apps/site/test/site/realtime_schedule_test.exs
+++ b/apps/site/test/site/realtime_schedule_test.exs
@@ -282,7 +282,8 @@ defmodule Site.RealtimeScheduleTest do
           name: "Orange Line",
           type: 1,
           color: "ED8B00",
-          sort_order: 99_999
+          sort_order: 99_999,
+          fare_class: :unknown_fare
         }
       }
     ]

--- a/apps/site/test/site_web/controllers/fare_controller_test.exs
+++ b/apps/site/test/site_web/controllers/fare_controller_test.exs
@@ -92,7 +92,7 @@ defmodule SiteWeb.FareControllerTest do
           ]
         end
       ) do
-        conn = get(conn, fare_path(conn, :one_way_by_stop_id, "stop_id"))
+        conn = get(conn, fare_path(conn, :one_way_by_stop_id, %{"stop_id" => "stop_id"}))
         fares_response = json_response(conn, 200)
 
         assert fares_response == [

--- a/apps/site/test/site_web/controllers/route_controller_test.exs
+++ b/apps/site/test/site_web/controllers/route_controller_test.exs
@@ -13,6 +13,12 @@ defmodule SiteWeb.RouteControllerTest do
            %Route{id: "subway_route", color: "ADFF2F", type: 0},
            %Route{id: "746", name: "SL route", color: "ADFF2F", type: 3}
          ]
+       end,
+       by_stop: fn _, _ ->
+         [
+           %Route{fare_class: :ferry_fare},
+           %Route{fare_class: :local_bus_fare}
+         ]
        end
      ]},
     {RoutePatterns.Repo, [],
@@ -30,15 +36,15 @@ defmodule SiteWeb.RouteControllerTest do
   end
 
   describe "get_by_stop_id/2" do
-    test "returns routes with polyline data", %{conn: conn} do
+    test "returns routes with polyline data and fares", %{conn: conn} do
       conn = get(conn, route_path(conn, :get_by_stop_id, "stop_id"))
-      response = json_response(conn, 200)
+      %{"routes" => routes_response, "fares" => fares_response} = json_response(conn, 200)
 
       assert [
                %{"id" => "route", "color" => "ADFF2F", "polylines" => polylines},
                %{"id" => "subway_route", "color" => "ADFF2F", "polylines" => subway_polylines},
                %{"id" => "746", "color" => "ADFF2F", "polylines" => sl_polylines}
-             ] = response
+             ] = routes_response
 
       assert [
                %{
@@ -51,6 +57,11 @@ defmodule SiteWeb.RouteControllerTest do
 
       assert Enum.count(subway_polylines) > 0
       assert Enum.count(sl_polylines) > 0
+
+      assert fares_response == [
+               ["Local bus one-way", "$1.70"],
+               ["Ferry one-way", "$2.40 – $9.75"]
+             ]
     end
   end
 end

--- a/apps/site/test/site_web/controllers/route_controller_test.exs
+++ b/apps/site/test/site_web/controllers/route_controller_test.exs
@@ -13,12 +13,6 @@ defmodule SiteWeb.RouteControllerTest do
            %Route{id: "subway_route", color: "ADFF2F", type: 0},
            %Route{id: "746", name: "SL route", color: "ADFF2F", type: 3}
          ]
-       end,
-       by_stop: fn _, _ ->
-         [
-           %Route{fare_class: :ferry_fare},
-           %Route{fare_class: :local_bus_fare}
-         ]
        end
      ]},
     {RoutePatterns.Repo, [],
@@ -38,13 +32,13 @@ defmodule SiteWeb.RouteControllerTest do
   describe "get_by_stop_id/2" do
     test "returns routes with polyline data and fares", %{conn: conn} do
       conn = get(conn, route_path(conn, :get_by_stop_id, "stop_id"))
-      %{"routes" => routes_response, "fares" => fares_response} = json_response(conn, 200)
+      response = json_response(conn, 200)
 
       assert [
                %{"id" => "route", "color" => "ADFF2F", "polylines" => polylines},
                %{"id" => "subway_route", "color" => "ADFF2F", "polylines" => subway_polylines},
                %{"id" => "746", "color" => "ADFF2F", "polylines" => sl_polylines}
-             ] = routes_response
+             ] = response
 
       assert [
                %{
@@ -57,11 +51,6 @@ defmodule SiteWeb.RouteControllerTest do
 
       assert Enum.count(subway_polylines) > 0
       assert Enum.count(sl_polylines) > 0
-
-      assert fares_response == [
-               ["Local bus one-way", "$1.70"],
-               ["Ferry one-way", "$2.40 – $9.75"]
-             ]
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

The corresponding front-end work is in #1658 

**Asana Ticket:** [Amenity Modal | Fare Sales](https://app.asana.com/0/385363666817452/1204415037587451/f)
(There was no separate Asana ticket for the card content, but that work is in this PR too).

Inadvertently covers:
**Asana Ticket:** [Create list of all fare classes as shown in API](https://app.asana.com/0/385363666817452/1204827964810515/f)


* Adds support for parsing a route's `fare_class`. I deduced the valid values for this field by finding [the source code in `gtfs_creator`](https://github.com/mbta/gtfs_creator/blob/e031d3618840c4f33f62c7c4541140b621efa547/gtfs_creator2/validate.py#L504) 🙃 
  * Adds support for this field in the front-end too, but makes it optional so that I don't have to change 40+ TypeScript files... looks like that's we did for the route's `color` too.
* Adds a function to `Fares.Repo` to make it easier to retrieve the relevant `%Fares.Fare{}` objects for a specific `fare_class` value.
* In our Route controller's `get_by_stop_id/2` function, I added the route-derived fares information to the response, so that I could show those values in the front-end table.
  * Instead of using the same routes shown in the departures list, I also include routes at connecting stops. This produced better results at larger multi-modal stations, e.g. at Haymarket station we'll see local bus and express bus fares that technically apply to the adjacent bus stop; at Aquarium station we'll see the ferry fare at the adjacent terminal, and so on.
<img width="689" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/0b1375d6-d19c-44a2-89af-c83a6d8d9919">

  * I have some logic masking the effect of routes with free or special fares. This produced better results because we don't have prices for special fares anyway, and for the moment don't want to show "Free fare $0.00" in our table. For these cases, we inspect the route and try to determine its appropriate "typical" fare based on mode. (The stop below is only served by the currently-free 23 bus):
<img width="869" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/0869d317-c769-4578-b892-f26b88473ca7">

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
