### PR TITLE
refactor(Routes.Route): remove deprecated custom_route? value

### DIFF
--- a/assets/ts/schedule/components/__schedule.d.ts
+++ b/assets/ts/schedule/components/__schedule.d.ts
@@ -97,17 +97,14 @@ export interface LineDiagramVehicle {
   tooltip: string;
 }
 
-interface RouteStopRoute extends Route {
-  "custom_route?": boolean;
-}
 export interface RouteStop {
   id: string;
   name: string;
   zone: string | null;
   branch: string | null;
   station_info: Stop & { parent_id: string | null; child_ids: string[] };
-  route: RouteStopRoute | null;
-  connections: RouteStopRoute[];
+  route: Route | null;
+  connections: Route[];
   stop_features: string[];
   "terminus?": boolean;
   "is_beginning?": boolean;

--- a/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
+++ b/assets/ts/schedule/components/__tests__/ScheduleDirectionTest.tsx
@@ -52,7 +52,6 @@ const route = {
     1: "End"
   },
   description: "key_bus_route",
-  "custom_route?": false,
   header: "",
   alerts: [],
   line_id: null
@@ -72,7 +71,6 @@ const oneDirectionRoute = {
     1: "End"
   },
   description: "key_bus_route",
-  "custom_route?": false,
   header: "",
   alerts: [],
   line_id: null

--- a/assets/ts/schedule/components/__tests__/test-data/lineDiagramData.json
+++ b/assets/ts/schedule/components/__tests__/test-data/lineDiagramData.json
@@ -1,6 +1,6 @@
 {
   "stop_tree": {
-    "by_id": { 
+    "by_id": {
       "a": {
         "id": "a",
         "value": {
@@ -37,8 +37,7 @@
             "id": "111",
             "direction_names": { "0": "Outbound", "1": "Inbound" },
             "direction_destinations": { "0": "Woodlawn", "1": "Haymarket" },
-            "description": "key_bus_route",
-            "custom_route?": false
+            "description": "key_bus_route"
           },
           "name": "Elm St opp Haskell Ave",
           "terminus?": true,
@@ -51,9 +50,11 @@
               "long_name": "Wonderland - Wellington",
               "id": "110",
               "direction_names": { "0": "Outbound", "1": "Inbound" },
-              "direction_destinations": { "0": "Wonderland", "1": "Wellington" },
-              "description": "local_bus",
-              "custom_route?": false
+              "direction_destinations": {
+                "0": "Wonderland",
+                "1": "Wellington"
+              },
+              "description": "local_bus"
             }
           ],
           "closed_stop_info": null,
@@ -96,8 +97,7 @@
             "id": "111",
             "direction_names": { "0": "Outbound", "1": "Inbound" },
             "direction_destinations": { "0": "Woodlawn", "1": "Haymarket" },
-            "description": "key_bus_route",
-            "custom_route?": false
+            "description": "key_bus_route"
           },
           "name": "Elm St opp Haskell Ave",
           "terminus?": true,
@@ -110,9 +110,11 @@
               "long_name": "Wonderland - Wellington",
               "id": "110",
               "direction_names": { "0": "Outbound", "1": "Inbound" },
-              "direction_destinations": { "0": "Wonderland", "1": "Wellington" },
-              "description": "local_bus",
-              "custom_route?": false
+              "direction_destinations": {
+                "0": "Wonderland",
+                "1": "Wellington"
+              },
+              "description": "local_bus"
             }
           ],
           "closed_stop_info": null,
@@ -155,8 +157,7 @@
             "id": "111",
             "direction_names": { "0": "Outbound", "1": "Inbound" },
             "direction_destinations": { "0": "Woodlawn", "1": "Haymarket" },
-            "description": "key_bus_route",
-            "custom_route?": false
+            "description": "key_bus_route"
           },
           "name": "Elm St opp Haskell Ave",
           "terminus?": true,
@@ -169,9 +170,11 @@
               "long_name": "Wonderland - Wellington",
               "id": "110",
               "direction_names": { "0": "Outbound", "1": "Inbound" },
-              "direction_destinations": { "0": "Wonderland", "1": "Wellington" },
-              "description": "local_bus",
-              "custom_route?": false
+              "direction_destinations": {
+                "0": "Wonderland",
+                "1": "Wellington"
+              },
+              "description": "local_bus"
             }
           ],
           "closed_stop_info": null,

--- a/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -21,7 +21,7 @@ import {
   isSubwayRoute
 } from "../../../models/route";
 import { Alert, Route } from "../../../__v3api";
-import { RouteStop, RouteStopRoute, StopId, StopTree } from "../__schedule";
+import { RouteStop, StopId, StopTree } from "../__schedule";
 import { branchPosition, diagramWidth } from "./line-diagram-helpers";
 import StopConnections from "./StopConnections";
 import StopFeatures from "./StopFeatures";
