### PR TITLE
Charge a transfer fee for bus to subway transfers

### DIFF
--- a/lib/dotcom_web/views/trip_plan_view.ex
+++ b/lib/dotcom_web/views/trip_plan_view.ex
@@ -578,6 +578,8 @@ defmodule DotcomWeb.TripPlanView do
         # If this is part of a free transfer, don't add fare
         cond do
           Transfer.is_maybe_transfer?(three_legs) -> acc
+          # If this is a bus to subway transfer, add the transfer fee of 70 cents
+          Transfer.is_bus_to_subway_transfer?(two_legs) -> acc + 70
           Transfer.is_maybe_transfer?(two_legs) -> acc
           true -> acc + (leg |> Fares.get_fare_by_type(fare_type) |> fare_cents())
         end

--- a/lib/dotcom_web/views/trip_plan_view.ex
+++ b/lib/dotcom_web/views/trip_plan_view.ex
@@ -579,7 +579,7 @@ defmodule DotcomWeb.TripPlanView do
         cond do
           Transfer.is_maybe_transfer?(three_legs) -> acc
           # If this is a bus to subway transfer, add the transfer fee of 70 cents
-          Transfer.is_bus_to_subway_transfer?(two_legs) -> acc + 70
+          Transfer.bus_to_subway_transfer?(two_legs) -> acc + 70
           Transfer.is_maybe_transfer?(two_legs) -> acc
           true -> acc + (leg |> Fares.get_fare_by_type(fare_type) |> fare_cents())
         end

--- a/lib/dotcom_web/views/trip_plan_view.ex
+++ b/lib/dotcom_web/views/trip_plan_view.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file
 defmodule DotcomWeb.TripPlanView do
   @moduledoc "Contains the logic for the Trip Planner"
   use DotcomWeb, :view

--- a/lib/dotcom_web/views/trip_plan_view.ex
+++ b/lib/dotcom_web/views/trip_plan_view.ex
@@ -582,11 +582,20 @@ defmodule DotcomWeb.TripPlanView do
         three_legs = transit_legs |> Enum.slice(leg_index - 2, 3)
         # If this is part of a free transfer, don't add fare
         cond do
-          Transfer.bus_to_subway_transfer?(three_legs) -> acc + 70
-          Transfer.is_maybe_transfer?(three_legs) -> acc
-          Transfer.bus_to_subway_transfer?(two_legs) -> acc + 70
-          Transfer.is_maybe_transfer?(two_legs) -> acc
-          true -> acc + (leg |> Fares.get_fare_by_type(fare_type) |> fare_cents())
+          Transfer.bus_to_subway_transfer?(three_legs) ->
+            if acc == 170, do: acc + 70, else: acc
+
+          Transfer.is_maybe_transfer?(three_legs) ->
+            acc
+
+          Transfer.bus_to_subway_transfer?(two_legs) ->
+            acc + 70
+
+          Transfer.is_maybe_transfer?(two_legs) ->
+            acc
+
+          true ->
+            acc + (leg |> Fares.get_fare_by_type(fare_type) |> fare_cents())
         end
       end
     end)

--- a/lib/dotcom_web/views/trip_plan_view.ex
+++ b/lib/dotcom_web/views/trip_plan_view.ex
@@ -559,6 +559,12 @@ defmodule DotcomWeb.TripPlanView do
     }
   end
 
+  @doc """
+  Gets the total fare for a given itinerary, based on the fare type.
+
+  Note that we have to check if there is a bus to subway transfer and manually add the transfer cost.
+  This is because OTP adds the transfer to the first leg of a subway to bus transfer, but not bus to subway.
+  """
   @spec get_one_way_total_by_type(TripPlan.Itinerary.t(), Fares.fare_type()) :: non_neg_integer
   def get_one_way_total_by_type(itinerary, fare_type) do
     transit_legs =

