### PR TITLE
fix(V3Api): encode url for v3 api requests

### DIFF
--- a/apps/stops/test/api_test.exs
+++ b/apps/stops/test/api_test.exs
@@ -50,7 +50,7 @@ defmodule Stops.ApiTest do
                "#{child_id} not found in parent.child_ids"
       end
 
-      assert {:ok, %Stop{} = child} = by_gtfs_id("South Station-01")
+      assert {:ok, %Stop{} = child} = by_gtfs_id("NEC-2287-01")
       assert child.name == "South Station"
       assert child.type == :stop
       assert child.platform_name == "Commuter Rail - Track 1"

--- a/apps/stops/test/repo_test.exs
+++ b/apps/stops/test/repo_test.exs
@@ -31,7 +31,7 @@ defmodule Stops.RepoTest do
 
   describe "get_parent/1" do
     test "returns the parent stop for a child stop" do
-      north_station_cr = get("North Station")
+      north_station_cr = get("BNT-0000-01")
       assert north_station_cr.is_child? == true
       assert north_station_cr.parent_id == "place-north"
       assert %Stop{id: "place-north"} = get_parent(north_station_cr)
@@ -43,7 +43,7 @@ defmodule Stops.RepoTest do
     end
 
     test "takes ids" do
-      assert %Stop{id: "place-north"} = get_parent("North Station")
+      assert %Stop{id: "place-north"} = get_parent("BNT-0000-01")
       assert %Stop{id: "place-north"} = get_parent("place-north")
     end
   end

--- a/apps/v3_api/lib/v3_api.ex
+++ b/apps/v3_api/lib/v3_api.ex
@@ -51,7 +51,7 @@ defmodule V3Api do
         use_cache?: true
       )
 
-    url = base_url <> url
+    url = base_url <> URI.encode(url)
     timeout = Keyword.fetch!(opts, :timeout)
 
     {time, response} =

--- a/apps/v3_api/test/services_test.exs
+++ b/apps/v3_api/test/services_test.exs
@@ -6,8 +6,8 @@ defmodule V3Api.ServicesTest do
   @opts ["page[limit]": 1, sort: "id"]
 
   describe "all/1" do
-    test "gets all services" do
-      assert %JsonApi{data: [%JsonApi.Item{}]} = Services.all(@opts)
+    test "gets all services (for a given filter)" do
+      assert %JsonApi{data: [%JsonApi.Item{}]} = Services.all(Keyword.put(@opts, :route, "Red"))
     end
   end
 

--- a/apps/v3_api/test/v3_api_test.exs
+++ b/apps/v3_api/test/v3_api_test.exs
@@ -20,6 +20,17 @@ defmodule V3ApiTest do
       refute response.data == %{}
     end
 
+    test "encodes the URL", %{bypass: bypass, url: url} do
+      Bypass.expect(bypass, fn conn ->
+        assert conn.request_path == "/normal%20response"
+        send_resp(conn, 200, ~s({"data": []}))
+      end)
+
+      response = V3Api.get_json("/normal response", [], base_url: url)
+      assert %JsonApi{} = response
+      refute response.data == %{}
+    end
+
     test "does not add headers normally", %{bypass: bypass, url: url} do
       Bypass.expect(bypass, fn conn ->
         assert List.keyfind(conn.req_headers, "x-wm-proxy-url", 0) == nil


### PR DESCRIPTION
#### Summary of changes

We discovered sometimes a service ID might contain a space character. And we were not able to get that service information from the API because we weren't encoding the URL. This fixes that, along with updating related tests.

It also appears the V3 API now doesn't allow for fetching all services without any filter parameters, so another test has been updated to account for that.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