@@ -64,20 +64,13 @@ const lineName = ({ name, route: routeStopRoute }: RouteStop): string => {
 const hasLivePredictions = (liveData?: LiveData): boolean =>
   !!liveData && liveData.headsigns.some(hasPredictionTime);
 
-const connectionsFor = (
-  routeStop: RouteStop,
-  stopTree: StopTree
-): RouteStopRoute[] => {
+const connectionsFor = (routeStop: RouteStop, stopTree: StopTree): Route[] => {
   const { connections } = routeStop;
   const greenLineConnections = connections.filter(isAGreenLineRoute);
   if (routeStop.route && hasBranches(stopTree) && greenLineConnections.length) {
     // If we can connect to other Green Line routes, they can connect back to
     // this route as well.
-    const routeStopRoute: RouteStopRoute = {
-      ...routeStop.route,
-      "custom_route?": false
-    };
-    return [routeStopRoute, ...connections];
+    return [routeStop.route, ...connections];
   }
   return connections;
 };
@@ -89,10 +82,7 @@ const visibleAlert = (alert: Alert): boolean => {
 const hasHighPriorityAlert = (stopId: StopId, alerts: Alert[]): boolean =>
   alertsByStop(alerts, stopId).filter(visibleAlert).length > 0;
 
-const routeForStop = (
-  stopTree: StopTree,
-  stopId: StopId
-): RouteStopRoute | null => {
+const routeForStop = (stopTree: StopTree, stopId: StopId): Route | null => {
   const { route } = stopForId(stopTree, stopId);
   return route;
 };
@@ -107,7 +97,7 @@ const hasUpcomingDeparturesIfSubway = (
   return !!liveData && liveData.headsigns.length > 0;
 };
 
-const schedulesButtonLabel = (route: RouteStopRoute | null): string => {
+const schedulesButtonLabel = (route: Route | null): string => {
   return route && isSubwayRoute(route)
     ? "View upcoming departures"
     : "View schedule";

--- a/assets/ts/schedule/components/line-diagram/StopConnections.tsx
+++ b/assets/ts/schedule/components/line-diagram/StopConnections.tsx
@@ -1,14 +1,11 @@
 import React from "react";
 import { sortBy } from "lodash";
-import { RouteStopRoute } from "../__schedule";
 import { TooltipWrapper, modeIcon } from "../../../helpers/icon";
 import { isABusRoute, isACommuterRailRoute } from "../../../models/route";
 import { routeBgClass } from "../../../helpers/css";
 import { Route } from "../../../__v3api";
 
-const filteredConnections = (
-  connections: RouteStopRoute[]
-): RouteStopRoute[] => {
+const filteredConnections = (connections: Route[]): Route[] => {
   const firstCRIndex = connections.findIndex(
     connection => connection.type === 2
   );
@@ -47,7 +44,7 @@ const connectionName = (connection: Route): string => {
 
 const StopConnections = (
   route_id: string,
-  connections: RouteStopRoute[]
+  connections: Route[]
 ): JSX.Element => (
   <div className="m-schedule-diagram__connections">
     {filteredConnections(connections).map((connectingRoute: Route) => (

--- a/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramTest.tsx
+++ b/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramTest.tsx
@@ -63,7 +63,6 @@ const route = {
     1: "End"
   },
   description: "key_bus_route",
-  "custom_route?": false,
   header: "",
   alerts: [],
   line_id: null

--- a/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
+++ b/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
@@ -167,7 +167,6 @@ const route = {
     1: "End"
   },
   description: "key_bus_route",
-  "custom_route?": false,
   header: "",
   alerts: [],
   line_id: null

--- a/assets/ts/schedule/components/line-diagram/__tests__/StopCardTest.tsx
+++ b/assets/ts/schedule/components/line-diagram/__tests__/StopCardTest.tsx
@@ -8,9 +8,10 @@ import {
   HeadsignWithCrowding,
   InformedEntitySet,
   Prediction,
+  Route,
   Schedule
 } from "../../../../__v3api";
-import { RouteStop, RouteStopRoute, StopTree } from "../../__schedule";
+import { RouteStop, StopTree } from "../../__schedule";
 import { TripPrediction } from "../../__trips";
 import { createStopTreeCoordStore } from "../graphics/useTreeStopPositions";
 import StopPredictions from "../StopPredictions";
@@ -159,7 +160,7 @@ describe("StopCard", () => {
     jest.spyOn(StopTreeHelpers, "stopForId").mockImplementation(
       () =>
         (({
-          route: { type: 1 } as RouteStopRoute,
+          route: { type: 1 } as Route,
           stop_features: [],
           connections: []
         } as unknown) as RouteStop)
@@ -188,7 +189,7 @@ describe("StopCard", () => {
     jest.spyOn(StopTreeHelpers, "stopForId").mockImplementation(
       () =>
         (({
-          route: { type: 1 } as RouteStopRoute,
+          route: { type: 1 } as Route,
           stop_features: [],
           connections: []
         } as unknown) as RouteStop)
@@ -216,7 +217,7 @@ describe("StopCard", () => {
     jest.spyOn(StopTreeHelpers, "stopForId").mockImplementation(
       () =>
         (({
-          route: { type: 3 } as RouteStopRoute,
+          route: { type: 3 } as Route,
           stop_features: [],
           connections: []
         } as unknown) as RouteStop)

--- a/assets/ts/schedule/components/line-diagram/__tests__/lineDiagramData/simple.json
+++ b/assets/ts/schedule/components/line-diagram/__tests__/lineDiagramData/simple.json
@@ -1,6 +1,8 @@
 [
   {
-    "stop_data": [{ "type": "terminus", "branch": null, "has_disruption?": true }],
+    "stop_data": [
+      { "type": "terminus", "branch": null, "has_disruption?": true }
+    ],
     "route_stop": {
       "zone": null,
       "stop_features": ["parking_lot"],
@@ -44,9 +46,7 @@
         "severity": "3",
         "effect": "detour",
         "lifecycle": "ongoing",
-        "active_period": [
-          ["2020-09-01 12:00", "2023-01-01 01:00"]
-        ]
+        "active_period": [["2020-09-01 12:00", "2023-01-01 01:00"]]
       }
     ]
   },
@@ -89,8 +89,7 @@
           "id": "Orange",
           "direction_names": { "0": "Southbound", "1": "Northbound" },
           "direction_destinations": { "0": "Forest Hills", "1": "Oak Grove" },
-          "description": "rapid_transit",
-          "custom_route?": false
+          "description": "rapid_transit"
         },
         {
           "type": 0,
@@ -102,8 +101,7 @@
             "0": "Cleveland Circle",
             "1": "North Station"
           },
-          "description": "rapid_transit",
-          "custom_route?": false
+          "description": "rapid_transit"
         }
       ],
       "closed_stop_info": null,
@@ -157,8 +155,7 @@
             "0": "Bedford VA Hospital",
             "1": "Alewife"
           },
-          "description": "local_bus",
-          "custom_route?": false
+          "description": "local_bus"
         },
         {
           "type": 3,
@@ -167,8 +164,7 @@
           "id": "67",
           "direction_names": { "0": "Outbound", "1": "Inbound" },
           "direction_destinations": { "0": "Turkey Hill", "1": "Alewife" },
-          "description": "local_bus",
-          "custom_route?": false
+          "description": "local_bus"
         }
       ],
       "closed_stop_info": null,
@@ -181,7 +177,9 @@
     ]
   },
   {
-    "stop_data": [{ "type": "terminus", "branch": null, "has_disruption?": false }],
+    "stop_data": [
+      { "type": "terminus", "branch": null, "has_disruption?": false }
+    ],
     "route_stop": {
       "zone": null,
       "stop_features": ["parking_lot", "access"],
@@ -219,8 +217,7 @@
           "id": "BOAT-A",
           "direction_names": { "0": "Outbound", "1": "Inbound" },
           "direction_destinations": { "0": "Boston", "1": "Atlantis" },
-          "description": "ferry",
-          "custom_route?": false
+          "description": "ferry"
         }
       ],
       "closed_stop_info": null,

--- a/assets/ts/schedule/components/schedule-finder/__tests__/ScheduleModalContentTest.tsx
+++ b/assets/ts/schedule/components/schedule-finder/__tests__/ScheduleModalContentTest.tsx
@@ -213,7 +213,6 @@ describe("ScheduleModalContent", () => {
     act(() => {
       const ferryRoute = {
         color: "008EAA",
-        "custom_route?": false,
         description: "ferry",
         direction_destinations: { 0: "Charlestown", 1: "Long Wharf" },
         direction_names: { 0: "Outbound", 1: "Inbound" },

--- a/assets/ts/schedule/components/schedule-finder/__tests__/test-data/departures.json
+++ b/assets/ts/schedule/components/schedule-finder/__tests__/test-data/departures.json
@@ -23,7 +23,6 @@
         "1": "Dudley"
       },
       "description": "key_bus_route",
-      "custom_route?": false,
       "color": "FFC72C"
     },
     "realtime": {
@@ -85,7 +84,6 @@
         "1": "Dudley"
       },
       "description": "key_bus_route",
-      "custom_route?": false,
       "color": "FFC72C"
     },
     "realtime": {

--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/DailyScheduleTest.tsx
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/DailyScheduleTest.tsx
@@ -3,12 +3,7 @@ import renderer, { act } from "react-test-renderer";
 import { ReactWrapper, mount } from "enzyme";
 import { createReactRoot } from "../../../../../app/helpers/testUtils";
 import * as dailyScheduleModule from "../DailySchedule";
-import {
-  DatesNotes,
-  DirectionId,
-  Service,
-  ServiceTypicality
-} from "../../../../../__v3api";
+import { DatesNotes, Service, ServiceTypicality } from "../../../../../__v3api";
 import { ServiceInSelector } from "../../../__schedule";
 import { render, screen } from "@testing-library/react";
 
@@ -431,7 +426,6 @@ describe("parseResults", () => {
             "1": "Nubian Station"
           },
           description: "key_bus_route",
-          "custom_route?": false,
           color: "FFC72C"
         },
         departure: {
@@ -482,7 +476,6 @@ describe("parseResults", () => {
             "1": "Nubian Station"
           },
           description: "key_bus_route",
-          "custom_route?": false,
           color: "FFC72C"
         },
         departure: {

--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/TableRowTest.tsx
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/TableRowTest.tsx
@@ -29,8 +29,7 @@ const journey = ({
       "0": "Stoughton or Wickford Junction",
       "1": "South Station"
     },
-    description: "commuter_rail",
-    "custom_route?": false
+    description: "commuter_rail"
   },
   departure: {
     time: "05:30 AM",

--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/test-data/crServiceData.json
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/test-data/crServiceData.json
@@ -22,8 +22,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "04:15 AM",
@@ -62,8 +61,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "06:03 AM",
@@ -102,8 +100,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "07:05 AM",
@@ -142,8 +139,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "08:04 AM",
@@ -182,8 +178,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "08:50 AM",
@@ -222,8 +217,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "09:40 AM",
@@ -262,8 +256,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "11:00 AM",
@@ -302,8 +295,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "11:45 AM",
@@ -342,8 +334,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "12:20 PM",
@@ -382,8 +373,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "01:35 PM",
@@ -422,8 +412,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "02:40 PM",
@@ -472,8 +461,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "02:45 PM",
@@ -512,8 +500,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "03:40 PM",
@@ -562,8 +549,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "04:15 PM",
@@ -612,8 +598,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "04:40 PM",
@@ -662,8 +647,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "05:03 PM",
@@ -712,8 +696,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "05:20 PM",
@@ -762,8 +745,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "05:45 PM",
@@ -802,8 +784,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "06:20 PM",
@@ -842,8 +823,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "06:30 PM",
@@ -882,8 +862,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "07:50 PM",
@@ -922,8 +901,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "08:15 PM",
@@ -962,8 +940,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "09:10 PM",
@@ -1002,8 +979,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "10:00 PM",
@@ -1042,8 +1018,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "10:30 PM",
@@ -1082,8 +1057,7 @@
         "0": "Forge Park/495",
         "1": "South Station"
       },
-      "description": "commuter_rail",
-      "custom_route?": false
+      "description": "commuter_rail"
     },
     "departure": {
       "time": "11:50 PM",

--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/test-data/serviceData.json
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/test-data/serviceData.json
@@ -22,8 +22,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:36 AM",
@@ -62,8 +61,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:46 AM",
@@ -102,8 +100,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:55 AM",
@@ -142,8 +139,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:03 AM",
@@ -182,8 +178,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:10 AM",
@@ -222,8 +217,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:17 AM",
@@ -262,8 +256,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:24 AM",
@@ -302,8 +295,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:31 AM",
@@ -342,8 +334,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:37 AM",
@@ -382,8 +373,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:43 AM",
@@ -422,8 +412,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:49 AM",
@@ -462,8 +451,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:54 AM",
@@ -502,8 +490,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:59 AM",
@@ -542,8 +529,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:03 AM",
@@ -582,8 +568,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:05 AM",
@@ -622,8 +607,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:09 AM",
@@ -662,8 +646,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:10 AM",
@@ -702,8 +685,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:13 AM",
@@ -742,8 +724,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:14 AM",
@@ -782,8 +763,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:19 AM",
@@ -822,8 +802,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:21 AM",
@@ -862,8 +841,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:24 AM",
@@ -902,8 +880,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:26 AM",
@@ -942,8 +919,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:27 AM",
@@ -982,8 +958,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:32 AM",
@@ -1022,8 +997,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:33 AM",
@@ -1062,8 +1036,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:37 AM",
@@ -1102,8 +1075,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:39 AM",
@@ -1142,8 +1114,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:42 AM",
@@ -1182,8 +1153,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:44 AM",
@@ -1222,8 +1192,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:46 AM",
@@ -1262,8 +1231,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:50 AM",
@@ -1302,8 +1270,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:51 AM",
@@ -1342,8 +1309,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:55 AM",
@@ -1382,8 +1348,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:57 AM",
@@ -1422,8 +1387,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:59 AM",
@@ -1462,8 +1426,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:01 AM",
@@ -1502,8 +1465,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:03 AM",
@@ -1542,8 +1504,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:07 AM",
@@ -1582,8 +1543,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:08 AM",
@@ -1622,8 +1582,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:12 AM",
@@ -1662,8 +1621,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:15 AM",
@@ -1702,8 +1660,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:17 AM",
@@ -1742,8 +1699,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:21 AM",
@@ -1782,8 +1738,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:22 AM",
@@ -1822,8 +1777,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:25 AM",
@@ -1862,8 +1816,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:26 AM",
@@ -1902,8 +1855,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:31 AM",
@@ -1942,8 +1894,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:33 AM",
@@ -1982,8 +1933,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:35 AM",
@@ -2022,8 +1972,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:38 AM",
@@ -2062,8 +2011,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:39 AM",
@@ -2102,8 +2050,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:43 AM",
@@ -2142,8 +2089,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:45 AM",
@@ -2182,8 +2128,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:48 AM",
@@ -2222,8 +2167,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:51 AM",
@@ -2262,8 +2206,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:53 AM",
@@ -2302,8 +2245,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:56 AM",
@@ -2342,8 +2284,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:57 AM",
@@ -2382,8 +2323,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:03 AM",
@@ -2422,8 +2362,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:05 AM",
@@ -2462,8 +2401,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:09 AM",
@@ -2502,8 +2440,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:13 AM",
@@ -2542,8 +2479,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:14 AM",
@@ -2582,8 +2518,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:20 AM",
@@ -2622,8 +2557,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:23 AM",
@@ -2662,8 +2596,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:27 AM",
@@ -2702,8 +2635,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:31 AM",
@@ -2742,8 +2674,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:33 AM",
@@ -2782,8 +2713,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:39 AM",
@@ -2822,8 +2752,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:40 AM",
@@ -2862,8 +2791,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:50 AM",
@@ -2902,8 +2830,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:05 AM",
@@ -2942,8 +2869,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:17 AM",
@@ -2982,8 +2908,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:20 AM",
@@ -3022,8 +2947,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:28 AM",
@@ -3062,8 +2986,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:35 AM",
@@ -3102,8 +3025,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:50 AM",
@@ -3142,8 +3064,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:56 AM",
@@ -3182,8 +3103,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "11:05 AM",
@@ -3222,8 +3142,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "11:20 AM",
@@ -3262,8 +3181,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "11:35 AM",
@@ -3302,8 +3220,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "11:50 AM",
@@ -3342,8 +3259,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:05 PM",
@@ -3382,8 +3298,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:08 PM",
@@ -3422,8 +3337,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:14 PM",
@@ -3462,8 +3376,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:20 PM",
@@ -3502,8 +3415,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:24 PM",
@@ -3542,8 +3454,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:34 PM",
@@ -3582,8 +3493,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:36 PM",
@@ -3622,8 +3532,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:44 PM",
@@ -3662,8 +3571,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:54 PM",
@@ -3702,8 +3610,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "01:02 PM",
@@ -3742,8 +3649,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "01:04 PM",
@@ -3782,8 +3688,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "01:14 PM",
@@ -3822,8 +3727,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "01:24 PM",
@@ -3862,8 +3766,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "01:32 PM",
@@ -3902,8 +3805,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "01:32 PM",
@@ -3942,8 +3844,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "01:34 PM",
@@ -3982,8 +3883,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "01:44 PM",
@@ -4022,8 +3922,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "01:54 PM",
@@ -4062,8 +3961,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "02:04 PM",
@@ -4102,8 +4000,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "02:14 PM",
@@ -4142,8 +4039,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "02:24 PM",
@@ -4182,8 +4078,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "02:33 PM",
@@ -4222,8 +4117,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "02:43 PM",
@@ -4262,8 +4156,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "02:53 PM",
@@ -4302,8 +4195,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "03:02 PM",
@@ -4342,8 +4234,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "03:12 PM",
@@ -4382,8 +4273,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "03:23 PM",
@@ -4422,8 +4312,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "03:32 PM",
@@ -4472,8 +4361,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "03:45 PM",
@@ -4512,8 +4400,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "03:42 PM",
@@ -4562,8 +4449,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "03:35 PM",
@@ -4612,8 +4498,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "03:52 PM",
@@ -4662,8 +4547,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "03:53 PM",
@@ -4712,8 +4596,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:01 PM",
@@ -4762,8 +4645,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:03 PM",
@@ -4812,8 +4694,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:09 PM",
@@ -4852,8 +4733,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:13 PM",
@@ -4902,8 +4782,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:19 PM",
@@ -4952,8 +4831,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:22 PM",
@@ -5002,8 +4880,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:24 PM",
@@ -5052,8 +4929,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:27 PM",
@@ -5102,8 +4978,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:31 PM",
@@ -5142,8 +5017,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:33 PM",
@@ -5192,8 +5066,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:38 PM",
@@ -5242,8 +5115,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:39 PM",
@@ -5292,8 +5164,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:43 PM",
@@ -5342,8 +5213,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:45 PM",
@@ -5392,8 +5262,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:48 PM",
@@ -5442,8 +5311,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:51 PM",
@@ -5482,8 +5350,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:53 PM",
@@ -5532,8 +5399,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "04:58 PM",
@@ -5582,8 +5448,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:00 PM",
@@ -5632,8 +5497,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:03 PM",
@@ -5682,8 +5546,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:06 PM",
@@ -5732,8 +5595,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:08 PM",
@@ -5782,8 +5644,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:12 PM",
@@ -5822,8 +5683,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:13 PM",
@@ -5872,8 +5732,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:18 PM",
@@ -5922,8 +5781,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:20 PM",
@@ -5972,8 +5830,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:23 PM",
@@ -6022,8 +5879,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:27 PM",
@@ -6072,8 +5928,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:28 PM",
@@ -6122,8 +5977,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:32 PM",
@@ -6162,8 +6016,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:33 PM",
@@ -6212,8 +6065,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:38 PM",
@@ -6252,8 +6104,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:41 PM",
@@ -6292,8 +6143,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:43 PM",
@@ -6332,8 +6182,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:47 PM",
@@ -6372,8 +6221,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:48 PM",
@@ -6412,8 +6260,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:53 PM",
@@ -6452,8 +6299,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:55 PM",
@@ -6492,8 +6338,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "05:58 PM",
@@ -6532,8 +6377,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:01 PM",
@@ -6572,8 +6416,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:02 PM",
@@ -6612,8 +6455,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:07 PM",
@@ -6652,8 +6494,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:09 PM",
@@ -6692,8 +6533,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:12 PM",
@@ -6732,8 +6572,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:16 PM",
@@ -6772,8 +6611,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:17 PM",
@@ -6812,8 +6650,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:22 PM",
@@ -6852,8 +6689,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:23 PM",
@@ -6892,8 +6728,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:27 PM",
@@ -6932,8 +6767,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:32 PM",
@@ -6972,8 +6806,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:37 PM",
@@ -7012,8 +6845,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:42 PM",
@@ -7052,8 +6884,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:47 PM",
@@ -7092,8 +6923,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:52 PM",
@@ -7132,8 +6962,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "06:57 PM",
@@ -7172,8 +7001,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:02 PM",
@@ -7212,8 +7040,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:06 PM",
@@ -7252,8 +7079,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:12 PM",
@@ -7292,8 +7118,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:17 PM",
@@ -7332,8 +7157,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:23 PM",
@@ -7372,8 +7196,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:25 PM",
@@ -7412,8 +7235,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:29 PM",
@@ -7452,8 +7274,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:38 PM",
@@ -7492,8 +7313,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:46 PM",
@@ -7532,8 +7352,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:49 PM",
@@ -7572,8 +7391,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:50 PM",
@@ -7612,8 +7430,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:53 PM",
@@ -7652,8 +7469,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "07:59 PM",
@@ -7692,8 +7508,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:09 PM",
@@ -7732,8 +7547,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:18 PM",
@@ -7772,8 +7586,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:25 PM",
@@ -7812,8 +7625,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:38 PM",
@@ -7852,8 +7664,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:46 PM",
@@ -7892,8 +7703,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:48 PM",
@@ -7932,8 +7742,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "08:51 PM",
@@ -7972,8 +7781,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:04 PM",
@@ -8012,8 +7820,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:17 PM",
@@ -8052,8 +7859,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:30 PM",
@@ -8092,8 +7898,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:43 PM",
@@ -8132,8 +7937,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "09:56 PM",
@@ -8172,8 +7976,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:05 PM",
@@ -8212,8 +8015,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:09 PM",
@@ -8252,8 +8054,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:22 PM",
@@ -8292,8 +8093,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:35 PM",
@@ -8332,8 +8132,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "10:48 PM",
@@ -8372,8 +8171,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "11:01 PM",
@@ -8412,8 +8210,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "11:14 PM",
@@ -8452,8 +8249,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "11:29 PM",
@@ -8492,8 +8288,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "11:44 PM",
@@ -8532,8 +8327,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "11:59 PM",
@@ -8572,8 +8366,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:14 AM",
@@ -8612,8 +8405,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:24 AM",
@@ -8652,8 +8444,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:30 AM",
@@ -8692,8 +8483,7 @@
         "0": "Design Center",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "12:50 AM",
@@ -8732,8 +8522,7 @@
         "0": "Silver Line Way",
         "1": "South Station"
       },
-      "description": "key_bus_route",
-      "custom_route?": false
+      "description": "key_bus_route"
     },
     "departure": {
       "time": "01:02 AM",

--- a/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/test-data/crDepartures.json
+++ b/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/test-data/crDepartures.json
@@ -23,7 +23,6 @@
         "1": "South Station"
       },
       "description": "commuter_rail",
-      "custom_route?": false,
       "color": "80276C"
     },
     "realtime": {
@@ -84,7 +83,6 @@
         "1": "South Station"
       },
       "description": "commuter_rail",
-      "custom_route?": false,
       "color": "80276C"
     },
     "realtime": {

--- a/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/test-data/enhancedBusJourneys.json
+++ b/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/test-data/enhancedBusJourneys.json
@@ -23,22 +23,13 @@
         "1": "Dudley"
       },
       "description": "key_bus_route",
-      "custom_route?": false,
       "color": "FFC72C"
     },
     "realtime": {
-      "scheduled_time": [
-        "1:47",
-        " ",
-        "PM"
-      ],
+      "scheduled_time": ["1:47", " ", "PM"],
       "prediction": {
         "track": null,
-        "time": [
-          "8",
-          " ",
-          "min"
-        ],
+        "time": ["8", " ", "min"],
         "status": null,
         "seconds": 491
       },
@@ -108,22 +99,13 @@
         "1": "Dudley"
       },
       "description": "key_bus_route",
-      "custom_route?": false,
       "color": "FFC72C"
     },
     "realtime": {
-      "scheduled_time": [
-        "1:36",
-        " ",
-        "PM"
-      ],
+      "scheduled_time": ["1:36", " ", "PM"],
       "prediction": {
         "track": null,
-        "time": [
-          "9",
-          " ",
-          "min"
-        ],
+        "time": ["9", " ", "min"],
         "status": null,
         "seconds": 546
       },

--- a/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/test-data/enhancedCRjourneys.json
+++ b/assets/ts/schedule/components/schedule-finder/upcoming-departures/__tests__/test-data/enhancedCRjourneys.json
@@ -23,8 +23,7 @@
         "1": "South Station"
       },
       "description": "commuter_rail",
-      "custom_route?": false,
-      "color": "80276C"
+            "color": "80276C"
     },
     "realtime": {
       "scheduled_time": ["1:55", " ", "PM"],
@@ -85,8 +84,7 @@
         "1": "South Station"
       },
       "description": "commuter_rail",
-      "custom_route?": false,
-      "color": "80276C"
+            "color": "80276C"
     },
     "realtime": {
       "scheduled_time": ["3:30", " ", "PM"],

--- a/assets/ts/stop/__tests__/stopData.json
+++ b/assets/ts/stop/__tests__/stopData.json
@@ -97,8 +97,7 @@
               "1": "Alewife",
               "0": "Ashmont/Braintree"
             },
-            "description": "rapid_transit",
-            "custom_route?": false
+            "description": "rapid_transit"
           },
           "directions": [
             {
@@ -230,8 +229,7 @@
               "1": "South Station",
               "0": "Logan Airport"
             },
-            "description": "key_bus_route",
-            "custom_route?": false
+            "description": "key_bus_route"
           },
           "directions": [
             {
@@ -308,8 +306,7 @@
               "1": "South Station",
               "0": "Design Center"
             },
-            "description": "key_bus_route",
-            "custom_route?": false
+            "description": "key_bus_route"
           },
           "directions": [
             {
@@ -386,8 +383,7 @@
               "1": "South Station",
               "0": "Chelsea"
             },
-            "description": "key_bus_route",
-            "custom_route?": false
+            "description": "key_bus_route"
           },
           "directions": [
             {
@@ -469,8 +465,7 @@
               "1": "South Station",
               "0": "Fairmount"
             },
-            "description": "commuter_rail",
-            "custom_route?": false
+            "description": "commuter_rail"
           },
           "directions": [
             {
@@ -531,8 +526,7 @@
               "1": "South Station",
               "0": "Worcester"
             },
-            "description": "commuter_rail",
-            "custom_route?": false
+            "description": "commuter_rail"
           },
           "directions": [
             {
@@ -625,8 +619,7 @@
               "1": "South Station",
               "0": "Forge Park/495"
             },
-            "description": "commuter_rail",
-            "custom_route?": false
+            "description": "commuter_rail"
           },
           "directions": [
             {
@@ -728,8 +721,7 @@
               "1": "South Station",
               "0": "Greenbush"
             },
-            "description": "commuter_rail",
-            "custom_route?": false
+            "description": "commuter_rail"
           },
           "directions": [
             {
@@ -790,8 +782,7 @@
               "1": "South Station",
               "0": "Kingston or Plymouth"
             },
-            "description": "commuter_rail",
-            "custom_route?": false
+            "description": "commuter_rail"
           },
           "directions": [
             {
@@ -868,8 +859,7 @@
               "1": "South Station",
               "0": "Middleborough/Lakeville"
             },
-            "description": "commuter_rail",
-            "custom_route?": false
+            "description": "commuter_rail"
           },
           "directions": [
             {
@@ -930,8 +920,7 @@
               "1": "South Station",
               "0": "Needham Heights"
             },
-            "description": "commuter_rail",
-            "custom_route?": false
+            "description": "commuter_rail"
           },
           "directions": [
             {
@@ -992,8 +981,7 @@
               "1": "South Station",
               "0": "Wickford Junction"
             },
-            "description": "commuter_rail",
-            "custom_route?": false
+            "description": "commuter_rail"
           },
           "directions": [
             {
@@ -1128,8 +1116,7 @@
               "0": "Harvard",
               "1": "Dudley"
             },
-            "description": "key_bus_route",
-            "custom_route?": false
+            "description": "key_bus_route"
           },
           "direction_id": 0
         }
@@ -1172,8 +1159,7 @@
               "0": "Oak Square",
               "1": "University Park or Kendall/MIT"
             },
-            "description": "local_bus",
-            "custom_route?": false
+            "description": "local_bus"
           },
           "direction_id": null
         },
@@ -1192,8 +1178,7 @@
               "0": "Central Square, Cambridge",
               "1": "Boston Medical Center"
             },
-            "description": "local_bus",
-            "custom_route?": false
+            "description": "local_bus"
           },
           "direction_id": 1
         },
@@ -1212,8 +1197,7 @@
               "0": "Rindge Avenue",
               "1": "Central Square, Cambridge"
             },
-            "description": "local_bus",
-            "custom_route?": false
+            "description": "local_bus"
           },
           "direction_id": null
         },
