### PR TITLE
Chore: Update GitHub actions to use assumed role

### DIFF
--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -14,6 +14,7 @@ jobs:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
+      role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
   notify:
     needs: [auto]

--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -11,10 +11,8 @@ jobs:
     with:
       deployment-env: dev
     secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
-      role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
   notify:
     needs: [auto]

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -20,6 +20,7 @@ jobs:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
+      role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
   notify:
     needs: [branch]

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -17,10 +17,8 @@ jobs:
     with:
       deployment-env: ${{ github.event.inputs.env }}
     secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
-      role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
   notify:
     needs: [branch]

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -26,6 +26,7 @@ jobs:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
+      role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
   notify:
     needs: [pr]

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -23,10 +23,8 @@ jobs:
     with:
       deployment-env: ${{ contains(github.event.pull_request.labels.*.name, 'dev-green') && 'dev-green' || 'dev-blue' }} # env not valid here either
     secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
-      role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
   notify:
     needs: [pr]

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -13,10 +13,8 @@ jobs:
       deployment-env: prod
       extra-docker-tag: ${{ github.event.release.tag_name }}
     secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
-      role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
   notify:
     needs: [release]

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -16,7 +16,8 @@ jobs:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
- 
+      role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+
   notify:
     needs: [release]
     uses: ./.github/workflows/use-notify-slack.yml

--- a/.github/workflows/use-deploy-ecs.yml
+++ b/.github/workflows/use-deploy-ecs.yml
@@ -13,18 +13,12 @@ on:
         required: false
         description: "Additional tag to apply to the docker image"
     secrets:
-      aws-access-key-id:
+      aws-role-arn:
         required: true
-        description: "AWS_ACCESS_KEY_ID value"
-      aws-secret-access-key:
-        required: true
-        description: "AWS_SECRET_ACCESS_KEY value"
+        description: "AWS_ROLE_ARN value"
       docker-repo:
         required: true
         description: "The Docker repository to upload the docker image to, formatted '....amazonaws.com/<app>'"
-      role-to-assume:
-        required: true
-        description: "AWS_ROLE_ARN value"
     outputs: 
       deployment-env:
         value: ${{ jobs.deploy.outputs.deployment-env }}
@@ -46,6 +40,11 @@ jobs:
     outputs:
       deployment-env: ${{ inputs.deployment-env }}
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws-role-arn }}
+          aws-region: us-east-1
       - run: |
           echo "inputs: ${{ toJson(inputs) }}"
 
@@ -66,8 +65,6 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.docker-repo }}
-          username: ${{ secrets.aws-access-key-id }}
-          password: ${{ secrets.aws-secret-access-key }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -82,9 +79,6 @@ jobs:
 
       - name: Upload assets from image into s3
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws-secret-access-key }}
-          AWS_DEFAULT_REGION: us-east-1
           AWS_DEFAULT_OUTPUT: json
         run: |
           bash upload_assets.sh assets-image
@@ -101,7 +95,6 @@ jobs:
 
       - uses: mbta/actions/deploy-ecs@v2
         with:
-          role-to-assume: ${{ secrets.aws-role-arn }}
           ecs-cluster: dotcom
           ecs-service: dotcom-${{ inputs.deployment-env }}
           docker-tag: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}

--- a/.github/workflows/use-deploy-ecs.yml
+++ b/.github/workflows/use-deploy-ecs.yml
@@ -34,6 +34,9 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: ${{ inputs.deployment-env }}
       url: ${{ inputs.deployment-env == 'prod' && 'https://www.mbta.com' || format('https://{0}.mbtace.com', inputs.deployment-env) }}
@@ -93,10 +96,9 @@ jobs:
           cache-from: type=gha,src=/tmp/.buildx-cache
           cache-to: type=gha,dest=/tmp/.buildx-cache,mode=max
 
-      - uses: mbta/actions/deploy-ecs@v1
+      - uses: mbta/actions/deploy-ecs@v2
         with:
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: dotcom
           ecs-service: dotcom-${{ inputs.deployment-env }}
           docker-tag: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}

--- a/.github/workflows/use-deploy-ecs.yml
+++ b/.github/workflows/use-deploy-ecs.yml
@@ -16,15 +16,15 @@ on:
       aws-access-key-id:
         required: true
         description: "AWS_ACCESS_KEY_ID value"
-      aws-role-arn:
-        required: true
-        description: "AWS_ROLE_ARN value"
       aws-secret-access-key:
         required: true
         description: "AWS_SECRET_ACCESS_KEY value"
       docker-repo:
         required: true
         description: "The Docker repository to upload the docker image to, formatted '....amazonaws.com/<app>'"
+      role-to-assume:
+        required: true
+        description: "AWS_ROLE_ARN value"
     outputs: 
       deployment-env:
         value: ${{ jobs.deploy.outputs.deployment-env }}

--- a/.github/workflows/use-deploy-ecs.yml
+++ b/.github/workflows/use-deploy-ecs.yml
@@ -16,6 +16,9 @@ on:
       aws-access-key-id:
         required: true
         description: "AWS_ACCESS_KEY_ID value"
+      aws-role-arn:
+        required: true
+        description: "AWS_ROLE_ARN value"
       aws-secret-access-key:
         required: true
         description: "AWS_SECRET_ACCESS_KEY value"
@@ -98,7 +101,7 @@ jobs:
 
       - uses: mbta/actions/deploy-ecs@v2
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.aws-role-arn }}
           ecs-cluster: dotcom
           ecs-service: dotcom-${{ inputs.deployment-env }}
           docker-tag: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Update workflows repo to point to V2 actions and use assumed role instead of keys](https://app.asana.com/0/0/1205570959197530/f)

This PR updates the `use-deploy-ecs` workflow to use v2 of the shared `build-push-ecr` and `deploy-ecs` actions. These updated actions assume an IAM role instead of relying on long-lasting AWS keys for an IAM user. 

Note: Other workflows that rely on the `deploy-ecs` [workflow](https://github.com/mbta/workflows/blob/main/.github/workflows/deploy-ecs.yml) will be updated at a later date.