### PR TITLE
refactor: connect to predictions stream using route+direction

### DIFF
--- a/apps/predictions/lib/stream_topic.ex
+++ b/apps/predictions/lib/stream_topic.ex
@@ -49,8 +49,7 @@ defmodule Predictions.StreamTopic do
 
   @spec filters(Stop.id_t()) :: [api_filter_t()]
   defp filters("stop:" <> stop_id) do
-    stop_id
-    |> RoutePatterns.Repo.by_stop_id([])
+    RoutePatterns.Repo.by_stop_id(stop_id)
     |> Enum.map(
       &%{
         route: &1.route_id,

--- a/apps/predictions/lib/stream_topic.ex
+++ b/apps/predictions/lib/stream_topic.ex
@@ -1,0 +1,67 @@
+defmodule Predictions.StreamTopic do
+  @moduledoc """
+  Translation between `SiteWeb.PredictionsChannel` topics, `Predictions.Store`
+  and `Predictions.Stream`.
+
+  The topic name joined in `SiteWeb.PredictionsChannel` is the input which
+  determines
+  - the appropriate `fetch_keys` needed to get relevant predictions from the
+    `Predictions.Store`
+  - one or more `Predictions.Stream` instances needed to fetch the relevant
+    predictions.
+
+  Every topic will be matched with one or more V3 API calls via
+  `Predictions.Stream` which filter the `/predictions` streaming endpoint on a
+  route and direction.
+  """
+
+  alias Predictions.Store
+  alias Routes.Route
+  alias Stops.Stop
+
+  defstruct [:topic, :fetch_keys, :streams]
+
+  @type t :: %__MODULE__{
+          topic: String.t(),
+          fetch_keys: Store.fetch_keys(),
+          streams: [String.t()]
+        }
+
+  @type api_filter_t :: %{
+          required(:route) => Route.id_t(),
+          required(:direction) => 0 | 1
+        }
+
+  @spec new(String.t()) :: t() | {:error, term()}
+  def new(topic) do
+    with "stop:" <> stop_id when stop_id != "" <- topic,
+         filters when filters != [] <- filters(topic) do
+      %__MODULE__{
+        topic: topic,
+        fetch_keys: [stop: stop_id],
+        streams: Enum.map(filters, &filter_to_string/1)
+      }
+    else
+      _ ->
+        {:error, :unsupported_topic}
+    end
+  end
+
+  @spec filters(Stop.id_t()) :: [api_filter_t()]
+  defp filters("stop:" <> stop_id) do
+    stop_id
+    |> RoutePatterns.Repo.by_stop_id([])
+    |> Enum.map(
+      &%{
+        route: &1.route_id,
+        direction: &1.direction_id
+      }
+    )
+    |> Enum.uniq()
+  end
+
+  @spec filter_to_string(api_filter_t()) :: String.t()
+  defp filter_to_string(%{route: r, direction: d}) do
+    "filter[route]=#{r}&filter[direction_id]=#{d}"
+  end
+end

--- a/apps/predictions/test/predictions_pub_sub_test.exs
+++ b/apps/predictions/test/predictions_pub_sub_test.exs
@@ -22,7 +22,7 @@ defmodule Predictions.PredictionsPubSubTest do
     stop: %Stop{id: @stop_id}
   }
 
-  @channel_args "route=#{@route_39}:stop=#{@stop_id}:direction_id=#{@direction_id}"
+  @channel_args "stop:#{@stop_id}"
 
   setup_all do
     start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})

--- a/apps/predictions/test/predictions_pub_sub_test.exs
+++ b/apps/predictions/test/predictions_pub_sub_test.exs
@@ -22,7 +22,7 @@ defmodule Predictions.PredictionsPubSubTest do
   @channel_args "stop:#{@stop_id}"
 
   setup_with_mocks([
-    {RoutePatterns.Repo, [], [by_stop_id: fn _stop_id, [] -> [%RoutePatterns.RoutePattern{}] end]}
+    {RoutePatterns.Repo, [], [by_stop_id: fn _stop_id -> [%RoutePatterns.RoutePattern{}] end]}
   ]) do
     start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
     start_supervised(Store)

--- a/apps/predictions/test/predictions_pub_sub_test.exs
+++ b/apps/predictions/test/predictions_pub_sub_test.exs
@@ -170,7 +170,6 @@ defmodule Predictions.PredictionsPubSubTest do
   end
 
   describe "handle_info/2 - :DOWN" do
