### PR TITLE
fix(DisplayTime): hide delayed time for subway

### DIFF
--- a/apps/site/assets/ts/stop/__tests__/DisplayTimeTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DisplayTimeTest.tsx
@@ -110,6 +110,23 @@ describe("DisplayTime", () => {
       expect(screen.findByText("Delayed 9:19 AM")).toBeTruthy();
       expect(screen.getByText("9:13 AM")).toHaveClass("strikethrough");
     });
+    it("predictions only (<1 hour away) (subway)", () => {
+      const nowTime = new Date("2023-06-01T09:10:00-04:00");
+      const departure = {
+        isDelayed: true,
+        schedule: { ...schedule, time: new Date("2023-06-01T09:13:00-04:00") },
+        prediction: {
+          ...prediction,
+          time: new Date("2023-06-01T09:19:00-04:00")
+        },
+        routeMode: "subway"
+      } as DepartureInfo;
+      render(
+        <DisplayTime departure={departure} isCR={false} targetDate={nowTime} />
+      );
+      expect(screen.queryByText("9 min")).toBeTruthy();
+      expect(screen.queryByText("9:13 AM")).toBeNull();
+    });
     it("predictions with scheduled time with strikethrough (<1 hour away) (CR)", () => {
       const nowTime = new Date("2023-06-01T09:10:00-04:00");
       const departure = {
@@ -143,6 +160,23 @@ describe("DisplayTime", () => {
       );
       expect(screen.findByText("Delayed 11:43 AM")).toBeTruthy();
       expect(screen.getByText("11:38 AM")).toHaveClass("strikethrough");
+    });
+    it("(for subway) shows only predicted time (1+ hour away)", () => {
+      const nowTime = new Date("2023-06-01T09:10:00-04:00");
+      const departure = {
+        isDelayed: true,
+        schedule: { ...schedule, time: new Date("2023-06-01T11:38:00-04:00") },
+        prediction: {
+          ...prediction,
+          time: new Date("2023-06-01T11:43:00-04:00")
+        },
+        routeMode: "subway"
+      } as DepartureInfo;
+      render(
+        <DisplayTime departure={departure} isCR={false} targetDate={nowTime} />
+      );
+      expect(screen.getByText("11:43 AM")).toBeDefined();
+      expect(screen.queryByText("11:38 AM")).toBeNull();
     });
   });
 });

--- a/apps/site/assets/ts/stop/components/DisplayTime.tsx
+++ b/apps/site/assets/ts/stop/components/DisplayTime.tsx
@@ -156,7 +156,8 @@ const DisplayTime = ({
   targetDate
 }: DisplayTimeProps): ReactElement<HTMLElement> | null => {
   const time = departureInfoToTime(departure);
-  const isDelayed = departure?.isDelayed;
+  const isDelayedAndDisplayed =
+    departure.isDelayed && departure.routeMode !== "subway";
   const isCancelled = departure?.isCancelled;
   const isLessThanHourAway = time
     ? differenceInSeconds(time, new Date()) < secondsInHour
@@ -177,10 +178,15 @@ const DisplayTime = ({
       {!isCancelled && (
         <>
           <div className="stop-routes__departures-time">
-            {isDelayed ? <DelayedTimeCountdown /> : <TimeCountdown />}
+            {isDelayedAndDisplayed ? (
+              <DelayedTimeCountdown />
+            ) : (
+              <TimeCountdown />
+            )}
           </div>
           <div className="stop-routes__departures-details fs-14">
-            {isDelayed && <DelayedTimeDetails />} <BaseTimeDetails />
+            {isDelayedAndDisplayed && <DelayedTimeDetails />}{" "}
+            <BaseTimeDetails />
           </div>
         </>
       )}


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Subway delayed trips should not show originally scheduled time on realtime tracking page](https://app.asana.com/0/385363666817452/1205079845268819/f)

Added a mode check to hide showing the delayed information detail (crossed out schedule time) for subway departures.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

