### PR TITLE
fix(DepartureTimes): Hide tomorrow when the time is relative

### DIFF
--- a/apps/site/assets/ts/helpers/date.ts
+++ b/apps/site/assets/ts/helpers/date.ts
@@ -1,11 +1,14 @@
 import {
   differenceInSeconds,
   getMinutes,
+  isSameDay,
   parseISO,
   secondsInHour,
   secondsInMinute
 } from "date-fns";
-import { formatInTimeZone } from "date-fns-tz";
+import { formatInTimeZone, utcToZonedTime } from "date-fns-tz";
+
+const BOSTON_TIMEZONE = "America/New_York";
 
 // this returns a Date() in the browser time zone, unlike new Date(unformatted)
 export const stringToDateObject = (unformatted: string): Date => {
@@ -80,7 +83,7 @@ export const formatToBostonTime = (
     formatString = "h aa"; // 5 AM
   }
   formatString = overrideFormat !== undefined ? overrideFormat : formatString;
-  return formatInTimeZone(dateTime, "America/New_York", formatString);
+  return formatInTimeZone(dateTime, BOSTON_TIMEZONE, formatString);
 };
 
 export const formatRelativeTime = (
@@ -96,6 +99,25 @@ export const formatRelativeTime = (
   }
 
   return formatToBostonTime(time, "h:mm aa");
+};
+
+export const isSameDayInBoston = (
+  dateTime1: Date | undefined,
+  dateTime2: Date | undefined
+): boolean => {
+  // if there is no day to compare then the it should be the same day
+  if (!dateTime1 || !dateTime2) {
+    return true;
+  }
+  // returns strings in mm/dd/yyyy format
+  const date1InBoston = dateTime1.toLocaleDateString("en-US", {
+    timeZone: BOSTON_TIMEZONE
+  });
+  const date2InBoston = dateTime2.toLocaleDateString("en-US", {
+    timeZone: BOSTON_TIMEZONE
+  });
+
+  return date1InBoston === date2InBoston;
 };
 
 export default formattedDate;

--- a/apps/site/assets/ts/helpers/date.ts
+++ b/apps/site/assets/ts/helpers/date.ts
@@ -1,12 +1,11 @@
 import {
   differenceInSeconds,
   getMinutes,
-  isSameDay,
   parseISO,
   secondsInHour,
   secondsInMinute
 } from "date-fns";
-import { formatInTimeZone, utcToZonedTime } from "date-fns-tz";
+import { formatInTimeZone } from "date-fns-tz";
 
 const BOSTON_TIMEZONE = "America/New_York";
 

--- a/apps/site/assets/ts/stop/__tests__/DisplayTimeTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DisplayTimeTest.tsx
@@ -176,5 +176,22 @@ describe("DisplayTime", () => {
       expect(screen.getByText("11:43 AM")).toBeDefined();
       expect(screen.queryByText("11:38 AM")).toBeNull();
     });
