### PR TITLE
refactor: create `LocationService` behaviour

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,8 @@ config :dotcom, :httpoison, HTTPoison
 
 config :dotcom, :mbta_api_module, MBTA.Api
 
+config :dotcom, :location_service, LocationService
+
 config :dotcom, :repo_modules,
   predictions: Predictions.Repo,
   route_patterns: RoutePatterns.Repo,

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,8 @@ import Config
 
 config :elixir, ansi_enabled: true
 
+config :dotcom, :aws, ExAws
+
 config :dotcom, :cms_api_module, CMS.Api
 
 config :dotcom, :httpoison, HTTPoison

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,6 +9,8 @@ config :dotcom, :httpoison, HTTPoison.Mock
 config :dotcom, :cms_api_module, CMS.Api.Static
 config :dotcom, :mbta_api_module, MBTA.Api.Mock
 
+config :dotcom, :location_service, LocationService.Mock
+
 config :dotcom, :repo_modules,
   predictions: Predictions.Repo.Mock,
   route_patterns: RoutePatterns.Repo.Mock,

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,7 @@
 import Config
 
+config :dotcom, :aws, ExAws.Mock
+
 config :dotcom, :cache, Dotcom.Cache.TestCache
 
 config :dotcom, :httpoison, HTTPoison.Mock

