### PR TITLE
fix(force_ssl): Configure force_ssl in prod instead of runtime

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,3 +2,13 @@ import Config
 
 config :dotcom, :cache, Dotcom.Cache.Multilevel
 config :dotcom, :trip_plan_feedback_cache, Dotcom.Cache.TripPlanFeedback.Cache
+
+unless System.get_env("PORT") do
+  # configured separately so that we can have the health check not require
+  # SSL
+  config :dotcom, :secure_pipeline,
+    force_ssl: [
+      host: nil,
+      rewrite_on: [:x_forwarded_proto]
+    ]
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -183,16 +183,6 @@ if config_env() == :prod do
       port: System.get_env("STATIC_PORT")
     ]
 
-  unless System.get_env("PORT") do
-    # configured separately so that we can have the health check not require
-    # SSL
-    config :dotcom, :secure_pipeline,
-      force_ssl: [
-        host: nil,
-        rewrite_on: [:x_forwarded_proto]
-      ]
-  end
-
   config :dotcom,
     support_ticket_to_email: System.get_env("SUPPORT_TICKET_TO_EMAIL"),
     support_ticket_from_email: System.get_env("SUPPORT_TICKET_FROM_EMAIL"),


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
Move the `force_ssl` configuration to the `prod.exs` configuration file as it is not supported to be configured in the [`runtime.exs` file](https://hexdocs.pm/phoenix/using_ssl.html#force-ssl)

https://app.asana.com/0/555089885850811/1206388063560698

