### PR TITLE
AutocompleteJS v1.0 | Sales locations pages

### DIFF
--- a/apps/location_service/lib/aws_location/aws_location.ex
+++ b/apps/location_service/lib/aws_location/aws_location.ex
@@ -23,9 +23,14 @@ defmodule AWSLocation do
     |> Result.handle_response([latitude, longitude])
   end
 
-  @spec autocomplete(String.t(), number) :: LocationService.Suggestion.result()
+  @spec autocomplete(String.t(), number) ::
+          LocationService.Suggestion.result()
+          | {:error, :invalid_arguments}
+          | {:error, :zero_results}
   def autocomplete(search, limit) when 1 <= limit and limit <= 15 do
     Request.autocomplete(search, limit)
     |> Result.handle_response(%{search: search, limit: limit})
   end
+
+  def autocomplete(_, _), do: {:error, :invalid_arguments}
 end

--- a/apps/site/assets/css/_autocomplete-theme.scss
+++ b/apps/site/assets/css/_autocomplete-theme.scss
@@ -137,12 +137,12 @@
     padding-right: var(--aa-spacing-half);
   }
 }
-  
+
 #header-mobile {
   @extend %shared-autocomplete;
 }
 
-#error-page {
+%large-autocomplete {
   --aa-search-input-height: 2.5rem;
 
   @extend %shared-autocomplete;
@@ -163,5 +163,30 @@
     border-radius: .25rem;
     color: $white;
     transform: scale(-1, 1);
+  }
+}
+
+#error-page {
+  @extend %large-autocomplete;
+}
+
+#proposed-sales-locations,
+#sales-locations {
+  @extend %large-autocomplete;
+
+  .c-search-bar__autocomplete-results {
+    position: relative;
+
+    // Autocomplete.JS doesn't support multiple instances per page, and one way
+    // this manifests is it totally bungles the dynamic positioning of elements.
+    // Hence the need to wrangle with !important.
+    /* stylelint-disable declaration-no-important */
+    .aa-Panel {
+      left: 0 !important;
+      margin-top: .25rem;
+      top: 0 !important;
+      width: 100% !important;
+    }
+    /* stylelint-enable declaration-no-important */
   }
 }

--- a/apps/site/assets/js/algolia-result.js
+++ b/apps/site/assets/js/algolia-result.js
@@ -226,7 +226,7 @@ function _iconFromRoute(route) {
   }
 }
 
