### PR TITLE
Use dumb init

### DIFF
--- a/.github/workflows/push-monitor.yml
+++ b/.github/workflows/push-monitor.yml
@@ -1,6 +1,8 @@
 name: Push Monitor
 
 on:
+  schedule:
+    - cron: '0 */12 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/push-monitor.yml
+++ b/.github/workflows/push-monitor.yml
@@ -1,8 +1,6 @@
 name: Push Monitor
 
 on:
-  schedule:
-    - cron: '0 */12 * * *'
   workflow_dispatch:
 
 jobs:

--- a/deploy/monitor/Dockerfile
+++ b/deploy/monitor/Dockerfile
@@ -18,4 +18,4 @@ RUN ./node_modules/pm2/bin/pm2 set pm2-logrotate:compress true
 
 COPY integration /home/runner/integration
 
-CMD ["./node_modules/pm2/bin/pm2-runtime", "./integration/monitor/ecosystem.config.js"]
+CMD ["/usr/bin/dumb-init", "./node_modules/pm2/bin/pm2-runtime", "./integration/monitor/ecosystem.config.js"]

--- a/integration/health_checks/otp.js
+++ b/integration/health_checks/otp.js
@@ -2,7 +2,7 @@ const { status200 } = require("../utils");
 
 const options = {
   baseURL: process.env.OPEN_TRIP_PLANNER_URL,
-  url: "/health",
+  url: "/otp/actuators/health",
 };
 
 exports.check = async (_) => {


### PR DESCRIPTION
We need to actually call `dumb-init`. We can try redeploying the monitor every 12 hours until we can figure out how to run it somewhere where it won't crash. Maybe using dumb-init will solve the problem...probably not.

