### PR TITLE
feat(StopPageDepartures): Omit uncommon Green Line branches/headsigns with no upcoming service

### DIFF
--- a/apps/route_patterns/lib/route_pattern.ex
+++ b/apps/route_patterns/lib/route_pattern.ex
@@ -38,6 +38,7 @@ defmodule RoutePatterns.RoutePattern do
     :time_desc,
     :typicality,
     :service_id,
+    :canonical,
     sort_order: 0
   ]
 
@@ -57,6 +58,7 @@ defmodule RoutePatterns.RoutePattern do
           time_desc: String.t(),
           typicality: typicality_t(),
           sort_order: integer(),
+          canonical: boolean(),
           service_id: String.t()
         }
 
@@ -67,6 +69,7 @@ defmodule RoutePatterns.RoutePattern do
           "name" => name,
           "time_desc" => time_desc,
           "typicality" => typicality,
+          "canonical" => canonical,
           "sort_order" => sort_order
         },
         relationships: %{
@@ -95,6 +98,7 @@ defmodule RoutePatterns.RoutePattern do
       time_desc: time_desc,
       typicality: typicality,
       sort_order: sort_order,
+      canonical: canonical,
       service_id: service_id(trip_relationships)
     }
   end
@@ -106,6 +110,7 @@ defmodule RoutePatterns.RoutePattern do
           "name" => name,
           "time_desc" => time_desc,
           "typicality" => typicality,
+          "canonical" => canonical,
           "sort_order" => sort_order
         },
         relationships: %{
@@ -121,6 +126,7 @@ defmodule RoutePatterns.RoutePattern do
       route_id: route_id,
       time_desc: time_desc,
       typicality: typicality,
+      canonical: canonical,
       sort_order: sort_order
     }
   end

--- a/apps/routes/test/parser_test.exs
+++ b/apps/routes/test/parser_test.exs
@@ -141,7 +141,8 @@ defmodule Routes.ParserTest do
                 "name" => "rp",
                 "time_desc" => "td",
                 "typicality" => 1,
