### PR TITLE
background data refresh improvements

### DIFF
--- a/apps/predictions/config/config.exs
+++ b/apps/predictions/config/config.exs
@@ -1,30 +1,7 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure for your application as:
-#
-#     config :predictions, key: :value
-#
-# And access this configuration in your application as:
-#
-#     Application.get_env(:predictions, :key)
-#
-# Or configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+if config_env() == :test do
+  config :predictions, broadcast_interval_ms: 50
+else
+  config :predictions, broadcast_interval_ms: 10_000
+end

--- a/apps/site/assets/ts/app/__tests__/channels-test.ts
+++ b/apps/site/assets/ts/app/__tests__/channels-test.ts
@@ -144,6 +144,39 @@ describe("setupChannels", () => {
 
     jest.restoreAllMocks();
   });
+
+  describe("responds to visibilitychange event", () => {
+    beforeEach(() => {
+      setupChannels();
+      mockOnLoadEventListener();
+    });
+
+    it("joins channels when visible", () => {
+      window.channels = {};
+      // mock document.hidden = false
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        get: function() {
+          return false;
+        }
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(window.channels["vehicles:Red:0"]).toBeDefined();
+    });
+
+    it("leaves channels when not visible", () => {
+      expect(window.channels["vehicles:Red:0"]).toBeDefined();
+      // mock document.hidden = true
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        get: function() {
+          return true;
+        }
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(window.channels["vehicles:Red:0"]).toBeUndefined();
+    });
+  });
 });
 
 describe("joinChannel", () => {

--- a/apps/site/assets/ts/app/channels.ts
+++ b/apps/site/assets/ts/app/channels.ts
@@ -96,12 +96,14 @@ const setupChannels = (): void => {
   window.socket.connect();
   window.channels = {};
 
-  document.addEventListener("turbolinks:load", () => {
+  const joinAllChannels = (): void => {
     document.querySelectorAll("[data-channel]").forEach(el => {
       const channelId = el.getAttribute("data-channel");
       if (channelId) joinChannel(channelId);
     });
-  });
+  };
+
+  document.addEventListener("turbolinks:load", joinAllChannels);
 
   // leave subscribed channels when navigating away from a page.
   const leaveAllChannels = (): void => {
@@ -109,6 +111,14 @@ const setupChannels = (): void => {
   };
   document.addEventListener("turbolinks:before-render", leaveAllChannels);
   window.addEventListener("beforeunload", leaveAllChannels);
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      leaveAllChannels();
+    } else {
+      joinAllChannels();
+    }
+  });
 };
 
 export { joinChannel, leaveChannel };

--- a/apps/site/assets/ts/app/channels.ts
+++ b/apps/site/assets/ts/app/channels.ts
@@ -84,6 +84,15 @@ const leaveChannel = (id: string): void => {
 
 const setupChannels = (): void => {
   window.socket = new Socket("/socket", {});
+  window.socket.onClose(event => {
+    if (event.type === "close" && !event.wasClean) {
+      // eslint-disable-next-line no-console
+      console.log(
+        "Socket was forced closed by the browser -- reloading to establish WebSocket connection."
+      );
+      window.location.reload();
+    }
+  });
   window.socket.connect();
   window.channels = {};
 

--- a/apps/site/assets/ts/hooks/__tests__/useChannelTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/useChannelTest.tsx
@@ -131,4 +131,45 @@ describe("useChannel", () => {
     expect(mockChannel.leave).toHaveBeenCalled();
     expect(window.channels["mock-channel"]).not.toBeDefined();
   });
+
+  test("leaves channel when not visible, rejoins when visible", () => {
+    expect(window.channels["mock-channel"]).toBeUndefined();
+    renderHook(() =>
+      useChannel<MockData, MockReducer>(
+        "mock-channel",
+        mockReducer,
+        initialState
+      )
+    );
+    expect(window.channels["mock-channel"]).toBeDefined();
+
+    // mock document.hidden = true
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: function() {
+        return true;
+      }
+    });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    waitFor(() => {
+      expect(mockChannel.leave).toHaveBeenCalled();
+      expect(window.channels["mock-channel"]).not.toBeDefined();
+    });
+    // mock document.hidden = false
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: function() {
+        return false;
+      }
+    });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    waitFor(() => {
+      expect(mockChannel.join).toHaveBeenCalled();
+      expect(window.channels["mock-channel"]).toBeDefined();
+    });
+  });
 });

