### PR TITLE
hotfix(TimetableController): check for date in rating

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -47,7 +47,9 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     Util.log_duration(__MODULE__, :assign_trip_schedules, [conn])
   end
 
-  def assign_trip_schedules(%{assigns: %{route: route, direction_id: direction_id}} = conn) do
+  def assign_trip_schedules(
+        %{assigns: %{route: route, direction_id: direction_id, date_in_rating?: true}} = conn
+      ) do
     timetable_schedules = timetable_schedules(conn)
     header_schedules = header_schedules(timetable_schedules)
     vehicle_schedules = vehicle_schedules(conn, timetable_schedules)
@@ -81,6 +83,14 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     |> assign(:prior_stops, prior_stops)
     |> assign(:trip_messages, trip_messages(route, direction_id))
     |> assign(:all_stops, all_stops)
+  end
+
+  def assign_trip_schedules(conn) do
+    conn
+    |> assign(:timetable_schedules, [])
+    |> assign(:header_schedules, [])
+    |> assign(:vehicle_schedules, [])
+    |> assign(:prior_stops, %{})
   end
 
   @spec track_changes(


### PR DESCRIPTION
skip fetching data for dates outside the rating

it turns out we already had the pieces in place (`conn.assigns.date_in_rating?` is set to true or false using a plug), we just had to use it...

The extra function clause passes along some empty values so the page still renders the same as before. It looks like this.

<img width="1045" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/7ec29926-309c-49a2-a916-3e675640225d">
