### PR TITLE
refactor(DeparturesAndMap): can show shuttle routes at bus stops

### DIFF
--- a/apps/site/assets/css/_stop-card.scss
+++ b/apps/site/assets/css/_stop-card.scss
@@ -193,7 +193,7 @@ $radius: 4px;
 
   .bus-route-sign {
     min-width: 5ch;
-    padding: 0;
+    padding: 0 $base-spacing-sm;
   }
 
   .c-svg__icon {

--- a/apps/site/assets/ts/stop/__tests__/DeparturesAndMapShuttleTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DeparturesAndMapShuttleTest.tsx
@@ -15,7 +15,8 @@ const stop = {
   id: "test-stop",
   name: "Test Stop",
   latitude: 42.3519,
-  longitude: 71.0552
+  longitude: 71.0552,
+  "station?": true
 } as Stop;
 const now = Date.now();
 

--- a/apps/site/assets/ts/stop/__tests__/StopPageDeparturesTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageDeparturesTest.tsx
@@ -10,6 +10,7 @@ describe("StopPageDepartures", () => {
   it("renders with no data", async () => {
     const { asFragment } = renderWithRouter(
       <StopPageDepartures
+        isStation={true}
         routes={[]}
         alerts={[]}
         departureInfos={[]}
@@ -25,6 +26,7 @@ describe("StopPageDepartures", () => {
   it("renders with data", async () => {
     const { asFragment } = renderWithRouter(
       <StopPageDepartures
+        isStation={true}
         routes={routeData}
         alerts={[]}
         departureInfos={[]}
@@ -45,6 +47,7 @@ describe("StopPageDepartures", () => {
   it("doesn't show the filters if there is 1 mode present", async () => {
     renderWithRouter(
       <StopPageDepartures
+        isStation={true}
         routes={[routeData[0]]}
         alerts={[]}
         departureInfos={[]}

--- a/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
+++ b/apps/site/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
@@ -99,7 +99,7 @@ exports[`StopPageDepartures renders with data 2`] = `
           </div>
         </div>
         <div
-          aria-label="Open upcoming departures to Braintree"
+          aria-label="Open upcoming departures to Alewife"
           class="departure-card__headsign d-flex"
           role="button"
           tabindex="0"
@@ -107,7 +107,7 @@ exports[`StopPageDepartures renders with data 2`] = `
           <div
             class="departure-card__headsign-name"
           >
-            Braintree
+            Alewife
           </div>
           <div
             class="departure-card__content"
@@ -126,7 +126,7 @@ exports[`StopPageDepartures renders with data 2`] = `
           </div>
         </div>
         <div
-          aria-label="Open upcoming departures to Alewife"
+          aria-label="Open upcoming departures to Braintree"
           class="departure-card__headsign d-flex"
           role="button"
           tabindex="0"
@@ -134,7 +134,7 @@ exports[`StopPageDepartures renders with data 2`] = `
           <div
             class="departure-card__headsign-name"
           >
-            Alewife
+            Braintree
           </div>
           <div
             class="departure-card__content"

--- a/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
@@ -33,6 +33,7 @@ import {
 import useDepartureRow from "../../hooks/useDepartureRow";
 import { GroupedRoutePatterns } from "../stop-redesign-loader";
 import { DepartureInfo } from "../../models/departureInfo";
+import { isStopAStation } from "../../helpers/stops";
 
 interface DeparturesAndMapProps {
   routes: Route[];
@@ -121,11 +122,11 @@ const DeparturesAndMap = ({
   }, [setPredictionError, predictions]);
   const [realtimeAlerts, setRealtimeAlerts] = useState<Alert[]>([]);
 
+  const isStation = isStopAStation(stop);
   const mappedRouteIds = mapRouteIds(routes);
-  const updatedDepartureInfos = updateDepartureInfos(
-    departureInfos,
-    mappedRouteIds
-  );
+  const updatedDepartureInfos = isStation
+    ? updateDepartureInfos(departureInfos, mappedRouteIds)
+    : departureInfos;
 
   const { activeRow, resetRow } = useDepartureRow(routes);
   useEffect(() => {
@@ -247,6 +248,7 @@ const DeparturesAndMap = ({
           </div>
         ) : (
           <StopPageDepartures
+            isStation={isStation}
             routes={routes}
             departureInfos={updatedDepartureInfos}
             alerts={alerts}

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -12,6 +12,7 @@ import {
 } from "../stop-redesign-loader";
 
 interface StopPageDeparturesProps {
+  isStation: boolean;
   routes: Route[];
   departureInfos: DepartureInfo[];
   alerts: Alert[];
@@ -30,6 +31,7 @@ const modeSortFn = ({ type }: Route): number => {
 };
 
 const StopPageDepartures = ({
+  isStation,
   routes,
   departureInfos,
   alerts,
@@ -37,12 +39,14 @@ const StopPageDepartures = ({
 }: StopPageDeparturesProps): ReactElement<HTMLElement> => {
   // default to show all modes.
   const [selectedMode, setSelectedMode] = useState<ModeChoice>("all");
-  // Filters our all replacement buses that haven't been remapped in the parent component
-  const nonShuttleRoutes = filter(routes, r => !isRailReplacementBus(r));
-  const groupedRoutes = groupBy(nonShuttleRoutes, modeForRoute);
+  // Stations only: Filters out all replacement buses that haven't been remapped in the parent component
+  const adjustedRoutes = isStation
+    ? filter(routes, r => !isRailReplacementBus(r))
+    : routes;
+  const groupedRoutes = groupBy(adjustedRoutes, modeForRoute);
   const modesList = Object.keys(groupedRoutes) as ModeChoice[];
   const filteredRoutes =
-    selectedMode === "all" ? nonShuttleRoutes : groupedRoutes[selectedMode];
+    selectedMode === "all" ? adjustedRoutes : groupedRoutes[selectedMode];
   const currentAlerts = filter(alerts, a => isInNextXDays(a, 0));
   const groupedAlerts = alertsByRoute(currentAlerts);
 


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** No ticket

Adjusts the changes from #1769 to be applied only to stations, and not to bus stops. This allows the bus stops to show subway-replacement shuttles, which is helpful in the case of the current Mattapan/Ashmont/JFK shuttling.

This idea came about after seeing that the line diagram for Mattapan shows links to [the Red Line shuttle route](https://dev.mbtace.com/schedules/Shuttle-JFKMattapan/line), which in turn links to the stops being served by the shuttle. 

---

> [!IMPORTANT]  
> This PR seeks to help riders coming from these shuttle pages - when clicking a shuttle stop, the stop page can reflect those shuttles that are present.

**Before / after at bus stops serving subway-replacement shuttle routes:**

<img width="1484" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/a7cfc8de-62e5-4464-9751-440a7a7cad35">

<img width="1476" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/8d083d4e-beba-4357-a4cc-a4a91c20790e">

Departure cards at stations serving subway or commuter rail remain unchanged.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
