### PR TITLE
WIP: Pick between OTP1 and 2 based on mbta_id cookie

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -12,6 +12,8 @@
 export DRUPAL_ROOT=https://live-mbta.pantheonsite.io
 # export GOOGLE_API_KEY=
 export OPEN_TRIP_PLANNER_URL=http://otp-local.mbtace.com
+export OPEN_TRIP_PLANNER_2_URL=http://otp2-local.mbtace.com
+export OPEN_TRIP_PLANNER_2_PERCENTAGE=0
 export RECAPTCHA_PUBLIC_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 export RECAPTCHA_PRIVATE_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 # export STATIC_HOST=

--- a/apps/site/config/config.exs
+++ b/apps/site/config/config.exs
@@ -27,7 +27,11 @@ config :site, SiteWeb.ViewHelpers, google_tag_manager_id: System.get_env("GOOGLE
 config :laboratory,
   features: [
     {:stops_redesign, "Stops Page Redesign (Q1/Q2 2023)",
-     "Revamping of the Stop pages as part of the 🚉 Website - Stops Page Redesign epic"}
+     "Revamping of the Stop pages as part of the 🚉 Website - Stops Page Redesign epic"},
+    {:force_otp1, "Force OpenTripPlanner v1",
+     "Override randomized assignment between OTP instances and force OTP1."},
+    {:force_otp2, "Force OpenTripPlanner v2",
+     "Override randomized assignment between OTP instances and force OTP2 (this takes precedent if both flags are enabled)."}
   ],
   cookie: [
     # one month,

--- a/apps/site/lib/site/trip_plan/query.ex
+++ b/apps/site/lib/site/trip_plan/query.ex
@@ -23,15 +23,15 @@ defmodule Site.TripPlan.Query do
           itineraries: TripPlan.Api.t() | nil
         }
 
-  @spec from_query(map, Keyword.t()) :: t
-  def from_query(params, date_opts) do
+  @spec from_query(map, TripPlan.Api.connection_opts(), Keyword.t()) :: t
+  def from_query(params, connection_opts, date_opts) do
     opts = get_query_options(params)
 
     %__MODULE__{}
     |> Site.TripPlan.DateTime.validate(params, date_opts)
     |> Site.TripPlan.Location.validate(params)
     |> include_options(opts)
-    |> maybe_fetch_itineraries(opts)
+    |> maybe_fetch_itineraries(connection_opts, opts)
   end
 
   @spec get_query_options(map) :: keyword()
@@ -42,17 +42,18 @@ defmodule Site.TripPlan.Query do
     |> opts_from_query
   end
 
-  @spec maybe_fetch_itineraries(t, Keyword.t()) :: t
+  @spec maybe_fetch_itineraries(t, TripPlan.Api.connection_opts(), Keyword.t()) :: t
   defp maybe_fetch_itineraries(
          %__MODULE__{
            to: %NamedPosition{},
            from: %NamedPosition{}
          } = query,
+         connection_opts,
          opts
        ) do
     if Enum.empty?(query.errors) do
       query
-      |> fetch_itineraries([query.time | opts])
+      |> fetch_itineraries(connection_opts, [query.time | opts])
       |> parse_itinerary_result(query)
     else
       query
@@ -63,23 +64,24 @@ defmodule Site.TripPlan.Query do
     query
   end
 
-  @spec fetch_itineraries(t, Keyword.t()) :: TripPlan.Api.t()
+  @spec fetch_itineraries(t, String.t(), Keyword.t()) :: TripPlan.Api.t()
   defp fetch_itineraries(
          %__MODULE__{from: %NamedPosition{} = from, to: %NamedPosition{} = to},
+         connection_opts,
          opts
        ) do
     pid = self()
 
     if Keyword.get(opts, :wheelchair_accessible?) do