-                "sort_order" => 12_132_123
+                "sort_order" => 12_132_123,
+                "canonical" => false
               },
               relationships: %{
                 "representative_trip" => [%Item{id: "id"}],

--- a/apps/site/assets/ts/__v3api.d.ts
+++ b/apps/site/assets/ts/__v3api.d.ts
@@ -362,6 +362,7 @@ export interface RoutePattern {
   id: string;
   direction_id: DirectionId;
   sort_order: number;
+  canonical: boolean;
 }
 
 export interface StopHours {

--- a/apps/site/assets/ts/helpers/departureInfo.tsx
+++ b/apps/site/assets/ts/helpers/departureInfo.tsx
@@ -21,7 +21,7 @@ import {
 import { DirectionId, Route } from "../__v3api";
 import DisplayTime from "../stop/components/DisplayTime";
 import { getInfoKey } from "../stop/models/displayTimeConfig";
-import { RoutePatternWithPolyline } from "../stop/stop-redesign-loader";
+import { RoutePatternWithPolyline } from "../models/route-patterns";
 
 export const SUBWAY = "subway";
 export const BUS = "bus";

--- a/apps/site/assets/ts/models/route-patterns.ts
+++ b/apps/site/assets/ts/models/route-patterns.ts
@@ -1,7 +1,7 @@
 import { GroupedRoutePatterns } from "../stop/stop-redesign-loader";
 
 type RoutePatternGroup = GroupedRoutePatterns[keyof GroupedRoutePatterns];
-type RoutePatternGroupEntries = [
+export type RoutePatternGroupEntries = [
   keyof RoutePatternGroup,
   RoutePatternGroup[keyof RoutePatternGroup]
 ][];

--- a/apps/site/assets/ts/models/route-patterns.ts
+++ b/apps/site/assets/ts/models/route-patterns.ts
@@ -1,0 +1,25 @@
+import { GroupedRoutePatterns } from "../stop/stop-redesign-loader";
+
+type RoutePatternGroup = GroupedRoutePatterns[keyof GroupedRoutePatterns];
+type RoutePatternGroupEntries = [
+  keyof RoutePatternGroup,
+  RoutePatternGroup[keyof RoutePatternGroup]
+][];
+
+// sort headsigns to reflect the route pattern's sort_order
+const sortedGroupedRoutePatterns = (
+  groupedByHeadsign: RoutePatternGroup
+): RoutePatternGroupEntries => {
+  return Object.entries(groupedByHeadsign).sort((entryA, entryB) => {
+    const [orderA, orderB] = [
+      entryA,
+      entryB
+    ].map(([, { route_patterns: routePatterns }]) =>
+      Math.min(...routePatterns.map(rp => rp.sort_order))
+    );
+    return orderA - orderB;
+  });
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { sortedGroupedRoutePatterns };

--- a/apps/site/assets/ts/models/route-patterns.ts
+++ b/apps/site/assets/ts/models/route-patterns.ts
@@ -6,7 +6,7 @@ export interface RoutePatternWithPolyline
   extends Omit<RoutePattern, "representative_trip_polyline"> {
   representative_trip_polyline: Polyline;
 }
-type RoutePatternGroup = Record<
+export type RoutePatternGroup = Record<
   RoutePattern["headsign"],
   {
     direction_id: DirectionId;
@@ -21,7 +21,7 @@ export type RoutePatternGroupEntries = [
 ][];
 
 // sort headsigns to reflect the route pattern's sort_order
-const sortedGroupedRoutePatterns = (
+export const sortedGroupedRoutePatterns = (
   groupedByHeadsign: RoutePatternGroup
 ): RoutePatternGroupEntries =>
   sortBy(
@@ -30,5 +30,4 @@ const sortedGroupedRoutePatterns = (
       minBy(routePatterns, "sort_order")?.sort_order
   );
 
-// eslint-disable-next-line import/prefer-default-export
-export { sortedGroupedRoutePatterns };
+export default { sortedGroupedRoutePatterns };

--- a/apps/site/assets/ts/models/route-patterns.ts
+++ b/apps/site/assets/ts/models/route-patterns.ts
@@ -1,9 +1,5 @@
 import { minBy, sortBy } from "lodash";
-import {
-  GroupedRoutePatterns,
-  RoutePatternWithPolyline
-} from "../stop/stop-redesign-loader";
-import { DepartureInfo } from "./departureInfo";
+import { GroupedRoutePatterns } from "../stop/stop-redesign-loader";
 
 type RoutePatternGroup = GroupedRoutePatterns[keyof GroupedRoutePatterns];
 export type RoutePatternGroupEntries = [
@@ -21,13 +17,5 @@ const sortedGroupedRoutePatterns = (
       minBy(routePatterns, "sort_order")?.sort_order
   );
 
-const isNoncanonicalAndNoDepartures = (
-  routePatterns: RoutePatternWithPolyline[],
-  departures: DepartureInfo[]
-): boolean => {
-  const isNonCanonical = !routePatterns.find(rp => !!rp.canonical);
-  return isNonCanonical && departures.length === 0;
-};
-
 // eslint-disable-next-line import/prefer-default-export
-export { sortedGroupedRoutePatterns, isNoncanonicalAndNoDepartures };
+export { sortedGroupedRoutePatterns };

--- a/apps/site/assets/ts/models/route-patterns.ts
+++ b/apps/site/assets/ts/models/route-patterns.ts
@@ -1,4 +1,8 @@
-import { GroupedRoutePatterns } from "../stop/stop-redesign-loader";
+import {
+  GroupedRoutePatterns,
+  RoutePatternWithPolyline
+} from "../stop/stop-redesign-loader";
+import { DepartureInfo } from "./departureInfo";
 
 type RoutePatternGroup = GroupedRoutePatterns[keyof GroupedRoutePatterns];
 export type RoutePatternGroupEntries = [
@@ -21,5 +25,13 @@ const sortedGroupedRoutePatterns = (
   });
 };
 
+const isNoncanonicalAndNoDepartures = (
+  routePatterns: RoutePatternWithPolyline[],
+  departures: DepartureInfo[]
+): boolean => {
+  const isNonCanonical = !routePatterns.find(rp => !!rp.canonical);
+  return isNonCanonical && departures.length === 0;
+};
+
 // eslint-disable-next-line import/prefer-default-export
-export { sortedGroupedRoutePatterns };
+export { sortedGroupedRoutePatterns, isNoncanonicalAndNoDepartures };

--- a/apps/site/assets/ts/models/route-patterns.ts
+++ b/apps/site/assets/ts/models/route-patterns.ts
@@ -1,7 +1,20 @@
 import { minBy, sortBy } from "lodash";
-import { GroupedRoutePatterns } from "../stop/stop-redesign-loader";
+import { DirectionId, Route, RoutePattern } from "../__v3api";
+import { Polyline } from "../leaflet/components/__mapdata";
 
-type RoutePatternGroup = GroupedRoutePatterns[keyof GroupedRoutePatterns];
+export interface RoutePatternWithPolyline
+  extends Omit<RoutePattern, "representative_trip_polyline"> {
+  representative_trip_polyline: Polyline;
+}
+type RoutePatternGroup = Record<
+  RoutePattern["headsign"],
+  {
+    direction_id: DirectionId;
+    route_patterns: RoutePatternWithPolyline[];
+  }
+>;
+export type GroupedRoutePatterns = Record<Route["id"], RoutePatternGroup>;
+
 export type RoutePatternGroupEntries = [
   keyof RoutePatternGroup,
   RoutePatternGroup[keyof RoutePatternGroup]

--- a/apps/site/assets/ts/models/route-patterns.ts
+++ b/apps/site/assets/ts/models/route-patterns.ts
@@ -1,3 +1,4 @@
+import { minBy, sortBy } from "lodash";
 import {
   GroupedRoutePatterns,
   RoutePatternWithPolyline
@@ -13,17 +14,12 @@ export type RoutePatternGroupEntries = [
 // sort headsigns to reflect the route pattern's sort_order
 const sortedGroupedRoutePatterns = (
   groupedByHeadsign: RoutePatternGroup
-): RoutePatternGroupEntries => {
-  return Object.entries(groupedByHeadsign).sort((entryA, entryB) => {
-    const [orderA, orderB] = [
-      entryA,
-      entryB
-    ].map(([, { route_patterns: routePatterns }]) =>
-      Math.min(...routePatterns.map(rp => rp.sort_order))
-    );
-    return orderA - orderB;
-  });
-};
+): RoutePatternGroupEntries =>
+  sortBy(
+    Object.entries(groupedByHeadsign),
+    ([, { route_patterns: routePatterns }]) =>
+      minBy(routePatterns, "sort_order")?.sort_order
+  );
 
 const isNoncanonicalAndNoDepartures = (
   routePatterns: RoutePatternWithPolyline[],

--- a/apps/site/assets/ts/schedule/components/__tests__/ScheduleFinderTest.tsx
+++ b/apps/site/assets/ts/schedule/components/__tests__/ScheduleFinderTest.tsx
@@ -149,7 +149,8 @@ const routePatternsByDirection = {
       headsign: "Wachusett",
       id: "CR-Fitchburg-0-0",
       direction_id: 0,
-      sort_order: 3
+      sort_order: 3,
+      canonical: false
     }
   ],
   "1": [
@@ -166,7 +167,8 @@ const routePatternsByDirection = {
       headsign: "North Station",
       id: "CR-Fitchburg-0-1",
       direction_id: 1,
-      sort_order: 4
+      sort_order: 4,
+      canonical: false
     }
   ]
 } as RoutePatternsByDirection;

--- a/apps/site/assets/ts/schedule/components/__tests__/test-data/routePatternsByDirectionData.json
+++ b/apps/site/assets/ts/schedule/components/__tests__/test-data/routePatternsByDirectionData.json
@@ -18,7 +18,8 @@
       "headsign": "Pattern 1",
       "id": "pattern-1",
       "direction_id": 0,
-      "sort_order": 123
+      "sort_order": 123,
+      "canonical": false
     },
     {
       "typicality": 1,
@@ -38,7 +39,8 @@
       "headsign": "Pattern 3",
       "id": "pattern-3",
       "direction_id": 0,
-      "sort_order": 123
+      "sort_order": 123,
+      "canonical": false
     },
     {
       "typicality": 3,
@@ -58,7 +60,8 @@
       "headsign": "Pattern 3",
       "id": "pattern-4",
       "direction_id": 0,
-      "sort_order": 123
+      "sort_order": 123,
+      "canonical": false
     }
   ],
   "1": [
@@ -80,7 +83,8 @@
       "headsign": "Pattern 2",
       "id": "pattern-2",
       "direction_id": 1,
-      "sort_order": 123
+      "sort_order": 123,
+      "canonical": false
     }
   ]
 }

--- a/apps/site/assets/ts/schedule/components/direction/__tests__/BusMenuTest.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/__tests__/BusMenuTest.tsx
@@ -24,7 +24,8 @@ const routePatterns: EnhancedRoutePattern[] = [
     shape_priority: 1,
     time_desc: null,
     typicality: 1,
-    sort_order: 5
+    sort_order: 5,
+    canonical: false
   },
   {
     typicality: 3,
@@ -39,7 +40,8 @@ const routePatterns: EnhancedRoutePattern[] = [
     id: "66-B-0",
     headsign: "Watertown Yard via Union Square Allston",
     direction_id: 0,
-    sort_order: 7
+    sort_order: 7,
+    canonical: false
   }
 ];
 const singleRoutePattern = routePatterns.slice(0, 1);

--- a/apps/site/assets/ts/schedule/components/direction/__tests__/reducer-test.tsx
+++ b/apps/site/assets/ts/schedule/components/direction/__tests__/reducer-test.tsx
@@ -16,7 +16,8 @@ const routePatternsForInbound: EnhancedRoutePattern[] = [
     shape_priority: 1,
     time_desc: null,
     typicality: 1,
-    sort_order: 1
+    sort_order: 1,
+    canonical: false
   },
   {
     direction_id: 1,
@@ -31,7 +32,8 @@ const routePatternsForInbound: EnhancedRoutePattern[] = [
     shape_priority: 1,
     time_desc: "Weekdays only",
     typicality: 2,
-    sort_order: 2
+    sort_order: 2,
+    canonical: false
   }
 ];
 
@@ -58,7 +60,8 @@ const initialState: State = {
     shape_id: "1110180",
     time_desc: null,
     typicality: 1,
-    sort_order: 3
+    sort_order: 3,
+    canonical: false
   },
   directionId: 0,
   routePatternsByDirection: {
@@ -90,7 +93,8 @@ it("menuReducer handles 'toggleDirection'", () => {
       shape_priority: 1,
       time_desc: null,
       typicality: 1,
-      sort_order: 1
+      sort_order: 1,
+      canonical: false
     }
   };
 

--- a/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -6,7 +6,7 @@ import { baseRoute, renderWithRouter, TEST_LOADER_VALUE } from "./helpers";
 import { DepartureInfo } from "../../models/departureInfo";
 
 const testRoute = baseRoute(Object.keys(TEST_LOADER_VALUE)[0], 3);
-const routePatternsByHeadsign = Object.entries(TEST_LOADER_VALUE[testRoute.id]);
+const routePatternsByHeadsign = TEST_LOADER_VALUE[testRoute.id];
 
 describe("DepartureCard", () => {
   afterEach(cleanup);
@@ -126,7 +126,7 @@ describe("DepartureCard", () => {
 
     const departures = [] as DepartureInfo[];
     const route = baseRoute("Red", 1);
-    const routePatterns = Object.entries(TEST_LOADER_VALUE["Red"]);
+    const routePatterns = TEST_LOADER_VALUE["Red"];
     renderWithRouter(
       <DepartureCard
         route={route}

--- a/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -4,9 +4,21 @@ import DepartureCard from "../components/DepartureCard";
 import { Alert, RouteType } from "../../__v3api";
 import { baseRoute, renderWithRouter, TEST_LOADER_VALUE } from "./helpers";
 import { DepartureInfo } from "../../models/departureInfo";
+import { update } from "lodash";
+import { RoutePatternWithPolyline } from "../../models/route-patterns";
 
 const testRoute = baseRoute(Object.keys(TEST_LOADER_VALUE)[0], 3);
 const routePatternsByHeadsign = TEST_LOADER_VALUE[testRoute.id];
+
+// give all canonical: true route patterns to avoid rendering empty cards
+for (const h of Object.keys(routePatternsByHeadsign)) {
+  update(routePatternsByHeadsign, `${h}.route_patterns`, route_patterns =>
+    route_patterns.map((rp: RoutePatternWithPolyline) => ({
+      ...rp,
+      canonical: true
+    }))
+  );
+}
 
 describe("DepartureCard", () => {
   afterEach(cleanup);

--- a/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -6,7 +6,7 @@ import { baseRoute, renderWithRouter, TEST_LOADER_VALUE } from "./helpers";
 import { DepartureInfo } from "../../models/departureInfo";
 
 const testRoute = baseRoute(Object.keys(TEST_LOADER_VALUE)[0], 3);
-const routePatternsByHeadsign = TEST_LOADER_VALUE[testRoute.id];
+const routePatternsByHeadsign = Object.entries(TEST_LOADER_VALUE[testRoute.id]);
 
 describe("DepartureCard", () => {
   afterEach(cleanup);
@@ -126,7 +126,7 @@ describe("DepartureCard", () => {
 
     const departures = [] as DepartureInfo[];
     const route = baseRoute("Red", 1);
-    const routePatterns = TEST_LOADER_VALUE["Red"];
+    const routePatterns = Object.entries(TEST_LOADER_VALUE["Red"]);
     renderWithRouter(
       <DepartureCard
         route={route}

--- a/apps/site/assets/ts/stop/__tests__/DeparturesAndMapShuttleTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/DeparturesAndMapShuttleTest.tsx
@@ -97,7 +97,8 @@ const groupedRoutePatterns = {
           direction_id: 1,
           representative_trip_polyline: {
             id: "1"
-          }
+          },
+          canonical: false
         }
       ]
     }
@@ -113,7 +114,8 @@ const groupedRoutePatterns = {
           direction_id: 1,
           representative_trip_polyline: {
             id: "2"
-          }
+          },
+          canonical: false
         }
       ]
     },
@@ -127,7 +129,8 @@ const groupedRoutePatterns = {
           direction_id: 1,
           representative_trip_polyline: {
             id: "3"
-          }
+          },
+          canonical: false
         }
       ]
     }
@@ -146,7 +149,8 @@ const groupedRapidTransitRoutePatterns = {
           direction_id: 1,
           representative_trip_polyline: {
             id: "1"
-          }
+          },
+          canonical: false
         }
       ]
     }
@@ -162,7 +166,8 @@ const groupedRapidTransitRoutePatterns = {
           direction_id: 1,
           representative_trip_polyline: {
             id: "2"
-          }
+          },
+          canonical: true
         }
       ]
     }

--- a/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
+++ b/apps/site/assets/ts/stop/__tests__/StopPageRedesignTest.tsx
@@ -24,7 +24,7 @@ const renderWithAct = (children: React.ReactElement) =>
     renderWithRouter(children);
   });
 
-const testRoutes = Object.keys(TEST_LOADER_VALUE).map(id => baseRoute(id, 1));
+const testRoutes = Object.keys(TEST_LOADER_VALUE).map(id => baseRoute(id, 3));
 
 describe("StopPageRedesign", () => {
   beforeEach(() => {

--- a/apps/site/assets/ts/stop/__tests__/helpers.tsx
+++ b/apps/site/assets/ts/stop/__tests__/helpers.tsx
@@ -16,7 +16,7 @@ import { render } from "@testing-library/react";
 import {
   GroupedRoutePatterns,
   RoutePatternWithPolyline
-} from "../stop-redesign-loader";
+} from "../../models/route-patterns";
 
 export const newLatOrLon = (): number => +faker.string.numeric(2);
 const newPosition = (): [number, number] => [newLatOrLon(), newLatOrLon()];

--- a/apps/site/assets/ts/stop/__tests__/helpers.tsx
+++ b/apps/site/assets/ts/stop/__tests__/helpers.tsx
@@ -77,7 +77,8 @@ const customRoutePattern = (
     representative_trip_polyline: {
       ...newPolyline(),
       id: `${routePatternId}--shape`
-    }
+    },
+    canonical: route_id === "Red"
   } as RoutePatternWithPolyline;
 };
 const makeRoutePatternList = (

--- a/apps/site/assets/ts/stop/components/DepartureCard.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureCard.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from "react";
+import React, { ReactElement } from "react";
 import { Alert, Route } from "../../__v3api";
 import { routeName, routeToModeIcon } from "../../helpers/route-headers";
 import { routeBgClass } from "../../helpers/css";
@@ -10,6 +10,7 @@ import { departureInfoInRoutePatterns } from "../../helpers/departureInfo";
 import { isACommuterRailRoute } from "../../models/route";
 import DepartureTimes from "./DepartureTimes";
 import { GroupedRoutePatterns } from "../stop-redesign-loader";
+import { sortedGroupedRoutePatterns } from "../../models/route-patterns";
 
 const DepartureCard = ({
   alertsForRoute,
@@ -23,19 +24,8 @@ const DepartureCard = ({
   route: Route;
 }): ReactElement<HTMLElement> => {
   const { setRow } = useDepartureRow([route]);
-  // sort headsigns to reflect the route pattern's sort_order
-  const sortedRoutePatternsByHeadsign = useMemo(
-    () =>
-      Object.entries(routePatternsByHeadsign).sort((entryA, entryB) => {
-        const [orderA, orderB] = [
-          entryA,
-          entryB
-        ].map(([, { route_patterns: routePatterns }]) =>
-          Math.min(...routePatterns.map(rp => rp.sort_order))
-        );
-        return orderA - orderB;
-      }),
-    [routePatternsByHeadsign]
+  const sortedRoutePatternsByHeadsign = sortedGroupedRoutePatterns(
+    routePatternsByHeadsign
   );
 
   return (

--- a/apps/site/assets/ts/stop/components/DepartureCard.tsx
+++ b/apps/site/assets/ts/stop/components/DepartureCard.tsx
@@ -9,8 +9,7 @@ import { allAlertsForDirection } from "../../models/alert";
 import { departureInfoInRoutePatterns } from "../../helpers/departureInfo";
 import { isACommuterRailRoute } from "../../models/route";
 import DepartureTimes from "./DepartureTimes";
-import { GroupedRoutePatterns } from "../stop-redesign-loader";
-import { sortedGroupedRoutePatterns } from "../../models/route-patterns";
+import { RoutePatternGroupEntries } from "../../models/route-patterns";
 
 const DepartureCard = ({
   alertsForRoute,
@@ -20,13 +19,10 @@ const DepartureCard = ({
 }: {
   alertsForRoute: Alert[];
   departuresForRoute: DepartureInfo[];
-  routePatternsByHeadsign: GroupedRoutePatterns[keyof GroupedRoutePatterns];
+  routePatternsByHeadsign: RoutePatternGroupEntries;
   route: Route;
 }): ReactElement<HTMLElement> => {
   const { setRow } = useDepartureRow([route]);
-  const sortedRoutePatternsByHeadsign = sortedGroupedRoutePatterns(
-    routePatternsByHeadsign
-  );
 
   return (
     <li className="departure-card">
@@ -38,7 +34,7 @@ const DepartureCard = ({
         {renderSvg("c-svg__icon", routeToModeIcon(route), true)}{" "}
         {routeName(route)}
       </a>
-      {sortedRoutePatternsByHeadsign.map(
+      {routePatternsByHeadsign.map(
         ([
           headsign,
           { direction_id: directionId, route_patterns: routePatterns }

--- a/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
@@ -31,8 +31,8 @@ import {
   routeWideAlerts
 } from "../../models/alert";
 import useDepartureRow from "../../hooks/useDepartureRow";
-import { GroupedRoutePatterns } from "../stop-redesign-loader";
 import { DepartureInfo } from "../../models/departureInfo";
+import { GroupedRoutePatterns } from "../../models/route-patterns";
 
 interface DeparturesAndMapProps {
   routes: Route[];

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -10,11 +10,11 @@ import {
 import DepartureCard from "./DepartureCard";
 import { alertsByRoute, isInNextXDays } from "../../models/alert";
 import { DepartureInfo } from "../../models/departureInfo";
-import { GroupedRoutePatterns } from "../stop-redesign-loader";
 import {
-  isNoncanonicalAndNoDepartures,
-  sortedGroupedRoutePatterns
-} from "../../models/route-patterns";
+  GroupedRoutePatterns,
+  RoutePatternWithPolyline
+} from "../stop-redesign-loader";
+import { sortedGroupedRoutePatterns } from "../../models/route-patterns";
 import { departureInfoInRoutePatterns } from "../../helpers/departureInfo";
 
 interface StopPageDeparturesProps {
@@ -33,6 +33,14 @@ const modeSortFn = ({ type }: Route): number => {
     return 2;
   }
   return type;
+};
+
+const isNoncanonicalAndNoDepartures = (
+  routePatterns: RoutePatternWithPolyline[],
+  departures: DepartureInfo[]
+): boolean => {
+  const isNonCanonical = !routePatterns.find(rp => !!rp.canonical);
+  return isNonCanonical && departures.length === 0;
 };
 
 const StopPageDepartures = ({

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -1,21 +1,12 @@
-import { filter, groupBy, reject, sortBy } from "lodash";
+import { filter, groupBy, sortBy } from "lodash";
 import React, { ReactElement, useState } from "react";
 import { Alert, Route } from "../../__v3api";
 import DeparturesFilters, { ModeChoice } from "./DeparturesFilters";
-import {
-  isRailReplacementBus,
-  isSubwayRoute,
-  modeForRoute
-} from "../../models/route";
+import { isRailReplacementBus, modeForRoute } from "../../models/route";
 import DepartureCard from "./DepartureCard";
 import { alertsByRoute, isInNextXDays } from "../../models/alert";
 import { DepartureInfo } from "../../models/departureInfo";
-import {
-  GroupedRoutePatterns,
-  RoutePatternWithPolyline,
-  sortedGroupedRoutePatterns
-} from "../../models/route-patterns";
-import { departureInfoInRoutePatterns } from "../../helpers/departureInfo";
+import { GroupedRoutePatterns } from "../../models/route-patterns";
 
 interface StopPageDeparturesProps {
   routes: Route[];
@@ -33,14 +24,6 @@ const modeSortFn = ({ type }: Route): number => {
     return 2;
   }
   return type;
-};
-
-const isNoncanonicalAndNoDepartures = (
-  routePatterns: RoutePatternWithPolyline[],
-  departures: DepartureInfo[]
-): boolean => {
-  const isNonCanonical = !routePatterns.find(rp => !!rp.canonical);
-  return isNonCanonical && departures.length === 0;
 };
 
 const StopPageDepartures = ({
@@ -70,40 +53,17 @@ const StopPageDepartures = ({
         />
       )}
       <ul className="stop-departures list-unstyled">
-        {sortBy(filteredRoutes, [modeSortFn, "sort_order"]).map(route => {
-          const groupedByHeadsign = groupedRoutePatterns[route.id];
-          let sortedRoutePatternsByHeadsign = sortedGroupedRoutePatterns(
-            groupedByHeadsign
-          );
-          const departuresForRoute = departureInfos.filter(
-            d => d.route.id === route.id
-          );
-          if (isSubwayRoute(route)) {
-            // remove certain headsigns based on route pattern and departures
-            sortedRoutePatternsByHeadsign = reject(
-              sortedRoutePatternsByHeadsign,
-              entry => {
-                const [, { route_patterns: routePatterns }] = entry;
-                const departures = departuresForRoute.filter(d =>
-                  departureInfoInRoutePatterns(d, routePatterns)
-                );
-                return isNoncanonicalAndNoDepartures(routePatterns, departures);
-              }
-            );
-            // don't render a route card if there's no headsigns left to show
-            if (sortedRoutePatternsByHeadsign.length === 0) return null;
-          }
-
-          return (
-            <DepartureCard
-              key={route.id}
-              route={route}
-              routePatternsByHeadsign={sortedRoutePatternsByHeadsign}
-              alertsForRoute={groupedAlerts[route.id] || []}
-              departuresForRoute={departuresForRoute}
-            />
-          );
-        })}
+        {sortBy(filteredRoutes, [modeSortFn, "sort_order"]).map(route => (
+          <DepartureCard
+            key={route.id}
+            route={route}
+            routePatternsByHeadsign={groupedRoutePatterns[route.id]}
+            alertsForRoute={groupedAlerts[route.id] || []}
+            departuresForRoute={departureInfos.filter(
+              d => d.route.id === route.id
+            )}
+          />
+        ))}
       </ul>
     </div>
   );

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -7,6 +7,7 @@ import DepartureCard from "./DepartureCard";
 import { alertsByRoute, isInNextXDays } from "../../models/alert";
 import { DepartureInfo } from "../../models/departureInfo";
 import { GroupedRoutePatterns } from "../stop-redesign-loader";
+import { sortedGroupedRoutePatterns } from "../../models/route-patterns";
 
 interface StopPageDeparturesProps {
   routes: Route[];
@@ -55,11 +56,14 @@ const StopPageDepartures = ({
       <ul className="stop-departures list-unstyled">
         {sortBy(filteredRoutes, [modeSortFn, "sort_order"]).map(route => {
           const groupedByHeadsign = groupedRoutePatterns[route.id];
+          const sortedRoutePatternsByHeadsign = sortedGroupedRoutePatterns(
+            groupedByHeadsign
+          );
           return (
             <DepartureCard
               key={route.id}
               route={route}
-              routePatternsByHeadsign={groupedByHeadsign}
+              routePatternsByHeadsign={sortedRoutePatternsByHeadsign}
               alertsForRoute={groupedAlerts[route.id] || []}
               departuresForRoute={departureInfos.filter(
                 d => d.route.id === route.id

--- a/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageDepartures.tsx
@@ -12,9 +12,9 @@ import { alertsByRoute, isInNextXDays } from "../../models/alert";
 import { DepartureInfo } from "../../models/departureInfo";
 import {
   GroupedRoutePatterns,
-  RoutePatternWithPolyline
-} from "../stop-redesign-loader";
-import { sortedGroupedRoutePatterns } from "../../models/route-patterns";
+  RoutePatternWithPolyline,
+  sortedGroupedRoutePatterns
+} from "../../models/route-patterns";
 import { departureInfoInRoutePatterns } from "../../helpers/departureInfo";
 
 interface StopPageDeparturesProps {

--- a/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
+++ b/apps/site/assets/ts/stop/components/StopPageRedesign.tsx
@@ -18,7 +18,7 @@ import {
 } from "../../models/alert";
 import { FetchStatus } from "../../helpers/use-fetch";
 import { Alert } from "../../__v3api";
-import { GroupedRoutePatterns } from "../stop-redesign-loader";
+import { GroupedRoutePatterns } from "../../models/route-patterns";
 
 const isStopPageAlert = ({ effect }: Alert): boolean =>
   [

--- a/apps/site/assets/ts/stop/stop-redesign-loader.tsx
+++ b/apps/site/assets/ts/stop/stop-redesign-loader.tsx
@@ -9,24 +9,8 @@ import { ErrorBoundary } from "@sentry/react";
 import StopPageRedesign from "./components/StopPageRedesign";
 import Loading from "../components/Loading";
 import ErrorPage from "../components/ErrorPage";
-import { DirectionId, RoutePattern } from "../__v3api";
 import { fetchJson, isFetchFailed } from "../helpers/fetch-json";
-import { Polyline } from "../leaflet/components/__mapdata";
-
-export interface RoutePatternWithPolyline
-  extends Omit<RoutePattern, "representative_trip_polyline"> {
-  representative_trip_polyline: Polyline;
-}
-export type GroupedRoutePatterns = Record<
-  string,
-  Record<
-    string,
-    {
-      direction_id: DirectionId;
-      route_patterns: RoutePatternWithPolyline[];
-    }
-  >
->;
+import { GroupedRoutePatterns } from "../models/route-patterns";
 
 const fetchStopRoutePatterns = async (
   stopId: string


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Omit uncommon Green Line branches/headsigns with no upcoming service](https://app.asana.com/0/385363666817452/1205743915866207/f)

There are a couple extra commits because our code wasn't using the V3 API's `canonical` attribute for route patterns. Most of this PR's file changes are due to this.

The main part of this PR, in the final commit, checks the `canonical` value for subway route patterns against the list of departures to determine whether to hide a specific headsign. Additionally, if all the headsigns for a given route card end up hidden, the route card itself will also be hidden.

**Before and After:**

![image](https://github.com/mbta/dotcom/assets/2136286/f6bc7231-2a74-4f52-b995-e0ca7039909d)

In the early morning when the other Green Line branches run trains this way, those schedules/predictions _should_ show up on this page, though I haven't captured a screenshot for this yet.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.