--- a/lib/dotcom_web/views/trip_plan_view.ex
+++ b/lib/dotcom_web/views/trip_plan_view.ex
@@ -583,7 +583,9 @@ defmodule DotcomWeb.TripPlanView do
         # If this is part of a free transfer, don't add fare
         cond do
           Transfer.bus_to_subway_transfer?(three_legs) ->
-            if acc == 170, do: acc + 70, else: acc
+            if acc == Fares.get_fare_by_type(List.first(three_legs), fare_type) |> fare_cents(),
+              do: acc + 70,
+              else: acc
 
           Transfer.is_maybe_transfer?(three_legs) ->
             acc

--- a/lib/dotcom_web/views/trip_plan_view.ex
+++ b/lib/dotcom_web/views/trip_plan_view.ex
@@ -562,8 +562,7 @@ defmodule DotcomWeb.TripPlanView do
   @doc """
   Gets the total fare for a given itinerary, based on the fare type.
 
-  Note that we have to check if there is a bus to subway transfer and manually add the transfer cost.
-  This is because OTP adds the transfer to the first leg of a subway to bus transfer, but not bus to subway.
+  We have to check if there is a bus to subway transfer and manually add the transfer cost of $0.70.
   """
   @spec get_one_way_total_by_type(TripPlan.Itinerary.t(), Fares.fare_type()) :: non_neg_integer
   def get_one_way_total_by_type(itinerary, fare_type) do
@@ -583,8 +582,8 @@ defmodule DotcomWeb.TripPlanView do
         three_legs = transit_legs |> Enum.slice(leg_index - 2, 3)
         # If this is part of a free transfer, don't add fare
         cond do
+          Transfer.bus_to_subway_transfer?(three_legs) -> acc + 70
           Transfer.is_maybe_transfer?(three_legs) -> acc
-          # If this is a bus to subway transfer, add the transfer fee of 70 cents
           Transfer.bus_to_subway_transfer?(two_legs) -> acc + 70
           Transfer.is_maybe_transfer?(two_legs) -> acc
           true -> acc + (leg |> Fares.get_fare_by_type(fare_type) |> fare_cents())

--- a/lib/trip_plan/transfer.ex
+++ b/lib/trip_plan/transfer.ex
@@ -83,8 +83,7 @@ defmodule TripPlan.Transfer do
         %Leg{mode: %TransitDetail{route_id: from_route}},
         %Leg{mode: %TransitDetail{route_id: to_route}}
       ]) do
-    Fares.to_fare_atom(from_route) == :bus and
-      Fares.to_fare_atom(to_route) == :subway
+    Fares.to_fare_atom(from_route) == :bus && Fares.to_fare_atom(to_route) == :subway
   end
 
   def bus_to_subway_transfer?(_), do: false

--- a/lib/trip_plan/transfer.ex
+++ b/lib/trip_plan/transfer.ex
@@ -77,8 +77,17 @@ defmodule TripPlan.Transfer do
   def is_maybe_transfer?(_), do: false
 
   @doc """
-  Is the first leg a bus ride and the second leg a subway ride?
+  Is there a bus to subway transfer?
   """
