### PR TITLE
feat(DepartureTimes): Display badge when station closed

### DIFF
--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -507,12 +507,18 @@ describe("isSuppressiveAlert", () => {
   });
 
   test("for closures", () => {
-    const closureAlert = {
+    const stationClosureAlert = {
+      id: "c1",
+      effect: "station_closure",
+      lifecycle: "ongoing"
+    } as Alert;
+    const stopClosureAlert = {
       id: "c1",
       effect: "station_closure",
       lifecycle: "ongoing"
     } as Alert;
 
-    expect(isSuppressiveAlert(closureAlert, 3)).toBeTrue()
-  })
+    expect(isSuppressiveAlert(stationClosureAlert, 3)).toBeTrue();
+    expect(isSuppressiveAlert(stopClosureAlert, 3)).toBeTrue();
+  });
 });

--- a/apps/site/assets/ts/models/__tests__/alert-test.ts
+++ b/apps/site/assets/ts/models/__tests__/alert-test.ts
@@ -505,4 +505,14 @@ describe("isSuppressiveAlert", () => {
     expect(isSuppressiveAlert(currentDetourAlert, 0)).toBeFalse();
     expect(isSuppressiveAlert(currentDetourAlert, 3)).toBeFalse();
   });
+
+  test("for closures", () => {
+    const closureAlert = {
+      id: "c1",
+      effect: "station_closure",
+      lifecycle: "ongoing"
+    } as Alert;
+
+    expect(isSuppressiveAlert(closureAlert, 3)).toBeTrue()
+  })
 });

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -78,6 +78,9 @@ export const hasShuttleService = (alerts: Alert[]): boolean =>
 export const hasDetour = (alerts: Alert[]): boolean =>
   hasEffect(alerts, "detour");
 
+export const hasStationClosure = (alerts: Alert[]): boolean =>
+  hasEffect(alerts, "station_closure")
+
 export const alertsWithStop = (alerts: Alert[]): Alert[] =>
   alerts.filter(
     ({ informed_entity: entites }: Alert): boolean => !!entites.stop
@@ -282,6 +285,6 @@ export const isSuppressiveAlert = (
   const { effect } = alert;
   // if predictions are present, suspension or shuttle likely doesn't apply here
   const isValidSuppressiveAlert =
-    (effect === "suspension" || effect === "shuttle") && numPredictions === 0;
+    ((effect === "suspension" || effect === "shuttle") && numPredictions === 0) || effect === "station_closure";
   return isCurrentLifecycle(alert) && isValidSuppressiveAlert;
 };

--- a/apps/site/assets/ts/models/alert.ts
+++ b/apps/site/assets/ts/models/alert.ts
@@ -78,8 +78,14 @@ export const hasShuttleService = (alerts: Alert[]): boolean =>
 export const hasDetour = (alerts: Alert[]): boolean =>
   hasEffect(alerts, "detour");
 
+export const hasStopClosure = (alerts: Alert[]): boolean =>
+  hasEffect(alerts, "stop_closure");
+
 export const hasStationClosure = (alerts: Alert[]): boolean =>
-  hasEffect(alerts, "station_closure")
+  hasEffect(alerts, "station_closure");
+
+export const hasClosure = (alerts: Alert[]): boolean =>
+  hasStopClosure(alerts) || hasStationClosure(alerts);
 
 export const alertsWithStop = (alerts: Alert[]): Alert[] =>
   alerts.filter(
@@ -285,6 +291,9 @@ export const isSuppressiveAlert = (
   const { effect } = alert;
   // if predictions are present, suspension or shuttle likely doesn't apply here
   const isValidSuppressiveAlert =
-    ((effect === "suspension" || effect === "shuttle") && numPredictions === 0) || effect === "station_closure";
+    ((effect === "suspension" || effect === "shuttle") &&
+      numPredictions === 0) ||
+    effect === "station_closure" ||
+    effect === "stop_closure";
   return isCurrentLifecycle(alert) && isValidSuppressiveAlert;
 };

--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -488,4 +488,26 @@ describe("DepartureTimes", () => {
     expect(screen.queryByText("No upcoming trips")).not.toBeInTheDocument();
     expect(screen.queryByText("Somewhere there")).not.toBeInTheDocument();
   });
+
+  it("should render no service if the station is closed", () => {
+    const closureAlert = {
+      id: "c1",
+      effect: "station_closure",
+      lifecycle: "ongoing"
+    } as Alert;
+
+    render(
+      <DepartureTimes
+        route={route}
+        directionId={0}
+        stopName="asdf"
+        departuresForDirection={[]}
+        onClick={mockClickAction}
+        alertsForDirection={[closureAlert]}
+       />
+    )
+
+    expect(screen.getByText("No Service")).toBeInTheDocument()
+    expect(screen.getByText("See alternatives")).toBeInTheDocument();
+  })
 });

