### PR TITLE
feat(autocomplete): link to text fragment

### DIFF
--- a/apps/site/assets/ts/ui/__tests__/autocomplete-templates-test.tsx
+++ b/apps/site/assets/ts/ui/__tests__/autocomplete-templates-test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { LinkForItem } from "../autocomplete/templates/algolia";
+import { AutocompleteItem } from "../autocomplete/__autocomplete";
+
+test("LinkForItem renders simplelink", () => {
+  const contentItem = {
+    _content_url: "/page1",
+    _content_type: "page",
+    content_title: "Page One",
+    index: "drupal",
+    objectID: "sdfsda",
+    _highlightResult: { content_title: { matchedWords: ["one"] } }
+  } as AutocompleteItem;
+  render(
+    <LinkForItem item={contentItem} query="one">
+      <div>Content</div>
+    </LinkForItem>
+  );
+
+  expect(screen.getByRole("link")).toHaveAttribute("href", "/page1");
+});
+
+test("LinkForItem renders link to text fragment", () => {
+  const contentItemNoMatch = {
+    _content_url: "/page2",
+    _content_type: "page",
+    content_title: "Page Two",
+    index: "drupal",
+    objectID: "sdfsda",
+    _highlightResult: { content_title: { matchedWords: [] } }
+  } as AutocompleteItem;
+  render(
+    <LinkForItem item={contentItemNoMatch} query="searched text">
+      <div>Content</div>
+    </LinkForItem>
+  );
+
+  expect(screen.getByRole("link")).toHaveAttribute(
+    "href",
+    "/page2#:~:text=searched%20text"
+  );
+});


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [🔍  Search | Flex Pass Search Bug](https://app.asana.com/0/385363666817452/1204551723865238/f)

Making use of a browser feature called **Text Fragments** in order to have the search box navigate to a section of arbitrary text on the page. See the Asana issue for context behind why I decided to take that approach.

More resources around the browser feature:

- [Boldly link where no one has linked before: Text Fragments (web.dev)](https://web.dev/articles/text-fragments)
- [Text fragments (MDN reference)](https://developer.mozilla.org/en-US/docs/Web/Text_fragments)
- [URL Scroll-To-Text Fragment (Can I use...)](https://caniuse.com/url-scroll-to-text-fragment)

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
