### PR TITLE
feat(StopPageRedesign): surface error message if predictions aren't fetched

### DIFF
--- a/apps/site/assets/ts/__jest-extended.d.ts
+++ b/apps/site/assets/ts/__jest-extended.d.ts
@@ -1,0 +1,2 @@
+/* eslint-disable */
+import "jest-extended";

--- a/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
@@ -54,14 +54,13 @@ describe("usePredictionsChannel hook", () => {
   });
 
   test("initializes connection to appropriate channel", () => {
-    const { result } = renderHook(() =>
+    renderHook(() =>
       usePredictionsChannel({
         routeId: "Purple",
         stopId: "place-somewhere",
         directionId: 0
       })
     );
-    expect(result.current).toEqual([]);
     expect(
       window.channels[
         "predictions:route=Purple:stop=place-somewhere:direction_id=0"
@@ -160,9 +159,9 @@ describe("usePredictionsChannel hook", () => {
     expect(useChannelSpy).toHaveBeenCalledWith(
       null,
       expect.anything(),
-      expect.anything()
+      expect.toBeOneOf([expect.anything(), null])
     );
-    expect(result.current).toEqual([]);
+    expect(result.current).toEqual(null);
   });
 });
 

--- a/apps/site/assets/ts/hooks/usePredictionsChannel.ts
+++ b/apps/site/assets/ts/hooks/usePredictionsChannel.ts
@@ -94,16 +94,17 @@ function channelFromArgs(channelArgs: PredictionsChannelArgs): string | null {
  */
 const usePredictionsChannel = (
   args: PredictionsChannelArgs
-): PredictionWithTimestamp[] => {
+): PredictionWithTimestamp[] | null => {
   const channelName = channelFromArgs(args);
   const reducer: Reducer<
-    PredictionWithTimestamp[],
+    PredictionWithTimestamp[] | null,
     ChannelPredictionResponse
   > = (_oldGroupedPredictions, { predictions }) => {
     return sortBy(predictions.map(parsePrediction), "time");
   };
-  const initialState: PredictionWithTimestamp[] = [];
-  const state = useChannel(channelName, reducer, initialState);
+  // useChannel will return the initialState if the channel can't be joined / if
+  // the channelName is null;
+  const state = useChannel(channelName, reducer, null);
   return state;
 };
 

--- a/apps/site/assets/ts/stop/__tests__/DeparturesAndMapTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DeparturesAndMapTest.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import DeparturesAndMap from "../components/DeparturesAndMap";
 import { Alert, DirectionId, Stop } from "../../__v3api";
@@ -12,6 +12,8 @@ import { add } from "date-fns";
 import * as useVehiclesChannel from "../../hooks/useVehiclesChannel";
 import { Route } from "../../__v3api";
 import { FetchStatus } from "../../helpers/use-fetch";
+import * as usePredictionsChannel from "../../hooks/usePredictionsChannel";
+import { PredictionWithTimestamp } from "../../models/perdictions";
 
 const stop = {
   id: "test-stop",
@@ -97,6 +99,7 @@ describe("DeparturesAndMap", () => {
         stop={stop}
         routesWithPolylines={testRoutesWithPolylines}
         alerts={[]}
+        setPredictionError={jest.fn()}
       />
     );
 
@@ -114,6 +117,7 @@ describe("DeparturesAndMap", () => {
         stop={stop}
         routesWithPolylines={testRoutesWithPolylines}
         alerts={[]}
+        setPredictionError={jest.fn()}
       />
     );
 
@@ -133,6 +137,7 @@ describe("DeparturesAndMap", () => {
         stop={stop}
         routesWithPolylines={testRoutesWithPolylines}
         alerts={[]}
+        setPredictionError={jest.fn()}
       />
     );
 
@@ -167,6 +172,7 @@ describe("DeparturesAndMap", () => {
         stop={stop}
         routesWithPolylines={allRoutes}
         alerts={[]}
+        setPredictionError={jest.fn()}
       />
     );
 
@@ -223,6 +229,7 @@ describe("DeparturesAndMap", () => {
         stop={stop}
         routesWithPolylines={allRoutes}
         alerts={[]}
+        setPredictionError={jest.fn()}
       />
     );
 
@@ -335,6 +342,7 @@ describe("DeparturesAndMap", () => {
         stop={stop}
         routesWithPolylines={testRoutesWithPolylines}
         alerts={alerts}
+        setPredictionError={jest.fn()}
       />
     );
 
@@ -388,6 +396,7 @@ describe("DeparturesAndMap", () => {
         stop={stop}
         routesWithPolylines={testRoutesWithPolylines}
         alerts={alerts}
+        setPredictionError={jest.fn()}
       />
     );
 
@@ -400,5 +409,37 @@ describe("DeparturesAndMap", () => {
       screen.getByText("This affects the stop and route")
     ).toBeInTheDocument();
     expect(screen.queryByText("This should not show")).toBeNull();
+  });
+
+  it("should set error state when null predictions", () => {
+    jest.spyOn(usePredictionsChannel, "default").mockReturnValue(null);
+    const mockSetError = jest.fn();
+    render(
+      <DeparturesAndMap
+        routes={[route]}
+        stop={stop}
+        routesWithPolylines={testRoutesWithPolylines}
+        alerts={[]}
+        setPredictionError={mockSetError}
+      />
+    );
+    expect(mockSetError).toHaveBeenCalledWith(true);
+  });
+
+  it("should not set error state when non-null predictions", () => {
+    jest
+      .spyOn(usePredictionsChannel, "default")
+      .mockReturnValue([] as PredictionWithTimestamp[]);
+    const mockSetError = jest.fn();
+    render(
+      <DeparturesAndMap
+        routes={[route]}
+        stop={stop}
+        routesWithPolylines={testRoutesWithPolylines}
+        alerts={[]}
+        setPredictionError={mockSetError}
+      />
+    );
+    expect(mockSetError).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
@@ -35,6 +35,7 @@ interface DeparturesAndMapProps {
   stop: Stop;
   routesWithPolylines: RouteWithPolylines[];
   alerts: Alert[];
+  setPredictionError: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 type DepartureFilter = {
@@ -48,11 +49,18 @@ const DeparturesAndMap = ({
   routes,
   stop,
   routesWithPolylines,
-  alerts
+  alerts,
+  setPredictionError
 }: DeparturesAndMapProps): ReactElement<HTMLElement> => {
   const { data: schedules } = useSchedulesByStop(stop.id);
   const predictions = usePredictionsChannel({ stopId: stop.id });
-  const departureInfos = mergeIntoDepartureInfo(schedules || [], predictions);
+  const departureInfos = mergeIntoDepartureInfo(
+    schedules || [],
+    predictions || []
+  );
+  useEffect(() => {
+    setPredictionError(predictions === null);
+  }, [setPredictionError, predictions]);
   const [realtimeAlerts, setRealtimeAlerts] = useState<Alert[]>([]);
   const [
     departureFilters,

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -20,7 +20,7 @@ import { Alert } from "../../__v3api";
 const isStopPageAlert = ({ effect }: Alert): boolean =>
   ["suspension", "stop_closure", "station_closure", "shuttle"].includes(effect);
 
-const FullwidthErrorMessage = (
+const FullwidthErrorMessage = (): JSX.Element => (
   <div className="c-fullscreen-error__container">
     <div className="container">
       <p className="c-fullscreen-error__heading u-bold">
@@ -83,7 +83,7 @@ const StopPageRedesign = ({
   return (
     <article>
       <StopPageHeaderRedesign stop={stopResult.data} routes={routes} />
-      {hasPredictionError && FullwidthErrorMessage}
+      {hasPredictionError && FullwidthErrorMessage()}
       <div className="container">
         <Alerts
           alerts={alertsWithinSevenDays.filter(

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useState } from "react";
 import { concat, filter, omit } from "lodash";
 import { useStop, useFacilitiesByStop } from "../../hooks/useStop";
 import StationInformation from "./StationInformation";
@@ -20,11 +20,22 @@ import { Alert } from "../../__v3api";
 const isStopPageAlert = ({ effect }: Alert): boolean =>
   ["suspension", "stop_closure", "station_closure", "shuttle"].includes(effect);
 
+const FullwidthErrorMessage = (
+  <div className="c-fullscreen-error__container">
+    <div className="container">
+      <p className="c-fullscreen-error__heading u-bold">
+        Live information could not be loaded.
+      </p>
+      <p>Please refresh the page to try again.</p>
+    </div>
+  </div>
+);
 const StopPageRedesign = ({
   stopId
 }: {
   stopId: string;
 }): ReactElement<HTMLElement> => {
+  const [hasPredictionError, setPredictionError] = useState(false);
   const stopResult = useStop(stopId);
   const routesWithPolylinesResult = useRoutesByStop(stopId);
   const alertsForStopResult = useAlertsByStop(stopId);
@@ -72,6 +83,7 @@ const StopPageRedesign = ({
   return (
     <article>
       <StopPageHeaderRedesign stop={stopResult.data} routes={routes} />
+      {hasPredictionError && FullwidthErrorMessage}
       <div className="container">
         <Alerts
           alerts={alertsWithinSevenDays.filter(
@@ -83,6 +95,7 @@ const StopPageRedesign = ({
           stop={stopResult.data}
           routesWithPolylines={routesWithPolylinesResult.data}
           alerts={allStopPageAlerts}
+          setPredictionError={setPredictionError}
         />
         <footer>
           <StationInformation


### PR DESCRIPTION
## Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Bubble up prediction fetching error](https://app.asana.com/0/385363666817452/1205144855393526/f) and [Departures | Predictions aren't loading consistently](https://app.asana.com/0/385363666817452/1205093855734953/f)

1. #### Bubble up prediction fetching error

Use a `null` return type of `usePredictionsChannel` to signify the error state. Makes use of the fact that the underlying `useChannel` function is designed to return the `initialState` argument if the `channelName` argument happens to be `null`.

2. #### Add error message to top of page if predictions aren't fetched

If predictions are `null`, show the message at top. This uses some of the styling of the Transit Near Me error banner, but (a) doesn't use heading styling, just bolds the top text, and (b) removes the button to dismiss the message. 

I decided not to make a standalone reusable version of the error message component, figuring we could wait until we need to use this a second or third time...


## Future

I'm considering adding an `onError` callback to the `useChannel` hook and underlying `joinChannel` function, so that we can more properly respond to other types of errors in the channel.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
