### PR TITLE
feat: add mechanism for closing streams of prediction data

### DIFF
--- a/apps/predictions/lib/predictions_pub_sub.ex
+++ b/apps/predictions/lib/predictions_pub_sub.ex
@@ -100,7 +100,7 @@ defmodule Predictions.PredictionsPubSub do
     pattern = {registry_key, :"$2", key}
 
     guards = [
-      {:"=/=", :"$2", pid_to_omit},
+      {:"=/=", :"$2", pid_to_omit}
     ]
 
     body = [true]

--- a/apps/predictions/lib/predictions_pub_sub.ex
+++ b/apps/predictions/lib/predictions_pub_sub.ex
@@ -11,6 +11,7 @@ defmodule Predictions.PredictionsPubSub do
 
   @valid_filters ["route", "stop", "direction", "trip"]
   @broadcast_interval_ms Application.compile_env!(:predictions, [:broadcast_interval_ms])
+  @subscribers :prediction_subscriptions_registry
 
   @type broadcast_message :: {:new_predictions, [Prediction.t()]}
 
@@ -33,7 +34,7 @@ defmodule Predictions.PredictionsPubSub do
   def subscribe(key, server \\ __MODULE__) do
     StreamSupervisor.ensure_stream_is_started(key)
     {registry_key, predictions} = GenServer.call(server, {:subscribe, key})
-    Registry.register(:prediction_subscriptions_registry, registry_key, key)
+    Registry.register(@subscribers, registry_key, key)
     predictions
   end
 
@@ -48,17 +49,36 @@ defmodule Predictions.PredictionsPubSub do
   end
 
   @impl GenServer
-  def handle_call({:subscribe, keys}, _from, state) do
+  def handle_call({:subscribe, keys}, {from_pid, _ref}, state) do
     registry_key = self()
+
+    # Let us detect when the calling process goes down, and save the associated
+    # keys for easier lookup
+    Process.monitor(from_pid)
+    new_state = Map.put_new(state, from_pid, keys)
+
     predictions = keys |> table_keys() |> Store.fetch()
-    {:reply, {registry_key, predictions}, state}
+    {:reply, {registry_key, predictions}, new_state}
+  end
+
+  @impl GenServer
+  def handle_cast({:stop_stream, key}, state) do
+    # By this point, the caller_pid is no longer alive or registered/subscribed.
+    # Here we can check if there are other subscribers for the associated key.
+    # If there are no other subscribers remaining, we stop the associated
+    # predictions data stream.
+    if Registry.count_match(@subscribers, self(), key) == 0 do
+      StreamSupervisor.stop_stream(key)
+    end
+
+    {:noreply, state}
   end
 
   @impl GenServer
   def handle_info(:broadcast, state) do
     registry_key = self()
 
