### PR TITLE
fix(alert): show suspensions as diversion

### DIFF
--- a/assets/ts/models/alert.ts
+++ b/assets/ts/models/alert.ts
@@ -9,10 +9,14 @@ export const isHighSeverityOrHighPriority = ({
 }: Alert): boolean => priority === "high" || severity >= 7;
 
 export const isDiversion = ({ effect }: Alert): boolean =>
-  effect === "shuttle" ||
-  effect === "stop_closure" ||
-  effect === "station_closure" ||
-  effect === "detour";
+  [
+    "shuttle",
+    "suspension",
+    "stop_closure",
+    "station_closure",
+    "suspension",
+    "detour"
+  ].includes(effect);
 
 export const isHighPriorityAlert = ({ effect }: Alert): boolean =>
   effect === "detour" || effect === "suspension" || effect === "shuttle";

--- a/assets/ts/models/alert.ts
+++ b/assets/ts/models/alert.ts
@@ -14,7 +14,6 @@ export const isDiversion = ({ effect }: Alert): boolean =>
     "suspension",
     "stop_closure",
     "station_closure",
-    "suspension",
     "detour"
   ].includes(effect);
 


### PR DESCRIPTION
No ticket, was suggested by @shantigonzales to improve schedule page presentation of the Green Line suspensions happening this month.

| Before | After |
| --- | --- |
| ![green-b-before](https://github.com/mbta/dotcom/assets/2136286/2872afe4-d53d-4a16-9728-bed551638baa) | ![green-b-after](https://github.com/mbta/dotcom/assets/2136286/bd1fd350-d933-43a8-b772-4c0c0a834137) |



