### PR TITLE
Use elixir image because hex doesnt support otp 25 or 26

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 18.17.1
-erlang 26.2.1
+erlang 26.2.2
 elixir 1.16.1-otp-26

--- a/deploy/dotcom/Dockerfile
+++ b/deploy/dotcom/Dockerfile
@@ -3,7 +3,7 @@
 ###
 
 # 1.) Get the Elixir dependencies within an Elixir container
-FROM hexpm/elixir:1.16.1-erlang-26.2.1-debian-buster-20231009-slim as elixir-builder
+FROM elixir:1.16.1-slim as elixir-builder
 
 ENV LANG="C.UTF-8" MIX_ENV="prod"
 

--- a/deploy/dotcom/Dockerfile
+++ b/deploy/dotcom/Dockerfile
@@ -3,7 +3,7 @@
 ###
 
 # 1.) Get the Elixir dependencies within an Elixir container
-FROM elixir:1.16.1-slim as elixir-builder
+FROM hexpm/elixir:1.16.1-erlang-26.2.2-debian-buster-20240130-slim as elixir-builder
 
 ENV LANG="C.UTF-8" MIX_ENV="prod"
 


### PR DESCRIPTION
This hotfix uses the official Elixir image rather than one from Hex because Hex doesn't have any OTP 25 or 26 images.
