### PR TITLE
Flush caches by key

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -35,7 +35,7 @@ export WIREMOCK_TRIP_PLAN_PROXY_URL=http://otp-local.mbtace.com
 # export REDIS_HOST=
 # export REDIS_PORT=
 
-# These credentials control access to resetting cache entries for the CMS.
-# You can set them to be whatever you want, but they'll need to match those on the Drupal side.
+# These credentials control access to resetting cache entries.
+# You can set them to be whatever you want, but they'll need to match external users like Drupal.
 # export BASIC_AUTH_USERNAME=
 # export BASIC_AUTH_PASSWORD=

--- a/.envrc.template
+++ b/.envrc.template
@@ -37,5 +37,5 @@ export WIREMOCK_TRIP_PLAN_PROXY_URL=http://otp-local.mbtace.com
 
 # These credentials control access to resetting cache entries for the CMS.
 # You can set them to be whatever you want, but they'll need to match those on the Drupal side.
-# export CMS_BASIC_AUTH_USERNAME=
-# export CMS_BASIC_AUTH_PASSWORD=
+# export BASIC_AUTH_USERNAME=
+# export BASIC_AUTH_PASSWORD=

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,10 @@ import Config
 
 config :elixir, ansi_enabled: true
 
+config :dotcom, :redis, Dotcom.Cache.Multilevel.Redis
+config :dotcom, :redix, Redix
+config :dotcom, :redix_pub_sub, Redix.PubSub
+
 for config_file <- Path.wildcard("config/{deps,dotcom}/*.exs") do
   import_config("../#{config_file}")
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -80,7 +80,7 @@ redis_config = [
 ]
 
 # This is used by PubSub, we only use the first node in the cluster
-config :dotcom, :redis, redis_config[:redis_cluster][:configuration_endpoints][:conn_opts]
+config :dotcom, :redis_config, redis_config[:redis_cluster][:configuration_endpoints][:conn_opts]
 
 # Set caches that use the Redis cluster
 config :dotcom, Dotcom.Cache.Multilevel,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -95,15 +95,15 @@ config :dotcom, Dotcom.Cache.TripPlanFeedback.Cache, redis_config
 
 if config_env() == :test do
   config :dotcom, DotcomWeb.Router,