-    Registry.dispatch(:prediction_subscriptions_registry, registry_key, fn entries ->
+    Registry.dispatch(@subscribers, registry_key, fn entries ->
       Enum.each(entries, &send_data(&1))
     end)
 
@@ -69,6 +89,16 @@ defmodule Predictions.PredictionsPubSub do
   def handle_info({event, predictions}, state) do
     :ok = Store.update(event, predictions)
     {:noreply, state}
+  end
+
+  def handle_info(
+        {:DOWN, parent_ref, :process, caller_pid, _reason},
+        state
+      ) do
+    Process.demonitor(parent_ref, [:flush])
+    {key, new_state} = Map.pop(state, caller_pid)
+    GenServer.cast(__MODULE__, {:stop_stream, key})
+    {:noreply, new_state}
   end
 
   @spec table_keys(String.t()) :: [

--- a/apps/predictions/lib/stream.ex
+++ b/apps/predictions/lib/stream.ex
@@ -46,6 +46,15 @@ defmodule Predictions.Stream do
     |> broadcast(type, broadcast_fn)
   end
 
+  defp send_event(
+         %Event{
+           data: {:error, _} = error
+         },
+         _broadcast_fn
+       ) do
+    error
+  end
+
   @typep broadcast_fn :: (atom, String.t(), any -> :ok | {:error, any})
   @spec broadcast([Prediction.t() | String.t()], event_type, broadcast_fn) :: :ok
   defp broadcast([], _type, _broadcast_fn), do: :ok

--- a/apps/predictions/lib/stream_supervisor.ex
+++ b/apps/predictions/lib/stream_supervisor.ex
@@ -41,15 +41,7 @@ defmodule Predictions.StreamSupervisor do
 
   @spec start_stream(String.t()) :: {:ok, pid()}
   defp start_stream(key) do
-    DynamicSupervisor.start_child(
-      __MODULE__,
-      %{
-        id: Worker,
-        start: {Worker, :start_link, [key, via_tuple(key)]},
-        restart: :transient,
-        type: :worker
-      }
-    )
+    DynamicSupervisor.start_child(__MODULE__, {Worker, [key, via_tuple(key)]})
   end
 
   defp via_tuple(key) do

--- a/apps/predictions/lib/stream_supervisor.ex
+++ b/apps/predictions/lib/stream_supervisor.ex
@@ -55,4 +55,18 @@ defmodule Predictions.StreamSupervisor do
   defp via_tuple(key) do
     {:via, Registry, {@streams, key}}
   end
+
+  @spec stop_stream(String.t()) :: :ok
+  def stop_stream(key) do
+    case lookup(key) do
+      pid when is_pid(pid) ->
+        DynamicSupervisor.terminate_child(
+          __MODULE__,
+          pid
+        )
+
+      _ ->
+        :ok
+    end
+  end
 end

--- a/apps/predictions/lib/stream_supervisor.ex
+++ b/apps/predictions/lib/stream_supervisor.ex
@@ -2,8 +2,10 @@ defmodule Predictions.StreamSupervisor do
   @moduledoc """
   DynamicSupervisor managing streams of predictions from the API.
   """
-  import Predictions.PredictionsPubSub, only: [table_keys: 1]
   use DynamicSupervisor
+  alias Predictions.StreamSupervisor.Worker
+
+  @streams :prediction_streams_registry
 
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts), do: DynamicSupervisor.start_link(__MODULE__, opts, name: __MODULE__)
@@ -24,81 +26,33 @@ defmodule Predictions.StreamSupervisor do
       nil ->
         start_stream(keys)
 
-      pid ->
-        {:ok, pid}
+      stream_pid ->
+        {:ok, stream_pid}
     end
   end
 
   @spec lookup(String.t()) :: pid() | nil
   defp lookup(key) do
-    case Registry.lookup(:prediction_streams_registry, key) do
-      [{_pid, sses_pid}] ->
-        if Process.alive?(sses_pid), do: sses_pid
-
-      _ ->
-        nil
+    case Registry.lookup(@streams, key) do
+      [{stream_pid, _}] -> stream_pid
+      _ -> nil
     end
   end
 
   @spec start_stream(String.t()) :: {:ok, pid()}
-  defp start_stream(keys) do
-    with {:ok, sses_pid} <-
-           DynamicSupervisor.start_child(
-             __MODULE__,
-             {ServerSentEventStage, sses_opts(keys)}
-           ),
-         api_stream_name <- api_stream_name(keys),
-         sses_stream_name <- sses_stream_name(keys),
-         prediction_stream_name <- prediction_stream_name(keys),
-         {:ok, _api_stream_pid} <-
-           DynamicSupervisor.start_child(
-             __MODULE__,
-             {V3Api.Stream, name: api_stream_name, subscribe_to: sses_stream_name}
-           ),
-         {:ok, _predictions_stream_pid} <-
-           DynamicSupervisor.start_child(
-             __MODULE__,
-             {Predictions.Stream, name: prediction_stream_name, subscribe_to: api_stream_name}
-           ) do
-      Registry.register(:prediction_streams_registry, keys, sses_pid)
-      {:ok, sses_pid}
-    else
-      {:error, {:already_started, pid}} ->
-        {:ok, pid}
-    end
+  defp start_stream(key) do
+    DynamicSupervisor.start_child(
+      __MODULE__,
+      %{
+        id: Worker,
+        start: {Worker, :start_link, [key, via_tuple(key)]},
+        restart: :transient,
+        type: :worker
+      }
+    )
   end
 
-  # Parses the argument from the channel name, expecting a name formatted with
-  # `:` delimiters and `=` separators, e.g.
-  # `route=Red:direction_id=1:stop=place-sstat`
-  @spec sses_opts(String.t()) :: Keyword.t()
-  defp sses_opts(keys) do
-    filters =
-      table_keys(keys)
-      |> Enum.map(fn {k, v} -> "filter[#{k}]=#{v}&" end)
-      |> Enum.join()
-
-    path =
-      "/predictions?#{filters}fields[prediction]=status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence&include=route,trip,trip.occupancies,stop&fields[route]=long_name,short_name,type&fields[trip]=direction_id,headsign,name,bikes_allowed&fields[stop]=platform_code"
-
-    sses_opts =
-      V3Api.Stream.build_options(
-        name: sses_stream_name(keys),
-        path: path
-      )
-
-    sses_opts
+  defp via_tuple(key) do
+    {:via, Registry, {@streams, key}}
   end
-
-  @spec sses_stream_name(String.t()) :: atom()
-  defp sses_stream_name(keys),
-    do: :"predictions_sses_stream_#{keys}"
-
-  @spec api_stream_name(String.t()) :: atom()
-  defp api_stream_name(keys),
-    do: :"predictions_api_stream_#{keys}"
-
-  @spec prediction_stream_name(String.t()) :: atom()
-  defp prediction_stream_name(keys),
-    do: :"predictions_data_stream_#{keys}"
 end

--- a/apps/predictions/lib/stream_worker.ex
+++ b/apps/predictions/lib/stream_worker.ex
@@ -8,6 +8,15 @@ defmodule Predictions.StreamSupervisor.Worker do
     Supervisor.start_link(__MODULE__, key, name: name)
   end
 
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts},
+      restart: :transient,
+      type: :supervisor
+    }
+  end
+
   @impl Supervisor
   def init(key) do
     sses_stream_name = sses_stream_name(key)

