### PR TITLE
feat(DepartureCard): link to relevant direction

### DIFF
--- a/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -50,8 +50,8 @@ describe("DepartureCard", () => {
     );
     await waitFor(() => {
       expect(
-        screen.getByRole("link", { name: testRoute.name })
-      ).toHaveAttribute("href", `/schedules/${testRoute.id}`);
+        screen.getByRole("link", { name: testRoute.name }).getAttribute("href")
+      ).toStartWith(`/schedules/${testRoute.id}`);
     });
   });
 

--- a/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
+++ b/assets/ts/stop/__tests__/__snapshots__/StopPageDeparturesTest.tsx.snap
@@ -157,7 +157,7 @@ exports[`StopPageDepartures renders with data 2`] = `
       >
         <a
           class="departure-card__route u-bg--bus notranslate"
-          href="/schedules/16"
+          href="/schedules/16?schedule_direction[direction_id]=0"
         >
           <span
             aria-hidden="true"

--- a/assets/ts/stop/components/DepartureCard.tsx
+++ b/assets/ts/stop/components/DepartureCard.tsx
@@ -1,4 +1,4 @@
-import { reject } from "lodash";
+import { reject, uniq } from "lodash";
 import React, { ReactElement } from "react";
 import { Alert, Route } from "../../__v3api";
 import { routeName, routeToModeIcon } from "../../helpers/route-headers";
@@ -57,11 +57,21 @@ const DepartureCard = ({
     if (sortedRoutePatternsByHeadsign.length === 0) return null;
   }
 
+  const directionIds = uniq(
+    sortedRoutePatternsByHeadsign.map(
+      ([, { direction_id: directionId }]) => directionId
+    )
+  );
+  const routeHref =
+    directionIds.length === 1
+      ? `/schedules/${route.id}?schedule_direction[direction_id]=${directionIds[0]}`
+      : `/schedules/${route.id}`;
+
   return (
     <li className="departure-card">
       <a
         className={`departure-card__route ${routeBgClass(route)} notranslate`}
-        href={`/schedules/${route.id}`}
+        href={routeHref}
       >
         {renderSvg("c-svg__icon", routeToModeIcon(route), true)}{" "}
         {routeName(route)}


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Bus stop page route links should preserve direction/variant when possible](https://app.asana.com/0/555089885850811/1206524592491487/f)

Look at all the route patterns: if they all have the same `direction_id` then adjust the link to include the URL parameter for that direction.