### PR TITLE
feat: use the V3 API status endpoint to trigger cache flushes

### DIFF
--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -65,7 +65,8 @@ defmodule Dotcom.Application do
           {Phoenix.PubSub, name: Dotcom.PubSub},
           Alerts.BusStopChangeSupervisor,
           Alerts.CacheSupervisor,
-          {DotcomWeb.Endpoint, name: DotcomWeb.Endpoint}
+          {DotcomWeb.Endpoint, name: DotcomWeb.Endpoint},
+          MBTA.Api.StatusMonitor
         ]
 
     opts = [strategy: :one_for_one, name: Dotcom.Supervisor]

--- a/lib/mbta/status_monitor.ex
+++ b/lib/mbta/status_monitor.ex
@@ -1,0 +1,101 @@
+defmodule MBTA.Api.StatusMonitor do
+  @moduledoc """
+  Watches the MBTA V3 API's /status endpoint values for changes. If changed, we
+  flush the corresponding cache(s).
+  """
+
+  require Logger
+
+  use GenServer
+
+  import Dotcom.Cache.Multilevel, only: [flush_multiple_keys: 1]
+
+  @repo_cache_keys %{
+    "facility" => [
+      "facilities.repo|*"
+    ],
+    "route" => [
+      "routes.repo|*",
+      "route_patterns.repo|*"
+    ],
+    "schedule" => [
+      "schedules.repo|*",
+      "schedules.repo_condensed|*",
+      "schedules.hours_of_operation|*"
+    ],
+    "service" => [
+      "services.repo|*"
+    ],
+    "shape" => [
+      "routes.repo|get_shape|*",
+      "routes.repo|cached_get_shapes|*"
+    ],
+    "stop" => [
+      "stops.repo|*",
+      "routes.repo|cached_by_stop|*",
+      "routes.repo|do_by_stop_with_route_pattern|*"
+    ],
+    "trip" => [
+      "schedules.repo|fetch_trip|*",
+      "stops.repo|by_trip|*"
+    ]
+  }
+  @status_endpoints Map.keys(@repo_cache_keys)
+  @update_interval_ms 600_000
+
+  def start_link(status_map) do
+    GenServer.start_link(__MODULE__, status_map, [])
+  end
+
+  @impl GenServer
+  @doc """
+  Initializes a map keyed by each V3 API endpoint we're tracking the status of,
+  and triggers the monitoring process.
+  """
+  def init(_) do
+    status_map = Map.from_keys(@status_endpoints, nil)
+    send(self(), :update_status)
+    {:ok, status_map}
+  end
+
+  @impl GenServer
+  def handle_info(:update_status, status_map) do
+    Process.send_after(self(), :update_status, @update_interval_ms)
+
+    case get_status() do
+      {:error, error} ->
+        Logger.error("#{inspect(error)}")
+        {:noreply, status_map}
+
+      new_status_map ->
+        maybe_flush_keys(status_map, new_status_map)
+        {:noreply, new_status_map}
+    end
+  end
+
+  defp get_status do
+    case MBTA.Api.get_json("/status", []) do
+      %JsonApi{data: [%JsonApi.Item{type: "status", attributes: attributes}]} ->
+        attributes
+
+      {:error, _} = error ->
+        error
+
+      other ->
+        {:error, {:unexpected_response, other}}
+    end
+  end
+
+  defp maybe_flush_keys(status_map, new_status_map) when status_map == new_status_map, do: :ok
+
+  defp maybe_flush_keys(status_map, new_status_map) do
+    for key <- @status_endpoints do
+      if status_map[key] == new_status_map[key] do
+        :ok
+      else
+        @repo_cache_keys[key]
+        |> Enum.each(&flush_multiple_keys/1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I recently stumbled across the [V3 API's /status endpoint](https://api-dev.mbtace.com/status), which Dotcom doesn't yet use at all. I had an idea, initial version which is sketched out here. Succinctly, we can use this endpoint to detect when data in the V3 API has changed, and use that as a signal that we can flush the corresponding caches and let this data get repopulated anew.

Some scattered notes and reflections:

1. This setup means we'd flush all of these caches on application startup, which likely isn't ideal.
  1. This might be better left to a scheduled job outside of our application
  2. We might consider caching the status response itself, but then we just introduce another thing to keep in sync...
2. The chosen interval of 10 minutes was arbitrary, I dunno
3. The test situation needs to be sorted out (everything's broken, maybe because we'll have to mock the `/status` response pretty much everywhere that involves the `Endpoint` now?).