-    @describetag :skip
     test "can observe when the caller/subscribing task is exited, and remove from state" do
       {:ok, pid} =
         PredictionsPubSub.start_link(name: :subscribe_and_down, subscribe_fn: fn _, _ -> :ok end)

--- a/apps/predictions/test/predictions_pub_sub_test.exs
+++ b/apps/predictions/test/predictions_pub_sub_test.exs
@@ -5,26 +5,25 @@ defmodule Predictions.PredictionsPubSubTest do
   alias Routes.Route
   alias Stops.Stop
 
-  @route_39 "39"
-  @route_66 "66"
   @stop_id "place-where"
-  @direction_id 1
   @prediction39 %Prediction{
     id: "prediction39",
-    direction_id: @direction_id,
-    route: %Route{id: @route_39},
+    direction_id: 1,
+    route: %Route{id: "39"},
     stop: %Stop{id: @stop_id}
   }
   @prediction66 %Prediction{
     id: "prediction66",
-    direction_id: @direction_id,
-    route: %Route{id: @route_66},
-    stop: %Stop{id: @stop_id}
+    direction_id: 1,
+    route: %Route{id: "66"},
+    stop: %Stop{id: "other_stop"}
   }
 
   @channel_args "stop:#{@stop_id}"
 
-  setup_all do
+  setup_with_mocks([
+    {RoutePatterns.Repo, [], [by_stop_id: fn _stop_id, [] -> [%RoutePatterns.RoutePattern{}] end]}
+  ]) do
     start_supervised({Registry, keys: :duplicate, name: :prediction_subscriptions_registry})
     start_supervised(Store)
 
@@ -171,6 +170,7 @@ defmodule Predictions.PredictionsPubSubTest do
   end
 
   describe "handle_info/2 - :DOWN" do
+    @describetag :skip
     test "can observe when the caller/subscribing task is exited, and remove from state" do
       {:ok, pid} =
         PredictionsPubSub.start_link(name: :subscribe_and_down, subscribe_fn: fn _, _ -> :ok end)
