### PR TITLE
fix(Stops.RouteStop): omit shuttle connections

### DIFF
--- a/apps/stops/lib/route_stop.ex
+++ b/apps/stops/lib/route_stop.ex
@@ -307,6 +307,7 @@ defmodule Stops.RouteStop do
       |> Map.get(:id)
       |> Routes.Repo.by_stop(include: "stop.connecting_stops")
       |> Enum.reject(&(&1.id == route_stop.route.id))
+      |> Enum.reject(&(&1.description == :rail_replacement_bus))
 
     %{route_stop | connections: connections}
   end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Omit shuttles as connections on schedule page line map](https://app.asana.com/0/385363666817452/1205743983345585/f)


**Before:** (Mattapan Line)

<img width="497" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/0427dc4f-5f34-4259-b332-e334a641e85d">

This PR removes references to shuttle routes from the line diagram.

**After:**

<img width="490" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/a9c03a62-1693-4901-be8c-d019d4571378">


---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
