### PR TITLE
fix(Predictions.Stream): handle reset and remove events better

### DIFF
--- a/apps/predictions/lib/store.ex
+++ b/apps/predictions/lib/store.ex
@@ -39,6 +39,12 @@ defmodule Predictions.Store do
     GenServer.cast(__MODULE__, {event, predictions})
   end
 
+  @doc "Deletes predictions associated with the input fetch keys, e.g. clear([route: 'Red', direction: 1])"
+  @spec clear(fetch_keys) :: :ok
+  def clear(keys) do
+    GenServer.cast(__MODULE__, {:remove, Enum.map(fetch(keys), & &1.id)})
+  end
+
   # Server
   @impl GenServer
   def init(opts) do
@@ -50,7 +56,7 @@ defmodule Predictions.Store do
   @impl true
   def handle_cast({_, []}, table), do: {:noreply, table}
 
-  def handle_cast({event, predictions}, table) when event in [:add, :update, :reset] do
+  def handle_cast({event, predictions}, table) when event in [:add, :update] do
     :ets.insert(table, Enum.map(predictions, &to_record/1))
 
     {:noreply, table}

--- a/apps/predictions/lib/store.ex
+++ b/apps/predictions/lib/store.ex
@@ -34,9 +34,9 @@ defmodule Predictions.Store do
     GenServer.call(__MODULE__, {:fetch, keys})
   end
 
-  @spec update({atom, [[Prediction.t()]]}) :: :ok
-  def update({event, predictions_batches}) do
-    Enum.each(predictions_batches, &GenServer.cast(__MODULE__, {event, &1}))
+  @spec update({atom, [Prediction.t()]}) :: :ok
+  def update({event, predictions}) do
+    GenServer.cast(__MODULE__, {event, predictions})
   end
 
   # Server
@@ -56,10 +56,10 @@ defmodule Predictions.Store do
     {:noreply, table}
   end
 
-  def handle_cast({:remove, predictions}, table) do
-    Logger.info("Remove predictions event: #{inspect(Enum.map(predictions, & &1.id))}")
+  def handle_cast({:remove, prediction_ids}, table) do
+    Logger.info("Remove predictions event: #{inspect(prediction_ids)}")
 
-    for id <- Enum.map(predictions, & &1.id) do
+    for id <- prediction_ids do
       :ets.delete(table, id)
     end
 

--- a/apps/predictions/test/store_test.exs
+++ b/apps/predictions/test/store_test.exs
@@ -29,6 +29,16 @@ defmodule Predictions.StoreTest do
     end
   end
 
+  describe "clear/1" do
+    test "removes all predictions for a specified route and direction" do
+      predictions = fetch(route: "yellow", direction: 1)
+      assert length(predictions) > 0
+      clear(route: "yellow", direction: 1)
+      new_predictions = fetch(route: "yellow", direction: 1)
+      refute length(new_predictions) > 0
+    end
+  end
+
   describe "update/1" do
     test "adds predictions" do
       assert [] = fetch(prediction_id: "added")
@@ -44,34 +54,6 @@ defmodule Predictions.StoreTest do
       update({:update, [%Prediction{id: "new", stop: %Stop{id: "s3"}}]})
 
       assert [%Prediction{id: "new", stop: %Stop{id: "s3"}}] = fetch(prediction_id: "new")
-    end
-
-    test "resets predictions" do
-      update(
-        {:add,
-         [
-           [%Prediction{id: "uno", stop: %Stop{id: "s100"}}]
-         ]}
-      )
-
-      update(
-        {:reset,
-         [
-           [%Prediction{id: "uno", trip: %Trip{id: "added-trip"}}]
-         ]}
-      )
-
-      assert [prediction] = fetch(prediction_id: "uno")
-
-      assert %Prediction{id: "uno", trip: %Trip{id: "added-trip"}} = prediction
-      refute prediction.stop == %Stop{id: "s100"}
-    end
-
-    test "removes predictions" do
-      update({:add, [[%Prediction{id: "added"}]]})
-      assert [%Prediction{id: "added"}] = fetch(prediction_id: "added")
-      update({:remove, [[%Prediction{id: "added"}]]})
-      assert [] = fetch(prediction_id: "added")
     end
   end
 

--- a/apps/predictions/test/store_test.exs
+++ b/apps/predictions/test/store_test.exs
@@ -9,7 +9,7 @@ defmodule Predictions.StoreTest do
 
   setup_all do
     _ = start_link(name: :test_store)
-    :ok = Predictions.Store.update({:add, [base_predictions()]})
+    :ok = Predictions.Store.update({:add, base_predictions()})
     :ok
   end
 
@@ -32,16 +32,16 @@ defmodule Predictions.StoreTest do
   describe "update/1" do
     test "adds predictions" do
       assert [] = fetch(prediction_id: "added")
-      update({:add, [[%Prediction{id: "added"}]]})
+      update({:add, [%Prediction{id: "added"}]})
       assert [%Prediction{id: "added"}] = fetch(prediction_id: "added")
     end
 
     test "updates predictions" do
-      update({:add, [[%Prediction{id: "new", stop: %Stop{id: "s1"}}]]})
+      update({:add, [%Prediction{id: "new", stop: %Stop{id: "s1"}}]})
 
       assert [%Prediction{id: "new", stop: %Stop{id: "s1"}}] = fetch(prediction_id: "new")
 
