### PR TITLE
Add memory limits on processes and setup log rotation

### DIFF
--- a/deploy/monitor/Dockerfile
+++ b/deploy/monitor/Dockerfile
@@ -9,6 +9,9 @@ RUN npx playwright install chromium
 RUN npx playwright install-deps
 
 RUN ./node_modules/pm2/bin/pm2 install pm2-logrotate
+RUN ./node_modules/pm2/bin/pm2 set pm2-logrotate:max_size 1M
+RUN ./node_modules/pm2/bin/pm2 set pm2-logrotate:rotateInterval '*/15 * * * *'
+RUN ./node_modules/pm2/bin/pm2 set pm2-logrotate:compress true
 
 COPY integration /home/runner/integration
 

--- a/integration/monitor/ecosystem.config.js
+++ b/integration/monitor/ecosystem.config.js
@@ -4,11 +4,15 @@ module.exports = {
       name: "all-health-checks",
       script: "./integration/monitor/all-health-checks.js",
       instances: 1,
+      max_memory_restart: "256M",
+      exec_mode : "cluster"
     },
     {
       name: "all-scenarios",
       script: "./integration/monitor/all-scenarios.js",
       instances: 1,
+      max_memory_restart: "1024M",
+      exec_mode : "cluster"
     },
   ],
 };


### PR DESCRIPTION
The scenarios script keeps crashing and failing to restart. Running it locally, it doesn't look like it gets anywhere near the memory limit of the task. But, we should set a memory limit anyway. When it reaches the limit, the process will just be restarted. I think the crashes might be related to log rotation. So, I set up some log rotation configuration.