-      TripPlan.plan(from, to, opts)
+      TripPlan.plan(from, to, connection_opts, opts)
     else
       accessible_opts = Keyword.put(opts, :wheelchair_accessible?, true)
 
       [mixed_results, accessible_results] =
         Util.async_with_timeout(
           [
-            fn -> TripPlan.plan(from, to, opts, pid) end,
-            fn -> TripPlan.plan(from, to, accessible_opts, pid) end
+            fn -> TripPlan.plan(from, to, connection_opts, opts, pid) end,
+            fn -> TripPlan.plan(from, to, connection_opts, accessible_opts, pid) end
           ],
           {:error, :timeout},
           __MODULE__

--- a/apps/site/lib/site_web/controllers/trip_plan_controller.ex
+++ b/apps/site/lib/site_web/controllers/trip_plan_controller.ex
@@ -4,6 +4,7 @@ defmodule SiteWeb.TripPlanController do
   """
 
   use SiteWeb, :controller
+  require Logger
   alias Fares.{Fare, Month, OneWay}
   alias GoogleMaps.Geocode
   alias Routes.Route
@@ -219,11 +220,35 @@ defmodule SiteWeb.TripPlanController do
     |> render("vote.html")
   end
 
+  def get_conn_opts(conn) do
+    cookie = SiteWeb.Plugs.Cookies.id_cookie_name()
+    user_cookie = Map.get(conn.cookies, cookie, "0")
+
+    user_id =
+      try do
+        String.to_integer(user_cookie)
+      rescue
+        e in ArgumentError ->
+          Logger.warn(fn ->
+            "#{__MODULE__}.pick_url Couldn't parse #{cookie} cookie as an int, using 0. #{cookie}=#{user_cookie} parse_error=#{e.message}"
+          end)
+
+          0
+      end
+
+    [
+      user_id: user_id,
+      force_otp1: Laboratory.enabled?(conn, :force_otp1),
+      force_otp2: Laboratory.enabled?(conn, :force_otp2)
+    ]
+  end
+
   @spec render_plan(Plug.Conn.t(), map) :: Plug.Conn.t()
   defp render_plan(conn, plan) do
     query =
       Query.from_query(
         plan,
+        get_conn_opts(conn),
         now: conn.assigns.date_time,
         end_of_rating: Map.get(conn.assigns, :end_of_rating, Schedules.Repo.end_of_rating())
       )

--- a/apps/trip_plan/config/config.exs
+++ b/apps/trip_plan/config/config.exs
@@ -34,8 +34,9 @@ config :trip_plan, Geocode, module: TripPlan.Geocode.GoogleGeocode
 
 config :trip_plan, OpenTripPlanner,
   timezone: {:system, "OPEN_TRIP_PLANNER_TIMEZONE", "America/New_York"},
-  root_url: {:system, "OPEN_TRIP_PLANNER_URL"},
-  root_url_compare: {:system, "OPEN_TRIP_PLANNER_URL_COMPARE"},
+  otp1_url: {:system, "OPEN_TRIP_PLANNER_URL"},
+  otp2_url: {:system, "OPEN_TRIP_PLANNER_2_URL"},
+  otp2_percentage: {:system, "OPEN_TRIP_PLANNER_2_PERCENTAGE"},
   wiremock_proxy: {:system, "WIREMOCK_PROXY", "false"},
   wiremock_proxy_url: System.get_env("WIREMOCK_TRIP_PLAN_PROXY_URL")
 

--- a/apps/trip_plan/lib/trip_plan.ex
+++ b/apps/trip_plan/lib/trip_plan.ex
@@ -13,9 +13,21 @@ defmodule TripPlan do
   @doc """
   Tries to describe how to get between two places.
   """
-  @spec plan(Position.t(), Position.t(), TripPlan.Api.plan_opts(), pid()) :: TripPlan.Api.t()
-  def plan(from, to, opts, parent \\ self()) do
-    apply(module(Api), :plan, [from, to, Keyword.merge(@default_opts, opts), parent])
+  @spec plan(
+          Position.t(),
+          Position.t(),
+          TripPlan.Api.connection_opts(),
+          TripPlan.Api.plan_opts(),
+          pid()
+        ) :: TripPlan.Api.t()
+  def plan(from, to, connection_opts, opts, parent \\ self()) do
+    apply(module(Api), :plan, [
+      from,
+      to,
+      connection_opts,
+      Keyword.merge(@default_opts, opts),
+      parent
+    ])
   end
 
   @doc """

--- a/apps/trip_plan/lib/trip_plan/api.ex
+++ b/apps/trip_plan/lib/trip_plan/api.ex
@@ -16,6 +16,12 @@ defmodule TripPlan.Api do
           | {:optimize_for, :less_walking | :fewest_transfers}
           | {:max_walk_distance, float}
   @type plan_opts :: [plan_opt]
+  @type connection_opt ::
+          {:user_id, integer}
+          | {:force_otp1, boolean}
+          | {:force_otp2, boolean}
+  @type connection_opts :: [connection_opt]
+
   @type error ::
           :outside_bounds
           | :timeout
@@ -29,5 +35,10 @@ defmodule TripPlan.Api do
   @doc """
   Plans a trip between two locations.
   """
-  @callback plan(from :: Position.t(), to :: Position.t(), opts :: plan_opts) :: t
+  @callback plan(
+              from :: Position.t(),
+              to :: Position.t(),
+              conn_opts :: connection_opts,
+              opts :: plan_opts
+            ) :: t
 end

--- a/apps/trip_plan/lib/trip_plan/api/mock_planner.ex
+++ b/apps/trip_plan/lib/trip_plan/api/mock_planner.ex
@@ -21,35 +21,41 @@ defmodule TripPlan.Api.MockPlanner do
   @selected_routes ~w(1 350 Blue Red)s
 
   @impl true
-  def plan(from, to, opts) do
-    plan(from, to, opts, self())
+  def plan(from, to, connection_opts, opts) do
+    plan(from, to, connection_opts, opts, self())
   end
 
-  def plan(%NamedPosition{name: "Geocoded path_not_found"}, _to, _opts, _) do
+  def plan(%NamedPosition{name: "Geocoded path_not_found"}, _to, _opts, _connection_opts, _) do
     {:error, :path_not_found}
   end
 
-  def plan(%NamedPosition{name: "Geocoded Accessible error"} = from, to, opts, p) do
+  def plan(%NamedPosition{name: "Geocoded Accessible error"} = from, to, connection_opts, opts, p) do
     if Keyword.get(opts, :wheelchair_accessible?) do
       {:error, :not_accessible}
     else
-      plan(%{from | name: "Accessible error"}, to, opts, p)
+      plan(%{from | name: "Accessible error"}, to, connection_opts, opts, p)
     end
   end
 
-  def plan(%NamedPosition{name: "Geocoded Inaccessible error"} = from, to, opts, p) do
+  def plan(
+        %NamedPosition{name: "Geocoded Inaccessible error"} = from,
+        to,
+        connection_opts,
+        opts,
+        p
+      ) do
     if Keyword.get(opts, :wheelchair_accessible?) do
-      plan(%{from | name: "Inaccessible error"}, to, opts, p)
+      plan(%{from | name: "Inaccessible error"}, to, connection_opts, opts, p)
     else
       {:error, :not_accessible}
     end
   end
 
-  def plan(%NamedPosition{name: "Timeout error"}, _, _, _) do
+  def plan(%NamedPosition{name: "Timeout error"}, _, _, _, _) do
     :timer.sleep(:infinity)
   end
 
-  def plan(from, to, opts, parent) do
+  def plan(from, to, connection_opts, opts, parent) do
     start = DateTime.utc_now()
     duration = :rand.uniform(@max_duration)
     stop = Timex.shift(start, seconds: duration)
@@ -71,7 +77,7 @@ defmodule TripPlan.Api.MockPlanner do
       }
     ]
 
