### PR TITLE
fix(TimetableController): better reflect new service changes

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -286,7 +286,9 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     "38671" => "Weymouth Landing/East Braintree",
     "NHRML-0127-B" => "Reading",
     "place-ER-0115" => "Swampscott",
-    "place-wondl" => "Lynn"
+    "place-wondl" => "Lynn",
+    # Add Readville (canonically on other routes) back into the Providence timetable
+    "place-DB-0095" => "Route 128"
   }
   @shuttle_ids Map.keys(@shuttle_overrides)
 

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -189,11 +189,11 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   end
 
   defp stops_for_fairmount(1) do
-    ["place-DB-0095", "place-forhl", "place-rugg", "place-bbsta"]
+    ["place-NEC-2203", "place-forhl", "place-rugg", "place-bbsta"]
   end
 
   defp stops_for_fairmount(0) do
-    ["place-bbsta", "place-rugg", "place-forhl", "place-NEC-2203", "place-DB-0095"]
+    ["place-bbsta", "place-rugg", "place-forhl", "place-NEC-2203"]
   end
 
   def make_via_list(list) do

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -163,7 +163,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   end
 
   def trip_messages(%Routes.Route{id: "CR-Franklin"}, 1) do
-    ["740", "728", "758", "732", "760"]
+    ["740", "752", "728", "758", "732", "760"]
     |> Enum.flat_map(&franklin_via_fairmount(&1, 1))
     |> Enum.into(%{})
   end


### PR DESCRIPTION
A few more late-coming timetable-related changes arising from the service changes which started this week.

1. Enabled the "via Fairmount line" message for the 752 train.
2. Manually added the Readville stop to the Providence Line timetable (this stop isn't part of any of the Providence Line's canonical route patterns, but is still desired in this table).
3. Removed the 734 train from the Fairmount Line timetable (prior/current state shown below). This involved adding some logic which identifies trips that only make one stop in the timetable (in this train's case, its other stops are part of _another_ route).
<img width="461" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/f3182186-3e0b-4aa2-ace1-e21074fee7d8">
