### PR TITLE
hotfix(ScheduleDirection): fix line diagram for routes with repeated stops

### DIFF
--- a/apps/site/assets/ts/app/helpers/testUtils.ts
+++ b/apps/site/assets/ts/app/helpers/testUtils.ts
@@ -1,6 +1,18 @@
 /* eslint-disable */
 import toJson, { Json } from "enzyme-to-json";
 import { ReactWrapper } from "enzyme";
+import {
+  IndexedRouteStop,
+  StopTree
+} from "../../schedule/components/__schedule";
+
+export const testRouteStopListFromStopTree = (
+  tree: StopTree
+): IndexedRouteStop[] =>
+  Object.values(tree.byId).map((node, index) => ({
+    ...node.value,
+    routeIndex: index
+  }));
 
 export const createReactRoot = (): void => {
   document.body.innerHTML =

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -4,7 +4,8 @@ import {
   RoutePatternsByDirection,
   EnhancedRoutePattern,
   StopTree,
-  RouteStop
+  RouteStop,
+  IndexedRouteStop
 } from "./__schedule";
 import ScheduleDirectionMenu from "./direction/ScheduleDirectionMenu";
 import ScheduleDirectionButton from "./direction/ScheduleDirectionButton";
@@ -81,9 +82,12 @@ export const fetchLineData = (
       })
       .then(({ stop_tree, route_stop_lists }) => {
         const stopTree = stop_tree ? fromStopTreeData(stop_tree) : null;
+        const routeStopListsWithIndices: IndexedRouteStop[][] = (route_stop_lists as RouteStop[][]).map(
+          rs_list => rs_list.map((rs, index) => ({ ...rs, routeIndex: index }))
+        );
         dispatch({
           type: "FETCH_COMPLETE",
-          payload: { stopTree, routeStopLists: route_stop_lists }
+          payload: { stopTree, routeStopLists: routeStopListsWithIndices }
         });
       })
       // @ts-ignore
