### PR TITLE
Remove static url wrapper for ferry map link

### DIFF
--- a/lib/dotcom/map_helpers.ex
+++ b/lib/dotcom/map_helpers.ex
@@ -68,10 +68,5 @@ defmodule Dotcom.MapHelpers do
     )
   end
 
-  def image(:ferry) do
-    static_url(
-      DotcomWeb.Endpoint,
-      "/ferry-map"
-    )
-  end
+  def image(:ferry), do: "/ferry-map"
 end


### PR DESCRIPTION
Calling static_url in prod gives us a different (and wrong) URL for the ferry map. We can just not call it and use the relative URL.