-    cms_basic_auth: [
+    basic_auth: [
       username: "username",
       password: "password"
     ]
 else
   config :dotcom, DotcomWeb.Router,
-    cms_basic_auth: [
-      username: System.get_env("CMS_BASIC_AUTH_USERNAME"),
-      password: System.get_env("CMS_BASIC_AUTH_PASSWORD")
+    basic_auth: [
+      username: System.get_env("BASIC_AUTH_USERNAME"),
+      password: System.get_env("BASIC_AUTH_PASSWORD")
     ]
 end
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,7 @@
 import Config
 
 config :dotcom, :cache, Dotcom.Cache.TestCache
+config :dotcom, :redis, Redis.Mock
+config :dotcom, :redix, Redix.Mock
+config :dotcom, :redix_pub_sub, Redix.PubSub.Mock
 config :dotcom, :trip_plan_feedback_cache, Dotcom.Cache.TestCache

--- a/lib/cms/repo.ex
+++ b/lib/cms/repo.ex
@@ -102,7 +102,7 @@ defmodule CMS.Repo do
 
   @decorate cacheable(
               cache: @cache,
-              key: "/cms/whats-happening",
+              key: "cms.repo|whats-happening",
               on_error: :nothing,
               opts: [ttl: 60_000]
             )
@@ -122,7 +122,7 @@ defmodule CMS.Repo do
 
   @decorate cacheable(
               cache: @cache,
-              key: "/cms/important-notices",
+              key: "cms.repo|important-notices",
               on_error: :nothing,
               opts: [ttl: 60_000]
             )
@@ -161,7 +161,7 @@ defmodule CMS.Repo do
 
   @decorate cacheable(
               cache: @cache,
-              key: "/cms/schedules/#{route_id}",
+              key: "cms.repo|schedules|#{route_id}",
               on_error: :nothing,
               opts: [ttl: @ttl]
             )
@@ -193,7 +193,7 @@ defmodule CMS.Repo do
 
   @decorate cacheable(
               cache: @cache,
-              key: "/cms/route_pdfs/#{route_id}",
+              key: "cms.repo|route_pdfs|#{route_id}",
               on_error: :nothing,
               opts: [ttl: @ttl]
             )
@@ -221,11 +221,15 @@ defmodule CMS.Repo do
 
   @impl true
   def generate(_, _, [path, %Plug.Conn.Unfetched{aspect: :query_params}]) do
-    "/cms/#{String.trim(path, "/")}"
+    key = path |> String.trim("/") |> String.replace(~r/\//, "|")
+
+    "cms.repo|#{key}"
   end
 
   def generate(_, _, [path, params]) do
-    "/cms/#{String.trim(path, "/")}" <> params_to_string(params)
+    key = path |> String.trim("/") |> String.replace(~r/\//, "|")
+
+    "cms.repo|#{key}" <> params_to_string(params)
   end
 
   defp params_to_string(params) when params == %{}, do: ""

--- a/lib/dotcom/cache/multilevel.ex
+++ b/lib/dotcom/cache/multilevel.ex
@@ -38,13 +38,31 @@ defmodule Dotcom.Cache.Multilevel do
   Delete all entries where the key matches the pattern.
 
   First, we make sure we can get a connection to Redis.
-  Then, we get all the keys in Redis that match the pattern.
-  We use a cursor to stream the keys in batches of 100 using the SCAN command.
+  Second, we get all of the nodes in the cluster.
+
+  For each node:
+
+  We get all the keys in Redis that match the pattern.
+  Then, we use a cursor to stream the keys in batches of 100 using the SCAN command.
   Finally, we delete all the keys with the default delete/1 function.
   That way we'll delete from the Local, Redis, and publish the delete on the Publisher.
   """
   def flush_keys(pattern \\ "*") do
     case Application.get_env(:dotcom, :redis_config) |> @redix.start_link() do
+      {:ok, conn} -> (delete_from_nodes(conn, pattern) ++ [@redix.stop(conn)]) |> all_ok()
+      {:error, _} -> :error
+    end
+  end
+
+  defp delete_from_nodes(conn, pattern) do
+    case get_nodes(conn) do
+      [] -> :ok
+      nodes -> Enum.map(nodes, fn node -> delete_from_node(node, pattern) end)
+    end
+  end
+
+  defp delete_from_node([host, port], pattern) do
+    case @redix.start_link(host: host, port: port) do
       {:ok, conn} -> delete_redis_keys(conn, pattern)
       {:error, _} -> :error
     end
@@ -62,14 +80,31 @@ defmodule Dotcom.Cache.Multilevel do
 
     result = @redix.stop(conn)
 
-    if all_ok?([result | results]), do: :ok, else: :error
+    [result | results]
   end
 
-  defp all_ok?(list) do
-    Enum.all?(list, fn
-      :ok -> true
-      _ -> false
-    end)
+  defp all_ok(list) do
+    if Enum.all?(list, fn
+         :ok -> true
+         _ -> false
+       end) do
+      :ok
+    else
+      :error
+    end
+  end
+
+  defp get_nodes(conn) do
+    case @redix.command(conn, ["CLUSTER", "SLOTS"]) do
+      {:ok, slots} ->
+        slots
+        |> Enum.flat_map(fn slots -> Enum.slice(slots, 2..99) end)
+        |> Enum.map(fn slot -> Enum.slice(slot, 0..1) end)
+        |> Enum.sort_by(fn [_, port] -> port end)
+
+      {:error, _} ->
+        []
+    end
   end
 
   defp stream_keys(conn, pattern) do

--- a/lib/dotcom/cache/publisher.ex
+++ b/lib/dotcom/cache/publisher.ex
@@ -17,6 +17,7 @@ defmodule Dotcom.Cache.Publisher do
   alias Nebulex.Adapter.Stats
 
   @channel "dotcom:cache:publisher"
+  @redis Application.compile_env!(:dotcom, :redis)
 
   def channel, do: @channel
 
@@ -72,7 +73,7 @@ defmodule Dotcom.Cache.Publisher do
   def delete(meta, key, _) do
     command = "eviction"
 
-    Dotcom.Cache.Multilevel.Redis.command([
+    @redis.command([
       "PUBLISH",
       @channel,
       "#{command}|#{meta.publisher_id}|#{key}"

--- a/lib/dotcom/cache/subscriber.ex
+++ b/lib/dotcom/cache/subscriber.ex
@@ -14,6 +14,7 @@ defmodule Dotcom.Cache.Subscriber do
   @executions %{
     "eviction" => :delete
   }
+  @redix_pub_sub Application.compile_env!(:dotcom, :redix_pub_sub)
 
   def start_link(uuid) do
     GenServer.start_link(__MODULE__, uuid, [])
@@ -25,8 +26,8 @@ defmodule Dotcom.Cache.Subscriber do
   Starts a Redix.PubSub process and subscribes to the channel given by the Publisher.
   """
   def init(uuid) do
-    Application.get_env(:dotcom, :redis)
-    |> Redix.PubSub.start_link()
+    Application.get_env(:dotcom, :redis_config)
+    |> @redix_pub_sub.start_link()
     |> subscribe(@channel)
 
     {:ok, uuid}
@@ -67,6 +68,6 @@ defmodule Dotcom.Cache.Subscriber do
   end
 
   defp subscribe({:ok, pubsub}, channel) do
-    Redix.PubSub.subscribe(pubsub, channel, self())
+    @redix_pub_sub.subscribe(pubsub, channel, self())
   end
 end

--- a/lib/dotcom/redis/behaviour.ex
+++ b/lib/dotcom/redis/behaviour.ex
@@ -1,0 +1,13 @@
+defmodule Dotcom.Redis.Behaviour do
+  @moduledoc """
+  A behaviour module for NebulexRedisAdapter.
+  """
+
+  @callback command(Redix.command()) ::
+              {:ok, Redix.Protocol.redis_value()}
+              | {:error, atom() | Redix.Error.t() | Redix.ConnectionError.t()}
+
+  @implementation Application.compile_env!(:dotcom, :redis)
+
+  def command(cmd), do: @implementation.command(cmd)
+end

--- a/lib/dotcom/redix/behaviour.ex
+++ b/lib/dotcom/redix/behaviour.ex
@@ -1,0 +1,17 @@
+defmodule Dotcom.Redix.Behaviour do
+  @moduledoc """
+  A behaviour module for Redix.
+  """
+
+  @callback command(Redix.connection(), Redix.command()) ::
+              {:ok, Redix.Protocol.redis_value()}
+              | {:error, atom() | Redix.Error.t() | Redix.ConnectionError.t()}
+  @callback start_link(String.t() | keyword()) :: {:ok, pid()} | :ignore | {:error, term()}
+  @callback stop(Redix.connection()) :: :ok
+
+  @implementation Application.compile_env!(:dotcom, :redix)
+
+  def command(conn, cmd), do: @implementation.command(conn, cmd)
+  def start_link(opts), do: @implementation.start_link(opts)
+  def stop(conn), do: @implementation.stop(conn)
+end

--- a/lib/dotcom/redix/pub_sub/behaviour.ex
+++ b/lib/dotcom/redix/pub_sub/behaviour.ex
@@ -1,0 +1,19 @@
+defmodule Dotcom.Redix.PubSub.Behaviour do
+  @moduledoc """
+  A behaviour module for Redix.PubSub.
+  """
+
+  @callback start_link(String.t() | keyword()) :: {:ok, pid()} | :ignore | {:error, term()}
+  @callback subscribe(
+              Redix.PubSub.connection(),
+              String.t() | [String.t()],
+              Redix.PubSub.subscriber()
+            ) :: {:ok, reference()}
+
+  @implementation Application.compile_env!(:dotcom, :redix_pub_sub)
+
+  def start_link(opts), do: @implementation.start_link(opts)
+
+  def subscribe(conn, channels, subscriber),
+    do: @implementation.subscribe(conn, channels, subscriber)
+end

--- a/lib/dotcom_web/controllers/cache_controller.ex
+++ b/lib/dotcom_web/controllers/cache_controller.ex
@@ -37,9 +37,7 @@ defmodule DotcomWeb.CacheController do
   end
 
   defp flush_cache_function(cache) do
-    functions = cache.__info__(:functions)
-
-    if Keyword.has_key?(functions, :flush_keys) do
+    if cache.__info__(:functions) |> Keyword.has_key?(:flush_keys) do
       :flush_keys
     else
       :delete

--- a/lib/dotcom_web/controllers/cache_controller.ex
+++ b/lib/dotcom_web/controllers/cache_controller.ex
@@ -13,6 +13,7 @@ defmodule DotcomWeb.CacheController do
   @doc """
   Flushes the cache given a key in the path.
   Simply use a / in the path where you would use a | in the key.
+  Wildcards are supported.
 
   Examples:
 

--- a/lib/dotcom_web/controllers/cache_controller.ex
+++ b/lib/dotcom_web/controllers/cache_controller.ex
@@ -1,0 +1,47 @@
+defmodule DotcomWeb.CacheController do
+  @moduledoc """
+  A controller that allows us to interact with the cache.
+  Currently, we only support deleting keys from the cache.
+  """
+
+  require Logger
+
+  use DotcomWeb, :controller
+
+  @cache Application.compile_env!(:dotcom, :cache)
+
+  @doc """
+  Flushes the cache given a key in the path.
+  Simply use a / in the path where you would use a | in the key.
+
+  Examples:
+
+  /cache/stops.repo/stop/* -> stops.repo|stop|*
+  /cache/stops.repo/stop/1 -> stops.repo|stop|1
+  """
+  def flush_cache_keys(conn, %{"path" => path}) do
+    key = Enum.join(path, "|")
+
+    try do
+      Kernel.apply(@cache, flush_cache_function(@cache), [key])
+    rescue
+      e in Redix.ConnectionError ->
+        Logger.warning("dotcom_web.cache_controller.error error=redis-#{e.reason}")
+
+      e in Redix.Error ->
+        Logger.warning("dotcom_web.cache_controller.error error=redis-#{e.message}")
+    end
+
+    send_resp(conn, 202, "") |> halt()
+  end
+
+  defp flush_cache_function(cache) do
+    functions = cache.__info__(:functions)
+
+    if Keyword.has_key?(functions, :flush_keys) do
+      :flush_keys
+    else
+      :delete
+    end
+  end
+end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -54,10 +54,10 @@ defmodule DotcomWeb.Router do
     get("/_health", HealthController, :index)
   end
 
-  scope "/cms", DotcomWeb do
+  scope "/cache", DotcomWeb do
     pipe_through([:basic_auth])
 
-    patch("/*path", CMSController, :reset_cache_key)
+    delete("/*path", CacheController, :flush_cache_keys)
   end
 
   # redirect 't.mbta.com' and 'beta.mbta.com' to 'https://www.mbta.com'
@@ -283,7 +283,7 @@ defmodule DotcomWeb.Router do
   end
 
   defp basic_auth(conn, _) do
-    opts = Application.get_env(:dotcom, DotcomWeb.Router)[:cms_basic_auth]
+    opts = Application.get_env(:dotcom, DotcomWeb.Router)[:basic_auth]
 
     Plug.BasicAuth.basic_auth(conn, opts)
   end

--- a/test/dotcom/cache/multilevel_test.exs
+++ b/test/dotcom/cache/multilevel_test.exs
@@ -10,18 +10,21 @@ defmodule Dotcom.Cache.MultilevelTest do
   @cache Application.compile_env!(:dotcom, :cache)
 
   describe "flush_keys" do
-    test "deletes all keys from Redis" do
+    test "deletes all keys that match the pattern" do
       @cache.put("foo|bar", "baz")
       @cache.put("foo|baz", "bar")
+      @cache.put("bar|foo", "baz")
 
       expect(Redix.Mock, :start_link, fn _ -> {:ok, 0} end)
-      expect(Redix.Mock, :command, fn _, _ -> {:ok, [:stop, ["foo|bar", "foo|baz"]]} end)
+      expect(Redix.Mock, :command, fn _, _ -> {:ok, [1, ["foo|bar"]]} end)
+      expect(Redix.Mock, :command, fn _, _ -> {:ok, [:stop, ["foo|baz"]]} end)
       expect(Redix.Mock, :stop, fn _ -> :ok end)
 
       assert Dotcom.Cache.Multilevel.flush_keys("foo|*") == :ok
 
       assert @cache.get("foo|bar") == nil
       assert @cache.get("foo|baz") == nil
+      assert @cache.get("bar|foo") == "baz"
     end
   end
 end

--- a/test/dotcom/cache/multilevel_test.exs
+++ b/test/dotcom/cache/multilevel_test.exs
@@ -1,0 +1,3 @@
+defmodule Dotcom.Cache.MultilevelTest do
+  use ExUnit.Case, async: true
+end

--- a/test/dotcom/cache/multilevel_test.exs
+++ b/test/dotcom/cache/multilevel_test.exs
@@ -17,17 +17,27 @@ defmodule Dotcom.Cache.MultilevelTest do
 
       pattern = "foo|*"
 
+      # We start the link to get the cluster nodes
       expect(Redix.Mock, :start_link, fn _ -> {:ok, 0} end)
+      # We get the cluster nodes
+      expect(Redix.Mock, :command, fn _, ["CLUSTER", "SLOTS"] ->
+        {:ok, [[0, 1, ["127.0.0.1", 6379]]]}
+      end)
 
+      # One node is returned so we start a link to it
+      expect(Redix.Mock, :start_link, fn _ -> {:ok, 1} end)
+      # The first scan returns one key and gives us a cursor to continue
       expect(Redix.Mock, :command, fn _, ["SCAN", "0", "MATCH", ^pattern, _, _] ->
         {:ok, ["1", ["foo|bar"]]}
       end)
 
+      # The second scan returns one key and gives us a stop cursor "0"
       expect(Redix.Mock, :command, fn _, ["SCAN", "1", "MATCH", ^pattern, _, _] ->
         {:ok, ["0", ["foo|baz"]]}
       end)
 
-      expect(Redix.Mock, :stop, fn _ -> :ok end)
+      # We stop the connection to the node we got the list of nodes from as well as each node we operated on
+      expect(Redix.Mock, :stop, 2, fn _ -> :ok end)
 
       assert Dotcom.Cache.Multilevel.flush_keys(pattern) == :ok
 

--- a/test/dotcom/cache/multilevel_test.exs
+++ b/test/dotcom/cache/multilevel_test.exs
@@ -1,3 +1,27 @@
 defmodule Dotcom.Cache.MultilevelTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  setup :set_mox_global
+
+  setup :verify_on_exit!
+
+  @cache Application.compile_env!(:dotcom, :cache)
+
+  describe "flush_keys" do
+    test "deletes all keys from Redis" do
+      @cache.put("foo|bar", "baz")
+      @cache.put("foo|baz", "bar")
+
+      expect(Redix.Mock, :start_link, fn _ -> {:ok, 0} end)
+      expect(Redix.Mock, :command, fn _, _ -> {:ok, [:stop, ["foo|bar", "foo|baz"]]} end)
+      expect(Redix.Mock, :stop, fn _ -> :ok end)
+
+      assert Dotcom.Cache.Multilevel.flush_keys("foo|*") == :ok
+
+      assert @cache.get("foo|bar") == nil
+      assert @cache.get("foo|baz") == nil
+    end
+  end
 end

--- a/test/dotcom/cache/multilevel_test.exs
+++ b/test/dotcom/cache/multilevel_test.exs
@@ -16,8 +16,8 @@ defmodule Dotcom.Cache.MultilevelTest do
       @cache.put("bar|foo", "baz")
 
       expect(Redix.Mock, :start_link, fn _ -> {:ok, 0} end)
-      expect(Redix.Mock, :command, fn _, _ -> {:ok, [1, ["foo|bar"]]} end)
-      expect(Redix.Mock, :command, fn _, _ -> {:ok, [:stop, ["foo|baz"]]} end)
+      expect(Redix.Mock, :command, fn _, _ -> {:ok, ["1", ["foo|bar"]]} end)
+      expect(Redix.Mock, :command, fn _, _ -> {:ok, ["0", ["foo|baz"]]} end)
       expect(Redix.Mock, :stop, fn _ -> :ok end)
 
       assert Dotcom.Cache.Multilevel.flush_keys("foo|*") == :ok

--- a/test/dotcom/cache/publisher_test.exs
+++ b/test/dotcom/cache/publisher_test.exs
@@ -1,3 +1,59 @@
 defmodule Dotcom.Cache.PublisherTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  defmodule Cache do
+    use Nebulex.Cache, otp_app: :dotcom, adapter: Dotcom.Cache.Publisher
+  end
+
+  setup :set_mox_global
+
+  setup do
+    expect(Redix.PubSub.Mock, :start_link, fn _ -> {:ok, 0} end)
+    expect(Redix.PubSub.Mock, :subscribe, fn _, _, _ -> {:ok, 0} end)
+
+    {:ok, pid} = Cache.start_link(stats: true, telemetry: true)
+
+    on_exit(fn ->
+      :ok = Process.sleep(100)
+
+      if Process.alive?(pid), do: Cache.stop(pid)
+    end)
+
+    {:ok, cache: Cache}
+  end
+
+  setup :verify_on_exit!
+
+  describe "delete" do
+    test "publishes cache eviction messages to the Redis PubSub channel" do
+      expect(Redis.Mock, :command, fn ["PUBLISH", _, _] -> :ok end)
+
+      Cache.delete("foo")
+    end
+  end
+
+  describe "stats" do
+    test "increments the evictions counter" do
+      assert Cache.stats().measurements.evictions == 0
+
+      expect(Redis.Mock, :command, fn ["PUBLISH", _, _] -> :ok end)
+
+      Cache.delete("foo")
+
+      assert Cache.stats().measurements.evictions == 1
+    end
+
+    test "resets the evictions counter" do
+      assert Cache.stats().measurements.evictions == 0
+
+      expect(Redis.Mock, :command, fn ["PUBLISH", _, _] -> :ok end)
+
+      Cache.delete("foo")
+
+      assert Cache.stats().measurements.evictions == 1
+      assert Cache.stats().measurements.evictions == 0
+    end
+  end
 end

--- a/test/dotcom/cache/publisher_test.exs
+++ b/test/dotcom/cache/publisher_test.exs
@@ -1,0 +1,3 @@
+defmodule Dotcom.Cache.PublisherTest do
+  use ExUnit.Case, async: true
+end

--- a/test/dotcom/cache/subscriber_test.exs
+++ b/test/dotcom/cache/subscriber_test.exs
@@ -1,3 +1,65 @@
 defmodule Dotcom.Cache.SubscriberTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+  import Mox
+
+  setup :set_mox_global
+
+  setup do
+    expect(Redix.PubSub.Mock, :start_link, fn _ -> {:ok, 0} end)
+    expect(Redix.PubSub.Mock, :subscribe, fn _, _, _ -> {:ok, 0} end)
+
+    uuid = UUID.uuid4()
+
+    {:ok, pid} = GenServer.start_link(Dotcom.Cache.Subscriber, uuid)
+
+    %{pid: pid, uuid: uuid}
+  end
+
+  setup :verify_on_exit!
+
+  @cache Application.compile_env!(:dotcom, :cache)
+  @channel Dotcom.Cache.Publisher.channel()
+
+  describe "handle_info" do
+    test "returns the state if we get a subscription message", %{uuid: uuid} do
+      {:noreply, state} =
+        Dotcom.Cache.Subscriber.handle_info(
+          {:redix_pubsub, nil, nil, :subscribed, %{channel: @channel}},
+          uuid
+        )
+
+      assert state == uuid
+    end
+
+    test "executes the command", %{uuid: uuid} do
+      @cache.put("foo", "bar")
+
+      msg = {:redix_pubsub, nil, nil, :message, %{channel: @channel, payload: "eviction|0|foo"}}
+
+      {:noreply, _} = Dotcom.Cache.Subscriber.handle_info(msg, uuid)
+
+      assert @cache.get("foo") == nil
+    end
+  end
+
+  test "does not execute the command if the subscriber is the publisher", %{uuid: uuid} do
+    @cache.put("foo", "bar")
+
+    msg =
+      {:redix_pubsub, nil, nil, :message, %{channel: @channel, payload: "eviction|#{uuid}|foo"}}
+
+    {:noreply, _} = Dotcom.Cache.Subscriber.handle_info(msg, uuid)
+
+    refute @cache.get("foo") == nil
+  end
+
+  test "does not execute the command if the command is not in the execution list", %{uuid: uuid} do
+    msg = {:redix_pubsub, nil, nil, :message, %{channel: @channel, payload: "foo|0|key"}}
+
+    log = capture_log(fn -> Dotcom.Cache.Subscriber.handle_info(msg, uuid) end)
+
+    assert log =~ "unknown_command command=foo"
+  end
 end

--- a/test/dotcom/cache/subscriber_test.exs
+++ b/test/dotcom/cache/subscriber_test.exs
@@ -1,0 +1,3 @@
+defmodule Dotcom.Cache.SubscriberTest do
+  use ExUnit.Case, async: true
+end

--- a/test/dotcom_web/controllers/cache_controller_test.exs
+++ b/test/dotcom_web/controllers/cache_controller_test.exs
@@ -5,7 +5,7 @@ defmodule DotcomWeb.CacheControllerTest do
 
   describe "DELETE /cache/*path" do
     test "it removes an entry from the cache", %{conn: conn} do
-      paths = ["/cache/foo", "/cache/foo/bar", "/cache/foo/bar/baz"]
+      paths = ["/cache/foo", "/cache/foo/bar"]
 
       Enum.each(paths, fn path ->
         key = String.replace(path, "/cache/", "") |> String.split("/") |> Enum.join("|")

--- a/test/dotcom_web/controllers/cache_controller_test.exs
+++ b/test/dotcom_web/controllers/cache_controller_test.exs
@@ -1,0 +1,28 @@
+defmodule DotcomWeb.CacheControllerTest do
+  use DotcomWeb.ConnCase, async: false
+
+  @cache Application.compile_env!(:dotcom, :cache)
+
+  describe "DELETE /cache/*path" do
+    test "it removes an entry from the cache", %{conn: conn} do
+      paths = ["/cache/foo", "/cache/foo/bar", "/cache/foo/bar/baz"]
+
+      Enum.each(paths, fn path ->
+        key = String.replace(path, "/cache/", "") |> String.split("/") |> Enum.join("|")
+
+        @cache.put(key, "foo")
+
+        assert @cache.get(key) != nil
+
+        conn =
+          conn
+          |> put_req_header("content-type", "application/json")
+          |> put_req_header("authorization", "Basic " <> Base.encode64("username:password"))
+          |> delete(path)
+
+        assert @cache.get(key) == nil
+        assert conn.status == 202
+      end)
+    end
+  end
+end

--- a/test/dotcom_web/controllers/cms_controller_test.exs
+++ b/test/dotcom_web/controllers/cms_controller_test.exs
@@ -3,8 +3,6 @@ defmodule DotcomWeb.CMSControllerTest do
 
   alias Plug.Conn
 
-  @cache Application.compile_env!(:dotcom, :cache)
-
   describe "GET - page" do
     test "renders a basic page when the CMS returns a CMS.Page.Basic", %{conn: conn} do
       conn = get(conn, "/basic_page_no_sidebar")
@@ -182,27 +180,6 @@ defmodule DotcomWeb.CMSControllerTest do
       assert conn.status == 500
 
       assert html_response(conn, 500) =~ "Something went wrong on our end."
-    end
-  end
-
-  describe "PATCH /cms/*path" do
-    test "it removes an entry from the cache", %{conn: conn} do
-      paths = ["/cms/foo", "/cms/foo/bar", "/cms/foo/bar/baz"]
-
-      Enum.each(paths, fn path ->
-        @cache.put(path, "foo")
-
-        assert @cache.get(path) != nil
-
-        conn =
-          conn
-          |> put_req_header("content-type", "application/json")
-          |> put_req_header("authorization", "Basic " <> Base.encode64("username:password"))
-          |> patch(path)
-
-        assert @cache.get(path) == nil
-        assert conn.status == 202
-      end)
     end
   end
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,0 +1,5 @@
+# This file houses definitions for defining Mox mocks.
+
+Mox.defmock(Redis.Mock, for: Dotcom.Redis.Behaviour)
+Mox.defmock(Redix.Mock, for: Dotcom.Redix.Behaviour)
+Mox.defmock(Redix.PubSub.Mock, for: Dotcom.Redix.PubSub.Behaviour)


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1206042318802989/f

Adds the ability to flush the cache according to a given pattern (which could just be one key) by sending an HTTP request with Basic Auth.