### PR TITLE
fix: more forgiving event page date comparison

### DIFF
--- a/lib/dotcom_web/templates/event/_event_teaser.html.eex
+++ b/lib/dotcom_web/templates/event/_event_teaser.html.eex
@@ -4,7 +4,7 @@
   path_fn = fn -> cms_static_page_path(@conn, @event_teaser.path) end
 
   event_is_hidden = if @check_event_ended do
-    Date.compare(@conn.assigns.date, @event_teaser.date) != :lt
+    Date.compare(@conn.assigns.date, @event_teaser.date) == :gt
   else
     false
   end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Events page should show all events in a day](https://app.asana.com/0/385363666817452/1206330231992947/f)

Shows today's events instead of hiding them.