### PR TITLE
feat(Alerts): display updated_at timezone

### DIFF
--- a/assets/ts/components/Alerts.tsx
+++ b/assets/ts/components/Alerts.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from "react";
-import { format, parseISO } from "date-fns";
+import { parseISO } from "date-fns";
+import { format } from "date-fns-tz";
 import { Alert as AlertType, Lifecycle } from "../__v3api";
 import { handleReactEnterKeyPress } from "../helpers/keyboard-events-react";
 import { caret } from "../helpers/icon";
@@ -206,7 +207,7 @@ const alertDescription = (alert: AlertType): ReactElement<HTMLElement> => (
       />
       {alert.updated_at && (
         <div className="c-alert-item__updated">
-          Updated: {format(parseISO(alert.updated_at), "M/d/yyyy h:mm aa")}
+          Updated: {format(parseISO(alert.updated_at), "M/d/yyyy h:mm aa zzz")}
         </div>
       )}
     </div>

--- a/assets/ts/components/Alerts.tsx
+++ b/assets/ts/components/Alerts.tsx
@@ -1,6 +1,4 @@
 import React, { ReactElement, useState } from "react";
-import { parseISO } from "date-fns";
-import { format } from "date-fns-tz";
 import { Alert as AlertType, Lifecycle } from "../__v3api";
 import { handleReactEnterKeyPress } from "../helpers/keyboard-events-react";
 import { caret } from "../helpers/icon";
@@ -9,6 +7,7 @@ import shuttleIcon from "../../static/images/icon-shuttle-default.svg";
 import cancelIcon from "../../static/images/icon-cancelled-default.svg";
 import snowIcon from "../../static/images/icon-snow-default.svg";
 import alertIcon from "../../static/images/icon-alerts-triangle.svg";
+import { formatToBostonTime } from "../helpers/date";
 
 interface Props {
   alerts: AlertType[];
@@ -207,7 +206,8 @@ const alertDescription = (alert: AlertType): ReactElement<HTMLElement> => (
       />
       {alert.updated_at && (
         <div className="c-alert-item__updated">
-          Updated: {format(parseISO(alert.updated_at), "M/d/yyyy h:mm aa zzz")}
+          Updated:{" "}
+          {formatToBostonTime(alert.updated_at, "M/d/yyyy h:mm aa zzz")}
         </div>
       )}
     </div>

--- a/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
+++ b/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
@@ -87,7 +87,7 @@ exports[`it renders 1`] = `
                   className="c-alert-item__updated"
                 >
                   Updated: 
-                  4/11/2019 9:33 AM
+                  4/11/2019 10:33 AM EDT
                 </div>
               </div>
             </div>

--- a/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
+++ b/assets/ts/components/__tests__/__snapshots__/AlertsTest.tsx.snap
@@ -86,7 +86,8 @@ exports[`it renders 1`] = `
                 <div
                   className="c-alert-item__updated"
                 >
-                  Updated: 
+                  Updated:
+                   
                   4/11/2019 10:33 AM EDT
                 </div>
               </div>

--- a/lib/alerts/parser.ex
+++ b/lib/alerts/parser.ex
@@ -73,6 +73,10 @@ defmodule Alerts.Parser do
     defp parse_time(str) do
       str
       |> Timex.parse!("{ISO:Extended}")
+      # While the time strings are already notated with -05 Etc/GMT+5 or -04
+      # Etc/GMT+4 time zone, this additional conversion gives the DateTime a
+      # nicer timezone abbreviation (EST or EDT)
+      |> Timex.Timezone.convert("America/New_York")
     end
 
     # remove leading/trailing whitespace from description

--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -177,7 +177,7 @@ defmodule DotcomWeb.AlertView do
         Timex.format!(updated_at, "{M}/{D}/{YYYY}")
       end
 
-    time = format_schedule_time(updated_at)
+    time = Timex.format!(updated_at, "{h12}:{m} {AM} {Zabbr}")
 
     ["Updated: ", date, 32, time]
   end


### PR DESCRIPTION
No ticket, based on our discussion this morning. Added the time zone abbreviation to the displayed `updated_at` timestamps, for each the backend and frontend renderings of alerts. Converts the parsed alerts to use the `America/New_York` time zone. Updates the snapshot. This'll probably work?