@@ -1232,8 +1216,7 @@
               "0": "Sullivan",
               "1": "Central Square, Cambridge"
             },
-            "description": "local_bus",
-            "custom_route?": false
+            "description": "local_bus"
           },
           "direction_id": null
         }
@@ -1276,8 +1259,7 @@
               "0": "Central Square, Cambridge",
               "1": "Broadway Station"
             },
-            "description": "local_bus",
-            "custom_route?": false
+            "description": "local_bus"
           },
           "direction_id": 0
         },
@@ -1296,8 +1278,7 @@
               "0": "Oak Square",
               "1": "University Park or Kendall/MIT"
             },
-            "description": "local_bus",
-            "custom_route?": false
+            "description": "local_bus"
           },
           "direction_id": 0
         },
@@ -1316,8 +1297,7 @@
               "0": "Cedarwood",
               "1": "Central Square, Cambridge"
             },
-            "description": "local_bus",
-            "custom_route?": false
+            "description": "local_bus"
           },
           "direction_id": null
         },
@@ -1336,8 +1316,7 @@
               "0": "Central Square, Cambridge",
               "1": "Boston Medical Center"
             },
-            "description": "local_bus",
-            "custom_route?": false
+            "description": "local_bus"
           },
           "direction_id": 0
         },
@@ -1356,8 +1335,7 @@
               "0": "North Waltham",
               "1": "Central Square, Cambridge"
             },
