### PR TITLE
Fix two issues with search

### DIFF
--- a/assets/js/algolia-results.js
+++ b/assets/js/algolia-results.js
@@ -199,9 +199,21 @@ export class AlgoliaResults {
   }
 
   render(results) {
+    // We don't want to render pages where the URL is reference to a node.
+    // That means that the result is a page that has been unpublished.
+    const filtered_pages_hits = results.pages.hits.filter(
+      result => !/node\//.test(result._content_url)
+    );
+    const filtered_pages = Object.assign({}, results.pages, {
+      hits: filtered_pages_hits
+    });
+    const filtered_results = Object.assign({}, results, {
+      pages: filtered_pages
+    });
+
     if (this._container) {
       this._container.innerHTML = this._groups
-        .map(group => this._renderGroup(results, group))
+        .map(group => this._renderGroup(filtered_results, group))
         .join("");
 
       Array.from(
@@ -209,7 +221,7 @@ export class AlgoliaResults {
       ).forEach(this.addResultClickHandler);
 
       this._groups.forEach(group => this._addShowMoreListener(group));
-      this._addLocationListeners(results);
+      this._addLocationListeners(filtered_results);
     }
   }
 

--- a/assets/ts/ui/autocomplete/__autocomplete.d.ts
+++ b/assets/ts/ui/autocomplete/__autocomplete.d.ts
@@ -25,6 +25,7 @@ type StopItem = {
 type ContentItem = {
   _content_type: string;
   _content_url: string;
+  _search_result_url: string;
   content_title: string;
 } & AlgoliaItem;
 

--- a/assets/ts/ui/autocomplete/helpers.ts
+++ b/assets/ts/ui/autocomplete/helpers.ts
@@ -23,6 +23,10 @@ export function isContentItem(x: Item): x is ContentItem {
   return Object.keys(x).includes("_content_type");
 }
 
+export function isSearchResultItem(x: Item): x is ContentItem {
+  return isContentItem(x) && x._content_type == "search_result";
+}
+
 export const getTitleAttribute = (item: Item): string[] => {
   if (isStopItem(item)) {
     return ["stop", "name"];

--- a/assets/ts/ui/autocomplete/plugins/algolia.ts
+++ b/assets/ts/ui/autocomplete/plugins/algolia.ts
@@ -2,6 +2,7 @@ import { SearchResponse } from "@algolia/client-search";
 import { AutocompleteJSPlugin, debounced } from "../plugins";
 import AlgoliaItemTemplate from "../templates/algolia";
 import { AutocompleteItem } from "../__autocomplete";
+import { isSearchResultItem } from "../helpers";
 
 /**
  * Generates a plugin for Algolia Autocomplete which enables searching for our
@@ -36,7 +37,14 @@ export default function createAlgoliaBackendPlugin(
                   .then(resp =>
                     (resp.results as SearchResponse[]).flatMap(
                       ({ hits, index }) =>
-                        hits.map(hit => ({ ...hit, index } as AutocompleteItem))
+                        hits
+                          .map(hit => ({ ...hit, index } as AutocompleteItem))
+                          .filter(
+                            item =>
+                              !isSearchResultItem(item) ||
+                              (isSearchResultItem(item) &&
+                                !/node\//.test(item._content_url))
+                          )
                     )
                   ),
                 300

--- a/assets/ts/ui/autocomplete/templates/algolia.tsx
+++ b/assets/ts/ui/autocomplete/templates/algolia.tsx
@@ -28,7 +28,7 @@ export function LinkForItem(props: LinkForItemProps): React.ReactElement {
 
   // Search result items are a subset of content items that point to a different URL
   if (isSearchResultItem(item)) {
-    url = item._search_result_url.replace("internal:", "");
+    url = item._search_result_url.replace(/internal:/, "");
   }
 
   // Special case: When the matching text isn't part of the page title, help the

--- a/assets/ts/ui/autocomplete/templates/algolia.tsx
+++ b/assets/ts/ui/autocomplete/templates/algolia.tsx
@@ -7,6 +7,7 @@ import {
   getTitleAttribute,
   isContentItem,
   isRouteItem,
+  isSearchResultItem,
   isStopItem
 } from "../helpers";
 import {
@@ -22,7 +23,13 @@ interface LinkForItemProps {
 }
 export function LinkForItem(props: LinkForItemProps): React.ReactElement {
   const { item, query, children } = props;
-  const url = isContentItem(item) ? item._content_url : item.url;
+
+  var url = isContentItem(item) ? item._content_url : item.url;
+
+  // Search result items are a subset of content items that point to a different URL
+  if (isSearchResultItem(item)) {
+    url = item._search_result_url.replace("internal:", "");
+  }
 
   // Special case: When the matching text isn't part of the page title, help the
   // user locate the matching text by linking directly to / scrolling to the


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1206080145852890/f

Fixes an issue with the search header bar and the search page.

For the search header bar, we weren't getting the referenced URL for a search node. So, it was just rendering the search node. It also wasn't filtering out search results that don't have a real URL.

For the search page, we weren't filtering out search results that don't have a real URL.
