### PR TITLE
feat(ScheduleController): smaller schedules_for_stop response + logging

### DIFF
--- a/apps/site/lib/site_web/controllers/schedule_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule_controller.ex
@@ -63,6 +63,7 @@ defmodule SiteWeb.ScheduleController do
           data
           |> future_departures(conn, params)
           |> omit_last_stop_departures(params)
+          |> trim_response()
 
         case schedules do
           [%Schedule{} | _] ->
@@ -102,4 +103,12 @@ defmodule SiteWeb.ScheduleController do
   end
 
   defp omit_last_stop_departures(schedules, _), do: schedules
+
+  defp trim_response(schedules) do
+    schedules
+    |> Enum.map(&Map.drop(&1, [:stop]))
+    |> Enum.map(fn %Schedule{route: route} = schedule ->
+      %Schedule{schedule | route: Map.take(route, [:id])}
+    end)
+  end
 end

--- a/apps/site/lib/site_web/controllers/schedule_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule_controller.ex
@@ -64,7 +64,17 @@ defmodule SiteWeb.ScheduleController do
           |> future_departures(conn, params)
           |> omit_last_stop_departures(params)
 
-        json(conn, schedules)
+        case schedules do
+          [%Schedule{} | _] ->
+            json(conn, schedules)
+
+          _ ->
+            Logger.info(
+              "module=#{__MODULE__} fun=schedules_for_stop stop=#{stop_id} date_time=#{DateTime.to_string(date_time(conn.assigns))} no_schedules_returned"
+            )
+
+            json(conn, [])
+        end
     end
   end
 

--- a/apps/site/lib/site_web/controllers/schedule_controller.ex
+++ b/apps/site/lib/site_web/controllers/schedule_controller.ex
@@ -3,6 +3,8 @@ defmodule SiteWeb.ScheduleController do
   alias Routes.Route
   alias Schedules.Schedule
 
+  require Logger
+
   plug(SiteWeb.Plugs.Route when action not in [:schedules_for_stop])
 
   @spec show(Plug.Conn.t(), map) :: Phoenix.HTML.Safe.t()
@@ -47,20 +49,30 @@ defmodule SiteWeb.ScheduleController do
 
   @spec schedules_for_stop(Plug.Conn.t(), map) :: Plug.Conn.t()
   def schedules_for_stop(conn, %{"stop_id" => stop_id} = params) do
-    schedules =
-      Schedules.Repo.schedules_for_stop(stop_id, [])
-      |> future_departures(conn, params)
-      |> omit_last_stop_departures(params)
+    case Schedules.Repo.schedules_for_stop(stop_id, []) do
+      {:error, error} ->
+        _ =
+          Logger.error(
+            "module=#{__MODULE__} fun=schedules_for_stop stop=#{stop_id} date_time=#{DateTime.to_string(date_time(conn.assigns))} error=#{inspect(error)}"
+          )
 
-    json(conn, schedules)
+        SiteWeb.ControllerHelpers.return_internal_error(conn)
+
+      data ->
+        schedules =
+          data
+          |> future_departures(conn, params)
+          |> omit_last_stop_departures(params)
+
+        json(conn, schedules)
+    end
   end
 
+  defp date_time(%{"date_time" => date_time}), do: date_time
+  defp date_time(_), do: Util.now()
+
   defp future_departures(schedules, conn, %{"future_departures" => "true"}) do
-    now =
-      case conn.assigns do
-        %{"date_time" => date_time} -> date_time
-        _ -> Util.now()
-      end
+    now = date_time(conn.assigns)
 
     # Only list schedules with departure_time in the future
     schedules

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -401,5 +401,27 @@ defmodule SiteWeb.ScheduleControllerTest do
         assert Kernel.length(body) == 2
       end
     end
+
+    test "should report errors", %{conn: conn} do
+      with_mock(Schedules.Repo, [:passthrough],
+        schedules_for_stop: fn "TEST 1234", [] -> {:error, :not_found} end
+      ) do
+        log =
+          ExUnit.CaptureLog.capture_log(fn ->
+            conn = ScheduleController.schedules_for_stop(conn, %{"stop_id" => "TEST 1234"})
+
+            assert %{
+                     "error" => "Internal error"
+                   } = json_response(conn, 500)
+          end)
+
+        assert log =~ "[error] module=Elixir.SiteWeb.ScheduleController"
+        assert log =~ "fun=schedules_for_stop stop=TEST 1234"
+        assert log =~ "error=:not_found"
+      end
+    end
+
+      end
+    end
   end
 end

--- a/apps/site/test/site_web/controllers/schedule_controller_test.exs
+++ b/apps/site/test/site_web/controllers/schedule_controller_test.exs
@@ -307,11 +307,12 @@ defmodule SiteWeb.ScheduleControllerTest do
 
   describe "schedules_for_stop/2" do
     test "should return an array of schedules", %{conn: conn} do
