### PR TITLE
fix(HoursOfOperation): Filter out schedules with same departure and a…

### DIFF
--- a/lib/schedules/hours_of_operation.ex
+++ b/lib/schedules/hours_of_operation.ex
@@ -479,15 +479,17 @@ defmodule Schedules.HoursOfOperation do
     end)
   end
 
-  # This returns a single hours map for rapid transit routes
+  @doc """
+  This returns a single hours map for rapid transit routes
+  It ignores any departures that have the same start and end time, and are not the
+  terminus departure
+  """
   def departure_overall(data, headsigns, :rapid_transit) do
     departures = departure(data, headsigns, :rapid_transit)
 
-    # Remove single trip schedules (have the same first_departure and last_departure)
-    # from the overall calculation
     departures_filtered =
       Enum.filter(departures, fn x ->
-        x.first_departure != x.last_departure
+        x.first_departure != x.last_departure && x.is_terminus == true
       end)
 
     if Enum.empty?(departures_filtered) do

--- a/lib/schedules/hours_of_operation.ex
+++ b/lib/schedules/hours_of_operation.ex
@@ -483,6 +483,8 @@ defmodule Schedules.HoursOfOperation do
   def departure_overall(data, headsigns, :rapid_transit) do
     departures = departure(data, headsigns, :rapid_transit)
 
+    # Remove single trip schedules (have the same first_departure and last_departure)
+    # from the overall calculation
     departures_filtered =
       Enum.filter(departures, fn x ->
         x.first_departure != x.last_departure

--- a/lib/schedules/hours_of_operation.ex
+++ b/lib/schedules/hours_of_operation.ex
@@ -483,18 +483,19 @@ defmodule Schedules.HoursOfOperation do
   def departure_overall(data, headsigns, :rapid_transit) do
     departures = departure(data, headsigns, :rapid_transit)
 
-    if Enum.empty?(departures) do
+    departures_filtered =
+      Enum.filter(departures, fn x ->
+        x.first_departure != x.last_departure
+      end)
+
+    if Enum.empty?(departures_filtered) do
       :no_service
     else
       first_departure =
-        if Enum.empty?(departures),
-          do: nil,
-          else: Enum.min_by(departures, &DateTime.to_unix(&1.first_departure, :nanosecond))
+        Enum.min_by(departures_filtered, &DateTime.to_unix(&1.first_departure, :nanosecond))
 
       last_departure =
-        if Enum.empty?(departures),
-          do: nil,
-          else: Enum.min_by(departures, &DateTime.to_unix(&1.last_departure, :nanosecond))
+        Enum.min_by(departures_filtered, &DateTime.to_unix(&1.last_departure, :nanosecond))
 
       %Departures{
         first_departure: first_departure.first_departure,

--- a/test/schedules/hours_of_operation_test.exs
+++ b/test/schedules/hours_of_operation_test.exs
@@ -513,19 +513,64 @@ defmodule Schedules.HoursOfOperationTest do
     end
   end
 
+  describe "departure_overall/3" do
+    test "it should ignore times with the same departure and arrival when calculating overall" do
+      {stop_1_dep_1, stop_1_dep_1_time} =
+        build_schedule(%{
+          stop_id: "1",
+          departure_time: ~U[2022-12-27 10:45:00Z],
+          arrival_time: ~U[2022-12-27 10:45:00Z]
+        })
+
+      {stop_1_dep_2, stop_1_dep_2_time} =
+        build_schedule(%{
+          stop_id: "1",
+          departure_time: ~U[2022-12-27 23:45:00Z],
+          arrival_time: ~U[2022-12-27 23:45:00Z]
+        })
+
+      {stop_2_dep_1, _stop_2_dep_1_time} =
+        build_schedule(%{
+          stop_id: "2",
+          departure_time: ~U[2022-12-31 08:45:00Z],
+          arrival_time: ~U[2022-12-31 08:45:00Z]
+        })
+
+      departure =
+        departure_overall([stop_1_dep_1, stop_1_dep_2, stop_2_dep_1], [], :rapid_transit)
+
+      expected_departure = %Departures{
+        first_departure: stop_1_dep_1_time,
+        last_departure: stop_1_dep_2_time
+      }
+
+      assert expected_departure == departure
+    end
+  end
+
   defp test_stop_name("1"), do: %Stops.Stop{name: "Test Stop"}
   defp test_stop_name("2"), do: %Stops.Stop{name: "Test Stop 2"}
 
+  defp time(nil), do: nil
+  defp time(time), do: DateTime.to_iso8601(time)
+
   defp build_schedule(
-         %{stop_id: stop_id, departure_time: departure_time} \\ %{
+         data \\ %{
            stop_id: "1",
            departure_time: DateTime.utc_now()
          }
-       ) do
+       )
+
+  defp build_schedule(%{
+         stop_id: stop_id,
+         departure_time: departure_time,
+         arrival_time: arrival_time
+       }) do
     item = %JsonApi.Item{
       type: "schedule",
       attributes: %{
-        "departure_time" => DateTime.to_iso8601(departure_time)
+        "departure_time" => time(departure_time),
+        "arrival_time" => time(arrival_time)
       },
       relationships: %{
         "trip" => [
@@ -544,5 +589,9 @@ defmodule Schedules.HoursOfOperationTest do
     }
 
     {item, departure_time}
+  end
+
+  defp build_schedule(%{stop_id: stop_id, departure_time: departure_time}) do
+    build_schedule(%{stop_id: stop_id, departure_time: departure_time, arrival_time: nil})
   end
 end


### PR DESCRIPTION
…rrival time

<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
The green line has a couple schedules that are single trips off of one line and on to another.
These cause the overall hours to be wrong.  This pull request filters the schedules from the results so we can correctly calculate the first and last trains of the line.

This is similar to the existing logic that was present on the front end before the hours card rewrite as seen here:
https://github.com/mbta/dotcom/commit/e57b9316bcb50c668f61772dcc8490883a5d58a0

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Green Line pages show inaccurate first/last train times](https://app.asana.com/0/555089885850811/1206891993416187)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

