### PR TITLE
When only given a key, we dont need to scan redis

### DIFF
--- a/lib/dotcom/cache/multilevel.ex
+++ b/lib/dotcom/cache/multilevel.ex
@@ -48,6 +48,18 @@ defmodule Dotcom.Cache.Multilevel do
   That way we'll delete from the Local, Redis, and publish the delete on the Publisher.
   """
   def flush_keys(pattern \\ "*") do
+    if String.contains?(pattern, "*") do
+      flush_multiple_keys(pattern)
+    else
+      flush_single_key(pattern)
+    end
+  end
+
+  def flush_single_key(key) do
+    @cache.delete(key)
+  end
+
+  def flush_multiple_keys(pattern) do
     case Application.get_env(:dotcom, :redis_config) |> @redix.start_link() do
       {:ok, conn} -> (delete_from_nodes(conn, pattern) ++ [@redix.stop(conn)]) |> all_ok()
       {:error, _} -> :error

--- a/lib/dotcom/cache/multilevel.ex
+++ b/lib/dotcom/cache/multilevel.ex
@@ -35,6 +35,29 @@ defmodule Dotcom.Cache.Multilevel do
   @redix Application.compile_env!(:dotcom, :redix)
 
   @doc """
+  If the pattern contains an asterisk, we flush multiple keys.
+  We have to do so by scanning Redis for all keys that match the pattern.
+
+  If the pattern is just a single key, we can flush it directly.
+  """
+  def flush_keys(pattern \\ "*") do
+    if String.contains?(pattern, "*") do
+      flush_multiple_keys(pattern)
+    else
+      flush_single_key(pattern)
+    end
+  end
+
+  @doc """
+  Flush a single key from the cache.
+
+  This is especially helpful when the key doesn't exist in Redis, but does in the Local cache.
+  """
+  def flush_single_key(key) do
+    @cache.delete(key)
+  end
+
+  @doc """
   Delete all entries where the key matches the pattern.
 
   First, we make sure we can get a connection to Redis.
@@ -47,18 +70,6 @@ defmodule Dotcom.Cache.Multilevel do
   Finally, we delete all the keys with the default delete/1 function.
   That way we'll delete from the Local, Redis, and publish the delete on the Publisher.
   """
-  def flush_keys(pattern \\ "*") do
-    if String.contains?(pattern, "*") do
-      flush_multiple_keys(pattern)
-    else
-      flush_single_key(pattern)
-    end
-  end
-
-  def flush_single_key(key) do
-    @cache.delete(key)
-  end
-
   def flush_multiple_keys(pattern) do
     case Application.get_env(:dotcom, :redis_config) |> @redix.start_link() do
       {:ok, conn} -> (delete_from_nodes(conn, pattern) ++ [@redix.stop(conn)]) |> all_ok()

--- a/test/dotcom/cache/multilevel_test.exs
+++ b/test/dotcom/cache/multilevel_test.exs
@@ -46,4 +46,18 @@ defmodule Dotcom.Cache.MultilevelTest do
       assert @cache.get("bar|foo") == "baz"
     end
   end
+
+  test "deletes a single key when not given an asterisk" do
+    @cache.put("foo|bar", "baz")
+    @cache.put("foo|baz", "bar")
+    @cache.put("bar|foo", "baz")
+
+    key = "foo|bar"
+
+    assert Dotcom.Cache.Multilevel.flush_keys(key) == :ok
+
+    assert @cache.get("foo|bar") == nil
+    assert @cache.get("foo|baz") == "bar"
+    assert @cache.get("bar|foo") == "baz"
+  end
 end


### PR DESCRIPTION
It seems possible for L1 (ETS) and L2 (Redis) to get out of sync. When that happens, we can't flush the cache effectively if the key doesn't exist in Redis but does in ETS. We have to wait for the TTL. This PR makes it so that flushing a single key won't scan Redis for keys and will just send the command to delete it.