### PR TITLE
tests: fix tests using :mbta_api config

### DIFF
--- a/lib/mbta/api/stream.ex
+++ b/lib/mbta/api/stream.ex
@@ -48,9 +48,16 @@ defmodule MBTA.Api.Stream do
   """
   @spec build_options(Keyword.t()) :: Keyword.t()
   def build_options(opts) do
-    opts
-    |> set_url(config(:base_url))
-    |> Keyword.put(:headers, config(:headers))
+    with base_url when not is_nil(base_url) <- config(:base_url),
+         headers <- config(:headers),
+         key when not is_nil(key) <- List.keyfind(headers, "x-api-key", 0) do
+      opts
+      |> set_url(config(:base_url))
+      |> Keyword.put(:headers, config(:headers))
+    else
+      _ ->
+        raise ArgumentError, "Missing required configuration for MBTA API"
+    end
   end
 
   def init(opts) do

--- a/test/mbta/api/stream_test.exs
+++ b/test/mbta/api/stream_test.exs
@@ -5,15 +5,20 @@ defmodule MBTA.Api.StreamTest do
 
   describe "build_options" do
     test "includes api key" do
-      Application.put_env(:dotcom, :mbta_api, base_url: "foo", key: "bar")
+      Application.put_env(:dotcom, :mbta_api,
+        base_url: "foo",
+        headers: [
+          {"x-api-key", "bar"}
+        ]
+      )
 
       opts = Stream.build_options(path: "/vehicles")
       assert Keyword.get(opts, :url) =~ "/vehicles"
-      assert <<_::binary>> = Keyword.get(opts, :key)
+      assert [{"x-api-key", <<_::binary>>}] = Keyword.get(opts, :headers)
     end
 
     test "throws error if mbta api base url is missing" do
-      Application.put_env(:dotcom, :mbta_api, base_url: nil, key: "foo")
+      Application.put_env(:dotcom, :mbta_api, base_url: nil)
 
       assert_raise ArgumentError, "Missing required configuration for MBTA API", fn ->
         Stream.build_options(path: "/vehicles")
@@ -21,7 +26,13 @@ defmodule MBTA.Api.StreamTest do
     end
 
     test "throws error if mbta api key is missing" do
-      Application.put_env(:dotcom, :mbta_api, base_url: "http://example.com", key: nil)
+      Application.put_env(:dotcom, :mbta_api,
+        headers: [
+          {"MBTA-Version", "2019-07-01"},
+          {"x-api-key", nil},
+          {"x-enable-experimental-features", "true"}
+        ]
+      )
 
       assert_raise ArgumentError, "Missing required configuration for MBTA API", fn ->
         Stream.build_options(path: "/vehicles")

--- a/test/predictions/stream_supervisor_test.exs
+++ b/test/predictions/stream_supervisor_test.exs
@@ -19,7 +19,12 @@ defmodule Predictions.StreamSupervisorTest do
   end
 
   setup do
-    Application.put_env(:dotcom, :mbta_api, base_url: "foo", key: "bar")
+    Application.put_env(:dotcom, :mbta_api,
+      base_url: "foo",
+      headers: [
+        {"x-api-key", "bar"}
+      ]
+    )
   end
 
   setup :close_active_workers


### PR DESCRIPTION
Sorry for breaking this in my earlier commit. This should reinstate the `"Missing required configuration for MBTA API"` error message under the expected conditions.