### PR TITLE
fix(TimetableController): update via-Fairmount trains

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule/timetable_controller.ex
@@ -147,25 +147,45 @@ defmodule SiteWeb.ScheduleController.TimetableController do
   """
   @spec trip_messages(Routes.Route.t(), 0 | 1) :: %{{String.t(), String.t()} => String.t()}
   def trip_messages(%Routes.Route{id: "CR-Franklin"}, 0) do
-    train = "731"
+    ["741", "757", "759", "735"]
+    |> Enum.flat_map(&franklin_via_fairmount(&1, 0))
+    |> Enum.into(%{})
+  end
 
-    [
-      List.duplicate(train, 4),
-      ["place-bbsta", "place-rugg", "place-NEC-2203", "place-DB-0095"],
-      ["Via", "Fair-", "mount", "Line"]
-    ]
-    |> make_via_list()
-    |> Map.put({train}, "Via Fairmount Line")
+  def trip_messages(%Routes.Route{id: "CR-Franklin"}, 1) do
+    ["740", "728", "758", "732", "760"]
+    |> Enum.flat_map(&franklin_via_fairmount(&1, 1))
+    |> Enum.into(%{})
   end
 
   def trip_messages(_, _) do
     %{}
   end
 
+  defp franklin_via_fairmount(train, direction) do
+    stops = stops_for_fairmount(direction)
+
+    [
+      List.duplicate(train, length(stops)),
+      stops,
+      ["Via", "Fair-", "mount", "Line", "-"]
+    ]
+    |> make_via_list()
+    |> Enum.concat([{{train}, "Via Fairmount Line"}])
+  end
+
+  defp stops_for_fairmount(1) do
+    ["place-DB-0095", "place-forhl", "place-rugg", "place-bbsta"]
+  end
+
+  defp stops_for_fairmount(0) do
+    ["place-bbsta", "place-rugg", "place-forhl", "place-NEC-2203", "place-DB-0095"]
+  end
+
   def make_via_list(list) do
     list
     |> List.zip()
-    |> Map.new(fn {train, stop, value} -> {{train, stop}, value} end)
+    |> Enum.map(fn {train, stop, value} -> {{train, stop}, value} end)
   end
 
   defp all_stops(conn, _) do

--- a/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule/timetable_controller_test.exs
@@ -97,22 +97,20 @@ defmodule SiteWeb.ScheduleController.TimetableControllerTest do
   end
 
   describe "trip_messages/2" do
-    test "returns proper messages for CR Franklin" do
-      assert trip_messages(%Routes.Route{id: "CR-Franklin"}, 1) == %{}
-
-      assert [
-               "731"
-             ] ==
+    test "returns proper messages for a CR Franklin train running via Fairmount" do
+      assert Enum.member?(
                %Routes.Route{id: "CR-Franklin"}
                |> trip_messages(0)
                |> Map.keys()
                |> Enum.map(&elem(&1, 0))
                |> Enum.uniq()
-               |> Enum.sort()
+               |> Enum.sort(),
+               "735"
+             )
     end
 
-    test "returns proper messages for CR Fairmount" do
-      assert trip_messages(%Routes.Route{id: "CR-Fairmount"}, 1) == %{}
+    test "returns proper messages for others" do
+      assert trip_messages(%Routes.Route{id: "CR-Worcester"}, 1) == %{}
     end
   end
 

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -55,9 +55,13 @@ defmodule SiteWeb.ScheduleControllerTest do
       assert conn.assigns.trip_messages
     end
 
+    @doc """
+    FIXME: The map_size will change whenever the schedule changes the number of trains needing these messages.
+    """
     test "assigns trip messages for a few route/directions", %{conn: conn} do
       for {route_id, direction_id, expected_size} <- [
-            {"CR-Franklin", 0, 5}
+            {"CR-Franklin", 0, 24},
+            {"CR-Franklin", 1, 25}
           ] do
         path =
           timetable_path(conn, :show, route_id, schedule_direction: %{direction_id: direction_id})


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Timetable | Add "via Fairmount line" note to more Franklin/Foxboro trains](https://app.asana.com/0/385363666817452/1205632277310611/f)

I basically followed the approach of [this prior state of code](https://github.com/mbta/dotcom/commit/f3747d824254fdf9988d36d58cdf0f4486e7106c). The "Via Fair- Mount Line" messages shows in the timetable for CR-Franklin for 4-5 trains in each direction, spanning 5 or 4 cells between Reading and Back Bay stations (the difference accounts for Hyde Park being omitted in one direction).

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

