### PR TITLE
feat(PredictionsBanner): Banner only shows when the socket errors out

### DIFF
--- a/apps/site/assets/ts/app/__tests__/channels-test.ts
+++ b/apps/site/assets/ts/app/__tests__/channels-test.ts
@@ -91,6 +91,8 @@ describe("setupChannels", () => {
     setupChannels();
     mockOnLoadEventListener();
     const channel = window.channels["vehicles:Red:0"];
+    const mockEventListener = jest.fn();
+    document.addEventListener("vehicles:Red:0", mockEventListener);
     const consoleMock = jest
       .spyOn(global.console, "error")
       .mockImplementation(() => {});
@@ -100,6 +102,10 @@ describe("setupChannels", () => {
       "failed to join vehicles:Red:0",
       "bad day"
     );
+    const event = new CustomEvent("vehicles:Red:0", {
+      detail: { error: "bad day" }
+    });
+    expect(mockEventListener).toHaveBeenCalledWith(event);
 
     consoleMock.mockRestore();
   });
@@ -114,6 +120,27 @@ describe("setupChannels", () => {
     // @ts-ignore... phoenix.js isn't properly typed. and technically this is a private property. how else to trigger a channel event!
     channel.joinPush.trigger("ok");
     expect(console.log).toHaveBeenCalledWith("success joining vehicles:Red:0");
+
+    consoleMock.mockRestore();
+  });
+
+  it("responds to an error", () => {
+    // This should test the onError callback of the channel
+    // TODO write this tomorrow
+    setupChannels();
+    mockOnLoadEventListener();
+    const mockEventListener = jest.fn();
+    document.addEventListener("vehicles:Red:0", mockEventListener);
+    const channel = window.channels["vehicles:Red:0"];
+    const consoleMock = jest
+      .spyOn(global.console, "error")
+      .mockImplementation(() => {});
+    // @ts-ignore... phoenix.js isn't properly typed. and technically this is a private property. how else to trigger a channel event!
+    channel.trigger("phx_error", { reason: "bad data" });
+    const event = new CustomEvent("vehicles:Red:0", {
+      detail: { error: "bad data" }
+    });
+    expect(mockEventListener).toHaveBeenCalledWith(event);
 
     consoleMock.mockRestore();
   });

--- a/apps/site/assets/ts/app/channels.ts
+++ b/apps/site/assets/ts/app/channels.ts
@@ -54,7 +54,6 @@ const joinChannel = <T>(
         if (handleJoin && event) {
           handleJoin(event);
         }
-        /* eslint-enable no-console */
         if (isVehicleChannel(channelId)) {
           const [, route_id, direction_id] = channelId.split(":");
           channel.push("init", { route_id, direction_id });
@@ -69,6 +68,7 @@ const joinChannel = <T>(
 
   channel.onError((reason: string) => {
     console.error(`error on channel ${channelId} : ${reason}`);
+    /* eslint-enable no-console */
     const errorEvent = new CustomEvent<{ error: string }>(channelId, {
       detail: { error: reason }
     });

--- a/apps/site/assets/ts/app/channels.ts
+++ b/apps/site/assets/ts/app/channels.ts
@@ -41,10 +41,14 @@ const joinChannel = <T>(
   if (!["joined", "joining"].includes(channel.state)) {
     channel
       .join()
-      .receive("error", ({ reason }) =>
+      .receive("error", ({ reason }) => {
         /* eslint-disable no-console */
-        console.error(`failed to join ${channelId}`, reason)
-      )
+        console.error(`failed to join ${channelId}`, reason);
+        const errorEvent = new CustomEvent<{ error: string }>(channelId, {
+          detail: { error: reason }
+        });
+        document.dispatchEvent(errorEvent);
+      })
       .receive("ok", event => {
         console.log(`success joining ${channelId}`);
         if (handleJoin && event) {
@@ -61,6 +65,14 @@ const joinChannel = <T>(
   channel.on("data", (data: T) => {
     const event = new CustomEvent<T>(channelId, { detail: data });
     document.dispatchEvent(event);
+  });
+
+  channel.onError((reason: string) => {
+    console.error(`error on channel ${channelId} : ${reason}`);
+    const errorEvent = new CustomEvent<{ error: string }>(channelId, {
+      detail: { error: reason }
+    });
+    document.dispatchEvent(errorEvent);
   });
 
   if (isVehicleChannel(channelId)) {

--- a/apps/site/assets/ts/helpers/socketTestHelpers.ts
+++ b/apps/site/assets/ts/helpers/socketTestHelpers.ts
@@ -16,7 +16,8 @@ export const makeMockChannel = (
     leave: jest.fn(),
     on: jest.fn(),
     off: jest.fn(),
-    receive: jest.fn()
+    receive: jest.fn(),
+    onError: jest.fn()
   };
   result.join.mockImplementation(() => result);
   result.receive.mockImplementation((message, handler) => {

--- a/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
@@ -161,7 +161,7 @@ describe("usePredictionsChannel hook", () => {
       expect.anything(),
       expect.toBeOneOf([expect.anything(), null])
     );
-    expect(result.current).toEqual(null);
+    expect(result.current).toEqual([]);
   });
 });
 

--- a/apps/site/assets/ts/hooks/usePredictionsChannel.ts
+++ b/apps/site/assets/ts/hooks/usePredictionsChannel.ts
@@ -33,6 +33,7 @@ export interface StreamPrediction {
 
 interface ChannelPredictionResponse {
   predictions: StreamPrediction[];
+  error: string;
 }
 
 export interface PredictionsByHeadsign {
@@ -100,12 +101,15 @@ const usePredictionsChannel = (
   const reducer: Reducer<
     PredictionWithTimestamp[] | null,
     ChannelPredictionResponse
-  > = (_oldGroupedPredictions, { predictions }) => {
-    return sortBy(predictions.map(parsePrediction), "time");
+  > = (_oldGroupedPredictions, detail) => {
+    if (detail.error) {
+      return null;
+    }
+    return sortBy(detail.predictions.map(parsePrediction), "time");
   };
   // useChannel will return the initialState if the channel can't be joined / if
   // the channelName is null;
-  const state = useChannel(channelName, reducer, null);
+  const state = useChannel(channelName, reducer, []);
   return state;
 };
 


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
Set the default value of the predictions channel to an empty array.  The channel helpers now return null if there are any errors.  Allowing the error banner to behave as originally intended.

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Loading error banner appears while loading](https://app.asana.com/0/555089885850811/1205250017202658)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