--- a/apps/site/assets/ts/hooks/useChannel.ts
+++ b/apps/site/assets/ts/hooks/useChannel.ts
@@ -1,5 +1,6 @@
-import { useReducer, useEffect, Reducer } from "react";
+import { useReducer, useEffect, Reducer, useLayoutEffect } from "react";
 import { joinChannel, leaveChannel } from "../app/channels";
+import { usePageVisibility } from "./usePageVisibility";
 
 // extract the state and action types from the given reducer
 // is there a way to do this without using "any"?
@@ -44,6 +45,22 @@ function useChannel<
       }
     };
   }, [channelId]);
+
+  const isVisible = usePageVisibility();
+  useLayoutEffect(() => {
+    if (channelId !== null) {
+      if (!isVisible) {
+        leaveChannel(channelId);
+      } else {
+        joinChannel<OnDataEventType[]>(channelId, dispatch);
+      }
+    }
+    return () => {
+      if (channelId !== null) {
+        leaveChannel(channelId);
+      }
+    };
+  }, [isVisible, channelId]);
 
   useEffect(() => {
     // Set up an event listener to listen to the channel's custom event

--- a/apps/site/assets/ts/hooks/usePageVisibility.ts
+++ b/apps/site/assets/ts/hooks/usePageVisibility.ts
@@ -1,0 +1,19 @@
+/* eslint-disable import/prefer-default-export */
+import { useState, useLayoutEffect } from "react";
+
+/** returns true if the page is visible
+ * returns false if the page is hidden
+ */
+export const usePageVisibility = (): boolean => {
+  const [hidden, setHidden] = useState<boolean>(false);
+  const callback = (): void => {
+    setHidden(document.hidden);
+  };
+  useLayoutEffect(() => {
+    document.addEventListener("visibilitychange", callback);
+    return () => {
+      document.removeEventListener("visibilitychange", callback);
+    };
+  }, []);
+  return !hidden;
+};


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Data Refresh when Stop Page in Background](https://app.asana.com/0/385363666817452/1205161605826762/f)

The three commits do different things, but they're all in the realm of improving the client experience of receiving data from the predictions channel.

1. ### `feat(channels): add socket close event listener`
This is the fundamental commit that prevents stale predictions from sticking around. 

**The problem:** In our case, after leaving a tab open in the background for ~10 minutes, the browser closes the WebSocket connection. With no more predictions data being received until a user refreshes the page. 

> [!NOTE]
> [Phoenix.js](https://hexdocs.pm/phoenix/js/) is _supposed_ to handle this situation (it's not uncommon or unexpected, after all) and automatically reconnect, but for whatever reason it doesn't. Perhaps it's fixed in a future version, but we're not in a great position to upgrade.

**The improvement:** Add an event listener to the socket's `onClose` event. If this is triggered, force a page reload via `window.location.reload()`. This is essentially what Glides and Skate do, and Anna and I figured it was an okay mitigation to take in this case, because this problem is generally only encountered on inactive tabs (so refreshing won't interrupt any user actions).

2. ### `feat(useChannel and channels): on visibilitychange`

**The problem:** The client's always receiving data, even when not actively using the tab! This will probably waste energy and cellular data.

**The improvement:** Be a bit more judicious, and leave channels when the page is not active, and rejoin when resuming activity. We use the widely-supported [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) for this, and pretty much copy Glide's approach. 

3.  ### `feat(PredictionsPubSub): batch updates`

**The problem:** The channel broadcasts many updates at once containing the same data, instead of sending the client all the data in one. It turns out that the events sent from the V3 API's ServerSentEvents stream are themselves not batched.

**The improvement:** Instead of broadcasting with _every_ event, only broadcast periodically. This PR sets this to 10 seconds.

## How to preview

It turns out the Phoenix socket supports a `logger` argument which we can use to turn on logging for all websocket activity. So adding this change in `channels.ts`  will print out every event in the DevTools console.

```javascript
  // replace window.socket = new Socket("/socket", {});
  window.socket = new Socket("/socket", {
    logger(kind, message, data) {
      // eslint-disable-next-line no-console
      console.log(
        new Date().toLocaleTimeString(),
        `[${kind}] ${message}`,
        data
      );
    }
  });

```


---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
