### PR TITLE
hotfix(autocomplete): use separate panelContainer

### DIFF
--- a/apps/site/assets/css/_autocomplete-theme.scss
+++ b/apps/site/assets/css/_autocomplete-theme.scss
@@ -1,131 +1,137 @@
 @import '@algolia/autocomplete-theme-classic';
 
+.aa-Autocomplete {
+  --aa-icon-color-rgb: 22, 92, 150; // $brand-primary;
+  --aa-primary-color-rgb: 22, 92, 150; // $brand-primary;
+  --aa-search-input-height: 2.25rem;
+}
+
 // right now #header-desktop is the only search using the new library, so it's
 // the only one styled here. the #header-desktop can be removed once we migrate
 // the rest over
-.c-search-bar__autocomplete#header-desktop {
-  .aa-Autocomplete {
-    --aa-icon-color-rgb: 22, 92, 150; // $brand-primary;
-    --aa-primary-color-rgb: 22, 92, 150; // $brand-primary;
-    --aa-search-input-height: 2.25rem;
-  }
-
-  .aa-Item {
-    @include icon-size-inline(1em);
-    border-bottom: $border;
-    border-radius: 0;
-    font-weight: normal;
-
-    &:hover {
-      background-color: $brand-primary-lightest;
+#header-desktop {
+  .c-search-bar__autocomplete {
+    .aa-Label {
+      margin-bottom: unset;
     }
 
-    em {
-      font-style: inherit;
-      font-weight: bold;
+    .aa-Input {
+      // stylelint-disable-next-line declaration-no-important
+      height: var(--aa-search-input-height) !important;
     }
 
-    > a,
-    > button {
-      color: currentColor;
-      display: flex;
-      font-weight: inherit;
-      gap: .25rem;
-      min-width: 0;
-      padding: calc(#{$base-spacing} / 2) $base-spacing;
+    .aa-InputWrapperPrefix {
+      order: 3; // move search icon to end.
     }
 
-    a:hover {
-      text-decoration: none;
+    .aa-InputWrapper {
+      order: 1;
+      padding-left: 1rem;
+    }
+
+    .aa-InputWrapperSuffix {
+      order: 2;
+    }
+
+    .aa-Form {
+      border: 3px solid $brand-primary;
+      border-radius: .5rem;
+
+      &:focus-within {
+        border-color: $brand-primary-lightest;
+        box-shadow: unset;
+      }
+    }
+
+    .aa-LoadingIndicator,
+    .aa-SubmitButton {
+      padding-left: var(--aa-spacing-half);
+      width: calc(var(--aa-spacing) * 1.25 + var(--aa-icon-size) - 1px);
+    }
+
+    .aa-ClearButton {
+      @include fa-icon-solid($fa-var-times-circle);
+      color: rgba(var(--aa-icon-color-rgb), var(--aa-icon-color-alpha));
+      padding-right: var(--aa-spacing-half);
+      // hide default icon
+      .aa-ClearIcon { display: none; }
+    }
+
+    .aa-SubmitButton {
+      @include fa-icon-solid($fa-var-search);
+      color: rgba(var(--aa-icon-color-rgb), var(--aa-icon-color-alpha));
+      // hide default icon
+      .aa-SubmitIcon { display: none; }
+    }
+
+    .aa-GradientBottom,
+    .aa-GradientTop { all: unset; }
+  }
+
+  .c-search-bar__autocomplete-results {
+    .aa-ItemContent {
+      mark {
+        padding: 0;
+      }
+      > * {
+        margin-right: .25rem;
+      }
+    }
+
+    .aa-ItemContentTitle {
+      display: unset;
+      margin: unset;
+      overflow: visible;
+      text-overflow: unset;
+      white-space: normal;
+    }
+
+    .aa-PanelLayout {
+      padding: unset;
+    }
+
+    .aa-Panel {
+      // stylelint-disable-next-line declaration-no-important
+      top: 3.25rem !important;
+      z-index: var(--aa-base-z-index);
+    }
+
+    .aa-Item {
+      border-bottom: $border;
+      border-radius: 0;
+      font-weight: normal;
+
+      &:hover {
+        background-color: $brand-primary-lightest;
+      }
+
+      em {
+        font-style: inherit;
+        font-weight: bold;
+      }
+
+      > a,
+      > button {
+        color: currentColor;
+        display: flex;
+        font-weight: inherit;
+        gap: .25rem;
+        min-width: 0;
+        padding: calc(#{$base-spacing} / 2) $base-spacing;
+      }
+
+      a:hover {
+        text-decoration: none;
+      }
+
+      [class*=c-svg__icon] {
+        width: 1em;
+      }
+    }
+
+    .aa-ItemContent,
+    .aa-ItemContentBody {
+      display: unset;
     }
   }
-
-  .aa-ItemContent,
-  .aa-ItemContentBody {
-    display: unset;
-  }
-
-  .aa-ItemContent {
-    mark {
-      padding: 0;
-    }
-    > * {
-      margin-right: .25rem;
-    }
-  }
-
-  .aa-ItemContentTitle {
-    display: unset;
-    margin: unset;
-    overflow: visible;
-    text-overflow: unset;
-    white-space: normal;
-  }
-
-  .aa-PanelLayout {
-    padding: unset;
-  }
-
-  .aa-Panel {
-    // stylelint-disable-next-line declaration-no-important
-    top: 3.25rem !important;
-    z-index: var(--aa-base-z-index);
-  }
-
-  .aa-Label {
-    margin-bottom: unset;
-  }
-
-  .aa-Input {
-    // stylelint-disable-next-line declaration-no-important
-    height: var(--aa-search-input-height) !important;
-  }
-
-  .aa-InputWrapperPrefix {
-    order: 3; // move search icon to end.
-  }
-
-  .aa-InputWrapper {
-    order: 1;
-    padding-left: 1rem;
-  }
-
-  .aa-InputWrapperSuffix {
-    order: 2;
-  }
-
-  .aa-Form {
-    border: 3px solid $brand-primary;
-    border-radius: .5rem;
-
-    &:focus-within {
-      border-color: $brand-primary-lightest;
-      box-shadow: unset;
-    }
-  }
-
-  .aa-LoadingIndicator,
-  .aa-SubmitButton {
-    padding-left: var(--aa-spacing-half);
-    width: calc(var(--aa-spacing) * 1.25 + var(--aa-icon-size) - 1px);
-  }
-
-  .aa-ClearButton {
-    @include fa-icon-solid($fa-var-times-circle);
-    color: rgba(var(--aa-icon-color-rgb), var(--aa-icon-color-alpha));
-    padding-right: var(--aa-spacing-half);
-    // hide default icon
-    .aa-ClearIcon { display: none; }
-  }
-
-  .aa-SubmitButton {
-    @include fa-icon-solid($fa-var-search);
-    color: rgba(var(--aa-icon-color-rgb), var(--aa-icon-color-alpha));
-    // hide default icon
-    .aa-SubmitIcon { display: none; }
-  }
-
-  .aa-GradientBottom,
-  .aa-GradientTop { all: unset; }
 }
-

--- a/apps/site/assets/ts/ui/__tests__/__snapshots__/autocomplete-test.ts.snap
+++ b/apps/site/assets/ts/ui/__tests__/__snapshots__/autocomplete-test.ts.snap
@@ -2,128 +2,140 @@
 
 exports[`Algolia v1 autocomplete matches snapshot 1`] = `
 <div
-  class="c-search-bar__autocomplete"
-  data-algolia="routes,stops,drupal"
-  data-geolocation=""
-  data-locations=""
   data-turbolinks-permanent=""
   id="test-autocomplete"
 >
+  
+   
   <div
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-labelledby="autocomplete-1-label"
-    class="aa-Autocomplete"
-    role="combobox"
+    class="c-search-bar__autocomplete"
+    data-algolia="routes,stops,drupal"
+    data-geolocation=""
+    data-locations=""
   >
-    <form
-      action=""
-      class="aa-Form"
-      novalidate=""
-      role="search"
+    <div
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-labelledby="label"
+      class="aa-Autocomplete"
+      role="combobox"
     >
-      <div
-        class="aa-InputWrapperPrefix"
+      <form
+        action=""
+        class="aa-Form"
+        novalidate=""
+        role="search"
       >
-        <label
-          class="aa-Label"
-          for="autocomplete-1-input"
-          id="autocomplete-1-label"
+        <div
+          class="aa-InputWrapperPrefix"
         >
-          <button
-            class="aa-SubmitButton"
-            title="Submit"
-            type="submit"
+          <label
+            class="aa-Label"
+            for="input"
+            id="label"
+          >
+            <button
+              class="aa-SubmitButton"
+              title="Submit"
+              type="submit"
+            >
+              <svg
+                class="aa-SubmitIcon"
+                fill="currentColor"
+                height="20"
+                viewBox="0 0 24 24"
+                width="20"
+              >
+                <path
+                  d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z"
+                />
+              </svg>
+            </button>
+          </label>
+          <div
+            class="aa-LoadingIndicator"
+            hidden=""
           >
             <svg
-              class="aa-SubmitIcon"
-              fill="currentColor"
+              class="aa-LoadingIcon"
               height="20"
-              viewBox="0 0 24 24"
+              viewBox="0 0 100 100"
               width="20"
             >
+              <circle
+                cx="50"
+                cy="50"
+                fill="none"
+                r="35"
+                stroke="currentColor"
+                stroke-dasharray="164.93361431346415 56.97787143782138"
+                stroke-width="6"
+              >
+                
+  
+                <animatetransform
+                  attributeName="transform"
+                  dur="1s"
+                  keyTimes="0;0.40;0.65;1"
+                  repeatCount="indefinite"
+                  type="rotate"
+                  values="0 50 50;90 50 50;180 50 50;360 50 50"
+                />
+                
+
+              </circle>
+            </svg>
+          </div>
+        </div>
+        <div
+          class="aa-InputWrapper"
+        >
+          <input
+            aria-autocomplete="both"
+            aria-labelledby="label"
+            autocapitalize="off"
+            autocomplete="off"
+            autocorrect="off"
+            class="aa-Input c-form__input-container"
+            enterkeyhint="search"
+            id="input"
+            maxlength="512"
+            placeholder="Search for routes, info, and more"
+            spellcheck="false"
+            type="search"
+          />
+        </div>
+        <div
+          class="aa-InputWrapperSuffix"
+        >
+          <button
+            class="aa-ClearButton"
+            hidden=""
+            title="Clear"
+            type="reset"
+          >
+            <svg
+              class="aa-ClearIcon"
+              fill="currentColor"
+              height="18"
+              viewBox="0 0 24 24"
+              width="18"
+            >
               <path
-                d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z"
+                d="M5.293 6.707l5.293 5.293-5.293 5.293c-0.391 0.391-0.391 1.024 0 1.414s1.024 0.391 1.414 0l5.293-5.293 5.293 5.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-5.293-5.293 5.293-5.293c0.391-0.391 0.391-1.024 0-1.414s-1.024-0.391-1.414 0l-5.293 5.293-5.293-5.293c-0.391-0.391-1.024-0.391-1.414 0s-0.391 1.024 0 1.414z"
               />
             </svg>
           </button>
-        </label>
-        <div
-          class="aa-LoadingIndicator"
-          hidden=""
-        >
-          <svg
-            class="aa-LoadingIcon"
-            height="20"
-            viewBox="0 0 100 100"
-            width="20"
-          >
-            <circle
-              cx="50"
-              cy="50"
-              fill="none"
-              r="35"
-              stroke="currentColor"
-              stroke-dasharray="164.93361431346415 56.97787143782138"
-              stroke-width="6"
-            >
-              
-  
-              <animatetransform
-                attributeName="transform"
-                dur="1s"
-                keyTimes="0;0.40;0.65;1"
-                repeatCount="indefinite"
-                type="rotate"
-                values="0 50 50;90 50 50;180 50 50;360 50 50"
-              />
-              
-
-            </circle>
-          </svg>
         </div>
-      </div>
-      <div
-        class="aa-InputWrapper"
-      >
-        <input
-          aria-autocomplete="both"
-          aria-labelledby="autocomplete-1-label"
-          autocapitalize="off"
-          autocomplete="off"
-          autocorrect="off"
-          class="aa-Input c-form__input-container"
-          enterkeyhint="search"
-          id="autocomplete-1-input"
-          maxlength="512"
-          placeholder="Search for routes, info, and more"
-          spellcheck="false"
-          type="search"
-        />
-      </div>
-      <div
-        class="aa-InputWrapperSuffix"
-      >
-        <button
-          class="aa-ClearButton"
-          hidden=""
-          title="Clear"
-          type="reset"
-        >
-          <svg
-            class="aa-ClearIcon"
-            fill="currentColor"
-            height="18"
-            viewBox="0 0 24 24"
-            width="18"
-          >
-            <path
-              d="M5.293 6.707l5.293 5.293-5.293 5.293c-0.391 0.391-0.391 1.024 0 1.414s1.024 0.391 1.414 0l5.293-5.293 5.293 5.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-5.293-5.293 5.293-5.293c0.391-0.391 0.391-1.024 0-1.414s-1.024-0.391-1.414 0l-5.293 5.293-5.293-5.293c-0.391-0.391-1.024-0.391-1.414 0s-0.391 1.024 0 1.414z"
-            />
-          </svg>
-        </button>
-      </div>
-    </form>
+      </form>
+    </div>
   </div>
+  
+    
+  <div
+    class="c-search-bar__autocomplete-results"
+  />
+  
+  
 </div>
 `;

--- a/apps/site/assets/ts/ui/__tests__/autocomplete-test.ts
+++ b/apps/site/assets/ts/ui/__tests__/autocomplete-test.ts
@@ -12,11 +12,14 @@ const body = `
   <div
     data-turbolinks-permanent
     id="test-autocomplete"
-    class="c-search-bar__autocomplete"
-    data-geolocation
-    data-locations
-    data-algolia="routes,stops,drupal"
-  ></div>
+  >
+   <div class="c-search-bar__autocomplete"
+      data-geolocation
+      data-locations
+      data-algolia="routes,stops,drupal"
+    ></div>
+    <div class="c-search-bar__autocomplete-results"></div>
+  </div>
   <div id="test-autocomplete-no-attributes"></div>
 `;
 
@@ -46,11 +49,9 @@ describe("Algolia v1 autocomplete", () => {
       "test-autocomplete-no-attributes"
     );
     expect(container).toBeDefined();
-    setupAlgoliaAutocomplete(container!);
-    const generatedAutocompleteSearchForm = within(container!).getByRole(
-      "search"
-    );
-    expect(generatedAutocompleteSearchForm).toBeDefined();
+    expect(() => {
+      setupAlgoliaAutocomplete(container!);
+    }).toThrowWithMessage(Error, "container needed");
   });
 
   it("doesn't instantiate with invalid container", () => {

--- a/apps/site/assets/ts/ui/autocomplete/index.ts
+++ b/apps/site/assets/ts/ui/autocomplete/index.ts
@@ -16,10 +16,18 @@ const reactRenderer = {
  * Creates the Algolia Autocomplete instances for various search experiences on
  * MBTA.com.
  */
-function setupAlgoliaAutocomplete(container: HTMLElement): void {
+function setupAlgoliaAutocomplete(wrapper: HTMLElement): void {
+  const container = wrapper.querySelector<HTMLElement>(
+    ".c-search-bar__autocomplete"
+  );
+  const panelContainer = wrapper.querySelector<HTMLElement>(
+    ".c-search-bar__autocomplete-results"
+  );
+  if (!container || !panelContainer) throw new Error("container needed");
   const options: AutocompleteOptions<Item> = {
+    id: container.id,
     container,
-    panelContainer: container,
+    panelContainer,
     detachedMediaQuery: "none",
     classNames: {
       input: "c-form__input-container"

--- a/apps/site/lib/site_web/components.ex
+++ b/apps/site/lib/site_web/components.ex
@@ -65,11 +65,15 @@ defmodule SiteWeb.Components do
       phx-hook="AlgoliaAutocomplete"
       data-turbolinks-permanent
       id={@id}
-      class="c-search-bar__autocomplete"
-      data-geolocation={@geolocation}
-      data-locations={@locations}
-      data-algolia={Enum.join(@valid_indexes, ",")}
-    />
+    >
+      <div
+        class="c-search-bar__autocomplete"
+        data-geolocation={@geolocation}
+        data-locations={@locations}
+        data-algolia={Enum.join(@valid_indexes, ",")}
+      />
+      <div class="c-search-bar__autocomplete-results" />
+    </div>
     """
   end
 end

--- a/apps/site/test/site_web/components_test.exs
+++ b/apps/site/test/site_web/components_test.exs
@@ -24,11 +24,16 @@ defmodule SiteWeb.ComponentsTest do
     end
 
     test "renders with AlgoliaAutocomplete hook and appropriate data attributes" do
-      assert render_component(
-               &algolia_autocomplete/1,
-               %{id: "testID", locations: true, algolia_indexes: [:stops, :routes]}
-             ) ==
-               ~s(<div phx-hook="AlgoliaAutocomplete" data-turbolinks-permanent id="testID" class="c-search-bar__autocomplete" data-locations data-algolia="routes,stops"></div>)
+      assert """
+             <div phx-hook="AlgoliaAutocomplete" data-turbolinks-permanent id="testID">
+               <div class="c-search-bar__autocomplete" data-locations data-algolia="routes,stops"></div>
+               <div class="c-search-bar__autocomplete-results"></div>
+             </div>
+             """ =~
+               render_component(
+                 &algolia_autocomplete/1,
+                 %{id: "testID", locations: true, algolia_indexes: [:stops, :routes]}
+               )
     end
   end
 end


### PR DESCRIPTION
this fixes a Safari bug where the tab order traps keyboard focus in between the autocomplete input and submit buttons. the bug only happened on Safari, when using the React renderer instead of the default Preact renderer.

some CSS refactoring was needed to target elements that are inside the new panelContainer element.


#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
Asana Ticket: [Can't tab past navbar search on macOS/Safari](https://app.asana.com/0/385363666817452/1205862370279606/f)