-function getPopularIcon(icon) {
+export function getPopularIcon(icon) {
   switch (icon) {
     case "airplane":
       return TEMPLATES.fontAwesomeIcon.render({ icon: "fa-plane" });

--- a/apps/site/assets/js/trip-planner-location-controls.js
+++ b/apps/site/assets/js/trip-planner-location-controls.js
@@ -490,8 +490,8 @@ TripPlannerLocControls.POPULAR = [
     name: "North Station",
     features: [
       "orange_line",
-      "green-line-c",
-      "green-line-e",
+      "green_line_c",
+      "green_line_e",
       "bus",
       "commuter_rail",
       "access"

--- a/apps/site/assets/ts/ui/__tests__/autocomplete-helpers-test.ts
+++ b/apps/site/assets/ts/ui/__tests__/autocomplete-helpers-test.ts
@@ -8,7 +8,6 @@ import {
 } from "../autocomplete/__autocomplete";
 import {
   getTitleAttribute,
-  transitNearMeURL,
   STATE_CHANGE_HANDLERS
 } from "./../autocomplete/helpers";
 import * as MediaBreakpoints from "../../helpers/media-breakpoints";
@@ -41,15 +40,6 @@ test("getTitleAttribute indicates name to highlight", () => {
   expect(getTitleAttribute(contentItemWithHighlightResult)).toEqual([
     "_content_title"
   ]);
-});
-
-test("transitNearMeURL maps a lat/lon to a URL", () => {
-  const urlNoParams = transitNearMeURL(1, 2);
-  expect(urlNoParams).toEqual("/transit-near-me?latitude=1&longitude=2");
-  const urlWithParams = transitNearMeURL(1, 2, "other=params,go,here");
-  expect(urlWithParams).toEqual(
-    "/transit-near-me?latitude=1&longitude=2&other=params,go,here"
-  );
 });
 
 describe("onStateChange handlers - nav", () => {

--- a/apps/site/assets/ts/ui/__tests__/autocomplete-plugins-test.ts
+++ b/apps/site/assets/ts/ui/__tests__/autocomplete-plugins-test.ts
@@ -32,20 +32,42 @@ const mockAlgoliaResponse = {
   ] as SearchResponse[]
 };
 
-const mockLocationPredictions = {
-  predictions: JSON.stringify([
-    { address: "123 Sesame St", highlighted_spans: {} },
-    { address: "50 Wisteria Lane", highlighted_spans: {} },
-    { address: "1600 Pennsylvania Ave", highlighted_spans: {} }
-  ])
-};
-
-const mockAddressDetails = {
-  result: JSON.stringify({
-    latitude: 1,
-    longitude: 2,
-    formatted: ""
-  })
+const mockLocations = {
+  result: [
+    {
+      address: "123 Sesame St",
+      highlighted_spans: {},
+      latitude: 1,
+      longitude: 2,
+      urls: {
+        "transit-near-me": "/transit-near-me/1/2",
+        "retail-sales-locations": "/retail/1/2",
+        "proposed-sales-locations": "/proposed/1/2"
+      }
+    },
+    {
+      address: "50 Wisteria Lane",
+      highlighted_spans: {},
+      latitude: 3,
+      longitude: 4,
+      urls: {
+        "transit-near-me": "/transit-near-me/3/4",
+        "retail-sales-locations": "/retail/3/4",
+        "proposed-sales-locations": "/proposed/3/4"
+      }
+    },
+    {
+      address: "1600 Pennsylvania Ave",
+      highlighted_spans: {},
+      latitude: 5,
+      longitude: 6,
+      urls: {
+        "transit-near-me": "/transit-near-me/5/6",
+        "retail-sales-locations": "/retail/5/6",
+        "proposed-sales-locations": "/proposed/5/6"
+      }
+    }
+  ]
 };
 
 const mockFetch = (returnedData: unknown) => () =>
@@ -114,16 +136,13 @@ describe("Algolia v1 plugins", () => {
   });
 
   describe("locations", () => {
-    beforeEach(() => {
-      window.fetch = jest
-        .fn()
-        .mockImplementationOnce(mockFetch(mockLocationPredictions))
-        .mockImplementation(mockFetch(mockAddressDetails));
+    beforeAll(() => {
+      window.fetch = jest.fn().mockImplementation(mockFetch(mockLocations));
     });
 
     test("does nothing without a query", () => {
       const params = {} as GetSourcesParams<Item>;
-      const { getSources } = createLocationsPlugin();
+      const { getSources } = createLocationsPlugin(3);
       expect(getSources!(params)).toEqual([]);
     });
 
@@ -131,30 +150,59 @@ describe("Algolia v1 plugins", () => {
       const params = {
         query: "some area"
       } as GetSourcesParams<Item>;
-      const { getSources } = createLocationsPlugin();
+      const { getSources } = createLocationsPlugin(3);
       const sources = (await getSources!(params)) as AutocompleteSource<Item>[];
       await sources[0].getItems(params);
-      expect(window.fetch).toHaveBeenCalledWith(
-        "/places/autocomplete/some%20area/2/null"
-      );
+      expect(window.fetch).toHaveBeenCalledWith("/places/search/some%20area/3");
     });
 
-    test("returns results with URLs to transit near me", async () => {
+    test("returns results with URLs to chosen URL type", async () => {
       const params = {
         query: "this place"
       } as GetSourcesParams<Item>;
-      const { getSources } = createLocationsPlugin();
+      const { getSources } = createLocationsPlugin(3, "transit-near-me");
       const sources = (await getSources!(params)) as AutocompleteSource<Item>[];
       const response = await sources[0].getItems(params);
-      const urls = (response as LocationItem[]).map(r => r.url);
-      urls.forEach(u => {
-        expect(u).toStartWith("/transit-near-me?");
-        expect(u).toContain("&query=this%20place");
+      (response as LocationItem[]).forEach(location => {
+        expect(location.url).toContain("/transit-near-me");
       });
     });
   });
 
   describe("geolocation", () => {
+    beforeAll(() => {
+      window.fetch = jest.fn().mockImplementation(
+        mockFetch({
+          result: {
+            address: "51.1, 45.3",
+            highlighted_spans: {},
+            latitude: 51.1,
+            longitude: 45.3,
+            urls: {
+              "transit-near-me": "/transit-near-me/51.1/45.3",
+              "retail-sales-locations": "/retail/51.1/45.3",
+              "proposed-sales-locations": "/proposed/51.1/45.3"
+            }
+          }
+        })
+      );
+
+      const mockGeolocation = {
+        getCurrentPosition: jest.fn().mockImplementationOnce(success =>
+          Promise.resolve(
+            success({
+              coords: {
+                latitude: 51.1,
+                longitude: 45.3
+              }
+            })
+          )
+        )
+      };
+      (global as any).navigator.geolocation = mockGeolocation;
+      (global as any).Turbolinks = { visit: jest.fn() };
+    });
+
     test("return source defining template", async () => {
       const templateItem = {} as LocationItem;
       const params = {
@@ -196,7 +244,7 @@ describe("Algolia v1 plugins", () => {
       const params = {
         setIsOpen: value => {}
       } as GetSourcesParams<Item>;
-      const { getSources } = createGeolocationPlugin();
+      const { getSources } = createGeolocationPlugin("retail-sales-locations");
       const sources = (await getSources!(params)) as AutocompleteSource<Item>[];
       const itemTemplate = sources[0].templates.item as SourceTemplates<
         Item
@@ -211,27 +259,13 @@ describe("Algolia v1 plugins", () => {
           } as AutocompleteState<Item>
         })
       );
-      const mockGeolocation = {
-        getCurrentPosition: jest.fn().mockImplementationOnce(success =>
-          Promise.resolve(
-            success({
-              coords: {
-                latitude: 51.1,
-                longitude: 45.3
-              }
-            })
-          )
-        )
-      };
-      (global as any).navigator.geolocation = mockGeolocation;
-      (global as any).Turbolinks = { visit: jest.fn() };
       fireEvent.click(screen.getByRole("button"));
       await waitFor(() => {
         expect(
           window.navigator.geolocation.getCurrentPosition
         ).toHaveBeenCalled();
         expect(window.Turbolinks.visit).toHaveBeenCalledWith(
-          "/transit-near-me?latitude=51.1&longitude=45.3"
+          "/retail/51.1/45.3"
         );
       });
     });

--- a/apps/site/assets/ts/ui/autocomplete/__autocomplete.d.ts
+++ b/apps/site/assets/ts/ui/autocomplete/__autocomplete.d.ts
@@ -28,8 +28,10 @@ type ContentItem = {
 } & AlgoliaItem;
 
 export type LocationItem = {
-  highlighted_spans: HighlightedSpan[];
+  longitude: number;
+  latitude: number;
   address: string;
+  highlighted_spans: HighlightedSpan[];
   url: string;
 };
 

--- a/apps/site/assets/ts/ui/autocomplete/__autocomplete.d.ts
+++ b/apps/site/assets/ts/ui/autocomplete/__autocomplete.d.ts
@@ -2,6 +2,7 @@ import { Hit } from "@algolia/client-search";
 import { BaseItem } from "@algolia/autocomplete-core";
 import { Route, RouteType, Stop } from "../../__v3api";
 import { HighlightedSpan } from "../../helpers/text";
+import { TripPlannerLocControls } from "../../../js/trip-planner-location-controls";
 
 type AlgoliaItem = Hit<{ index: string }> & BaseItem;
 
@@ -35,5 +36,7 @@ export type LocationItem = {
   url: string;
 };
 
+export type PopularItem = typeof TripPlannerLocControls.POPULAR[number];
+
 export type AutocompleteItem = RouteItem | StopItem | ContentItem;
-export type Item = AutocompleteItem | LocationItem;
+export type Item = AutocompleteItem | LocationItem | PopularItem;

--- a/apps/site/assets/ts/ui/autocomplete/helpers.ts
+++ b/apps/site/assets/ts/ui/autocomplete/helpers.ts
@@ -4,6 +4,7 @@ import {
   ContentItem,
   Item,
   LocationItem,
+  PopularItem,
   RouteItem,
   StopItem
 } from "./__autocomplete";
@@ -58,7 +59,7 @@ export type WithUrls<T> = T & { urls: Record<string, string> };
 
 // The backend returns all possible URLs, use urlType to get the desired one
 export const itemWithUrl = (
-  initialItem: WithUrls<LocationItem>,
+  initialItem: WithUrls<LocationItem | PopularItem>,
   urlType: string
 ): Omit<typeof initialItem, "urls"> => {
   const item = omit(initialItem, "urls");

--- a/apps/site/assets/ts/ui/autocomplete/helpers.ts
+++ b/apps/site/assets/ts/ui/autocomplete/helpers.ts
@@ -1,4 +1,5 @@
 import { omit } from "lodash";
+import { OnSubmitParams } from "@algolia/autocomplete-core";
 import { OnStateChangeProps } from "@algolia/autocomplete-js";
 import {
   ContentItem,
@@ -53,6 +54,15 @@ export const STATE_CHANGE_HANDLERS: Record<
   (props: OnStateChangeProps<Item>) => void
 > = {
   nav: navStateChange
+};
+
+export const SUBMIT_HANDLERS: Record<
+  string,
+  (props: OnSubmitParams<Item>) => void
+> = {
+  to_search_page({ state }) {
+    window.Turbolinks.visit(`/search?query=${state.query}`);
+  }
 };
 
 export type WithUrls<T> = T & { urls: Record<string, string> };

--- a/apps/site/assets/ts/ui/autocomplete/helpers.ts
+++ b/apps/site/assets/ts/ui/autocomplete/helpers.ts
@@ -1,5 +1,12 @@
+import { omit } from "lodash";
 import { OnStateChangeProps } from "@algolia/autocomplete-js";
-import { ContentItem, Item, RouteItem, StopItem } from "./__autocomplete";
+import {
+  ContentItem,
+  Item,
+  LocationItem,
+  RouteItem,
+  StopItem
+} from "./__autocomplete";
 import { isLGDown } from "../../helpers/media-breakpoints";
 
 export function isStopItem(x: Item): x is StopItem {
@@ -27,16 +34,6 @@ export const getTitleAttribute = (item: Item): string[] => {
   return Object.keys(item._highlightResult);
 };
 
-export function transitNearMeURL(
-  latitude: number,
-  longitude: number,
-  extraParams?: string
-): string | null {
-  return `/transit-near-me?latitude=${latitude}&longitude=${longitude}${
-    extraParams ? `&${extraParams}` : ""
-  }`;
-}
-
 const navStateChange: (props: OnStateChangeProps<Item>) => void = ({
   state
 }) => {
@@ -55,4 +52,16 @@ export const STATE_CHANGE_HANDLERS: Record<
   (props: OnStateChangeProps<Item>) => void
 > = {
   nav: navStateChange
+};
+
+export type WithUrls<T> = T & { urls: Record<string, string> };
+
+// The backend returns all possible URLs, use urlType to get the desired one
+export const itemWithUrl = (
+  initialItem: WithUrls<LocationItem>,
+  urlType: string
+): Omit<typeof initialItem, "urls"> => {
+  const item = omit(initialItem, "urls");
+  item.url = initialItem.urls[urlType];
+  return item;
 };

--- a/apps/site/assets/ts/ui/autocomplete/index.ts
+++ b/apps/site/assets/ts/ui/autocomplete/index.ts
@@ -6,7 +6,7 @@ import {
 import { createElement, Fragment } from "react";
 import { render } from "react-dom";
 import { Item } from "./__autocomplete";
-import { STATE_CHANGE_HANDLERS } from "./helpers";
+import { STATE_CHANGE_HANDLERS, SUBMIT_HANDLERS } from "./helpers";
 import getPlugins from "./plugins";
 
 // replace the default Preact-based renderer used by AutocompleteJS
@@ -46,9 +46,7 @@ function setupAlgoliaAutocomplete(wrapper: HTMLElement): void {
     openOnFocus: true,
     onStateChange:
       STATE_CHANGE_HANDLERS[`${container.dataset.stateChangeListener}`],
-    onSubmit({ state }) {
-      window.Turbolinks.visit(`/search?query=${state.query}`);
-    },
+    onSubmit: SUBMIT_HANDLERS[`${container.dataset.submitHandler}`],
     placeholder: container.dataset.placeholder,
     plugins: getPlugins(container.dataset),
     renderer: reactRenderer

--- a/apps/site/assets/ts/ui/autocomplete/index.ts
+++ b/apps/site/assets/ts/ui/autocomplete/index.ts
@@ -8,6 +8,7 @@ import { render } from "react-dom";
 import { Item } from "./__autocomplete";
 import { STATE_CHANGE_HANDLERS, SUBMIT_HANDLERS } from "./helpers";
 import getPlugins from "./plugins";
+import { parseQuery } from "../../helpers/query";
 
 // replace the default Preact-based renderer used by AutocompleteJS
 const reactRenderer = {
@@ -21,6 +22,14 @@ function setupVeilCloseListener(autocompleteApi: AutocompleteApi<Item>): void {
   document
     .querySelector("[data-nav='veil']")
     ?.addEventListener("click", () => autocompleteApi.setIsOpen(false));
+}
+
+function getLikelyQueryParams(): string | undefined {
+  const searchParams = parseQuery(
+    window.location.search,
+    window.decodeURIComponent
+  );
+  return searchParams.query || searchParams.name || searchParams.address;
 }
 
 /**
@@ -42,6 +51,12 @@ function setupAlgoliaAutocomplete(wrapper: HTMLElement): void {
     detachedMediaQuery: "none",
     classNames: {
       input: "c-form__input-container"
+    },
+    initialState: {
+      query:
+        container.dataset.initialState === ""
+          ? getLikelyQueryParams()
+          : undefined
     },
     openOnFocus: true,
     onStateChange:

--- a/apps/site/assets/ts/ui/autocomplete/plugins.ts
+++ b/apps/site/assets/ts/ui/autocomplete/plugins.ts
@@ -17,12 +17,13 @@ export default function getPlugins(
   dataset: DOMStringMap
 ): AutocompleteJSPlugin[] {
   const plugins = [];
-  const { geolocation, locations, algolia } = dataset;
+  const { geolocation, locationsCount, locationsUrlType, algolia } = dataset;
   if (geolocation !== undefined) {
-    plugins.push(createGeolocationPlugin());
+    plugins.push(createGeolocationPlugin(locationsUrlType));
   }
-  if (locations !== undefined) {
-    plugins.push(createLocationsPlugin());
+  if (locationsCount !== undefined) {
+    const numberOfLocations = parseInt(locationsCount, 10) || 3;
+    plugins.push(createLocationsPlugin(numberOfLocations, locationsUrlType));
   }
   const algoliaIndexes = algolia ? algolia.split(",") : [];
   if (algoliaIndexes.length) {

--- a/apps/site/assets/ts/ui/autocomplete/plugins.ts
+++ b/apps/site/assets/ts/ui/autocomplete/plugins.ts
@@ -4,6 +4,7 @@ import { debouncePromise } from "../../helpers/debounce";
 import createLocationsPlugin from "./plugins/locations";
 import createAlgoliaBackendPlugin from "./plugins/algolia";
 import createGeolocationPlugin from "./plugins/geolocation";
+import createPopularLocationsPlugin from "./plugins/popular";
 
 export type AutocompleteJSPlugin = Partial<AutocompletePlugin<Item, {}>>;
 
@@ -17,13 +18,22 @@ export default function getPlugins(
   dataset: DOMStringMap
 ): AutocompleteJSPlugin[] {
   const plugins = [];
-  const { geolocation, locationsCount, locationsUrlType, algolia } = dataset;
+  const {
+    geolocation,
+    popularLocations,
+    locationsCount,
+    locationsUrlType,
+    algolia
+  } = dataset;
   if (geolocation !== undefined) {
     plugins.push(createGeolocationPlugin(locationsUrlType));
   }
   if (locationsCount !== undefined) {
     const numberOfLocations = parseInt(locationsCount, 10) || 3;
     plugins.push(createLocationsPlugin(numberOfLocations, locationsUrlType));
+  }
+  if (popularLocations !== undefined) {
+    plugins.push(createPopularLocationsPlugin(locationsUrlType));
   }
   const algoliaIndexes = algolia ? algolia.split(",") : [];
   if (algoliaIndexes.length) {

--- a/apps/site/assets/ts/ui/autocomplete/plugins/geolocation.ts
+++ b/apps/site/assets/ts/ui/autocomplete/plugins/geolocation.ts
@@ -5,9 +5,11 @@ import getGeolocationTemplate from "../templates/geolocation";
 /**
  * Generates a plugin for Algolia Autocomplete which enables geolocation. This
  * displays a prompt on search input focus to enable geolocation, executes the
- * geolocation, and uses the resulting location to navigate to Transit Near Me.
+ * geolocation, and on selection navigates to a URL.
  */
-export default function createGeolocationPlugin(): AutocompleteJSPlugin {
+export default function createGeolocationPlugin(
+  urlType: string = "transit-near-me"
+): AutocompleteJSPlugin {
   return {
     getSources({ query, setIsOpen }) {
       if (!query) {
@@ -15,7 +17,7 @@ export default function createGeolocationPlugin(): AutocompleteJSPlugin {
           {
             sourceId: "geolocation",
             templates: {
-              item: getGeolocationTemplate(setIsOpen)
+              item: getGeolocationTemplate(setIsOpen, urlType)
             },
             getItems() {
               // a hack to make the template appear, no backend is queried in this case

--- a/apps/site/assets/ts/ui/autocomplete/plugins/popular.ts
+++ b/apps/site/assets/ts/ui/autocomplete/plugins/popular.ts
@@ -1,0 +1,35 @@
+import { fetchJsonOrThrow } from "../../../helpers/fetch-json";
+import { PopularItem } from "../__autocomplete";
+import { WithUrls, itemWithUrl } from "../helpers";
+import { AutocompleteJSPlugin, debounced } from "../plugins";
+import PopularItemTemplate from "../templates/popular";
+
+/**
+ * Generates a plugin for Algolia Autocomplete which displays a list of popular
+ * locations on search input focus, and on selection navigates to a URL.
+ */
+export default function createPopularLocationsPlugin(
+  urlType: string = "transit-near-me"
+): AutocompleteJSPlugin {
+  return {
+    getSources({ query }) {
+      if (!query) {
+        return debounced([
+          {
+            sourceId: "popular",
+            templates: {
+              item: PopularItemTemplate
+            },
+            async getItems() {
+              const { result: locations } = await fetchJsonOrThrow<{
+                result: WithUrls<PopularItem>[];
+              }>("/places/popular");
+              return locations.map(location => itemWithUrl(location, urlType));
+            }
+          }
+        ]);
+      }
+      return [];
+    }
+  };
+}

--- a/apps/site/assets/ts/ui/autocomplete/templates/location.tsx
+++ b/apps/site/assets/ts/ui/autocomplete/templates/location.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { SourceTemplates } from "@algolia/autocomplete-js";
-import { Item, LocationItem } from "../__autocomplete";
+import { LocationItem } from "../__autocomplete";
 import { highlightText } from "../../../helpers/text";
 
-const LocationItemTemplate: SourceTemplates<Item>["item"] = ({ item }) => {
-  const { address, highlighted_spans } = item as LocationItem;
+export const LocationItemTemplate: SourceTemplates<LocationItem>["item"] = ({
+  item
+}) => {
+  const { address, highlighted_spans } = item;
   return (
-    <a href={(item as LocationItem).url}>
+    <a href={item.url} data-turbolinks="false">
       <span
         aria-hidden="true"
         className="c-search-result__content-icon fa fa-map-marker"

--- a/apps/site/assets/ts/ui/autocomplete/templates/popular.tsx
+++ b/apps/site/assets/ts/ui/autocomplete/templates/popular.tsx
@@ -1,0 +1,37 @@
+import { uniqueId } from "lodash";
+import React from "react";
+import { SourceTemplates } from "@algolia/autocomplete-js";
+import { PopularItem } from "../__autocomplete";
+import { getFeatureIcons, getPopularIcon } from "../../../../js/algolia-result";
+
+const PopularItemTemplate: SourceTemplates<PopularItem>["item"] = ({
+  item
+}) => {
+  const iconHtml = getPopularIcon(item.icon);
+  const featureIcons = getFeatureIcons(item, "popular");
+  return (
+    <a href={item.url} className="aa-ItemLink" data-turbolinks="false">
+      <div className="aa-ItemContent">
+        <span
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: iconHtml
+          }}
+        />
+        {featureIcons.map((feature: string) => (
+          <span
+            key={uniqueId()}
+            className="c-search-result__feature-icons"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: feature }}
+          />
+        ))}
+        <span className="aa-ItemContentBody">
+          <span className="aa-ItemContentTitle notranslate">{item.name}</span>
+        </span>
+      </div>
+    </a>
+  );
+};
+
+export default PopularItemTemplate;

--- a/apps/site/lib/site_web/components.ex
+++ b/apps/site/lib/site_web/components.ex
@@ -27,6 +27,11 @@ defmodule SiteWeb.Components do
     values: ["transit-near-me", "retail-sales-locations", "proposed-sales-locations"]
   )
 
+  attr(:popular_locations, :boolean,
+    required: false,
+    doc: "Enable display of popular locations on initial focus."
+  )
+
   attr(:geolocation, :boolean,
     required: false,
     doc: "Enable prompt for user geolocation."
@@ -62,6 +67,7 @@ defmodule SiteWeb.Components do
     assigns =
       assigns
       |> assign_new(:algolia_indexes, fn -> [] end)
+      |> assign_new(:popular_locations, fn -> false end)
       |> assign_new(:geolocation, fn -> false end)
       |> assign_new(:locations_count, fn -> false end)
       |> assign_new(:locations_url_type, fn -> false end)
@@ -93,6 +99,7 @@ defmodule SiteWeb.Components do
       <div
         class="c-search-bar__autocomplete"
         data-geolocation={@geolocation}
+        data-popular-locations={@popular_locations}
         data-locations-count={@locations_count}
         data-locations-url-type={@locations_url_type}
         data-algolia={@valid_indexes}

--- a/apps/site/lib/site_web/components.ex
+++ b/apps/site/lib/site_web/components.ex
@@ -15,9 +15,16 @@ defmodule SiteWeb.Components do
       "Enable searching one or more Algolia indexes. Valid indexes are defined in `Algolia.Query.valid_indexes()`."
   )
 
-  attr(:locations, :boolean,
+  attr(:locations_count, :integer,
     required: false,
-    doc: "Enable search of locations via the AWS Location Service."
+    doc:
+      "Number of locations returned via the AWS Location Service. Omitting this will result in no location searching"
+  )
+
+  attr(:locations_url_type, :string,
+    required: false,
+    doc: "Type of URL to request for each location.",
+    values: ["transit-near-me", "retail-sales-locations", "proposed-sales-locations"]
   )
 
   attr(:geolocation, :boolean,
@@ -47,7 +54,7 @@ defmodule SiteWeb.Components do
   error will be raised if no search attributes are set to `true`.
 
   ```elixir
-  <.algolia_autocomplete id="transit-near-me-locations" locations={true} algolia_indexes={[:stops]} />
+  <.algolia_autocomplete id="transit-near-me-locations" locations_count={3} locations_url_type="transit-near-me" algolia_indexes={[:stops]} />
   <.algolia_autocomplete id="cms-search" algolia_indexes={[:drupal]} />
   ```
   """
@@ -56,7 +63,8 @@ defmodule SiteWeb.Components do
       assigns
       |> assign_new(:algolia_indexes, fn -> [] end)
       |> assign_new(:geolocation, fn -> false end)
-      |> assign_new(:locations, fn -> false end)
+      |> assign_new(:locations_count, fn -> false end)
+      |> assign_new(:locations_url_type, fn -> false end)
 
     valid_algolia_indexes =
       Query.valid_indexes()
@@ -65,7 +73,7 @@ defmodule SiteWeb.Components do
 
     if length(valid_algolia_indexes) == 0 and
          !assigns.geolocation and
-         !assigns.locations do
+         !assigns.locations_count do
       raise "Nothing to search! Please enable at least one search type."
     end
 
@@ -85,7 +93,8 @@ defmodule SiteWeb.Components do
       <div
         class="c-search-bar__autocomplete"
         data-geolocation={@geolocation}
-        data-locations={@locations}
+        data-locations-count={@locations_count}
+        data-locations-url-type={@locations_url_type}
         data-algolia={@valid_indexes}
         data-placeholder={@placeholder}
         data-state-change-listener={@state_change_listener}

--- a/apps/site/lib/site_web/components.ex
+++ b/apps/site/lib/site_web/components.ex
@@ -53,6 +53,11 @@ defmodule SiteWeb.Components do
     default: "to_search_page"
   )
 
+  attr(:initial_state, :boolean,
+    required: false,
+    doc: "Whether to populate the input's initial query state, based on the URL query params"
+  )
+
   @doc """
   Instantiates a search box using Algolia's Autocomplete.js library, configured
   to search our application's Algolia indexes, AWS Location Service, and
@@ -77,6 +82,7 @@ defmodule SiteWeb.Components do
       |> assign_new(:locations_count, fn -> false end)
       |> assign_new(:locations_url_type, fn -> false end)
       |> assign_new(:submit_handler, fn -> false end)
+      |> assign_new(:initial_state, fn -> false end)
 
     valid_algolia_indexes =
       Query.valid_indexes()
@@ -112,6 +118,7 @@ defmodule SiteWeb.Components do
         data-placeholder={@placeholder}
         data-state-change-listener={@state_change_listener}
         data-submit-handler={@submit_handler}
+        data-initial-state={@initial_state}
       />
       <div class="c-search-bar__autocomplete-results" />
     </div>

--- a/apps/site/lib/site_web/components.ex
+++ b/apps/site/lib/site_web/components.ex
@@ -48,6 +48,11 @@ defmodule SiteWeb.Components do
     default: nil
   )
 
+  attr(:submit_handler, :string,
+    doc: "Name of event handler that responds to Autocomplete.js form submission",
+    default: "to_search_page"
+  )
+
   @doc """
   Instantiates a search box using Algolia's Autocomplete.js library, configured
   to search our application's Algolia indexes, AWS Location Service, and
@@ -71,6 +76,7 @@ defmodule SiteWeb.Components do
       |> assign_new(:geolocation, fn -> false end)
       |> assign_new(:locations_count, fn -> false end)
       |> assign_new(:locations_url_type, fn -> false end)
+      |> assign_new(:submit_handler, fn -> false end)
 
     valid_algolia_indexes =
       Query.valid_indexes()
@@ -105,6 +111,7 @@ defmodule SiteWeb.Components do
         data-algolia={@valid_indexes}
         data-placeholder={@placeholder}
         data-state-change-listener={@state_change_listener}
+        data-submit-handler={@submit_handler}
       />
       <div class="c-search-bar__autocomplete-results" />
     </div>

--- a/apps/site/lib/site_web/controllers/fare_controller.ex
+++ b/apps/site/lib/site_web/controllers/fare_controller.ex
@@ -69,9 +69,16 @@ defmodule SiteWeb.FareController do
   end
 
   def find_locations(conn, %{"latitude" => lat, "longitude" => lon} = params, proposed_or_retail) do
+    address =
+      case params do
+        %{"address" => value} -> value
+        %{"name" => value} -> value
+        _ -> lat <> "," <> lon
+      end
+
     params =
       Map.put(params, "location", %{
-        "address" => lat <> "," <> lon,
+        "address" => address,
         "latitude" => lat,
         "longitude" => lon
       })

--- a/apps/site/lib/site_web/controllers/places_controller.ex
+++ b/apps/site/lib/site_web/controllers/places_controller.ex
@@ -3,6 +3,7 @@ defmodule SiteWeb.PlacesController do
   Routes for requesting data from Google Maps.
   """
   use SiteWeb, :controller
+  alias LocationService.Address
   alias Plug.Conn
   alias SiteWeb.ControllerHelpers
 
@@ -59,6 +60,118 @@ defmodule SiteWeb.PlacesController do
     end
   end
 
+  @doc """
+  /places/urls with latitude and longitude params will return an object containing URLs specific to that location for Transit Near Me, the Retail Sales Location page, and the Proposed Sales Location pages, e.g.
+
+  %{
+    "latitude" => "1",
+    "longitude" => "2",
+    "url" => null,
+    "urls" => %{
+      "proposed-sales-locations" => "/fare-transformation/proposed-sales-locations?latitude=1&longitude=2",
+      "retail-sales-locations" => "/fares/retail-sales-locations?location[latitude]=1&location[longitude]=2",
+      "transit-near-me" => "/transit-near-me?latitude=1&longitude=2"
+    }
+  }
+  """
+  def with_urls(conn, %{"latitude" => lat, "longitude" => lon} = _params) do
+    json(conn, %{result: add_urls(%{latitude: lat, longitude: lon})})
+  end
+
+  @doc """
+  /places/popular returns a static list of popular locations, each with an object containing URLs specific to that location for Transit Near Me, the Retail Sales Location page, and the Proposed Sales Location pages, e.g.
+
+  %{
+    "urls" => {
+      "transit_near_me" => "/transit-near-me?latitude=42.352271&longitude=-71.055242&name=South+Station",
+      "retail-sales-locations" => "/fares/retail-sales-locations?location[latitude]=42.352271&location[longitude]=-71.055242&location[name]=South+Station",
+      "proposed_sales_locations" => "/fare-transformation/proposed-sales-locations?location[latitude]=42.352271&location[longitude]=-71.055242&location[name]=South+Station"
+    },
+    "url" => null,
+    "name" => "South Station",
+    "longitude" => -71.055242,
+    "latitude" => 42.352271,
+    "icon" => "station",
+    "features" => ["red_line", "bus", "commuter_rail", "access"]
+  }
+  """
+  def popular(conn, _) do
+    json(conn, %{result: Enum.map(popular_locations(), &add_urls/1)})
+  end
+
+  @doc """
+  First fetches address suggestions, then geocodes each suggestion to get a list of coordinates for a search query.
+  /places/search/Prudential/6 returns 6 results, each with an object containing URLs specific to that location for Transit Near Me, the Retail Sales Location page, and the Proposed Sales Location pages.
+  """
+  def search(conn, %{"query" => query, "hit_limit" => hit_limit_str}) do
+    with {hit_limit, ""} <- Integer.parse(hit_limit_str) do
+      case AWSLocation.autocomplete(query, hit_limit) do
+        {:ok, suggestions} ->
+          json(conn, %{result: with_coordinates(suggestions)})
+
+        {:error, error} ->
+          case error do
+            :zero_results ->
+              json(conn, %{result: []})
+
+            _ ->
+              ControllerHelpers.return_internal_error(conn)
+          end
+      end
+    else
+      _ ->
+        ControllerHelpers.return_invalid_arguments_error(conn)
+    end
+  end
+
+  @spec with_coordinates([Suggestion.t()]) :: [
+          %{
+            required(:latitude) => number,
+            required(:longitude) => number,
+            required(:address) => String.t(),
+            required(:highlighted_spans) => [LocationService.Utils.HighlightedSpan.t()] | nil,
+            required(:url) => nil,
+            required(:urls) => %{
+              required(:"transit-near-me") => String.t(),
+              required(:"retail-sales-locations") => String.t(),
+              required(:"proposed-sales-locations") => String.t()
+            }
+          }
+        ]
+  defp with_coordinates(suggestions) do
+    suggestions
+    |> Enum.map(&{&1, AWSLocation.geocode(&1.address)})
+    |> Enum.filter(&match?({_suggestion, {:ok, [%Address{} | _]}}, &1))
+    |> Enum.map(fn {suggestion, {:ok, [address | _]}} ->
+      address
+      |> Map.take([:latitude, :longitude])
+      |> Map.merge(Map.from_struct(suggestion))
+      |> add_urls()
+    end)
+  end
+
+  defp add_urls(map) do
+    params =
+      case map do
+        %{address: _} -> Map.take(map, [:address, :latitude, :longitude])
+        %{name: _} -> Map.take(map, [:name, :latitude, :longitude])
+        %{latitude: _} -> Map.take(map, [:latitude, :longitude])
+      end
+
+    map
+    |> Map.put_new(:urls, %{
+      "retail-sales-locations" =>
+        fare_path(SiteWeb.Endpoint, :show, "retail-sales-locations", params),
+      "proposed-sales-locations" =>
+        fare_path(
+          SiteWeb.Endpoint,
+          :show_transformation,
+          params
+        ),
+      "transit-near-me" => transit_near_me_path(SiteWeb.Endpoint, :index, params)
+    })
+  end
+
   defp parse_location(%{"latitude" => latitude_str, "longitude" => longitude_str}) do
     with {latitude, ""} <- Float.parse(latitude_str),
          {longitude, ""} <- Float.parse(longitude_str) do
@@ -67,5 +180,41 @@ defmodule SiteWeb.PlacesController do
       _ ->
         :invalid_lat_lng
     end
+  end
+
+  defp popular_locations() do
+    # copied from TripPlannerLocControls.POPULAR
+    [
+      %{
+        icon: "airplane",
+        name: "Boston Logan Airport",
+        features: [],
+        latitude: 42.365396,
+        longitude: -71.017547
+      },
+      %{
+        icon: "station",
+        name: "South Station",
+        features: ["red_line", "bus", "commuter_rail", "access"],
+        latitude: 42.352271,
+        longitude: -71.055242,
+        stop_id: "place-sstat"
+      },
+      %{
+        icon: "station",
+        name: "North Station",
+        features: [
+          "orange_line",
+          "green-line-c",
+          "green-line-e",
+          "bus",
+          "commuter_rail",
+          "access"
+        ],
+        latitude: 42.365577,
+        longitude: -71.06129,
+        stop_id: "place-north"
+      }
+    ]
   end
 end

--- a/apps/site/lib/site_web/controllers/places_controller.ex
+++ b/apps/site/lib/site_web/controllers/places_controller.ex
@@ -205,8 +205,8 @@ defmodule SiteWeb.PlacesController do
         name: "North Station",
         features: [
           "orange_line",
-          "green-line-c",
-          "green-line-e",
+          "green_line_c",
+          "green_line_e",
           "bus",
           "commuter_rail",
           "access"

--- a/apps/site/lib/site_web/router.ex
+++ b/apps/site/lib/site_web/router.ex
@@ -242,6 +242,10 @@ defmodule SiteWeb.Router do
     get("/autocomplete/:input/:hit_limit/:token", PlacesController, :autocomplete)
     get("/details/:address", PlacesController, :details)
     get("/reverse-geocode/:latitude/:longitude", PlacesController, :reverse_geocode)
+
+    get("/search/:query/:hit_limit", PlacesController, :search)
+    get("/popular", PlacesController, :popular)
+    get("/urls", PlacesController, :with_urls)
   end
 
   # static files

--- a/apps/site/lib/site_web/templates/error/error_layout.html.heex
+++ b/apps/site/lib/site_web/templates/error/error_layout.html.heex
@@ -19,7 +19,8 @@
       <.algolia_autocomplete
         id="error-page"
         geolocation={true}
-        locations={true}
+        locations_count={2}
+        locations_url_type="transit-near-me"
         algolia_indexes={[:stops, :routes, :drupal]}
         placeholder="Search the MBTA"
       />

--- a/apps/site/lib/site_web/templates/fare/proposed_sales_locations.html.heex
+++ b/apps/site/lib/site_web/templates/fare/proposed_sales_locations.html.heex
@@ -37,9 +37,9 @@
         <% end %>
       </div>
       <%= if Application.get_env(:site, :dev_server?) do %>
-        <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/tnm.js" %>"></script>
+        <script defer src={"#{Application.get_env(:site, :webpack_path)}/tnm.js"}></script>
       <% else %>
-        <script defer src="<%= static_url(@conn, "/js/tnm.js") %>"></script>
+        <script defer src={static_url(@conn, "/js/tnm.js")}></script>
       <% end %>
     </div>
     <%= if !is_nil(@nearby_proposed_locations) do %>
@@ -48,7 +48,7 @@
       <% else %>
         <div class="psl-types-buttons hidden">
           <%= for type <- psl_types do %>
-            <button class="psl-type-button" data-group="<%= type %>"><%= type %></button>
+            <button class="psl-type-button" data-group={type}><%= type %></button>
           <% end %>
         </div>
         <%= render SiteWeb.FareView, "_nearby_locations.html", conn: @conn, address: @address, locations: @nearby_proposed_locations, search_position: @search_position %>

--- a/apps/site/lib/site_web/templates/fare/proposed_sales_locations.html.heex
+++ b/apps/site/lib/site_web/templates/fare/proposed_sales_locations.html.heex
@@ -24,6 +24,7 @@
           locations_url_type="proposed-sales-locations"
           placeholder="Enter a location"
           submit_handler={nil}
+          initial_state={true}
         />
       </p>
       <%= if Application.get_env(:site, :dev_server?) do %>

--- a/apps/site/lib/site_web/templates/fare/proposed_sales_locations.html.heex
+++ b/apps/site/lib/site_web/templates/fare/proposed_sales_locations.html.heex
@@ -15,27 +15,16 @@
       </p>
 
       <h2 class="mb-2">Find Proposed Locations Near You</h2>
-      <p></p>
-      <div class="transit-near-me">
-        <%= form_for @conn, @conn.request_path, [as: :location, method: :get, class: "form m-transit-near-me__input"], fn f -> %>
-          <%=
-            SiteWeb.PartialView.render(
-              "_search_input.html",
-              form: f,
-              field: :address,
-              autocomplete?: true,
-              prefix: "transit-near-me",
-              aria_label: "",
-              placeholder: "Enter a location",
-              value: input_value(@search_position)
-            )
-          %>
-          <%= Phoenix.HTML.Form.hidden_input f, :latitude,
-                                            value: assigns[:latitude], id: "search-transit-near-me__latitude" %>
-          <%= Phoenix.HTML.Form.hidden_input f, :longitude,
-                                            value: assigns[:longitude], id: "search-transit-near-me__longitude" %>
-        <% end %>
-      </div>
+      <p>
+        <.algolia_autocomplete
+          id="proposed-sales-locations"
+          geolocation={true}
+          popular_locations={true}
+          locations_count={5}
+          locations_url_type="proposed-sales-locations"
+          placeholder="Enter a location"
+        />
+      </p>
       <%= if Application.get_env(:site, :dev_server?) do %>
         <script defer src={"#{Application.get_env(:site, :webpack_path)}/tnm.js"}></script>
       <% else %>

--- a/apps/site/lib/site_web/templates/fare/proposed_sales_locations.html.heex
+++ b/apps/site/lib/site_web/templates/fare/proposed_sales_locations.html.heex
@@ -23,6 +23,7 @@
           locations_count={5}
           locations_url_type="proposed-sales-locations"
           placeholder="Enter a location"
+          submit_handler={nil}
         />
       </p>
       <%= if Application.get_env(:site, :dev_server?) do %>

--- a/apps/site/lib/site_web/templates/fare/retail_sales_locations.html.heex
+++ b/apps/site/lib/site_web/templates/fare/retail_sales_locations.html.heex
@@ -16,6 +16,7 @@
           locations_url_type="retail-sales-locations"
           placeholder="Enter a location"
           submit_handler={nil}
+          initial_state={true}
         />
       </p>
       <%= if Application.get_env(:site, :dev_server?) do %>

--- a/apps/site/lib/site_web/templates/fare/retail_sales_locations.html.heex
+++ b/apps/site/lib/site_web/templates/fare/retail_sales_locations.html.heex
@@ -15,6 +15,7 @@
           locations_count={5}
           locations_url_type="retail-sales-locations"
           placeholder="Enter a location"
+          submit_handler={nil}
         />
       </p>
       <%= if Application.get_env(:site, :dev_server?) do %>

--- a/apps/site/lib/site_web/templates/fare/retail_sales_locations.html.heex
+++ b/apps/site/lib/site_web/templates/fare/retail_sales_locations.html.heex
@@ -29,9 +29,9 @@
         <% end %>
       </div>
       <%= if Application.get_env(:site, :dev_server?) do %>
-        <script defer src="<%= "#{Application.get_env(:site, :webpack_path)}/tnm.js" %>"></script>
+        <script defer src={"#{Application.get_env(:site, :webpack_path)}/tnm.js"}></script>
       <% else %>
-        <script defer src="<%= static_url(@conn, "/js/tnm.js") %>"></script>
+        <script defer src={static_url(@conn, "/js/tnm.js")}></script>
       <% end %>
     </div>
     <%= if !is_nil(@fare_sales_locations) do %>

--- a/apps/site/lib/site_web/templates/fare/retail_sales_locations.html.heex
+++ b/apps/site/lib/site_web/templates/fare/retail_sales_locations.html.heex
@@ -7,27 +7,16 @@
       </p>
 
       <h2>Find a Store Near You</h2>
-      <p></p>
-      <div class="transit-near-me">
-        <%= form_for @conn, @conn.request_path, [as: :location, method: :get, class: "form m-transit-near-me__input"], fn f -> %>
-          <%=
-            SiteWeb.PartialView.render(
-              "_search_input.html",
-              form: f,
-              field: :address,
-              autocomplete?: true,
-              prefix: "transit-near-me",
-              aria_label: "",
-              placeholder: "Enter a location",
-              value: input_value(@search_position)
-            )
-          %>
-          <%= Phoenix.HTML.Form.hidden_input f, :latitude,
-                                            value: assigns[:latitude], id: "search-transit-near-me__latitude" %>
-          <%= Phoenix.HTML.Form.hidden_input f, :longitude,
-                                            value: assigns[:longitude], id: "search-transit-near-me__longitude" %>
-        <% end %>
-      </div>
+      <p>
+        <.algolia_autocomplete
+          id="sales-locations"
+          geolocation={true}
+          popular_locations={true}
+          locations_count={5}
+          locations_url_type="retail-sales-locations"
+          placeholder="Enter a location"
+        />
+      </p>
       <%= if Application.get_env(:site, :dev_server?) do %>
         <script defer src={"#{Application.get_env(:site, :webpack_path)}/tnm.js"}></script>
       <% else %>

--- a/apps/site/lib/site_web/templates/layout/_new_header.html.heex
+++ b/apps/site/lib/site_web/templates/layout/_new_header.html.heex
@@ -18,7 +18,8 @@
           <.algolia_autocomplete
             id="header-desktop"
             geolocation={true}
-            locations={true}
+            locations_count={2}
+            locations_url_type="transit-near-me"
             algolia_indexes={[:stops, :routes, :drupal]}
             state_change_listener="nav"
           />

--- a/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.heex
+++ b/apps/site/lib/site_web/templates/layout/_new_nav_mobile.html.heex
@@ -36,7 +36,8 @@
     <.algolia_autocomplete
       id="header-mobile"
       geolocation={true}
-      locations={true}
+      locations_count={2}
+      locations_url_type="transit-near-me"
       algolia_indexes={[:stops, :routes, :drupal]}
     />
   </div>

--- a/apps/site/test/site_web/components_test.exs
+++ b/apps/site/test/site_web/components_test.exs
@@ -19,33 +19,41 @@ defmodule SiteWeb.ComponentsTest do
     test "raises an error without required ID" do
       assert_raise KeyError,
                    fn ->
-                     render_component(&algolia_autocomplete/1, %{locations: true})
+                     render_component(&algolia_autocomplete/1, %{
+                       locations_count: 3,
+                       locations_url_type: "transit-near-me"
+                     })
                    end
     end
 
     test "renders with AlgoliaAutocomplete hook and appropriate data attributes" do
       assert """
              <div phx-hook="AlgoliaAutocomplete" data-turbolinks-permanent id="testID">
-               <div class="c-search-bar__autocomplete" data-locations data-algolia="routes,stops" data-placeholder="Search for routes, info, and more"></div>
+               <div class="c-search-bar__autocomplete" data-locations-count="6" data-locations-url-type="transit-near-me" data-algolia="routes,stops" data-placeholder="Search for routes, info, and more"></div>
                <div class="c-search-bar__autocomplete-results"></div>
              </div>
              """ =~
                render_component(
                  &algolia_autocomplete/1,
-                 %{id: "testID", locations: true, algolia_indexes: [:stops, :routes]}
+                 %{
+                   id: "testID",
+                   locations_count: 6,
+                   locations_url_type: "transit-near-me",
+                   algolia_indexes: [:stops, :routes]
+                 }
                )
     end
 
     test "can indicate a state change listener by name" do
       assert """
              <div phx-hook="AlgoliaAutocomplete" data-turbolinks-permanent id="test_with_listener">
-               <div class="c-search-bar__autocomplete" data-locations data-placeholder="Search for routes, info, and more" data-state-change-listener="nav"></div>
+               <div class="c-search-bar__autocomplete" data-geolocation data-placeholder="Search for routes, info, and more" data-state-change-listener="nav"></div>
                <div class="c-search-bar__autocomplete-results"></div>
              </div>
              """ =~
                render_component(
                  &algolia_autocomplete/1,
-                 %{id: "test_with_listener", locations: true, state_change_listener: "nav"}
+                 %{id: "test_with_listener", geolocation: true, state_change_listener: "nav"}
                )
     end
   end

--- a/apps/site/test/site_web/components_test.exs
+++ b/apps/site/test/site_web/components_test.exs
@@ -29,7 +29,7 @@ defmodule SiteWeb.ComponentsTest do
     test "renders with AlgoliaAutocomplete hook and appropriate data attributes" do
       assert """
              <div phx-hook="AlgoliaAutocomplete" data-turbolinks-permanent id="testID">
-               <div class="c-search-bar__autocomplete" data-locations-count="6" data-locations-url-type="transit-near-me" data-algolia="routes,stops" data-placeholder="Search for routes, info, and more"></div>
+               <div class="c-search-bar__autocomplete" data-locations-count="6" data-locations-url-type="transit-near-me" data-algolia="routes,stops" data-placeholder="Search for routes, info, and more" data-submit-handler="to_search_page"></div>
                <div class="c-search-bar__autocomplete-results"></div>
              </div>
              """ =~
@@ -47,7 +47,7 @@ defmodule SiteWeb.ComponentsTest do
     test "can indicate a state change listener by name" do
       assert """
              <div phx-hook="AlgoliaAutocomplete" data-turbolinks-permanent id="test_with_listener">
-               <div class="c-search-bar__autocomplete" data-geolocation data-placeholder="Search for routes, info, and more" data-state-change-listener="nav"></div>
+               <div class="c-search-bar__autocomplete" data-geolocation data-placeholder="Search for routes, info, and more" data-state-change-listener="nav" data-submit-handler="to_search_page"></div>
                <div class="c-search-bar__autocomplete-results"></div>
              </div>
              """ =~


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [AutocompleteJS v1.0 | Sales locations pages](https://app.asana.com/0/385363666817452/1205902725457090/f)

- /fares/retail-sales-locations
- /fare-transformation/proposed-sales-locations

Updates the big search input on these two pages to upgrade the underlying AutocompleteJS library to version 1 by adopting our custom functional component, `<.algolia_autocomplete />`.

# Backend

In the dropdown, clicking a location is supposed to take you to a relevant URL for that location. Before, we had this hard-coded to link to Transit Near Me. But that won't work for these two pages, as they're supposed to keep you on the same page! I got tired of stringing together URLs and moved over the URL-creating to the backend (so that I could use Phoenix's route helpers to just create the right URL, e.g. `fare_path(SiteWeb.Endpoint, :show, "retail-sales-locations", params)`).

So, with this capability in mind, I ended up writing new backend endpoints for fetching locations. There are three different types of locations being dealt with here.
1. The geolocation pulled up by the browser
2. The location we search for via AWS Location Service
3. The prepopulated locations suggested at the start 

# Frontend

- Suggested popular locations plugin, just hardcopies the locations.
(old screenshot).
![image](https://github.com/mbta/dotcom/assets/2136286/bcdd33b4-5eb9-4ada-a034-a336157ec1aa)

- Turns off `onSubmit` option for these, because we don't want clicking the search icon to take people to the `/search` page.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../apps/site/load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

