### PR TITLE
feat(useSchedules): update time, filter schedules

### DIFF
--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -38,6 +38,10 @@ defmodule SiteWeb.Router do
     plug(:accepts, ["json"])
   end
 
+  pipeline :cached_hourly do
+    plug(SiteWeb.Plugs.CacheControl, max_age: 3_600)
+  end
+
   pipeline :cached_daily do
     plug(SiteWeb.Plugs.CacheControl, max_age: 86_400)
   end
@@ -207,8 +211,13 @@ defmodule SiteWeb.Router do
 
     get("/alerts", AlertController, :show_by_routes)
     get("/stops/:stop_id/alerts", AlertController, :show_by_stop)
-    get("/stops/:stop_id/schedules", ScheduleController, :schedules_for_stop)
     get("/stop/:stop_id/facilities", StopController, :get_facilities)
+  end
+
+  scope "/api", SiteWeb do
+    pipe_through([:secure, :browser, :cached_hourly])
+
+    get("/stops/:stop_id/schedules", ScheduleController, :schedules_for_stop)
   end
 
   scope "/api", SiteWeb do


### PR DESCRIPTION
This PR is based on the changes from #1650, which is needed for this PR to update the displayed schedules as expected.

#### Summary of changes

**Asana Ticket:** [Departure data refresh investigation](https://app.asana.com/0/385363666817452/1204573540717218/f)

### Highlights

* The `useSchedules` hook now has an internal state, that updates a timestamp every 15 seconds. The timestamp is used to re-filter the list of schedules to ensure no stale schedules are returned.
  * I learned a lot about how timers in Jest work while trying to test this
* I adjusted the schedules endpoint to set a cache header with a `max_age` of an hour. This means the client will get a refreshed version after an hour has elapsed, and prevents the client from fetching the same ~1.35MB of schedules over and over whenever the component state updates.
  * I felt like caching for an hour would be better than for a day (which could cause clients to fetch yesterday's cached data on a given morning, which would be problematic).

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
