### PR TITLE
feat(TimetableController): revised stop sorting

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -147,8 +147,9 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
 
       schedules ->
         schedules
-        |> Enum.reject(&Schedules.Schedule.no_times?/1)
-        |> Enum.filter(&(&1.route.line_id == route.line_id))
+        |> Enum.filter(
+          &(&1.route.line_id == route.line_id and not Schedules.Schedule.no_times?(&1))
+        )
     end
   end
 

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -148,6 +148,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
       schedules ->
         schedules
         |> Enum.reject(&Schedules.Schedule.no_times?/1)
+        |> Enum.filter(&(&1.route.line_id == route.line_id))
     end
   end
 

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -58,7 +58,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     %{
       trip_schedules: trip_schedules,
       all_stops: all_stops
-    } = build_timetable(conn.assigns.all_stops, timetable_schedules)
+    } = build_timetable(conn.assigns.all_stops, timetable_schedules, direction_id)
 
     canonical_rps =
       RoutePatterns.Repo.by_route_id(route.id,
@@ -227,20 +227,40 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
 
   defp tab_name(conn, _), do: assign(conn, :tab, "timetable")
 
-  @spec build_timetable([Stops.Stop.t()], [Schedules.Schedule.t()]) :: %{
+  @spec build_timetable([Stops.Stop.t()], [Schedules.Schedule.t()], 0 | 1) :: %{
           required(:trip_schedules) => %{
             required({Schedules.Trip.id_t(), Stops.Stop.id_t()}) => Schedules.Schedule.t()
           },
           required(:all_stops) => [Stops.Stop.t()]
         }
-  def build_timetable(all_stops, schedules) do
+  def build_timetable(all_stops, schedules, direction_id) do
     trip_schedules = Map.new(schedules, &trip_schedule(&1))
-    all_stops = remove_unused_stops(all_stops, schedules)
+
+    all_stops =
+      remove_unused_stops(all_stops, schedules)
+      |> Enum.sort_by(fn stop ->
+        {zone_to_sortable(stop.zone, direction_id),
+         trip_schedule_sequence_for_stop(stop, schedules)}
+      end)
 
     %{
       trip_schedules: trip_schedules,
       all_stops: all_stops
     }
+  end
+
+  defp zone_to_sortable("1A", _), do: 0
+  defp zone_to_sortable(zone, 0), do: String.to_integer(zone)
+  defp zone_to_sortable(zone, 1), do: -String.to_integer(zone)
+
+  # translate each stop into a general stop_sequence value a given stop will
+  # have a different value for stop_sequence depending on the other stops in the
+  # trip, so we summarize here by taking the maximum value
+  defp trip_schedule_sequence_for_stop(stop, schedules) do
+    schedules
+    |> Enum.filter(&(&1.stop == stop))
+    |> Enum.map(& &1.stop_sequence)
+    |> Enum.max(fn -> 0 end)
   end
 
   @spec trip_schedule(Schedules.Schedule.t()) ::

--- a/test/dotcom_web/controllers/schedule/timetable_controller_test.exs
+++ b/test/dotcom_web/controllers/schedule/timetable_controller_test.exs
@@ -2,15 +2,11 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
   @moduledoc false
   use ExUnit.Case, async: true
   import DotcomWeb.ScheduleController.TimetableController
+  import Test.Support.Factory
   alias Routes.Route
   alias Stops.Stop
   alias Schedules.{Schedule, Trip}
 
-  @stops [
-    %Stop{id: "1"},
-    %Stop{id: "2"},
-    %Stop{id: "3"}
-  ]
   @schedules [
     %Schedule{
       stop_sequence: 1,
@@ -46,7 +42,7 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
       stop_sequence: 5,
       time: DateTime.from_unix!(50_000),
       route: %Route{description: :rail_replacement_bus},
-      stop: %Stop{id: "5", name: "name3"},
+      stop: %Stop{id: "5", name: "name3", zone: "5"},
       trip: %Trip{id: "trip-5", headsign: "shuttle", name: "789"}
     }
   ]
@@ -70,29 +66,60 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
     "shuttle-trip-4" => %{stop_name: "shuttle", stop_sequence: 4, trip_id: "trip-4"}
   }
 
-  describe "build_timetable/2" do
-    test "trip_schedules: a map from trip_id/stop_id to a schedule" do
-      %{trip_schedules: trip_schedules} = build_timetable(@stops, @schedules)
+  setup_all do
+    stops = build_list(3, :stop)
+    trips = build_list(6, :trip, %{direction_id: 0})
+    route = build(:route)
 
-      for schedule <- @schedules do
+    schedules =
+      for trip <- trips do
+        build(:schedule, %{
+          route: route,
+          trip: trip,
+          stop: Faker.Util.pick(stops)
+        })
+      end
+
+    {:ok,
+     %{
+       stops: stops,
+       schedules: schedules
+     }}
+  end
+
+  describe "build_timetable/3" do
+    test "trip_schedules: a map from trip_id/stop_id to a schedule", %{
+      stops: stops,
+      schedules: schedules
+    } do
+      %{trip_schedules: trip_schedules} = build_timetable(stops, schedules, 0)
+
+      for schedule <- schedules do
         assert trip_schedules[{schedule.trip.id, schedule.stop.id}] == schedule
       end
 
-      assert map_size(trip_schedules) == length(@schedules)
+      assert map_size(trip_schedules) == length(schedules)
     end
 
-    test "all_stops: list of the stops in the same order" do
-      %{all_stops: all_stops} = build_timetable(@stops, @schedules)
-
-      assert all_stops == @stops
+    test "all_stops: list of the stops gets reordered by schedules/stop zone", %{
+      stops: stops,
+      schedules: schedules
+    } do
+      # stops are already in the "ideal" order; make it wrong here
+      stops = Enum.reverse(stops)
+      %{all_stops: all_stops} = build_timetable(stops, schedules, 0)
+      refute all_stops == stops
     end
 
-    test "all_stops: if a stop isn't used, it's removed from the list" do
-      schedules = Enum.take(@schedules, 1)
+    test "all_stops: if a stop isn't used, it's removed from the list", %{
+      stops: stops,
+      schedules: schedules
+    } do
+      [%Schedules.Schedule{stop: stop_to_remove} | _] = schedules
+      schedules = schedules |> Enum.reject(&(&1.stop == stop_to_remove))
 
-      %{all_stops: all_stops} = build_timetable(@stops, schedules)
-      # other two stops were removed
-      assert [%{id: "1"}] = all_stops
+      %{all_stops: all_stops} = build_timetable(stops, schedules, 0)
+      refute stop_to_remove in all_stops
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,7 +4,47 @@ defmodule Test.Support.Factory do
   """
   use ExMachina
 
+  alias Routes.Route
+  alias Schedules.{Schedule, Trip}
+  alias Stops.Stop
   alias TripPlan.{Itinerary, Leg, NamedPosition, PersonalDetail, TransitDetail}
+
+  def stop_factory do
+    %Stop{
+      id: sequence(:id, &"stop-#{&1}"),
+      address: Faker.Address.street_address(),
+      municipality: Faker.Address.city(),
+      latitude: Faker.Address.latitude(),
+      longitude: Faker.Address.longitude(),
+      type: :stop,
+      zone: sequence(:zone, ["1A", "1", "2", "3", "4", "5", "6", "7", "8"])
+    }
+  end
+
+  def route_factory do
+    %Route{
+      id: sequence(:id, &"route-#{&1}"),
+      direction_destinations: %{
+        0 => Faker.Address.street_name(),
+        1 => Faker.Address.street_name()
+      }
+    }
+  end
+
+  def trip_factory do
+    %Trip{
+      id: sequence(:id, &"trip-#{&1}")
+    }
+  end
+
+  def schedule_factory do
+    %Schedule{
+      trip: build(:trip),
+      stop: build(:stop),
+      route: build(:route),
+      stop_sequence: Faker.random_between(0, 10) * 10
+    }
+  end
 
   def itinerary_factory do
     start = Faker.DateTime.forward(1)


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Fix incorrectly ordered timetable stops](https://app.asana.com/0/555089885850811/1206815695536344/f)


The primary change: Ensure stop sorting is consistent with each stop's `zone` number and schedule's `stop_sequence` values

So the simplest sorting that worked consitently across all commuter rail lines involved comparing the `stop_sequence` across all trips. Technically sorting initially by `zone` wasn't needed to show stops in a sensible order, but I found that adding it improved the legibility of a few timetables by placing certain termini stops more proximate to its adjacent stops.

This came with a slight caveat - for Newburyport/Rockport, having two branches which reach similar distances, the branched stops end up displaying interlined instead of clustering by branch. I'd tried a few different things which might help that (e.g. group by route pattern) but this proved more complicated and unreliable.


---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.