### PR TITLE
fix(SiteWeb.StopController): don't show route patterns for services that aren't running today

### DIFF
--- a/apps/route_patterns/lib/route_pattern.ex
+++ b/apps/route_patterns/lib/route_pattern.ex
@@ -37,6 +37,7 @@ defmodule RoutePatterns.RoutePattern do
     :route_id,
     :time_desc,
     :typicality,
+    :service_id,
     sort_order: 0
   ]
 
@@ -55,7 +56,8 @@ defmodule RoutePatterns.RoutePattern do
           route_id: Route.id_t(),
           time_desc: String.t(),
           typicality: typicality_t(),
-          sort_order: integer()
+          sort_order: integer(),
+          service_id: String.t()
         }
 
   def new(%Item{
@@ -92,7 +94,8 @@ defmodule RoutePatterns.RoutePattern do
       route_id: route_id,
       time_desc: time_desc,
       typicality: typicality,
-      sort_order: sort_order
+      sort_order: sort_order,
+      service_id: service_id(trip_relationships)
     }
   end
 
@@ -152,4 +155,15 @@ defmodule RoutePatterns.RoutePattern do
   end
 
   defp stop_ids(_), do: nil
+
+  defp service_id(%{
+         "service" => [
+           %Item{
+             id: service_id
+           }
+         ]
+       }),
+       do: service_id
+
+  defp service_id(_), do: nil
 end

--- a/apps/services/lib/repo.ex
+++ b/apps/services/lib/repo.ex
@@ -38,4 +38,8 @@ defmodule Services.Repo do
   defp handle_response(%JsonApi{data: data}) do
     Enum.map(data, &Service.new/1)
   end
+
+  defp handle_response({:error, [%JsonApi.Error{code: "not_found"}]}) do
+    []
+  end
 end

--- a/apps/services/lib/repo.ex
+++ b/apps/services/lib/repo.ex
@@ -7,6 +7,14 @@ defmodule Services.Repo do
   alias Services.Service
   alias V3Api.Services, as: ServicesApi
 
+  def by_id(id) when is_binary(id) do
+    cache(id, fn _ ->
+      ServicesApi.get(id)
+      |> handle_response()
+    end)
+    |> List.first()
+  end
+
   def by_route_id(route_id, params \\ [])
 
   def by_route_id([route_id] = route, params) when is_list(route) do

--- a/apps/services/lib/service.ex
+++ b/apps/services/lib/service.ex
@@ -203,7 +203,7 @@ defmodule Services.Service do
   @spec parse_listed_dates([String.t()]) :: [NaiveDateTime.t()]
   defp parse_listed_dates(date_strings) do
     date_strings
-    |> Enum.map(&Timex.parse(&1, "{YYYY}-{0M}-{D}"))
+    |> Enum.map(&Timex.parse(&1, "{ISOdate}"))
     |> Enum.filter(&(elem(&1, 0) == :ok))
     |> Enum.map(&elem(&1, 1))
   end

--- a/apps/services/test/repo_test.exs
+++ b/apps/services/test/repo_test.exs
@@ -7,8 +7,16 @@ defmodule Services.RepoTest do
     :ok
   end
 
+  test "by_id fetches service by ID" do
+    assert %Service{} = Repo.by_id("canonical")
+  end
+
   test "by_route_id fetches services for a route" do
     assert [%Service{} | _] = Repo.by_route_id("Red")
+  end
+
+  test "by_route_id fetches services for a list" do
+    assert [%Service{} | _] = Repo.by_route_id(["Red"])
   end
 
   test "by_route_id fetches services for the green line" do

--- a/apps/services/test/service_test.exs
+++ b/apps/services/test/service_test.exs
@@ -89,6 +89,52 @@ defmodule Services.ServiceTest do
     end
   end
 
+  describe "serves_date?/2" do
+    test "computes if the date is covered by a Service" do
+      # date in added_dates
+      assert Service.serves_date?(
+               %Service{
+                 added_dates: ["2022-12-15", "2022-12-14"],
+                 start_date: ~D[2022-12-14],
+                 end_date: ~D[2022-12-15],
+                 valid_days: []
+               },
+               ~D[2022-12-15]
+             )
+
+      # date in removed_dates
+      refute Service.serves_date?(
+               %Service{
+                 removed_dates: ["2022-12-15", "2022-12-14"],
+                 start_date: ~D[2022-12-11],
+                 end_date: ~D[2022-12-22],
+                 valid_days: []
+               },
+               ~D[2022-12-15]
+             )
+
+      # date is on right valid_days
+      assert Service.serves_date?(
+               %Service{
+                 start_date: ~D[2022-12-11],
+                 end_date: ~D[2022-12-22],
+                 valid_days: [4, 5, 6]
+               },
+               ~D[2022-12-15]
+             )
+
+      # date not on right valid_days
+      refute Service.serves_date?(
+               %Service{
+                 start_date: ~D[2022-12-11],
+                 end_date: ~D[2022-12-22],
+                 valid_days: [1, 2, 3]
+               },
+               ~D[2022-12-15]
+             )
+    end
+  end
+
   defp test_services(_) do
     [
       %Service{

--- a/apps/v3_api/lib/services.ex
+++ b/apps/v3_api/lib/services.ex
@@ -4,4 +4,8 @@ defmodule V3Api.Services do
   def all(params \\ []) do
     V3Api.get_json("/services/", params)
   end
+
+  def get(id, params \\ []) do
+    V3Api.get_json("/services/#{id}", params)
+  end
 end

--- a/apps/v3_api/test/services_test.exs
+++ b/apps/v3_api/test/services_test.exs
@@ -1,0 +1,20 @@
+defmodule V3Api.ServicesTest do
+  use ExUnit.Case
+
+  alias V3Api.Services
+
+  @opts ["page[limit]": 1, sort: "id"]
+
+  describe "all/1" do
+    test "gets all services" do
+      assert %JsonApi{data: [%JsonApi.Item{}]} = Services.all(@opts)
+    end
+  end
+
+  describe "get/1" do
+    test "gets the services by ID" do
+      %JsonApi{data: [%JsonApi.Item{} = service]} = Services.get("canonical")
+      assert service.id == "canonical"
+    end
+  end
+end


### PR DESCRIPTION
Instead of using all route patterns from the whole rating, this PR adjusts the stop page's backend response for route patterns to remove those associated with services that aren't applicable today. 

On the stop page, this removes headsigns associated with route patterns for this weekend's shuttle service, later disruptions, and so on.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