--- a/apps/predictions/lib/stream_worker.ex
+++ b/apps/predictions/lib/stream_worker.ex
@@ -1,0 +1,52 @@
+defmodule Predictions.StreamSupervisor.Worker do
+  @moduledoc "Each request to the streaming predictions"
+  use Supervisor
+  import Predictions.PredictionsPubSub, only: [table_keys: 1]
+
+  @spec start_link(String.t(), Tuple.t()) :: Supervisor.on_start()
+  def start_link(key, name) do
+    Supervisor.start_link(__MODULE__, key, name: name)
+  end
+
+  @impl true
+  def init(key) do
+    sses_stream_name = sses_stream_name(key)
+    api_stream_name = :"predictions_api_stream_#{key}"
+    prediction_stream_name = :"predictions_data_stream_#{key}"
+
+    Supervisor.init(
+      [
+        {ServerSentEventStage, sses_opts(key)},
+        {V3Api.Stream, name: api_stream_name, subscribe_to: sses_stream_name},
+        {Predictions.Stream, name: prediction_stream_name, subscribe_to: api_stream_name}
+      ],
+      strategy: :rest_for_one
+    )
+  end
+
+  # Parses the argument from the channel name, expecting a name formatted with
+  # `:` delimiters and `=` separators, e.g.
+  # `route=Red:direction_id=1:stop=place-sstat`
+  @spec sses_opts(String.t()) :: Keyword.t()
+  defp sses_opts(key) do
+    filters =
+      table_keys(key)
+      |> Enum.map(fn {k, v} -> "filter[#{k}]=#{v}&" end)
+      |> Enum.join()
+
+    path =
+      "/predictions?#{filters}fields[prediction]=status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence&include=route,trip,trip.occupancies,stop&fields[route]=long_name,short_name,type&fields[trip]=direction_id,headsign,name,bikes_allowed&fields[stop]=platform_code"
+
+    sses_opts =
+      V3Api.Stream.build_options(
+        name: sses_stream_name(key),
+        path: path
+      )
+
+    sses_opts
+  end
+
+  @spec sses_stream_name(String.t()) :: atom()
+  defp sses_stream_name(key),
+    do: :"predictions_sses_stream_#{key}"
+end

--- a/apps/predictions/lib/stream_worker.ex
+++ b/apps/predictions/lib/stream_worker.ex
@@ -8,7 +8,7 @@ defmodule Predictions.StreamSupervisor.Worker do
     Supervisor.start_link(__MODULE__, key, name: name)
   end
 
-  @impl true
+  @impl Supervisor
   def init(key) do
     sses_stream_name = sses_stream_name(key)
     api_stream_name = :"predictions_api_stream_#{key}"

--- a/apps/predictions/test/predictions_pub_sub_test.exs
+++ b/apps/predictions/test/predictions_pub_sub_test.exs
@@ -1,5 +1,5 @@
 defmodule Predictions.PredictionsPubSubTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import Mock
   alias Predictions.{Prediction, PredictionsPubSub, Store}
   alias Routes.Route
@@ -34,10 +34,69 @@ defmodule Predictions.PredictionsPubSubTest do
     {:ok, pid: pid}
   end
 
