### PR TITLE
feat: redirect bad schedules URLs

### DIFF
--- a/lib/dotcom_web/plugs/schedule_redirector.ex
+++ b/lib/dotcom_web/plugs/schedule_redirector.ex
@@ -1,0 +1,25 @@
+defmodule DotcomWeb.Plugs.ScheduleRedirector do
+  @moduledoc """
+  Catch-all for unsupported `/schedules/:route_id/*` URLs.
+  Redirects to the default `/schedules/:route_id` path.
+  """
+
+  @behaviour Plug
+
+  import DotcomWeb.Router.Helpers, only: [schedule_path: 3]
+  import Phoenix.Controller, only: [redirect: 2]
+
+  alias Plug.Conn
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(%Conn{path_info: ["schedules", route_id | _]} = conn, _opts) do
+    conn
+    |> redirect(to: schedule_path(conn, :show, route_id))
+    |> Conn.halt()
+  end
+
+  def call(conn, _opts), do: conn
+end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -194,6 +194,7 @@ defmodule DotcomWeb.Router do
 
     get("/schedules/:route", ScheduleController, :show, as: :schedule)
     get("/schedules/:route/pdf", ScheduleController.Pdf, :pdf, as: :route_pdf)
+    get("/schedules/:route/*path", Plugs.ScheduleRedirector, [])
     get("/style-guide", StyleGuideController, :index)
     get("/style-guide/principles", Redirector, to: "/style-guide")
     get("/style-guide/about", Redirector, to: "/style-guide")

--- a/lib/dotcom_web/www_redirector.ex
+++ b/lib/dotcom_web/www_redirector.ex
@@ -1,7 +1,22 @@
 defmodule DotcomWeb.WwwRedirector do
+  @moduledoc """
+  Enables redirecting obsolete subdomains to www.mbta.com.
+
+  ## Example
+
+  Redirect all paths for `obsolete.mbta.com`:
+
+  ```elixir
+  scope "/", DotcomWeb, host: "obsolete." do
+    get("/*path", WwwRedirector, [])
+  end
+  ```
+  """
+
   @behaviour Plug
-  import Plug.Conn, only: [put_status: 2, halt: 1]
+
   import Phoenix.Controller, only: [redirect: 2]
+  import Plug.Conn, only: [put_status: 2, halt: 1]
 
   alias Plug.Conn
 

--- a/test/dotcom_web/plugs/schedule_redirector_test.exs
+++ b/test/dotcom_web/plugs/schedule_redirector_test.exs
@@ -1,0 +1,11 @@
+defmodule DotcomWeb.Plugs.ScheduleRedirectorTest do
+  use DotcomWeb.ConnCase, async: true
+
+  alias DotcomWeb.Plugs.ScheduleRedirector
+
+  test "call", %{conn: conn} do
+    conn = ScheduleRedirector.call(%{conn | path_info: ["schedules", "79", "schedule"]}, [])
+    assert redirected_to(conn, :found) == "/schedules/79"
+    assert conn.halted
+  end
+end


### PR DESCRIPTION
No ticket. I'm just tired of seeing tons of failed visits to `/schedules/:route_id/schedule` (e.g. the prior pattern for a schedule page, likely linked from many old pages across the Internet) constantly.

I wrote this plug, inspired by `Www.Redirector`, to redirect those to the appropriate place (`/schedules/:route_id`).