### PR TITLE
wip: consolidate logic to `useFetch`

### DIFF
--- a/apps/site/assets/ts/hooks/__tests__/useAlertsTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/useAlertsTest.tsx
@@ -102,9 +102,12 @@ describe("useAlertsByRoute", () => {
   });
 
   it("should return an alert array for one route id", async () => {
-    const { result, waitFor } = renderHook(() => useAlertsByRoute("route-id"), {
-      wrapper: HookWrapper
-    });
+    const { result, waitFor } = renderHook(
+      () => useAlertsByRoute(["route-id"]),
+      {
+        wrapper: HookWrapper
+      }
+    );
     await waitFor(() =>
       expect(result.current.status).toEqual(FetchStatus.Data)
     );
@@ -152,7 +155,7 @@ describe("useAlertsByRoute", () => {
         )
     );
     const { result, waitFor } = renderHook(
-      () => useAlertsByRoute("bad-route"),
+      () => useAlertsByRoute(["bad-route"]),
       {
         wrapper: HookWrapper
       }

--- a/apps/site/assets/ts/hooks/__tests__/useFetchTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/useFetchTest.tsx
@@ -1,0 +1,73 @@
+import { renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { SWRConfig } from "swr";
+import useFetch from "../useFetch";
+import { FetchStatus } from "../../helpers/use-fetch";
+
+const unmockedFetch = global.fetch;
+const HookWrapper: React.FC = ({ children }) => (
+  <SWRConfig value={{ dedupingInterval: 0 }}>{children}</SWRConfig>
+);
+
+describe("useFetch", () => {
+  beforeEach(() => {
+    // provide mocked network response
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve: Function) =>
+          resolve({
+            json: () => [1, 2, 3],
+            ok: true,
+            status: 200,
+            statusText: "OK"
+          })
+        )
+    );
+  });
+
+  it("should return data", async () => {
+    const { result, waitFor } = renderHook(
+      () => useFetch<number[]>("/api/something"),
+      { wrapper: HookWrapper }
+    );
+    await waitFor(() =>
+      expect(result.current.status).toEqual(FetchStatus.Data)
+    );
+    await waitFor(() => {
+      expect(result.current.data).toEqual([1, 2, 3]);
+    });
+  });
+
+  it("returns error status if API returns an error", async () => {
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve: Function) =>
+          resolve({
+            json: () => [],
+            ok: false,
+            status: 500,
+            statusText: "ERROR"
+          })
+        )
+    );
+    const { result, waitFor } = renderHook(
+      () => useFetch<number[]>("/api/something"),
+      { wrapper: HookWrapper }
+    );
+    await waitFor(() => expect(result.current.status).toBe(FetchStatus.Error));
+  });
+
+  it("handles a null URL by resolving with undefined data", async () => {
+    global.fetch = jest.fn();
+    const { result, waitFor } = renderHook(() => useFetch<number[]>(null), {
+      wrapper: HookWrapper
+    });
+    await waitFor(() => expect(result.current.status).toBe(FetchStatus.Data));
+    await waitFor(() => expect(result.current.data).toBe(undefined));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  afterAll(() => {
+    global.fetch = unmockedFetch;
+  });
+});

--- a/apps/site/assets/ts/hooks/useAlerts.ts
+++ b/apps/site/assets/ts/hooks/useAlerts.ts
@@ -1,31 +1,13 @@
-import useSWR from "swr";
-import { fetchJsonOrThrow } from "../helpers/fetch-json";
 import { Alert } from "../__v3api";