+  defp close_active_workers(context) do
+    Predictions.StreamSupervisor
+    |> DynamicSupervisor.which_children()
+    |> Enum.each(&DynamicSupervisor.terminate_child(Predictions.StreamSupervisor, elem(&1, 1)))
+
+    context
+  end
+
+  setup :close_active_workers
+
   describe "subscribe/2" do
     test "clients get existing predictions upon subscribing", %{pid: pid} do
       with_mock(Store, [:passthrough], fetch: fn _keys -> [@prediction39] end) do
         assert PredictionsPubSub.subscribe(@channel_args, pid) == [@prediction39]
+      end
+    end
+
+    test "worker starts upon subscribing", %{pid: pid} do
+      with_mock(Store, [:passthrough], fetch: fn _keys -> [] end) do
+        assert count_workers() == 0
+        t = subscribe_task(@channel_args, pid)
+        assert count_workers() == 1
+        on_exit(fn -> shutdown_subscribe_task(t) end)
+      end
+    end
+
+    test "additional clients don't start extra workers", %{pid: pid} do
+      with_mock(Store, [:passthrough], fetch: fn _keys -> [] end) do
+        assert count_workers() == 0
+        t1 = subscribe_task(@channel_args, pid)
+        assert count_workers() == 1
+        t2 = subscribe_task(@channel_args, pid)
+        assert count_workers() == 1
+        t3 = subscribe_task(@channel_args, pid)
+        assert count_workers() == 1
+        assert count_subscribers(pid) == 3
+        on_exit(fn -> shutdown_subscribe_task([t1, t2, t3]) end)
+      end
+    end
+
+    test "client disconnection doesn't terminate worker until no subscribers remain", %{pid: pid} do
+      with_mock(Store, [:passthrough], fetch: fn _keys -> [] end) do
+        task1 = subscribe_task(@channel_args, pid)
+        task2 = subscribe_task(@channel_args, pid)
+        task3 = subscribe_task(@channel_args, pid)
+        assert count_workers() == 1
+        assert count_subscribers(pid) == 3
+        assert [child1] = DynamicSupervisor.which_children(Predictions.StreamSupervisor)
+
+        shutdown_subscribe_task(task1)
+        assert count_subscribers(pid) == 2
+        assert count_workers() == 1
+        shutdown_subscribe_task(task2)
+        assert count_subscribers(pid) == 1
+        assert count_workers() == 1
+        shutdown_subscribe_task(task3)
+        assert count_subscribers(pid) == 0
+        assert count_workers() == 0
+        assert [] = DynamicSupervisor.which_children(Predictions.StreamSupervisor)
+        # starts a different stream after stopping
+        _ = PredictionsPubSub.subscribe(@channel_args, pid)
+        assert [child2] = DynamicSupervisor.which_children(Predictions.StreamSupervisor)
+        assert child1 != child2
       end
     end
   end
@@ -164,5 +223,43 @@ defmodule Predictions.PredictionsPubSubTest do
                ^p3 => "stop=3"
              } = :sys.get_state(pid)
     end
+  end
+
+  defp count_workers() do
+    Supervisor.count_children(Predictions.StreamSupervisor)
+    |> Map.get(:active)
+  end
+
+  defp count_subscribers(pid) do
+    Registry.lookup(:prediction_subscriptions_registry, pid)
+    |> Enum.count()
+  end
+
+  defp subscribe_task(channel, subscriber_server) do
+    parent = self()
+
+    {:ok, task} =
+      Task.start(fn ->
+        send(parent, PredictionsPubSub.subscribe(channel, subscriber_server))
+        Process.sleep(:infinity)
+      end)
+
+    # depends on predictions being empty or mocked to an empty list
+    assert_receive []
+    # worker takes time to start, subscriber takes time to be registered
+    Process.sleep(2000)
+    task
+  end
+
+  defp shutdown_subscribe_task([_ | _] = tasks) do
+    Enum.each(tasks, &shutdown_subscribe_task/1)
+  end
+
+  defp shutdown_subscribe_task(task) do
+    ref = Process.monitor(task)
+    Process.exit(task, :brutal_kill)
+    assert_receive {:DOWN, ^ref, :process, ^task, :brutal_kill}, 5000
+    # subscriber takes time to be unregistered
+    Process.sleep(1000)
   end
 end

--- a/apps/predictions/test/predictions_pub_sub_test.exs
+++ b/apps/predictions/test/predictions_pub_sub_test.exs
@@ -152,10 +152,8 @@ defmodule Predictions.PredictionsPubSubTest do
       Process.exit(task, :normal)
       assert_receive {:DOWN, ^ref, :process, ^task, :normal}
 
