### PR TITLE
hotfix(TimetableController): don't sort ferry stops by route pattern

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -224,6 +224,18 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
           },
           required(:trip_stops) => [Stops.Stop.t()]
         }
+  def build_timetable(%Conn{assigns: %{route: %Route{id: route_id, type: 4}}} = conn, schedules) do
+    trip_schedules = Map.new(schedules, &trip_schedule(&1))
+
+    trip_stops =
+      @stops_repo.by_route(route_id, conn.assigns.direction_id)
+
+    %{
+      trip_schedules: trip_schedules,
+      trip_stops: trip_stops
+    }
+  end
+
   def build_timetable(conn, schedules) do
     trip_schedules = Map.new(schedules, &trip_schedule(&1))
     inbound? = conn.assigns.direction_id == 1

--- a/lib/routes/route.ex
+++ b/lib/routes/route.ex
@@ -238,7 +238,6 @@ defmodule Routes.Route do
   def hidden?(%{id: "9702"}), do: true
   def hidden?(%{id: "9703"}), do: true
   def hidden?(%{id: "Logan-" <> _}), do: true
-  def hidden?(%{id: "CapeFlyer"}), do: true
   def hidden?(%{id: "Boat-F3"}), do: true
   def hidden?(_), do: false
 

--- a/test/routes/route_test.exs
+++ b/test/routes/route_test.exs
@@ -253,8 +253,7 @@ defmodule Routes.RouteTest do
         "9701",
         "9702",
         "9703",
-        "Logan-Airport",
-        "CapeFlyer"
+        "Logan-Airport"
       ]
 
       for route_id <- hidden_routes do


### PR DESCRIPTION
1. Ferry timetables are all out of order! It turns out using route patterns as a basis for ferry stops does not work well at all, because two of our ferry routes have many route patterns and many possible combinations of stops. I'm adding a separate clause here to handle those more simply.
2. Just threw this in... we'll want to start showing the CapeFlyer route soon, so I've removed it from hidden routes. Note we won't see it yet, because Transit Data still has to expose that route in the V3 API.