### PR TITLE
refactor(StopPageRedesign): use route patterns

### DIFF
--- a/apps/site/assets/css/_stop-card.scss
+++ b/apps/site/assets/css/_stop-card.scss
@@ -217,23 +217,24 @@ $radius: 4px;
   }
 
   .departure-card__headsign {
-    align-items: baseline;
+    align-items: center;
     border: .25px solid $gray-lightest;
     cursor: pointer;
+    gap: .5rem;
+    justify-content: flex-end;
     padding: .5rem;
   }
 
   .departure-card__headsign-name {
     @include h4();
     flex-grow: 1;
-    margin: 0 .5rem 0 0;
+    margin: 0;
     max-width: 16.25rem;
     padding-left: .5rem;
   }
 
   .departure-card__content {
     align-items: center;
-    align-self: center;
     display: flex;
     flex-grow: 1;
     flex-wrap: wrap;
@@ -253,6 +254,7 @@ $radius: 4px;
     justify-content: flex-end;
 
     .stop-routes__departures-details {
+      font-family: $headings-font-family;
       text-align: right;
 
       // if delayed, hide from here

--- a/apps/site/assets/ts/helpers/departureInfo.tsx
+++ b/apps/site/assets/ts/helpers/departureInfo.tsx
@@ -21,6 +21,7 @@ import {
 import { DirectionId, Route } from "../__v3api";
 import DisplayTime from "../stop/components/DisplayTime";
 import { getInfoKey } from "../stop/models/displayTimeConfig";
+import { RoutePatternWithPolyline } from "../stop/stop-redesign-loader";
 
 export const SUBWAY = "subway";
 export const BUS = "bus";
@@ -186,6 +187,24 @@ const departuresListFromInfos = (
     .value();
 };
 
+const departureInfoInRoutePatterns = (
+  departureInfo: DepartureInfo,
+  routePatterns: RoutePatternWithPolyline[]
+): boolean => {
+  const isMatch = !!routePatterns.find(
+    rp => rp.id === departureInfo.trip.route_pattern_id
+  );
+  // This second case is needed for the edge case where the route pattern is
+  // canonical but the schedules/predictions are not serving canonical route
+  // patterns (e.g. due to shuttles or other disruptions)
+  const isSimilar = !!routePatterns.find(
+    rp =>
+      rp.headsign === departureInfo.trip.headsign &&
+      rp.route_id === departureInfo.route.id
+  );
+  return isMatch || isSimilar;
+};
+
 export {
   mergeIntoDepartureInfo,
   departureInfoToTime,
@@ -193,5 +212,6 @@ export {
   getNextUnCancelledDeparture,
   isAtDestination,
   isCommuterRail,
-  departuresListFromInfos
+  departuresListFromInfos,
+  departureInfoInRoutePatterns
 };

--- a/apps/site/assets/ts/hooks/__tests__/useRouteTest.tsx
+++ b/apps/site/assets/ts/hooks/__tests__/useRouteTest.tsx
@@ -1,8 +1,9 @@
 import { renderHook } from "@testing-library/react-hooks";
 import React from "react";
 import { SWRConfig } from "swr";
-import { RouteWithPolylines, useRoutesByStop } from "../useRoute";
+import { useRoutes } from "../useRoute";
 import { FetchStatus } from "../../helpers/use-fetch";
+import { Route } from "../../__v3api";
 
 const unmockedFetch = global.fetch;
 const HookWrapper: React.FC = ({ children }) => (
@@ -12,85 +13,25 @@ const HookWrapper: React.FC = ({ children }) => (
 const testData = [
   {
     id: "0",
-    type: 0,
-    polylines: [
-      {
-        id: "0",
-        "dotted?": false,
-        weight: 2,
-        positions: [
-          [1, 2],
-          [3, 4]
-        ],
-        color: "#ABC123"
-      }
-    ]
+    type: 0
   },
   {
     id: "1",
-    type: 1,
-    polylines: [
-      {
-        id: "1",
-        "dotted?": false,
-        weight: 2,
-        positions: [
-          [5, 2],
-          [7, 4]
-        ],
-        color: "#ABC123"
-      }
-    ]
+    type: 1
   },
   {
     id: "2",
-    type: 2,
-    polylines: [
-      {
-        id: "2",
-        "dotted?": false,
-        weight: 2,
-        positions: [
-          [9, 2],
-          [3, 4]
-        ],
-        color: "#ABC123"
-      }
-    ]
+    type: 2
   },
   {
     id: "3",
-    type: 3,
-    polylines: [
-      {
-        id: "3",
-        "dotted?": false,
-        weight: 2,
-        positions: [
-          [2, 2],
-          [8, 4]
-        ],
-        color: "#ABC123"
-      }
-    ]
+    type: 3
   },
   {
     id: "4",
-    type: 4,
-    polylines: [
-      {
-        id: "4",
-        "dotted?": false,
-        weight: 2,
-        positions: [
-          [9, 2],
-          [3, 4]
-        ],
-        color: "#ABC123"
-      }
-    ]
+    type: 4
   }
-] as RouteWithPolylines[];
+] as Route[];
 
 describe("useRoute", () => {
   beforeEach(() => {
@@ -108,42 +49,33 @@ describe("useRoute", () => {
     );
   });
 
-  describe("useRoutesByStop", () => {
-    it("should return an array of routes and lines", async () => {
-      const { result, waitFor } = renderHook(() => useRoutesByStop("stop-id"), {
-        wrapper: HookWrapper
-      });
-      await waitFor(() =>
-        expect(result.current.status).toEqual(FetchStatus.Data)
-      );
-
-      await waitFor(() => expect(result.current.data).toEqual(testData));
-      const routeWithPolylines = result.current.data![0];
-      expect(typeof routeWithPolylines).toBe("object");
-      expect(routeWithPolylines.polylines[0]).toHaveProperty("color");
-      expect(routeWithPolylines.polylines[0]).toHaveProperty("weight");
-      expect(routeWithPolylines.polylines[0]).toHaveProperty("positions");
+  it("should return an array of routes", async () => {
+    const { result, waitFor } = renderHook(() => useRoutes(["stop-id"]), {
+      wrapper: HookWrapper
     });
+    await waitFor(() =>
+      expect(result.current.status).toEqual(FetchStatus.Data)
+    );
 
-    it("returns error status if API returns an error", async () => {
-      global.fetch = jest.fn(
-        () =>
-          new Promise((resolve: Function) =>
-            resolve({
-              json: () => [],
-              ok: false,
-              status: 500,
-              statusText: "ERROR"
-            })
-          )
-      );
-      const { result, waitFor } = renderHook(() => useRoutesByStop("stop-id"), {
-        wrapper: HookWrapper
-      });
-      await waitFor(() =>
-        expect(result.current.status).toBe(FetchStatus.Error)
-      );
+    await waitFor(() => expect(result.current.data).toEqual(testData));
+  });
+
+  it("returns error status if API returns an error", async () => {
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve: Function) =>
+          resolve({
+            json: () => [],
+            ok: false,
+            status: 500,
+            statusText: "ERROR"
+          })
+        )
+    );
+    const { result, waitFor } = renderHook(() => useRoutes(["stop-id"]), {
+      wrapper: HookWrapper
     });
+    await waitFor(() => expect(result.current.status).toBe(FetchStatus.Error));
   });
 
   afterAll(() => {

--- a/apps/site/assets/ts/hooks/useRoute.ts
+++ b/apps/site/assets/ts/hooks/useRoute.ts
@@ -1,23 +1,22 @@
 import useSWR from "swr";
+import { sortBy } from "lodash";
 import { fetchJsonOrThrow } from "../helpers/fetch-json";
 import { Route } from "../__v3api";
-import { Polyline } from "../leaflet/components/__mapdata";
 import { FetchState, FetchStatus } from "../helpers/use-fetch";
 
-export type RouteWithPolylines = Route & { polylines: Polyline[] };
-
-const fetchData = async (url: string): Promise<RouteWithPolylines[]> =>
+const fetchData = async (url: string): Promise<Route[]> =>
   fetchJsonOrThrow(url);
 
-const useRoutesByStop = (stopId: string): FetchState<RouteWithPolylines[]> => {
-  const { data, error } = useSWR<RouteWithPolylines[]>(
-    `/api/routes/by-stop/${stopId}`,
+const useRoutes = (routeIds: string[]): FetchState<Route[]> => {
+  const { data, error } = useSWR<Route[]>(
+    routeIds.length ? `/api/routes/${routeIds.join(",")}` : null,
     fetchData
   );
   if (error) {
     return { status: FetchStatus.Error };
   }
-  return { status: FetchStatus.Data, data };
+  const sortedRoutes = data ? sortBy(data, ["sort_order"]) : data;
+  return { status: FetchStatus.Data, data: sortedRoutes };
 };
 // eslint-disable-next-line import/prefer-default-export
-export { useRoutesByStop };
+export { useRoutes };

--- a/apps/site/assets/ts/stop/__tests__/StopPageDeparturesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageDeparturesTest.tsx
@@ -1,61 +1,49 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import StopPageDepartures from "../components/StopPageDepartures";
-import { Route, RouteType } from "../../__v3api";
-import { renderWithRouter } from "./helpers";
+import { Route } from "../../__v3api";
+import { baseRoute, renderWithRouter } from "./helpers";
 
-const baseRoute = (name: string, type: RouteType): Route =>
-  ({
-    id: name,
-    direction_destinations: { 0: "Somewhere there", 1: "Over yonder" },
-    name: `${name} Route`,
-    type
-  } as Route);
-const routeData: Route[] = [baseRoute("4B", 3), baseRoute("Magenta", 1)];
+const routeData: Route[] = [baseRoute("16", 3), baseRoute("Red", 1)];
 
 describe("StopPageDepartures", () => {
-  it("renders with no data", () => {
+  it("renders with no data", async () => {
     const { asFragment } = renderWithRouter(
-      <StopPageDepartures
-        routes={[]}
-        stopName=""
-        alerts={[]}
-        departureInfos={[]}
-      />
+      <StopPageDepartures routes={[]} alerts={[]} departureInfos={[]} />
     );
-    expect(asFragment()).toMatchSnapshot();
-    expect(screen.getByRole("list")).toBeEmptyDOMElement();
-  });
-
-  it("renders with data", () => {
-    const { asFragment } = renderWithRouter(
-      <StopPageDepartures
-        routes={routeData}
-        stopName=""
-        alerts={[]}
-        departureInfos={[]}
-      />
-    );
-    expect(asFragment()).toMatchSnapshot();
-    expect(screen.getAllByRole("list")[0]).not.toBeEmptyDOMElement();
-    ["All", "Bus", "Subway"].forEach(name => {
-      expect(
-        screen.getByRole("button", { name: new RegExp(name) })
-      ).toBeDefined();
+    await waitFor(() => {
+      expect(asFragment()).toMatchSnapshot();
+      expect(screen.getByRole("list")).toBeEmptyDOMElement();
     });
   });
 
-  it("doesn't show the filters if there is 1 mode present", () => {
+  it("renders with data", async () => {
+    const { asFragment } = renderWithRouter(
+      <StopPageDepartures routes={routeData} alerts={[]} departureInfos={[]} />
+    );
+    await waitFor(() => {
+      expect(asFragment()).toMatchSnapshot();
+      expect(screen.getAllByRole("list")[0]).not.toBeEmptyDOMElement();
+      ["All", "Bus", "Subway"].forEach(name => {
+        expect(
+          screen.getByRole("button", { name: new RegExp(name) })
+        ).toBeDefined();
+      });
+    });
+  });
+
+  it("doesn't show the filters if there is 1 mode present", async () => {
     renderWithRouter(
       <StopPageDepartures
         routes={[routeData[0]]}
-        stopName=""
         alerts={[]}
         departureInfos={[]}
       />
     );
-    expect(
-      screen.queryByRole("button", { name: new RegExp("All") })
-    ).toBeNull();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: new RegExp("All") })
+      ).toBeNull();
+    });
   });
 });

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
@@ -72,7 +72,7 @@ exports[`StopPageDepartures renders with data 2`] = `
           </span>
         </a>
         <div
-          aria-label="Open upcoming departures to Ashmont"
+          aria-label="Open upcoming departures to Braintree"
           class="departure-card__headsign d-flex"
           role="button"
           tabindex="0"
@@ -80,7 +80,7 @@ exports[`StopPageDepartures renders with data 2`] = `
           <div
             class="departure-card__headsign-name"
           >
-            Ashmont
+            Braintree
           </div>
           <div
             class="departure-card__content"
@@ -99,7 +99,7 @@ exports[`StopPageDepartures renders with data 2`] = `
           </div>
         </div>
         <div
-          aria-label="Open upcoming departures to Braintree"
+          aria-label="Open upcoming departures to Ashmont"
           class="departure-card__headsign d-flex"
           role="button"
           tabindex="0"
@@ -107,7 +107,7 @@ exports[`StopPageDepartures renders with data 2`] = `
           <div
             class="departure-card__headsign-name"
           >
-            Braintree
+            Ashmont
           </div>
           <div
             class="departure-card__content"

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StopPageDepartures renders with data 1`] = `
+exports[`StopPageDepartures renders with data 1`] = `<DocumentFragment />`;
+
+exports[`StopPageDepartures renders with data 2`] = `
 <DocumentFragment>
   <div
     class="routes"
@@ -52,9 +54,9 @@ exports[`StopPageDepartures renders with data 1`] = `
         class="departure-card"
       >
         <a
-          class="departure-card__route u-bg--unknown"
+          class="departure-card__route u-bg--red-line"
           data-turbolinks="false"
-          href="/schedules/Magenta"
+          href="/schedules/Red"
         >
           <span
             aria-hidden="true"
@@ -66,9 +68,90 @@ exports[`StopPageDepartures renders with data 1`] = `
           <span
             class=""
           >
-            Magenta Route
+            Red Route
           </span>
         </a>
+        <div
+          aria-label="Open upcoming departures to Ashmont"
+          class="departure-card__headsign d-flex"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="departure-card__headsign-name"
+          >
+            Ashmont
+          </div>
+          <div
+            class="departure-card__content"
+          >
+            <div
+              class="font-helvetica-neue fs-14 u-nowrap"
+            >
+              No upcoming trips
+            </div>
+          </div>
+          <div>
+            <i
+              aria-hidden="true"
+              class="fa fa-angle-right notranslate fa-fw"
+            />
+          </div>
+        </div>
+        <div
+          aria-label="Open upcoming departures to Braintree"
+          class="departure-card__headsign d-flex"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="departure-card__headsign-name"
+          >
+            Braintree
+          </div>
+          <div
+            class="departure-card__content"
+          >
+            <div
+              class="font-helvetica-neue fs-14 u-nowrap"
+            >
+              No upcoming trips
+            </div>
+          </div>
+          <div>
+            <i
+              aria-hidden="true"
+              class="fa fa-angle-right notranslate fa-fw"
+            />
+          </div>
+        </div>
+        <div
+          aria-label="Open upcoming departures to Alewife"
+          class="departure-card__headsign d-flex"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="departure-card__headsign-name"
+          >
+            Alewife
+          </div>
+          <div
+            class="departure-card__content"
+          >
+            <div
+              class="font-helvetica-neue fs-14 u-nowrap"
+            >
+              No upcoming trips
+            </div>
+          </div>
+          <div>
+            <i
+              aria-hidden="true"
+              class="fa fa-angle-right notranslate fa-fw"
+            />
+          </div>
+        </div>
       </li>
       <li
         class="departure-card"
@@ -76,7 +159,7 @@ exports[`StopPageDepartures renders with data 1`] = `
         <a
           class="departure-card__route u-bg--bus"
           data-turbolinks="false"
-          href="/schedules/4B"
+          href="/schedules/16"
         >
           <span
             aria-hidden="true"
@@ -88,16 +171,45 @@ exports[`StopPageDepartures renders with data 1`] = `
           <span
             class="bus-route-sign"
           >
-            4B Route
+            16 Route
           </span>
         </a>
+        <div
+          aria-label="Open upcoming departures to Harbor Point"
+          class="departure-card__headsign d-flex"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="departure-card__headsign-name"
+          >
+            Harbor Point
+          </div>
+          <div
+            class="departure-card__content"
+          >
+            <div
+              class="font-helvetica-neue fs-14 u-nowrap"
+            >
+              No upcoming trips
+            </div>
+          </div>
+          <div>
+            <i
+              aria-hidden="true"
+              class="fa fa-angle-right notranslate fa-fw"
+            />
+          </div>
+        </div>
       </li>
     </ul>
   </div>
 </DocumentFragment>
 `;
 
-exports[`StopPageDepartures renders with no data 1`] = `
+exports[`StopPageDepartures renders with no data 1`] = `<DocumentFragment />`;
+
+exports[`StopPageDepartures renders with no data 2`] = `
 <DocumentFragment>
   <div
     class="routes"

--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -89,9 +89,8 @@ describe("DepartureTimes", () => {
     expect(screen.getByText("45 min"));
     expect(screen.getByText("50 min"));
     expect(screen.getByText("11:40 AM"));
-    // We don't support predictions without schedules yet
-    // expect(screen.getByText("Test 3"))
-    // expect(screen.getByText("11:45 AM"))
+    expect(screen.getByText("Test 3"));
+    expect(screen.getByText("11:45 AM"));
   });
 
   it.each`
@@ -101,16 +100,6 @@ describe("DepartureTimes", () => {
   `(
     `displays $expectedBadge when high priority alert has effect $alertEffect`,
     ({ alertEffect, expectedBadge }) => {
-      const schedules =
-        alertEffect === "suspension"
-          ? []
-          : ([
-              {
-                route: { type: 2 },
-                trip: { direction_id: 0 }
-              }
-            ] as ScheduleWithTimestamp[]);
-
       const alerts = [
         {
           id: "1234",
@@ -122,12 +111,14 @@ describe("DepartureTimes", () => {
         }
       ] as Alert[];
 
+      // these are special cases that're only valid if there are also no
+      // departures, see doc for isSuppressiveAlert
       renderWithRouter(
         <DepartureTimes
           route={route}
           directionId={0}
           stopName="ThatStation"
-          departuresForDirection={mergeIntoDepartureInfo(schedules, [])}
+          departuresForDirection={[]}
           alertsForDirection={alerts}
         />
       );

--- a/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -1,39 +1,37 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import DepartureTimes from "../../components/DepartureTimes";
-import { baseRoute, renderWithRouter } from "../helpers";
+import { renderWithRouter } from "../helpers";
 import { Alert, Route } from "../../../__v3api";
 import { DepartureInfo } from "../../../models/departureInfo";
 import { ScheduleWithTimestamp } from "../../../models/schedules";
 import { PredictionWithTimestamp } from "../../../models/predictions";
 import { mergeIntoDepartureInfo } from "../../../helpers/departureInfo";
 import { getNextTwoTimes } from "../../models/displayTimeConfig";
-import * as useDepartureRow from "../../../hooks/useDepartureRow";
-
-const route = baseRoute("TestRoute", 1);
-const destinationText = route.direction_destinations[0]!;
 
 describe("DepartureTimes", () => {
-  it("should display a default", () => {
+  it("should display a default", async () => {
     renderWithRouter(
       <DepartureTimes
-        route={route}
-        directionId={0}
-        stopName=""
-        departuresForDirection={[]}
+        headsign="Some place"
+        departures={[]}
         alertsForDirection={[]}
+        isCR={false}
+        onClick={jest.fn()}
       />
     );
-    expect(screen.findByText(destinationText)).toBeDefined();
-    expect(
-      screen.queryByRole("button", {
-        name: `Open upcoming departures to ${destinationText}`
-      })
-    ).toBeDefined();
+    await waitFor(() => {
+      expect(screen.findByText("Some place")).toBeDefined();
+      expect(
+        screen.queryByRole("button", {
+          name: `Open upcoming departures to ${"Some place"}`
+        })
+      ).toBeDefined();
+    });
   });
 
-  it("should render rows if there are schedules", () => {
+  it("should render rows if there are schedules", async () => {
     const dateToCompare = new Date("2022-04-27T10:30:00-04:00");
     const predictions = [
       {
@@ -73,24 +71,22 @@ describe("DepartureTimes", () => {
     ] as ScheduleWithTimestamp[];
     renderWithRouter(
       <DepartureTimes
-        route={route}
-        directionId={0}
-        stopName=""
-        departuresForDirection={mergeIntoDepartureInfo(
+        headsign="Test 1"
+        departures={mergeIntoDepartureInfo(
           schedules,
           predictions as PredictionWithTimestamp[]
         )}
         overrideDate={dateToCompare}
         alertsForDirection={[]}
+        isCR={false}
+        onClick={jest.fn()}
       />
     );
-    expect(screen.getByText("Test 1"));
-    expect(screen.getByText("Test 2"));
-    expect(screen.getByText("45 min"));
-    expect(screen.getByText("50 min"));
-    expect(screen.getByText("11:40 AM"));
-    expect(screen.getByText("Test 3"));
-    expect(screen.getByText("11:45 AM"));
+    await waitFor(() => {
+      expect(screen.getByText("Test 1"));
+      expect(screen.getByText("45 min"));
+      expect(screen.getByText("50 min"));
+    });
   });
 
   it.each`
@@ -99,7 +95,7 @@ describe("DepartureTimes", () => {
     ${"shuttle"}    | ${"Shuttle Service"}
   `(
     `displays $expectedBadge when high priority alert has effect $alertEffect`,
-    ({ alertEffect, expectedBadge }) => {
+    async ({ alertEffect, expectedBadge }) => {
       const alerts = [
         {
           id: "1234",
@@ -115,19 +111,21 @@ describe("DepartureTimes", () => {
       // departures, see doc for isSuppressiveAlert
       renderWithRouter(
         <DepartureTimes
-          route={route}
-          directionId={0}
-          stopName="ThatStation"
-          departuresForDirection={[]}
+          headsign="ThatStation"
+          departures={[]}
           alertsForDirection={alerts}
+          isCR={false}
+          onClick={jest.fn()}
         />
       );
-      expect(screen.getByText(expectedBadge)).toBeDefined();
-      expect(screen.getByText("See alternatives")).toBeDefined();
+      await waitFor(() => {
+        expect(screen.getByText(expectedBadge)).toBeDefined();
+        expect(screen.getByText("See alternatives")).toBeDefined();
+      });
     }
   );
 
-  it("should display the high priority alert badge over the information alert badge", () => {
+  it("should display the high priority alert badge over the information alert badge", async () => {
     const schedules = [] as ScheduleWithTimestamp[];
 
     const alerts = [
@@ -151,19 +149,21 @@ describe("DepartureTimes", () => {
 
     renderWithRouter(
       <DepartureTimes
-        route={route}
-        directionId={0}
-        stopName="ThisStop"
-        departuresForDirection={mergeIntoDepartureInfo(schedules, [])}
+        headsign="ThisStop"
+        departures={mergeIntoDepartureInfo(schedules, [])}
         alertsForDirection={alerts}
+        isCR={false}
+        onClick={jest.fn()}
       />
     );
-    expect(screen.getByText("No Service")).toBeDefined();
-    expect(screen.queryByText("Detour")).toBeNull();
-    expect(screen.getByText("See alternatives")).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByText("No Service")).toBeDefined();
+      expect(screen.queryByText("Detour")).toBeNull();
+      expect(screen.getByText("See alternatives")).toBeDefined();
+    });
   });
 
-  it("should display the detour badge with times if detour alert is present", () => {
+  it("should display the detour badge with times if detour alert is present", async () => {
     const dateToCompare = new Date("2022-04-27T10:30:00-04:00");
     const predictions = [
       {
@@ -199,18 +199,19 @@ describe("DepartureTimes", () => {
 
     renderWithRouter(
       <DepartureTimes
-        route={route}
-        directionId={0}
-        stopName=""
-        departuresForDirection={mergeIntoDepartureInfo(schedules, predictions)}
+        headsign=""
+        departures={mergeIntoDepartureInfo(schedules, predictions)}
         alertsForDirection={[detourAlert] as Alert[]}
         overrideDate={dateToCompare}
+        isCR={false}
+        onClick={jest.fn()}
       />
     );
-
-    expect(screen.getByText("Detour")).toBeDefined();
-    expect(screen.getByText("45 min")).toBeDefined();
-    expect(screen.queryByText("See alternatives")).toBeNull();
+    await waitFor(() => {
+      expect(screen.getByText("Detour")).toBeDefined();
+      expect(screen.getByText("45 min")).toBeDefined();
+      expect(screen.queryByText("See alternatives")).toBeNull();
+    });
   });
 
   describe("getNextTwoTimes", () => {
@@ -328,11 +329,6 @@ describe("DepartureTimes", () => {
 
   it("should allow the clicking of rows", async () => {
     const setRowSpy = jest.fn();
-    jest.spyOn(useDepartureRow, "default").mockReturnValue({
-      setRow: setRowSpy,
-      resetRow: jest.fn(),
-      activeRow: null
-    });
     const compareTime = new Date("2022-04-24T11:15:00-04:00");
     const schedules = [
       {
@@ -355,28 +351,29 @@ describe("DepartureTimes", () => {
     const user = userEvent.setup();
     renderWithRouter(
       <DepartureTimes
-        route={route}
-        directionId={0}
-        stopName=""
-        departuresForDirection={mergeIntoDepartureInfo(schedules, [])}
+        headsign="Test 1"
+        departures={mergeIntoDepartureInfo(schedules, [])}
         alertsForDirection={[]}
         overrideDate={compareTime}
+        isCR={false}
+        onClick={setRowSpy}
       />
     );
 
-    const row = screen.getByText("Test 1");
-    expect(row).toBeDefined();
-
-    await user.click(row);
-    expect(setRowSpy).toHaveBeenCalledTimes(1);
-    expect(setRowSpy).toHaveBeenCalledWith({
-      directionId: "0",
-      headsign: "Test 1",
-      routeId: "TestRoute"
+    let btn: HTMLElement;
+    await waitFor(() => {
+      btn = screen.getByRole("button", {
+        name: /Open upcoming departures to Test 1/
+      });
+      expect(btn).toBeDefined();
     });
+    await user.click(
+      screen.getByRole("button", { name: /Open upcoming departures to Test 1/ })
+    );
+    expect(setRowSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("should render `Track [Track Name] if commuter rail", () => {
+  it("should render `Track [Track Name] if commuter rail", async () => {
     const dateToCompare = new Date("2022-04-27T10:30:00-04:00");
     const departures = [
       {
@@ -439,50 +436,39 @@ describe("DepartureTimes", () => {
 
     renderWithRouter(
       <DepartureTimes
-        route={route}
-        directionId={0}
-        stopName=""
-        departuresForDirection={departures}
+        headsign="Test 1"
+        departures={departures}
         overrideDate={dateToCompare}
         alertsForDirection={[]}
+        isCR={true}
+        onClick={jest.fn()}
       />
     );
 
-    expect(screen.getByText("Track 3")).toBeDefined();
-    const notCRTrack = screen.queryByText("Track 1");
-    expect(notCRTrack).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Track 3")).toBeDefined();
+      const notCRTrack = screen.queryByText("Track 1");
+      expect(notCRTrack).not.toBeInTheDocument();
+    });
   });
 
-  it("renders 'No upcoming trips' when no predictions or schedules", () => {
+  it("renders 'No upcoming trips' when no predictions or schedules", async () => {
     renderWithRouter(
       <DepartureTimes
-        route={route}
-        directionId={0}
-        stopName="Alewife"
-        departuresForDirection={[]}
+        headsign="Alewife"
+        departures={[]}
         alertsForDirection={[]}
+        isCR={false}
+        onClick={jest.fn()}
       />
     );
-    expect(screen.getByText("No upcoming trips")).toBeDefined();
-    expect(screen.getByText("Somewhere there")).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByText("No upcoming trips")).toBeDefined();
+      expect(screen.getByText("Alewife")).toBeDefined();
+    });
   });
 
-  it("doesn't render when current stop is same as destination", () => {
-    renderWithRouter(
-      <DepartureTimes
-        route={route}
-        directionId={0}
-        stopName="Somewhere there"
-        departuresForDirection={[]}
-        alertsForDirection={[]}
-      />
-    );
-
-    expect(screen.queryByText("No upcoming trips")).not.toBeInTheDocument();
-    expect(screen.queryByText("Somewhere there")).not.toBeInTheDocument();
-  });
-
-  it("should render no service if the station is closed", () => {
+  it("should render no service if the station is closed", async () => {
     const closureAlert = {
       id: "c1",
       effect: "station_closure",
@@ -491,19 +477,20 @@ describe("DepartureTimes", () => {
 
     renderWithRouter(
       <DepartureTimes
-        route={route}
-        directionId={0}
-        stopName="asdf"
-        departuresForDirection={[]}
+        headsign="Ashmont"
+        departures={[]}
         alertsForDirection={[closureAlert]}
+        isCR={true}
+        onClick={jest.fn()}
       />
     );
-
-    expect(screen.getByText("No Service")).toBeInTheDocument();
-    expect(screen.getByText("See alternatives")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("No Service")).toBeInTheDocument();
+      expect(screen.getByText("See alternatives")).toBeInTheDocument();
+    });
   });
 
-  it("should render no service if the stop is closed", () => {
+  it("should render no service if the stop is closed", async () => {
     const closureAlert = {
       id: "c1",
       effect: "stop_closure",
@@ -512,15 +499,17 @@ describe("DepartureTimes", () => {
 
     renderWithRouter(
       <DepartureTimes
-        route={route}
-        directionId={0}
-        stopName="asdf"
-        departuresForDirection={[]}
+        headsign="Harbor Point"
+        departures={[]}
         alertsForDirection={[closureAlert]}
+        isCR={false}
+        onClick={jest.fn()}
       />
     );
 
-    expect(screen.getByText("No Service")).toBeInTheDocument();
-    expect(screen.getByText("See alternatives")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("No Service")).toBeInTheDocument();
+      expect(screen.getByText("See alternatives")).toBeInTheDocument();
+    });
   });
 });

--- a/apps/site/assets/ts/stop/components/DepartureTimes.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureTimes.tsx
@@ -2,14 +2,7 @@ import { groupBy } from "lodash";
 import React, { ReactElement, ReactNode } from "react";
 import { Alert, DirectionId, Route } from "../../__v3api";
 import renderFa from "../../helpers/render-fa";
-import {
-  hasClosure,
-  hasDetour,
-  hasShuttleService,
-  hasSuspension,
-  isSuppressiveAlert
-} from "../../models/alert";
-import Badge from "../../components/Badge";
+import DeparturesWithBadge from "./DeparturesWithBadge";
 import { DepartureInfo } from "../../models/departureInfo";
 import {
   departuresListFromInfos,
@@ -18,119 +11,6 @@ import {
 import { breakTextAtSlash } from "../../helpers/text";
 import { handleReactEnterKeyPress } from "../../helpers/keyboard-events-react";
 import useDepartureRow from "../../hooks/useDepartureRow";
-
-const toHighPriorityAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
-  if (hasSuspension(alerts) || hasClosure(alerts)) {
-    return <Badge text="No Service" contextText="Route Status" />;
-  }
-
-  if (hasShuttleService(alerts)) {
-    return <Badge text="Shuttle Service" contextText="Route Status" />;
-  }
-
-  return undefined;
-};
-
-const toInformativeAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
-  if (hasDetour(alerts)) {
-    return <Badge text="Detour" contextText="Route Status" />;
-  }
-
-  return undefined;
-};
-
-const alertBadgeWrapper = (
-  alertClass: string,
-  alertBadge: JSX.Element
-): JSX.Element => {
-  return (
-    <div
-      className={alertClass}
-      style={{ float: "right", whiteSpace: "nowrap", marginTop: "0.25rem" }}
-    >
-      {alertBadge}
-    </div>
-  );
-};
-
-const departureTimeRow = (
-  departures: DepartureInfo[],
-  isCR: boolean,
-  alerts: Alert[],
-  alertBadge?: JSX.Element,
-  targetDate?: Date
-): JSX.Element => {
-  let alertClass = "departure-card__alert";
-  if (alertBadge && departures.length > 0) {
-    // Informative badges need more padding between them and the time
-    alertClass += " pt-4";
-  }
-
-  const timeList = departuresListFromInfos(
-    departures,
-    isCR,
-    targetDate,
-    isCR ? 1 : 2,
-    true,
-    ({ children }) => (
-      <div className="stop-routes__departures-group">{children}</div>
-    )
-  );
-  return (
-    <div className="departure-card__content">
-      {timeList.length > 0 ? (
-        <div className="departure-card__times">{timeList}</div>
-      ) : (
-        !alertBadge && <div>No upcoming trips</div>
-      )}
-
-      {hasDetour(alerts) &&
-        timeList.length > 0 &&
-        alertBadgeWrapper(alertClass, alertBadge!)}
-      {(hasShuttleService(alerts) ||
-        hasSuspension(alerts) ||
-        hasClosure(alerts) ||
-        (hasDetour(alerts) && timeList.length === 0)) &&
-        alertBadge && (
-          <>
-            <div style={{ float: "right" }}>See alternatives</div>
-            <br />
-            {alertBadgeWrapper(alertClass, alertBadge)}
-          </>
-        )}
-    </div>
-  );
-};
-
-const getRow = (
-  departures: DepartureInfo[],
-  alerts: Alert[],
-  overrideDate?: Date
-): JSX.Element => {
-  // High priority badges might override the displaying of times
-  const numPredictions = departures.filter(d => !!d.prediction).length;
-  const suppressiveAlerts = alerts.filter(alert =>
-    isSuppressiveAlert(alert, numPredictions)
-  );
-  const alertBadge = toHighPriorityAlertBadge(suppressiveAlerts);
-  const isCR = departures[0]
-    ? departures[0].routeMode === "commuter_rail"
-    : false;
-  if (alertBadge) {
-    return departureTimeRow([], isCR, alerts, alertBadge);
-  }
-
-  // informative badges compliment the times being shown
-  const informativeAlertBadge = toInformativeAlertBadge(alerts);
-
-  return departureTimeRow(
-    departures,
-    isCR,
-    alerts,
-    informativeAlertBadge,
-    overrideDate
-  );
-};
 
 interface DepartureTimesProps {
   route: Route;
@@ -158,15 +38,13 @@ const ClickableDepartureRow = ({
       onClick={onClick}
       onKeyDown={e => handleReactEnterKeyPress(e, onClick)}
       aria-label={`Open upcoming departures to ${headsignName}`}
-      className="departure-card__headsign d-flex justify-content-space-between"
+      className="departure-card__headsign d-flex"
     >
       <div className="departure-card__headsign-name">
         {breakTextAtSlash(headsignName)}
       </div>
       {children}
-      <div style={{ marginLeft: "0.5em" }}>
-        {renderFa("fa-fw", "fa-angle-right")}
-      </div>
+      <div>{renderFa("fa-fw", "fa-angle-right")}</div>
     </div>
   );
 };
@@ -186,6 +64,38 @@ const DepartureTimes = ({
       directionId: `${directionId}`,
       headsign: headsignText
     });
+  const isCR = departuresForDirection[0]
+    ? departuresForDirection[0].routeMode === "commuter_rail"
+    : false;
+
+  const rowContent = (departures: DepartureInfo[]): ReactElement => {
+    const timeList = departuresListFromInfos(
+      departures,
+      isCR,
+      overrideDate,
+      isCR ? 1 : 2,
+      true,
+      ({ children }) => (
+        <div className="stop-routes__departures-group">{children}</div>
+      )
+    );
+    return (
+      <div className="departure-card__content">
+        <DeparturesWithBadge
+          alerts={alertsForDirection}
+          departuresLength={departures.length}
+        >
+          {timeList.length > 0 ? (
+            <div className="departure-card__times">{timeList}</div>
+          ) : (
+            <div className="font-helvetica-neue fs-14 u-nowrap">
+              No upcoming trips
+            </div>
+          )}
+        </DeparturesWithBadge>
+      </div>
+    );
+  };
   if (!departuresForDirection.length) {
     // display using route's destination
     const destination = route.direction_destinations[directionId];
@@ -196,7 +106,7 @@ const DepartureTimes = ({
         onClick={callback(destination)}
         headsignName={destination}
       >
-        {getRow(departuresForDirection, alertsForDirection, overrideDate)}
+        {rowContent(departuresForDirection)}
       </ClickableDepartureRow>
     );
   }
@@ -212,7 +122,7 @@ const DepartureTimes = ({
             onClick={callback(headsign)}
             headsignName={headsign}
           >
-            {getRow(departures, alertsForDirection, overrideDate)}
+            {rowContent(departures)}
           </ClickableDepartureRow>
         );
       })}

--- a/apps/site/assets/ts/stop/components/DeparturesWithBadge.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesWithBadge.tsx
@@ -1,0 +1,74 @@
+import React, { ReactElement, ReactNode } from "react";
+import { Alert } from "../../__v3api";
+import {
+  hasClosure,
+  hasDetour,
+  hasShuttleService,
+  hasSuspension,
+  isSuppressiveAlert
+} from "../../models/alert";
+import Badge from "../../components/Badge";
+
+const toHighPriorityAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
+  if (hasSuspension(alerts) || hasClosure(alerts)) {
+    return <Badge text="No Service" contextText="Route Status" />;
+  }
+
+  if (hasShuttleService(alerts)) {
+    return <Badge text="Shuttle Service" contextText="Route Status" />;
+  }
+
+  return undefined;
+};
+
+const toInformativeAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
+  if (hasDetour(alerts)) {
+    return <Badge text="Detour" contextText="Route Status" />;
+  }
+
+  return undefined;
+};
+
+const alertBadgeWrapper = (alertBadge: JSX.Element): JSX.Element => {
+  return (
+    <div
+      className="departure-card__alert"
+      style={{ float: "right", whiteSpace: "nowrap", marginTop: "0.25rem" }}
+    >
+      {alertBadge}
+    </div>
+  );
+};
+
+const DeparturesWithBadge = ({
+  alerts,
+  departuresLength,
+  children
+}: {
+  alerts: Alert[];
+  departuresLength: number;
+  children: ReactNode;
+}): ReactElement | null => {
+  const suppressiveAlerts = alerts.filter(alert =>
+    isSuppressiveAlert(alert, departuresLength)
+  );
+  const priorityBadge = toHighPriorityAlertBadge(suppressiveAlerts);
+  const secondaryBadge = toInformativeAlertBadge(alerts);
+  if (!(priorityBadge || secondaryBadge)) return <>{children}</>;
+  const displayBadge = (priorityBadge || secondaryBadge)!;
+
+  return (
+    <>
+      {priorityBadge ? (
+        <div className="font-helvetica-neue fs-14" style={{ float: "right" }}>
+          See alternatives
+        </div>
+      ) : (
+        children
+      )}
+      {alertBadgeWrapper(displayBadge)}
+    </>
+  );
+};
+
+export default DeparturesWithBadge;

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -1,17 +1,21 @@
 import { filter, groupBy, sortBy } from "lodash";
 import React, { ReactElement, useState } from "react";
+import { useLoaderData } from "react-router-dom";
 import { Alert, Route } from "../../__v3api";
 import DeparturesFilters, { ModeChoice } from "./DeparturesFilters";
 import { modeForRoute } from "../../models/route";
 import DepartureCard from "./DepartureCard";
 import { alertsByRoute, isInNextXDays } from "../../models/alert";
 import { DepartureInfo } from "../../models/departureInfo";
+import {
+  GroupedRoutePatterns,
+  RoutePatternWithPolyline
+} from "../stop-redesign-loader";
 
 interface StopPageDeparturesProps {
   routes: Route[];
   departureInfos: DepartureInfo[];
   alerts: Alert[];
-  stopName: string;
 }
 
 // Commuter Rail, then Subway, then Bus
@@ -28,18 +32,17 @@ const modeSortFn = ({ type }: Route): number => {
 const StopPageDepartures = ({
   routes,
   departureInfos,
-  alerts,
-  stopName
+  alerts
 }: StopPageDeparturesProps): ReactElement<HTMLElement> => {
   // default to show all modes.
   const [selectedMode, setSelectedMode] = useState<ModeChoice>("all");
   const groupedRoutes = groupBy(routes, modeForRoute);
-  const groupedDepartures = groupBy(departureInfos, "route.id");
   const modesList = Object.keys(groupedRoutes) as ModeChoice[];
   const filteredRoutes =
     selectedMode === "all" ? routes : groupedRoutes[selectedMode];
   const currentAlerts = filter(alerts, a => isInNextXDays(a, 0));
   const groupedAlerts = alertsByRoute(currentAlerts);
+  const groupedRoutePatterns = useLoaderData() as GroupedRoutePatterns;
 
   return (
     <div className="routes">
@@ -51,16 +54,21 @@ const StopPageDepartures = ({
         />
       )}
       <ul className="stop-departures list-unstyled">
-        {sortBy(filteredRoutes, [modeSortFn, "sort_order"]).map(route => (
-          <DepartureCard
-            key={route.id}
-            route={route}
-            departuresForRoute={groupedDepartures[route.id]}
-            stopName={stopName}
-            // This list should only have one value, is there another way to do this?
-            alertsForRoute={groupedAlerts[route.id]}
-          />
-        ))}
+        {sortBy(filteredRoutes, [modeSortFn, "sort_order"]).map(route => {
+          const groupedByHeadsign: Record<string, RoutePatternWithPolyline[]> =
+            groupedRoutePatterns[route.id];
+          return (
+            <DepartureCard
+              key={route.id}
+              route={route}
+              routePatternsByHeadsign={groupedByHeadsign}
+              alertsForRoute={groupedAlerts[route.id] || []}
+              departuresForRoute={departureInfos.filter(
+                d => d.route.id === route.id
+              )}
+            />
+          );
+        })}
       </ul>
     </div>
   );

--- a/apps/site/assets/ts/stop/stop-redesign-loader.tsx
+++ b/apps/site/assets/ts/stop/stop-redesign-loader.tsx
@@ -9,10 +9,40 @@ import { ErrorBoundary } from "@sentry/react";
 import StopPageRedesign from "./components/StopPageRedesign";
 import Loading from "../components/Loading";
 import ErrorPage from "../components/ErrorPage";
+import { RoutePattern } from "../__v3api";
+import { fetchJson, isFetchFailed } from "../helpers/fetch-json";
+import { Polyline } from "../leaflet/components/__mapdata";
+
+export interface RoutePatternWithPolyline
+  extends Omit<RoutePattern, "representative_trip_polyline"> {
+  representative_trip_polyline: Polyline;
+}
+export type GroupedRoutePatterns = Record<
+  string,
+  Record<string, RoutePatternWithPolyline[]>
+>;
+
+const fetchStopRoutePatterns = async (
+  stopId: string
+): Promise<GroupedRoutePatterns | null> => {
+  const data = await fetchJson<GroupedRoutePatterns>(
+    `/api/stop/${stopId}/route-patterns`
+  );
+  if (isFetchFailed(data)) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Failed to fetch route pattern information: ${data.status} ${data.statusText}`
+    );
+    return null;
+  }
+  return data;
+};
 
 const routesConfig = (stopId: string): RouteObject[] => [
   {
     path: "/stops/:stopId",
+    loader: () => fetchStopRoutePatterns(stopId),
+    shouldRevalidate: () => false,
     element: (
       <ErrorBoundary fallback={ErrorPage}>
         <StopPageRedesign stopId={stopId} />

--- a/apps/site/lib/site_web/controllers/route_controller.ex
+++ b/apps/site/lib/site_web/controllers/route_controller.ex
@@ -5,8 +5,8 @@ defmodule SiteWeb.RouteController do
   use SiteWeb, :controller
   alias Routes.{Repo, Route}
 
-  @spec get(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def get(conn, %{"route_ids" => route_ids} = _params) do
+  @spec get_by_route_ids(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def get_by_route_ids(conn, %{"route_ids" => route_ids} = _params) do
     routes =
       route_ids
       |> String.split(",")

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -226,7 +226,7 @@ defmodule SiteWeb.Router do
     get("/stop/:id", StopController, :get)
     get("/stop/:id/route-patterns", StopController, :grouped_route_patterns)
     get("/map-config", MapConfigController, :get)
-    get("/routes/:route_ids", RouteController, :get)
+    get("/routes/:route_ids", RouteController, :get_by_route_ids)
     get("/fares/one-way", FareController, :one_way_by_stop_id)
   end
 

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -226,7 +226,7 @@ defmodule SiteWeb.Router do
     get("/stop/:id", StopController, :get)
     get("/stop/:id/route-patterns", StopController, :grouped_route_patterns)
     get("/map-config", MapConfigController, :get)
-    get("/routes/by-stop/:stop_id", RouteController, :get_by_stop_id)
+    get("/routes/:route_ids", RouteController, :get)
     get("/fares/one-way", FareController, :one_way_by_stop_id)
   end
 

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -224,6 +224,7 @@ defmodule SiteWeb.Router do
     pipe_through([:secure, :browser, :cached_daily])
 
     get("/stop/:id", StopController, :get)
+    get("/stop/:id/route-patterns", StopController, :grouped_route_patterns)
     get("/map-config", MapConfigController, :get)
     get("/routes/by-stop/:stop_id", RouteController, :get_by_stop_id)
     get("/fares/one-way", FareController, :one_way_by_stop_id)

--- a/apps/site/test/site_web/controllers/route_controller_test.exs
+++ b/apps/site/test/site_web/controllers/route_controller_test.exs
@@ -1,56 +1,19 @@
 defmodule SiteWeb.RouteControllerTest do
   use SiteWeb.ConnCase, async: false
   import Mock
-  alias RoutePatterns.RoutePattern
-  alias Routes.Route
+  alias Routes.{Repo, Route}
 
-  setup_with_mocks([
-    {Routes.Repo, [:passthrough],
-     [
-       by_stop: fn _ ->
-         [
-           %Route{id: "route", color: "ADFF2F"},
-           %Route{id: "subway_route", color: "ADFF2F", type: 0},
-           %Route{id: "746", name: "SL route", color: "ADFF2F", type: 3}
-         ]
-       end
-     ]},
-    {RoutePatterns.Repo, [],
-     [
-       by_route_id: fn _, _ ->
-         [
-           %RoutePattern{shape_id: "1", representative_trip_polyline: "safsadfasds"},
-           %RoutePattern{shape_id: "2", representative_trip_polyline: "werwqetrewq"}
-         ]
-       end
-     ]},
-    {Polyline, [], [decode: fn _ -> [{1, 2}, {3, 4}, {5, 6}] end]}
-  ]) do
-    :ok
-  end
+  describe "get/2" do
+    test "returns routes", %{conn: conn} do
+      with_mock Repo, get: fn id -> %Route{id: id} end do
+        conn = get(conn, route_path(conn, :get, "route_id1,route_id2"))
+        response = json_response(conn, 200)
 
-  describe "get_by_stop_id/2" do
-    test "returns routes with polyline data and fares", %{conn: conn} do
-      conn = get(conn, route_path(conn, :get_by_stop_id, "stop_id"))
-      response = json_response(conn, 200)
-
-      assert [
-               %{"id" => "route", "color" => "ADFF2F", "polylines" => polylines},
-               %{"id" => "subway_route", "color" => "ADFF2F", "polylines" => subway_polylines},
-               %{"id" => "746", "color" => "ADFF2F", "polylines" => sl_polylines}
-             ] = response
-
-      assert [
-               %{
-                 "color" => "#ADFF2F",
-                 "positions" => _,
-                 "weight" => _
-               }
-               | _
-             ] = polylines
-
-      assert Enum.count(subway_polylines) > 0
-      assert Enum.count(sl_polylines) > 0
+        assert [
+                 %{"id" => "route_id1"},
+                 %{"id" => "route_id2"}
+               ] = response
+      end
     end
   end
 end

--- a/apps/site/test/site_web/controllers/route_controller_test.exs
+++ b/apps/site/test/site_web/controllers/route_controller_test.exs
@@ -3,10 +3,10 @@ defmodule SiteWeb.RouteControllerTest do
   import Mock
   alias Routes.{Repo, Route}
 
-  describe "get/2" do
+  describe "get_by_route_ids/2" do
     test "returns routes", %{conn: conn} do
       with_mock Repo, get: fn id -> %Route{id: id} end do
-        conn = get(conn, route_path(conn, :get, "route_id1,route_id2"))
+        conn = get(conn, route_path(conn, :get_by_route_ids, "route_id1,route_id2"))
         response = json_response(conn, 200)
 
         assert [

--- a/apps/site/test/site_web/controllers/stop_controller_test.exs
+++ b/apps/site/test/site_web/controllers/stop_controller_test.exs
@@ -163,4 +163,37 @@ defmodule SiteWeb.StopControllerTest do
       end
     end
   end
+
+  describe "endpoints" do
+    test "grouped_route_patterns returns stop's route patterns by route & headsign", %{
+      conn: conn
+    } do
+      with_mock(RoutePatterns.Repo,
+        by_stop_id: fn "place-here" ->
+          [
+            %RoutePatterns.RoutePattern{
+              route_id: "Purple-A",
+              headsign: "Tree Hill",
+              name: "Here Square - Tree Hill"
+            }
+          ]
+        end
+      ) do
+        response =
+          get(conn, stop_path(conn, :grouped_route_patterns, "place-here")) |> json_response(200)
+
+        assert %{
+                 "Purple-A" => %{
+                   "Tree Hill" => [
+                     %{
+                       "headsign" => "Tree Hill",
+                       "name" => "Here Square - Tree Hill"
+                     }
+                     | _
+                   ]
+                 }
+               } = response
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Stops showing Headsign for Route Even if One Direction of Travel](https://app.asana.com/0/385363666817452/1205268760549362/f)

## Backend highlights
- Adds `/api/stop/:stop_id/route-patterns` to get a JSON object of augmented route patterns grouped by headsign and route ID.
- Replaces the `/routes/by-stop/:stop_id` with `/routes/:route_ids` that returns a JSON response containing a simple list of routes.
- The polyline information continues to be computed in the backend, but is now part of the route pattern response as opposed to appending the routes response.

## Frontend highlights
- Adds a `loader` to the React Router's configuration to fetch the route patterns, which will be available from within child components via React Router's `useLoaderData()` hook. Disables revalidation because this data is not going to change.
- Adds a helper function, `departureInfoInRoutePatterns`, to filter the list of departures against a list of route patterns.
- Lots of restructuring:
  - `<StopPageRedesign />`
    - Get route patterns, and use the route IDs from that to fetch routes
    - Don't wait for routes to return a defined response, since they never will for stops that don't have any route patterns (South Attleboro)
  - `<DeparturesAndMap />`
    - Remove no longer needed `routesWithPolylines` prop
    - Get route patterns, use the included polylines
  - `<StopPageDepartures />`
    - Get route patterns, figure out route patterns for the filtered routes
  - `<DepartureCard />`
    - Add `routePatternsByHeadsign` prop
    - Refactors to render a `<DepartureTimes />` per each headsign
    - Sets an `onClick` variable to pass to child
  - `<DepartureTimes />`
    - Adds `headsign`, `isCR`, and `onClick` props
    - Removes check of stop name against route's direction_destination as it should no longer be needed. Removes no longer needed `route`, `directionId` and `stopName` props.
    - Renames `departuresForDirection` prop to just `departures` (they were filtered by `departureInfoInRoutePatterns` earlier)
---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [x] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