+  def bus_to_subway_transfer?([
+        first_leg = %Leg{mode: %TransitDetail{}},
+        middle_leg = %Leg{mode: %TransitDetail{}},
+        last_leg = %Leg{mode: %TransitDetail{}}
+      ]) do
+    bus_to_subway_transfer?([first_leg, middle_leg]) ||
+      bus_to_subway_transfer?([middle_leg, last_leg])
+  end
+
   def bus_to_subway_transfer?([
         %Leg{mode: %TransitDetail{route_id: from_route}},
         %Leg{mode: %TransitDetail{route_id: to_route}}

--- a/lib/trip_plan/transfer.ex
+++ b/lib/trip_plan/transfer.ex
@@ -76,6 +76,9 @@ defmodule TripPlan.Transfer do
 
   def is_maybe_transfer?(_), do: false
 
+  @doc """
+  Is the first leg a bus and the second leg a subway?
+  """
   def bus_to_subway_transfer?([
         %Leg{mode: %TransitDetail{route_id: from_route}},
         %Leg{mode: %TransitDetail{route_id: to_route}}

--- a/lib/trip_plan/transfer.ex
+++ b/lib/trip_plan/transfer.ex
@@ -76,6 +76,16 @@ defmodule TripPlan.Transfer do
 
   def is_maybe_transfer?(_), do: false
 
+  def is_bus_to_subway_transfer?([
+        %Leg{mode: %TransitDetail{route_id: from_route}},
+        %Leg{mode: %TransitDetail{route_id: to_route}}
+      ]) do
+    Fares.to_fare_atom(from_route) == :bus and
+      Fares.to_fare_atom(to_route) == :subway
+  end
+
+  def is_bus_to_subway_transfer?(_), do: false
+
   defp same_station?(from_stop, to_stop) do
     to_parent_stop = Stops.Repo.get_parent(to_stop)
     from_parent_stop = Stops.Repo.get_parent(from_stop)

--- a/lib/trip_plan/transfer.ex
+++ b/lib/trip_plan/transfer.ex
@@ -77,7 +77,7 @@ defmodule TripPlan.Transfer do
   def is_maybe_transfer?(_), do: false
 
   @doc """
-  Is the first leg a bus and the second leg a subway?
+  Is the first leg a bus ride and the second leg a subway ride?
   """
   def bus_to_subway_transfer?([
         %Leg{mode: %TransitDetail{route_id: from_route}},

--- a/lib/trip_plan/transfer.ex
+++ b/lib/trip_plan/transfer.ex
@@ -76,7 +76,7 @@ defmodule TripPlan.Transfer do
 
   def is_maybe_transfer?(_), do: false
 
-  def is_bus_to_subway_transfer?([
+  def bus_to_subway_transfer?([
         %Leg{mode: %TransitDetail{route_id: from_route}},
         %Leg{mode: %TransitDetail{route_id: to_route}}
       ]) do
@@ -84,7 +84,7 @@ defmodule TripPlan.Transfer do
       Fares.to_fare_atom(to_route) == :subway
   end
 
-  def is_bus_to_subway_transfer?(_), do: false
+  def bus_to_subway_transfer?(_), do: false
 
   defp same_station?(from_stop, to_stop) do
     to_parent_stop = Stops.Repo.get_parent(to_stop)

--- a/test/dotcom_web/views/trip_plan_view_test.exs
+++ b/test/dotcom_web/views/trip_plan_view_test.exs
@@ -1,9 +1,12 @@
 defmodule DotcomWeb.TripPlanViewTest do
   use DotcomWeb.ConnCase, async: true
+
   import DotcomWeb.TripPlanView
+  import Mox
   import Phoenix.HTML, only: [safe_to_string: 1]
-  import UrlHelpers, only: [update_url: 2]
   import Schedules.Repo, only: [end_of_rating: 0]
+  import UrlHelpers, only: [update_url: 2]
+
   alias Fares.Fare
   alias Routes.Route
   alias Dotcom.TripPlan.{IntermediateStop, ItineraryRow, Query}
@@ -72,6 +75,8 @@ defmodule DotcomWeb.TripPlanViewTest do
     },
     reduced_one_way_fare: nil
   }
+
+  setup :verify_on_exit!
 
   describe "itinerary_explanation/2" do
     @base_explanation_query %Query{
@@ -1286,6 +1291,10 @@ closest arrival to 12:00 AM, Thursday, January 1st."
         start: nil,
         stop: nil
       }
+
+      expect(MBTA.Api.Mock, :get_json, fn _, _ ->
+        {:error, nil}
+      end)
 
       assert get_one_way_total_by_type(itinerary, :highest_one_way_fare) == 290
     end


### PR DESCRIPTION
Currently, for a subway -> bus transfer the fare for the first leg is $2.40 which covers the transfer. But, for bus -> subway the fare for the first leg is $1.70. So, we need to add the extra $0.70 transfer fee.