-    send(parent, {:planned_trip, {from, to, opts}, {:ok, itineraries}})
+    send(parent, {:planned_trip, {from, to, connection_opts, opts}, {:ok, itineraries}})
     {:ok, itineraries}
   end
 

--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner.ex
@@ -7,12 +7,12 @@ defmodule TripPlan.Api.OpenTripPlanner do
   alias TripPlan.NamedPosition
   alias Util.Position
 
-  def plan(from, to, opts, _parent) do
-    plan(from, to, opts)
+  def plan(from, to, connection_opts, opts, _parent) do
+    plan(from, to, connection_opts, opts)
   end
 
   @impl true
-  def plan(from, to, opts) do
+  def plan(from, to, connection_opts, opts) do
     with {:ok, params} <- build_params(from, to, opts) do
       params =
         Map.merge(
@@ -26,9 +26,51 @@ defmodule TripPlan.Api.OpenTripPlanner do
           }
         )
 
-      root_url = params["root_url"] || config(:root_url)
+      root_url = params["root_url"] || pick_url(connection_opts)
       full_url = "#{root_url}/otp/routers/default/plan"
       send_request(full_url, params, &parse_json/1)
+    end
+  end
+
+  def pick_url(connection_opts) do
+    cond do
+      connection_opts[:force_otp2] ->
+        config(:otp2_url)
+
+      connection_opts[:force_otp1] ->
+        config(:otp1_url)
+
+      true ->
+        user_id = connection_opts[:user_id]
+        percent_threshold = get_otp2_percentage()
+
+        :rand.seed(:exsss, user_id)
+        placement = :rand.uniform()
+        use_otp2 = placement < percent_threshold / 100
+
+        Logger.info(fn ->
+          "#{__MODULE__}.pick_url placement=#{placement} otp2_percentage=#{percent_threshold}% mbta_id=#{user_id} use_otp2=#{use_otp2}"
+        end)
+
+        # IO.inspect(" placement=#{placement} otp2_percentage=#{percent_threshold} mbta_id=#{user_id} use_otp2=#{use_otp2}")
+        if use_otp2 do
+          config(:otp2_url)
+        else
+          config(:otp1_url)
+        end
+    end
+  end
+
+  def get_otp2_percentage() do
+    try do
+      String.to_integer(config(:otp2_percentage))
+    rescue
+      e in ArgumentError ->
+        Logger.warn(fn ->
+          "#{__MODULE__}.pick_url Couldn't parse OPEN_TRIP_PLANNER_2_PERCENTAGE env var as an int, using 0. OPEN_TRIP_PLANNER_2_PERCENTAGE=#{config(:otp2_percentage)} parse_error=#{e.message}"
+        end)
+
+        0
     end
   end
 
