### PR TITLE
refactor(DepartureTimes): improved handling of Suspension and Shuttle alerts

### DIFF
--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -19,7 +19,8 @@ import {
   alertsAffectingBothDirections,
   hasFacilityAlert,
   alertsByActivity,
-  alertsByFacility
+  alertsByFacility,
+  isSuppressiveAlert
 } from "../alert";
 import { add } from "date-fns";
 
@@ -437,5 +438,58 @@ describe("alertsByFacility", () => {
     ] as Facility[];
 
     expect(alertsByFacility(facilities, alerts)).toEqual([alert1]);
+  });
+});
+
+describe("isSuppressiveAlert", () => {
+  test("for shuttles", () => {
+    const shuttleAlert = {
+      id: "d1",
+      effect: "shuttle",
+      lifecycle: "upcoming"
+    } as Alert;
+    const currentShuttleAlert = {
+      id: "d2",
+      effect: "shuttle",
+      lifecycle: "new"
+    } as Alert;
+    expect(isSuppressiveAlert(shuttleAlert, 0)).toBeFalse();
+    expect(isSuppressiveAlert(shuttleAlert, 3)).toBeFalse();
+    expect(isSuppressiveAlert(currentShuttleAlert, 0)).toBeTrue();
+    expect(isSuppressiveAlert(currentShuttleAlert, 3)).toBeTrue();
+  });
+
+  test("for suspensions", () => {
+    const suspensionAlert = {
+      id: "d1",
+      effect: "suspension",
+      lifecycle: "upcoming"
+    } as Alert;
+    const currentSuspensionAlert = {
+      id: "d2",
+      effect: "suspension",
+      lifecycle: "new"
+    } as Alert;
+    expect(isSuppressiveAlert(suspensionAlert, 0)).toBeFalse();
+    expect(isSuppressiveAlert(suspensionAlert, 3)).toBeFalse();
+    expect(isSuppressiveAlert(currentSuspensionAlert, 0)).toBeTrue();
+    expect(isSuppressiveAlert(currentSuspensionAlert, 3)).toBeFalse();
+  });
+
+  test("for detours", () => {
+    const detourAlert = {
+      id: "d1",
+      effect: "detour",
+      lifecycle: "upcoming"
+    } as Alert;
+    const currentDetourAlert = {
+      id: "d2",
+      effect: "detour",
+      lifecycle: "new"
+    } as Alert;
+    expect(isSuppressiveAlert(detourAlert, 0)).toBeFalse();
+    expect(isSuppressiveAlert(detourAlert, 3)).toBeFalse();
+    expect(isSuppressiveAlert(currentDetourAlert, 0)).toBeFalse();
+    expect(isSuppressiveAlert(currentDetourAlert, 3)).toBeFalse();
   });
 });

--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -456,7 +456,7 @@ describe("isSuppressiveAlert", () => {
     expect(isSuppressiveAlert(shuttleAlert, 0)).toBeFalse();
     expect(isSuppressiveAlert(shuttleAlert, 3)).toBeFalse();
     expect(isSuppressiveAlert(currentShuttleAlert, 0)).toBeTrue();
-    expect(isSuppressiveAlert(currentShuttleAlert, 3)).toBeTrue();
+    expect(isSuppressiveAlert(currentShuttleAlert, 3)).toBeFalse();
   });
 
   test("for suspensions", () => {

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -263,3 +263,25 @@ export const alertsByFacility = (
     return false;
   });
 };