-            "description": "local_bus",
-            "custom_route?": false
+            "description": "local_bus"
           },
           "direction_id": 0
         }

--- a/assets/ts/tnm/__tests__/realtimeData.json
+++ b/assets/ts/tnm/__tests__/realtimeData.json
@@ -20,7 +20,6 @@
       "direction_names": { "1": "Northbound", "0": "Southbound" },
       "direction_destinations": { "1": "Oak Grove", "0": "Forest Hills" },
       "description": "rapid_transit",
-      "custom_route?": false,
       "alerts": [{}]
     },
     "predicted_schedules_by_route_pattern": {
@@ -113,7 +112,6 @@
       "direction_names": { "1": "Inbound", "0": "Outbound" },
       "direction_destinations": { "1": "North Station", "0": "Haverhill" },
       "description": "commuter_rail",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -220,7 +218,6 @@
       "direction_names": { "1": "Inbound", "0": "Outbound" },
       "direction_destinations": { "1": "Wellington", "0": "Malden Center" },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -340,7 +337,6 @@
         "0": "Woodland Road, Stoneham"
       },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -451,7 +447,6 @@
       "direction_names": { "1": "Inbound", "0": "Outbound" },
       "direction_destinations": { "1": "Sullivan", "0": "Malden Center" },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -562,7 +557,6 @@
       "direction_names": { "1": "Inbound", "0": "Outbound" },
       "direction_destinations": { "1": "Sullivan", "0": "Malden Center" },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": [{}]
     },
     "predicted_schedules_by_route_pattern": {
@@ -679,7 +673,6 @@
       "direction_names": { "1": "Inbound", "0": "Outbound" },
       "direction_destinations": { "1": "Sullivan", "0": "Malden Center" },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": [{}]
     },
     "predicted_schedules_by_route_pattern": {
@@ -787,7 +780,6 @@
         "0": "Lebanon Street, Malden"
       },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -964,7 +956,6 @@
       "direction_names": { "1": "Inbound", "0": "Outbound" },
       "direction_destinations": { "1": "Wellington", "0": "Linden Square" },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -1078,7 +1069,6 @@
         "0": "Melrose Highlands"
       },
       "description": "commuter_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -1133,7 +1123,6 @@
         "0": "Redstone Shopping Center"
       },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -1253,7 +1242,6 @@
         "0": "Reading Depot"
       },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -1353,7 +1341,6 @@
         "0": "Reading Depot"
       },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -1473,7 +1460,6 @@
         "0": "Kennedy Drive or Jack Satter House"
       },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {
@@ -1638,7 +1624,6 @@
         "0": "Saugus Center"
       },
       "description": "local_bus",