+
+    it("should not show Tomorrow if the time is relative", () => {
+      const nowTime = new Date("2023-06-01T23:55:00-04:00");
+      const departure = {
+        schedule: { ...schedule, time: new Date("2023-06-02T00:10:00-04:00") },
+        prediction: {
+          ...prediction,
+          time: new Date("2023-06-02T00:10:00-04:00")
+        },
+        routeMode: "subway"
+      } as DepartureInfo;
+      render(
+        <DisplayTime departure={departure} isCR={false} targetDate={nowTime} />
+      );
+      expect(screen.queryByText("Tomorrow")).toBe(null);
+      expect(screen.getByText("15 min")).toBeInTheDocument();
+    });
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/DisplayTimeTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DisplayTimeTest.tsx
@@ -55,7 +55,6 @@ describe("DisplayTime", () => {
           isCR={false}
         />
       );
-      screen.debug();
       expect(screen.queryByText("Tomorrow")).toBeTruthy();
     });
     it("with track name", () => {

--- a/apps/site/assets/ts/stop/__tests__/DisplayTimeTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DisplayTimeTest.tsx
@@ -38,7 +38,7 @@ describe("DisplayTime", () => {
     it("with tomorrow indication", () => {
       const dateNow = new Date();
       render(<DisplayTime departure={departureWithPrediction} isCR={false} />);
-      expect(screen.queryByText("Tomorrow")).toBeFalsy();
+      expect(screen.queryByText("Tomorrow")).toBeNull();
 
       const dateTomorrow = new Date(dateNow);
       dateTomorrow.setDate(dateTomorrow.getDate() + 1);
@@ -46,7 +46,6 @@ describe("DisplayTime", () => {
         <DisplayTime
           departure={
             {
-              ...departureWithPrediction,
               schedule: {
                 ...departureWithPrediction.schedule,
                 time: dateTomorrow
@@ -56,6 +55,7 @@ describe("DisplayTime", () => {
           isCR={false}
         />
       );
+      screen.debug();
       expect(screen.queryByText("Tomorrow")).toBeTruthy();
     });
     it("with track name", () => {
@@ -190,6 +190,7 @@ describe("DisplayTime", () => {
       render(
         <DisplayTime departure={departure} isCR={false} targetDate={nowTime} />
       );
+
       expect(screen.queryByText("Tomorrow")).toBe(null);
       expect(screen.getByText("15 min")).toBeInTheDocument();
     });

--- a/apps/site/assets/ts/stop/components/DisplayTime.tsx
+++ b/apps/site/assets/ts/stop/components/DisplayTime.tsx
@@ -121,7 +121,10 @@ const DisplayTime = ({
             )}{" "}
             {/* Prioritize displaying Tomorrow over track name if both are present */}
             <span className="time-details">
-              {tomorrow ? "Tomorrow" : trackName || null}
+              {/* Only show tomorrow if time is not displayed in relative time */}
+              {tomorrow && !(!(isCancelled || isSkipped) && isCR)
+                ? "Tomorrow"
+                : trackName || null}
             </span>
           </div>
         </>

--- a/apps/site/assets/ts/stop/components/DisplayTime.tsx
+++ b/apps/site/assets/ts/stop/components/DisplayTime.tsx
@@ -24,7 +24,6 @@
  */
 
 import React, { ReactElement } from "react";
-import { isTomorrow } from "date-fns";
 import { DepartureInfo } from "../../models/departureInfo";
 import realtimeIcon from "../../../static/images/icon-realtime-tracking.svg";
 import SVGIcon from "../../helpers/render-svg";
@@ -33,6 +32,13 @@ import {
   displayInfoContainsPrediction
 } from "../../helpers/departureInfo";
 import BasicTime from "./BasicTime";
+import { isSameDayInBoston } from "../../helpers/date";
+import {
+  differenceInMinutes,
+  differenceInSeconds,
+  isTomorrow,
+  secondsInHour
+} from "date-fns";
 
 interface DisplayTimeProps {
   departure: DepartureInfo;
@@ -53,7 +59,7 @@ interface DisplayTimeProps {
 const DisplayTime = ({
   departure,
   isCR,
-  targetDate
+  targetDate = new Date()
 }: DisplayTimeProps): ReactElement<HTMLElement> | null => {
   const {
     isCancelled,
@@ -67,7 +73,10 @@ const DisplayTime = ({
   const time = departureInfoToTime(departure);
   const track = prediction?.track;
   const trackName = isCR && !!track && `Track ${track}`;
-  const tomorrow = !!time && isTomorrow(time);
+  const tomorrow = !isSameDayInBoston(targetDate, time);
+  const willPrintInRelative =
+    differenceInSeconds(time, targetDate) < secondsInHour;
+  const willSetRelativeProp = !(isCancelled || isSkipped) && !isCR;
 
   return (
     <>
@@ -122,7 +131,7 @@ const DisplayTime = ({
             {/* Prioritize displaying Tomorrow over track name if both are present */}
             <span className="time-details">
               {/* Only show tomorrow if time is not displayed in relative time */}
-              {tomorrow && !(!(isCancelled || isSkipped) && isCR)
+              {tomorrow && !willPrintInRelative && willSetRelativeProp
                 ? "Tomorrow"
                 : trackName || null}
             </span>

--- a/apps/site/assets/ts/stop/components/DisplayTime.tsx
+++ b/apps/site/assets/ts/stop/components/DisplayTime.tsx
@@ -24,6 +24,7 @@
  */
 
 import React, { ReactElement } from "react";
+import { differenceInSeconds, secondsInHour } from "date-fns";
 import { DepartureInfo } from "../../models/departureInfo";
 import realtimeIcon from "../../../static/images/icon-realtime-tracking.svg";
 import SVGIcon from "../../helpers/render-svg";
@@ -33,12 +34,6 @@ import {
 } from "../../helpers/departureInfo";
 import BasicTime from "./BasicTime";
 import { isSameDayInBoston } from "../../helpers/date";
-import {
-  differenceInMinutes,
-  differenceInSeconds,
-  isTomorrow,
-  secondsInHour
-} from "date-fns";
 
 interface DisplayTimeProps {
   departure: DepartureInfo;


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
Remove `Tomorrow` from showing up on the time on the departure cards, and departure list.
This only happens if the time is set to relative.

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Departure Times | Text Mis Aligned close to midnight](https://app.asana.com/0/555089885850811/1205225444022104)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

