### PR TITLE
Resolve an issue with Massport shuttle labels

### DIFF
--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
@@ -171,6 +171,7 @@ defmodule TripPlan.Api.OpenTripPlanner.Parser do
     case feed do
       "mbta-ma-us" -> id
       "22722274" -> "Massport-" <> id
+      "2272_2274" -> "Massport-" <> id
       _ -> id
     end
   end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Fix massport shuttle labels in the trip planner](https://app.asana.com/0/1204355099788517/1205378240957261/f)

OTP2 fixed an issue where underscores were removed from GTFS feed IDs, but dotcom was expecting the Massport ID to always be missing the underscore that it has in GTFS. This was resulting in Massport shuttles not being labeled as such and just appearing as regular buses. This adds another case with the underscore to mark IDs as Massport ones.

Broken:
![Screenshot 2023-08-31 at 11 29 50 AM](https://github.com/mbta/dotcom/assets/12971446/03fb9497-9637-4f67-9285-4477a28b50d4)
(Yes, that 88 schedule link goes to the MBTA 88 😱)

Fixed:
![Screenshot 2023-08-31 at 11 29 24 AM](https://github.com/mbta/dotcom/assets/12971446/2a6075f4-553d-4134-aa34-8649a6ef14af)

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

