### PR TITLE
feat(FareSalesAmenityCard): add info and modal (frontend)

### DIFF
--- a/apps/site/assets/css/_amenity.scss
+++ b/apps/site/assets/css/_amenity.scss
@@ -14,6 +14,24 @@
   .c-modal__close {
     margin: .65rem;
   }
+
+  .fare-sales-table {
+    border: $border;
+    width: 100%;
+
+    thead tr {
+      @extend %table-header;
+    }
+
+    th,
+    td {
+      padding: $base-spacing calc(#{$grid-gutter-width} / 2);
+    }
+
+    tbody tr:nth-of-type(even) {
+      background-color: $gray-bordered-background;
+    }
+  }
 }
 
 .access-amenities-header {
@@ -23,12 +41,12 @@
   height: 3.75rem;
 }
 
-tr:nth-child(2n+3) {
-  background-color: $gray-lightest;
-}
-
 .access-amenities-row {
   height: 4rem;
+
+  &:nth-child(2n+3) {
+    background-color: $gray-lightest;
+  }
 }
 
 .status {

--- a/apps/site/assets/ts/hooks/__tests__/useFetchTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/useFetchTest.tsx
@@ -1,0 +1,63 @@
+import { renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { SWRConfig } from "swr";
+import useFetch from "../useFetch";
+import { FetchStatus } from "../../helpers/use-fetch";
+
+const unmockedFetch = global.fetch;
+const HookWrapper: React.FC = ({ children }) => (
+  <SWRConfig value={{ dedupingInterval: 0 }}>{children}</SWRConfig>
+);
+
+describe("useFetch", () => {
+  beforeEach(() => {
+    // provide mocked network response
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve: Function) =>
+          resolve({
+            json: () => [1, 2, 3],
+            ok: true,
+            status: 200,
+            statusText: "OK"
+          })
+        )
+    );
+  });
+
+  it("should return data", async () => {
+    const { result, waitFor } = renderHook(
+      () => useFetch<number[]>("/api/something"),
+      { wrapper: HookWrapper }
+    );
+    await waitFor(() =>
+      expect(result.current.status).toEqual(FetchStatus.Data)
+    );
+    await waitFor(() => {
+      expect(result.current.data).toEqual([1, 2, 3]);
+    });
+  });
+
+  it("returns error status if API returns an error", async () => {
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve: Function) =>
+          resolve({
+            json: () => [],
+            ok: false,
+            status: 500,
+            statusText: "ERROR"
+          })
+        )
+    );
+    const { result, waitFor } = renderHook(
+      () => useFetch<number[]>("/api/something"),
+      { wrapper: HookWrapper }
+    );
+    await waitFor(() => expect(result.current.status).toBe(FetchStatus.Error));
+  });
+
+  afterAll(() => {
+    global.fetch = unmockedFetch;
+  });
+});

--- a/apps/site/assets/ts/hooks/useFetch.ts
+++ b/apps/site/assets/ts/hooks/useFetch.ts
@@ -1,0 +1,25 @@
+import useSWR from "swr";
+import { fetchJsonOrThrow } from "../helpers/fetch-json";
+import { FetchState, FetchStatus } from "../helpers/use-fetch";
+
+/**
+ * Generic helper function for fetching JSON from a URL. Specify the expected
+ * return type as the type parameter, e.g
+ * `useFetch<Schedule[]>("/api/schedules/or/something")`
+ * @param {string} backendUrl - The path, usually starting with /api/, that our
+ * backend will respond with data from.
+ * @returns {{ status: FetchStatus, data: T }} An object containing the fetch
+ * status, and the returned data.
+ */
+const useFetch = <T>(backendPath: string): FetchState<T> => {
+  const { data, error } = useSWR<T>(
+    backendPath,
+    async (url: string): Promise<T> => fetchJsonOrThrow(url)
+  );
+  if (error) {
+    return { status: FetchStatus.Error };
+  }
+  return { status: FetchStatus.Data, data };
+};
+
+export default useFetch;