-      "custom_route?": false,
       "alerts": []
     },
     "predicted_schedules_by_route_pattern": {

--- a/assets/ts/tnm/__tests__/state.json
+++ b/assets/ts/tnm/__tests__/state.json
@@ -496,7 +496,6 @@
         "direction_names": { "0": "Southbound", "1": "Northbound" },
         "direction_destinations": { "0": "Forest Hills", "1": "Oak Grove" },
         "description": "rapid_transit",
-        "custom_route?": false,
         "alerts": [{}]
       },
       "stops_with_directions": [
@@ -521,7 +520,7 @@
                   "headsign": "Forest Hills",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["1", " ", "min"],
@@ -531,7 +530,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["14", " ", "min"],
@@ -553,7 +552,7 @@
                   "headsign": "Oak Grove",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["5", " ", "min"],
@@ -563,7 +562,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["26", " ", "min"],
@@ -592,7 +591,6 @@
         "direction_names": { "0": "Outbound", "1": "Inbound" },
         "direction_destinations": { "0": "Haverhill", "1": "North Station" },
         "description": "commuter_rail",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -617,7 +615,7 @@
                   "headsign": "Haverhill",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["5:26", " ", "PM"],
@@ -627,7 +625,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["5:46", " ", "PM"],
@@ -649,7 +647,7 @@
                   "headsign": "North Station",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["5:53", " ", "PM"],
@@ -683,7 +681,6 @@
         "direction_names": { "0": "Outbound", "1": "Inbound" },
         "direction_destinations": { "0": "Malden Center", "1": "Wellington" },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -708,7 +705,7 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["10", " ", "min"],
@@ -718,7 +715,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["50", " ", "min"],
@@ -740,7 +737,7 @@
                   "headsign": "Wellington",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["12", " ", "min"],
@@ -750,7 +747,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["52", " ", "min"],
@@ -782,7 +779,6 @@
           "1": "Wellington"
         },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -807,7 +803,7 @@
                   "headsign": "Woodland Rd",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["3", " ", "min"],
