### PR TITLE
feat(PredictionsChannel): remove at terminal stops

### DIFF
--- a/apps/site/test/site_web/channels/predictions_channel_test.exs
+++ b/apps/site/test/site_web/channels/predictions_channel_test.exs
@@ -1,12 +1,12 @@
 defmodule SiteWeb.PredictionsChannelTest do
-  use SiteWeb.ChannelCase
+  use SiteWeb.ChannelCase, async: false
 
   import Test.Support.EnvHelpers
-
+  import Mock
   alias Phoenix.Socket
   alias Predictions.Prediction
   alias Routes.Route
-  alias Schedules.Trip
+  alias Schedules.{Schedule, Trip}
   alias Stops.Stop
   alias SiteWeb.{PredictionsChannel, UserSocket}
 
@@ -19,7 +19,7 @@ defmodule SiteWeb.PredictionsChannelTest do
     direction_id: @direction,
     route: %Route{id: @route_39},
     stop: %Stop{id: @stop_fh},
-    trip: %Trip{},
+    trip: %Trip{id: "trip_id"},
     time: Timex.shift(Util.now(), hours: 2)
   }
 
@@ -65,6 +65,76 @@ defmodule SiteWeb.PredictionsChannelTest do
                )
 
       assert_push("data", %{predictions: [@prediction39]})
+    end
+
+    test "doesn't push certain predictions", %{socket: socket} do
+      {:ok, _, socket} =
+        subscribe_and_join(
+          socket,
+          PredictionsChannel,
+          @channel_name
+        )
+
+      predictions_from_stream = [
+        @prediction39,
+        # Prediction with no trip info - should be removed
+        %Prediction{@prediction39 | trip: nil},
+        # Prediction with time in past - should be removed
+        %Prediction{@prediction39 | time: Timex.shift(Util.now(), minutes: -1)},
+        # Prediction for cancelled schedule in the future
+        %Prediction{
+          @prediction39
+          | time: nil,
+            schedule_relationship: :cancelled,
+            stop_sequence: 3
+        },
+        # Prediction for cancelled schedule in the past - should be removed
+        %Prediction{
+          @prediction39
+          | time: nil,
+            schedule_relationship: :cancelled,
+            stop_sequence: 4
+        },
+        # Prediction likely at terminal stop - should be removed
+        %Prediction{
+          @prediction39
+          | stop_sequence: 6,
+            arrival_time: @prediction39.time,
+            departure_time: nil
+        }
+      ]
+
+      trip_id = @prediction39.trip.id
+
+      with_mock(Schedules.Repo,
+        schedule_for_trip: fn
+          ^trip_id, [stop_sequence: 3] ->
+            [%Schedule{time: Timex.shift(Util.now(), minutes: 5)}]
+
+          ^trip_id, [stop_sequence: 4] ->
+            [%Schedule{time: Timex.shift(Util.now(), minutes: -5)}]
+
+          ^trip_id, [stop_sequence: 6] ->
+            [%Schedule{last_stop?: true}]
+
+          _, _ ->
+            []
+        end
+      ) do
+        {:noreply, _socket} =
+          PredictionsChannel.handle_info(
+            {:new_predictions, predictions_from_stream},
+            socket
+          )
+
+        assert_push("data", %{predictions: [@prediction39, other_prediction]})
+
+        assert %Prediction{
+                 time: nil,
+                 schedule_relationship: :cancelled,
+                 stop_sequence: 3
+               } = other_prediction
+      end
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Investigate why Terminal Predictions and Headsigns showing](https://app.asana.com/0/385363666817452/1205175614190107/f)

Basically, once we stopped filtering out all predictions having `nil` departure times, we resumed sending predictions arriving at terminals to the frontend. This PR takes them back out.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