@@ -205,7 +209,7 @@ const ScheduleDirection = ({
 
   const routeStopList =
     lineState.data && lineState.data.routeStopLists
-      ? (lineState.data.routeStopLists as RouteStop[][]).find(
+      ? (lineState.data.routeStopLists as IndexedRouteStop[][]).find(
           rsList => !!rsList.find(rs => rs.branch === state.routePattern.name)
         ) || []
       : [];

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -3,7 +3,8 @@ import { Alert, DirectionId, EnhancedRoute } from "../../__v3api";
 import {
   RoutePatternsByDirection,
   EnhancedRoutePattern,
-  StopTree
+  StopTree,
+  RouteStop
 } from "./__schedule";
 import ScheduleDirectionMenu from "./direction/ScheduleDirectionMenu";
 import ScheduleDirectionButton from "./direction/ScheduleDirectionButton";
@@ -26,7 +27,8 @@ export interface Props {
   routePatternsByDirection: RoutePatternsByDirection;
   mapData?: MapData;
   staticMapData?: StaticMapData;
-  stopTree: StopTree;
+  stopTree: StopTree | null;
+  routeStopLists: RouteStop[][] | null;
   alerts: Alert[];
   busVariantId: string | null;
 }
@@ -78,11 +80,11 @@ export const fetchLineData = (
         if (response.ok) return response.json();
         throw new Error(response.statusText);
       })
-      .then(({ stop_tree }) => {
-        const stopTree: StopTree = fromStopTreeData(stop_tree);
+      .then(({ stop_tree, route_stop_lists }) => {
+        const stopTree = stop_tree ? fromStopTreeData(stop_tree) : null;
         dispatch({
           type: "FETCH_COMPLETE",
-          payload: { stopTree }
+          payload: { stopTree, routeStopLists: route_stop_lists }
         });
       })
       // @ts-ignore
@@ -97,6 +99,7 @@ const ScheduleDirection = ({
   mapData,
   staticMapData,
   stopTree: initialStopTree,
+  routeStopLists: initialRouteStopLists,
   alerts,
   busVariantId
 }: Props): ReactElement<HTMLElement> => {
@@ -186,7 +189,8 @@ const ScheduleDirection = ({
 
   const [lineState, dispatchLineData] = useReducer(fetchReducer, {
     data: {
-      stopTree: initialStopTree
+      stopTree: initialStopTree,
+      routeStopLists: initialRouteStopLists
     },
     isLoading: false,
     error: false

--- a/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -19,7 +19,6 @@ import {
 } from "../../models/route";
 import LineDiagram from "./line-diagram/LineDiagram";
 import { fromStopTreeData } from "./ScheduleLoader";
-import { isEmptyTree } from "../../helpers/stop-tree";
 
 export interface Props {
   route: EnhancedRoute;
@@ -204,7 +203,12 @@ const ScheduleDirection = ({
     );
   }, [route, state.directionId, busVariantId, currentRoutePatternIdForData]);
 
-  const hasValidTree = lineState.data && !isEmptyTree(lineState.data.stopTree);
+  const routeStopList =
+    lineState.data && lineState.data.routeStopLists
+      ? (lineState.data.routeStopLists as RouteStop[][]).find(
+          rsList => !!rsList.find(rs => rs.branch === state.routePattern.name)
+        ) || []
+      : [];
   return (
     <>
       <div className="m-schedule-direction">
@@ -225,9 +229,10 @@ const ScheduleDirection = ({
           <ScheduleDirectionButton dispatch={dispatch} />
         ) : null}
       </div>
-      {isSubwayRoute(route) && hasValidTree && (
+      {isSubwayRoute(route) && (
         <LineDiagram
-          stopTree={lineState.data.stopTree}
+          stopTree={lineState.data && lineState.data.stopTree}
+          routeStopList={routeStopList}
           route={route}
           directionId={state.directionId}
           alerts={alerts}
@@ -259,9 +264,10 @@ const ScheduleDirection = ({
           </a>
         </>
       )}
-      {!isSubwayRoute(route) && hasValidTree && (
+      {!isSubwayRoute(route) && (
         <LineDiagram
-          stopTree={lineState.data.stopTree}
+          stopTree={lineState.data && lineState.data.stopTree}
+          routeStopList={routeStopList}
           route={route}
           directionId={state.directionId}
           alerts={alerts}

--- a/apps/site/assets/ts/schedule/components/ScheduleLoader.tsx
+++ b/apps/site/assets/ts/schedule/components/ScheduleLoader.tsx
@@ -137,11 +137,13 @@ export const ScheduleLoader = ({
     schedule_note: scheduleNote,
     today,
     stop_tree,
+    route_stop_lists: routeStopLists,
     alerts,
     variant: busVariantId
   } = schedulePageData;
-  const stopTree: StopTree = fromStopTreeData(stop_tree);
-
+  const stopTree: StopTree | null = stop_tree
+    ? fromStopTreeData(stop_tree)
+    : null;
   const routeIsSuspended = Object.keys(routePatternsByDirection).length === 0;
 
   const currentState = getCurrentState();
@@ -319,6 +321,7 @@ export const ScheduleLoader = ({
           directionId={readjustedDirectionId}
           route={route}
           routePatternsByDirection={routePatternsByDirection}
+          routeStopLists={routeStopLists}
           mapData={mapData}
           staticMapData={staticMapData}
           stopTree={stopTree}

--- a/apps/site/assets/ts/schedule/components/__schedule.d.ts
+++ b/apps/site/assets/ts/schedule/components/__schedule.d.ts
@@ -115,6 +115,10 @@ export interface RouteStop {
   closed_stop_info: ClosedStopInfo | null;
 }
 
+export interface IndexedRouteStop extends RouteStop {
+  routeIndex: number;
+}
+
 export interface SimpleStopMap {
   [key: string]: SimpleStop[];
 }

--- a/apps/site/assets/ts/schedule/components/__schedule.d.ts
+++ b/apps/site/assets/ts/schedule/components/__schedule.d.ts
@@ -44,7 +44,8 @@ export interface SchedulePageData {
   stops: SimpleStopMap;
   direction_id: DirectionId;
   route_patterns: RoutePatternsByDirection;
-  stop_tree: StopTreeData;
+  stop_tree: StopTreeData | null;
+  route_stop_lists: RouteStop[][];
   alerts: Alert[];
   today: string;
   variant: string | null;

--- a/apps/site/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import {
   createReactRoot,
-  enzymeToJsonWithoutProps
+  enzymeToJsonWithoutProps,
+  testRouteStopListFromStopTree
 } from "../../../app/helpers/testUtils";
 import { mount } from "enzyme";
 import {
@@ -33,7 +34,7 @@ const { stop_tree } = (lineDiagramData as unknown) as {
   stop_tree: StopTreeData;
 };
 const stopTree: StopTree = fromStopTreeData(stop_tree);
-const testRouteStopList = Object.values(stopTree.byId).map(node => node.value);
+const testRouteStopList = testRouteStopListFromStopTree(stopTree);
 
 const route = {
   type: 3,
@@ -546,7 +547,7 @@ describe("fetchLineData", () => {
       () =>
         new Promise((resolve: Function) =>
           resolve({
-            json: () => lineDiagramData,
+            json: () => ({ stop_tree, route_stop_lists: [] }),
             ok: true,
             status: 200,
             statusText: "OK"
@@ -563,7 +564,7 @@ describe("fetchLineData", () => {
       });
       expect(spy).toHaveBeenCalledWith({
         type: "FETCH_COMPLETE",
-        payload: { stopTree }
+        payload: { stopTree, routeStopLists: [] }
       });
     });
   });

--- a/apps/site/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
@@ -33,6 +33,7 @@ const { stop_tree } = (lineDiagramData as unknown) as {
   stop_tree: StopTreeData;
 };
 const stopTree: StopTree = fromStopTreeData(stop_tree);
+const testRouteStopList = Object.values(stopTree.byId).map(node => node.value);
 
 const route = {
   type: 3,
@@ -170,6 +171,7 @@ const getComponent = () => (
     routePatternsByDirection={routePatternsByDirection}
     mapData={mapData}
     stopTree={stopTree}
+    routeStopLists={[testRouteStopList]}
     alerts={[]}
     busVariantId={null}
   />
@@ -182,6 +184,7 @@ const getSingleDirectionComponent = () => (
     routePatternsByDirection={routePatternsByDirection}
     mapData={mapData}
     stopTree={stopTree}
+    routeStopLists={[testRouteStopList]}
     alerts={[]}
     busVariantId={null}
   />
@@ -194,6 +197,7 @@ const getSubwayComponent = () => (
     directionId={directionId}
     routePatternsByDirection={routePatternsByDirection}
     stopTree={stopTree}
+    routeStopLists={[testRouteStopList]}
     alerts={[]}
     busVariantId={null}
   />
@@ -206,6 +210,7 @@ const getCRComponent = () => (
     routePatternsByDirection={routePatternsByDirection}
     mapData={mapData}
     stopTree={stopTree}
+    routeStopLists={[testRouteStopList]}
     alerts={[]}
     busVariantId={null}
   />
@@ -218,6 +223,7 @@ const getStaticMapComponent = () => (
     directionId={directionId}
     routePatternsByDirection={routePatternsByDirection}
     stopTree={stopTree}
+    routeStopLists={[testRouteStopList]}
     alerts={[]}
     busVariantId={null}
   />
@@ -246,6 +252,7 @@ const getGreenLineComponent = () => {
       directionId={directionId}
       routePatternsByDirection={routePatternsByDirection}
       stopTree={stopTree}
+      routeStopLists={[testRouteStopList]}
       alerts={[]}
       busVariantId={null}
     />
@@ -259,6 +266,7 @@ const getVariantComponent = () => (
     routePatternsByDirection={routePatternsByDirection}
     mapData={mapData}
     stopTree={stopTree}
+    routeStopLists={[testRouteStopList]}
     alerts={[]}
     busVariantId="pattern-3"
   />

--- a/apps/site/assets/ts/schedule/components/__tests__/ScheduleLoaderTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/ScheduleLoaderTest.tsx
@@ -71,6 +71,9 @@ const stops = {
 const { stop_tree: stopTreeData } = (lineDiagramData as unknown) as {
   stop_tree: StopTreeData;
 };
+const testRouteStopList = Object.values(stopTreeData.by_id).map(
+  node => node.value
+);
 
 const fares = [
   {
@@ -243,6 +246,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -275,6 +279,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -319,6 +324,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -352,6 +358,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -395,6 +402,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -435,6 +443,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -468,6 +477,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -520,6 +530,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -587,6 +598,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -633,6 +645,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -688,6 +701,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -727,6 +741,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -784,6 +799,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -831,6 +847,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -876,6 +893,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routes,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -1006,6 +1024,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}
@@ -1049,6 +1068,7 @@ describe("ScheduleLoader", () => {
             route_patterns: routePatternsByDirection,
             today: "2019-12-05",
             stop_tree: stopTreeData,
+            route_stop_lists: [testRouteStopList],
             alerts: [],
             variant: null
           }}

--- a/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/__tests__/__snapshots__/ScheduleDirectionTest.tsx.snap
@@ -56,6 +56,96 @@ exports[`can render green line 1`] = `
       </button>
     </ScheduleDirectionButton>
   </div>
+  <LineDiagram>
+    <SearchBox>
+      <div
+        className="m-schedule-diagram__filter c-form__input-container"
+      >
+        <label
+          className="sr-only"
+          htmlFor="stop-search"
+        >
+          Search for a station
+        </label>
+        <input
+          className="c-form__input"
+          id="stop-search"
+          onChange={[Function]}
+          placeholder="Search for a station"
+          type="text"
+          value=""
+        />
+        <button
+          aria-label="search"
+          className="c-form__submit-btn"
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            aria-hidden="false"
+            className="notranslate c-svg__icon-search-reverse-default"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </button>
+      </div>
+    </SearchBox>
+    <Provider>
+      <LineDiagramWithStops>
+        <div
+          className="m-schedule-diagram u-no-crowding-data"
+        >
+          <SimpleDiagram>
+            <svg
+              aria-labelledby="diagram-title diagram-desc"
+              className="line-diagram-svg green-line"
+              height="100%"
+              role="img"
+              style={
+                Object {
+                  "left": 5,
+                  "overflow": "visible",
+                }
+              }
+              width="36px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="diagram-title"
+              >
+                Line diagram for 
+                Green Line
+              </title>
+              <desc
+                id="diagram-desc"
+              >
+                0 stops going Eastbound to Park Street / Government Center / North Station / Lechmere
+              </desc>
+              <defs>
+                <pattern
+                  height="10"
+                  id="diagonalHatch"
+                  patternTransform="rotate(45 0 0)"
+                  patternUnits="userSpaceOnUse"
+                  width="10"
+                >
+                  <line
+                    className="line-diagram-svg__line"
+                    strokeWidth="16px"
+                    y2={8}
+                  />
+                </pattern>
+              </defs>
+            </svg>
+          </SimpleDiagram>
+          <ol />
+        </div>
+      </LineDiagramWithStops>
+    </Provider>
+  </LineDiagram>
 </ScheduleDirection>
 `;
 
@@ -100,6 +190,101 @@ exports[`renders a CR component 1`] = `
       </button>
     </ScheduleDirectionButton>
   </div>
+  <LineDiagram>
+    <h3
+      className="m-schedule-diagram__heading"
+    >
+      Stations
+    </h3>
+    <SearchBox>
+      <div
+        className="m-schedule-diagram__filter c-form__input-container"
+      >
+        <label
+          className="sr-only"
+          htmlFor="stop-search"
+        >
+          Search for a station
+        </label>
+        <input
+          className="c-form__input"
+          id="stop-search"
+          onChange={[Function]}
+          placeholder="Search for a station"
+          type="text"
+          value=""
+        />
+        <button
+          aria-label="search"
+          className="c-form__submit-btn"
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            aria-hidden="false"
+            className="notranslate c-svg__icon-search-reverse-default"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </button>
+      </div>
+    </SearchBox>
+    <Provider>
+      <LineDiagramWithStops>
+        <div
+          className="m-schedule-diagram u-no-crowding-data"
+        >
+          <SimpleDiagram>
+            <svg
+              aria-labelledby="diagram-title diagram-desc"
+              className="line-diagram-svg commuter-rail"
+              height="100%"
+              role="img"
+              style={
+                Object {
+                  "left": 5,
+                  "overflow": "visible",
+                }
+              }
+              width="36px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="diagram-title"
+              >
+                Line diagram for 
+                route 1
+              </title>
+              <desc
+                id="diagram-desc"
+              >
+                0 stops going Inbound to End
+              </desc>
+              <defs>
+                <pattern
+                  height="10"
+                  id="diagonalHatch"
+                  patternTransform="rotate(45 0 0)"
+                  patternUnits="userSpaceOnUse"
+                  width="10"
+                >
+                  <line
+                    className="line-diagram-svg__line"
+                    strokeWidth="16px"
+                    y2={8}
+                  />
+                </pattern>
+              </defs>
+            </svg>
+          </SimpleDiagram>
+          <ol />
+        </div>
+      </LineDiagramWithStops>
+    </Provider>
+  </LineDiagram>
 </ScheduleDirection>
 `;
 
@@ -149,6 +334,101 @@ exports[`renders a bus component 1`] = `
       </button>
     </ScheduleDirectionButton>
   </div>
+  <LineDiagram>
+    <h3
+      className="m-schedule-diagram__heading"
+    >
+      Stops
+    </h3>
+    <SearchBox>
+      <div
+        className="m-schedule-diagram__filter c-form__input-container"
+      >
+        <label
+          className="sr-only"
+          htmlFor="stop-search"
+        >
+          Search for a stop
+        </label>
+        <input
+          className="c-form__input"
+          id="stop-search"
+          onChange={[Function]}
+          placeholder="Search for a stop"
+          type="text"
+          value=""
+        />
+        <button
+          aria-label="search"
+          className="c-form__submit-btn"
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            aria-hidden="false"
+            className="notranslate c-svg__icon-search-reverse-default"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </button>
+      </div>
+    </SearchBox>
+    <Provider>
+      <LineDiagramWithStops>
+        <div
+          className="m-schedule-diagram u-no-crowding-data"
+        >
+          <SimpleDiagram>
+            <svg
+              aria-labelledby="diagram-title diagram-desc"
+              className="line-diagram-svg bus"
+              height="100%"
+              role="img"
+              style={
+                Object {
+                  "left": 5,
+                  "overflow": "visible",
+                }
+              }
+              width="36px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="diagram-title"
+              >
+                Line diagram for 
+                route 1
+              </title>
+              <desc
+                id="diagram-desc"
+              >
+                0 stops going Inbound to End
+              </desc>
+              <defs>
+                <pattern
+                  height="10"
+                  id="diagonalHatch"
+                  patternTransform="rotate(45 0 0)"
+                  patternUnits="userSpaceOnUse"
+                  width="10"
+                >
+                  <line
+                    className="line-diagram-svg__line"
+                    strokeWidth="16px"
+                    y2={8}
+                  />
+                </pattern>
+              </defs>
+            </svg>
+          </SimpleDiagram>
+          <ol />
+        </div>
+      </LineDiagramWithStops>
+    </Provider>
+  </LineDiagram>
 </ScheduleDirection>
 `;
 
@@ -193,6 +473,96 @@ exports[`renders a subway component 1`] = `
       </button>
     </ScheduleDirectionButton>
   </div>
+  <LineDiagram>
+    <SearchBox>
+      <div
+        className="m-schedule-diagram__filter c-form__input-container"
+      >
+        <label
+          className="sr-only"
+          htmlFor="stop-search"
+        >
+          Search for a station
+        </label>
+        <input
+          className="c-form__input"
+          id="stop-search"
+          onChange={[Function]}
+          placeholder="Search for a station"
+          type="text"
+          value=""
+        />
+        <button
+          aria-label="search"
+          className="c-form__submit-btn"
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            aria-hidden="false"
+            className="notranslate c-svg__icon-search-reverse-default"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </button>
+      </div>
+    </SearchBox>
+    <Provider>
+      <LineDiagramWithStops>
+        <div
+          className="m-schedule-diagram u-no-crowding-data"
+        >
+          <SimpleDiagram>
+            <svg
+              aria-labelledby="diagram-title diagram-desc"
+              className="line-diagram-svg unknown"
+              height="100%"
+              role="img"
+              style={
+                Object {
+                  "left": 5,
+                  "overflow": "visible",
+                }
+              }
+              width="36px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="diagram-title"
+              >
+                Line diagram for 
+                route 1
+              </title>
+              <desc
+                id="diagram-desc"
+              >
+                0 stops going Inbound to End
+              </desc>
+              <defs>
+                <pattern
+                  height="10"
+                  id="diagonalHatch"
+                  patternTransform="rotate(45 0 0)"
+                  patternUnits="userSpaceOnUse"
+                  width="10"
+                >
+                  <line
+                    className="line-diagram-svg__line"
+                    strokeWidth="16px"
+                    y2={8}
+                  />
+                </pattern>
+              </defs>
+            </svg>
+          </SimpleDiagram>
+          <ol />
+        </div>
+      </LineDiagramWithStops>
+    </Provider>
+  </LineDiagram>
 </ScheduleDirection>
 `;
 
@@ -253,6 +623,101 @@ exports[`renders with a static map 1`] = `
     />
     View map as a PDF
   </a>
+  <LineDiagram>
+    <h3
+      className="m-schedule-diagram__heading"
+    >
+      Stops
+    </h3>
+    <SearchBox>
+      <div
+        className="m-schedule-diagram__filter c-form__input-container"
+      >
+        <label
+          className="sr-only"
+          htmlFor="stop-search"
+        >
+          Search for a stop
+        </label>
+        <input
+          className="c-form__input"
+          id="stop-search"
+          onChange={[Function]}
+          placeholder="Search for a stop"
+          type="text"
+          value=""
+        />
+        <button
+          aria-label="search"
+          className="c-form__submit-btn"
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            aria-hidden="false"
+            className="notranslate c-svg__icon-search-reverse-default"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </button>
+      </div>
+    </SearchBox>
+    <Provider>
+      <LineDiagramWithStops>
+        <div
+          className="m-schedule-diagram u-no-crowding-data"
+        >
+          <SimpleDiagram>
+            <svg
+              aria-labelledby="diagram-title diagram-desc"
+              className="line-diagram-svg ferry"
+              height="100%"
+              role="img"
+              style={
+                Object {
+                  "left": 5,
+                  "overflow": "visible",
+                }
+              }
+              width="36px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="diagram-title"
+              >
+                Line diagram for 
+                route 1
+              </title>
+              <desc
+                id="diagram-desc"
+              >
+                0 stops going Inbound to End
+              </desc>
+              <defs>
+                <pattern
+                  height="10"
+                  id="diagonalHatch"
+                  patternTransform="rotate(45 0 0)"
+                  patternUnits="userSpaceOnUse"
+                  width="10"
+                >
+                  <line
+                    className="line-diagram-svg__line"
+                    strokeWidth="16px"
+                    y2={8}
+                  />
+                </pattern>
+              </defs>
+            </svg>
+          </SimpleDiagram>
+          <ol />
+        </div>
+      </LineDiagramWithStops>
+    </Provider>
+  </LineDiagram>
 </ScheduleDirection>
 `;
 
@@ -313,5 +778,100 @@ exports[`respects the initially selected pattern ID, if specified 1`] = `
       </button>
     </ScheduleDirectionButton>
   </div>
+  <LineDiagram>
+    <h3
+      className="m-schedule-diagram__heading"
+    >
+      Stops
+    </h3>
+    <SearchBox>
+      <div
+        className="m-schedule-diagram__filter c-form__input-container"
+      >
+        <label
+          className="sr-only"
+          htmlFor="stop-search"
+        >
+          Search for a stop
+        </label>
+        <input
+          className="c-form__input"
+          id="stop-search"
+          onChange={[Function]}
+          placeholder="Search for a stop"
+          type="text"
+          value=""
+        />
+        <button
+          aria-label="search"
+          className="c-form__submit-btn"
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            aria-hidden="false"
+            className="notranslate c-svg__icon-search-reverse-default"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </button>
+      </div>
+    </SearchBox>
+    <Provider>
+      <LineDiagramWithStops>
+        <div
+          className="m-schedule-diagram u-no-crowding-data"
+        >
+          <SimpleDiagram>
+            <svg
+              aria-labelledby="diagram-title diagram-desc"
+              className="line-diagram-svg bus"
+              height="100%"
+              role="img"
+              style={
+                Object {
+                  "left": 5,
+                  "overflow": "visible",
+                }
+              }
+              width="36px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="diagram-title"
+              >
+                Line diagram for 
+                route 1
+              </title>
+              <desc
+                id="diagram-desc"
+              >
+                0 stops going Outbound to Begin
+              </desc>
+              <defs>
+                <pattern
+                  height="10"
+                  id="diagonalHatch"
+                  patternTransform="rotate(45 0 0)"
+                  patternUnits="userSpaceOnUse"
+                  width="10"
+                >
+                  <line
+                    className="line-diagram-svg__line"
+                    strokeWidth="16px"
+                    y2={8}
+                  />
+                </pattern>
+              </defs>
+            </svg>
+          </SimpleDiagram>
+          <ol />
+        </div>
+      </LineDiagramWithStops>
+    </Provider>
+  </LineDiagram>
 </ScheduleDirection>
 `;

--- a/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/ExpandableBranch.tsx
@@ -100,6 +100,7 @@ const ExpandableBranch = ({
             <StopCard
               key={stopId}
               stopTree={stopTree}
+              routeStopList={[]}
               stopId={stopId}
               alerts={alertsByStop(alerts, stopId)}
               onClick={handleStopClick}

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -8,7 +8,12 @@ import { isSubwayRoute } from "../../../models/route";
 import { Alert, DirectionId, Route } from "../../../__v3api";
 import { getCurrentState, storeHandler } from "../../store/ScheduleStore";
 import { changeOrigin } from "../ScheduleLoader";
-import { RouteStop, SelectedOrigin, StopTree } from "../__schedule";
+import {
+  IndexedRouteStop,
+  RouteStop,
+  SelectedOrigin,
+  StopTree
+} from "../__schedule";
 import { createStopTreeCoordStore } from "./graphics/useTreeStopPositions";
 import LineDiagramWithStops from "./LineDiagramWithStops";
 import StopCard from "./StopCard";
@@ -17,7 +22,7 @@ import { alertsByStop } from "../../../models/alert";
 interface Props {
   stopTree: StopTree | null;
   route: Route;
-  routeStopList: RouteStop[];
+  routeStopList: IndexedRouteStop[];
   directionId: DirectionId;
   alerts: Alert[];
 }

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -15,8 +15,9 @@ import StopCard from "./StopCard";
 import { alertsByStop } from "../../../models/alert";
 
 interface Props {
-  stopTree: StopTree;
+  stopTree: StopTree | null;
   route: Route;
+  routeStopList: RouteStop[];
   directionId: DirectionId;
   alerts: Alert[];
 }
@@ -41,17 +42,20 @@ const updateURL = (origin: SelectedOrigin, direction?: DirectionId): void => {
 
 const LineDiagram = ({
   stopTree,
+  routeStopList,
   route,
   directionId,
   alerts
 }: Props): ReactElement<HTMLElement> => {
-  const stopTreeCoordStore = createStopTreeCoordStore(stopTree);
+  const stopTreeCoordStore = stopTree
+    ? createStopTreeCoordStore(stopTree)
+    : createStopTreeCoordStore(routeStopList);
   const liveData = useRealtime(route, directionId, true);
   const [query, setQuery] = useState("");
 
-  const allStops: RouteStop[] = stopIds(stopTree).map(stopId =>
-    stopForId(stopTree, stopId)
-  );
+  const allStops: RouteStop[] = stopTree
+    ? stopIds(stopTree).map(stopId => stopForId(stopTree, stopId))
+    : routeStopList;
   const filteredStops: RouteStop[] = allStops.filter(stop =>
     stop.name.toLowerCase().includes(query.toLowerCase())
   );
@@ -97,6 +101,7 @@ const LineDiagram = ({
                 key={stop.id}
                 stopTree={stopTree}
                 stopId={stop.id}
+                routeStopList={routeStopList}
                 alerts={alertsByStop(alerts, stop.id)}
                 onClick={handleStopClick}
                 liveData={liveData?.[stop.id]}
@@ -116,6 +121,7 @@ const LineDiagram = ({
         <Provider store={stopTreeCoordStore}>
           <LineDiagramWithStops
             stopTree={stopTree}
+            routeStopList={routeStopList}
             route={route}
             directionId={directionId}
             alerts={alerts}

--- a/apps/site/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../../helpers/stop-tree";
 import { hasPredictionTime } from "../../../models/prediction";
 import { Alert, DirectionId, Route } from "../../../__v3api";
-import { RouteStop, StopId, StopTree } from "../__schedule";
+import { IndexedRouteStop, RouteStop, StopId, StopTree } from "../__schedule";
 import { Diagram, SimpleDiagram } from "./graphics/Diagram";
 import useTreeStopPositions, { RefMap } from "./graphics/useTreeStopPositions";
 import ExpandableBranch from "./ExpandableBranch";
@@ -18,7 +18,7 @@ import { alertsByStop } from "../../../models/alert";
 
 interface Props {
   stopTree: StopTree | null;
-  routeStopList: RouteStop[];
+  routeStopList: IndexedRouteStop[];
   route: Route;
   directionId: DirectionId;
   alerts: Alert[];
@@ -312,10 +312,9 @@ const LineDiagramWithStops = ({
             />
           ) : (
             <>
-              {routeStopList.map((routeStop, index) => (
+              {routeStopList.map(routeStop => (
                 <StopCard
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={`stop-card-${index}-${routeStop.id}`}
+                  key={`stop-card-${routeStop.routeIndex}`}
                   stopTree={null}
                   routeStopList={routeStopList}
                   stopId={routeStop.id}

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/DiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/DiagramTest.tsx
@@ -3,7 +3,7 @@ import * as redux from "react-redux";
 import { mount, ReactWrapper } from "enzyme";
 import { RouteStop, StopTree } from "../../__schedule";
 import { createStopTreeCoordStore } from "../graphics/useTreeStopPositions";
-import Diagram from "../graphics/Diagram";
+import { Diagram } from "../graphics/Diagram";
 import { Route, RouteType } from "../../../../__v3api";
 import Stop from "../graphics/Stop";
 import { LiveDataByStop } from "../__line-diagram";

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramTest.tsx
@@ -10,6 +10,7 @@ import * as ScheduleStore from "../../../store/ScheduleStore";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as store from "../../../store/ScheduleStore";
 import userEvent from "@testing-library/user-event";
+import { testRouteStopListFromStopTree } from "../../../../app/helpers/testUtils";
 
 const stopTree: StopTree = {
   byId: {
@@ -48,7 +49,7 @@ const stopTree: StopTree = {
   },
   startingNodes: ["a"]
 };
-const testRouteStopList = Object.values(stopTree.byId).map(node => node.value);
+const testRouteStopList = testRouteStopListFromStopTree(stopTree);
 const route = {
   type: 3 as RouteType,
   name: "route 1",

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramTest.tsx
@@ -48,7 +48,7 @@ const stopTree: StopTree = {
   },
   startingNodes: ["a"]
 };
-
+const testRouteStopList = Object.values(stopTree.byId).map(node => node.value);
 const route = {
   type: 3 as RouteType,
   name: "route 1",
@@ -80,6 +80,7 @@ describe("LineDiagram", () => {
     wrapper = mount(
       <LineDiagram
         stopTree={stopTree}
+        routeStopList={testRouteStopList}
         route={route}
         directionId={1}
         alerts={[]}
@@ -107,6 +108,7 @@ describe("LineDiagram", () => {
     const subwayWrapper = mount(
       <LineDiagram
         stopTree={stopTree}
+        routeStopList={testRouteStopList}
         route={subwayRoute}
         directionId={1}
         alerts={[]}
@@ -146,6 +148,7 @@ describe("LineDiagram", () => {
     render(
       <LineDiagram
         stopTree={stopTree}
+        routeStopList={testRouteStopList}
         route={route}
         directionId={0}
         alerts={[]}
@@ -163,6 +166,7 @@ describe("LineDiagram", () => {
     render(
       <LineDiagram
         stopTree={stopTree}
+        routeStopList={testRouteStopList}
         route={route}
         directionId={0}
         alerts={[]}
@@ -180,6 +184,7 @@ describe("LineDiagram", () => {
     render(
       <LineDiagram
         stopTree={stopTree}
+        routeStopList={testRouteStopList}
         route={route}
         directionId={0}
         alerts={[]}

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
@@ -9,6 +9,7 @@ import { cloneDeep } from "lodash";
 import * as simpleLiveData from "./lineDiagramData/live-data.json";
 import { LiveDataByStop } from "../__line-diagram";
 import { Alert, InformedEntitySet, RouteType } from "../../../../__v3api";
+import { testRouteStopListFromStopTree } from "../../../../app/helpers/testUtils";
 
 const stopTree: StopTree = {
   byId: {
@@ -148,7 +149,7 @@ const stopTree: StopTree = {
   startingNodes: ["a1", "b1", "c1"]
 };
 
-const testRouteStopList = Object.values(stopTree.byId).map(node => node.value);
+const testRouteStopList = testRouteStopListFromStopTree(stopTree);
 const store = UseTreeStopPositions.createStopTreeCoordStore(stopTree);
 
 const route = {

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
@@ -147,6 +147,8 @@ const stopTree: StopTree = {
   },
   startingNodes: ["a1", "b1", "c1"]
 };
+
+const testRouteStopList = Object.values(stopTree.byId).map(node => node.value);
 const store = UseTreeStopPositions.createStopTreeCoordStore(stopTree);
 
 const route = {
@@ -187,6 +189,7 @@ describe("LineDiagramWithStops", () => {
       <redux.Provider store={store}>
         <LineDiagramWithStops
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           route={route}
           directionId={1}
           alerts={[]}
@@ -214,6 +217,7 @@ describe("LineDiagramWithStops", () => {
       <redux.Provider store={store}>
         <LineDiagramWithStops
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           route={route}
           directionId={1}
           alerts={[]}
@@ -239,6 +243,7 @@ describe("LineDiagramWithStops", () => {
       <redux.Provider store={store}>
         <LineDiagramWithStops
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           route={route}
           directionId={1}
           alerts={[currentDiversionAlert]}

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/LineTest.tsx
@@ -5,7 +5,7 @@ import { aroundNow } from "../../../../models/__tests__/alert-test";
 import { Alert, InformedEntitySet } from "../../../../__v3api";
 import { RouteStop, StopTree } from "../../__schedule";
 import { BASE_LINE_WIDTH } from "../graphics/graphic-helpers";
-import Line from "../graphics/Line";
+import { Line } from "../graphics/Line";
 import { createStopTreeCoordStore } from "../graphics/useTreeStopPositions";
 
 const routeStopA: RouteStop = { id: "a" } as RouteStop;

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/StopCardTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/StopCardTest.tsx
@@ -18,6 +18,7 @@ import StopCard from "../StopCard";
 import { LiveData } from "../__line-diagram";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { testRouteStopListFromStopTree } from "../../../../app/helpers/testUtils";
 
 const stopTree: StopTree = {
   byId: {
@@ -90,7 +91,7 @@ const stopTree: StopTree = {
   startingNodes: ["a"]
 };
 const store = createStopTreeCoordStore(stopTree);
-const testRouteStopList = Object.values(stopTree.byId).map(node => node.value);
+const testRouteStopList = testRouteStopListFromStopTree(stopTree);
 
 const alertA: Alert = {
   id: "MOCK-ALERT-A",

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/StopCardTest.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/StopCardTest.tsx
@@ -90,6 +90,7 @@ const stopTree: StopTree = {
   startingNodes: ["a"]
 };
 const store = createStopTreeCoordStore(stopTree);
+const testRouteStopList = Object.values(stopTree.byId).map(node => node.value);
 
 const alertA: Alert = {
   id: "MOCK-ALERT-A",
@@ -124,6 +125,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"a"}
           alerts={[alertA, alertB]}
           onClick={handleStopClick}
@@ -157,6 +159,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"a"}
           alerts={[]}
           onClick={handleStopClick}
@@ -185,6 +188,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"a"}
           alerts={[]}
           onClick={handleStopClick}
@@ -212,6 +216,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"a"}
           alerts={[]}
           onClick={handleStopClick}
@@ -231,6 +236,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"a"}
           alerts={[alertA, alertB]}
           onClick={handleStopClick}
@@ -249,6 +255,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"a"}
           alerts={[alertA, alertB]}
           onClick={handleStopClick}
@@ -277,6 +284,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"a"}
           alerts={[alertA, alertB]}
           onClick={handleStopClick}
@@ -322,6 +330,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"a"}
           alerts={[alertA, alertB]}
           onClick={handleStopClick}
@@ -346,6 +355,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"d"}
           alerts={[]}
           onClick={() => {}}
@@ -361,6 +371,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"e"}
           alerts={[]}
           onClick={() => {}}
@@ -376,6 +387,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"f"}
           alerts={[]}
           onClick={() => {}}
@@ -391,6 +403,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"e"}
           alerts={[]}
           onClick={() => {}}
@@ -409,6 +422,7 @@ describe("StopCard", () => {
       <redux.Provider store={store}>
         <StopCard
           stopTree={stopTree}
+          routeStopList={testRouteStopList}
           stopId={"b"}
           alerts={[]}
           onClick={clickSpy}

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/DiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/DiagramTest.tsx.snap
@@ -3,21 +3,21 @@
 exports[`Diagram renders and matches snapshot 1`] = `
 "<Provider store={{...}}>
   <Diagram stopTree={{...}} route={{...}} directionId={1} alerts={{...}} liveData={{...}}>
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"a1\\" liveData={{...}}>
+    <LiveVehicleIconSet isStart={true} stop={{...}} liveData={{...}}>
       <VehicleIcons stop={{...}} vehicles={{...}} />
     </LiveVehicleIconSet>
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"a2\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"b1\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"b2\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"b3\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"c1\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"c2\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"m1\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"m2\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"m3\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"x1\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"x2\\" liveData={{...}} />
-    <LiveVehicleIconSet stopTree={{...}} stopId=\\"y1\\" liveData={{...}} />
+    <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={true} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={true} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+    <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
     <svg xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" aria-labelledby=\\"diagram-title diagram-desc\\" className=\\"line-diagram-svg bus\\" width=\\"36px\\" height=\\"100%\\" style={{...}}>
       <title id=\\"diagram-title\\">
         Line diagram for 

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramTest.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LineDiagram renders and matches snapshot 1`] = `
-"<LineDiagram stopTree={{...}} route={{...}} directionId={1} alerts={{...}}>
+"<LineDiagram stopTree={{...}} routeStopList={{...}} route={{...}} directionId={1} alerts={{...}}>
   <h3 className=\\"m-schedule-diagram__heading\\">
     Stops
   </h3>
@@ -17,12 +17,12 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
     </div>
   </SearchBox>
   <Provider store={{...}}>
-    <LineDiagramWithStops stopTree={{...}} route={{...}} directionId={1} alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={[undefined]}>
+    <LineDiagramWithStops stopTree={{...}} routeStopList={{...}} route={{...}} directionId={1} alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={[undefined]}>
       <div className=\\"m-schedule-diagram u-no-crowding-data\\">
         <Diagram stopTree={{...}} route={{...}} directionId={1} alerts={{...}} liveData={[undefined]}>
-          <LiveVehicleIconSet stopTree={{...}} stopId=\\"a\\" liveData={[undefined]} />
-          <LiveVehicleIconSet stopTree={{...}} stopId=\\"b\\" liveData={[undefined]} />
-          <LiveVehicleIconSet stopTree={{...}} stopId=\\"c\\" liveData={[undefined]} />
+          <LiveVehicleIconSet isStart={true} stop={{...}} liveData={[undefined]} />
+          <LiveVehicleIconSet isStart={false} stop={{...}} liveData={[undefined]} />
+          <LiveVehicleIconSet isStart={false} stop={{...}} liveData={[undefined]} />
           <svg xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" aria-labelledby=\\"diagram-title diagram-desc\\" className=\\"line-diagram-svg bus\\" width=\\"36px\\" height=\\"100%\\" style={{...}}>
             <title id=\\"diagram-title\\">
               Line diagram for 
@@ -55,7 +55,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
         </Diagram>
         <ol>
           <NextStopOrBranch stopTree={{...}} stopId=\\"a\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={[undefined]}>
-            <StopCard stopTree={{...}} stopId=\\"a\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+            <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"a\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
               <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                 <section className=\\"m-schedule-diagram__content\\">
                   <GlxOpen pageType=\\"line-diagram\\" stopId=\\"a\\" />
@@ -83,7 +83,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
               </li>
             </StopCard>
             <NextStopOrBranch stopTree={{...}} stopId=\\"b\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={[undefined]}>
-              <StopCard stopTree={{...}} stopId=\\"b\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+              <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"b\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                 <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                   <section className=\\"m-schedule-diagram__content\\">
                     <GlxOpen pageType=\\"line-diagram\\" stopId=\\"b\\" />
@@ -111,7 +111,7 @@ exports[`LineDiagram renders and matches snapshot 1`] = `
                 </li>
               </StopCard>
               <NextStopOrBranch stopTree={{...}} stopId=\\"c\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={[undefined]}>
-                <StopCard stopTree={{...}} stopId=\\"c\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"c\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                   <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                     <section className=\\"m-schedule-diagram__content\\">
                       <GlxOpen pageType=\\"line-diagram\\" stopId=\\"c\\" />

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -2,22 +2,22 @@
 
 exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
 "<Provider store={{...}}>
-  <LineDiagramWithStops stopTree={{...}} route={{...}} directionId={1} alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
+  <LineDiagramWithStops stopTree={{...}} routeStopList={{...}} route={{...}} directionId={1} alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
     <div className=\\"m-schedule-diagram \\">
       <Diagram stopTree={{...}} route={{...}} directionId={1} alerts={{...}} liveData={{...}}>
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"a1\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"a2\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"b1\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"b2\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"b3\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"c1\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"c2\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"m1\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"m2\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"m3\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"x1\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"x2\\" liveData={{...}} />
-        <LiveVehicleIconSet stopTree={{...}} stopId=\\"y1\\" liveData={{...}} />
+        <LiveVehicleIconSet isStart={true} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={true} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={true} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
+        <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
         <svg xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" aria-labelledby=\\"diagram-title diagram-desc\\" className=\\"line-diagram-svg bus\\" width=\\"36px\\" height=\\"100%\\" style={{...}}>
           <title id=\\"diagram-title\\">
             Line diagram for 
@@ -111,7 +111,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
       </Diagram>
       <ol>
         <NextStopOrBranch stopTree={{...}} stopId=\\"b1\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-          <StopCard stopTree={{...}} stopId=\\"b1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+          <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"b1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <GlxOpen pageType=\\"line-diagram\\" stopId=\\"b1\\" />
@@ -143,7 +143,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
             </li>
           </StopCard>
           <NextStopOrBranch stopTree={{...}} stopId=\\"b2\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-            <StopCard stopTree={{...}} stopId=\\"b2\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+            <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"b2\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
               <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                 <section className=\\"m-schedule-diagram__content\\">
                   <GlxOpen pageType=\\"line-diagram\\" stopId=\\"b2\\" />
@@ -175,7 +175,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
               </li>
             </StopCard>
             <NextStopOrBranch stopTree={{...}} stopId=\\"b3\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-              <StopCard stopTree={{...}} stopId=\\"b3\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+              <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"b3\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                 <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                   <section className=\\"m-schedule-diagram__content\\">
                     <GlxOpen pageType=\\"line-diagram\\" stopId=\\"b3\\" />
@@ -207,7 +207,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                 </li>
               </StopCard>
               <NextStopOrBranch stopTree={{...}} stopId=\\"m1\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                <StopCard stopTree={{...}} stopId=\\"a1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"a1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                   <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                     <section className=\\"m-schedule-diagram__content\\">
                       <GlxOpen pageType=\\"line-diagram\\" stopId=\\"a1\\" />
@@ -271,7 +271,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                   </div>
                 </ExpandableBranch>
                 <NextStopOrBranch stopTree={{...}} stopId=\\"m1\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                  <StopCard stopTree={{...}} stopId=\\"m1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                  <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"m1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                     <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                       <section className=\\"m-schedule-diagram__content\\">
                         <GlxOpen pageType=\\"line-diagram\\" stopId=\\"m1\\" />
@@ -303,7 +303,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                     </li>
                   </StopCard>
                   <NextStopOrBranch stopTree={{...}} stopId=\\"m2\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                    <StopCard stopTree={{...}} stopId=\\"c1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                    <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"c1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                       <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                         <section className=\\"m-schedule-diagram__content\\">
                           <GlxOpen pageType=\\"line-diagram\\" stopId=\\"c1\\" />
@@ -367,7 +367,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                       </div>
                     </ExpandableBranch>
                     <NextStopOrBranch stopTree={{...}} stopId=\\"m2\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                      <StopCard stopTree={{...}} stopId=\\"m2\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                      <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"m2\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                           <section className=\\"m-schedule-diagram__content\\">
                             <GlxOpen pageType=\\"line-diagram\\" stopId=\\"m2\\" />
@@ -399,7 +399,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                         </li>
                       </StopCard>
                       <NextStopOrBranch stopTree={{...}} stopId=\\"m3\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                        <StopCard stopTree={{...}} stopId=\\"m3\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                        <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"m3\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                           <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                             <section className=\\"m-schedule-diagram__content\\">
                               <GlxOpen pageType=\\"line-diagram\\" stopId=\\"m3\\" />
@@ -431,7 +431,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                           </li>
                         </StopCard>
                         <NextStopOrBranch stopTree={{...}} stopId=\\"x1\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                          <StopCard stopTree={{...}} stopId=\\"y1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                          <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"y1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                               <section className=\\"m-schedule-diagram__content\\">
                                 <GlxOpen pageType=\\"line-diagram\\" stopId=\\"y1\\" />
@@ -458,7 +458,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                             </li>
                           </StopCard>
                           <NextStopOrBranch stopTree={{...}} stopId=\\"x1\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                            <StopCard stopTree={{...}} stopId=\\"x1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                            <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"x1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                               <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                                 <section className=\\"m-schedule-diagram__content\\">
                                   <GlxOpen pageType=\\"line-diagram\\" stopId=\\"x1\\" />
@@ -490,7 +490,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                               </li>
                             </StopCard>
                             <NextStopOrBranch stopTree={{...}} stopId=\\"x2\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                              <StopCard stopTree={{...}} stopId=\\"x2\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                              <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"x2\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                                 <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                                   <section className=\\"m-schedule-diagram__content\\">
                                     <GlxOpen pageType=\\"line-diagram\\" stopId=\\"x2\\" />

--- a/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
+++ b/apps/site/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`StopCard renders and matches snapshot 1`] = `
 "<Provider store={{...}}>
-  <StopCard stopTree={{...}} stopId=\\"a\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={{...}}>
+  <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"a\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={{...}}>
     <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
       <section className=\\"m-schedule-diagram__content\\">
         <GlxOpen pageType=\\"line-diagram\\" stopId=\\"a\\" />

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Diagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Diagram.tsx
@@ -13,7 +13,12 @@ import {
 } from "../../../../helpers/stop-tree";
 import { isAGreenLineRoute } from "../../../../models/route";
 import { Alert, DirectionId, Route } from "../../../../__v3api";
-import { RouteStop, StopId, StopTree } from "../../__schedule";
+import {
+  IndexedRouteStop,
+  RouteStop,
+  StopId,
+  StopTree
+} from "../../__schedule";
 import { diagramWidth } from "../line-diagram-helpers";
 import VehicleIcons from "../VehicleIcons";
 import { LiveDataByStop } from "../__line-diagram";
@@ -97,7 +102,7 @@ const LiveVehicleIconSet = ({
 };
 
 interface SimpleProps {
-  routeStopList: RouteStop[];
+  routeStopList: IndexedRouteStop[];
   route: Route;
   directionId: DirectionId;
   alerts: Alert[];
@@ -114,8 +119,7 @@ const SimpleDiagram = ({
   <>
     {routeStopList.map((routeStop, index) => (
       <LiveVehicleIconSet
-        // eslint-disable-next-line react/no-array-index-key
-        key={`${index}-${routeStop.id}`}
+        key={`vehicle-set-${routeStop.routeIndex}`}
         isStart={index === 0}
         stop={routeStop}
         liveData={liveData}
@@ -150,9 +154,8 @@ const SimpleDiagram = ({
       })}
 
       {/* Draw circles for each stop */
-      routeStopList.map((routeStop, index) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <Stop key={`${index}-${routeStop.id}`} stopId={routeStop.id} />
+      routeStopList.map(routeStop => (
+        <Stop key={`stop-${routeStop.routeIndex}`} stopId={routeStop.id} />
       ))}
     </svg>
   </>

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Diagram.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Diagram.tsx
@@ -19,7 +19,7 @@ import VehicleIcons from "../VehicleIcons";
 import { LiveDataByStop } from "../__line-diagram";
 import { BASE_LINE_WIDTH, DiagonalHatchPattern } from "./graphic-helpers";
 import Stop from "./Stop";
-import Line from "./Line";
+import { Line, SimpleLine } from "./Line";
 import Merges from "./Merges";
 
 interface Props {
@@ -34,11 +34,11 @@ const routeName = (route: Route): string =>
   isAGreenLineRoute(route) ? "Green Line" : route.name;
 
 const diagramDescription = (
-  stopTree: StopTree,
+  pathLength: number,
   route: Route,
   directionId: DirectionId
 ): string => {
-  const text = `${longestPathLength(stopTree)} stops`;
+  const text = `${pathLength} stops`;
   const {
     direction_destinations: destinations,
     direction_names: names
@@ -71,43 +71,53 @@ const branchingDescription = (stopTree: StopTree): string => {
 };
 
 const LiveVehicleIconSet = ({
-  stopTree,
-  stopId,
+  isStart,
+  stop,
   liveData
 }: {
-  stopTree: StopTree;
-  stopId: StopId;
+  isStart: boolean;
+  stop: RouteStop;
   liveData?: LiveDataByStop;
 }): ReactElement<HTMLElement> | null => {
+  const stopId = stop.id;
   if (!liveData || !liveData[stopId]) return null;
   const vehicles = uniqBy(liveData[stopId].vehicles, "id");
   // Hide vehicles arriving to the origin from 'off the line'
-  const vehicleData = isStartNode(stopTree, stopId)
+  const vehicleData = isStart
     ? vehicles.filter(vehicle => vehicle.status === "stopped")
     : vehicles;
 
   return (
     <VehicleIcons
       key={`${stopId}-vehicles`}
-      stop={stopForId(stopTree, stopId)}
+      stop={stop}
       vehicles={vehicleData}
     />
   );
 };
 
-const Diagram = ({
-  stopTree,
+interface SimpleProps {
+  routeStopList: RouteStop[];
+  route: Route;
+  directionId: DirectionId;
+  alerts: Alert[];
+  liveData?: LiveDataByStop;
+}
+
+const SimpleDiagram = ({
+  routeStopList,
   route,
   directionId,
   alerts,
   liveData
-}: Props): ReactElement<HTMLElement> => (
+}: SimpleProps): ReactElement<HTMLElement> => (
   <>
-    {stopIds(stopTree).map(stopId => (
+    {routeStopList.map((routeStop, index) => (
       <LiveVehicleIconSet
-        key={stopId}
-        stopTree={stopTree}
-        stopId={stopId}
+        // eslint-disable-next-line react/no-array-index-key
+        key={`${index}-${routeStop.id}`}
+        isStart={index === 0}
+        stop={routeStop}
         liveData={liveData}
       />
     ))}
@@ -122,7 +132,60 @@ const Diagram = ({
     >
       <title id="diagram-title">Line diagram for {routeName(route)}</title>
       <desc id="diagram-desc">
-        {diagramDescription(stopTree, route, directionId)}
+        {diagramDescription(routeStopList.length, route, directionId)}
+      </desc>
+      <defs>{DiagonalHatchPattern()}</defs>
+      {/* Draw lines between stops */
+      routeStopList.map((routeStop, index) => {
+        const nextStop = routeStopList[index + 1];
+        if (!nextStop) return null;
+        return (
+          <SimpleLine
+            key={`${routeStop.id}-${nextStop.id}`}
+            fromId={routeStop.id}
+            toId={nextStop.id}
+            alerts={alerts}
+          />
+        );
+      })}
+
+      {/* Draw circles for each stop */
+      routeStopList.map((routeStop, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Stop key={`${index}-${routeStop.id}`} stopId={routeStop.id} />
+      ))}
+    </svg>
+  </>
+);
+
+const Diagram = ({
+  stopTree,
+  route,
+  directionId,
+  alerts,
+  liveData
+}: Props): ReactElement<HTMLElement> => (
+  <>
+    {stopIds(stopTree).map(stopId => (
+      <LiveVehicleIconSet
+        key={stopId}
+        isStart={isStartNode(stopTree, stopId)}
+        stop={stopForId(stopTree, stopId)}
+        liveData={liveData}
+      />
+    ))}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-labelledby="diagram-title diagram-desc"
+      className={`line-diagram-svg ${routeToModeName(route)}`}
+      width={`${diagramWidth(1)}px`}
+      height="100%"
+      style={{ left: BASE_LINE_WIDTH / 2, overflow: "visible" }}
+    >
+      <title id="diagram-title">Line diagram for {routeName(route)}</title>
+      <desc id="diagram-desc">
+        {diagramDescription(longestPathLength(stopTree), route, directionId)}
         {hasBranchLines(stopTree) && branchingDescription(stopTree)}
       </desc>
       <defs>{DiagonalHatchPattern()}</defs>
@@ -153,4 +216,4 @@ const Diagram = ({
   </>
 );
 
-export default Diagram;
+export { Diagram, SimpleDiagram };

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Line.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Line.tsx
@@ -97,4 +97,37 @@ const Line = ({
   );
 };
 
-export default Line;
+const SimpleLine = ({
+  fromId,
+  toId,
+  alerts
+}: Omit<Props, "stopTree">): ReactElement | null => {
+  const fromCoords: StopCoord | null = useSelector(
+    (state: CoordState) => state[fromId]
+  );
+  const toCoords: StopCoord | null = useSelector(
+    (state: CoordState) => state[toId]
+  );
+  if (!fromCoords || !toCoords) return null;
+
+  const x = BASE_LINE_WIDTH + 1;
+  const [, y1] = fromCoords;
+  const [, y2] = toCoords;
+  const strokeProp =
+    hasAnActiveDiversion(fromId, alerts) && hasAnActiveDiversion(toId, alerts)
+      ? { stroke: "url(#diagonalHatch)" }
+      : {};
+  return (
+    <line
+      className="line-diagram-svg__line"
+      strokeWidth={`${BASE_LINE_WIDTH}px`}
+      x1={`${x}px`}
+      x2={`${x}px`}
+      y1={`${y1}px`}
+      y2={`${y2}px`}
+      {...strokeProp}
+    />
+  );
+};
+
+export { Line, SimpleLine };

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/Merges.tsx
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/Merges.tsx
@@ -16,7 +16,7 @@ import {
   MERGE_RADIUS,
   StopCoord
 } from "./graphic-helpers";
-import Line from "./Line";
+import { Line } from "./Line";
 
 interface Props {
   stopTree: StopTree;

--- a/apps/site/assets/ts/schedule/components/line-diagram/graphics/useTreeStopPositions.ts
+++ b/apps/site/assets/ts/schedule/components/line-diagram/graphics/useTreeStopPositions.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useDispatch } from "react-redux";
 import { createStore, Store } from "redux";
 import { stopIds } from "../../../../helpers/stop-tree";
-import { StopId, StopTree } from "../../__schedule";
+import { RouteStop, StopId, StopTree } from "../../__schedule";
 import { branchPosition } from "../line-diagram-helpers";
 import {
   BASE_LINE_WIDTH,
@@ -14,10 +14,16 @@ import {
 
 export type RefMap = Map<string, HTMLElement | null>;
 
+const isRouteStopList = (
+  stopOrList: StopTree | RouteStop[]
+): stopOrList is RouteStop[] => Array.isArray(stopOrList);
+
 export const createStopTreeCoordStore = (
-  stopTree: StopTree
+  stopTreeOrList: StopTree | RouteStop[]
 ): Store<CoordState, CoordAction> => {
-  const ids: StopId[] = stopIds(stopTree);
+  const ids: StopId[] = isRouteStopList(stopTreeOrList)
+    ? stopTreeOrList.map(rs => rs.id)
+    : stopIds(stopTreeOrList);
 
   const initialCoordState: CoordState = ids.reduce(
     (acc, id) => ({ ...acc, [id]: null }),
@@ -39,14 +45,16 @@ const xCoordForStop = (stopTree: StopTree, id: StopId): number =>
   BRANCH_SPACING * (branchPosition(stopTree, id) - 1) + BASE_LINE_WIDTH + 1;
 
 export default function useTreeStopPositions(
-  stopTree: StopTree
+  stopTreeOrList: StopTree | RouteStop[]
 ): [RefMap, () => void] {
   const stopRefsMap = useRef(new Map() as RefMap);
   const dispatchStopCoords = useDispatch();
 
   const updateAllStops = useCallback((): void => {
     stopRefsMap.current.forEach((el, stopId) => {
-      const x = xCoordForStop(stopTree, stopId);
+      const x = isRouteStopList(stopTreeOrList)
+        ? BASE_LINE_WIDTH + 1
+        : xCoordForStop(stopTreeOrList, stopId);
       let coordinates = null;
       if (el) {
         const { offsetTop, offsetHeight } = el;
@@ -60,7 +68,7 @@ export default function useTreeStopPositions(
         coords: coordinates
       });
     });
-  }, [dispatchStopCoords, stopRefsMap, stopTree]);
+  }, [dispatchStopCoords, stopRefsMap, stopTreeOrList]);
 
   useEffect(() => {
     updateAllStops();

--- a/apps/site/lib/site_web/controllers/schedule/line.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line.ex
@@ -135,15 +135,14 @@ defmodule SiteWeb.ScheduleController.Line do
 
     branch_route_stops = LineHelpers.get_branch_route_stops(route, direction_id)
 
-    stop_tree =
-      branch_route_stops
-      |> Enum.map(&Enum.map(&1.stops, fn route_stop -> {route_stop.id, route_stop} end))
-      |> UnrootedPolytree.from_lists()
+    {stop_tree, route_stop_lists} =
+      LineHelpers.get_stop_tree_or_lists(branch_route_stops, route.type)
 
     conn
     |> assign(:route_patterns, route_patterns_map)
     |> assign(:direction_id, direction_id)
     |> assign(:stop_tree, stop_tree)
+    |> assign(:route_stop_lists, route_stop_lists)
     |> assign(:branches, static_branches)
     |> assign(:map_img_src, map_img_src)
     |> assign(:dynamic_map_data, dynamic_map_data)

--- a/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line/helpers.ex
@@ -354,4 +354,27 @@ defmodule SiteWeb.ScheduleController.Line.Helpers do
       [i, j]
     end
   end
+
+  @doc """
+  Skip computing the branched tree structure for non-rail route types, because
+  the website doesn't show these in a branching format.
+  """
+  @spec get_stop_tree_or_lists([RouteStops.t()], Route.type_int()) ::
+          {UnrootedPolytree.t() | nil, [[RouteStop.t()]] | nil}
+
+  def get_stop_tree_or_lists(_, 4), do: {nil, nil}
+
+  def get_stop_tree_or_lists(route_stops_lists, 3),
+    do: {nil, Enum.map(route_stops_lists, & &1.stops)}
+
+  def get_stop_tree_or_lists([], _), do: {nil, []}
+
+  def get_stop_tree_or_lists(route_stops_lists, _) do
+    tree =
+      route_stops_lists
+      |> Enum.map(&Enum.map(&1.stops, fn route_stop -> {route_stop.id, route_stop} end))
+      |> UnrootedPolytree.from_lists()
+
+    {tree, nil}
+  end
 end

--- a/apps/site/lib/site_web/controllers/schedule/line_api.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_api.ex
@@ -34,14 +34,12 @@ defmodule SiteWeb.ScheduleController.LineApi do
             conn.query_params["route_pattern"]
           )
 
-        stop_tree =
-          branch_route_stops
-          |> Enum.map(&Enum.map(&1.stops, fn route_stop -> {route_stop.id, route_stop} end))
-          |> UnrootedPolytree.from_lists()
+        {stop_tree, route_stop_lists} =
+          LineHelpers.get_stop_tree_or_lists(branch_route_stops, route.type)
 
         json(
           conn,
-          %{stop_tree: stop_tree}
+          %{stop_tree: stop_tree, route_stop_lists: route_stop_lists}
         )
 
       :not_found ->

--- a/apps/site/lib/site_web/controllers/schedule/line_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/line_controller.ex
@@ -68,6 +68,7 @@ defmodule SiteWeb.ScheduleController.LineController do
         direction_id: conn.assigns.direction_id,
         route_patterns: conn.assigns.route_patterns,
         stop_tree: conn.assigns.stop_tree,
+        route_stop_lists: conn.assigns.route_stop_lists,
         alerts: conn.assigns.alerts,
         today: conn.assigns.date_time |> DateTime.to_date() |> Date.to_iso8601(),
         variant: conn.assigns.variant

--- a/apps/site/test/site_web/controllers/line_api_test.exs
+++ b/apps/site/test/site_web/controllers/line_api_test.exs
@@ -1,5 +1,5 @@
 defmodule SiteWeb.LineApiTest do
-  use SiteWeb.ConnCase
+  use SiteWeb.ConnCase, async: true
 
   describe "show" do
     test "success response", %{conn: conn} do

--- a/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/line/helpers_test.exs
@@ -3,7 +3,7 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
 
   alias Routes.{Route}
   alias SiteWeb.ScheduleController.Line.Helpers
-  alias Stops.{RouteStops, Stop}
+  alias Stops.{RouteStops, RouteStop, Stop}
 
   doctest Helpers
 
@@ -875,6 +875,48 @@ defmodule SiteWeb.ScheduleController.Line.HelpersTest do
                  %RoutePatterns.RoutePattern{typicality: 4, shape_priority: 1},
                  %RoutePatterns.RoutePattern{typicality: 5, shape_priority: 1}
                ])
+    end
+  end
+
+  describe "get_stop_tree_or_lists/2" do
+    setup do
+      test_route_stops = [
+        %RouteStops{
+          branch: "Branch-A",
+          stops: [
+            %RouteStop{id: "a"},
+            %RouteStop{id: "b"},
+            %RouteStop{id: "c"},
+            %RouteStop{id: "d"}
+          ]
+        },
+        %RouteStops{
+          branch: "Branch-B",
+          stops: [
+            %RouteStop{id: "a"},
+            %RouteStop{id: "b"},
+            %RouteStop{id: "e"},
+            %RouteStop{id: "f"}
+          ]
+        }
+      ]
+
+      {:ok, route_stops: test_route_stops}
+    end
+
+    test "returns tree for rail route types", %{route_stops: route_stops} do
+      assert {%UnrootedPolytree{}, nil} = Helpers.get_stop_tree_or_lists(route_stops, 0)
+      assert {%UnrootedPolytree{}, nil} = Helpers.get_stop_tree_or_lists(route_stops, 1)
+      assert {%UnrootedPolytree{}, nil} = Helpers.get_stop_tree_or_lists(route_stops, 2)
+    end
+
+    test "returns list for bus route type", %{route_stops: route_stops} do
+      assert {nil, stops_lists} = Helpers.get_stop_tree_or_lists(route_stops, 3)
+      assert [[%RouteStop{} | _], [%RouteStop{} | _]] = stops_lists
+    end
+
+    test "returns neither for ferry route type", %{route_stops: route_stops} do
+      assert {nil, nil} = Helpers.get_stop_tree_or_lists(route_stops, 4)
     end
   end
 


### PR DESCRIPTION
No ticket - fixing a bug on dev with the 217 & 120 bus route schedule pages.

## Background

- #1755 

The recent PR updated how stops were being fetched for the line diagram, but came with corrected data that broke the line diagram code on at least two pages. It turns out the recursive code that parses the stops to draw the branches on the line diagram assumes that each stop ID is unique, which is assuredly not the case for the 217 and 120 routes, each of which repeat at least one stop along its route.

## Highlighted changes

The approach I took here was to just not compute the stop tree for pages for a ferry or bus route. We don't need it - these either don't have line diagrams or have simple lines that won't branch.

### Backend

- Consolidated the two places that were computing a stop tree into one function
- Adjusted that function to return different data depending on the route type - allowing us to send `nil` stop tree 

### Frontend

- Refactored many components to work with a `null` stop tree.
- Use the list of stops from the backend if the stop tree is `null`

#### Fixed 217 route

![image](https://github.com/mbta/dotcom/assets/2136286/8dcb75d0-e1c7-4f0d-bab1-aba6f3301831)


---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [x] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