@@ -197,7 +197,7 @@ defmodule Predictions.PredictionsPubSubTest do
             this = self()
 
             assert %{
-                     ^this => @channel_args,
+                     ^this => _filters,
                      ^p1 => "stop=1",
                      ^p2 => "stop=2",
                      ^p3 => "stop=3"

--- a/apps/predictions/test/stream_supervisor_test.exs
+++ b/apps/predictions/test/stream_supervisor_test.exs
@@ -44,27 +44,27 @@ defmodule Predictions.StreamSupervisorTest do
 
   describe "ensure_stream_is_started/1" do
     test "starts a stream if not already started" do
-      prediction_key = "route=Purple:stop=awesome-station:direction=1"
-      assert {:ok, _pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
+      filter_key = "filter[route]=Purple&filter[direction_id]=1"
+      assert {:ok, _pid} = StreamSupervisor.ensure_stream_is_started(filter_key)
     end
 
     test "returns existing stream from registry" do
-      prediction_key = "route=Pink:stop=place:direction=0"
-      {:ok, pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
-      assert {:ok, ^pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
+      filter_key = "filter[route]=Pink&filter[direction_id]=0"
+      {:ok, pid} = StreamSupervisor.ensure_stream_is_started(filter_key)
+      assert {:ok, ^pid} = StreamSupervisor.ensure_stream_is_started(filter_key)
     end
   end
 
   describe "stop_stream/1" do
     test "closes a stream by registered key" do
-      prediction_key = "stop=there2000"
-      {:ok, pid} = StreamSupervisor.ensure_stream_is_started(prediction_key)
+      filter_key = "filter[route]=Teal&filter[direction_id]=1"
+      {:ok, pid} = StreamSupervisor.ensure_stream_is_started(filter_key)
       assert Process.alive?(pid)
 
       assert [{_, ^pid, :supervisor, [Predictions.StreamSupervisor.Worker]}] =
                DynamicSupervisor.which_children(Predictions.StreamSupervisor)
 
-      :ok = StreamSupervisor.stop_stream(prediction_key)
+      :ok = StreamSupervisor.stop_stream(filter_key)
       refute Process.alive?(pid)
       assert [] = DynamicSupervisor.which_children(Predictions.StreamSupervisor)
     end

--- a/apps/predictions/test/stream_topic_test.exs
+++ b/apps/predictions/test/stream_topic_test.exs
@@ -8,7 +8,7 @@ defmodule Predictions.StreamTopicTest do
   alias Predictions.StreamTopic
 
   setup_with_mocks([
-    {RoutePatterns.Repo, [], [by_stop_id: fn id, [] -> mock_route_patterns(id) end]}
+    {RoutePatterns.Repo, [], [by_stop_id: fn id -> mock_route_patterns(id) end]}
   ]) do
     :ok
   end

--- a/apps/predictions/test/stream_topic_test.exs
+++ b/apps/predictions/test/stream_topic_test.exs
@@ -1,0 +1,56 @@
+defmodule Predictions.StreamTopicTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: false
+
+  import Predictions.StreamTopic
+  import Mock
+  alias Predictions.StreamTopic
+
+  setup_with_mocks([
+    {RoutePatterns.Repo, [], [by_stop_id: fn id, [] -> mock_route_patterns(id) end]}
+  ]) do
+    :ok
+  end
+
+  describe "new/1" do
+    test "works for stop id with route patterns" do
+      topic = "stop:stopId"
+
+      assert %StreamTopic{
+               topic: ^topic,
+               fetch_keys: [stop: "stopId"],
+               streams: streams
+             } = new("stop:stopId")
+
+      assert ["filter[route]=Route1&filter[direction_id]=0" | _] = streams
+    end
+
+    test "doesn't work for stop without route patterns" do
+      assert {:error, :unsupported_topic} = new("stop:unserved_stop")
+    end
+
+    test "doesn't work for other topics" do
+      bad_topics = [
+        "trip:tripId",
+        "route:routeId",
+        "Red:0",
+        ""
+      ]
+
+      for topic <- bad_topics do
+        assert {:error, :unsupported_topic} = new(topic)
+      end
+    end
+  end
+
+  defp mock_route_patterns("unserved_stop"), do: []
+
+  defp mock_route_patterns(_id) do
+    [
+      %{route_id: "Route1", direction_id: 0},
+      %{route_id: "Route1", direction_id: 1},
+      %{route_id: "Route2", direction_id: 1}
+    ]
+  end
+end

--- a/apps/predictions/test/stream_topic_test.exs
+++ b/apps/predictions/test/stream_topic_test.exs
@@ -6,6 +6,7 @@ defmodule Predictions.StreamTopicTest do
   import Predictions.StreamTopic
   import Mock
   alias Predictions.StreamTopic
+  alias RoutePatterns.RoutePattern
 
   setup_with_mocks([
     {RoutePatterns.Repo, [], [by_stop_id: fn id -> mock_route_patterns(id) end]}
@@ -23,11 +24,11 @@ defmodule Predictions.StreamTopicTest do
                streams: streams
              } = new("stop:stopId")
 
-      assert ["filter[route]=Route1&filter[direction_id]=0" | _] = streams
+      assert ["filter[direction_id]=0&filter[route]=Route1" | _] = streams
     end
 
     test "doesn't work for stop without route patterns" do
-      assert {:error, :unsupported_topic} = new("stop:unserved_stop")
+      assert {:error, :no_streams_found} = new("stop:unserved_stop")
     end
 
     test "doesn't work for other topics" do
@@ -48,9 +49,9 @@ defmodule Predictions.StreamTopicTest do
 
   defp mock_route_patterns(_id) do
     [
-      %{route_id: "Route1", direction_id: 0},
-      %{route_id: "Route1", direction_id: 1},
-      %{route_id: "Route2", direction_id: 1}
+      %RoutePattern{route_id: "Route1", direction_id: 0},
+      %RoutePattern{route_id: "Route1", direction_id: 1},
+      %RoutePattern{route_id: "Route2", direction_id: 1}
     ]
   end
 end

--- a/apps/route_patterns/lib/repo.ex
+++ b/apps/route_patterns/lib/repo.ex
@@ -43,6 +43,12 @@ defmodule RoutePatterns.Repo do
     |> Enum.sort(&reorder_mrts(&1, &2, route_id))
   end
 
+  def by_stop_id(stop_id, opts) do
+    opts
+    |> Keyword.put(:stop, stop_id)
+    |> cache(&api_all/1)
+  end
+
   defp api_all(opts) do
     case RoutePatternsApi.all(opts) do
       {:error, error} ->

--- a/apps/route_patterns/lib/repo.ex
+++ b/apps/route_patterns/lib/repo.ex
@@ -43,9 +43,8 @@ defmodule RoutePatterns.Repo do
     |> Enum.sort(&reorder_mrts(&1, &2, route_id))
   end
 
-  def by_stop_id(stop_id, opts) do
-    opts
-    |> Keyword.put(:stop, stop_id)
+  def by_stop_id(stop_id) do
+    [stop: stop_id]
     |> cache(&api_all/1)
   end
 

--- a/apps/route_patterns/test/repo_test.exs
+++ b/apps/route_patterns/test/repo_test.exs
@@ -36,9 +36,9 @@ defmodule RoutePatterns.RepoTest do
     end
   end
 
-  describe "by_stop_id/2" do
+  describe "by_stop_id/1" do
     test "returns route patterns for a stop" do
-      assert [%RoutePattern{} | _] = Repo.by_stop_id("place-sstat", [])
+      assert [%RoutePattern{} | _] = Repo.by_stop_id("place-sstat")
     end
   end
 end

--- a/apps/route_patterns/test/repo_test.exs
+++ b/apps/route_patterns/test/repo_test.exs
@@ -35,4 +35,10 @@ defmodule RoutePatterns.RepoTest do
       assert alewife_patterns |> Enum.map(& &1.direction_id) |> Enum.uniq() == [1]
     end
   end
+
+  describe "by_stop_id/2" do
+    test "returns route patterns for a stop" do
+      assert [%RoutePattern{} | _] = Repo.by_stop_id("place-sstat", [])
+    end
+  end
 end

--- a/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/usePredictionsChannelTest.tsx
@@ -56,24 +56,16 @@ describe("usePredictionsChannel hook", () => {
   test("initializes connection to appropriate channel", () => {
     renderHook(() =>
       usePredictionsChannel({
-        routeId: "Purple",
-        stopId: "place-somewhere",
-        directionId: 0
+        stopId: "place-somewhere"
       })
     );
-    expect(
-      window.channels[
-        "predictions:route=Purple:stop=place-somewhere:direction_id=0"
-      ]
-    ).toBeTruthy();
+    expect(window.channels["predictions:stop:place-somewhere"]).toBeTruthy();
   });
 
   test("gets and outputs data", () => {
     const { result } = renderHook(() =>
       usePredictionsChannel({
-        routeId: "Purple",
-        stopId: "place-somewhere",
-        directionId: 0
+        stopId: "place-somewhere"
       })
     );
 
@@ -81,7 +73,7 @@ describe("usePredictionsChannel hook", () => {
     act(() => {
       const event = new CustomEvent<{
         predictions: StreamPrediction[];
-      }>("predictions:route=Purple:stop=place-somewhere:direction_id=0", {
+      }>("predictions:stop:place-somewhere", {
         detail: {
           predictions: predictionsFromStream
         }
@@ -103,7 +95,7 @@ describe("usePredictionsChannel hook", () => {
     act(() => {
       const event = new CustomEvent<{
         predictions: StreamPrediction[];
-      }>("predictions:stop=place-overthere", {
+      }>("predictions:stop:place-overthere", {
         detail: {
           predictions: predictionsFromStream
         }
@@ -117,9 +109,7 @@ describe("usePredictionsChannel hook", () => {
   test("doesn't output data if same as new data", () => {
     const { result } = renderHook(() =>
       usePredictionsChannel({
-        routeId: "Purple",
-        stopId: "place-somewhere",
-        directionId: 0
+        stopId: "place-somewhere"
       })
     );
 
@@ -127,7 +117,7 @@ describe("usePredictionsChannel hook", () => {
     act(() => {
       const event = new CustomEvent<{
         predictions: StreamPrediction[];
-      }>("predictions:route=Purple:stop=place-somewhere:direction_id=0", {
+      }>("predictions:stop:place-somewhere", {
         detail: {
           predictions: predictionsFromStream
         }
@@ -142,7 +132,7 @@ describe("usePredictionsChannel hook", () => {
     act(() => {
       const event = new CustomEvent<{
         predictions: StreamPrediction[];
-      }>("predictions:route=Purple:stop=place-somewhere:direction_id=0", {
+      }>("predictions:stop:place-somewhere", {
         detail: {
           predictions: predictionsFromStream
         }

--- a/apps/site/assets/ts/hooks/usePredictionsChannel.ts
+++ b/apps/site/assets/ts/hooks/usePredictionsChannel.ts
@@ -65,26 +65,15 @@ export const parsePrediction = (
 });
 
 interface PredictionsChannelArgs {
-  routeId?: string;
   stopId?: string;
-  directionId?: 0 | 1;
 }
 
 function channelFromArgs(channelArgs: PredictionsChannelArgs): string | null {
-  const keysWithValues = Object.entries({
-    route: "routeId",
-    stop: "stopId",
-    direction_id: "directionId"
-  })
-    .map(([key, arg]) => {
-      const value = channelArgs[arg as keyof PredictionsChannelArgs];
-      if (value !== undefined) {
-        return `:${key}=${value}`;
-      }
-      return "";
-    })
-    .join("");
-  return keysWithValues === "" ? null : `predictions${keysWithValues}`;
+  const { stopId } = channelArgs;
+  if (stopId) {
+    return `predictions:stop:${stopId}`;
+  }
+  return null;
 }
 
 /**

--- a/apps/site/lib/site_web/channels/predictions_channel.ex
+++ b/apps/site/lib/site_web/channels/predictions_channel.ex
@@ -20,11 +20,10 @@ defmodule SiteWeb.PredictionsChannel do
       )
 
     case predictions_subscribe_fn.(topic) do
-      {:error, reason} ->
+      {:error, _reason} ->
         {:error,
          %{
-           message:
-             "Cannot subscribe to predictions data streams for #{topic} because #{inspect(reason)}"
+           message: "Cannot subscribe to predictions for #{topic}."
          }}
 
       predictions ->

--- a/apps/site/test/site_web/channels/predictions_channel_test.exs
+++ b/apps/site/test/site_web/channels/predictions_channel_test.exs
@@ -26,25 +26,55 @@ defmodule SiteWeb.PredictionsChannelTest do
   @channel_name "predictions:stop:#{@stop_fh}"
 
   setup do
-    reassign_env(:site, :predictions_subscribe_fn, fn _ ->
-      [@prediction39]
-    end)
-
     socket = socket(UserSocket, "", %{})
-
     {:ok, socket: socket}
   end
 
   describe "join/3" do
-    test "subscribes to predictions for a route ID, stop ID, and direction, and returns the current list of predictions",
-         %{
-           socket: socket
-         } do
+    test "subscribes to predictions for a stop ID and returns the current list of predictions", %{
+      socket: socket
+    } do
+      reassign_env(:site, :predictions_subscribe_fn, fn _ ->
+        [@prediction39]
+      end)
+
       assert {:ok, %{predictions: [@prediction39]}, %Socket{}} =
                subscribe_and_join(
                  socket,
                  PredictionsChannel,
                  @channel_name
+               )
+    end
+
+    test "can't join any topic", %{socket: socket} do
+      assert {:error,
+              %{
+                message: "Cannot subscribe to predictions for route:Orange."
+              }} =
+               subscribe_and_join(
+                 socket,
+                 PredictionsChannel,
+                 "predictions:route:Orange"
+               )
+
+      assert {:error,
+              %{
+                message: "Cannot subscribe to predictions for Red:1."
+              }} =
+               subscribe_and_join(
+                 socket,
+                 PredictionsChannel,
+                 "predictions:Red:1"
+               )
+
+      assert {:error,
+              %{
+                message: "Cannot subscribe to predictions for trip:123456."
+              }} =
+               subscribe_and_join(
+                 socket,
+                 PredictionsChannel,
+                 "predictions:trip:123456"
                )
     end
   end

--- a/apps/site/test/site_web/channels/predictions_channel_test.exs
+++ b/apps/site/test/site_web/channels/predictions_channel_test.exs
@@ -23,7 +23,7 @@ defmodule SiteWeb.PredictionsChannelTest do
     time: Timex.shift(Util.now(), hours: 2)
   }
 
-  @channel_name "predictions:route=#{@route_39}:stop=#{@stop_fh}:direction_id=#{@direction}"
+  @channel_name "predictions:stop:#{@stop_fh}"
 
   setup do
     reassign_env(:site, :predictions_subscribe_fn, fn _ ->


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Refactor the predictions stream to always connect to predictions for a route+direction instead of allowing connections per-stop](https://app.asana.com/0/385363666817452/1205293745657620/f)

`SiteWeb.PredictionsChannel` defines a topic for a stop, and a new abstraction, `Predictions.StreamTopic`, translates this into one or more route/direction combinations, in accordance to the route patterns in service for each stop.

Each route/direction is associated with a distinct V3 API stream. Each stream is registered separately, so that we can handle leaving topics/closing streams in a granular way. For example, if both `stop:place-state` and `stop:place-wondl` are joined, then `stop:place-state` is left, the streams associated with predictions for the Orange line would be closed, but the ones for the Blue line would remain open.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
