### PR TITLE
refactor(RapidTransitHoursOfOperation): check date before formatting

### DIFF
--- a/assets/ts/schedule/components/RapidTransitHoursOfOperation.tsx
+++ b/assets/ts/schedule/components/RapidTransitHoursOfOperation.tsx
@@ -1,5 +1,5 @@
 import { isDate, isSaturday, isSunday, parseISO } from "date-fns";
-import { map, min } from "lodash";
+import { min } from "lodash";
 import React, { ReactElement } from "react";
 import { formatToBostonTime } from "../../helpers/date";
 import useHoursOfOperation from "../../hooks/useHoursOfOperation";


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Sentry Error: RangeError: Invalid time value](https://app.asana.com/0/555089885850811/1207115579685725/f)

Avoids potentially passing invalid dates to the underlying `formatToBostonTime`.
