### PR TITLE
fix(Stops.RouteStop): remove Fairmount/Foxboro logic

### DIFF
--- a/cypress/e2e/smoke.cy.js
+++ b/cypress/e2e/smoke.cy.js
@@ -122,7 +122,7 @@ describe("passes smoke test", () => {
     const schedule_sections = [
       ["Boat-F1", "timetable"],
       ["CR-Worcester", "timetable"],
-      ["CR-Worcester", "line"],
+      ["CR-Fairmount", "line"],
       ["Green", "line"],
       ["Green-E", "line"],
       ["Red", "line"],
@@ -132,6 +132,9 @@ describe("passes smoke test", () => {
       cy.visit(`/schedules/${route}/${tab}`);
       if (tab == "line") {
         cy.get(".m-schedule-diagram");
+        // test both directions
+        cy.contains("Change Direction").click();
+        cy.url().should("contain", "schedule_direction%5Bdirection_id%5D=1");
       } else {
         cy.get(".m-timetable");
       }

--- a/lib/stops/route_stop.ex
+++ b/lib/stops/route_stop.ex
@@ -191,40 +191,6 @@ defmodule Stops.RouteStop do
     do_list_from_shapes(shape.name, Enum.map(stops, & &1.id), stops, route)
   end
 
-  def list_from_shapes(shapes, stops, %Route{id: "CR-Fairmount"} = route, 0) do
-    mainline = Enum.find(shapes, &(&1.name == "South Station - Readville via Fairmount"))
-    foxboro_extension = Enum.find(shapes, &(&1.name == "South Station - Foxboro via Fairmount"))
-
-    distinct_stop_ids =
-      if foxboro_extension do
-        mainline.stop_ids |> Enum.concat(foxboro_extension.stop_ids) |> Enum.uniq()
-      else
-        mainline.stop_ids
-      end
-
-    [do_list_from_shapes(mainline.name, distinct_stop_ids, stops, route)]
-    |> merge_branch_list(0)
-  end
-
-  def list_from_shapes(shapes, stops, %Route{id: "CR-Fairmount"} = route, 1) do
-    mainline = Enum.find(shapes, &(&1.name == "Readville - South Station via Fairmount"))
-
-    foxboro_extension =
-      Enum.find(shapes, &(&1.name == "Forge Park/495 - South Station via Fairmount"))
-
-    distinct_stop_ids =
-      if foxboro_extension do
-        ["place-FS-0049" | foxboro_extension.stop_ids]
-        |> Enum.concat(mainline.stop_ids)
-        |> Enum.uniq()
-      else
-        mainline.stop_ids
-      end
-
-    [do_list_from_shapes(foxboro_extension.name, distinct_stop_ids, stops, route)]
-    |> merge_branch_list(1)
-  end
-
   def list_from_shapes(shapes, stops, route, direction_id) do
     shapes
     |> Enum.map(&do_list_from_shapes(&1.name, &1.stop_ids, stops, route))


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** No ticket

[Link to relevant error source in Splunk](https://mbta.splunkcloud.com/en-US/app/search/show_source?sid=1705519178.13357441&offset=0&latest_time=), which is fairly reproducible when visiting `/schedules/CR-Fairmount/line?schedule_direction%5Bdirection_id%5D=1` - viewing the Fairmount Line's `/line` page initialized to the `1` `direction_id` results in a 500 error because of a function assuming that a shape with a name referencing the Foxboro line exists. This might be something that changed names when the rating changed recently and all the underlying data was updated. 

I suspect this logic was originally put in place due to side effects of our system's somewhat confusing routing of _some_ trains on the Franklin/Foxboro line going "via Fairmount line" (as seen on the timetables and PDF). Anyway, I fixed it but then realized if I remove all the special logic for this route, the resulting line diagram's the same.

I also enhanced the smoke tests to visit both directions in a `/line` schedule page.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

