### PR TITLE
Revert "Convert all RepoCache caches to Nebulex (#1900)"

### DIFF
--- a/lib/alerts/supervisor.ex
+++ b/lib/alerts/supervisor.ex
@@ -1,0 +1,27 @@
+defmodule Alerts.Supervisor do
+  @moduledoc """
+  Supervisor for loading and caching V3 API alerts.
+  """
+  use Supervisor
+
+  def start_link(_) do
+    Supervisor.start_link(__MODULE__, [])
+  end
+
+  @impl Supervisor
+  def init(_) do
+    children =
+      case Application.get_env(:dotcom, :alerts_bus_stop_change_bucket) do
+        nil ->
+          [Alerts.CacheSupervisor]
+
+        _ ->
+          [
+            Alerts.CacheSupervisor,
+            Alerts.BusStopChangeSupervisor
+          ]
+      end
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -24,6 +24,32 @@ defmodule Dotcom.Application do
       update_static_url(Application.get_env(:dotcom, DotcomWeb.Endpoint))
     )
 
+    to_be_deprecated = [
+      %{
+        id: ConCache,
+        start:
+          {ConCache, :start_link,
+           [
+             [
+               ttl: :timer.seconds(60),
+               ttl_check: :timer.seconds(5),
+               ets_options: [read_concurrency: true]
+             ],
+             [name: :line_diagram_realtime_cache]
+           ]}
+      },
+      RepoCache.Log,
+      Schedules.Repo,
+      Schedules.RepoCondensed,
+      Facilities.Repo,
+      Stops.Repo,
+      Algolia.Api,
+      LocationService,
+      Services.Repo,
+      RoutePatterns.Repo,
+      Dotcom.RealtimeSchedule
+    ]
+
     children =
       [
         {Application.get_env(:dotcom, :cache, Dotcom.Cache.Multilevel), []},
@@ -39,6 +65,7 @@ defmodule Dotcom.Application do
         else
           []
         end ++
+        to_be_deprecated ++
         if Application.get_env(:dotcom, :start_data_processes) do
           [
             Vehicles.Supervisor,
@@ -61,8 +88,8 @@ defmodule Dotcom.Application do
           Routes.Supervisor,
           Predictions.Supervisor,
           {Phoenix.PubSub, name: Dotcom.PubSub},
-          Alerts.BusStopChangeSupervisor,
-          Alerts.CacheSupervisor,
+          Alerts.Supervisor,
+          Fares.Supervisor,
           {DotcomWeb.Endpoint, name: DotcomWeb.Endpoint}
         ]
 

--- a/lib/dotcom/content_rewriters/liquid_objects/fare.ex
+++ b/lib/dotcom/content_rewriters/liquid_objects/fare.ex
@@ -280,7 +280,7 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.Fare do
   @spec filter_insert([repo_arg], [{fare_key, String.t()}]) :: [repo_arg]
   defp filter_insert(old_args, new_args) do
     Enum.reduce(new_args, old_args, fn {k, v}, args ->
-      Keyword.put(args, k, String.to_atom(v))
+      Keyword.put(args, k, String.to_existing_atom(v))
     end)
   end
 

--- a/lib/dotcom_web/controllers/schedule/line_api.ex
+++ b/lib/dotcom_web/controllers/schedule/line_api.ex
@@ -1,17 +1,10 @@
 defmodule DotcomWeb.ScheduleController.LineApi do
-  @moduledoc """
-  Provides JSON endpoints for retrieving line diagram data.
-  """
-
+  @moduledoc "Provides JSON endpoints for retrieving line diagram data."
   use DotcomWeb, :controller
-  use Nebulex.Caching.Decorators
 
   alias Dotcom.TransitNearMe
   alias DotcomWeb.ScheduleController.Line.Helpers, as: LineHelpers
   alias Vehicles.Vehicle
-
-  @cache Application.compile_env!(:dotcom, :cache)
-  @ttl :timer.minutes(1)
 
   @typep simple_vehicle :: %{
            id: String.t(),
@@ -68,14 +61,18 @@ defmodule DotcomWeb.ScheduleController.LineApi do
           |> assign(:direction_id, String.to_integer(direction_id))
           |> assign_vehicle_tooltips([])
 
+        cache_key = {route_id, direction_id, conn.assigns.date}
+
         payload =
-          do_realtime(
-            route_id,
-            direction_id,
-            conn.assigns.date,
-            conn.assigns.date_time,
-            conn.assigns.vehicle_tooltips
-          )
+          ConCache.get_or_store(:line_diagram_realtime_cache, cache_key, fn ->
+            do_realtime(
+              route_id,
+              direction_id,
+              conn.assigns.date,
+              conn.assigns.date_time,
+              conn.assigns.vehicle_tooltips
+            )
+          end)
 
         conn
         |> put_resp_content_type("application/json")
@@ -86,17 +83,6 @@ defmodule DotcomWeb.ScheduleController.LineApi do
     end
   end
 
-  @decorate cacheable(
-              cache: @cache,
-              key:
-                Dotcom.Cache.KeyGenerator.generate(__MODULE__, :do_realtime, [
-                  route_id,
-                  direction_id,
-                  date
-                ]),
-              on_error: :nothing,
-              opts: [ttl: @ttl]
-            )
   defp do_realtime(route_id, direction_id, date, now, tooltips) do
     headsigns_by_stop =
       TransitNearMe.time_data_for_route_by_stop(

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -303,10 +303,6 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     %{stop_sequence: s, stop_name: headsign, trip_id: ti}
   end
 
-  defp construct_vehicle_data(_) do
-    %{stop_sequence: nil, stop_name: nil, trip_id: nil}
-  end
-
   @spec prior_stops(map) :: map
   def prior_stops(vehicle_schedules) do
     vehicle_schedules

--- a/lib/facilities/repo.ex
+++ b/lib/facilities/repo.ex
@@ -2,12 +2,12 @@ defmodule Facilities.Repo do
   @moduledoc """
   Repo to get facilitiy information.
   """
+  use RepoCache, ttl: :timer.hours(1)
 
-  use Nebulex.Caching.Decorators
-
-  @cache Application.compile_env!(:dotcom, :cache)
-  @ttl :timer.hours(24)
-
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  def get_for_stop(stop_id), do: V3Api.Facilities.filter_by([{"stop", stop_id}])
+  def get_for_stop(stop_id) do
+    cache(stop_id, fn stop_id ->
+      [{"stop", stop_id}]
+      |> V3Api.Facilities.filter_by()
+    end)
+  end
 end

--- a/lib/fares/supervisor.ex
+++ b/lib/fares/supervisor.ex
@@ -1,0 +1,21 @@
+defmodule Fares.Supervisor do
+  @moduledoc """
+  Supervisor managing data supporting the display of fare information, such as
+  prices, types of passes, and sales locations.
+  """
+  use Supervisor
+
+  def start_link(_) do
+    Supervisor.start_link(__MODULE__, [])
+  end
+
+  @impl Supervisor
+  def init(_) do
+    children = [
+      Fares.Repo,
+      Fares.RetailLocations.Data
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/predictions/repo.ex
+++ b/lib/predictions/repo.ex
@@ -1,19 +1,12 @@
 defmodule Predictions.Repo do
-  @moduledoc """
-  Predictions repo module
-  """
+  @moduledoc "Predictions repo module"
 
+  use RepoCache, ttl: :timer.seconds(10), ttl_check: :timer.seconds(2)
   require Logger
   require Routes.Route
-
-  use Nebulex.Caching.Decorators
-
-  alias Predictions.Parser
   alias Routes.Route
+  alias Predictions.Parser
   alias Stops.Stop
-
-  @cache Application.compile_env!(:dotcom, :cache)
-  @ttl :timer.seconds(10)
 
   @default_params [
     "fields[prediction]":
@@ -28,7 +21,7 @@ defmodule Predictions.Repo do
 
     opts
     |> add_all_optional_params()
-    |> cache_fetch()
+    |> cache(&fetch/1)
     |> filter_by_min_time(Keyword.get(opts, :min_time))
     |> load_from_other_repos
   end
@@ -69,11 +62,6 @@ defmodule Predictions.Repo do
         cache_trips(data)
         Enum.flat_map(data, &parse/1)
     end
-  end
-
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  defp cache_fetch(opts) do
-    fetch(opts)
   end
 
   defp cache_trips(data) do

--- a/lib/predictions/supervisor.ex
+++ b/lib/predictions/supervisor.ex
@@ -4,6 +4,7 @@ defmodule Predictions.Supervisor do
 
   Children include:
   - StreamSupervisor: Dynamically sets up per-route streams of predictions from the API.
+  - Repo: Manages ad-hoc API requests.
   """
 
   use Supervisor
@@ -20,7 +21,8 @@ defmodule Predictions.Supervisor do
       {Registry, keys: :duplicate, name: :prediction_subscriptions_registry},
       Predictions.Store,
       Predictions.StreamSupervisor,
-      Predictions.PredictionsPubSub
+      Predictions.PredictionsPubSub,
+      Predictions.Repo
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/repo_cache/log.ex
+++ b/lib/repo_cache/log.ex
@@ -1,0 +1,147 @@
+defmodule RepoCache.Log do
+  @moduledoc """
+  Responsible for logging hit/miss rates for the different caches.
+
+  Maintains an ETS table of hit/miss rates, which looks like:
+
+  {{repo_module, function_name}, hit_count, miss_count}
+
+  Every 60 seconds, we reset the counts and log the rates, along with the
+  sizes of the tables.
+
+  """
+  use GenServer
+  require Logger
+
+  @table __MODULE__
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, [], name: name)
+  end
+
+  def log(hit_or_miss, mod, name) do
+    do_log({mod, name}, hit_or_miss)
+  rescue
+    ArgumentError ->
+      :error
+  end
+
+  defp do_log(key, :hit) do
+    default = {key, 1, 0}
+
+    :ets.update_counter(
+      @table,
+      key,
+      {2, 1},
+      default
+    )
+
+    :ok
+  end
+
+  defp do_log(key, :miss) do
+    default = {key, 0, 1}
+
+    :ets.update_counter(
+      @table,
+      key,
+      {3, 1},
+      default
+    )
+
+    :ok
+  end
+
+  def all do
+    :ets.tab2list(@table)
+  end
+
+  def init([]) do
+    table_opts = [:named_table, :public, :set, {:write_concurrency, true}]
+
+    @table =
+      try do
+        :ets.new(@table, table_opts)
+      rescue
+        ArgumentError ->
+          true = :ets.delete(@table)
+          :ets.new(@table, table_opts)
+      end
+
+    schedule_log()
+    {:ok, []}
+  end
+
+  def schedule_log do
+    Process.send_after(self(), :output_log, 60_000)
+  end
+
+  def handle_info(:output_log, state) do
+    _ =
+      all()
+      |> reset_table()
+      |> output_cache_hit_rates()
+      |> output_sizes()
+
+    schedule_log()
+    {:noreply, state, :hibernate}
+  end
+
+  def handle_info(msg, state) do
+    _ = Logger.error("module=#{__MODULE__} error=unexpected_message message=#{inspect(msg)}")
+    {:noreply, state}
+  end
+
+  def reset_table(values) do
+    for {key, hit, miss} <- values do
+      # remove the previous hit/miss count from each
+      _ = :ets.update_counter(@table, key, [{2, -hit}, {3, -miss}])
+    end
+
+    values
+  end
+
+  def output_cache_hit_rates(values) do
+    for value <- values do
+      _ =
+        Logger.info(fn ->
+          {{mod, name}, hit, miss} = value
+          total = hit + miss
+
+          hit_rate =
+            case total do
+              0 -> 0.0
+              _ -> Float.round(hit / total, 2)
+            end
+
+          "repocache_report mod=#{mod} fun=#{name} hit=#{hit} miss=#{miss} total=#{total} hit_rate=#{hit_rate}"
+        end)
+    end
+
+    values
+  end
+
+  def output_sizes(values) do
+    modules = values |> Enum.map(&elem(elem(&1, 0), 0)) |> Enum.uniq()
+
+    for mod <- modules do
+      {:ok, table} = ets_table(mod)
+
+      _ =
+        Logger.info(fn ->
+          size = :ets.info(table, :size)
+          memory = :ets.info(table, :memory)
+          "repocache_report table=#{mod} size=#{size} memory=#{memory}"
+        end)
+    end
+
+    values
+  end
+
+  defp ets_table(mod) do
+    {:ok, ConCache.ets(mod)}
+  rescue
+    _ -> :error
+  end
+end

--- a/lib/repo_cache/repo_cache.ex
+++ b/lib/repo_cache/repo_cache.ex
@@ -1,0 +1,141 @@
+defmodule RepoCache do
+  @moduledoc """
+
+  Helps repositories cache their results easily.
+
+  ## Usage
+
+  defmodule Repo do
+    use RepoCache
+
+    def method(opts) do
+      opts
+      |> cache(fn opts ->
+        # long process returning the data to cache
+      end)
+    end
+  end
+
+  ## Options
+
+  Both `use` and calls to `cache` take a `ttl` parameter, which is a number
+  of milliseconds to cache the value.
+
+  """
+  defmacro __using__(opts \\ []) do
+    opts = include_defaults(opts)
+
+    quote location: :keep do
+      require unquote(__MODULE__)
+      import unquote(__MODULE__), only: [cache: 2, cache: 3]
+
+      def opts, do: unquote(opts)
+
+      unquote(server_functions())
+    end
+  end
+
+  defp include_defaults(opts) do
+    opts =
+      opts
+      |> Keyword.put_new(:ttl, :timer.seconds(1))
+      |> Keyword.put(:read_concurrency, true)
+      |> Keyword.put(:write_concurrency, true)
+
+    Keyword.put_new(opts, :ttl_check, opts[:ttl])
+  end
+
+  defmacro cache(fun_param, fun, cache_opts \\ []) do
+    quote do
+      [mod | _] = __ENV__.context_modules
+      {name, _} = __ENV__.function
+
+      unquote(__MODULE__).do_cache(
+        mod,
+        name,
+        unquote(fun),
+        unquote(fun_param),
+        unquote(cache_opts)
+      )
+    end
+  end
+
+  def server_functions do
+    quote do
+      def start_link(opts) do
+        name =
+          case Keyword.get(opts, :name) do
+            nil -> __MODULE__
+            name -> :"#{__MODULE__}:#{name}"
+          end
+
+        ConCache.start_link(opts(), name: name)
+      end
+
+      def start_link do
+        ConCache.start_link(opts(), name: __MODULE__)
+      end
+
+      def default_ttl do
+        Keyword.get(opts(), :ttl)
+      end
+
+      def clear_cache do
+        __MODULE__
+        |> ConCache.ets()
+        |> :ets.delete_all_objects()
+      end
+
+      def child_spec(opts) do
+        %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, [opts]},
+          type: :worker,
+          restart: :permanent,
+          shutdown: 500
+        }
+      end
+    end
+  end
+
+  def do_cache(mod, name, fun, fun_param, cache_opts) do
+    key = {name, fun_param}
+    timeout = Keyword.get(cache_opts, :timeout)
+
+    case ConCache.get(mod, key) do
+      nil ->
+        RepoCache.Log.log(:miss, mod, name)
+
+        ConCache.isolated(mod, key, timeout, fn ->
+          do_cache_isolated(fun, fun_param, mod, key, cache_opts)
+        end)
+
+      value ->
+        RepoCache.Log.log(:hit, mod, name)
+        value
+    end
+  end
+
+  defp do_cache_isolated(fun, fun_param, mod, key, cache_opts) do
+    # We try again to get a value: if we were waiting a while for the lock,
+    # another process may have already updated the cache for us.
+    case ConCache.get(mod, key) do
+      nil ->
+        maybe_set_value(fun.(fun_param), mod, key, cache_opts)
+
+      value ->
+        value
+    end
+  end
+
+  defp maybe_set_value({:error, _} = error, _, _, _) do
+    error
+  end
+
+  defp maybe_set_value(value, mod, key, cache_opts) do
+    ttl = Keyword.get(cache_opts, :ttl, mod.default_ttl())
+    item = %ConCache.Item{value: value, ttl: ttl}
+    ConCache.dirty_put(mod, key, item)
+    value
+  end
+end

--- a/lib/routes/repo.ex
+++ b/lib/routes/repo.ex
@@ -1,9 +1,10 @@
 defmodule Routes.Repo do
   @moduledoc "Repo for fetching Route resources and their associated data from the V3 API."
 
-  require Logger
+  @behaviour Routes.RepoApi
 
-  use Nebulex.Caching.Decorators
+  require Logger
+  use RepoCache, ttl: :timer.hours(1)
 
   import Routes.Parser
 
@@ -11,32 +12,23 @@ defmodule Routes.Repo do
   alias Routes.{Route, Shape}
   alias V3Api.{Shapes}
 
-  @cache Application.compile_env!(:dotcom, :cache)
-  @ttl :timer.hours(1)
-
   @default_opts [include: "route_patterns"]
-
-  @behaviour Routes.RepoApi
 
   @impl Routes.RepoApi
   def all do
-    case cached_all(@default_opts) do
+    case cache(@default_opts, fn _ ->
+           result = handle_response(V3Api.Routes.all(@default_opts))
+
+           for {:ok, routes} <- [result],
+               route <- routes do
+             ConCache.put(__MODULE__, {:get, route.id}, {:ok, route})
+           end
+
+           result
+         end) do
       {:ok, routes} -> routes
       {:error, _} -> []
     end
-  end
-
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  defp cached_all(opts) do
-    result = handle_response(V3Api.Routes.all(opts))
-
-    for {:ok, routes} <- [result], route <- routes do
-      key = Dotcom.Cache.KeyGenerator.generate(__MODULE__, :cached_get, [route.id, opts])
-
-      @cache.put(key, {:ok, route})
-    end
-
-    result
   end
 
   # Used to spoof any Massport route as the data doesn't exist in the API
@@ -57,43 +49,38 @@ defmodule Routes.Repo do
   def get(id) when is_binary(id) do
     opts = @default_opts
 
-    case cached_get(id, opts) do
+    case cache({id, opts}, fn {id, opts} ->
+           with %{data: [route]} <- V3Api.Routes.get(id, opts) do
+             {:ok, parse_route(route)}
+           end
+         end) do
       {:ok, route} -> route
       {:error, _} -> nil
     end
   end
 
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  defp cached_get(id, opts) do
-    with %{data: [route]} <- V3Api.Routes.get(id, opts) do
-      {:ok, parse_route(route)}
-    end
-  end
-
   @impl Routes.RepoApi
   def get_shapes(route_id, opts, filter_negative_priority? \\ true) do
-    shapes = Keyword.put(opts, :route, route_id) |> cached_get_shapes()
+    opts = Keyword.put(opts, :route, route_id)
+
+    shapes =
+      cache(Enum.sort(opts), fn _ ->
+        case Shapes.all(opts) do
+          {:error, _} ->
+            []
+
+          %JsonApi{data: data} ->
+            shapes = Enum.flat_map(data, &parse_shape/1)
+
+            for shape <- shapes do
+              ConCache.put(__MODULE__, {:get_shape, shape.id}, [shape])
+            end
+
+            shapes
+        end
+      end)
 
     filter_shapes_by_priority(shapes, filter_negative_priority?)
-  end
-
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  defp cached_get_shapes(opts) do
-    case Shapes.all(opts) do
-      {:error, _} ->
-        []
-
-      %JsonApi{data: data} ->
-        shapes = Enum.flat_map(data, &parse_shape/1)
-
-        for shape <- shapes do
-          key = Dotcom.Cache.KeyGenerator.generate(__MODULE__, :get_shape, shape.id)
-
-          @cache.put(key, [shape])
-        end
-
-        shapes
-    end
   end
 
   @spec filter_shapes_by_priority([Shape.t()], boolean) :: [Shape.t()]
@@ -109,22 +96,23 @@ defmodule Routes.Repo do
   end
 
   @impl Routes.RepoApi
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   def get_shape(shape_id) do
-    case Shapes.by_id(shape_id) do
-      {:error, _} ->
-        []
+    cache(shape_id, fn _ ->
+      case Shapes.by_id(shape_id) do
+        {:error, _} ->
+          []
 
-      %JsonApi{data: data} ->
-        Enum.flat_map(data, &parse_shape/1)
-    end
+        %JsonApi{data: data} ->
+          Enum.flat_map(data, &parse_shape/1)
+      end
+    end)
   end
 
   @impl Routes.RepoApi
   def by_type(types) when is_list(types) do
     types = Enum.sort(types)
 
-    case by_type_cached(types) do
+    case cache(types, &by_type_uncached/1) do
       {:ok, routes} -> routes
       {:error, _} -> []
     end
@@ -142,48 +130,40 @@ defmodule Routes.Repo do
     end
   end
 
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  defp by_type_cached(types) do
-    by_type_uncached(types)
-  end
-
   @impl Routes.RepoApi
   def by_stop(stop_id, opts \\ []) do
     opts = Keyword.merge(@default_opts, opts)
 
-    case cached_by_stop(stop_id, opts) do
+    case cache({stop_id, opts}, fn {stop_id, opts} ->
+           stop_id |> V3Api.Routes.by_stop(opts) |> handle_response
+         end) do
       {:ok, routes} -> routes
       {:error, _} -> []
     end
-  end
-
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  defp cached_by_stop(stop_id, opts) do
-    stop_id |> V3Api.Routes.by_stop(opts) |> handle_response
   end
 
   @impl Routes.RepoApi
   def by_stop_and_direction(stop_id, direction_id, opts \\ []) do
     opts = Keyword.merge(@default_opts, opts)
 
-    case cached_by_stop_and_direction(stop_id, direction_id, opts) do
+    case cache({stop_id, direction_id, opts}, fn {stop_id, direction_id, opts} ->
+           stop_id
+           |> V3Api.Routes.by_stop_and_direction(direction_id, opts)
+           |> handle_response
+         end) do
       {:ok, routes} -> routes
       {:error, _} -> []
     end
   end
 
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  defp cached_by_stop_and_direction(stop_id, direction_id, opts) do
-    stop_id |> V3Api.Routes.by_stop_and_direction(direction_id, opts) |> handle_response
-  end
-
   @impl Routes.RepoApi
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   def by_stop_with_route_pattern(stop_id) do
-    [stop: stop_id, include: "route_patterns"]
-    |> V3Api.Routes.all()
-    |> Map.get(:data, [])
-    |> Enum.map(&parse_route_with_route_pattern/1)
+    cache({stop_id, [include: "route_patterns"]}, fn {stop_id, _opts} ->
+      [stop: stop_id, include: "route_patterns"]
+      |> V3Api.Routes.all()
+      |> Map.get(:data, [])
+      |> Enum.map(&parse_route_with_route_pattern/1)
+    end)
   end
 
   @doc """

--- a/lib/routes/supervisor.ex
+++ b/lib/routes/supervisor.ex
@@ -10,7 +10,9 @@ defmodule Routes.Supervisor do
 
   @impl Supervisor
   def init(_) do
-    children = []
+    children = [
+      Routes.Repo
+    ]
 
     children =
       if Application.get_env(:dotcom, :route_populate_caches?) &&

--- a/lib/schedules/repo.ex
+++ b/lib/schedules/repo.ex
@@ -1,18 +1,11 @@
 defmodule Schedules.Repo do
-  @moduledoc """
-  Repo for V3 API Schedule resources.
-  """
-
-  use Nebulex.Caching.Decorators
-
+  @moduledoc "Repo for V3 API Schedule resources."
   import Kernel, except: [to_string: 1]
+  use RepoCache, ttl: :timer.hours(1)
 
   alias Routes.Route
   alias Schedules.{Parser, Schedule}
   alias Util
-
-  @cache Application.compile_env!(:dotcom, :cache)
-  @ttl :timer.hours(1)
 
   @type schedule_pair :: {Schedule.t(), Schedule.t()}
 
@@ -41,8 +34,9 @@ defmodule Schedules.Repo do
 
   # Will almost always use cache, unless the calling function explicitly passes "no_cache"
   defp cache_condition(params, true), do: all_from_params(params)
-  defp cache_condition(params, _), do: cache_all_from_params(params)
+  defp cache_condition(params, _), do: cache(params, &all_from_params/1)
 
+  @spec schedule_for_trip(Schedules.Trip.id_t(), Keyword.t()) :: [Schedule.t()] | {:error, any}
   def schedule_for_trip(trip_id, opts \\ [])
 
   def schedule_for_trip("", _) do
@@ -55,21 +49,24 @@ defmodule Schedules.Repo do
     |> Keyword.merge(opts |> Keyword.delete(:min_time))
     |> Keyword.put(:trip, trip_id)
     |> Keyword.put_new_lazy(:date, &Util.service_date/0)
-    |> cache_all_from_params()
+    |> cache(&all_from_params/1)
     |> filter_by_min_time(Keyword.get(opts, :min_time))
     |> load_from_other_repos
   end
 
+  @spec schedules_for_stop(Stop.id_t(), Keyword.t()) :: [Schedule.t()] | {:error, any}
   def schedules_for_stop(stop_id, opts) do
     @default_params
     |> Keyword.merge(opts |> Keyword.delete(:min_time))
     |> Keyword.put(:stop, stop_id)
     |> add_optional_param(opts, :trip)
-    |> cache_all_from_params()
+    |> cache(&all_from_params/1)
     |> filter_by_min_time(Keyword.get(opts, :min_time))
     |> load_from_other_repos
   end
 
+  @spec trip(String.t(), trip_by_id_fn) :: Schedules.Trip.t() | nil
+        when trip_by_id_fn: (String.t() -> JsonApi.t() | {:error, any})
   def trip(trip_id, trip_by_id_fn \\ &V3Api.Trips.by_id/2)
 
   def trip("", _trip_fn) do
@@ -78,13 +75,12 @@ defmodule Schedules.Repo do
   end
 
   def trip(trip_id, trip_by_id_fn) do
-    case fetch_trip(trip_id, trip_by_id_fn) do
+    case cache(trip_id, &fetch_trip(&1, trip_by_id_fn)) do
       {:ok, value} -> value
       {:error, _} -> nil
     end
   end
 
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   defp fetch_trip(trip_id, trip_by_id_fn) do
     trip_opts =
       case Util.config(:dotcom, :enable_experimental_features) do
@@ -104,6 +100,7 @@ defmodule Schedules.Repo do
     end
   end
 
+  @spec end_of_rating() :: Date.t() | nil
   def end_of_rating(all_fn \\ &V3Api.Schedules.all/1) do
     case rating_dates(all_fn) do
       {_start_date, end_date} -> end_date
@@ -111,15 +108,17 @@ defmodule Schedules.Repo do
     end
   end
 
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
+  @spec rating_dates() :: {Date.t(), Date.t()} | :error
   def rating_dates(all_fn \\ &V3Api.Schedules.all/1) do
-    with {:error, [%{code: "no_service"} = error]} <- all_fn.(route: "Red", date: "1970-01-01"),
-         {:ok, start_date} <- Date.from_iso8601(error.meta["start_date"]),
-         {:ok, end_date} <- Date.from_iso8601(error.meta["end_date"]) do
-      {start_date, end_date}
-    else
-      _ -> :error
-    end
+    cache(all_fn, fn all_fn ->
+      with {:error, [%{code: "no_service"} = error]} <- all_fn.(route: "Red", date: "1970-01-01"),
+           {:ok, start_date} <- Date.from_iso8601(error.meta["start_date"]),
+           {:ok, end_date} <- Date.from_iso8601(error.meta["end_date"]) do
+        {start_date, end_date}
+      else
+        _ -> :error
+      end
+    end)
   end
 
   defp all_from_params(params) do
@@ -132,11 +131,6 @@ defmodule Schedules.Repo do
       |> Enum.filter(&has_trip?/1)
       |> Enum.sort_by(&date_sorter/1)
     end
-  end
-
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  defp cache_all_from_params(params) do
-    all_from_params(params)
   end
 
   def has_trip?({_, trip_id, _, _, _, _, _, _, _, _, _}) when is_nil(trip_id) do
@@ -234,21 +228,24 @@ defmodule Schedules.Repo do
     schedules
     |> Enum.map(fn {route_id, trip_id, stop_id, arrival_time, departure_time, time, flag?,
                     early_departure?, last_stop?, stop_sequence, pickup_type} ->
-      %Schedules.Schedule{
-        route: Routes.Repo.get(route_id),
-        trip: trip(trip_id),
-        platform_stop_id: stop_id,
-        stop: Stops.Repo.get_parent(stop_id),
-        arrival_time: arrival_time,
-        departure_time: departure_time,
-        time: time,
-        flag?: flag?,
-        early_departure?: early_departure?,
-        last_stop?: last_stop?,
-        stop_sequence: stop_sequence,
-        pickup_type: pickup_type
-      }
+      Task.async(fn ->
+        %Schedules.Schedule{
+          route: Routes.Repo.get(route_id),
+          trip: trip(trip_id),
+          platform_stop_id: stop_id,
+          stop: Stops.Repo.get_parent(stop_id),
+          arrival_time: arrival_time,
+          departure_time: departure_time,
+          time: time,
+          flag?: flag?,
+          early_departure?: early_departure?,
+          last_stop?: last_stop?,
+          stop_sequence: stop_sequence,
+          pickup_type: pickup_type
+        }
+      end)
     end)
+    |> Enum.map(&Task.await/1)
   end
 
   # Fetching predictions will also insert trips into cache using this function
@@ -262,10 +259,7 @@ defmodule Schedules.Repo do
     |> Stream.map(&id_and_trip/1)
     |> Stream.uniq_by(&elem(&1, 0))
     |> Enum.each(fn {id, trip} ->
-      key =
-        Dotcom.Cache.KeyGenerator.generate(__MODULE__, :fetch_trip, [id, &V3Api.Trips.by_id/2])
-
-      @cache.put(key, {:ok, trip}, ttl: @ttl)
+      ConCache.dirty_put(__MODULE__, {:trip, id}, {:ok, trip})
     end)
   end
 

--- a/lib/schedules/repo_condensed.ex
+++ b/lib/schedules/repo_condensed.ex
@@ -1,22 +1,19 @@
 defmodule Schedules.RepoCondensed do
   @moduledoc """
+
   An alternate way to fetch schedules that is more light weight and easier to cache.
 
   This uses a longer than usual timeout for initial caching as sometime (especially in dev)
   it may take a long time to warm the cache.
+
   """
-
-  use Nebulex.Caching.Decorators
-
   import Kernel, except: [to_string: 1]
+  use RepoCache, ttl: :timer.hours(1)
 
   alias Routes.Route
   alias Schedules.{Parser, Repo, ScheduleCondensed}
   alias Stops.Repo, as: StopsRepo
   alias V3Api.Schedules, as: SchedulesApi
-
-  @cache Application.compile_env!(:dotcom, :cache)
-  @ttl :timer.hours(1)
 
   # the long timeout is to address a worst-case scenario of cold schedule cache
   @long_timeout 15_000
@@ -38,11 +35,11 @@ defmodule Schedules.RepoCondensed do
     |> add_optional_param(opts, :direction_id)
     |> add_optional_param(opts, :stop_sequences, :stop_sequence)
     |> add_optional_param(opts, :stop_ids, :stop)
-    |> all_from_params()
+    |> cache(&all_from_params/1, timeout: 10_000)
     |> filter_by_min_time(Keyword.get(opts, :min_time))
   end
 
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
+  @spec all_from_params(Keyword.t()) :: [Parser.record()] | {:error, any}
   defp all_from_params(params) do
     with %JsonApi{data: data} <- SchedulesApi.all(params) do
       data = Enum.filter(data, &valid?/1)

--- a/mix.exs
+++ b/mix.exs
@@ -76,6 +76,9 @@ defmodule DotCom.Mixfile do
       {:bypass, "1.0.0", [only: :test]},
       # latest version 1.0.5; cannot upgrade because of server_sent_event_stage expects castore < 1
       {:castore, "0.1.22"},
+      # latest version 1.0.0; cannot upgrade because setup appears to have changed
+      # rather than upgrading, we should change all caching over to Nebulex
+      {:con_cache, "0.12.1"},
       {:crc, "0.10.5"},
       # latest version 1.7.5; cannot upgrade because it causes our ci to fail
       # this version just came out in the last few days, so it might be a bug that gets fixed soon


### PR DESCRIPTION
This partially reverts commit 0c863d4fe522bcb5d0e453822fc988d62f3a9add.
This doesn't update tests, and is intended to be "good enough" to bring the site back to a stable state while we continue to investigate. This branch can be deployed directly via the [Deploy: selected branch](https://github.com/mbta/dotcom/actions/workflows/deploy-manual.yml) action.