### PR TITLE
Use the ferry-map vanity url

### DIFF
--- a/lib/dotcom/map_helpers.ex
+++ b/lib/dotcom/map_helpers.ex
@@ -71,7 +71,7 @@ defmodule Dotcom.MapHelpers do
   def image(:ferry) do
     static_url(
       DotcomWeb.Endpoint,
-      "/sites/default/files/media/2024-03/2024-03-22-ferry-map.jpg"
+      "/ferry-map"
     )
   end
 end


### PR DESCRIPTION
I confirmed this works on Chrome, Vivaldi, and Safari. If someone can check on Firefox, I think we're good.

