### PR TITLE
feat(TripPlanner): Use Stop ID to query OTP

### DIFF
--- a/apps/site/assets/js/trip-planner-location-controls.js
+++ b/apps/site/assets/js/trip-planner-location-controls.js
@@ -22,6 +22,10 @@ export class TripPlannerLocControls {
     this.toLng = this.getById(TripPlannerLocControls.SELECTORS.to.lng);
     this.fromLat = this.getById(TripPlannerLocControls.SELECTORS.from.lat);
     this.fromLng = this.getById(TripPlannerLocControls.SELECTORS.from.lng);
+    this.fromStopId = this.getById(
+      TripPlannerLocControls.SELECTORS.from.stop_id
+    );
+    this.toStopId = this.getById(TripPlannerLocControls.SELECTORS.to.stop_id);
     this.controller = null;
     this.toInputDirty = false;
     this.fromInputDirty = false;
@@ -315,6 +319,7 @@ export class TripPlannerLocControls {
     }) => {
       switch (type) {
         case "stops":
+          this.setStopValue(ac, hit);
           this.setAutocompleteValue(
             ac,
             hit.stop.name,
@@ -342,6 +347,7 @@ export class TripPlannerLocControls {
           ac.useMyLocationSearch();
           break;
         case "popular":
+          this.setStopValue(ac, hit);
           this.setAutocompleteValue(
             ac,
             hit.name,
@@ -355,6 +361,13 @@ export class TripPlannerLocControls {
           console.error(`onHitSelected not implemented for ${type}.`);
       }
     };
+  }
+
+  setStopValue(ac, hit) {
+    if (hit.stop?.id) {
+      const stopIdEl = this.getById(ac._selectors.stop_id);
+      stopIdEl.value = hit.stop.id;
+    }
   }
 
   setAutocompleteValue(ac, name, latEl, lngEl, lat, lng) {
@@ -429,7 +442,8 @@ TripPlannerLocControls.SELECTORS = {
     locationLoadingIndicator: "trip-plan__loading-indicator--to",
     required: "trip-plan__required--to",
     locationError: "trip-plan__location-error--to",
-    announcer: "trip-plan__announcer--to"
+    announcer: "trip-plan__announcer--to",
+    stop_id: "to_stop_id"
   },
   from: {
     input: "from",
@@ -440,7 +454,8 @@ TripPlannerLocControls.SELECTORS = {
     locationLoadingIndicator: "trip-plan__loading-indicator--from",
     required: "trip-plan__required--from",
     locationError: "trip-plan__location-error--from",
-    announcer: "trip-plan__announcer--from"
+    announcer: "trip-plan__announcer--from",
+    stop_id: "from_stop_id"
   },
   map: "trip-plan-map--initial"
 };

--- a/apps/site/lib/site/trip_plan/location.ex
+++ b/apps/site/lib/site/trip_plan/location.ex
@@ -68,6 +68,7 @@ defmodule Site.TripPlan.Location do
     field = Atom.to_string(field_atom)
     {lat_bin, params} = Map.pop(params, field <> "_latitude")
     {lng_bin, params} = Map.pop(params, field <> "_longitude")
+    {stop_id, params} = Map.pop(params, field <> "_stop_id")
 
     with {lat, ""} <- Float.parse(lat_bin),
          {lng, ""} <- Float.parse(lng_bin) do
@@ -76,7 +77,8 @@ defmodule Site.TripPlan.Location do
       position = %NamedPosition{
         latitude: lat,
         longitude: lng,
-        name: encode_name(name)
+        name: encode_name(name),
+        stop_id: stop_id
       }
 
       query

--- a/apps/site/lib/site_web/templates/partial/_trip_planner_widget.html.eex
+++ b/apps/site/lib/site_web/templates/partial/_trip_planner_widget.html.eex
@@ -8,8 +8,8 @@
 
   from_error = ""
   to_error = ""
-  from_position = %{name: "", latitude: "", longitude: ""}
-  to_position = %{name: "", latitude: "", longitude: ""}
+  from_position = %{name: "", latitude: "", longitude: "", stop_id: ""}
+  to_position = %{name: "", latitude: "", longitude: "", stop_id: ""}
 
 %>
 <div class="c-trip-plan-widget">

--- a/apps/site/lib/site_web/templates/trip_plan/_to_from_inputs.html.eex
+++ b/apps/site/lib/site_web/templates/trip_plan/_to_from_inputs.html.eex
@@ -24,6 +24,7 @@
       ></input>
       <input id="from_latitude" name="plan[from_latitude]" type="hidden" value="<%= @from_position.latitude %>">
       <input id="from_longitude" name="plan[from_longitude]" type="hidden" value="<%= @from_position.longitude %>">
+      <input id="from_stop_id" name="plan[from_stop_id]" type="hidden" value="<%= @from_position.stop_id %>">
       <i aria-hidden="true" id="trip-plan__loading-indicator--from" class="fa fa-cog fa-spin c-search-bar__loading-indicator"></i>
       <i id="trip-plan__reset--from" class="c-form__reset-icon fa fa-times-circle"></i>
       <div id="trip-plan__announcer--from" aria-live="polite" class="sr-only"></div>
@@ -58,6 +59,7 @@
       ></input>
       <input id="to_latitude" name="plan[to_latitude]" type="hidden" value="<%= @to_position.latitude %>">
       <input id="to_longitude" name="plan[to_longitude]" type="hidden" value="<%= @to_position.longitude %>">
+      <input id="to_stop_id" name="plan[to_stop_id]" type="hidden" value="<%= @to_position.stop_id %>">
       <i aria-hidden="true" id="trip-plan__loading-indicator--to" class="fa fa-cog fa-spin c-search-bar__loading-indicator"></i>
       <i id="trip-plan__reset--to" class="c-form__reset-icon fa fa-times-circle"></i>
       <div id="trip-plan__announcer--to" aria-live="polite" class="sr-only"></div>

--- a/apps/site/test/site/trip_plan/location_test.exs
+++ b/apps/site/test/site/trip_plan/location_test.exs
@@ -8,6 +8,7 @@ defmodule Site.TripPlan.LocationTest do
       params = %{
         "to_latitude" => "42.5678",
         "to_longitude" => "-71.2345",
+        "to_stop_id" => "To_Id",
         "to" => "To Location"
       }
 
@@ -15,6 +16,7 @@ defmodule Site.TripPlan.LocationTest do
                to: %NamedPosition{
                  latitude: 42.5678,
                  longitude: -71.2345,
+                 stop_id: "To_Id",
                  name: "To Location"
                }
              }
@@ -53,6 +55,7 @@ defmodule Site.TripPlan.LocationTest do
       params = %{
         "from_latitude" => "42.5678",
         "from_longitude" => "-71.2345",
+        "from_stop_id" => "From_Id",
         "from" => "From Location"
       }
 
@@ -60,6 +63,7 @@ defmodule Site.TripPlan.LocationTest do
                from: %NamedPosition{
                  latitude: 42.5678,
                  longitude: -71.2345,
+                 stop_id: "From_Id",
                  name: "From Location"
                }
              }

--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner.ex
@@ -16,7 +16,7 @@ defmodule TripPlan.Api.OpenTripPlanner do
     with {:ok, params} <- build_params(from, to, opts) do
       param_string = Enum.map_join(params, "\n", fn {key, val} -> ~s{#{key}: #{val}} end)
 
-      graph_ql_query = """
+      graphql_query = """
       {
         plan(
           #{param_string}
@@ -28,7 +28,7 @@ defmodule TripPlan.Api.OpenTripPlanner do
       root_url = Keyword.get(opts, :root_url, nil) || pick_url(connection_opts)
       graphql_url = "#{root_url}/otp/routers/default/index/"
 
-      send_request(graphql_url, graph_ql_query, accessible?, &parse_ql/2)
+      send_request(graphql_url, graphql_query, accessible?, &parse_ql/2)
     end
   end
 

--- a/apps/trip_plan/lib/trip_plan/api/open_trip_planner/builder.ex
+++ b/apps/trip_plan/lib/trip_plan/api/open_trip_planner/builder.ex
@@ -20,6 +20,10 @@ defmodule TripPlan.Api.OpenTripPlanner.Builder do
     })
   end
 
+  defp location(%NamedPosition{stop_id: stop_id} = np) when not is_nil(stop_id) do
+    "\"#{np.name}::mbta-ma-us:#{stop_id}\""
+  end
+
   defp location(%NamedPosition{} = np) do
     "\"#{np.name}::#{Position.latitude(np)},#{Position.longitude(np)}\""
   end

--- a/apps/trip_plan/test/api/open_trip_planner/builder_test.exs
+++ b/apps/trip_plan/test/api/open_trip_planner/builder_test.exs
@@ -12,6 +12,16 @@ defmodule TripPlan.Api.OpenTripPlanner.BuilderTest do
     longitude: -71.0832908
   }
 
+  @from_stop %TripPlan.NamedPosition{
+    name: "FromStop",
+    stop_id: "From_Id"
+  }
+
+  @to_stop %TripPlan.NamedPosition{
+    name: "ToStop",
+    stop_id: "To_Id"
+  }
+
   describe "build_params/1" do
     test "depart_at sets date/time options" do
       expected =
@@ -154,6 +164,22 @@ defmodule TripPlan.Api.OpenTripPlanner.BuilderTest do
     test "bad options return an error" do
       expected = {:error, {:bad_param, {:bad, :arg}}}
       actual = build_params(@from_inside, @to_inside, bad: :arg)
+      assert expected == actual
+    end
+
+    test "use stop id from to/from location" do
+      expected = {
+        :ok,
+        %{
+          "fromPlace" => "\"FromStop::mbta-ma-us:From_Id\"",
+          "toPlace" => "\"ToStop::mbta-ma-us:To_Id\"",
+          "locale" => "\"en\"",
+          "transportModes" => "[{mode: WALK}, {mode: TRANSIT}]",
+          "walkReluctance" => 15
+        }
+      }
+
+      actual = build_params(@from_stop, @to_stop, [])
       assert expected == actual
     end
   end


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
This pull request allows us to query OTP using stop ids.  This is supposed to remove walking directions to get to the initial stop if the user is already assumed at the stop.

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Fix Trip planner origin and destinations](https://app.asana.com/0/home/1201123880594717/1205711841709226)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

