### PR TITLE
chore: reference main branch name

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -12,7 +12,7 @@ on:
 
   workflow_run:
     workflows:
-      - "Deploy: master branch"
+      - "Deploy: main branch"
     types:
       - completed
 

--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -1,9 +1,9 @@
-# Deploy to dev on merge or push into master
-name: "Deploy: master branch"
+# Deploy to dev on merge or push into main
+name: "Deploy: main branch"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 concurrency:
   group: dev
@@ -27,6 +27,6 @@ jobs:
     with:
       job-status: ${{ needs.auto.result }}
       success-message: |
-        :ballot_box_with_check: `dev` updated to latest commit on master
+        :ballot_box_with_check: `dev` updated to latest commit on main
       failure-message: |
-        :ballot_box_with_check: `dev` not updated to latest commit on master
+        :ballot_box_with_check: `dev` not updated to latest commit on main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # Don't bother running if it's just a script or docs change
     paths-ignore:
@@ -27,7 +27,7 @@ jobs:
     name: File changes
     uses: ./.github/workflows/changed-files.yml
     with:
-      # If it's a Dependabot PR, or a push to master, we want to run every test
+      # If it's a Dependabot PR, or a push to main, we want to run every test
       force: ${{ github.event_name == 'push' || contains(github.head_ref, 'dependabot/hex') || contains(github.head_ref, 'dependabot/npm_and_yarn') }}
 
   build_app:
@@ -77,7 +77,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-all
-    - run: git fetch origin master:master
+    - run: git fetch origin main:main
     - run: npm run ci:lint:ex
 
   elixir_unit:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/mbta/dotcom/actions/workflows/tests.yml/badge.svg?branch=master)
+![](https://github.com/mbta/dotcom/actions/workflows/tests.yml/badge.svg?branch=main)
 ![](https://github.com/mbta/dotcom/actions/workflows/deploy-prod.yml/badge.svg)
 ![](https://github.com/mbta/dotcom/actions/workflows/deploy-dev.yml/badge.svg)
 ![](https://github.com/mbta/dotcom/actions/workflows/deploy-dev-blue.yml/badge.svg)

--- a/assets/package.json
+++ b/assets/package.json
@@ -144,7 +144,7 @@
   },
   "scripts": {
     "preinstall": "npm install --package-lock-only --ignore-scripts && npx force-resolutions",
-    "eslint:js": "git diff --name-only --diff-filter=dx origin/master... | grep js/.*\\.js | awk -F/js '{print \"js\"$2}' | xargs eslint -c .eslintrc.js",
+    "eslint:js": "git diff --name-only --diff-filter=dx origin/main... | grep js/.*\\.js | awk -F/js '{print \"js\"$2}' | xargs eslint -c .eslintrc.js",
     "eslint:js:fix": "npm run eslint:js -- --fix",
     "eslint:ts": "cd ts && eslint -c .eslintrc.js --ext .ts,.tsx --max-warnings=0 .",
     "eslint:ts:fix": "cd ts && eslint -c .eslintrc.js --ext .ts,.tsx --fix .",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -5,7 +5,7 @@
 This can be done on GitHub Actions via the following:
 
 - Create a tag following this format
-  - Pull the latest master locally
+  - Pull the latest main locally
   - Create a tag `git tag year.month.day.release_number` (ex. `2023.12.18.01`)
   - Push the tag `git push origin --tags`
 - [Create a release](https://github.com/mbta/dotcom/releases). Select a relevant tag, follow the naming convention, click "generate release notes", and publish. This will trigger the [Deploy: release](.github/workflows/deploy-release.yml) workflow that will kick off a deploy to production.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,7 +25,7 @@ Each test can be run locally by invoking the corresponding NPM script. All the t
 ```sh
  npm run ci:lint:js
  # cd assets
- # git diff --name-only --diff-filter=dx origin/master... | grep js/.*\\.js | xargs npx eslint -c .eslintrc.js
+ # git diff --name-only --diff-filter=dx origin/main... | grep js/.*\\.js | xargs npx eslint -c .eslintrc.js
  ```
 *Runs only if a file with the `.js` extension was changed.*
 
@@ -40,7 +40,7 @@ Each test can be run locally by invoking the corresponding NPM script. All the t
 ### Linting / Elixir
 ```sh
 npm run ci:lint:ex
-# mix credo diff master -a
+# mix credo diff main -a
 ```
 *Runs only if a file with the `.ex` or `.exs` extension was changed.*
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ci:lint:ts": "npm run --prefix assets eslint:ts",
     "ci:lint:js": "npm run --prefix assets eslint:js",
     "ci:lint:scss": "npm run --prefix assets stylelint -- css/**/*.scss",
-    "ci:lint:ex": "mix credo diff master -a",
+    "ci:lint:ex": "mix credo diff main -a",
     "ci:unit:exunit": "mix coveralls.html",
     "ci:unit:mocha": "npm run --prefix assets mocha",
     "ci:unit:jest": "npm run --prefix assets jest",


### PR DESCRIPTION
Finally renamed `master` branch to `main`.

On your local machines, you can do the following:

```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```