### PR TITLE
fix(Routes.Repo): log errors in by_stop_route_route_pattern

### DIFF
--- a/lib/routes/repo.ex
+++ b/lib/routes/repo.ex
@@ -184,13 +184,20 @@ defmodule Routes.Repo do
         Enum.map(data, &parse_route_with_route_pattern/1)
 
       error ->
-        Logger.error("by_stop_with_route_pattern stop_id=#{stop_id} error=#{inspect(error)}")
+        Logger.error(
+          "#{__MODULE__} by_stop_with_route_pattern stop_id=#{stop_id} error=#{inspect(error)}"
+        )
 
         []
     end
   end
 
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
+  @decorate cacheable(
+              cache: @cache,
+              match: fn %{data: data} -> is_list(data) && data != [] end,
+              on_error: :nothing,
+              opts: [ttl: @ttl]
+            )
   def do_by_stop_with_route_pattern(opts) do
     V3Api.Routes.all(opts)
   end

--- a/lib/routes/repo.ex
+++ b/lib/routes/repo.ex
@@ -178,12 +178,21 @@ defmodule Routes.Repo do
   end
 
   @impl Routes.RepoApi
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   def by_stop_with_route_pattern(stop_id) do
-    [stop: stop_id, include: "route_patterns"]
-    |> V3Api.Routes.all()
-    |> Map.get(:data, [])
-    |> Enum.map(&parse_route_with_route_pattern/1)
+    case do_by_stop_with_route_pattern(stop: stop_id, include: "route_patterns") do
+      %{data: data} ->
+        Enum.map(data, &parse_route_with_route_pattern/1)
+
+      error ->
+        Logger.error("by_stop_with_route_pattern stop_id=#{stop_id} error=#{inspect(error)}")
+
+        []
+    end
+  end
+
+  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
+  def do_by_stop_with_route_pattern(opts) do
+    V3Api.Routes.all(opts)
   end
 
   @doc """


### PR DESCRIPTION
Just another tiny change. I'm not sure if this was already caching error responses, but at least this way it's written clearer and also logs errors.