### PR TITLE
fix(RealtimeSchedule): partial revert of #1915

### DIFF
--- a/lib/dotcom/realtime_schedule.ex
+++ b/lib/dotcom/realtime_schedule.ex
@@ -175,13 +175,13 @@ defmodule Dotcom.RealtimeSchedule do
       Task.async(fn ->
         next_two_predictions =
           [
-            route: route_pattern.route_id,
-            direction_id: route_pattern.direction_id
+            stop: stop_id,
+            route_pattern: route_pattern.id,
+            sort: "time",
+            "page[limit]": @predicted_schedules_per_stop
           ]
           |> predictions_fn.()
           |> Enum.filter(& &1.time)
-          |> Enum.filter(&(&1.stop.id == stop_id && &1.trip.route_pattern_id == route_pattern.id))
-          |> Enum.take(@predicted_schedules_per_stop)
 
         {key, next_two_predictions}
       end)

--- a/lib/predictions/repo.ex
+++ b/lib/predictions/repo.ex
@@ -43,8 +43,11 @@ defmodule Predictions.Repo do
   defp add_all_optional_params(opts) do
     @default_params
     |> add_optional_param(opts, :route)
+    |> add_optional_param(opts, :stop)
     |> add_optional_param(opts, :direction_id)
     |> add_optional_param(opts, :trip)
+    |> add_optional_param(opts, :route_pattern)
+    |> add_optional_param(opts, :"page[limit]")
     |> add_optional_param(opts, :sort)
   end
 

--- a/test/dotcom/realtime_schedule_test.exs
+++ b/test/dotcom/realtime_schedule_test.exs
@@ -189,6 +189,49 @@ defmodule Dotcom.RealtimeScheduleTest do
       %{
         stop: %{accessibility: [], address: nil, id: "place-ogmnl", name: nil, parking_lots: []},
         predicted_schedules_by_route_pattern: %{
+          "Forest Hills" => %{
+            direction_id: 0,
+            predicted_schedules: [
+              %{
+                prediction: %{
+                  __struct__: Predictions.Prediction,
+                  departing?: false,
+                  direction_id: 1,
+                  id: "prediction-40709316-70036-190",
+                  schedule_relationship: nil,
+                  status: nil,
+                  stop_sequence: 190,
+                  arrival_time: @now,
+                  departure_time: @now_departure,
+                  time: ["arriving"],
+                  track: nil,
+                  headsign: "Oak Grove",
+                  vehicle_id: "vehicle_id",
+                  platform_stop_id: "70036"
+                },
+                schedule: nil
+              },
+              %{
+                prediction: %{
+                  __struct__: Predictions.Prediction,
+                  departing?: false,
+                  direction_id: 1,
+                  id: "prediction-40709317-70036-190",
+                  schedule_relationship: nil,
+                  status: nil,
+                  stop_sequence: 190,
+                  arrival_time: @now,
+                  departure_time: @now_departure,
+                  time: ["arriving"],
+                  track: nil,
+                  headsign: "Oak Grove",
+                  vehicle_id: nil,
+                  platform_stop_id: "70036"
+                },
+                schedule: nil
+              }
+            ]
+          },
           "Oak Grove" => %{
             direction_id: 1,
             predicted_schedules: [


### PR DESCRIPTION
More specifically, this is a partial revert of 8a50295235a40c7f8b7b9e77d72770a8af36cfaf

This takes `Dotcom.RealtimeSchedule` (used in Transit Near Me) back to the original request parameters for fetching predictions at a frequent interval. We're hoping it improves performance by (1) requesting less data from the V3 API and (2) having less data to parse through on our end.