--- a/lib/dotcom_web/controllers/fare_controller.ex
+++ b/lib/dotcom_web/controllers/fare_controller.ex
@@ -8,8 +8,6 @@ defmodule DotcomWeb.FareController do
   plug(:meta_description)
 
   @options %{
-    geocode_fn: &LocationService.geocode/1,
-    reverse_geocode_fn: &LocationService.reverse_geocode/2,
     nearby_fn: %{
       retail: &Fares.RetailLocations.get_nearby/1,
       proposed: &Fares.ProposedLocations.get_nearby/1

--- a/lib/dotcom_web/controllers/places_controller.ex
+++ b/lib/dotcom_web/controllers/places_controller.ex
@@ -14,7 +14,7 @@ defmodule DotcomWeb.PlacesController do
     with {hit_limit, ""} <- Integer.parse(hit_limit_str),
          {:ok, predictions} <-
            @location_service.autocomplete(input, hit_limit) do
-      json(conn, %{predictions: Poison.encode!(predictions)})
+      json(conn, %{predictions: Jason.encode!(predictions)})
     else
       {:error, :internal_error} ->
         ControllerHelpers.return_internal_error(conn)
@@ -31,7 +31,7 @@ defmodule DotcomWeb.PlacesController do
   def details(conn, %{"address" => address}) do
     case @location_service.geocode(address) do
       {:ok, results} ->
-        json(conn, %{result: results |> List.first() |> Poison.encode!()})
+        json(conn, %{result: results |> List.first() |> Jason.encode!()})
 
       {:error, :internal_error} ->
         ControllerHelpers.return_internal_error(conn)
@@ -45,7 +45,7 @@ defmodule DotcomWeb.PlacesController do
   def reverse_geocode(conn, params) do
     with {:ok, latitude, longitude} <- parse_location(params),
          {:ok, results} <- @location_service.reverse_geocode(latitude, longitude) do
-      json(conn, %{results: Poison.encode!(results)})
+      json(conn, %{results: Jason.encode!(results)})
     else
       :invalid_lat_lng ->
         ControllerHelpers.return_invalid_arguments_error(conn)

--- a/lib/dotcom_web/controllers/transit_near_me_controller.ex
+++ b/lib/dotcom_web/controllers/transit_near_me_controller.ex
@@ -26,7 +26,7 @@ defmodule DotcomWeb.TransitNearMeController do
   end
 
   defp assign_location(conn) do
-    location_fn = Map.get(conn.assigns, :location_fn, &Location.get/2)
+    location_fn = Map.get(conn.assigns, :location_fn, &Location.get/1)
 
     location = location_fn.(conn.params, [])
 

--- a/lib/location_service/address.ex
+++ b/lib/location_service/address.ex
@@ -2,6 +2,7 @@ defmodule LocationService.Address do
   @moduledoc """
   An address provided by a Geocode lookup.
   """
+  @derive Jason.Encoder
   @type t :: %__MODULE__{
           formatted: String.t(),
           latitude: float,

--- a/lib/location_service/aws_location/request.ex
+++ b/lib/location_service/aws_location/request.ex
@@ -2,6 +2,7 @@ defmodule AWSLocation.Request do
   @moduledoc """
   Constructs and dispatches requests to AWS Location service
   """
+  @aws Application.compile_env!(:dotcom, :aws)
 
   @base_request_body %{
     FilterBBox: [-71.9380, 41.3193, -69.6189, 42.8266],
@@ -26,7 +27,7 @@ defmodule AWSLocation.Request do
   @doc "Autocompletes some text, limiting the number of results returned"
   @spec autocomplete(String.t(), number) :: LocationService.Suggestion.result()
   def autocomplete(search, limit) when 1 <= limit and limit <= 15 do
-    ExAws.request(%ExAws.Operation.RestQuery{
+    @aws.request(%ExAws.Operation.RestQuery{
       http_method: :post,
       body:
         @base_request_body
@@ -51,7 +52,7 @@ defmodule AWSLocation.Request do
       service: :places,
       path: path
     }
-    |> ExAws.request()
+    |> @aws.request()
   end
 
   defp place_index_path(:text), do: place_index_base("esri") <> "/search/text"

--- a/lib/location_service/behaviour.ex
+++ b/lib/location_service/behaviour.ex
@@ -1,0 +1,34 @@
+defmodule LocationService.Behaviour do
+  @moduledoc """
+  The behaviour for interacting with AWS Location Service
+  """
+
+  @type result ::
+          {:ok, nonempty_list(LocationService.Address.t())}
+          | {:error, :zero_results | :internal_error}
+
+  @doc """
+  Geocodes free-form text, such as an address, name, city, or region to allow
+  you to search for Places or points of interest.
+
+  https://docs.aws.amazon.com/location-places/latest/APIReference/API_SearchPlaceIndexForText.html
+
+  Caches the result using the input address as key.
+  """
+  @callback geocode(String.t()) :: result
+
+  @doc """
+  Uses AWS Location Service to perform a geocode lookup. Caches the result using
+  the input address as key.
+  """
+  @callback reverse_geocode(number, number) :: result
+
+  @doc """
+  Uses AWS Location Service to do autocompletion. Caches the result using the
+  search term and limit as key.
+  """
+  @callback autocomplete(String.t(), number) ::
+              LocationService.Suggestion.result()
+              | {:error, :invalid_arguments}
+              | {:error, :zero_results}
+end

--- a/lib/location_service/location_service.ex
+++ b/lib/location_service/location_service.ex
@@ -13,37 +13,20 @@ defmodule LocationService do
   @cache Application.compile_env!(:dotcom, :cache)
   @ttl :timer.hours(24)
 
-  @type result ::
-          {:ok, nonempty_list(LocationService.Address.t())}
-          | {:error, :zero_results | :internal_error}
+  @behaviour LocationService.Behaviour
 
-  @doc "Geocodes free-form text, such as an address, name, city, or region to allow you to search for Places or points of interest.
-
-  https://docs.aws.amazon.com/location-places/latest/APIReference/API_SearchPlaceIndexForText.html
-
-  Caches the result using the input address as key."
-  @spec geocode(String.t()) :: result
   @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   def geocode(address) when is_binary(address) do
     Request.new(address)
     |> Result.handle_response(address)
   end
 
-  @doc "Uses AWS Location Service to perform a
-  geocode lookup. Caches the result using the input address as key."
-  @spec reverse_geocode(number, number) :: result
   @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   def reverse_geocode(latitude, longitude) when is_float(latitude) and is_float(longitude) do
     Request.new([latitude, longitude])
     |> Result.handle_response([latitude, longitude])
   end
 
-  @doc "Uses AWS Location Service to do
-  autocompletion. Caches the result using the search term and limit as key."
-  @spec autocomplete(String.t(), number) ::
-          LocationService.Suggestion.result()
-          | {:error, :invalid_arguments}
-          | {:error, :zero_results}
   @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   def autocomplete(search, limit) when 1 <= limit and limit <= 15 do
     Request.autocomplete(search, limit)

--- a/lib/location_service/result.ex
+++ b/lib/location_service/result.ex
@@ -9,7 +9,7 @@ defmodule LocationService.Result do
   - process results
   - log results or errors
   """
-  @spec handle_response({:ok | :error, any}, any) :: LocationService.result()
+  @spec handle_response({:ok | :error, any}, any) :: LocationService.Behaviour.result()
   def handle_response({:ok, %{status_code: 200, body: body}}, input) do
     Jason.decode(body)
     |> handle_response(input)

--- a/lib/location_service/suggestion.ex
+++ b/lib/location_service/suggestion.ex
@@ -8,6 +8,7 @@ defmodule LocationService.Suggestion do
         }
 
   @enforce_keys [:address, :highlighted_spans]
+  @derive Jason.Encoder
   defstruct address: nil,
             highlighted_spans: nil
 

--- a/lib/location_service/utils.ex
+++ b/lib/location_service/utils.ex
@@ -5,6 +5,7 @@ defmodule LocationService.Utils do
             length: non_neg_integer()
           }
 
+    @derive Jason.Encoder
     @enforce_keys [:offset, :length]
     defstruct offset: nil,
               length: nil

--- a/test/dotcom_web/controllers/places_controller_test.exs
+++ b/test/dotcom_web/controllers/places_controller_test.exs
@@ -23,9 +23,7 @@ defmodule DotcomWeb.PlacesControllerTest do
       hit_limit = Faker.random_between(3, 5)
       suggestions = build_list(3, :suggestion)
 
-      expect(LocationService.Mock, :autocomplete, fn arg1, arg2 ->
-        assert arg1 == input
-        assert arg2 == hit_limit
+      expect(LocationService.Mock, :autocomplete, fn ^input, ^hit_limit ->
         {:ok, suggestions}
       end)
 

--- a/test/dotcom_web/controllers/places_controller_test.exs
+++ b/test/dotcom_web/controllers/places_controller_test.exs
@@ -108,16 +108,14 @@ defmodule DotcomWeb.PlacesControllerTest do
 
   describe "reverse_geocode" do
     test "responds with the address given a latitude and longitude", %{conn: conn} do
-      latitude = "42.3484012"
-      longitude = "-71.039176"
+      latitude = Faker.Address.latitude()
+      longitude = Faker.Address.longitude()
 
-      expect(LocationService.Mock, :reverse_geocode, fn arg1, arg2 ->
-        assert "#{arg1}" == latitude
-        assert "#{arg2}" == longitude
+      expect(LocationService.Mock, :reverse_geocode, fn ^latitude, ^longitude ->
         {:ok, build_list(3, :address)}
       end)
 
-      conn = reverse_geocode(conn, %{"latitude" => latitude, "longitude" => longitude})
+      conn = reverse_geocode(conn, %{"latitude" => "#{latitude}", "longitude" => "#{longitude}"})
       assert conn.status == 200
       body = json_response(conn, 200)
       assert is_list(Jason.decode!(body["results"]))
@@ -136,10 +134,11 @@ defmodule DotcomWeb.PlacesControllerTest do
         {:error, :internal_error}
       end)
 
-      latitude = "42.3484012"
-      longitude = "-71.039176"
-
-      conn = reverse_geocode(conn, %{"latitude" => latitude, "longitude" => longitude})
+      conn =
+        reverse_geocode(conn, %{
+          "latitude" => "#{Faker.Address.latitude()}",
+          "longitude" => "#{Faker.Address.longitude()}"
+        })
 
       assert conn.status == 500
       assert %{"error" => "Internal error"} = json_response(conn, 500)
@@ -150,9 +149,11 @@ defmodule DotcomWeb.PlacesControllerTest do
         {:error, :zero_results}
       end)
 
-      latitude = "42.3484012"
-      longitude = "-71.039176"
-      conn = reverse_geocode(conn, %{"latitude" => latitude, "longitude" => longitude})
+      conn =
+        reverse_geocode(conn, %{
+          "latitude" => "#{Faker.Address.latitude()}",
+          "longitude" => "#{Faker.Address.longitude()}"
+        })
 
       assert conn.status == 500
       assert %{"error" => "Zero results"} = json_response(conn, 500)
@@ -183,9 +184,7 @@ defmodule DotcomWeb.PlacesControllerTest do
       search_term = Faker.App.name()
       hit_limit = Faker.random_between(1, 10)
 
-      expect(LocationService.Mock, :autocomplete, fn arg1, arg2 ->
-        assert arg1 == search_term
-        assert arg2 == hit_limit
+      expect(LocationService.Mock, :autocomplete, fn ^search_term, ^hit_limit ->
         {:ok, []}
       end)
 

--- a/test/dotcom_web/controllers/transit_near_me/location_test.exs
+++ b/test/dotcom_web/controllers/transit_near_me/location_test.exs
@@ -35,8 +35,7 @@ defmodule DotcomWeb.TransitNearMeController.LocationTest do
     test "geocodes address if lat/lng is not provided" do
       address = Faker.Address.street_address()
 
-      expect(LocationService.Mock, :geocode, fn arg ->
-        assert arg == address
+      expect(LocationService.Mock, :geocode, fn ^address ->
         {:ok, []}
       end)
 
@@ -52,8 +51,7 @@ defmodule DotcomWeb.TransitNearMeController.LocationTest do
     test "geocodes address if lat/lng is nil" do
       address = Faker.Address.street_address()
 
-      expect(LocationService.Mock, :geocode, fn arg ->
-        assert arg == address
+      expect(LocationService.Mock, :geocode, fn ^address ->
         {:ok, []}
       end)
 
@@ -71,8 +69,7 @@ defmodule DotcomWeb.TransitNearMeController.LocationTest do
     test "geocodes address from param" do
       address = Faker.Address.street_address()
 
-      expect(LocationService.Mock, :geocode, fn arg ->
-        assert arg == address
+      expect(LocationService.Mock, :geocode, fn ^address ->
         {:ok, []}
       end)
 
@@ -86,8 +83,7 @@ defmodule DotcomWeb.TransitNearMeController.LocationTest do
     test "geocodes address if lat/lng are not floats" do
       address = Faker.Address.street_address()
 
-      expect(LocationService.Mock, :geocode, fn arg ->
-        assert arg == address
+      expect(LocationService.Mock, :geocode, fn ^address ->
         {:ok, []}
       end)
 
@@ -103,17 +99,17 @@ defmodule DotcomWeb.TransitNearMeController.LocationTest do
     end
 
     test "reverse geocodes lat/lng if address is not provided" do
+      latitude = Faker.Address.latitude()
+      longitude = Faker.Address.longitude()
+
       params = %{
         "location" => %{
-          "latitude" => "#{Faker.Address.latitude()}",
-          "longitude" => "#{Faker.Address.longitude()}"
+          "latitude" => "#{latitude}",
+          "longitude" => "#{longitude}"
         }
       }
 
-      expect(LocationService.Mock, :reverse_geocode, fn arg, arg2 ->
-        assert "#{arg}" == params["location"]["latitude"]
-        assert "#{arg2}" == params["location"]["longitude"]
-
+      expect(LocationService.Mock, :reverse_geocode, fn ^latitude, ^longitude ->
         {:ok, build_list(2, :address)}
       end)
 

--- a/test/location_service/location_service_test.exs
+++ b/test/location_service/location_service_test.exs
@@ -27,7 +27,7 @@ defmodule LocationServiceTest do
 
   describe "geocode/1" do
     test "can parse a response with results", %{good_response: good_response} do
-      stub(ExAws.Mock, :request, fn _ ->
+      expect(ExAws.Mock, :request, fn _ ->
         {:ok, good_response}
       end)
 
@@ -43,7 +43,7 @@ defmodule LocationServiceTest do
     end
 
     test "can parse a response with no results", %{no_results: no_results} do
-      stub(ExAws.Mock, :request, fn _ ->
+      expect(ExAws.Mock, :request, fn _ ->
         {:ok, no_results}
       end)
 
@@ -51,7 +51,7 @@ defmodule LocationServiceTest do
     end
 
     test "can parse a response with no body" do
-      stub(ExAws.Mock, :request, fn _ ->
+      expect(ExAws.Mock, :request, fn _ ->
         {:ok, %{status_code: 412}}
       end)
 
@@ -59,7 +59,7 @@ defmodule LocationServiceTest do
     end
 
     test "can parse a response with error" do
-      stub(ExAws.Mock, :request, fn _ ->
+      expect(ExAws.Mock, :request, fn _ ->
         {:error, {:http_error, 500, "bad news"}}
       end)
 
@@ -110,7 +110,7 @@ defmodule LocationServiceTest do
         }
         |> Jason.encode()
 
-      stub(ExAws.Mock, :request, fn _ ->
+      expect(ExAws.Mock, :request, fn _ ->
         {:ok, %{status_code: 200, body: body_string}}
       end)
 
@@ -120,7 +120,7 @@ defmodule LocationServiceTest do
     end
 
     test "can parse a response with error" do
-      stub(ExAws.Mock, :request, fn _ ->
+      expect(ExAws.Mock, :request, fn _ ->
         {:error, {:http_error, 500, "bad news"}}
       end)
 

--- a/test/support/factory/location_service.ex
+++ b/test/support/factory/location_service.ex
@@ -1,0 +1,25 @@
+defmodule Test.Support.Factory.LocationService do
+  @moduledoc """
+  Data generation for LocationService outputs.
+  """
+
+  use ExMachina
+
+  def address_factory do
+    %LocationService.Address{
+      formatted: Faker.Address.street_address(),
+      latitude: Faker.Address.latitude(),
+      longitude: Faker.Address.longitude()
+    }
+  end
+
+  def suggestion_factory do
+    %LocationService.Suggestion{
+      address: Faker.Address.street_address(),
+      highlighted_spans: %LocationService.Utils.HighlightedSpan{
+        offset: Faker.random_between(0, 10),
+        length: Faker.random_between(0, 10)
+      }
+    }
+  end
+end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -8,6 +8,7 @@ Mox.defmock(Req.Mock, for: Req.Behaviour)
 Mox.defmock(Dotcom.Redis.Mock, for: Dotcom.Redis.Behaviour)
 Mox.defmock(Dotcom.Redix.Mock, for: Dotcom.Redix.Behaviour)
 Mox.defmock(Dotcom.Redix.PubSub.Mock, for: Dotcom.Redix.PubSub.Behaviour)
+Mox.defmock(LocationService.Mock, for: LocationService.Behaviour)
 
 Mox.defmock(CMS.Api.Mock, for: CMS.Api.Behaviour)
 Mox.defmock(MBTA.Api.Mock, for: MBTA.Api.Behaviour)

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,6 +1,7 @@
 # This file houses definitions for defining Mox mocks.
 
 # External
+Mox.defmock(ExAws.Mock, for: ExAws.Behaviour)
 Mox.defmock(HTTPoison.Mock, for: HTTPoison.Base)
 Mox.defmock(Req.Mock, for: Req.Behaviour)
 
@@ -8,12 +9,11 @@ Mox.defmock(Req.Mock, for: Req.Behaviour)
 Mox.defmock(Dotcom.Redis.Mock, for: Dotcom.Redis.Behaviour)
 Mox.defmock(Dotcom.Redix.Mock, for: Dotcom.Redix.Behaviour)
 Mox.defmock(Dotcom.Redix.PubSub.Mock, for: Dotcom.Redix.PubSub.Behaviour)
-Mox.defmock(LocationService.Mock, for: LocationService.Behaviour)
 
 Mox.defmock(CMS.Api.Mock, for: CMS.Api.Behaviour)
+Mox.defmock(LocationService.Mock, for: LocationService.Behaviour)
 Mox.defmock(MBTA.Api.Mock, for: MBTA.Api.Behaviour)
 Mox.defmock(OpenTripPlannerClient.Mock, for: OpenTripPlannerClient.Behaviour)
-Mox.defmock(ExAws.Mock, for: ExAws.Behaviour)
 
 # Repos
 Mox.defmock(Predictions.Repo.Mock, for: Predictions.Repo.Behaviour)

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -12,6 +12,7 @@ Mox.defmock(Dotcom.Redix.PubSub.Mock, for: Dotcom.Redix.PubSub.Behaviour)
 Mox.defmock(CMS.Api.Mock, for: CMS.Api.Behaviour)
 Mox.defmock(MBTA.Api.Mock, for: MBTA.Api.Behaviour)
 Mox.defmock(OpenTripPlannerClient.Mock, for: OpenTripPlannerClient.Behaviour)
+Mox.defmock(ExAws.Mock, for: ExAws.Behaviour)
 
 # Repos
 Mox.defmock(Predictions.Repo.Mock, for: Predictions.Repo.Behaviour)


### PR DESCRIPTION
No ticket, just refactoring and a bunch of test rewriting.

Since `LocationService` uses `ExAws`, and `ExAws` comes with its own behaviour module, I went ahead and setup mocking for that as well, and used that to rewrite the `LocationService` tests.