### PR TITLE
Close the context in Playwright to avoid crashes

### DIFF
--- a/deploy/monitor/Dockerfile
+++ b/deploy/monitor/Dockerfile
@@ -7,8 +7,8 @@ COPY package*.json .
 ENV PLAYWRIGHT_BROWSERS_PATH=0
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
-RUN npx playwright install chromium --with-deps
 RUN npm ci --ignore-scripts
+RUN npx playwright install chromium --with-deps
 
 RUN ./node_modules/pm2/bin/pm2 install pm2-logrotate
 RUN ./node_modules/pm2/bin/pm2 set pm2-logrotate:max_size 1M

--- a/deploy/monitor/Dockerfile
+++ b/deploy/monitor/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/playwright:v1.42.1-jammy
 
-RUN apt install dumb-init -y
+RUN apt-get update
+RUN apt-get install dumb-init -y
 
 RUN useradd -m runner
 USER runner

--- a/deploy/monitor/Dockerfile
+++ b/deploy/monitor/Dockerfile
@@ -1,14 +1,12 @@
-FROM node:21-bookworm
+FROM mcr.microsoft.com/playwright:v1.42.1-jammy
 
+RUN useradd -m runner
+USER runner
 WORKDIR /home/runner
 
 COPY package*.json .
 
-ENV PLAYWRIGHT_BROWSERS_PATH=0
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-
 RUN npm ci --ignore-scripts
-RUN npx playwright install chromium --with-deps
 
 RUN ./node_modules/pm2/bin/pm2 install pm2-logrotate
 RUN ./node_modules/pm2/bin/pm2 set pm2-logrotate:max_size 1M

--- a/deploy/monitor/Dockerfile
+++ b/deploy/monitor/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/playwright:v1.42.1-jammy
 
+RUN apt install dumb-init -y
+
 RUN useradd -m runner
 USER runner
 WORKDIR /home/runner

--- a/deploy/monitor/Dockerfile
+++ b/deploy/monitor/Dockerfile
@@ -5,8 +5,7 @@ WORKDIR /home/runner
 COPY package*.json .
 
 RUN npm ci --ignore-scripts
-RUN npx playwright install chromium
-RUN npx playwright install-deps
+RUN npx playwright install chromium --with-deps
 
 RUN ./node_modules/pm2/bin/pm2 install pm2-logrotate
 RUN ./node_modules/pm2/bin/pm2 set pm2-logrotate:max_size 1M

--- a/deploy/monitor/Dockerfile
+++ b/deploy/monitor/Dockerfile
@@ -4,8 +4,11 @@ WORKDIR /home/runner
 
 COPY package*.json .
 
-RUN npm ci --ignore-scripts
+ENV PLAYWRIGHT_BROWSERS_PATH=0
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 RUN npx playwright install chromium --with-deps
+RUN npm ci --ignore-scripts
 
 RUN ./node_modules/pm2/bin/pm2 install pm2-logrotate
 RUN ./node_modules/pm2/bin/pm2 set pm2-logrotate:max_size 1M

--- a/integration/monitor/worker.js
+++ b/integration/monitor/worker.js
@@ -36,5 +36,7 @@ parentPort.on("message", async (_) => {
   client.gauge(workerData.name, duration);
   logger.info({ metric, duration });
 
+  await page.close();
+  await context.close();
   await browser.close();
 });

--- a/integration/scenarios/search-for-a-subway-line.js
+++ b/integration/scenarios/search-for-a-subway-line.js
@@ -44,5 +44,9 @@ exports.scenario = async ({ page, baseURL }) => {
   const end5 = performance.now();
   const duration5 = Math.floor(end5 - start5);
 
-  logger.info([duration1, duration2, duration3, duration4, duration5]);
+  const duration = Math.floor(
+    duration1 + duration2 + duration3 + duration4 + duration5,
+  );
+
+  logger.info({ durations: [duration1, duration2, duration3, duration4, duration5], duration });
 };

--- a/integration/scenarios/search-for-a-subway-line.js
+++ b/integration/scenarios/search-for-a-subway-line.js
@@ -1,31 +1,16 @@
 const { expect } = require("@playwright/test");