--- a/apps/site/assets/ts/stop/__tests__/DeparturesAndMapTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DeparturesAndMapTest.tsx
@@ -72,12 +72,17 @@ const v2 = {
 const testRoutesWithPolylines: RouteWithPolylines[] = [
   routeWithPolylines("SomeBus", 3, 0)
 ];
-jest
-  .spyOn(useRoute, "useRoutesByStop")
-  .mockReturnValue({ status: FetchStatus.Data, data: testRoutesWithPolylines });
 
-beforeEach(() => {
+beforeAll(() => {
   jest.spyOn(useVehiclesChannel, "default").mockReturnValue([]);
+  jest.spyOn(useRoute, "useRoutesByStop").mockReturnValue({
+    status: FetchStatus.Data,
+    data: testRoutesWithPolylines
+  });
+});
+
+afterAll(() => {
+  jest.resetAllMocks();
 });
 
 describe("DeparturesAndMap", () => {

--- a/apps/site/assets/ts/stop/__tests__/DeparturesAndMapTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DeparturesAndMapTest.tsx
@@ -6,6 +6,7 @@ import { DirectionId, Stop } from "../../__v3api";
 import { RouteWithPolylines } from "../../hooks/useRoute";
 import { baseRoute, routeWithPolylines } from "./helpers";
 import * as useRoute from "../../hooks/useRoute";
+import * as useSchedules from "../../hooks/useSchedules";
 import { ScheduleWithTimestamp } from "../../models/schedules";
 import { add } from "date-fns";
 import * as useVehiclesChannel from "../../hooks/useVehiclesChannel";
@@ -73,12 +74,15 @@ const testRoutesWithPolylines: RouteWithPolylines[] = [
   routeWithPolylines("SomeBus", 3, 0)
 ];
 
-beforeAll(() => {
-  jest.spyOn(useVehiclesChannel, "default").mockReturnValue([]);
+beforeEach(() => {
+  jest
+    .spyOn(useSchedules, "useSchedulesByStop")
+    .mockReturnValue({ status: FetchStatus.Data, data: schedules });
   jest.spyOn(useRoute, "useRoutesByStop").mockReturnValue({
     status: FetchStatus.Data,
     data: testRoutesWithPolylines
   });
+  jest.spyOn(useVehiclesChannel, "default").mockReturnValue([]);
 });
 
 afterAll(() => {

--- a/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
@@ -3,16 +3,14 @@ import { screen, within } from "@testing-library/dom";
 import { render } from "@testing-library/react";
 import StopPageRedesign from "../components/StopPageRedesign";
 import * as useStop from "../../hooks/useStop";
-import { Stop, ParkingLot, InformedEntitySet, Alert } from "../../__v3api";
+import { InformedEntitySet, Alert } from "../../__v3api";
 import * as useRoute from "../../hooks/useRoute";
-import { newLatOrLon, routeWithPolylines } from "./helpers";
+import { customStop, newLatOrLon, routeWithPolylines } from "./helpers";
 import { RouteWithPolylines } from "../../hooks/useRoute";
 import * as useSchedules from "../../hooks/useSchedules";
 import * as useAlerts from "../../hooks/useAlerts";
 import { add, format } from "date-fns";
 import { FetchStatus } from "../../helpers/use-fetch";
-import { gl } from "date-fns/locale";
-import ReactDOMServer from "react-dom/server";
 
 describe("StopPageRedesign", () => {
   beforeEach(() => {
@@ -37,14 +35,13 @@ describe("StopPageRedesign", () => {
 
     jest.spyOn(useStop, "useStop").mockReturnValue({
       status: FetchStatus.Data,
-      data: {
+      data: customStop({
         id: "123",
         name: "Test Stop",
-        parking_lots: [] as ParkingLot[],
         accessibility: ["ramp"],
         latitude: newLatOrLon(),
         longitude: newLatOrLon()
-      } as Stop
+      })
     });
   });
 

--- a/apps/site/assets/ts/stop/__tests__/components/StationInformationTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/StationInformationTest.tsx
@@ -1,22 +1,22 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import StationInformation from "../../components/StationInformation";
-import { ParkingLot, Stop } from "../../../__v3api";
+import { customStop } from "../helpers";
 
-const stationStop = {
+const stationStop = customStop({
   name: "First Station",
   "station?": true,
   bike_storage: ["bike_storage_rack"],
   accessibility: ["accessible", "ramp"],
-  parking_lots: [] as ParkingLot[]
-} as Stop;
-const busStop = {
+  "has_fare_machine?": true
+});
+const busStop = customStop({
   name: "Second Pl",
   "station?": false,
   bike_storage: ["bike_storage_rack"],
-  accessibility: ["accessible", "ramp"],
-  parking_lots: [] as ParkingLot[]
-} as Stop;
+  accessibility: ["accessible"],
+  "has_fare_machine?": false
+});
 
 describe("StationInformation", () => {
   it("should have headings", () => {

--- a/apps/site/assets/ts/stop/__tests__/components/amenities/FareSalesAmenityCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/amenities/FareSalesAmenityCardTest.tsx
@@ -1,10 +1,68 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import FareSalesAmenityCard from "../../../components/amenities/FareSalesAmenityCard";
+import { customStop } from "../../helpers";
+import * as useFetch from "../../../../hooks/useFetch";
+import { FetchStatus } from "../../../../helpers/use-fetch";
 
+const testFaresData = [
+  ["Spaceship one-way", "$9999"],
+  ["Scooter one-way", "$2.11"]
+];
+
+beforeAll(() => {
+  jest
+    .spyOn(useFetch, "default")
+    .mockReturnValue({ status: FetchStatus.Data, data: testFaresData });
+});
+
+afterAll(() => {
+  jest.resetAllMocks();
+});
+
+const stopWithVendingMachine = customStop({
+  name: "Station Name",
+  "has_fare_machine?": true
+});
+const stopWithoutVendingMachine = customStop({});
 describe("FareSalesAmenityCard", () => {
-  it("should render the title", () => {
-    render(<FareSalesAmenityCard />);
+  it("should render the title and description", () => {
+    render(<FareSalesAmenityCard stop={stopWithVendingMachine} />);
     expect(screen.getByText("Fare Sales")).toBeDefined();
+    expect(
+      screen.getByText("Purchase fares at fare vending machines.")
+    ).toBeDefined();
+    screen.getByRole("button").click(); // open modal
+    expect(
+      screen.getByRole("heading", { name: "Fare Options at Station Name" })
+    ).toBeDefined();
+    expect(screen.getByRole("heading", { name: "Fare Types" })).toBeDefined();
+    expect(
+      screen.getByRole("heading", { name: "Fare Vending Machines" })
+    ).toBeDefined();
+  });
+
+  it("should render different description for stops without vending machine", () => {
+    render(<FareSalesAmenityCard stop={stopWithoutVendingMachine} />);
+    expect(screen.getByText("Fare Sales")).toBeDefined();
+    expect(
+      screen.getByText("Purchase fares at nearby retail sales locations.")
+    ).toBeDefined();
+    screen.getByRole("button").click(); // open modal
+    expect(
+      screen.getByRole("heading", { name: "Fare Retail Locations" })
+    ).toBeDefined();
+  });
+
+  it("should render a table with fares", () => {
+    render(<FareSalesAmenityCard stop={stopWithoutVendingMachine} />);
+    screen.getByRole("button").click(); // open modal
+    expect(screen.getByRole("heading", { name: "Fare Types" })).toBeDefined();
+    const table = screen.getByRole("table");
+    expect(table).toBeDefined();
+    const rows = within(table).getAllByRole("row");
+    expect(rows).toHaveLength(testFaresData.length + 1); // +1 for header row
+    expect(rows[1].textContent).toContain("Spaceship one-way$9999");
+    expect(rows[2].textContent).toContain("Scooter one-way$2.11");
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/helpers.ts
+++ b/apps/site/assets/ts/stop/__tests__/helpers.ts
@@ -1,7 +1,15 @@
 import { faker } from "@faker-js/faker";
 import { uniqueId } from "lodash";
 import { Polyline } from "../../leaflet/components/__mapdata";
-import { Route, RouteType } from "../../__v3api";
+import {
+  AccessibilityType,
+  BikeStorageType,
+  FareFacilityType,
+  ParkingLot,
+  Route,
+  RouteType,
+  Stop
+} from "../../__v3api";
 import { RouteWithPolylines } from "../../hooks/useRoute";
 
 export const newLatOrLon = (): number => +faker.string.numeric(2);
@@ -36,3 +44,25 @@ export const routeWithPolylines = (
     polylines
   };
 };
+
+const defaultStop: Stop = {
+  accessibility: [] as AccessibilityType[],
+  address: faker.location.streetAddress(),
+  bike_storage: [] as BikeStorageType[],
+  closed_stop_info: null,
+  "has_charlie_card_vendor?": false,
+  "has_fare_machine?": false,
+  fare_facilities: [] as FareFacilityType[],
+  id: "stopId",
+  "is_child?": false,
+  latitude: 42.460574,
+  longitude: -71.457804,
+  municipality: "Boston",
+  name: "Stop Name",
+  note: null,
+  parking_lots: [] as ParkingLot[],
+  "station?": false,
+  type: "stop"
+};
+export const customStop = (args: Partial<Stop>): Stop =>
+  Object.assign({}, defaultStop, args);

--- a/apps/site/assets/ts/stop/components/StationInformation.tsx
+++ b/apps/site/assets/ts/stop/components/StationInformation.tsx
@@ -74,7 +74,7 @@ const StationInformation = ({
           isStation={isStation}
         />
         {isStation && <h3 className="hidden-md-up">Purchasing Fares</h3>}
-        <FareSalesAmenityCard />
+        <FareSalesAmenityCard stop={stop} />
       </div>
     </div>
   );

--- a/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/AmenityCard.tsx
@@ -43,6 +43,23 @@ export const AmenityLink = ({
   </p>
 );
 
+export const AmenityImage = ({
+  src,
+  altText,
+  className = "mt-1 mb-1"
+}: {
+  src: string;
+  altText: string;
+  className?: string;
+}): JSX.Element => (
+  <img
+    className={`img-fluid ${className}`}
+    src={src}
+    alt={altText}
+    style={{ maxHeight: "250px" }}
+  />
+);
+
 const AmenityCard = ({
   headerText,
   icon,

--- a/apps/site/assets/ts/stop/components/amenities/BikeStorageAmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/BikeStorageAmenityCard.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import AmenityCard, { AmenityLink, AmenityModal } from "./AmenityCard";
+import AmenityCard, {
+  AmenityImage,
+  AmenityLink,
+  AmenityModal
+} from "./AmenityCard";
 import { bikeIcon } from "../../../helpers/icon";
 import { Alert, BikeStorageType } from "../../../__v3api";
 import Alerts from "../../../components/Alerts";
@@ -58,11 +62,10 @@ const BikeStorageAmenityCard = ({
             {hasBikeFacilityAlert && <Alerts alerts={alerts} />}
             <h2 className="h3 mt-8">Facility Information</h2>
             {hasPedalAndPark && (
-              <img
-                className="img-fluid mt-8 mb-1"
+              <AmenityImage
+                className="mt-8 mb-1"
                 src="https://cdn.mbta.com/sites/default/files/styles/max_2600x2600/public/media/2020-07/bike-parking-back-bay.jpg"
-                alt="MBTA Pedal and Park bike storage"
-                style={{ maxHeight: "250px" }}
+                altText="MBTA Pedal and Park bike storage"
               />
             )}
             <ul>

--- a/apps/site/assets/ts/stop/components/amenities/FareSalesAmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/FareSalesAmenityCard.tsx
@@ -89,7 +89,7 @@ const FareSalesAmenityCard = ({ stop }: { stop: Stop }): JSX.Element => {
   const icon = faresIcon("c-svg__icon");
   const hasFareVendingMachine = stop["has_fare_machine?"];
   const faresData = useFetch<[string, string][]>(
-    `/api/fares/one-way/by-stop/${stop.id}`
+    `/api/fares/one-way?stop_id=${stop.id}`
   );
 
   return (

--- a/apps/site/assets/ts/stop/components/amenities/FareSalesAmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/FareSalesAmenityCard.tsx
@@ -16,8 +16,8 @@ const FareRetailLocations = (stop: Stop): JSX.Element => (
         href={`/fares/retail-sales-locations?location[address]=${stop.address}&location[latitude]=${stop.latitude}&location[longitude]=${stop.longitude}`}
       >
         nearby retail location
-      </a>
-      .
+      </a>{" "}
+      or pay with cash on any bus.
     </p>
   </>
 );
@@ -25,6 +25,12 @@ const FareRetailLocations = (stop: Stop): JSX.Element => (
 const FareVendingMachines = (): JSX.Element => (
   <>
     <h2 className="h3 mb-8">Fare Vending Machines</h2>
+    <img
+      className="img-fluid mt-1 mb-1"
+      src="https://cdn.mbta.com/sites/default/files/styles/max_2600x2600/public/media/2021-11/Fare-Transformation-new-fvms-Nov2021.jpg"
+      alt="MBTA fare vending machines"
+      style={{ maxHeight: "250px" }}
+    />
     <p className="mt-0 mb-0">At fare vending machines, you can:</p>
     <ul>
       <li>Purchase a CharlieCard or reload an existing one</li>

--- a/apps/site/assets/ts/stop/components/amenities/FareSalesAmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/FareSalesAmenityCard.tsx
@@ -1,13 +1,114 @@
 import React from "react";
-import AmenityCard from "./AmenityCard";
+import AmenityCard, { AmenityLink, AmenityModal } from "./AmenityCard";
 import { faresIcon } from "../../../helpers/icon";
+import { Stop } from "../../../__v3api";
+import useFetch from "../../../hooks/useFetch";
+import { FetchState, FetchStatus } from "../../../helpers/use-fetch";
+import Loading from "../../../components/Loading";
 
-const FareSalesAmenityCard = (): JSX.Element => {
-  const icon = (
-    <span className="m-stop-page__icon">{faresIcon("c-svg__icon")}</span>
+const FareRetailLocations = (stop: Stop): JSX.Element => (
+  <>
+    <h2 className="h3 mb-8">Fare Retail Locations</h2>
+    <p className="mt-0">
+      This stop does not have fare vending machines, but you can purchase fares
+      at a{" "}
+      <a
+        href={`/fares/retail-sales-locations?location[address]=${stop.address}&location[latitude]=${stop.latitude}&location[longitude]=${stop.longitude}`}
+      >
+        nearby retail location
+      </a>
+      .
+    </p>
+  </>
+);
+
+const FareVendingMachines = (): JSX.Element => (
+  <>
+    <h2 className="h3 mb-8">Fare Vending Machines</h2>
+    <p className="mt-0 mb-0">At fare vending machines, you can:</p>
+    <ul>
+      <li>Purchase a CharlieCard or reload an existing one</li>
+      <li>Purchase tappable CharlieTickets</li>
+    </ul>
+    <p className="mt-0 mb-0">You can pay for your fare with:</p>
+    <ul>
+      <li>Apple Pay</li>
+      <li>Google Pay</li>
+      <li>Samsung Pay</li>
+      <li>Credit/debit cards</li>
+      <li>EBT card</li>
+      <li>Cash</li>
+    </ul>
+  </>
+);
+
+const fareTable = (tableData: [string, string][]): React.ReactElement => (
+  <>
+    <h2 id="fare-types" className="h3 mt-8">
+      Fare Types
+    </h2>
+    <table aria-labelledby="fare-types" className="fare-sales-table">
+      <thead>
+        <tr>
+          <th scope="col">Trip Type</th>
+          <th scope="col">Cost</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tableData.map(([name, price]) => (
+          <tr key={name}>
+            <td>{name}</td>
+            <td>{price}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </>
+);
+
+const renderFareTable = ({
+  status,
+  data
+}: FetchState<[string, string][]>): React.ReactElement | null => {
+  switch (status) {
+    case FetchStatus.Loading:
+      return <Loading />;
+    default:
+      if (data && data.length > 0) return fareTable(data);
+      return null;
+  }
+};
+
+const FareSalesAmenityCard = ({ stop }: { stop: Stop }): JSX.Element => {
+  const icon = faresIcon("c-svg__icon");
+  const hasFareVendingMachine = stop["has_fare_machine?"];
+  const faresData = useFetch<[string, string][]>(
+    `/api/fares/one-way/by-stop/${stop.id}`
   );
 
-  return <AmenityCard headerText="Fare Sales" icon={icon} />;
+  return (
+    <AmenityCard
+      headerText="Fare Sales"
+      icon={icon}
+      modalContent={
+        <AmenityModal headerText={`Fare Options at ${stop.name}`}>
+          {renderFareTable(faresData)}
+          {hasFareVendingMachine
+            ? FareVendingMachines()
+            : FareRetailLocations(stop)}
+          <AmenityLink url="/fares" text="Learn more about fares" />
+          <AmenityLink
+            url="/fares/reduced"
+            text="Learn about reduced fares and eligibility"
+          />
+        </AmenityModal>
+      }
+    >
+      {hasFareVendingMachine
+        ? "Purchase fares at fare vending machines."
+        : "Purchase fares at nearby retail sales locations."}
+    </AmenityCard>
+  );
 };
 
 export default FareSalesAmenityCard;

--- a/apps/site/assets/ts/stop/components/amenities/FareSalesAmenityCard.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/FareSalesAmenityCard.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import AmenityCard, { AmenityLink, AmenityModal } from "./AmenityCard";
+import AmenityCard, {
+  AmenityImage,
+  AmenityLink,
+  AmenityModal
+} from "./AmenityCard";
 import { faresIcon } from "../../../helpers/icon";
 import { Stop } from "../../../__v3api";
 import useFetch from "../../../hooks/useFetch";
@@ -25,11 +29,9 @@ const FareRetailLocations = (stop: Stop): JSX.Element => (
 const FareVendingMachines = (): JSX.Element => (
   <>
     <h2 className="h3 mb-8">Fare Vending Machines</h2>
-    <img
-      className="img-fluid mt-1 mb-1"
+    <AmenityImage
       src="https://cdn.mbta.com/sites/default/files/styles/max_2600x2600/public/media/2021-11/Fare-Transformation-new-fvms-Nov2021.jpg"
-      alt="MBTA fare vending machines"
-      style={{ maxHeight: "250px" }}
+      altText="MBTA fare vending machines"
     />
     <p className="mt-0 mb-0">At fare vending machines, you can:</p>
     <ul>


### PR DESCRIPTION
#### Summary of changes

The front-end piece of #1654 

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Amenity Modal | Fare Sales](https://app.asana.com/0/385363666817452/1204415037587451/f)

- Some refactoring to account for the changed data structure now including fares
- Made a helper method for scaffolding a Stop for our tests.
- Added the modal content and amenity card text. Shows either information about fare vending machines or a link to view retail sales locations.
- Used styling from `.responsive-table` as a reference for the CSS (but couldn't copy it outright... too many differences)
