### PR TITLE
Take an arbitrary path for delete cache

### DIFF
--- a/lib/dotcom_web/controllers/cms_controller.ex
+++ b/lib/dotcom_web/controllers/cms_controller.ex
@@ -47,27 +47,18 @@ defmodule DotcomWeb.CMSController do
 
   @doc """
   Resets a cache key based on the URL params.
-  PATCH /cms/foo/bar will reset the cache key /cms/foo/bar.
-  This corresponds to the CMS page /foo/bar.
+  The path after /cms is joined with / to form the cache key.
+  So, it can be of arbitrary length.
+  PATCH /cms/foo/bar/baz will reset the cache key /cms/foo/bar/baz.
+  This corresponds to the CMS page /foo/bar/baz.
   """
-  def reset_cache_key(conn, %{"object" => object, "id" => id}) do
+  def reset_cache_key(conn, %{"path" => path}) do
+    joined_path = Enum.join(path, "/")
+
     try do
-      @cache.delete("/cms/#{object}/#{id}")
+      @cache.delete("/cms/#{joined_path}")
 
-      Logger.notice("cms.cache.delete path=/cms/#{object}/#{id}")
-    rescue
-      e in Redix.ConnectionError -> Logger.warning("cms.cache.delete error=redis-#{e.reason}")
-      e in Redix.Error -> Logger.warning("cms.cache.delete error=redis-#{e.message}")
-    end
-
-    send_resp(conn, 202, "") |> halt()
-  end
-
-  def reset_cache_key(conn, %{"id" => id}) do
-    try do
-      @cache.delete("/cms/#{id}")
-
-      Logger.notice("cms.cache.delete path=/cms/#{id}")
+      Logger.notice("cms.cache.delete path=/cms/#{joined_path}")
     rescue
       e in Redix.ConnectionError -> Logger.warning("cms.cache.delete error=redis-#{e.reason}")
       e in Redix.Error -> Logger.warning("cms.cache.delete error=redis-#{e.message}")

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -58,8 +58,7 @@ defmodule DotcomWeb.Router do
   scope "/cms", DotcomWeb do
     pipe_through([:basic_auth])
 
-    patch("/:object/:id", CMSController, :reset_cache_key)
-    patch("/:id", CMSController, :reset_cache_key)
+    patch("/*path", CMSController, :reset_cache_key)
   end
 
   # redirect 't.mbta.com' and 'beta.mbta.com' to 'https://www.mbta.com'

--- a/test/dotcom_web/controllers/cms_controller_test.exs
+++ b/test/dotcom_web/controllers/cms_controller_test.exs
@@ -185,41 +185,24 @@ defmodule DotcomWeb.CMSControllerTest do
     end
   end
 
-  describe "PATCH /cms/*" do
+  describe "PATCH /cms/*path" do
     test "it removes an entry from the cache", %{conn: conn} do
-      path = "/cms/foo"
+      paths = ["/cms/foo", "/cms/foo/bar", "/cms/foo/bar/baz"]
 
-      @cache.put(path, "bar")
+      Enum.each(paths, fn path ->
+        @cache.put(path, "foo")
 
-      assert @cache.get(path) != nil
+        assert @cache.get(path) != nil
 
-      conn =
-        conn
-        |> put_req_header("content-type", "application/json")
-        |> put_req_header("authorization", "Basic " <> Base.encode64("username:password"))
-        |> patch(path)
+        conn =
+          conn
+          |> put_req_header("content-type", "application/json")
+          |> put_req_header("authorization", "Basic " <> Base.encode64("username:password"))
+          |> patch(path)
 
-      assert @cache.get(path) == nil
-      assert conn.status == 202
-    end
-  end
-
-  describe "PATCH /cms/**/*" do
-    test "it removes an entry from the cache", %{conn: conn} do
-      path = "/cms/foo/bar"
-
-      @cache.put(path, "baz")
-
-      assert @cache.get(path) != nil
-
-      conn =
-        conn
-        |> put_req_header("content-type", "application/json")
-        |> put_req_header("authorization", "Basic " <> Base.encode64("username:password"))
-        |> patch(path)
-
-      assert @cache.get(path) == nil
-      assert conn.status == 202
+        assert @cache.get(path) == nil
+        assert conn.status == 202
+      end)
     end
   end
 end


### PR DESCRIPTION
Deleting from the cache is failing for paths with > 2 component parts /one/two/three. This fix makes it so the path can be of any length.

