### PR TITLE
Fix broken search links

### DIFF
--- a/assets/ts/ui/autocomplete/templates/algolia.tsx
+++ b/assets/ts/ui/autocomplete/templates/algolia.tsx
@@ -31,6 +31,9 @@ export function LinkForItem(props: LinkForItemProps): React.ReactElement {
     url = item._search_result_url.replace(/(internal|entity):/g, "/");
   }
 
+  // Strip extra forward slashes as they break relative links
+  url = url.replace(/\/\//g, "/");
+
   // Special case: When the matching text isn't part of the page title, help the
   // user locate the matching text by linking directly to / scrolling to the
   // matching text on the page.


### PR DESCRIPTION
https://app.asana.com/0/home/1204957179328166/1206833764807735

Super simple. The links sometimes have two forward slashes. When that is the case, we need to remove the first one so the link stays relative to the current domain.