### PR TITLE
Add more information to input id and change integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ npm install --ignore-scripts
 npx playwright test all-scenarios
 ```
 
+You can run a single test (and optionally use `--debug` or `--ui`):
+
+```
+npx playwright test all-scenarios --grep @search_for_a_subway_line
+```
+
 ## Load Tests
 
 ```

--- a/assets/ts/ui/autocomplete/index.ts
+++ b/assets/ts/ui/autocomplete/index.ts
@@ -45,7 +45,7 @@ function setupAlgoliaAutocomplete(wrapper: HTMLElement): void {
   );
   if (!container || !panelContainer) throw new Error("container needed");
   const options: AutocompleteOptions<Item> = {
-    id: container.id,
+    id: container.id || "search",
     container,
     panelContainer,
     detachedMediaQuery: "none",

--- a/integration/scenarios/search-for-a-static-page.js
+++ b/integration/scenarios/search-for-a-static-page.js
@@ -6,10 +6,10 @@ exports.scenario = async ({ page, baseURL }) => {
   // We should be able to use down arrow and enter to select the first result.
   // But, the enter key does not load the page. So, we have to click the first result.
   await page
-    .locator("div.search-wrapper input#input")
+    .locator("div.search-wrapper input#search-input")
     .pressSequentially("safety");
-  await page.waitForSelector("ul#algolia-list");
-  await page.locator("ul#algolia-list li:first-child a").click();
+  await page.waitForSelector("ul#search-algolia-list");
+  await page.locator("ul#search-algolia-list li:first-child a").click();
 
   await expect(page.getByRole("heading", { name: "Safety" })).toBeVisible();
 };

--- a/integration/scenarios/search-for-a-station.js
+++ b/integration/scenarios/search-for-a-station.js
@@ -6,10 +6,10 @@ exports.scenario = async ({ page, baseURL }) => {
   // We should be able to use down arrow and enter to select the first result.
   // But, the enter key does not load the page. So, we have to click the first result.
   await page
-    .locator("div.search-wrapper input#input")
+    .locator("div.search-wrapper input#search-input")
     .pressSequentially("Symphony");
-  await page.waitForSelector("ul#algolia-list");
-  await page.locator("ul#algolia-list li:first-child a").click();
+  await page.waitForSelector("ul#search-algolia-list");
+  await page.locator("ul#search-algolia-list li:first-child a").click();
 
   await expect(
     page.getByRole("heading", { name: "Symphony", exact: true }),

--- a/integration/scenarios/search-for-a-subway-line.js
+++ b/integration/scenarios/search-for-a-subway-line.js
@@ -6,10 +6,10 @@ exports.scenario = async ({ page, baseURL }) => {
   // We should be able to use down arrow and enter to select the first result.
   // But, the enter key does not load the page. So, we have to click the first result.
   await page
-    .locator("div.search-wrapper input#input")
+    .locator("div.search-wrapper input#search-input")
     .pressSequentially("Blue Line");
-  await page.waitForSelector("ul#algolia-list");
-  await page.locator("ul#algolia-list li:first-child a").click();
+  await page.waitForSelector("ul#search-algolia-list");
+  await page.locator("ul#search-algolia-list li:first-child a").click();
 
   await expect(page.locator("h1.schedule__route-name")).toHaveText(
     "Blue Line",

--- a/integration/scenarios/search-for-a-subway-line.js
+++ b/integration/scenarios/search-for-a-subway-line.js
@@ -4,7 +4,8 @@ exports.scenario = async ({ page, baseURL }) => {
   await page.goto(`${baseURL}/search`);
 
   // We should be able to use down arrow and enter to select the first result.
-  // But, the enter key does not load the page. So, we have to click the first result.
+  // But, the down arrow does not do anything.
+  // The tab button takes me to the left side nav rather than the search results :(.
   await page
     .locator("input#search-global__input")
     .pressSequentially("Blue Line");

--- a/integration/scenarios/search-for-a-subway-line.js
+++ b/integration/scenarios/search-for-a-subway-line.js
@@ -1,15 +1,15 @@
 const { expect } = require("@playwright/test");
 
 exports.scenario = async ({ page, baseURL }) => {
-  await page.goto(`${baseURL}/`);
+  await page.goto(`${baseURL}/search`);
 
   // We should be able to use down arrow and enter to select the first result.
   // But, the enter key does not load the page. So, we have to click the first result.
   await page
-    .locator("div.search-wrapper input#search-input")
+    .locator("input#search-global__input")
     .pressSequentially("Blue Line");
-  await page.waitForSelector("ul#search-algolia-list");
-  await page.locator("ul#search-algolia-list li:first-child a").click();
+  await page.waitForSelector("div#search-results-container");
+  await page.locator("div.c-search-result__hit a").first().click();
 
   await expect(page.locator("h1.schedule__route-name")).toHaveText(
     "Blue Line",


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1206695418505883/f

I added a sensible default that when no container id is given, the term 'search' is used to construct ids.

I changed the search for a subway scenario to use the search page so now we have multiple search pathways covered.