-import { FetchState, FetchStatus } from "../helpers/use-fetch";
-
-const fetchData = async (url: string): Promise<Alert[]> =>
-  fetchJsonOrThrow(url);
+import { FetchState } from "../helpers/use-fetch";
+import useFetch from "./useFetch";
 
 const useAlertsByStop = (stopId: string): FetchState<Alert[]> => {
-  const { data, error } = useSWR<Alert[]>(
-    `/api/stops/${stopId}/alerts`,
-    fetchData
-  );
-  if (error) {
-    return { status: FetchStatus.Error };
-  }
-  return { status: FetchStatus.Data, data };
+  return useFetch<Alert[]>(`/api/stops/${stopId}/alerts`);
 };
 
 const useAlertsByRoute = (routeIds: string[]): FetchState<Alert[]> => {
-  const { data, error } = useSWR<Alert[]>(
-    `/api/alerts?route_ids=${routeIds.join(",")}`,
-    fetchData
-  );
-  if (error) {
-    return { status: FetchStatus.Error };
-  }
-  return { status: FetchStatus.Data, data };
+  return useFetch<Alert[]>(`/api/alerts?route_ids=${routeIds.join(",")}`);
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/apps/site/assets/ts/hooks/useAlerts.ts
+++ b/apps/site/assets/ts/hooks/useAlerts.ts
@@ -17,22 +17,13 @@ const useAlertsByStop = (stopId: string): FetchState<Alert[]> => {
   return { status: FetchStatus.Data, data };
 };
 
-const useAlertsByRoute = (routeId: string | string[]): FetchState<Alert[]> => {
-  const route_id_array = Array.isArray(routeId) ? routeId : [routeId];
+const useAlertsByRoute = (routeIds: string[]): FetchState<Alert[]> => {
   const { data, error } = useSWR<Alert[]>(
-    route_id_array.length === 0
-      ? null
-      : `/api/alerts?route_ids=${route_id_array.join(",")}`,
+    `/api/alerts?route_ids=${routeIds.join(",")}`,
     fetchData
   );
-
   if (error) {
     return { status: FetchStatus.Error };
-  }
-  if (route_id_array.length === 0) {
-    // no alerts to return if there were no route ids passed
-    // don't return the value of data directly because it will be undefined
-    return { status: FetchStatus.Data, data: [] };
   }
   return { status: FetchStatus.Data, data };
 };

--- a/apps/site/assets/ts/hooks/useFetch.ts
+++ b/apps/site/assets/ts/hooks/useFetch.ts
@@ -1,0 +1,27 @@
+import useSWR from "swr";
+import { fetchJsonOrThrow } from "../helpers/fetch-json";
+import { FetchState, FetchStatus } from "../helpers/use-fetch";
+
+/**
+ * Generic helper function for fetching JSON from a URL. Specify the expected
+ * return type as the type parameter, e.g
+ * `useFetch<Schedule[]>("/api/schedules/or/something")`
+ * @param {string | null} backendUrl - The path, usually starting with /api/,
+ * that our backend will respond with data from. If this value is null, useSWR's
+ * behavior will in effect disable the fetch, and the returned data will simply
+ * be undefined.
+ * @returns {FetchState<T>} An object containing the fetch status, and
+ * (optionally) the fetched data.
+ */
+const useFetch = <T>(backendPath: string | null): FetchState<T> => {
+  const { data, error } = useSWR<T>(
+    backendPath,
+    async (url: string): Promise<T> => fetchJsonOrThrow(url)
+  );
+  if (error) {
+    return { status: FetchStatus.Error };
+  }
+  return { status: FetchStatus.Data, data };
+};
+
+export default useFetch;

--- a/apps/site/assets/ts/hooks/useMapConfig.ts
+++ b/apps/site/assets/ts/hooks/useMapConfig.ts
@@ -1,15 +1,13 @@
-import useSWR from "swr";
-import { fetchJsonOrThrow } from "../helpers/fetch-json";
+import useFetch from "./useFetch";
 
-const fetchData = async (url: string): Promise<MapConfig> =>
-  fetchJsonOrThrow(url);
-
-export interface MapConfig {
-  tile_server_url: string;
-}
-
-const useMapConfig = (): MapConfig | undefined => {
-  const { data } = useSWR<MapConfig>(`/api/map-config`, fetchData);
+const useMapConfig = ():
+  | {
+      tile_server_url: string;
+    }
+  | undefined => {
+  const { data } = useFetch<{
+    tile_server_url: string;
+  }>("/api/map-config");
   return data;
 };
 

--- a/apps/site/assets/ts/hooks/useRoute.ts
+++ b/apps/site/assets/ts/hooks/useRoute.ts
@@ -1,23 +1,12 @@
-import useSWR from "swr";
-import { fetchJsonOrThrow } from "../helpers/fetch-json";
 import { Route } from "../__v3api";
 import { Polyline } from "../leaflet/components/__mapdata";
-import { FetchState, FetchStatus } from "../helpers/use-fetch";
+import { FetchState } from "../helpers/use-fetch";
+import useFetch from "./useFetch";
 
 export type RouteWithPolylines = Route & { polylines: Polyline[] };
 
-const fetchData = async (url: string): Promise<RouteWithPolylines[]> =>
-  fetchJsonOrThrow(url);
-
 const useRoutesByStop = (stopId: string): FetchState<RouteWithPolylines[]> => {
-  const { data, error } = useSWR<RouteWithPolylines[]>(
-    `/api/routes/by-stop/${stopId}`,
-    fetchData
-  );
-  if (error) {
-    return { status: FetchStatus.Error };
-  }
-  return { status: FetchStatus.Data, data };
+  return useFetch<RouteWithPolylines[]>(`/api/routes/by-stop/${stopId}`);
 };
 // eslint-disable-next-line import/prefer-default-export
 export { useRoutesByStop };

--- a/apps/site/assets/ts/hooks/useSchedules.ts
+++ b/apps/site/assets/ts/hooks/useSchedules.ts
@@ -1,8 +1,7 @@
-import useSWR from "swr";
 import { pick } from "lodash";
-import { fetchJsonOrThrow } from "../helpers/fetch-json";
 import { ScheduleWithTimestamp } from "../models/schedules";
-import { FetchState, FetchStatus } from "../helpers/use-fetch";
+import { FetchState } from "../helpers/use-fetch";
+import useFetch from "./useFetch";
 
 interface ScheduleData extends Omit<ScheduleWithTimestamp, "time"> {
   time: string;
@@ -30,21 +29,13 @@ const parse = (schedule: ScheduleData): ScheduleWithTimestamp =>
       : null
   } as ScheduleWithTimestamp);
 
-const fetchData = async (url: string): Promise<ScheduleData[]> =>
-  fetchJsonOrThrow(url);
-
 const useSchedulesByStop = (
   stopId: string
 ): FetchState<ScheduleWithTimestamp[]> => {
-  const { data, error } = useSWR<ScheduleData[]>(
-    `/api/stops/${stopId}/schedules?last_stop_departures=false&future_departures=true`,
-    fetchData
+  const { status, data } = useFetch<ScheduleData[]>(
+    `/api/stops/${stopId}/schedules?last_stop_departures=false&future_departures=true`
   );
-  if (error) {
-    return { status: FetchStatus.Error };
-  }
-  const parsedData = data?.map(d => parse(d));
-  return { status: FetchStatus.Data, data: parsedData };
+  return { status, data: data?.map(d => parse(d)) };
 };
 // eslint-disable-next-line import/prefer-default-export
 export { useSchedulesByStop };

--- a/apps/site/assets/ts/hooks/useStop.ts
+++ b/apps/site/assets/ts/hooks/useStop.ts
@@ -1,29 +1,13 @@
-import useSWR from "swr";
-import { fetchJsonOrThrow } from "../helpers/fetch-json";
 import { Facility, Stop } from "../__v3api";
-import { FetchState, FetchStatus } from "../helpers/use-fetch";
-
-const fetchData = async (url: string): Promise<Stop> => fetchJsonOrThrow(url);
-const fetchFacilityData = async (url: string): Promise<Facility[]> =>
-  fetchJsonOrThrow(url);
+import { FetchState } from "../helpers/use-fetch";
+import useFetch from "./useFetch";
 
 const useStop = (stopId: string): FetchState<Stop> => {
-  const { data, error } = useSWR<Stop>(`/api/stop/${stopId}`, fetchData);
-  if (error) {
-    return { status: FetchStatus.Error };
-  }
-  return { status: FetchStatus.Data, data };
+  return useFetch<Stop>(`/api/stop/${stopId}`);
 };
 
 const useFacilitiesByStop = (stopId: string): FetchState<Facility[]> => {
-  const { data, error } = useSWR<Facility[]>(
-    `/api/stop/${stopId}/facilities`,
-    fetchFacilityData
-  );
-  if (error) {
-    return { status: FetchStatus.Error };
-  }
-  return { status: FetchStatus.Data, data };
+  return useFetch<Facility[]>(`/api/stop/${stopId}/facilities`);
 };
 
 export { useStop, useFacilitiesByStop };

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -29,9 +29,7 @@ const StopPageRedesign = ({
   const alertsForStopResult = useAlertsByStop(stopId);
   const facilities = useFacilitiesByStop(stopId);
   const alertsForRoutesResult = useAlertsByRoute(
-    routesWithPolylinesResult.status === FetchStatus.Data
-      ? routesWithPolylinesResult.data?.map(r => r.id) || []
-      : []
+    routesWithPolylinesResult.data?.map(r => r.id) || []
   );
 
   if (


### PR DESCRIPTION
#### Summary of changes

I introduced `useFetch` in https://github.com/mbta/dotcom/pull/1658/commits/05fee508f836976ff48579b6f58bfedee94ddb5e, this is the attempt to use it across all our fetches in the stops page redesign.

**I considered deleting all the hooks** and using `useFetch` directly and repeatedly, which would produce code something like this

```typescript
  const stopResult = useFetch<Stop>(`/api/stop/${stopId}`);
  const routesWithPolylinesResult = useFetch<
    (Route & { polylines: Polyline[] })[]
  >(`/api/routes/by-stop/${stopId}`);
  const alertsForStopResult = useFetch<Alert[]>(`/api/stops/${stopId}/alerts`);
  const facilities = useFetch<Facility[]>(`/api/stop/${stopId}/facilities`);
  const alertsForRoutesResult = useFetch<Alert[]>(`/api/alerts?route_ids=${
    (routesWithPolylinesResult.data || []).map(r => r.id).join(",")}`);
```

But it felt messy, would've made refactoring all the tests and hook mocking a heavy lift, and `useSchedulesByStop` had some additional logic (parsing the data before returning).

Welcome feedback, visions, comments.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