@@ -59,7 +101,7 @@ defmodule TripPlan.Api.OpenTripPlanner do
 
     _ =
       Logger.info(fn ->
-        "#{__MODULE__}.plan_response url=#{url} params=#{inspect(params)} #{status_text(response)} duration=#{duration / :timer.seconds(1)}"
+        "#{__MODULE__}.plan_response url=#{url} is_otp2=#{String.contains?(url, config(:otp2_url))} params=#{inspect(params)} #{status_text(response)} duration=#{duration / :timer.seconds(1)}"
       end)
 
     response

--- a/apps/trip_plan/test/api/open_trip_planner/http_test.exs
+++ b/apps/trip_plan/test/api/open_trip_planner/http_test.exs
@@ -42,7 +42,8 @@ defmodule TripPlan.Api.OpenTripPlanner.HttpTest do
         Logger.configure(level: old_level)
       end)
 
-      new_config = put_in(old_config[:root_url], host)
+      new_config = put_in(old_config[:otp1_url], host)
+      new_config = put_in(new_config[:otp2_url], host)
       Application.put_env(:trip_plan, OpenTripPlanner, new_config)
       Logger.configure(level: :info)
 


### PR DESCRIPTION
This generates a random value, seeded by the mbta_id cookie, which stays static per user (until cookies are cleared), to determine which instance of OTP they should be served. The percentage of traffic being served OTP2 can be configured with a new env var.

Two new feature flags are also included, which can be used to force a specific version (OTP2 is picked if both are selected).

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Make dotcom changes to perform traffic splitting between OTP1 and OTP2](https://app.asana.com/0/1204355099788517/1205204806153400/f)

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.


