### PR TITLE
feat: route RSS path to StaticFileController

### DIFF
--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -121,6 +121,7 @@ defmodule SiteWeb.Router do
     get("/events/*path_params", EventController, :show)
 
     get("/news", NewsEntryController, :index)
+    get("/news/rss.xml", StaticFileController, :index)
     get("/news/*path_params", NewsEntryController, :show)
 
     get("/projects", ProjectController, :index)


### PR DESCRIPTION
> **Note**
> There's a corresponding open PR at https://github.com/mbta/devops/pull/1028 that will add an endpoint to our prod CDN to the news RSS feed via the `/news/rss.xml` URL. This was already done on our dev CDN a few weeks ago. What this means is this can be tested on dev now, but won't work on prod until the linked open PR is merged and applied.

Our router normally takes this request to the `NewsEntryController`, which predictably fails to fetch a news entry and leads to a 404 page. This one-line change redirects requests to `/news/rss.xml` to the CDN directly via our existing `StaticFileController`.

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Drupal News RSS Feed](https://app.asana.com/0/385363666817452/1204747418355403/f)
