### PR TITLE
fix(Schedules.Repo): stop caching unfound trips

### DIFF
--- a/lib/schedules/repo.ex
+++ b/lib/schedules/repo.ex
@@ -107,9 +107,6 @@ defmodule Schedules.Repo do
       %JsonApi{} = response ->
         {:ok, Parser.trip(response)}
 
-      {:error, [%JsonApi.Error{code: "not_found"} | _]} ->
-        {:ok, nil}
-
       error ->
         error
     end


### PR DESCRIPTION
Instead of returning `{:ok, nil}`, let the error propagate in `Schedules.Repo.fetch_trip/2`. That way the response isn't cached.
The caller function, `Schedules.Repo.trip/2`, happens to match the error and return `nil`. So downstream nothing actually changes :tada: 