### PR TITLE
fixup(DeparturesAndMap): allow text wrapping

### DIFF
--- a/apps/site/assets/css/_stop-card.scss
+++ b/apps/site/assets/css/_stop-card.scss
@@ -303,24 +303,22 @@ $radius: 4px;
 }
 
 .back-to-routes {
-  align-items: center;
   background-color: $gray-bordered-background;
   border: .25px solid $gray-lighter;
   color: $brand-primary;
-  display: flex;
-  font-size: 1rem;
-  height: 2.5rem;
-  padding-left: .625rem;
-  text-decoration: underline;
-  text-underline-offset: .2rem;
-  :first-child {
-    cursor: pointer;
-    display: inline-block;
-    font-weight: 400;
-    :first-child {
-      font-weight: 900;
-      padding-right: .5rem;
-    }
+
+  .btn {
+    align-items: baseline;
+    display: flex;
+    gap: .5em;
+    padding: $base-spacing-sm;
+    white-space: unset;
+  }
+
+  span {
+    text-align: left;
+    text-decoration: underline;
+    text-underline-offset: .2rem;
   }
 }
 

--- a/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
@@ -154,15 +154,15 @@ const DeparturesAndMap = ({
 
   const BackToRoutes = (
     <div className="back-to-routes">
-      <div
+      <button
+        className="btn"
         onClick={unsetDepartureInfo}
         onKeyDown={unsetDepartureInfo}
-        aria-label={`Back to all ${stop.name} routes`}
-        role="presentation"
+        type="button"
       >
-        {renderFa("", "fa-angle-left")}
-        {`Back to all ${stop.name} routes`}
-      </div>
+        {renderFa("", "fa-fw fa-angle-left")}
+        <span className="btn-link">{`Back to all ${stop.name} routes`}</span>
+      </button>
     </div>
   );
 


### PR DESCRIPTION
Adjust the "Back to all routes" control so that it can wrap long test. While we're here, also change this element to a button. This enables keyboard navigability and is more accessible.

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Realtime Tracking Page | Text in navigation bar falls outside of container](https://app.asana.com/0/385363666817452/1205172693755923/f)

<img width="538" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/f5f08c3b-42cd-40ba-9f85-02696b0a65a3">

<img width="607" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/38b15856-5576-45c6-acc4-e585d179a990">

(normal view without wrapping, for reference):

<img width="582" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/b1e39c84-f6c3-49ff-97b9-adff4c0433c2">


---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.