@@ -817,7 +813,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["39", " ", "min"],
@@ -839,7 +835,7 @@
                   "headsign": "Wellington",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["27", " ", "min"],
@@ -849,7 +845,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["71", " ", "min"],
@@ -878,7 +874,6 @@
         "direction_names": { "0": "Outbound", "1": "Inbound" },
         "direction_destinations": { "0": "Malden Center", "1": "Sullivan" },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -903,7 +898,7 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["7", " ", "min"],
@@ -913,7 +908,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["8", " ", "min"],
@@ -935,7 +930,7 @@
                   "headsign": "Sullivan",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["arriving"],
@@ -945,7 +940,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["9", " ", "min"],
@@ -974,7 +969,6 @@
         "direction_names": { "0": "Outbound", "1": "Inbound" },
         "direction_destinations": { "0": "Malden Center", "1": "Sullivan" },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": [{}]
       },
       "stops_with_directions": [
@@ -999,7 +993,7 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["15", " ", "min"],
@@ -1009,7 +1003,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["45", " ", "min"],
@@ -1031,7 +1025,7 @@
                   "headsign": "Sullivan",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["16", " ", "min"],
@@ -1041,7 +1035,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["46", " ", "min"],
@@ -1070,7 +1064,6 @@
         "direction_names": { "0": "Outbound", "1": "Inbound" },
         "direction_destinations": { "0": "Malden Center", "1": "Sullivan" },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": [{}]
       },
       "stops_with_directions": [
@@ -1095,7 +1088,7 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["17", " ", "min"],
@@ -1105,7 +1098,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["35", " ", "min"],
@@ -1127,7 +1120,7 @@
                   "headsign": "Sullivan",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["18", " ", "min"],
@@ -1137,7 +1130,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["36", " ", "min"],
@@ -1169,7 +1162,6 @@
           "1": "Wellington"
         },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -1194,7 +1186,7 @@
                   "headsign": "Lebanon Loop",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["16", " ", "min"],
@@ -1204,7 +1196,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["29", " ", "min"],
@@ -1238,7 +1230,7 @@
                   "headsign": "Wellington",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["15", " ", "min"],
@@ -1248,7 +1240,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["31", " ", "min"],
@@ -1265,7 +1257,7 @@
                   "headsign": "Wellington",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["70", " ", "min"],
@@ -1275,7 +1267,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["92", " ", "min"],
@@ -1304,7 +1296,6 @@
         "direction_names": { "0": "Outbound", "1": "Inbound" },
         "direction_destinations": { "0": "Linden Square", "1": "Wellington" },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -1329,7 +1320,7 @@
                   "headsign": "Linden Square",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["2", " ", "min"],
@@ -1339,7 +1330,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["23", " ", "min"],
@@ -1361,7 +1352,7 @@
                   "headsign": "Wellington",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["4", " ", "min"],
@@ -1371,7 +1362,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["23", " ", "min"],
@@ -1403,7 +1394,6 @@
           "1": "Oak Grove"
         },
         "description": "commuter_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -1461,7 +1451,6 @@
           "1": "Malden Center"
         },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -1486,7 +1475,7 @@
                   "headsign": "Redstone",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["2", " ", "min"],
@@ -1496,7 +1485,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["34", " ", "min"],
@@ -1518,7 +1507,7 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["25", " ", "min"],
@@ -1528,7 +1517,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": null,
                         "time": ["61", " ", "min"],
@@ -1560,7 +1549,6 @@
           "1": "Malden Center"
         },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -1585,7 +1573,7 @@
                   "headsign": "Reading Depot",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["72", " ", "min"],
@@ -1607,7 +1595,7 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["44", " ", "min"],
@@ -1617,7 +1605,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["77", " ", "min"],
@@ -1649,7 +1637,6 @@
           "1": "Malden Center"
         },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -1674,7 +1661,7 @@
                   "headsign": "Reading Depot",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["47", " ", "min"],
@@ -1684,7 +1671,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["107", " ", "min"],
@@ -1706,7 +1693,7 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["8", " ", "min"],
@@ -1716,7 +1703,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "2",
                         "time": ["102", " ", "min"],