-      with_mock(Schedules.Repo,
+      with_mock(Schedules.Repo, [:passthrough],
         schedules_for_stop: fn
           "TEST 1234", [] ->
             [
               %Schedules.Schedule{
+                route: %Routes.Route{id: "route"},
                 stop: %Stops.Stop{id: "TEST 1234"},
                 departure_time: ~U[2219-05-18 22:25:06.098765Z]
               }
@@ -324,24 +325,27 @@ defmodule SiteWeb.ScheduleControllerTest do
         conn = ScheduleController.schedules_for_stop(conn, %{"stop_id" => "TEST 1234"})
         body = json_response(conn, 200)
         assert Kernel.length(body) == 1
-        assert %{"stop" => %{"id" => "TEST 1234"}} = Enum.at(body, 0)
+        assert %{"departure_time" => "2219-05-18T22:25:06.098765Z"} = Enum.at(body, 0)
       end
     end
 
     test "should not return past schedules", %{conn: conn} do
-      with_mock(Schedules.Repo,
+      with_mock(Schedules.Repo, [:passthrough],
         schedules_for_stop: fn
           "TEST 1234", [] ->
             [
               %Schedules.Schedule{
+                route: %Routes.Route{id: "route"},
                 stop: %Stops.Stop{id: "TEST 1234"},
                 departure_time: ~U[2019-05-18 21:25:06.098765Z]
               },
               %Schedules.Schedule{
+                route: %Routes.Route{id: "route"},
                 stop: %Stops.Stop{id: "TEST 1234"},
                 departure_time: ~U[2219-05-18 22:25:06.098765Z]
               },
               %Schedules.Schedule{
+                route: %Routes.Route{id: "route"},
                 stop: %Stops.Stop{id: "TEST 1234"},
                 departure_time: ~U[2219-05-18 23:25:06.098765Z]
               }
@@ -359,27 +363,29 @@ defmodule SiteWeb.ScheduleControllerTest do
 
         body = json_response(conn, 200)
         assert Kernel.length(body) == 2
-        assert %{"stop" => %{"id" => "TEST 1234"}} = Enum.at(body, 0)
         assert %{"departure_time" => "2219-05-18T22:25:06.098765Z"} = Enum.at(body, 0)
       end
     end
 
     test "should not return schedules that are the last stop on its route", %{conn: conn} do
-      with_mock(Schedules.Repo,
+      with_mock(Schedules.Repo, [:passthrough],
         schedules_for_stop: fn
           "TEST 1234", [] ->
             [
               %Schedules.Schedule{
+                route: %Routes.Route{id: "route"},
                 stop: %Stops.Stop{id: "TEST 1234"},
                 departure_time: ~U[2219-05-18 22:25:06.098765Z],
                 last_stop?: false
               },
               %Schedules.Schedule{
+                route: %Routes.Route{id: "route"},
                 stop: %Stops.Stop{id: "TEST 1234"},
                 departure_time: ~U[2219-05-18 22:25:06.098765Z],
                 last_stop?: false
               },
               %Schedules.Schedule{
+                route: %Routes.Route{id: "route"},
                 stop: %Stops.Stop{id: "TEST 1234"},
                 departure_time: ~U[2219-05-18 22:25:06.098765Z],
                 last_stop?: true


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Stop pages intermittently missing Commuter Rail schedules](https://app.asana.com/0/385363666817452/1205814823003719/f)

I happened to be able to consistently reproduce the problem for a particular bus route on a particular stop on prod... but ultimately I never figured out a definitive cause for this. Splunk didn't reveal any errors. No network problems or console errors. I suspect that caching _might_ exacerbate the problem and cause the backend to return `[]` instead of re-trying within the cache `max_age` window. But still, ideally it wouldn't erroneously return `[]` in the first place.

This PR does 3 things:

1. Returns an error response if the `Schedules.Repo.schedules_for_stop/2` call returns `{:error, error}` value. An error will be logged in Splunk and the frontend would handle it by showing the error view with the bus gif.
2. Logs a message if the list of schedules returned happens to be empty. Just for informational/future debugging purposes should be issue persist and not be directly related to a `Schedules.Repo` error.
3. Dramatically reduces the size of the JSON response for `SiteWeb.ScheduleController.schedules_for_stop/2` in hopes of improving performance. It removes data that's not used on the frontend. 

Comparison for **Alewife Station** (`/api/stops/place-alfcl/schedules?last_stop_departures=false&future_departures=true`), using Chrome DevTools with no caching and "Fast 3G" network throttling setting:

|  | Before | After | **Difference**
| --- | --- | --- | --- |
|  Response size | 272 kB | 53.4 kB | **-80%** |
| Time | 2.49s | 885ms | **-64%** |


---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.