### PR TITLE
fix: show Massport routes in trip planner result

### DIFF
--- a/lib/dotcom_web/views/helpers.ex
+++ b/lib/dotcom_web/views/helpers.ex
@@ -202,7 +202,7 @@ defmodule DotcomWeb.ViewHelpers do
   def mode_name(type) when type in ["2272", "983", :massport_shuttle],
     do: "Massport Shuttle"
 
-  def mode_name("Massport-" <> _route), do: "Massport Shuttle"
+  def mode_name("Massport" <> _route), do: "Massport Shuttle"
 
   def mode_name(:access), do: "Access"
   def mode_name(:the_ride), do: "The Ride"

--- a/lib/routes/route.ex
+++ b/lib/routes/route.ex
@@ -81,7 +81,7 @@ defmodule Routes.Route do
   def type_atom("2274"), do: :logan_express
   def type_atom("983"), do: :massport_shuttle
   def type_atom("2272"), do: :massport_shuttle
-  def type_atom("Massport-" <> _), do: :massport_shuttle
+  def type_atom("Massport" <> _), do: :massport_shuttle
   def type_atom("the_ride"), do: :the_ride
 
   @spec types_for_mode(gtfs_route_type | subway_lines_type) :: [0..4]
@@ -110,7 +110,7 @@ defmodule Routes.Route do
   def icon_atom(%__MODULE__{id: "Green-C"}), do: :green_line_c
   def icon_atom(%__MODULE__{id: "Green-D"}), do: :green_line_d
   def icon_atom(%__MODULE__{id: "Green-E"}), do: :green_line_e
-  def icon_atom(%__MODULE__{id: "Massport-" <> _}), do: :massport_shuttle
+  def icon_atom(%__MODULE__{id: "Massport" <> _}), do: :massport_shuttle
 
   for silver_line_route <- @silver_line do
     def icon_atom(%__MODULE__{id: unquote(silver_line_route)}), do: unquote(:silver_line)


### PR DESCRIPTION
<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [FunctionClauseError: no function clause matching in Routes.Route.type_atom/1](https://app.asana.com/0/555089885850811/1207206768475697/f)

A GTFS file from Massport is used to enable the trip planner to parse and use Massport routes, which we in turn need to parse and render with the results. Sometimes the Massport GTFS changes their naming slightly, which is what I think caused the bug here. 