@@ -1748,7 +1735,6 @@
           "1": "Malden Center"
         },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -1773,7 +1759,7 @@
                   "headsign": "Kennedy Dr",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["24", " ", "min"],
@@ -1783,7 +1769,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["69", " ", "min"],
@@ -1805,7 +1791,7 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["62", " ", "min"],
@@ -1815,7 +1801,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["107", " ", "min"],
@@ -1832,7 +1818,7 @@
                   "headsign": "Malden",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["1", " ", "min"],
@@ -1842,7 +1828,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["68", " ", "min"],
@@ -1874,7 +1860,6 @@
           "1": "Malden Center"
         },
         "description": "local_bus",
-        "custom_route?": false,
         "alerts": []
       },
       "stops_with_directions": [
@@ -1916,7 +1901,7 @@
                   "headsign": "Saugus Center via Square One Mall",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["8", " ", "min"],
@@ -1926,7 +1911,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["66", " ", "min"],
@@ -1965,7 +1950,7 @@
                   "headsign": "Malden via Square One Mall",
                   "times": [
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["62", " ", "min"],
@@ -1975,7 +1960,7 @@
                       "delay": 0
                     },
                     {
-                      "prediction": { 
+                      "prediction": {
                         "schedule_relationship": null,
                         "track": "1",
                         "time": ["arriving"],
@@ -2024,7 +2009,6 @@
                 "1": "Oak Grove"
               },
               "description": "rapid_transit",
-              "custom_route?": false,
               "alerts": [{}]
             }
           ]
@@ -2044,7 +2028,6 @@
                 "1": "North Station"
               },
               "description": "commuter_rail",
-              "custom_route?": false,
               "alerts": []
             }
           ]
@@ -2064,7 +2047,6 @@
                 "1": "Wellington"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": []
             },
             {
@@ -2079,7 +2061,6 @@
                 "1": "Wellington"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": []
             },
             {
@@ -2094,7 +2075,6 @@
                 "1": "Sullivan"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": []
             },
             {
@@ -2109,7 +2089,6 @@
                 "1": "Sullivan"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": [{}]
             },
             {
@@ -2124,7 +2103,6 @@
                 "1": "Sullivan"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": [{}]
             },
             {
@@ -2139,7 +2117,6 @@
                 "1": "Wellington"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": []
             },
             {
@@ -2154,7 +2131,6 @@
                 "1": "Wellington"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": []
             },
             {
@@ -2169,7 +2145,6 @@
                 "1": "Oak Grove"
               },
               "description": "commuter_bus",
-              "custom_route?": false,
               "alerts": []
             },
             {
@@ -2184,7 +2159,6 @@
                 "1": "Malden Center"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": []
             },
             {
@@ -2199,7 +2173,6 @@
                 "1": "Malden Center"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": []
             },
             {
@@ -2214,7 +2187,6 @@
                 "1": "Malden Center"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": []
             },
             {
@@ -2229,7 +2201,6 @@
                 "1": "Malden Center"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": []
             },
             {
@@ -2244,7 +2215,6 @@
                 "1": "Malden Center"
               },
               "description": "local_bus",
-              "custom_route?": false,
               "alerts": []
             }
           ]

--- a/lib/dotcom/trip_plan/related_link.ex
+++ b/lib/dotcom/trip_plan/related_link.ex
@@ -92,9 +92,12 @@ defmodule Dotcom.TripPlan.RelatedLink do
       String.starts_with?(route.id, "Massport") ->
         new("Massport schedules", "https://massport.com/", icon_name)
 
-      route.custom_route? ->
-        leg = Enum.find(itinerary.legs, &match?(%TripPlan.Leg{url: url} when url != nil, &1))
-        new("Route information", leg.url, icon_name)
+      route.external_agency_name == "Logan Express" ->
+        new(
+          "Logan Express schedules",
+          "https://www.massport.com/logan-airport/getting-to-logan/logan-express",
+          icon_name
+        )
 
       true ->
         base_text =
@@ -115,7 +118,7 @@ defmodule Dotcom.TripPlan.RelatedLink do
 
     for leg <- itinerary,
         {:ok, route_id} <- [Leg.route_id(leg)],
-        %Route{custom_route?: false} = route <- [route_by_id.(route_id)] do
+        %Route{external_agency_name: nil} = route <- [route_by_id.(route_id)] do
       fare_link(route, leg)
     end
     |> Enum.uniq()

--- a/lib/dotcom_web/controllers/trip_plan_controller.ex
+++ b/lib/dotcom_web/controllers/trip_plan_controller.ex
@@ -490,16 +490,19 @@ defmodule DotcomWeb.TripPlanController do
     } = Enum.find(legs, &(Leg.route_id(&1) == {:ok, id}))
 
     %Route{
-      external_agency_name: if(type == "2", do: "Massport"),
+      external_agency_name: agency_name(type),
       description: description,
       id: mode.route_id,
       long_name: long_name,
       name: name,
       type: type,
-      custom_route?: true,
       color: "000000"
     }
   end
+
+  defp agency_name("Logan Express"), do: "Logan Express"
+  defp agency_name("2"), do: "Massport"
+  defp agency_name(_), do: nil
 
   defp meta_description(conn, _) do
     conn

--- a/lib/routes/repo.ex
+++ b/lib/routes/repo.ex
@@ -40,21 +40,7 @@ defmodule Routes.Repo do
     result
   end
 
-  # Used to spoof any Massport route as the data doesn't exist in the API
-  # But is in the GTFS data
   @impl Routes.Repo.Behaviour
-  def get("Massport-" <> id) do
-    %Route{
-      description: "Massport Generated Route",
-      id: "Massport-" <> id,
-      long_name: "Massport-" <> id,
-      name: "Massport-" <> id,
-      type: "Massport-" <> id,
-      custom_route?: true,
-      color: "000000"
-    }
-  end
-
   def get(id) when is_binary(id) do
     opts = @default_opts
 

--- a/lib/routes/route.ex
+++ b/lib/routes/route.ex
@@ -3,7 +3,7 @@ defmodule Routes.Route do
 
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
 
-  @derive {Jason.Encoder, except: [:external_agency_name]}
+  @derive Jason.Encoder
 
   defstruct color: "",
             description: :unknown,

--- a/lib/routes/route.ex
+++ b/lib/routes/route.ex
@@ -6,7 +6,6 @@ defmodule Routes.Route do
   @derive {Jason.Encoder, except: [:external_agency_name]}
 
   defstruct color: "",
-            custom_route?: false,
             description: :unknown,
             direction_destinations: :unknown,
             direction_names: %{0 => "Outbound", 1 => "Inbound"},
@@ -27,7 +26,6 @@ defmodule Routes.Route do
   ## Fields
   * `:color` - A hex code representing the color to be shown on wayfinding,
     corresponding to the GTFS routes.txt `route_color` field.
-  * `:custom_route?` - `true` if this data comes from outside the MBTA GTFS.
   * `:description` - corresponds to the GTFS routes.txt `route_desc` field
   * `:direction_destinations` - map describing the terminus for each direction,
     as might be described on a vehicle headsign