+
+/**
+ * Sometimes we want to use the alerts to affect the display of departures. This
+ * is mainly when:
+ * - A shuttle is in service
+ * - A suspension is underway – accounting for the fact that, when a suspension
+ *   applies to a range of stops, the first/last stops in that range might only
+ *   experience the suspension in a single direction. We might not have
+ *   sufficient data in the alert itself to conclusively determine that, but we
+ *   can approximate this by observing whether arrival/departure data is
+ *   present.
+ */
+export const isSuppressiveAlert = (
+  alert: Alert,
+  numDepartures: number
+): boolean => {
+  const { effect } = alert;
+  // is departures are present, then the suspension likely doesn't apply
+  const isRelevantSuspension = effect === "suspension" && numDepartures === 0;
+  const isShuttle = effect === "shuttle";
+  return isCurrentLifecycle(alert) && (isShuttle || isRelevantSuspension);
+};

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -277,11 +277,11 @@ export const alertsByFacility = (
  */
 export const isSuppressiveAlert = (
   alert: Alert,
-  numDepartures: number
+  numPredictions: number
 ): boolean => {
   const { effect } = alert;
-  // is departures are present, then the suspension likely doesn't apply
-  const isRelevantSuspension = effect === "suspension" && numDepartures === 0;
+  // if predictions are present, then the suspension likely doesn't apply
+  const isRelevantSuspension = effect === "suspension" && numPredictions === 0;
   const isShuttle = effect === "shuttle";
   return isCurrentLifecycle(alert) && (isShuttle || isRelevantSuspension);
 };

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -280,8 +280,8 @@ export const isSuppressiveAlert = (
   numPredictions: number
 ): boolean => {
   const { effect } = alert;
-  // if predictions are present, then the suspension likely doesn't apply
-  const isRelevantSuspension = effect === "suspension" && numPredictions === 0;
-  const isShuttle = effect === "shuttle";
-  return isCurrentLifecycle(alert) && (isShuttle || isRelevantSuspension);
+  // if predictions are present, suspension or shuttle likely doesn't apply here
+  const isValidSuppressiveAlert =
+    (effect === "suspension" || effect === "shuttle") && numPredictions === 0;
+  return isCurrentLifecycle(alert) && isValidSuppressiveAlert;
 };

--- a/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -3,8 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import DepartureCard from "../components/DepartureCard";
 import { Alert, RouteType } from "../../__v3api";
 import { baseRoute } from "./helpers";
-import { ScheduleWithTimestamp } from "../../models/schedules";
-import { mergeIntoDepartureInfo } from "../../helpers/departureInfo";
+import { DepartureInfo } from "../../models/departureInfo";
 
 const mockClickAction = jest.fn();
 
@@ -97,41 +96,34 @@ describe("DepartureCard", () => {
         informed_entity: {
           direction_id: [0]
         },
-        effect: "shuttle"
+        effect: "shuttle",
+        lifecycle: "new"
       },
       {
         id: "4321",
         informed_entity: {
           direction_id: [null]
         },
-        effect: "suspension"
+        effect: "suspension",
+        lifecycle: "new"
       },
       {
         id: "0987",
         informed_entity: {
           direction_id: [1]
         },
-        effect: "detour"
+        effect: "detour",
+        lifecycle: "new"
       }
     ] as Alert[];
 
-    const schedules = [
-      {
-        route: baseRoute("749", 3),
-        trip: { id: "1", direction_id: 0, headsign: "Way 0" }
-      },
-      {
-        route: baseRoute("749", 3),
-        trip: { id: "2", direction_id: 1, headsign: "Way 1" }
-      }
-    ] as ScheduleWithTimestamp[];
-    const departures = mergeIntoDepartureInfo(schedules, []);
+    const departures = [] as DepartureInfo[];
 
     render(
       <DepartureCard
         route={baseRoute("749", 3)}
         departuresForRoute={departures}
-        stopName=""
+        stopName="Shining Time Station"
         alertsForRoute={alerts}
         onClick={() => {}}
       />

--- a/apps/site/assets/ts/stop/__tests__/DepartureListTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureListTest.tsx
@@ -271,32 +271,6 @@ describe("DepartureList", () => {
     expect(screen.getByText("25 min")).toBeInTheDocument();
   });
 
-  it("should not display schedules/predictions if shuttle alert", () => {
-    const alerts = [
-      {
-        id: "1234",
-        informed_entity: {
-          direction_id: [0]
-        },
-        effect: "shuttle",
-        lifecycle: "ongoing"
-      }
-    ] as Alert[];
-
-    render(
-      <DepartureList
-        alerts={alerts}
-        route={route}
-        stop={stop}
-        departures={departures}
-        directionId={0}
-        headsign="Emerald City"
-        targetDate={new Date("2022-04-27T11:00:00-04:00")}
-      />
-    );
-    expect(screen.queryAllByRole("listitem")).toHaveLength(0);
-  });
-
   it("should display schedules/predictions if shuttle alert is in future", () => {
     const alerts = [
       {

--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -103,12 +103,15 @@ describe("DepartureTimes", () => {
   `(
     `displays $expectedBadge when high priority alert has effect $alertEffect`,
     ({ alertEffect, expectedBadge }) => {
-      const schedules = [
-        {
-          route: { type: 2 },
-          trip: { direction_id: 0 }
-        }
-      ] as ScheduleWithTimestamp[];
+      const schedules =
+        alertEffect === "suspension"
+          ? []
+          : ([
+              {
+                route: { type: 2 },
+                trip: { direction_id: 0 }
+              }
+            ] as ScheduleWithTimestamp[]);
 
       const alerts = [
         {
@@ -116,7 +119,8 @@ describe("DepartureTimes", () => {
           informed_entity: {
             direction_id: [0]
           },
-          effect: alertEffect
+          effect: alertEffect,
+          lifecycle: "new"
         }
       ] as Alert[];
 
@@ -124,7 +128,7 @@ describe("DepartureTimes", () => {
         <DepartureTimes
           route={route}
           directionId={0}
-          stopName=""
+          stopName="ThatStation"
           departuresForDirection={mergeIntoDepartureInfo(schedules, [])}
           alertsForDirection={alerts}
           onClick={() => {}}
@@ -136,12 +140,7 @@ describe("DepartureTimes", () => {
   );
 
   it("should display the high priority alert badge over the information alert badge", () => {
-    const schedules = [
-      {
-        route: { type: 1 },
-        trip: { direction_id: 0 }
-      }
-    ] as ScheduleWithTimestamp[];
+    const schedules = [] as ScheduleWithTimestamp[];
 
     const alerts = [
       {
@@ -149,14 +148,16 @@ describe("DepartureTimes", () => {
         informed_entity: {
           direction_id: [0]
         },
-        effect: "suspension"
+        effect: "suspension",
+        lifecycle: "new"
       },
       {
         id: "123",
         informed_entity: {
           direction_id: [0]
         },
-        effect: "detour"
+        effect: "detour",
+        lifecycle: "new"
       }
     ] as Alert[];
 
@@ -164,7 +165,7 @@ describe("DepartureTimes", () => {
       <DepartureTimes
         route={route}
         directionId={0}
-        stopName=""
+        stopName="ThisStop"
         departuresForDirection={mergeIntoDepartureInfo(schedules, [])}
         alertsForDirection={alerts}
         onClick={() => {}}

--- a/apps/site/assets/ts/stop/components/DepartureList.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureList.tsx
@@ -44,8 +44,10 @@ const DepartureList = ({
     departures,
     (d: DepartureInfo) => !(d.isCancelled && d.routeMode === SUBWAY)
   );
+  const numPredictions = modeSpecificDepartures.filter(d => !!d.prediction)
+    .length;
   const alertsShouldSuppressDepartures = alerts.some(alert =>
-    isSuppressiveAlert(alert, modeSpecificDepartures.length)
+    isSuppressiveAlert(alert, numPredictions)
   );
   const tripForSelectedRoutePattern: Trip | undefined =
     modeSpecificDepartures[0]?.trip;

--- a/apps/site/assets/ts/stop/components/DepartureList.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureList.tsx
@@ -6,7 +6,7 @@ import { SUBWAY, departuresListFromInfos } from "../../helpers/departureInfo";
 import { routeBgClass } from "../../helpers/css";
 import { routeName, routeToModeIcon } from "../../helpers/route-headers";
 import renderSvg from "../../helpers/render-svg";
-import { hasSuspension, isCurrentLifecycle } from "../../models/alert";
+import { isSuppressiveAlert } from "../../models/alert";
 import Alerts from "../../components/Alerts";
 import { isACommuterRailRoute } from "../../models/route";
 
@@ -44,10 +44,9 @@ const DepartureList = ({
     departures,
     (d: DepartureInfo) => !(d.isCancelled && d.routeMode === SUBWAY)
   );
-  const alertsShouldSuppressDepartures =
-    alerts.some(alert => {
-      return isCurrentLifecycle(alert) && alert.effect === "shuttle";
-    }) || hasSuspension(alerts);
+  const alertsShouldSuppressDepartures = alerts.some(alert =>
+    isSuppressiveAlert(alert, modeSpecificDepartures.length)
+  );
   const tripForSelectedRoutePattern: Trip | undefined =
     modeSpecificDepartures[0]?.trip;
 

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -5,7 +5,8 @@ import renderFa from "../../helpers/render-fa";
 import {
   hasDetour,
   hasShuttleService,
-  hasSuspension
+  hasSuspension,
+  isSuppressiveAlert
 } from "../../models/alert";
 import Badge from "../../components/Badge";
 import { DepartureInfo } from "../../models/departureInfo";
@@ -121,7 +122,10 @@ const getRow = (
   overrideDate?: Date
 ): JSX.Element => {
   // High priority badges override the displaying of times
-  const alertBadge = toHighPriorityAlertBadge(alerts);
+  const suppressiveAlerts = alerts.filter(alert =>
+    isSuppressiveAlert(alert, departures.length)
+  );
+  const alertBadge = toHighPriorityAlertBadge(suppressiveAlerts);
   const isCR = departures[0]
     ? departures[0].routeMode === "commuter_rail"
     : false;

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -194,12 +194,7 @@ const DepartureTimes = ({
         >
           {!isAtDestination(stopName, route, directionId) &&
             destination &&
-            departureTimeRow(
-              destination,
-              [],
-              route.type === 2,
-              alertsForDirection
-            )}
+            getRow(destination, [], alertsForDirection, overrideDate)}
         </div>
       )}
     </>

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -121,9 +121,10 @@ const getRow = (
   alerts: Alert[],
   overrideDate?: Date
 ): JSX.Element => {
-  // High priority badges override the displaying of times
+  // High priority badges might override the displaying of times
+  const numPredictions = departures.filter(d => !!d.prediction).length;
   const suppressiveAlerts = alerts.filter(alert =>
-    isSuppressiveAlert(alert, departures.length)
+    isSuppressiveAlert(alert, numPredictions)
   );
   const alertBadge = toHighPriorityAlertBadge(suppressiveAlerts);
   const isCR = departures[0]


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Departures | “No Service” badge is shown and predictions are being suppressed for Green Line routes that are only affected in one direction](https://app.asana.com/0/385363666817452/1205213256266703/f)

## The Problem 
The main issue this PR was trying to solve involved a Suspension alert on the Green Line in Government Center/Haymarket/North Station from earlier this week. That alert did not specify an affected direction. 

Because the changes in this PR might affect the display of **all** alert badges (Detour, Suspension/No Service, Shuttle) I'm creating some test alerts for the reviewer to verify that several things display as expected on **dev-blue**:

- The suspension from the PR has been recreated in test Alerts UI, so can be seen at Government Center (stop ID place-gover) and North Station (place-north). On the master branch those stations look like this:

<img width="409" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/9d1f5055-c705-49f0-9f81-a3eead0fadc3">

The problem is that both directions say "No service", but in reality these two stops have partial service. Government Center should show service in the Westbound direction, and North Station should show service in the Eastbound direction.

- I made a shuttle alert on a portion of the Blue Line. On the master branch that looks like this:
<img width="552" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/1ef8bb10-9a00-4062-95fb-81ba0da031a1">

It's a similar problem to the one for suspensions, where only one direction _should_ be affected.

- There's a detour on the 66 bus at Tremont St @ Huntington Ave (stop ID 1362). On the master branch it looks like this (and should remain unchanged):
<img width="414" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/242a6b5b-5933-484b-884e-6fed38d5514e">

## After

> [!Warning]
> I am unable to reproduce the conditions that were in play for the recent Green Line suspension. I can make an alert, but the data present at the time was also crucial to what ended up showing on this page: at the time of the actual suspension, predictions and schedules were removed from the API where applicable. **The predictions and schedules on dev-blue are not indicative of real-world conditions during this type of alert.**

The result is sorta still a mess (because of the issue noted above), but the one improvement it has is that, if predictions are present in the data, then we surface those in lieu of showing a `No Service` or `Shuttle Service` badge. We're making the assumption that live predictions = the alert is incorrectly configured. Example below:

![image](https://github.com/mbta/dotcom/assets/2136286/213ea48f-d9c1-418a-923a-cc6527836255)


---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
