### PR TITLE
feat(OpenTripPlanner): add stop ID to response

### DIFF
--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner.ex
@@ -178,6 +178,9 @@ defmodule TripPlan.Api.OpenTripPlanner do
             lon
             departureTime
             arrivalTime
+            stop {
+              gtfsId
+            }
           }
           to {
             name
@@ -185,6 +188,9 @@ defmodule TripPlan.Api.OpenTripPlanner do
             lon
             departureTime
             arrivalTime
+            stop {
+              gtfsId
+            }
           }
           route {
             gtfsId

--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner/parser.ex
@@ -97,14 +97,25 @@ defmodule TripPlan.Api.OpenTripPlanner.Parser do
       start: parse_time(json["startTime"]),
       stop: parse_time(json["endTime"]),
       mode: parse_mode(json),
-      from: parse_named_position(json["from"], "stopId"),
-      to: parse_named_position(json["to"], "stopId"),
+      from: parse_named_position(json["from"], "stop"),
+      to: parse_named_position(json["to"], "stop"),
       polyline: json["legGeometry"]["points"],
       name: json["route"],
       long_name: json["routeLongName"],
       type: json["agencyId"],
       url: json["agencyUrl"],
       description: json["mode"]
+    }
+  end
+
+  def parse_named_position(json, "stop") do
+    stop = json["stop"]
+
+    %NamedPosition{
+      name: json["name"],
+      stop_id: if(stop, do: id_after_colon(stop["gtfsId"])),
+      longitude: json["lon"],
+      latitude: json["lat"]
     }
   end
 


### PR DESCRIPTION
Noticed the itineraries were no longer linking to intermediate stops, and that that was from the `%NamedPosition{}` always having a `nil` `stop_id`. 

Left is #1791 , right is on current dev - note hyperlinked stop names, attached alert icons.

<img width="797" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/e90cc6f2-0c10-4915-88f1-207f6af489b6">

This PR repopulates that value and fixes the result to show links and alert icons as before.

