### PR TITLE
fix: check current lifecycle when counting out of order amenities

### DIFF
--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -4,6 +4,7 @@ import {
   Alert,
   Facility,
   InformedEntitySet,
+  Lifecycle,
   TimePeriodPairs
 } from "../../__v3api";
 import {
@@ -410,6 +411,18 @@ describe("hasCurrentFacilityAlert", () => {
 
     expect(hasCurrentFacilityAlert(facilityId, [facilityAlert])).toBe(true);
     expect(hasCurrentFacilityAlert(facilityId, [alert2])).toBe(false);
+  });
+
+  test("should only return true if it has current alerts", () => {
+    let facilityId = "ele-125";
+    const facilityAlert = {
+      ...alert1,
+      lifecycle: "upcoming" as Lifecycle,
+      informed_entity: {
+        facility: ["ele-125"]
+      } as InformedEntitySet
+    };
+    expect(hasCurrentFacilityAlert(facilityId, [facilityAlert])).toBe(false);
   });
 });
 

--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -17,7 +17,7 @@ import {
   alertsByRoute,
   alertsByDirectionId,
   alertsAffectingBothDirections,
-  hasFacilityAlert,
+  hasCurrentFacilityAlert,
   alertsByActivity,
   alertsByFacility,
   isSuppressiveAlert
@@ -398,7 +398,7 @@ describe("alertsAffectingBothDirections", () => {
   });
 });
 
-describe("hasFacilityAlert", () => {
+describe("hasCurrentFacilityAlert", () => {
   test("should return true when facilityId matches facility in alert else false", () => {
     let facilityId = "ele-125";
     const facilityAlert = {
@@ -408,8 +408,8 @@ describe("hasFacilityAlert", () => {
       } as InformedEntitySet
     };
 
-    expect(hasFacilityAlert(facilityId, [facilityAlert])).toBe(true);
-    expect(hasFacilityAlert(facilityId, [alert2])).toBe(false);
+    expect(hasCurrentFacilityAlert(facilityId, [facilityAlert])).toBe(true);
+    expect(hasCurrentFacilityAlert(facilityId, [alert2])).toBe(false);
   });
 });
 

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -239,11 +239,11 @@ export const isGlobalBannerAlert = (alert: Alert): boolean => {
   return alert.banner != null;
 };
 
-export const hasFacilityAlert = (
+export const hasCurrentFacilityAlert = (
   facilityId: string,
   alerts: Alert[]
 ): boolean => {
-  return alerts.some(alert => {
+  return alerts.filter(isCurrentLifecycle).some(alert => {
     if (alert.informed_entity?.facility) {
       return alert.informed_entity.facility.includes(facilityId);
     }

--- a/apps/site/assets/ts/stop/components/AccessAmenitiesModal.tsx
+++ b/apps/site/assets/ts/stop/components/AccessAmenitiesModal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Alert, Facility } from "../../__v3api";
 import Alerts from "../../components/Alerts";
-import { hasFacilityAlert } from "../../models/alert";
+import { hasCurrentFacilityAlert } from "../../models/alert";
 import { AmenityModal, AmenityLink } from "./amenities/AmenityCard";
 
 const AccessAmenitiesModal = ({
@@ -43,7 +43,7 @@ const AccessAmenitiesModal = ({
                     <td className="ps-16 pe-16">
                       {facility.attributes.short_name}
                     </td>
-                    {hasFacilityAlert(facility.id, alerts) ? (
+                    {hasCurrentFacilityAlert(facility.id, alerts) ? (
                       <td className="status">
                         <i className="fa-solid fa-circle amenity-status amenity-out" />
                         Out of Order

--- a/apps/site/assets/ts/stop/components/amenities/access-amenities-helpers.tsx
+++ b/apps/site/assets/ts/stop/components/amenities/access-amenities-helpers.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Alert, Facility } from "../../../__v3api";
 import Badge from "../../../components/Badge";
+import { isCurrentLifecycle } from "../../../models/alert";
 
 export const availabilityMessage = (
   brokenFacilities: number,
@@ -20,7 +21,8 @@ export const cardBadge = (
   accessFacilities: Facility[],
   alerts: Alert[]
 ): React.ReactNode => {
-  const workingFacilities = accessFacilities.length - alerts.length;
+  const currentAlerts = alerts.filter(isCurrentLifecycle);
+  const workingFacilities = accessFacilities.length - currentAlerts.length;
   if (accessFacilities.length > 0) {
     let backgroundClass = "u-success-background";
     if (workingFacilities === 0) {


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Elevator Status Affected by Upcoming Alerts](https://app.asana.com/0/385363666817452/1205268550058218/f)

The first commit fixes the table, the second fixes the badge, both should now display the correct number of current outages.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
