### PR TITLE
fix(DepartureList): better mobile fullheight view

### DIFF
--- a/apps/site/assets/css/_stop-card.scss
+++ b/apps/site/assets/css/_stop-card.scss
@@ -80,6 +80,14 @@ $radius: 4px;
 
   .back-to-routes + .stop-routes {
     grid-row: 2 / 3;
+
+    // on mobile, adopt a full-screen "app" view,
+    // this is the scrollable section
+    @include media-breakpoint-down(sm) {
+      overflow-y: scroll;
+      overscroll-behavior: contain;
+      -webkit-overflow-scrolling: touch;
+    }
   }
 
   .stop-map {
@@ -93,8 +101,10 @@ $radius: 4px;
     // with map above departure list
     @include media-breakpoint-down(sm) {
       bottom: 0;
-      display: block;
+      display: grid;
       left: 0;
+      gap: 0;
+      grid-template-rows: auto 1fr;
       padding-bottom: 0;
       padding-top: 0;
       position: fixed;
@@ -163,8 +173,8 @@ $radius: 4px;
   &--realtime {
     @extend .stop-departures;
     @include media-breakpoint-down(sm) {
-      height: unset;
-      max-height: 100vh;
+      max-height: unset;
+      overflow-y: unset;
     }
   }
 

--- a/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
+++ b/apps/site/assets/ts/stop/components/DeparturesAndMap.tsx
@@ -233,9 +233,9 @@ const DeparturesAndMap = ({
       className={`stop-routes-and-map ${activeRow ? "selected-departure" : ""}`}
     >
       {activeRow && BackToRoutes}
-      <div className="stop-routes">
+      <div ref={refEl} className="stop-routes">
         {activeRow ? (
-          <div ref={refEl} className="stop-departures--realtime">
+          <div className="stop-departures--realtime">
             <DepartureList
               route={activeRow.route}
               stop={stop}


### PR DESCRIPTION
Let the fixed positioning maintain the boundaries of this section, but give it a grid display and lay out the scrollable section as a scrollable grid item. This does end up moving the scrollable functionality from `.stop-departures--realtime` to its parent element.

I tested this out using the MacOS built-in Simulator application for an iPhone 14 Plus and iPhone 14 Pro. To me it looks like it no longer sliiiightly truncates the end of the departures list.

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Stop page | long departure lists should not be cut short on mobile](https://app.asana.com/0/385363666817452/1205822245998059/f)