-      update({:update, [[%Prediction{id: "new", stop: %Stop{id: "s3"}}]]})
+      update({:update, [%Prediction{id: "new", stop: %Stop{id: "s3"}}]})
 
       assert [%Prediction{id: "new", stop: %Stop{id: "s3"}}] = fetch(prediction_id: "new")
     end

--- a/apps/predictions/test/stream_supervisor_test.exs
+++ b/apps/predictions/test/stream_supervisor_test.exs
@@ -44,12 +44,14 @@ defmodule Predictions.StreamSupervisorTest do
 
   describe "ensure_stream_is_started/1" do
     test "starts a stream if not already started" do
-      filter_key = "filter[route]=Purple&filter[direction_id]=1"
+      filter_key =
+        {[route: "Purple", direction: 1], "filter[route]=Purple&filter[direction_id]=1"}
+
       assert {:ok, _pid} = StreamSupervisor.ensure_stream_is_started(filter_key)
     end
 
     test "returns existing stream from registry" do
-      filter_key = "filter[route]=Pink&filter[direction_id]=0"
+      filter_key = {[route: "Pink", direction: 0], "filter[route]=Pink&filter[direction_id]=0"}
       {:ok, pid} = StreamSupervisor.ensure_stream_is_started(filter_key)
       assert {:ok, ^pid} = StreamSupervisor.ensure_stream_is_started(filter_key)
     end
@@ -57,14 +59,14 @@ defmodule Predictions.StreamSupervisorTest do
 
   describe "stop_stream/1" do
     test "closes a stream by registered key" do
-      filter_key = "filter[route]=Teal&filter[direction_id]=1"
+      filter_key = {[route: "Teal", direction: 1], "filter[route]=Teal&filter[direction_id]=1"}
       {:ok, pid} = StreamSupervisor.ensure_stream_is_started(filter_key)
       assert Process.alive?(pid)
 
       assert [{_, ^pid, :supervisor, [Predictions.StreamSupervisor.Worker]}] =
                DynamicSupervisor.which_children(Predictions.StreamSupervisor)
 
-      :ok = StreamSupervisor.stop_stream(filter_key)
+      :ok = StreamSupervisor.stop_stream(elem(filter_key, 1))
       refute Process.alive?(pid)
       assert [] = DynamicSupervisor.which_children(Predictions.StreamSupervisor)
     end

--- a/apps/predictions/test/stream_test.exs
+++ b/apps/predictions/test/stream_test.exs
@@ -73,7 +73,8 @@ defmodule Predictions.StreamTest do
         Stream.start_link(
           name: :start_link_test,
           broadcast_fn: broadcast_fn,
-          subscribe_to: mock_api
+          subscribe_to: mock_api,
+          clear_keys: [route: "route_id", direction: 0]
         )
 
       :erlang.trace(stream_pid, true, [:receive])
@@ -108,7 +109,8 @@ defmodule Predictions.StreamTest do
                    Stream.start_link(
                      name: :error_logging_api_test,
                      broadcast_fn: fn _, _, _ -> :ok end,
-                     subscribe_to: mock_api
+                     subscribe_to: mock_api,
+                     clear_keys: []
                    )
 
           refute_receive _
@@ -135,7 +137,8 @@ defmodule Predictions.StreamTest do
                    Stream.start_link(
                      name: :error_logging_test,
                      broadcast_fn: broadcast_fn,
-                     subscribe_to: mock_api
+                     subscribe_to: mock_api,
+                     clear_keys: []
                    )
 
           refute_receive _

--- a/apps/predictions/test/stream_topic_test.exs
+++ b/apps/predictions/test/stream_topic_test.exs
@@ -24,7 +24,10 @@ defmodule Predictions.StreamTopicTest do
                streams: streams
              } = new("stop:stopId")
 
-      assert ["filter[direction_id]=0&filter[route]=Route1" | _] = streams
+      assert [
+               {[route: "Route1", direction: 0], "filter[direction_id]=0&filter[route]=Route1"}
+               | _
+             ] = streams
     end
 
     test "doesn't work for stop without route patterns" do

--- a/apps/site/lib/site_web/channels/predictions_channel.ex
+++ b/apps/site/lib/site_web/channels/predictions_channel.ex
@@ -32,6 +32,11 @@ defmodule SiteWeb.PredictionsChannel do
   end
 
   @impl Channel
+  def terminate(_, socket) do
+    GenServer.cast(Predictions.PredictionsPubSub, {:closed_channel, socket.channel_pid})
+  end
+
+  @impl Channel
   @spec handle_info({:new_predictions, [Prediction.t()]}, Socket.t()) :: {:noreply, Socket.t()}
   def handle_info({:new_predictions, predictions}, socket) do
     :ok = push(socket, "data", %{predictions: filter_new(predictions)})


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Predictions.Store | remove predictions on :reset event](https://app.asana.com/0/385363666817452/1206160446331599/f) 

- Handles reset events by removing the relevant predictions before adding new predictions to `Predictions.Store`
- Fixes parsing to correctly handle the `:remove` event, as discovered during  [Stop page displaying mystery extra Red Line prediction](https://app.asana.com/0/385363666817452/1205862370279611/f)

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.