### PR TITLE
Switch AWS Location Service provider to Esri

### DIFF
--- a/apps/location_service/lib/aws_location/request.ex
+++ b/apps/location_service/lib/aws_location/request.ex
@@ -56,9 +56,9 @@ defmodule AWSLocation.Request do
 
   defp place_index_path(:text), do: place_index_base("esri") <> "/search/text"
 
-  defp place_index_path(:position), do: place_index_base("here") <> "/search/position"
+  defp place_index_path(:position), do: place_index_base("esri") <> "/search/position"
 
-  defp place_index_path(:suggestions), do: place_index_base("here") <> "/search/suggestions"
+  defp place_index_path(:suggestions), do: place_index_base("esri") <> "/search/suggestions"
 
   defp place_index_base(data_provider) when data_provider in ["esri", "here"] do
     {:system, env_var, default} = Application.get_env(:location_service, :aws_index_prefix)

--- a/apps/location_service/test/aws_location/request_test.exs
+++ b/apps/location_service/test/aws_location/request_test.exs
@@ -38,7 +38,7 @@ defmodule AWSLocation.RequestTest do
                body: %{
                  Position: [-71.214, 42.124]
                },
-               path: "/places/v0/indexes/dotcom-dev-here/search/position"
+               path: "/places/v0/indexes/dotcom-dev-esri/search/position"
              } = operation
     end
 
@@ -78,7 +78,7 @@ defmodule AWSLocation.RequestTest do
                  Text: ^search_text,
                  MaxResults: 1
                },
-               path: "/places/v0/indexes/dotcom-dev-here/search/suggestions"
+               path: "/places/v0/indexes/dotcom-dev-esri/search/suggestions"
              } = operation
     end
 
@@ -107,7 +107,7 @@ defmodule AWSLocation.RequestTest do
       operation = autocomplete("Everywhere", 1)
 
       assert %ExAws.Operation.RestQuery{
-               path: "/places/v0/indexes/dotcom-prod-here/search/suggestions"
+               path: "/places/v0/indexes/dotcom-prod-esri/search/suggestions"
              } = operation
     end
   end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Switch geocoding search from HERE to Esri](https://app.asana.com/0/385363666817452/1204974196349553/f)

AWS Location Services requests can use two different geodata sources. We were previously using a mix of the two for different purposes, but one of the sources, HERE, was giving incorrect results in many different cases (many based around incorrect zip codes). This switches all searches to instead use the other source, Esri. If we start seeing more problems, we can switch back, but for now, Esri looks more reliable.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
