### PR TITLE
fix(DeparturesAndMap): add headsign to departure filters

### DIFF
--- a/apps/site/assets/ts/stop/__tests__/DepartureListTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureListTest.tsx
@@ -65,6 +65,7 @@ describe("DepartureList", () => {
         stop={stop}
         departures={mergeIntoDepartureInfo([], predictions)}
         directionId={0}
+        headsign={"Cucamonga"}
         alerts={[]}
       />
     );
@@ -80,6 +81,7 @@ describe("DepartureList", () => {
         stop={stop}
         departures={mergeIntoDepartureInfo(schedules, [])}
         directionId={0}
+        headsign={"Atlantis"}
         alerts={[]}
       />
     );
@@ -97,6 +99,7 @@ describe("DepartureList", () => {
         stop={stop}
         departures={departures}
         directionId={0}
+        headsign={"Disney"}
         alerts={[]}
       />
     );
@@ -114,6 +117,7 @@ describe("DepartureList", () => {
         stop={stop}
         departures={departures}
         directionId={0}
+        headsign={"Bermuda"}
         alerts={[]}
       />
     );
@@ -162,6 +166,7 @@ describe("DepartureList", () => {
         stop={stop}
         departures={departures}
         directionId={0}
+        headsign={"San Fransokyo"}
         alerts={alerts}
       />
     );
@@ -179,11 +184,12 @@ describe("DepartureList", () => {
         stop={stop}
         departures={departures}
         directionId={0}
+        headsign={"Gotham"}
         alerts={[]}
       />
     );
     expect(
-      screen.getByRole("heading", { name: `${stop.name} to TestRoute Route` })
+      screen.getByRole("heading", { name: `${stop.name} to Gotham` })
     ).toBeDefined();
   });
 
@@ -195,6 +201,7 @@ describe("DepartureList", () => {
         stop={stop}
         departures={[]}
         directionId={0}
+        headsign="Riverdale"
       />
     );
     expect(screen.getByText("No upcoming trips today")).toBeDefined();
@@ -224,6 +231,7 @@ describe("DepartureList", () => {
         stop={stop}
         departures={mergeIntoDepartureInfo(schedules, predictions)}
         directionId={0}
+        headsign="Smallville"
       />
     );
     expect(screen.getByText("Cancelled")).toBeInTheDocument();
@@ -262,6 +270,7 @@ describe("DepartureList", () => {
         stop={stop}
         departures={mergeIntoDepartureInfo(schedules, predictions)}
         directionId={0}
+        headsign="Emerald City"
         targetDate={new Date("2022-04-27T11:00:00-04:00")}
       />
     );

--- a/apps/site/assets/ts/stop/__tests__/StopMapRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopMapRedesignTest.tsx
@@ -57,7 +57,7 @@ describe("StopMapRedesign", () => {
         stop={testStop}
         lines={[]}
         vehicles={[]}
-        selectedRoute={null}
+        selectedRoute={undefined}
       />
     );
     expect(screen.queryByLabelText("Map with stop")).not.toBeNull();
@@ -74,7 +74,7 @@ describe("StopMapRedesign", () => {
         stop={testStop}
         lines={lines}
         vehicles={[]}
-        selectedRoute={null}
+        selectedRoute={undefined}
       />
     );
 

--- a/apps/site/assets/ts/stop/components/DepartureCard.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureCard.tsx
@@ -1,12 +1,13 @@
 import React, { ReactElement } from "react";
 import { groupBy } from "lodash";
-import { Alert, DirectionId, Route } from "../../__v3api";
+import { Alert, Route } from "../../__v3api";
 import { routeName, routeToModeIcon } from "../../helpers/route-headers";
 import { routeBgClass } from "../../helpers/css";
 import renderSvg from "../../helpers/render-svg";
 import DepartureTimes from "./DepartureTimes";
 import { allAlertsForDirection } from "../../models/alert";
 import { DepartureInfo } from "../../models/departureInfo";
+import { DepartureFilterFn } from "./DeparturesAndMap";
 
 const DepartureCard = ({
   route,
@@ -17,7 +18,7 @@ const DepartureCard = ({
 }: {
   route: Route;
   departuresForRoute: DepartureInfo[];
-  onClick: (route: Route, directionId: DirectionId) => void;
+  onClick: DepartureFilterFn;
   alertsForRoute: Alert[];
   stopName: string;
 }): ReactElement<HTMLElement> => {

--- a/apps/site/assets/ts/stop/components/DepartureList.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureList.tsx
@@ -24,6 +24,7 @@ interface DepartureListProps {
   stop: Stop;
   departures: DepartureInfo[];
   directionId: DirectionId;
+  headsign: string;
   alerts: Alert[];
   targetDate?: Date | undefined;
 }
@@ -41,6 +42,7 @@ const DepartureList = ({
   stop,
   departures,
   directionId,
+  headsign,
   alerts,
   targetDate
 }: DepartureListProps): ReactElement<HTMLElement> => {
@@ -79,9 +81,7 @@ const DepartureList = ({
       </div>
       <h2 className="departure-list__sub-header">
         <div className="departure-list__origin-stop-name">{stop.name} to</div>
-        <div className="departure-list__headsign">
-          {tripForSelectedRoutePattern?.headsign}
-        </div>
+        <div className="departure-list__headsign">{headsign}</div>
       </h2>
       {allCurrentAlerts.length ? <Alerts alerts={allCurrentAlerts} /> : null}
       {departures.length === 0 && displayNoUpcomingTrips()}

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -198,8 +198,12 @@ const DepartureTimes = ({
       ) : (
         <div
           key={`${route.direction_destinations[directionId]}-${route.id}`}
-          onClick={() => onClick({ route, directionId, headsign })}
-          onKeyDown={() => onClick({ route, directionId, headsign })}
+          onClick={() =>
+            onClick({ route, directionId, headsign: destination! })
+          }
+          onKeyDown={() =>
+            onClick({ route, directionId, headsign: destination! })
+          }
           role="presentation"
         >
           {!isAtDestination(stopName, route, directionId) &&

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -16,6 +16,7 @@ import {
 } from "../models/displayTimeConfig";
 import { DepartureInfo } from "../../models/departureInfo";
 import { isAtDestination } from "../../helpers/departureInfo";
+import { DepartureFilterFn } from "./DeparturesAndMap";
 
 const toHighPriorityAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
   if (hasSuspension(alerts)) {
@@ -163,7 +164,7 @@ interface DepartureTimesProps {
   stopName: string;
   // override date primarily used for testing
   overrideDate?: Date;
-  onClick: (route: Route, directionId: DirectionId) => void;
+  onClick: DepartureFilterFn;
 }
 
 const DepartureTimes = ({
@@ -185,8 +186,8 @@ const DepartureTimes = ({
             return (
               <div
                 key={`${headsign}-${route.id}`}
-                onClick={() => onClick(route, directionId)}
-                onKeyDown={() => onClick(route, directionId)}
+                onClick={() => onClick({ route, directionId, headsign })}
+                onKeyDown={() => onClick({ route, directionId, headsign })}
                 role="presentation"
               >
                 {getRow(headsign, departures, alertsForDirection, overrideDate)}
@@ -197,8 +198,8 @@ const DepartureTimes = ({
       ) : (
         <div
           key={`${route.direction_destinations[directionId]}-${route.id}`}
-          onClick={() => onClick(route, directionId)}
-          onKeyDown={() => onClick(route, directionId)}
+          onClick={() => onClick({ route, directionId, headsign })}
+          onKeyDown={() => onClick({ route, directionId, headsign })}
           role="presentation"
         >
           {!isAtDestination(stopName, route, directionId) &&

--- a/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
@@ -161,6 +161,7 @@ const DeparturesAndMap = ({
               : defaultPolylines
           }
           vehicles={departureFilters ? vehiclesForSelectedRoute : []}
+          selectedRoute={departureFilters?.route}
         />
       </div>
     </div>

--- a/apps/site/assets/ts/stop/components/StopMapRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopMapRedesign.tsx
@@ -20,10 +20,10 @@ interface Props {
   stop: Stop;
   lines: Polyline[];
   vehicles: Vehicle[];
-  selectedRoute: Route | null;
+  selectedRoute?: Route;
 }
 
-const routeToModeIconName = (route: Route | null): string => {
+const routeToModeIconName = (route?: Route): string => {
   if (route) {
     if (isACommuterRailRoute(route)) return "mode-commuter-rail-small";
     if (isASilverLineRoute(route)) return "mode-bus-silver";

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -1,16 +1,17 @@
 import { groupBy, sortBy } from "lodash";
 import React, { ReactElement, useState } from "react";
-import { Alert, DirectionId, Route } from "../../__v3api";
+import { Alert, Route } from "../../__v3api";
 import DeparturesFilters, { ModeChoice } from "./DeparturesFilters";
 import { modeForRoute } from "../../models/route";
 import DepartureCard from "./DepartureCard";
 import { alertsByRoute } from "../../models/alert";
 import { DepartureInfo } from "../../models/departureInfo";
+import { DepartureFilterFn } from "./DeparturesAndMap";
 
 interface StopPageDeparturesProps {
   routes: Route[];
   departureInfos: DepartureInfo[];
-  onClick: (route: Route, directionId: DirectionId) => void;
+  onClick: DepartureFilterFn;
   alerts: Alert[];
   stopName: string;
 }


### PR DESCRIPTION
Most of this PR is just renaming, but it fixes a major issue where, for directions having multiple destinations, clicking on each of them led to the same view (e.g. clicking Ashmont or Braintree each lead to a "Red Line to Ashmont" list with the same list of departures, instead of showing different lists).

#### Summary of changes

**Asana Ticket**: [Departures | Different destinations lead to the same realtime tracking page](https://app.asana.com/0/385363666817452/1205084471790526/f)

- remove repetition by defining a type for the filter and the function that handles it
- use headsign to help filter departures
- pass in the headsign as a prop to DepartureList
- simplify the filter type a bit by having a null state instead of a state where each object key can have a null value.