--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -504,10 +504,32 @@ describe("DepartureTimes", () => {
         departuresForDirection={[]}
         onClick={mockClickAction}
         alertsForDirection={[closureAlert]}
-       />
-    )
+      />
+    );
 
-    expect(screen.getByText("No Service")).toBeInTheDocument()
+    expect(screen.getByText("No Service")).toBeInTheDocument();
     expect(screen.getByText("See alternatives")).toBeInTheDocument();
-  })
+  });
+
+  it("should render no service if the stop is closed", () => {
+    const closureAlert = {
+      id: "c1",
+      effect: "stop_closure",
+      lifecycle: "ongoing"
+    } as Alert;
+
+    render(
+      <DepartureTimes
+        route={route}
+        directionId={0}
+        stopName="asdf"
+        departuresForDirection={[]}
+        onClick={mockClickAction}
+        alertsForDirection={[closureAlert]}
+      />
+    );
+
+    expect(screen.getByText("No Service")).toBeInTheDocument();
+    expect(screen.getByText("See alternatives")).toBeInTheDocument();
+  });
 });

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -3,9 +3,9 @@ import React, { ReactElement, ReactNode } from "react";
 import { Alert, DirectionId, Route } from "../../__v3api";
 import renderFa from "../../helpers/render-fa";
 import {
+  hasClosure,
   hasDetour,
   hasShuttleService,
-  hasStationClosure,
   hasSuspension,
   isSuppressiveAlert
 } from "../../models/alert";
@@ -20,7 +20,7 @@ import { breakTextAtSlash } from "../../helpers/text";
 import { handleReactEnterKeyPress } from "../../helpers/keyboard-events-react";
 
 const toHighPriorityAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
-  if (hasSuspension(alerts) || hasStationClosure(alerts)) {
+  if (hasSuspension(alerts) || hasClosure(alerts)) {
     return <Badge text="No Service" contextText="Route Status" />;
   }
 
@@ -89,7 +89,7 @@ const departureTimeRow = (
         alertBadgeWrapper(alertClass, alertBadge!)}
       {(hasShuttleService(alerts) ||
         hasSuspension(alerts) ||
-        hasStationClosure(alerts) ||
+        hasClosure(alerts) ||
         (hasDetour(alerts) && timeList.length === 0)) &&
         alertBadge && (
           <>

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -5,6 +5,7 @@ import renderFa from "../../helpers/render-fa";
 import {
   hasDetour,
   hasShuttleService,
+  hasStationClosure,
   hasSuspension,
   isSuppressiveAlert
 } from "../../models/alert";
@@ -19,7 +20,7 @@ import { breakTextAtSlash } from "../../helpers/text";
 import { handleReactEnterKeyPress } from "../../helpers/keyboard-events-react";
 
 const toHighPriorityAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
-  if (hasSuspension(alerts)) {
+  if (hasSuspension(alerts) || hasStationClosure(alerts)) {
     return <Badge text="No Service" contextText="Route Status" />;
   }
 
@@ -88,6 +89,7 @@ const departureTimeRow = (
         alertBadgeWrapper(alertClass, alertBadge!)}
       {(hasShuttleService(alerts) ||
         hasSuspension(alerts) ||
+        hasStationClosure(alerts) ||
         (hasDetour(alerts) && timeList.length === 0)) &&
         alertBadge && (
           <>


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
Stop displaying train times where there is a station closure alert

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Scheduled Trips Still Showing During Closure](https://app.asana.com/0/555089885850811/1205113827581160)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

