### PR TITLE
chore: add custom `ERL_FULLSWEEP_AFTER` value

### DIFF
--- a/rel/vm.args
+++ b/rel/vm.args
@@ -6,3 +6,6 @@
 
 # Enable SMP automatically based on availability
 -smp auto
+
+# Make GC run more often
+-env ERL_FULLSWEEP_AFTER 20


### PR DESCRIPTION
No ticket.

I was observing how our redesigned stop page increased our memory usage noticeably. One thing our stop page does that's new is maintain a connection to streaming predictions from the V3 API, and publish the streaming updates to subscribed channels via Phoenix PubSub.

![image](https://github.com/mbta/dotcom/assets/2136286/11fdbbdd-76aa-4c19-b2b5-5a5b4859d086)

Eventually I found a blog post[0] suggesting that maintaining long-lived connections to Phoenix Channels can result in higher memory usage than necessary, and that setting a smaller value for `ERL_FULLSWEEP_AFTER` can force the system to do a full-sweep garbage collection sooner. 

I do have some other optimizations planned in the next couple days, but I wanted to deploy this change in isolation so I can observe its effect.

[0]: [Using Phoenix Channels? High Memory Usage? Save Money With ERL_FULLSWEEP_AFTER](https://blog.guzman.codes/using-phoenix-channels-high-memory-usage-save-money-with-erlfullsweepafter)