### PR TITLE
feat: re-deploy the monitor 

### DIFF
--- a/.github/workflows/push-monitor.yml
+++ b/.github/workflows/push-monitor.yml
@@ -1,7 +1,24 @@
 name: Push Monitor
 
 on:
+  # UI provided by Github, values populated by repository
   workflow_dispatch:
+    inputs:
+      deployment-env:
+        description: "Environment to deploy to"
+        required: true
+        type: environment
+  # Invoked via another workflow, value passed in by string
+  workflow_call:
+    inputs:
+      deployment-env:
+        description: "Environment to deploy to"
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-monitor-${{ inputs.deployment-env }}
+  cancel-in-progress: true
 
 jobs:
   push:
@@ -20,34 +37,10 @@ jobs:
           docker-repo: "${{ secrets.TID_AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/dotcom-monitor"
           dockerfile-path: "-f ./deploy/monitor/Dockerfile ."
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-      - name: Deploy Monitor to Dev Blue
+      - name: Deploy Monitor to ${{ inputs.deployment-env }}
         uses: mbta/actions/deploy-ecs@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: dotcom
-          ecs-service: dotcom-monitor-dev-blue
-          docker-tag: ${{ steps.ecr.outputs.docker-tag }}
-      - name: Deploy Monitor to Dev Green
-        uses: mbta/actions/deploy-ecs@v2
-        if: always()
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          ecs-cluster: dotcom
-          ecs-service: dotcom-monitor-dev-green
-          docker-tag: ${{ steps.ecr.outputs.docker-tag }}
-      - name: Deploy Monitor to Dev
-        uses: mbta/actions/deploy-ecs@v2
-        if: always()
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          ecs-cluster: dotcom
-          ecs-service: dotcom-monitor-dev
-          docker-tag: ${{ steps.ecr.outputs.docker-tag }}
-      - name: Deploy Monitor to Prod
-        uses: mbta/actions/deploy-ecs@v2
-        if: always()
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          ecs-cluster: dotcom
-          ecs-service: dotcom-monitor-prod
+          ecs-service: dotcom-monitor-${{ inputs.deployment-env }}
           docker-tag: ${{ steps.ecr.outputs.docker-tag }}

--- a/.github/workflows/use-deploy-ecs.yml
+++ b/.github/workflows/use-deploy-ecs.yml
@@ -169,6 +169,17 @@ jobs:
     needs: deploy
     name: Redeploy Dotcom Monitor ${{ inputs.deployment-env }} if needed
     steps:
-     -  uses: ./.github/workflows/push-monitor.yml
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            monitor:
+              - 'deploy/monitor/**'
+              - 'integration/**'
+      - uses: ./.github/workflows/push-monitor.yml
+        if: steps.changes.outputs.monitor == 'true'
         with:
           deployment-env: ${{ inputs.deployment-env }}

--- a/.github/workflows/use-deploy-ecs.yml
+++ b/.github/workflows/use-deploy-ecs.yml
@@ -164,3 +164,11 @@ jobs:
         path: playwright-report
         retention-days: 30
 
+  monitor:
+    runs-on: ubuntu-latest
+    needs: deploy
+    name: Redeploy Dotcom Monitor ${{ inputs.deployment-env }} if needed
+    steps:
+     -  uses: ./.github/workflows/push-monitor.yml
+        with:
+          deployment-env: ${{ inputs.deployment-env }}


### PR DESCRIPTION
This might not be the desired strategy - maybe we want to deploy the monitor as soon as any changes are merged into master, instead of tying it to deploys this way?
This will not work until the `dorny/paths-filter@v3` action is whitelisted by the org.