-      # The exited task's key is sent with :stop_stream to
-      # PredictionsPubSub.handle_cast/2
-      assert_receive {:trace, ^pid, :send, {:"$gen_cast", {:stop_stream, @channel_args}},
-                      PredictionsPubSub}
+      # The exited task triggers call to terminate_child
+      assert_receive {:trace, ^pid, :send, {:"$gen_call", _, {:terminate_child, _}}, _}
 
       # The caller process is removed from the state
       assert task not in Map.keys(:sys.get_state(pid))

--- a/apps/predictions/test/predictions_pub_sub_test.exs
+++ b/apps/predictions/test/predictions_pub_sub_test.exs
@@ -212,7 +212,7 @@ defmodule Predictions.PredictionsPubSubTest do
       assert_receive {:DOWN, ^ref, :process, ^task, :normal}
 
       # The exited task triggers call to terminate_child
-      assert_receive {:trace, ^pid, :send, {:"$gen_call", _, {:terminate_child, _}}, _}
+      assert_receive {:trace, ^pid, :send, {:"$gen_call", _, {:terminate_child, _}}, _}, 2000
 
       # The caller process is removed from the state
       assert task not in Map.keys(:sys.get_state(pid))

--- a/apps/predictions/test/stream_supervisor_test.exs
+++ b/apps/predictions/test/stream_supervisor_test.exs
@@ -44,4 +44,19 @@ defmodule Predictions.StreamSupervisorTest do
       assert {:ok, ^pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
     end
   end
+
+  describe "stop_stream/1" do
+    test "closes a stream by registered key" do
+      prediction_key = "stop=there2000"
+      {:ok, pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
+      assert Process.alive?(pid)
+
+      assert [{_, ^pid, :worker, [Predictions.StreamSupervisor.Worker]}] =
+               DynamicSupervisor.which_children(Predictions.StreamSupervisor)
+
+      :ok = StreamSupervisor.stop_stream(prediction_key)
+      refute Process.alive?(pid)
+      assert [] = DynamicSupervisor.which_children(Predictions.StreamSupervisor)
+    end
+  end
 end

--- a/apps/v3_api/lib/stream.ex
+++ b/apps/v3_api/lib/stream.ex
@@ -116,4 +116,6 @@ defmodule V3Api.Stream do
     str = Atom.to_string(atom)
     defp event(unquote(str)), do: unquote(atom)
   end
+
+  defp event("error"), do: :unknown
 end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Close open connections to the API when there are no longer subscriptions to the stream](https://app.asana.com/0/385363666817452/1205293745657616/f)

I ended up not implementing an explicit `unsubscribe` function as originally written in the attached Asana ticket, as I came to realize:

* Subscribers listed in the `:prediction_subscriptions_registry` were already being removed automatically,
* When subscribers were removed, this wasn't via an `:unsubscribe` event. The processes that were subscribed were simply being shut down whenever a channel was closed.

I considered adding some code to a `terminate/2` callback in `SiteWeb.PredictionsChannel`, but ran into some race conditions around handling its `pid` and lookup in the registry, then I came across this note in the `Registry` docs:

> Looking up, dispatching and registering are efficient and immediate at the cost of delayed unsubscription. For example, if a process crashes, its keys are automatically removed from the registry but the change may not propagate immediately. 

and this note in the Phoenix `Channel` docs:

> Generally speaking, if you want to clean something up, it is better to monitor your channel process and do the clean up from another process.
> Consider `Process.monitor(self)` on subscribe instead

And through a lot of trial and error, I eventually realized that the calling process was what's being somewhat magically registered every time `PredictionsPubSub.subscribe/1` is called. So ultimately I decided to use `Process.monitor/1` on it, and added some functionality to respond to the calling process being terminated.
* Checks the subscribers registry to see if any other subscribers remain for the given key
* If not, then `DynamicSupervisor.terminate_child/2` it

In the meantime, I also refactored `Predictions.StreamSupervisor` slightly. Instead of starting three interconnected (via `GenStage`) child processes for each key, it wraps the children in a new supervising worker process (`Predictions.StreamSupervisor.Worker`) that can more cleanly be started/stopped. It also uses a `:via` tuple for the worker name, so that these workers can automatically be registered/unregistered to the registry tracking streams by key, instead of manually registering the `pid` of the process running the `ServerSentEventStage` stream.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
