### PR TITLE
fix(navigation): fix tab order and layout shift

### DIFF
--- a/apps/site/assets/css/_global-navigation.scss
+++ b/apps/site/assets/css/_global-navigation.scss
@@ -133,7 +133,7 @@ nav.m-menu--desktop {
 .m-menu--desktop__menu {
   background-color: $brand-primary-lightest-contrast;
   box-shadow: 0 7px 14px 0 $gray-shadow;
-  height: 0; // start off closed
+  display: none; // start off closed
   left: 0;
   overflow: hidden;
   position: absolute;
@@ -143,7 +143,7 @@ nav.m-menu--desktop {
 
   // opened
   .m-menu--desktop__toggle[aria-expanded='true'] + & {
-    height: initial;
+    display: initial;
   }
 }
 

--- a/apps/site/assets/css/_global-navigation.scss
+++ b/apps/site/assets/css/_global-navigation.scss
@@ -24,8 +24,9 @@ header {
 }
 
 [data-nav-open] {
-  body {
-    overflow: hidden; // prevent scrolling
+  .body-wrapper {
+    overflow: inherit; // same value as on body
+    position: relative; // so children elements using `position: absolute` are in the right place
   }
 
   .m-menu--cover {

--- a/apps/site/assets/ts/app/global-navigation.ts
+++ b/apps/site/assets/ts/app/global-navigation.ts
@@ -154,7 +154,6 @@ export function setup(rootElement: HTMLElement): void {
     if (aMenuIsBeingExpanded) {
       // eslint-disable-next-line no-param-reassign
       rootElement.dataset.navOpen = "true";
-      disableBodyScroll(header);
       if (observedDataAttributes.includes(TOGGLE_NAMES.mobile)) {
         // eslint-disable-next-line no-param-reassign
         header.dataset.navOpen = "true";
@@ -164,6 +163,7 @@ export function setup(rootElement: HTMLElement): void {
       } else if (observedDataAttributes.includes(TOGGLE_NAMES.search)) {
         // eslint-disable-next-line no-param-reassign
         header.dataset.searchOpen = "true";
+        disableBodyScroll(header);
       }
     } else {
       // only do this if no other menu is expanded
@@ -190,6 +190,26 @@ export function setup(rootElement: HTMLElement): void {
       aMenuIsBeingExpanded &&
       observedDataAttributes.includes(TOGGLE_NAMES.desktop)
     ) {
+      // Disable scrolling the page, but accomodate any visible scrollbars in
+      // order to avoid horizontal shift in the layout when scrolling becomes
+      // disabled. This additionally requires adjusting the width of the veil,
+      // to maintain a pleasing appearance.
+      disableBodyScroll(header, { reserveScrollBarGap: true });
+      const cover = rootElement.querySelector<HTMLElement>("[data-nav='veil']");
+      if (
+        cover &&
+        !cover.style.paddingRight &&
+        rootElement.dataset.navOpen === "true"
+      ) {
+        const body = rootElement.querySelector("body");
+        // this was added by { reserveScrollBarGap: true }
+        const paddingRight = body?.style.paddingRight;
+        if (paddingRight && paddingRight !== "") {
+          // add same 'padding' for veil by substracting from width
+          cover.style.width = `calc(100% - ${paddingRight})`;
+        }
+      }
+
       const thisMenu = mutations.map(({ target }) =>
         (target as Element).getAttribute("aria-controls")
       )[0];


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Address keyboard navigation issues with header navigation bar](https://app.asana.com/0/385363666817452/1205380245423065/f)
**Asana Ticket:** [Opening navbar dropdowns shifts whole page](https://app.asana.com/0/385363666817452/1205466554569829/f)

The first was addressed by changing a CSS property; setting `display: none` takes the element out of the accessibility tree, thus it's not reachable via tab key. 

The second needed the addition of `{ reserveScrollBarGap: true }` to the `disableBodyScroll` call, along with some CSS and JS hackery to get the expanded menu and the background grey cover to look decent.