### PR TITLE
refactor(Algolia): tweak application config

### DIFF
--- a/apps/algolia/config/config.exs
+++ b/apps/algolia/config/config.exs
@@ -1,6 +1,4 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 config :algolia, :config,
   app_id: {:system, "ALGOLIA_APP_ID"},
@@ -22,29 +20,4 @@ config :algolia, :index_suffix, ""
 
 config :algolia, :http_pool, :algolia_http_pool
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :algolia, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:algolia, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-import_config "#{Mix.env()}.exs"
+import_config "#{config_env()}.exs"

--- a/apps/algolia/config/config.exs
+++ b/apps/algolia/config/config.exs
@@ -16,7 +16,7 @@ config :algolia, :indexes, [
 
 config :algolia, :track_clicks?, false
 
-config :algolia, :index_suffix, ""
+config :algolia, :index_suffix, "_test"
 
 config :algolia, :http_pool, :algolia_http_pool
 

--- a/apps/algolia/config/dev.exs
+++ b/apps/algolia/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/apps/algolia/config/prod.exs
+++ b/apps/algolia/config/prod.exs
@@ -1,10 +1,5 @@
 import Config
 
-config :algolia, :keys,
-  app_id: "${ALGOLIA_APP_ID}",
-  search: "${ALGOLIA_SEARCH_KEY}",
-  write: "${ALGOLIA_WRITE_KEY}"
-
 config :algolia, :click_analytics_url, "https://insights.algolia.io"
 config :algolia, :track_clicks?, true
 config :algolia, :track_analytics?, true

--- a/apps/algolia/config/prod.exs
+++ b/apps/algolia/config/prod.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :algolia, :keys,
   app_id: "${ALGOLIA_APP_ID}",

--- a/apps/algolia/config/prod.exs
+++ b/apps/algolia/config/prod.exs
@@ -8,3 +8,4 @@ config :algolia, :keys,
 config :algolia, :click_analytics_url, "https://insights.algolia.io"
 config :algolia, :track_clicks?, true
 config :algolia, :track_analytics?, true
+config :algolia, :index_suffix, ""

--- a/apps/algolia/config/test.exs
+++ b/apps/algolia/config/test.exs
@@ -14,5 +14,3 @@ config :algolia, :indexes, [
 ]
 
 config :algolia, :click_analytics_url, :not_set
-
-config :algolia, :index_suffix, "_test"

--- a/apps/algolia/config/test.exs
+++ b/apps/algolia/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :algolia, :config,
   app_id: "ALGOLIA_APP_ID",


### PR DESCRIPTION
#### Summary of changes

Asana Ticket: No ticket

These are a few small changes in the Algolia backend configuration that shouldn't result in any noticeable changes.

1. `use Mix.Config` is deprecated, so firstly this PR [migrates the configuration to use `import Config`](https://hexdocs.pm/elixir/1.12/Config.html#module-migrating-from-use-mix-config)
2. Nothing was using the configuration described in `config :algolia, :keys,` so that's deleted here 💀 
3. Nothing's using the `config :algolia, :index_suffix` bit either, but I am planning on using it in my next PR, so I haven't deleted it.
4. I changed the index_suffix from default of `""` and test value of `"_test"` to default of `"_test"` and prod value of `""`. This was me thinking it'd be better for us to query the `routes_test`, `stops_test`, `drupal_test` indexes when we're working on dev, whereas we can leave working with the `routes`/`stops`/`drupal` indexes to the `MIX_ENV=prod` environment. (Note this isn't implemented yet though, everything's still working on the non-test indexes for now)

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.