### PR TITLE
Change keys to use downcase because that is what gets sent to bust

### DIFF
--- a/lib/cms/repo.ex
+++ b/lib/cms/repo.ex
@@ -162,7 +162,7 @@ defmodule CMS.Repo do
 
   @decorate cacheable(
               cache: @cache,
-              key: "cms.repo|schedules|#{route_id}",
+              key: "cms.repo|schedules|#{String.downcase(route_id)}",
               on_error: :nothing,
               opts: [ttl: @ttl]
             )
@@ -194,7 +194,7 @@ defmodule CMS.Repo do
 
   @decorate cacheable(
               cache: @cache,
-              key: "cms.repo|route_pdfs|#{route_id}",
+              key: "cms.repo|route-pdfs|#{String.downcase(route_id)}",
               on_error: :nothing,
               opts: [ttl: @ttl]
             )


### PR DESCRIPTION
We were a little off on the cache keys that get sent. They are downcase even if our route_id is mixed case. Also, it's `route-pdfs` and not `route_pdfs`.