### PR TITLE
feat(SiteWeb.Router): add /charlie/* redirects

### DIFF
--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -62,6 +62,11 @@ defmodule SiteWeb.Router do
     get("/*path", WwwRedirector, [])
   end
 
+  # redirect 'mbta.com/charlie/*'  to 'charlie.mbta.com/*'
+  scope "/charlie", SiteWeb do
+    get("/*path", WwwRedirector, host: "https://charlie.mbta.com")
+  end
+
   scope "/", SiteWeb do
     pipe_through([:secure, :browser])
 

--- a/apps/site/lib/site_web/www_redirector.ex
+++ b/apps/site/lib/site_web/www_redirector.ex
@@ -24,12 +24,22 @@ defmodule SiteWeb.WwwRedirector do
     |> halt()
   end
 
-  defp redirect_url(site_url, %Conn{request_path: path, query_string: query})
+  # If path_params are matched via SiteWeb.Router, use that to determine path
+  defp redirect_url(site_url, %Conn{path_params: %{"path" => path}, query_string: query}) do
+    revised_path = "/" <> Enum.join(path, "/")
+    do_redirect_url(site_url, revised_path, query)
+  end
+
+  defp redirect_url(site_url, %Conn{request_path: path, query_string: query}) do
+    do_redirect_url(site_url, path, query)
+  end
+
+  defp do_redirect_url(site_url, path, query)
        when is_binary(query) and query != "" do
     "#{site_url}#{path}?#{query}"
   end
 
-  defp redirect_url(site_url, %Conn{request_path: path}) do
+  defp do_redirect_url(site_url, path, _) do
     "#{site_url}#{path}"
   end
 end

--- a/apps/site/lib/site_web/www_redirector.ex
+++ b/apps/site/lib/site_web/www_redirector.ex
@@ -6,10 +6,13 @@ defmodule SiteWeb.WwwRedirector do
   alias Plug.Conn
 
   @impl true
-  def init([]), do: []
+  def init(options), do: options
 
   @impl true
-  def call(conn, _options), do: site_redirect(SiteWeb.Endpoint.url(), conn)
+  def call(conn, options) do
+    url = Keyword.get(options, :host, SiteWeb.Endpoint.url())
+    site_redirect(url, conn)
+  end
 
   @spec site_redirect(String.t(), Conn.t()) :: Plug.Conn.t()
   def site_redirect(site_url, conn) do

--- a/apps/site/test/site/lib/www_redirector_test.exs
+++ b/apps/site/test/site/lib/www_redirector_test.exs
@@ -14,6 +14,23 @@ defmodule SiteWeb.WwwRedirectorTest do
     assert_conn_redirected_halted(conn, "https://myfakedomain.xyz/news")
   end
 
+  @doc "Use case: The path_params are populated in the router, and if they're part of a scoped route, the redirected URL should not include the path prefix."
+  test "omits scoped route path prefix", %{conn: conn} do
+    request_path = "/charlie/page/one/two"
+
+    conn = %{
+      conn
+      | request_path: request_path,
+        query_string: nil,
+        path_params: %{"path" => ["page", "one", "two"]}
+    }
+
+    conn = WwwRedirector.call(conn, host: "https://myfakedomain.xyz")
+
+    refute redirected_to(conn, :moved_permanently) == "https://myfakedomain.xyz#{request_path}"
+    assert_conn_redirected_halted(conn, "https://myfakedomain.xyz/page/one/two")
+  end
+
   describe "redirect" do
     test "top level redirected", %{conn: conn} do
       check_redirect_to_www_mbta(conn, "/", nil, "https://www.mbta.com/")

--- a/apps/site/test/site/lib/www_redirector_test.exs
+++ b/apps/site/test/site/lib/www_redirector_test.exs
@@ -9,6 +9,11 @@ defmodule SiteWeb.WwwRedirectorTest do
     assert_conn_redirected_halted(conn, SiteWeb.Endpoint.url() <> "/news")
   end
 
+  test "call with host option", %{conn: conn} do
+    conn = WwwRedirector.call(%{conn | request_path: "/news"}, host: "https://myfakedomain.xyz")
+    assert_conn_redirected_halted(conn, "https://myfakedomain.xyz/news")
+  end
+
   describe "redirect" do
     test "top level redirected", %{conn: conn} do
       check_redirect_to_www_mbta(conn, "/", nil, "https://www.mbta.com/")


### PR DESCRIPTION
#### Summary of changes

Asana Ticket: [Redirect requests to /charlie](https://app.asana.com/0/385363666817452/1205692575718677/f)

Added a couple features to the existing `SiteWeb.WwwRedirector` module, to support redirecting to an external host, and to support using the path that's matched by the router's `/*path` declaration. The latter was needed to prevent `mbta.com/charlie/something` from redirecting to `charlie.mbta.com/charlie/something`.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
