### PR TITLE
fix(Holidays): Add recent and near-future dates

### DIFF
--- a/apps/holiday/lib/repo.ex
+++ b/apps/holiday/lib/repo.ex
@@ -57,18 +57,21 @@ end
 
 defmodule Holiday.Repo do
   import Holiday.Repo.Helpers
-  # from https://www.sec.state.ma.us/cis/cishol/holidx.htm
-  @start_year 2019
+  # from https://www.sec.state.ma.us/divisions/cis/holiday-info.htm
+  @start_year 2023
   @holidays [
               # { name, [{month, day}, {month, day}, ...]},
-              {"New Years Day", [{1, 1}, {1, 1}, {1, 1}]},
-              {"Martin Luther King Day", [{1, 21}, {1, 20}, {1, 18}]},
-              {"President’s Day", [{2, 18}, {2, 17}, {2, 15}]},
-              {"Patriots’ Day", [{4, 15}, {4, 20}, {4, 19}]},
-              {"Memorial Day", [{5, 27}, {5, 25}, {5, 31}]},
+              {"New Year’s Day", [{1, 1}, {1, 1}, {1, 1}]},
+              {"Martin Luther King, Jr. Day", [{1, 16}, {1, 15}, {1, 20}]},
+              {"Washington’s Birthday", [{2, 20}, {2, 19}, {2, 17}]},
+              {"Patriots’ Day", [{4, 17}, {4, 15}, {4, 21}]},
+              {"Memorial Day", [{5, 29}, {5, 27}, {5, 26}]},
+              {"Juneteenth Independence Day", [{6, 19}, {6, 19}, {6, 19}]},
               {"Independence Day", [{7, 4}, {7, 4}, {7, 4}]},
-              {"Labor Day", [{9, 2}, {9, 7}, {9, 6}]},
-              {"Thanksgiving Day", [{11, 28}, {11, 26}, {11, 25}]},
+              {"Labor Day", [{9, 4}, {9, 2}, {9, 1}]},
+              {"Columbus Day", [{10, 9}, {10, 14}, {10, 13}]},
+              {"Veterans Day", [{11, 11}, {11, 11}, {11, 11}]},
+              {"Thanksgiving Day", [{11, 23}, {11, 28}, {11, 27}]},
               {"Christmas Day", [{12, 25}, {12, 25}, {12, 25}]}
             ]
             |> Enum.flat_map(&make_holiday(&1, @start_year))

--- a/apps/holiday/test/repo_test.exs
+++ b/apps/holiday/test/repo_test.exs
@@ -12,22 +12,22 @@ defmodule Holiday.RepoTest do
   end
 
   describe "by_date/1" do
-    test "returns Christmas Day on 2019-12-25" do
-      date = ~D[2019-12-25]
+    test "returns Christmas Day on 2023-12-25" do
+      date = ~D[2023-12-25]
       assert Holiday.Repo.by_date(date) == [%Holiday{date: date, name: "Christmas Day"}]
     end
 
-    test "returns nothing for 2020-11-01" do
-      date = ~D[2020-11-01]
+    test "returns nothing for 2024-11-01" do
+      date = ~D[2024-11-01]
       assert Holiday.Repo.by_date(date) == []
     end
   end
 
   describe "holidays_in_month/1" do
     test "returns all holidays in the given month" do
-      for date <- [~D[2019-12-01], ~D[2019-12-25], ~D[2019-12-31]] do
+      for date <- [~D[2023-12-01], ~D[2023-12-25], ~D[2023-12-31]] do
         assert Holiday.Repo.holidays_in_month(date) == [
-                 %Holiday{date: ~D[2019-12-25], name: "Christmas Day"}
+                 %Holiday{date: ~D[2023-12-25], name: "Christmas Day"}
                ]
       end
     end
@@ -35,7 +35,7 @@ defmodule Holiday.RepoTest do
 
   describe "following/2" do
     test "returns the holidays in the set after the date" do
-      date = ~D[2017-01-10]
+      date = ~D[2023-01-10]
 
       assert date
              |> Holiday.Repo.following()


### PR DESCRIPTION
No ticket, just updating the list of dates so that holidays show in the timetable's date picker again.

<img width="944" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/45d98f98-8e08-4dfd-83b8-5b3819e08f64">
