### PR TITLE
Match that a list of predictions isnt empty

### DIFF
--- a/lib/predictions/repo.ex
+++ b/lib/predictions/repo.ex
@@ -73,7 +73,7 @@ defmodule Predictions.Repo do
 
   @decorate cacheable(
               cache: @cache,
-              match: fn lst -> lst != [] end,
+              match: fn lst -> is_list(lst) && lst != [] end,
               on_error: :nothing,
               opts: [ttl: @ttl]
             )

--- a/lib/predictions/repo.ex
+++ b/lib/predictions/repo.ex
@@ -71,7 +71,12 @@ defmodule Predictions.Repo do
     end
   end
 
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
+  @decorate cacheable(
+              cache: @cache,
+              on_error: :nothing,
+              match: fn lst -> lst != [] end,
+              opts: [ttl: @ttl]
+            )
   defp cache_fetch(opts) do
     fetch(opts)
   end

--- a/lib/predictions/repo.ex
+++ b/lib/predictions/repo.ex
@@ -73,8 +73,8 @@ defmodule Predictions.Repo do
 
   @decorate cacheable(
               cache: @cache,
-              on_error: :nothing,
               match: fn lst -> lst != [] end,
+              on_error: :nothing,
               opts: [ttl: @ttl]
             )
   defp cache_fetch(opts) do


### PR DESCRIPTION
We don't want to cache empty predictions. Sometimes, when a node comes online the API informs us that predictions haven't changed. It looks in the cache, sees that it is empty, and returns an error which then gets converted to an empty list.

