### PR TITLE
refactor(PredictionsPubSub): change state, reduce memory

### DIFF
--- a/apps/site/lib/site_web/channels/predictions_channel.ex
+++ b/apps/site/lib/site_web/channels/predictions_channel.ex
@@ -32,6 +32,11 @@ defmodule SiteWeb.PredictionsChannel do
   end
 
   @impl Channel
+  def terminate(_, socket) do
+    GenServer.cast(Predictions.PredictionsPubSub, {:closed_channel, socket.channel_pid})
+  end
+
+  @impl Channel
   @spec handle_info({:new_predictions, [Prediction.t()]}, Socket.t()) :: {:noreply, Socket.t()}
   def handle_info({:new_predictions, predictions}, socket) do
     :ok = push(socket, "data", %{predictions: filter_new(predictions)})


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Investigate high memory usage from streaming predictions on stop page](https://app.asana.com/0/555089885850811/1206184081297463/f)

I was able to achieve lower sustained memory usage on `Predictions.PredictionsPubSub` by:
- Removing map-based state, because the reference to the old states are kept in memory. This uses ETS tables instead
- Removing overhead of `Process.monitor` by sending a custom message on channel `terminate/2`.
- Setting `:hibernate` on various calls in `Predictions.PredictionsPubSub`

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.