@@ -47,7 +45,6 @@ defmodule Routes.Route do
   """
   @type t :: %__MODULE__{
           color: String.t(),
-          custom_route?: boolean,
           description: gtfs_route_desc,
           direction_destinations: %{0 => String.t(), 1 => String.t()} | :unknown,
           direction_names: %{0 => String.t() | nil, 1 => String.t() | nil},

--- a/test/dotcom/realtime_schedule_test.exs
+++ b/test/dotcom/realtime_schedule_test.exs
@@ -20,7 +20,6 @@ defmodule Dotcom.RealtimeScheduleTest do
   @stop %Stop{id: "place-ogmnl"}
 
   @route %Route{
-    custom_route?: false,
     description: :rapid_transit,
     direction_destinations: %{0 => "Forest Hills", 1 => "Oak Grove"},
     direction_names: %{0 => "Southbound", 1 => "Northbound"},
@@ -81,7 +80,6 @@ defmodule Dotcom.RealtimeScheduleTest do
       direction_id: 1,
       id: "prediction-40709316-70036-190",
       route: %Routes.Route{
-        custom_route?: false,
         description: :rapid_transit,
         direction_destinations: %{0 => "Forest Hills", 1 => "Oak Grove"},
         direction_names: %{0 => "Southbound", 1 => "Northbound"},
@@ -291,7 +289,6 @@ defmodule Dotcom.RealtimeScheduleTest do
         route: %{
           __struct__: Routes.Route,
           alerts: @alerts |> Enum.map(&JsonHelpers.stringified_alert(&1, @now)),
-          custom_route?: false,
           description: :rapid_transit,
           direction_destinations: %{"0" => "Forest Hills", "1" => "Oak Grove"},
           direction_names: %{"0" => "Southbound", "1" => "Northbound"},

--- a/test/dotcom_web/controllers/transit_near_me_controller_test.exs
+++ b/test/dotcom_web/controllers/transit_near_me_controller_test.exs
@@ -270,7 +270,6 @@ defmodule DotcomWeb.TransitNearMeControllerTest do
               group_name: :bus,
               routes: [
                 %{
-                  custom_route?: false,
                   description: :key_bus_route,
                   direction_destinations: :unknown,
                   direction_names: %{"0" => "Outbound", "1" => "Inbound"},
@@ -281,7 +280,6 @@ defmodule DotcomWeb.TransitNearMeControllerTest do
                   href: "/39"
                 },
                 %{
-                  custom_route?: false,
                   description: :supplemental_bus,
                   direction_destinations: :unknown,
                   direction_names: %{"0" => "Outbound", "1" => "Inbound"},
@@ -292,7 +290,6 @@ defmodule DotcomWeb.TransitNearMeControllerTest do
                   href: "/170"
                 },
                 %{
-                  custom_route?: false,
                   description: :local_bus,
                   direction_destinations: :unknown,
                   direction_names: %{"0" => "Outbound", "1" => "Inbound"},

--- a/test/dotcom_web/controllers/trip_plan_controller_test.exs
+++ b/test/dotcom_web/controllers/trip_plan_controller_test.exs
@@ -812,7 +812,8 @@ defmodule DotcomWeb.TripPlanControllerTest do
     end
 
     test "doesn't set external_agency_name flag for regular routes", %{itineraries: itineraries} do
-      expect(Routes.Repo.Mock, :get, fn id ->
+      # called variable number of times, depending on the generated itineraries
+      stub(Routes.Repo.Mock, :get, fn id ->
         %Routes.Route{id: id}
       end)
 
@@ -840,9 +841,8 @@ defmodule DotcomWeb.TripPlanControllerTest do
           %{i | legs: legs}
         end)
 
-      # set up leg route to not be present in the V3 API, causing the fallback
-      # to populate the external_agency_name value
-      expect(Routes.Repo.Mock, :get, fn _ ->
+      # called variable number of times, depending on the generated itineraries
+      stub(Routes.Repo.Mock, :get, fn id ->
         nil
       end)
 

--- a/test/dotcom_web/controllers/trip_plan_controller_test.exs
+++ b/test/dotcom_web/controllers/trip_plan_controller_test.exs
@@ -811,28 +811,26 @@ defmodule DotcomWeb.TripPlanControllerTest do
       {:ok, %{itineraries: itineraries}}
     end
 
-    test "doesn't set custom_route? flag for regular routes", %{itineraries: itineraries} do
-      stub(Routes.Repo.Mock, :get, fn id ->
-        %Routes.Route{id: id, custom_route?: false}
+    test "doesn't set external_agency_name flag for regular routes", %{itineraries: itineraries} do
+      expect(Routes.Repo.Mock, :get, fn id ->
+        %Routes.Route{id: id}
       end)
 
       rfq = TripPlanController.routes_for_query(itineraries)
-      assert Enum.all?(rfq, fn {_route_id, route} -> !route.custom_route? end)
+      assert Enum.all?(rfq, fn {_route_id, route} -> !route.external_agency_name end)
     end
 
-    test "sets custom_route? flag for routes not present in API", %{itineraries: itineraries} do
-      expect(Routes.Repo.Mock, :get, fn _ ->
-        nil
-      end)
-
+    test "sets external_agency_name value for routes not present in API", %{
+      itineraries: itineraries
+    } do
+      # set up itineraries which have a leg type associated with external agency
       itineraries =
         Enum.map(itineraries, fn i ->
           legs =
             Enum.map(i.legs, fn l ->
               case l do
                 %{mode: %{route_id: _route_id}} ->
-                  mode = %{l.mode | route_id: "UNKNOWN"}
-                  %{l | mode: mode}
+                  %{l | type: "Logan Express"}
 
                 _ ->
                   l
@@ -842,8 +840,14 @@ defmodule DotcomWeb.TripPlanControllerTest do
           %{i | legs: legs}
         end)
 
+      # set up leg route to not be present in the V3 API, causing the fallback
+      # to populate the external_agency_name value
+      expect(Routes.Repo.Mock, :get, fn _ ->
+        nil
+      end)
+
       rfq = TripPlanController.routes_for_query(itineraries)
-      assert Enum.all?(rfq, fn {_route_id, route} -> route.custom_route? end)
+      assert Enum.all?(rfq, fn {_route_id, route} -> route.external_agency_name end)
     end
 
     test "identifies subsequent subway legs as free when trip is from the airport" do

--- a/test/dotcom_web/views/helpers_test.exs
+++ b/test/dotcom_web/views/helpers_test.exs
@@ -315,7 +315,6 @@ defmodule DotcomWeb.ViewHelpersTest do
           html_escape(
             direction_with_headsign(
               %Routes.Route{
-                custom_route?: false,
                 description: :rail_replacement_bus,
                 direction_destinations: %{0 => nil, 1 => nil},
                 direction_names: %{0 => "", 1 => ""},

--- a/test/dotcom_web/views/partial_view_test.exs
+++ b/test/dotcom_web/views/partial_view_test.exs
@@ -206,7 +206,6 @@ defmodule DotcomWeb.PartialViewTest do
         method: :alerts_path,
         item: %Routes.Route{
           color: "00843D",
-          custom_route?: false,
           description: :rapid_transit,
           direction_destinations: %{0 => "Heath Street", 1 => "North Station"},
           direction_names: %{0 => "Westbound", 1 => "Eastbound"},

--- a/test/routes/route_test.exs
+++ b/test/routes/route_test.exs
@@ -197,7 +197,6 @@ defmodule Routes.RouteTest do
   describe "to_json_safe/1" do
     test "converts a Route to a Json string with safe object keys" do
       route = %Route{
-        custom_route?: false,
         description: :rapid_transit,
         direction_destinations: %{0 => "Ashmont/Braintree", 1 => "Alewife"},
         direction_names: %{0 => "South", 1 => "North"},


### PR DESCRIPTION
Followup to:
- #2111 

This still doesn't fix the Trip Planner's handling of Massport routes, that needs some more refactoring that will follow next.