### PR TITLE
Dont cache predictions

### DIFF
--- a/lib/dotcom/transit_near_me.ex
+++ b/lib/dotcom/transit_near_me.ex
@@ -385,8 +385,13 @@ defmodule Dotcom.TransitNearMe do
     predictions_fn = Keyword.get(opts, :predictions_fn, &Predictions.Repo.all/1)
     now = Keyword.fetch!(opts, :now)
 
-    params
-    |> predictions_fn.()
+    predictions = predictions_fn.(params)
+
+    if predictions == [] do
+      Logger.warning("#{__MODULE__} no.predictions.for.schedule #{inspect(params)}")
+    end
+
+    predictions
     |> PredictedSchedule.group(schedules)
     |> Enum.filter(&(!PredictedSchedule.last_stop?(&1) and after_min_time?(&1, now)))
   end

--- a/lib/dotcom_web/controllers/schedule/line_api.ex
+++ b/lib/dotcom_web/controllers/schedule/line_api.ex
@@ -6,7 +6,6 @@ defmodule DotcomWeb.ScheduleController.LineApi do
   require Logger
 
   use DotcomWeb, :controller
-  use Nebulex.Caching.Decorators
 
   alias Dotcom.TransitNearMe
   alias DotcomWeb.ScheduleController.Line.Helpers, as: LineHelpers

--- a/lib/dotcom_web/controllers/schedule/line_api.ex
+++ b/lib/dotcom_web/controllers/schedule/line_api.ex
@@ -12,9 +12,6 @@ defmodule DotcomWeb.ScheduleController.LineApi do
   alias DotcomWeb.ScheduleController.Line.Helpers, as: LineHelpers
   alias Vehicles.Vehicle
 
-  @cache Application.compile_env!(:dotcom, :cache)
-  @ttl :timer.minutes(1)
-
   @typep simple_vehicle :: %{
            id: String.t(),
            headsign: String.t() | nil,
@@ -88,17 +85,6 @@ defmodule DotcomWeb.ScheduleController.LineApi do
     end
   end
 
-  @decorate cacheable(
-              cache: @cache,
-              key:
-                Dotcom.Cache.KeyGenerator.generate(__MODULE__, :do_realtime, [
-                  route_id,
-                  direction_id,
-                  date
-                ]),
-              on_error: :nothing,
-              opts: [ttl: @ttl]
-            )
   defp do_realtime(route_id, direction_id, date, now, tooltips) do
     headsigns_by_stop =
       TransitNearMe.time_data_for_route_by_stop(

--- a/lib/predictions/repo.ex
+++ b/lib/predictions/repo.ex
@@ -12,9 +12,6 @@ defmodule Predictions.Repo do
   alias Routes.Route
   alias Stops.Stop
 
-  @cache Application.compile_env!(:dotcom, :cache)
-  @ttl :timer.seconds(10)
-
   @default_params [
     "fields[prediction]":
       "status,departure_time,arrival_time,direction_id,schedule_relationship,stop_sequence",
@@ -71,12 +68,6 @@ defmodule Predictions.Repo do
     end
   end
 
-  @decorate cacheable(
-              cache: @cache,
-              match: fn lst -> is_list(lst) && lst != [] end,
-              on_error: :nothing,
-              opts: [ttl: @ttl]
-            )
   defp cache_fetch(opts) do
     fetch(opts)
   end

--- a/lib/predictions/repo.ex
+++ b/lib/predictions/repo.ex
@@ -6,8 +6,6 @@ defmodule Predictions.Repo do
   require Logger
   require Routes.Route
 
-  use Nebulex.Caching.Decorators
-
   alias Predictions.Parser
   alias Routes.Route
   alias Stops.Stop


### PR DESCRIPTION
We are narrowing down the issues with blank predictions. There is really no point in caching predictions because the TTL is only 10 seconds. And, we don't want to cache realtime responses because they can hold bad data for even longer: 1 minute.