### PR TITLE
refactor(TransitNearMeControllerTest): update mocks

### DIFF
--- a/lib/dotcom_web/controllers/transit_near_me_controller.ex
+++ b/lib/dotcom_web/controllers/transit_near_me_controller.ex
@@ -30,9 +30,7 @@ defmodule DotcomWeb.TransitNearMeController do
   end
 
   defp assign_stops(%{assigns: %{location: {:ok, [location | _]}}} = conn) do
-    data_fn = Map.get(conn.assigns, :data_fn, &TransitNearMe.build/2)
-
-    data = data_fn.(location, [])
+    data = TransitNearMe.build(location, [])
 
     case data do
       {:stops, {:error, _}} -> :error

--- a/test/dotcom_web/controllers/transit_near_me_controller_test.exs
+++ b/test/dotcom_web/controllers/transit_near_me_controller_test.exs
@@ -101,9 +101,7 @@ defmodule DotcomWeb.TransitNearMeControllerTest do
     test "assigns stops with routes", %{conn: conn} do
       stops = build_list(3, :stop_item)
 
-      expect(LocationService.Mock, :reverse_geocode, fn latitude, longitude ->
-        assert latitude == @latitude
-        assert longitude == @longitude
+      expect(LocationService.Mock, :reverse_geocode, fn @latitude, @longitude ->
         {:ok, [@located_address]}
       end)
 


### PR DESCRIPTION
Quick followup to https://github.com/mbta/dotcom/commit/aa9f9915f4ecaf4e5f7e220a54dc8fc9ce7b5ddd

- Removes the dependency injection from `TransitNearMeController`
- Refactors test to reflect changes

The rest of this test suite could use some more work... but I have reviews to do. ;) 