### PR TITLE
feat(StopPageRedesign): add an error boundary

### DIFF
--- a/apps/site/assets/ts/components/ErrorPage.tsx
+++ b/apps/site/assets/ts/components/ErrorPage.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { FallbackRender } from "@sentry/react";
+
+// Adapted from the templates in SiteWeb.ErrorView
+// To be used in an ErrorBoundary
+const ErrorPage: FallbackRender = errorData => {
+  // eslint-disable-next-line no-console
+  console.error("from Sentry", JSON.stringify(errorData));
+  return (
+    <div className="container error-page">
+      <div className="row">
+        <div className="col-md-6">
+          <h1 className="mt-1">Oh no! We&#39;re experiencing delays.</h1>
+          <p className="error-paragraph u-bold">
+            Something went wrong on our end.
+          </p>
+          <div className="error-links">
+            Go to{" "}
+            <a className="c-call-to-action" href="/">
+              {`the MBTA's home page`}
+            </a>{" "}
+            or{" "}
+            <a className="c-call-to-action" href="/customer-support">
+              report an issue
+            </a>
+            .
+          </div>
+        </div>
+        <div className="col-md-6">
+          <img alt="" src="/images/error-bus.gif" className="w-100" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/apps/site/assets/ts/jest.config.js
+++ b/apps/site/assets/ts/jest.config.js
@@ -10,7 +10,11 @@ module.exports = {
     "!**/*-loader.tsx", // not necessary to test loader files
     "!**/search.ts", // for now,
     "!./app/global-navigation.ts", // tested with Cypress
-    "!./helpers/socketTestHelpers.ts" // more test utilities
+    "!./helpers/socketTestHelpers.ts", // more test utilities
+    "!./components/ErrorPage.tsx",
+    "!./sentry.ts",
+    "!**/*.d.ts",
+    "!./ie-warning/**"
   ],
   coverageReporters: ["html"],
   coverageThreshold: {

--- a/apps/site/assets/ts/stop/stop-redesign-loader.tsx
+++ b/apps/site/assets/ts/stop/stop-redesign-loader.tsx
@@ -5,13 +5,20 @@ import {
   RouteObject,
   RouterProvider
 } from "react-router-dom";
+import { ErrorBoundary } from "@sentry/react";
 import StopPageRedesign from "./components/StopPageRedesign";
 import Loading from "../components/Loading";
+import ErrorPage from "../components/ErrorPage";
 
 const routesConfig = (stopId: string): RouteObject[] => [
   {
     path: "/stops/:stopId",
-    element: <StopPageRedesign stopId={stopId} />
+    element: (
+      <ErrorBoundary fallback={ErrorPage}>
+        <StopPageRedesign stopId={stopId} />
+      </ErrorBoundary>
+    ),
+    hasErrorBoundary: true
   }
 ];
 


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** No ticket

This PR adds an error boundary, because React Router highly recommends it, and their default display is super ugly! I used Sentry's built-in `ErrorBoundary` component for this, which has the bonus of automagically sending the error to Sentry.

### Highlights

- As the fallback display, I wrote a new React component, `ErrorPage`, that's meant to imitate our current error page.

<img width="1487" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/c828eac6-330b-4d1e-a608-282c3a1ec5a5">

> [!Note]
> There are some small deviations from our normal error pages:

- Our error pages typically show an error code at the top, but we don't technically know the error code as this error boundary could catch anything, so I've omitted that part.
- I couldn't use our current blinky bus SVG image because those have the error codes written on them. See?
<img width="308" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/975ef46e-bd57-47ba-aeae-c65a784dc2d2" />
But I found a cute GIF in our `/images/` folder with the more cartoony, less-specified blinky bus.

### Bonus change

- Removed a few files from being counted in the Javascript test coverage.