### PR TITLE
Add ignores and comments

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
     schedule:
       interval: "daily"
       time: "09:00"
+    ignore:
+      - dependency-name: "castore"
+      - dependency-name: "excoveralls"
+      - dependency-name: "html_sanitize_ex"
+      - dependency-name: "httpoison"
+      - dependency-name: "phoenix"
+      - dependency-name: "phoenix_html"
+      - dependency-name: "poison"
+      - dependency-name: "sentry"
+      - dependency-name: "timex" 
     open-pull-requests-limit: 1
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "assets" # Location of package manifests

--- a/mix.exs
+++ b/mix.exs
@@ -62,11 +62,9 @@ defmodule DotCom.Mixfile do
     ]
   end
 
-  # Specifies your project dependencies.
-  #
-  # Type `mix help deps` for examples and options.
-  #
   # You can check the status of each dependency by running `mix hex.outdated`.
+  # Dependencies that cannot be updated are noted in comments.
+  # Note that you should also update `.github/dependabot.yml` and remove ignore overrides for any dependencies you update.
   defp deps do
     [
       {:absinthe_client, "0.1.0"},


### PR DESCRIPTION
This will get dependabot to stop bothering us about dependencies that we already know we can't upgrade. When we fix the dependency, we'll remove it from the ignore list.

