### PR TITLE
Log all customer support errors when rendering so we know what they are

### DIFF
--- a/lib/dotcom_web/controllers/customer_support_controller.ex
+++ b/lib/dotcom_web/controllers/customer_support_controller.ex
@@ -211,6 +211,8 @@ defmodule DotcomWeb.CustomerSupportController do
   defp simple_filename(name), do: String.replace(name, ~r/(\s)+/, "-")
 
   defp render_form(conn, %{errors: errors, comments: comments}) do
+    Logger.warning("#{__MODULE__} form validation failed: #{inspect(errors)}")
+
     render(
       conn,
       "index.html",
@@ -222,6 +224,8 @@ defmodule DotcomWeb.CustomerSupportController do
   end
 
   defp render_form(conn, %{errors: errors}) do
+    Logger.warning("#{__MODULE__} form validation failed: #{inspect(errors)}")
+
     render(
       conn,
       "index.html",


### PR DESCRIPTION
https://mbta.slack.com/archives/C911LQH2N/p1718310447661849

We got a complaint about the customer support form not working, but no errors were logged. This will log errors whenever the user sees there was an error so that we know what they are.
