### PR TITLE
Chain service launch to reduce conflicts

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -3,25 +3,32 @@ services:
     nginx:
         image: nginx:stable-alpine3.17-slim
         depends_on:
-            - dotcom-1
-            - dotcom-2
+            dotcom-2:
+                condition: service_healthy
         volumes:
             - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
         expose:
             - 4001
         ports:
             - "4001:4001"
+        healthcheck:
+            test: curl --fail http://localhost:4001/_health || exit 1
+            interval: 60s
+            retries: 5
+            start_period: 20s
+            timeout: 10s
         networks:
             dotcom_network:
                 ipv4_address: 10.0.0.1
     dotcom-1:
         build:
             context: ../
-            dockerfile: ./deploy/dotcom/dev/Dockerfile
+            dockerfile: ./deploy/dotcom/dev/1/Dockerfile
         env_file:
             - ../.env
         depends_on:
-            - redis-cluster-init
+            redis-cluster-init:
+                condition: service_started
         environment:
             - MIX_ENV=dev
             - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
@@ -33,6 +40,12 @@ services:
         ports:
             - 4002:4002
             - 8092:8092
+        healthcheck:
+            test: curl --fail http://localhost:4002/_health || exit 1
+            interval: 60s
+            retries: 5
+            start_period: 60s
+            timeout: 10s
         volumes:
             - ../:/app
         networks:
@@ -41,9 +54,10 @@ services:
     dotcom-2:
         build:
             context: ../
-            dockerfile: ./deploy/dotcom/dev/Dockerfile
+            dockerfile: ./deploy/dotcom/dev/2/Dockerfile
         depends_on:
-            - redis-cluster-init
+            dotcom-1:
+                condition: service_healthy
         env_file:
             - ../.env
         environment:
@@ -57,6 +71,12 @@ services:
         ports:
             - 4003:4003
             - 8093:8093
+        healthcheck:
+            test: curl --fail http://localhost:4003/_health || exit 1
+            interval: 60s
+            retries: 5
+            start_period: 15s
+            timeout: 10s
         volumes:
             - ../:/app
         networks:
@@ -150,4 +170,4 @@ networks:
         ipam:
             config:
                 - subnet: 10.0.0.0/24
-                  gateway: 10.0.0.0
+                  gateway: 10.0.0.254

--- a/deploy/dotcom/dev/1/Dockerfile
+++ b/deploy/dotcom/dev/1/Dockerfile
@@ -14,4 +14,4 @@ COPY assets/package.json ./assets/package.json
 RUN mix local.hex --force
 RUN mix local.rebar --force
 
-CMD mix deps.get && npm install && npm run build && mix phx.digest && npm install --ignore-scripts && mix phx.server
+CMD mix deps.get && npm install --no-save && npm run build && mix phx.digest && npm install --ignore-scripts --no-save && mix phx.server

--- a/deploy/dotcom/dev/2/Dockerfile
+++ b/deploy/dotcom/dev/2/Dockerfile
@@ -1,0 +1,9 @@
+FROM hexpm/elixir:1.16.1-erlang-26.2.2-debian-buster-20240130
+
+RUN apt-get update && apt-get install -y curl git make build-essential inotify-tools
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+RUN apt-get install -y nodejs
+
+WORKDIR /app
+
+CMD mix deps.get && mix phx.server


### PR DESCRIPTION
Adds in dependencies between services so that multiple versions of dotcom don't have to compile the same things. This makes it slow and error prone. Instead, one version of the app launches and then a second one uses the work of the first one.