-const Logger = require("node-json-logger");
-const { performance } = require("node:perf_hooks");
-
-const logger = new Logger();
 
 exports.scenario = async ({ page, baseURL }) => {
-  const start1 = performance.now();
   await page.goto(`${baseURL}/`);
-  const end1 = performance.now();
-  const duration1 = Math.floor(end1 - start1);
 
   // We should be able to use down arrow and enter to select the first result.
   // But, the enter key does not load the page. So, we have to click the first result.
-  const start2 = performance.now();
   await page
     .locator("div.search-wrapper input#input")
     .pressSequentially("Green Line");
-  const end2 = performance.now();
-  const duration2 = Math.floor(end2 - start2);
-
-  const start3 = performance.now();
   await page.waitForSelector("ul#algolia-list");
   await page.locator("ul#algolia-list li:first-child a").click();
-  const end3 = performance.now();
-  const duration3 = Math.floor(end3 - start3);
 
-  const start4 = performance.now();
   await expect(page.locator("h1.schedule__route-name")).toHaveText(
     "Green Line",
   );
@@ -33,20 +18,9 @@ exports.scenario = async ({ page, baseURL }) => {
   await expect
     .poll(async () => page.locator("li.m-schedule-diagram__stop").count())
     .toBeGreaterThan(1);
-  const end4 = performance.now();
-  const duration4 = Math.floor(end4 - start4);
 
-  const start5 = performance.now();
   await page.locator("a.alerts-tab").click();
   await expect(
     page.getByRole("heading", { name: "Alerts", exact: true }),
   ).toBeVisible();
-  const end5 = performance.now();
-  const duration5 = Math.floor(end5 - start5);
-
-  const duration = Math.floor(
-    duration1 + duration2 + duration3 + duration4 + duration5,
-  );
-
-  logger.info({ durations: [duration1, duration2, duration3, duration4, duration5], duration });
 };

--- a/integration/scenarios/search-for-a-subway-line.js
+++ b/integration/scenarios/search-for-a-subway-line.js
@@ -1,16 +1,31 @@
 const { expect } = require("@playwright/test");
+const Logger = require("node-json-logger");
+const { performance } = require("node:perf_hooks");
+
+const logger = new Logger();
 
 exports.scenario = async ({ page, baseURL }) => {
+  const start1 = performance.now();
   await page.goto(`${baseURL}/`);
+  const end1 = performance.now();
+  const duration1 = Math.floor(end1 - start1);
 
   // We should be able to use down arrow and enter to select the first result.
   // But, the enter key does not load the page. So, we have to click the first result.
+  const start2 = performance.now();
   await page
     .locator("div.search-wrapper input#input")
     .pressSequentially("Green Line");
+  const end2 = performance.now();
+  const duration2 = Math.floor(end2 - start2);
+
+  const start3 = performance.now();
   await page.waitForSelector("ul#algolia-list");
   await page.locator("ul#algolia-list li:first-child a").click();
+  const end3 = performance.now();
+  const duration3 = Math.floor(end3 - start3);
 
+  const start4 = performance.now();
   await expect(page.locator("h1.schedule__route-name")).toHaveText(
     "Green Line",
   );
@@ -18,9 +33,16 @@ exports.scenario = async ({ page, baseURL }) => {
   await expect
     .poll(async () => page.locator("li.m-schedule-diagram__stop").count())
     .toBeGreaterThan(1);
+  const end4 = performance.now();
+  const duration4 = Math.floor(end4 - start4);
 
+  const start5 = performance.now();
   await page.locator("a.alerts-tab").click();
   await expect(
     page.getByRole("heading", { name: "Alerts", exact: true }),
   ).toBeVisible();
+  const end5 = performance.now();
+  const duration5 = Math.floor(end5 - start5);
+
+  logger.info([duration1, duration2, duration3, duration4, duration5]);
 };


### PR DESCRIPTION
We are seeing issues with Playwright where the browser becomes inaccessible. PM2 will continue to try to restart the process and fail. We don't know the root cause, but we should be closing the page and browser context before we close the browser. This *might* be the issue...causing some kind of memory leak. I've deployed this branch and we'll see if we have any issues.

