### PR TITLE
chore(Fares): remove obsolete logic

### DIFF
--- a/lib/dotcom_web/controllers/schedule/finder_api.ex
+++ b/lib/dotcom_web/controllers/schedule/finder_api.ex
@@ -8,7 +8,7 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
 
   use DotcomWeb, :controller
 
-  import DotcomWeb.ScheduleController.ScheduleApi, only: [format_time: 1, fares_for_service: 4]
+  import DotcomWeb.ScheduleController.ScheduleApi, only: [format_time: 1, fares_for_service: 3]
 
   require Logger
 
@@ -19,10 +19,6 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
   alias Predictions.Prediction
   alias Routes.Route
   alias Schedules.{Schedule, Trip}
-
-  import DotcomWeb.ScheduleController.ScheduleApi, only: [format_time: 1, fares_for_service: 4]
-
-  require Logger
 
   @predictions_repo Application.compile_env!(:dotcom, :repo_modules)[:predictions]
   # How many seconds a departure is considered recent
@@ -413,11 +409,9 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
 
   defp add_computed_fares_to_trip_info(trip_info, route) do
     origin = List.first(trip_info.times)
-    trip = PredictedSchedule.trip(origin)
     stop = PredictedSchedule.stop(origin)
 
     fare_params = %{
-      trip: trip,
       route: route,
       origin: stop.id,
       destination: trip_info.destination_id
@@ -449,7 +443,6 @@ defmodule DotcomWeb.ScheduleController.FinderApi do
   defp compute_fare(fare_params) do
     fares_for_service(
       fare_params.route,
-      fare_params.trip,
       fare_params.origin,
       fare_params.destination
     )

--- a/lib/dotcom_web/controllers/schedule/schedule_api.ex
+++ b/lib/dotcom_web/controllers/schedule/schedule_api.ex
@@ -98,7 +98,7 @@ defmodule DotcomWeb.ScheduleController.ScheduleApi do
     |> Enum.map(
       &Map.merge(
         &1,
-        fares_for_service(origin.route, origin.trip, origin.stop.id, &1.stop.id)
+        fares_for_service(origin.route, origin.stop.id, &1.stop.id)
       )
     )
   end
@@ -149,10 +149,10 @@ defmodule DotcomWeb.ScheduleController.ScheduleApi do
     %{schedules: time_formatted_schedules, duration: duration}
   end
 
-  @spec fares_for_service(map, map, String.t(), String.t()) :: map
-  def fares_for_service(route, trip, origin, destination) do
+  @spec fares_for_service(map, String.t(), String.t()) :: map
+  def fares_for_service(route, origin, destination) do
     %{
-      price: route |> OneWay.recommended_fare(trip, origin, destination) |> Format.price(),
+      price: route |> OneWay.recommended_fare(origin, destination) |> Format.price(),
       fare_link:
         fare_link(
           Route.type_atom(route.type),

--- a/lib/dotcom_web/controllers/trip_plan_controller.ex
+++ b/lib/dotcom_web/controllers/trip_plan_controller.ex
@@ -279,15 +279,14 @@ defmodule DotcomWeb.TripPlanController do
 
   defp leg_with_fares(%Leg{mode: %TransitDetail{}} = leg) do
     route = @routes_repo.get(leg.mode.route_id)
-    trip = Schedules.Repo.trip(leg.mode.trip_id)
     origin_id = leg.from.stop_id
     destination_id = leg.to.stop_id
 
     fares =
       if Leg.fare_complete_transit_leg?(leg) do
-        recommended_fare = OneWay.recommended_fare(route, trip, origin_id, destination_id)
-        base_fare = OneWay.base_fare(route, trip, origin_id, destination_id)
-        reduced_fare = OneWay.reduced_fare(route, trip, origin_id, destination_id)
+        recommended_fare = OneWay.recommended_fare(route, origin_id, destination_id)
+        base_fare = OneWay.base_fare(route, origin_id, destination_id)
+        reduced_fare = OneWay.reduced_fare(route, origin_id, destination_id)
 
         %{
           highest_one_way_fare: base_fare,
@@ -339,13 +338,13 @@ defmodule DotcomWeb.TripPlanController do
 
   defp highest_month_pass(
          %Leg{
-           mode: %TransitDetail{route_id: route_id, trip_id: trip_id},
+           mode: %TransitDetail{route_id: route_id},
            from: %NamedPosition{stop_id: origin_id},
            to: %NamedPosition{stop_id: destination_id}
          } = leg
        ) do
     if Leg.fare_complete_transit_leg?(leg) do
-      Month.base_pass(route_id, trip_id, origin_id, destination_id)
+      Month.base_pass(route_id, origin_id, destination_id)
     else
       nil
     end
@@ -356,13 +355,13 @@ defmodule DotcomWeb.TripPlanController do
 
   defp lowest_month_pass(
          %Leg{
-           mode: %TransitDetail{route_id: route_id, trip_id: trip_id},
+           mode: %TransitDetail{route_id: route_id},
            from: %NamedPosition{stop_id: origin_id},
            to: %NamedPosition{stop_id: destination_id}
          } = leg
        ) do
     if Leg.fare_complete_transit_leg?(leg) do
-      Month.recommended_pass(route_id, trip_id, origin_id, destination_id)
+      Month.recommended_pass(route_id, origin_id, destination_id)
     else
       nil
     end
@@ -373,13 +372,13 @@ defmodule DotcomWeb.TripPlanController do
 
   defp reduced_pass(
          %Leg{
-           mode: %TransitDetail{route_id: route_id, trip_id: trip_id},
+           mode: %TransitDetail{route_id: route_id},
            from: %NamedPosition{stop_id: origin_id},
            to: %NamedPosition{stop_id: destination_id}
          } = leg
        ) do
     if Leg.fare_complete_transit_leg?(leg) do
-      Month.reduced_pass(route_id, trip_id, origin_id, destination_id)
+      Month.reduced_pass(route_id, origin_id, destination_id)
     else
       nil
     end

--- a/lib/fares/month.ex
+++ b/lib/fares/month.ex
@@ -5,7 +5,6 @@ defmodule Fares.Month do
 
   alias Fares.{Fare, Repo}
   alias Routes.Route
-  alias Schedules.Trip
   alias Stops.Stop
 
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
@@ -14,122 +13,103 @@ defmodule Fares.Month do
 
   @spec recommended_pass(
           Route.t() | Route.id_t(),
-          Trip.t() | Trip.id_t() | nil,
           Stop.id_t(),
           Stop.id_t(),
           fare_fn()
         ) ::
           Fare.t() | nil
-  def recommended_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
-  def recommended_pass(nil, _, _, _, _), do: nil
+  def recommended_pass(route, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def recommended_pass(nil, _, _, _), do: nil
 
-  def recommended_pass(route_id, trip, origin_id, destination_id, fare_fn)
+  def recommended_pass(route_id, origin_id, destination_id, fare_fn)
       when is_binary(route_id) do
     route = @routes_repo.get(route_id)
-    recommended_pass(route, trip, origin_id, destination_id, fare_fn)
+    recommended_pass(route, origin_id, destination_id, fare_fn)
   end
 
-  def recommended_pass(route, trip_id, origin_id, destination_id, fare_fn)
-      when is_binary(trip_id) do
-    trip = Schedules.Repo.trip(trip_id)
-    recommended_pass(route, trip, origin_id, destination_id, fare_fn)
-  end
-
-  def recommended_pass(route, trip, origin_id, destination_id, fare_fn) do
+  def recommended_pass(route, origin_id, destination_id, fare_fn) do
     route
-    |> get_fares(trip, origin_id, destination_id, fare_fn)
+    |> get_fares(origin_id, destination_id, fare_fn)
     |> Enum.min_by(& &1.cents, fn -> nil end)
   end
 
   @spec base_pass(
           Route.t() | Route.id_t(),
-          Trip.t() | Trip.id_t() | nil,
           Stop.id_t(),
           Stop.id_t(),
           fare_fn()
         ) ::
           Fare.t() | nil
-  def base_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
-  def base_pass(nil, _, _, _, _), do: nil
+  def base_pass(route, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def base_pass(nil, _, _, _), do: nil
 
-  def base_pass(route_id, trip, origin_id, destination_id, fare_fn) when is_binary(route_id) do
+  def base_pass(route_id, origin_id, destination_id, fare_fn) when is_binary(route_id) do
     route = @routes_repo.get(route_id)
-    base_pass(route, trip, origin_id, destination_id, fare_fn)
+    base_pass(route, origin_id, destination_id, fare_fn)
   end
 
-  def base_pass(route, trip_id, origin_id, destination_id, fare_fn) when is_binary(trip_id) do
-    trip = Schedules.Repo.trip(trip_id)
-    base_pass(route, trip, origin_id, destination_id, fare_fn)
-  end
-
-  def base_pass(route, trip, origin_id, destination_id, fare_fn) do
+  def base_pass(route, origin_id, destination_id, fare_fn) do
     route
-    |> get_fares(trip, origin_id, destination_id, fare_fn)
+    |> get_fares(origin_id, destination_id, fare_fn)
     |> Enum.max_by(& &1.cents, fn -> nil end)
   end
 
   @spec reduced_pass(
           Route.t() | Route.id_t(),
-          Trip.t() | Trip.id_t() | nil,
           Stop.id_t(),
           Stop.id_t(),
           fare_fn()
         ) ::
           Fare.t() | nil
-  def reduced_pass(route, trip, origin_id, destination_id, fare_fn \\ &Repo.all/1)
-  def reduced_pass(nil, _, _, _, _), do: nil
+  def reduced_pass(route, origin_id, destination_id, fare_fn \\ &Repo.all/1)
+  def reduced_pass(nil, _, _, _), do: nil
 
-  def reduced_pass(route_id, trip, origin_id, destination_id, fare_fn) when is_binary(route_id) do
+  def reduced_pass(route_id, origin_id, destination_id, fare_fn) when is_binary(route_id) do
     route = @routes_repo.get(route_id)
-    reduced_pass(route, trip, origin_id, destination_id, fare_fn)
+    reduced_pass(route, origin_id, destination_id, fare_fn)
   end
 
-  def reduced_pass(route, trip_id, origin_id, destination_id, fare_fn) when is_binary(trip_id) do
-    trip = Schedules.Repo.trip(trip_id)
-    reduced_pass(route, trip, origin_id, destination_id, fare_fn)
-  end
-
-  def reduced_pass(route, trip, origin_id, destination_id, fare_fn) do
+  def reduced_pass(route, origin_id, destination_id, fare_fn) do
     route
-    |> get_fares(trip, origin_id, destination_id, fare_fn, :any)
+    |> get_fares(origin_id, destination_id, fare_fn, :any)
     |> List.first()
   end
 
-  @spec get_fares(Route.t(), Trip.t() | nil, Stop.id_t(), Stop.id_t(), fare_fn()) :: [Fare.t()]
-  @spec get_fares(Route.t(), Trip.t() | nil, Stop.id_t(), Stop.id_t(), fare_fn(), Fare.reduced()) ::
+  @spec get_fares(Route.t(), Stop.id_t(), Stop.id_t(), fare_fn()) :: [Fare.t()]
+  @spec get_fares(Route.t(), Stop.id_t(), Stop.id_t(), fare_fn(), Fare.reduced()) ::
           [
             Fare.t()
           ]
-  defp get_fares(route, trip, origin_id, destination_id, fare_fn, reduced \\ nil) do
+  defp get_fares(route, origin_id, destination_id, fare_fn, reduced \\ nil) do
     route_filters =
       route.type
       |> Route.type_atom()
-      |> name_or_mode_filter(route, origin_id, destination_id, trip)
+      |> name_or_mode_filter(route, origin_id, destination_id)
 
     [reduced: reduced, duration: :month]
     |> Keyword.merge(route_filters)
     |> fare_fn.()
   end
 
-  @spec name_or_mode_filter(atom(), Route.t(), Stop.id_t(), Stop.id_t(), Trip.t() | nil) ::
+  @spec name_or_mode_filter(atom(), Route.t(), Stop.id_t(), Stop.id_t()) ::
           Keyword.t()
-  defp name_or_mode_filter(:subway, _route, _origin_id, _destination_id, _trip) do
+  defp name_or_mode_filter(:subway, _route, _origin_id, _destination_id) do
     [mode: :subway]
   end
 
-  defp name_or_mode_filter(_, %{description: :rail_replacement_bus}, _, _, _) do
+  defp name_or_mode_filter(_, %{description: :rail_replacement_bus}, _, _) do
     [name: :free_fare]
   end
 
-  defp name_or_mode_filter(_, %{id: "CR-Foxboro"}, _, _, _) do
+  defp name_or_mode_filter(_, %{id: "CR-Foxboro"}, _, _) do
     [name: :foxboro]
   end
 
-  defp name_or_mode_filter(:massport_shuttle, _, _origin_id, _destination_id, _trip) do
+  defp name_or_mode_filter(:massport_shuttle, _, _origin_id, _destination_id) do
     [name: :massport_shuttle]
   end
 
-  defp name_or_mode_filter(:bus, %{id: route_id}, origin_id, _destination_id, _trip) do
+  defp name_or_mode_filter(:bus, %{id: route_id}, origin_id, _destination_id) do
     name =
       cond do
         Fares.express?(route_id) -> :express_bus
@@ -141,8 +121,8 @@ defmodule Fares.Month do
     [name: name]
   end
 
-  defp name_or_mode_filter(:commuter_rail, _, origin_id, destination_id, trip) do
-    case Fares.fare_for_stops(:commuter_rail, origin_id, destination_id, trip) do
+  defp name_or_mode_filter(:commuter_rail, _, origin_id, destination_id) do
+    case Fares.fare_for_stops(:commuter_rail, origin_id, destination_id) do
       {:ok, name} ->
         [name: name]
 
@@ -151,7 +131,7 @@ defmodule Fares.Month do
     end
   end
 
-  defp name_or_mode_filter(:ferry, _, origin_id, destination_id, _) do
+  defp name_or_mode_filter(:ferry, _, origin_id, destination_id) do
     [name: :ferry |> Fares.fare_for_stops(origin_id, destination_id) |> elem(1)]
   end
 end

--- a/lib/trip_info.ex
+++ b/lib/trip_info.ex
@@ -94,9 +94,8 @@ defmodule TripInfo do
        )
        when is_binary(origin_id) and is_binary(destination_id) do
     route = PredictedSchedule.route(time)
-    trip = PredictedSchedule.trip(time)
     duration = duration(times, origin_id)
-    base_fare = OneWay.recommended_fare(route, trip, origin_id, destination_id)
+    base_fare = OneWay.recommended_fare(route, origin_id, destination_id)
 
     %TripInfo{
       route: route,

--- a/test/fares/fares_test.exs
+++ b/test/fares/fares_test.exs
@@ -1,7 +1,12 @@
 defmodule FaresTest do
   use ExUnit.Case, async: true
   doctest Fares
-  alias Routes.Route
+
+  import Mox
+
+  alias Test.Support.Factories.{Routes.Route, Stops.Stop}
+
+  setup :verify_on_exit!
 
   describe "calculate_commuter_rail/2" do
     test "when the origin is zone 6, finds the zone 6 fares" do
@@ -21,20 +26,43 @@ defmodule FaresTest do
     # a subset of possible ferry stops
     @ferries ~w(Boat-Hingham Boat-Charlestown Boat-Logan Boat-Long-South Boat-Lewis Boat-Blossom Boat-Winthrop)
 
-    @tag :external
     test "returns the name of the commuter rail fare given the origin and destination" do
-      zone_1a = "place-north"
-      zone_4 = "Ballardvale"
-      zone_7 = "Haverhill"
+      zone_1a_stop = Stop.build(:stop, %{zone: "1A"})
+      zone_1a_stop_id = zone_1a_stop.id
+      zone_4_stop = Stop.build(:stop, %{zone: "4"})
+      zone_4_stop_id = zone_4_stop.id
+      zone_7_stop = Stop.build(:stop, %{zone: "7"})
+      zone_7_stop_id = zone_7_stop.id
 
-      assert Fares.fare_for_stops(:commuter_rail, zone_1a, zone_4) == {:ok, {:zone, "4"}}
-      assert Fares.fare_for_stops(:commuter_rail, zone_7, zone_1a) == {:ok, {:zone, "7"}}
-      assert Fares.fare_for_stops(:commuter_rail, zone_4, zone_7) == {:ok, {:interzone, "4"}}
+      stub(Stops.Repo.Mock, :get, fn id ->
+        case id do
+          ^zone_1a_stop_id -> zone_1a_stop
+          ^zone_4_stop_id -> zone_4_stop
+          ^zone_7_stop_id -> zone_7_stop
+        end
+      end)
+
+      assert Fares.fare_for_stops(:commuter_rail, zone_1a_stop_id, zone_4_stop_id) ==
+               {:ok, {:zone, "4"}}
+
+      assert Fares.fare_for_stops(:commuter_rail, zone_7_stop_id, zone_1a_stop_id) ==
+               {:ok, {:zone, "7"}}
+
+      assert Fares.fare_for_stops(:commuter_rail, zone_4_stop_id, zone_7_stop_id) ==
+               {:ok, {:interzone, "4"}}
     end
 
-    @tag :external
     test "returns an error if the fare doesn't exist" do
-      assert Fares.fare_for_stops(:commuter_rail, "place-north", "place-pktrm") == :error
+      cr_stop = Stop.build(:stop, %{zone: "3"})
+      cr_stop_id = cr_stop.id
+      other_stop = Stop.build(:stop, %{zone: nil})
+      other_stop_id = other_stop.id
+
+      Stops.Repo.Mock
+      |> expect(:get, fn ^cr_stop_id -> cr_stop end)
+      |> expect(:get, fn ^other_stop_id -> other_stop end)
+
+      assert Fares.fare_for_stops(:commuter_rail, cr_stop.id, other_stop.id) == :error
     end
 
     test "returns the name of the ferry fare given the origin and destination" do
@@ -64,15 +92,6 @@ defmodule FaresTest do
         assert Fares.fare_for_stops(:ferry, origin_id, destination_id) == {:ok, expected_name},
                "Unexpected result for #{origin_id} to #{destination_id}"
       end
-    end
-
-    @tag :external
-    test "trips between a 'combo' zone and a non-terminus stop are treated as the general zone" do
-      assert Fares.fare_for_stops(:commuter_rail, "place-qnctr", "place-PB-0245") ==
-               {:ok, {:interzone, "6"}}
-
-      assert Fares.fare_for_stops(:commuter_rail, "place-PB-0245", "place-qnctr") ==
-               {:ok, {:interzone, "6"}}
     end
   end
 
@@ -114,30 +133,40 @@ defmodule FaresTest do
 
   describe "to_fare_atom/1" do
     test "silver line rapid transit returns subway" do
-      assert Fares.to_fare_atom(%Route{type: 3, id: "741"}) == :subway
+      assert Fares.to_fare_atom(%Routes.Route{type: 3, id: "741"}) == :subway
     end
 
     test "silver line returns bus" do
-      assert Fares.to_fare_atom(%Route{type: 3, id: "751"}) == :bus
+      assert Fares.to_fare_atom(%Routes.Route{type: 3, id: "751"}) == :bus
     end
 
     test "express bus returns :express_bus" do
-      assert Fares.to_fare_atom(%Route{type: 3, id: "170"}) == :express_bus
+      assert Fares.to_fare_atom(%Routes.Route{type: 3, id: "170"}) == :express_bus
     end
 
     test "other types of routes return specific atoms" do
-      assert Fares.to_fare_atom(%Route{type: 0, id: "Green-B"}) == :subway
-      assert Fares.to_fare_atom(%Route{type: 1, id: "Red"}) == :subway
-      assert Fares.to_fare_atom(%Route{type: 2, id: "CR-Fitchburg"}) == :commuter_rail
-      assert Fares.to_fare_atom(%Route{type: 3, id: "1"}) == :bus
+      assert Fares.to_fare_atom(%Routes.Route{type: 0, id: "Green-B"}) == :subway
+      assert Fares.to_fare_atom(%Routes.Route{type: 1, id: "Red"}) == :subway
+      assert Fares.to_fare_atom(%Routes.Route{type: 2, id: "CR-Fitchburg"}) == :commuter_rail
+      assert Fares.to_fare_atom(%Routes.Route{type: 3, id: "1"}) == :bus
     end
 
-    @tag :external
     test "also works with route IDs" do
-      assert Fares.to_fare_atom("Green-B") == :subway
-      assert Fares.to_fare_atom("Red") == :subway
-      assert Fares.to_fare_atom("CR-Fitchburg") == :commuter_rail
-      assert Fares.to_fare_atom("1") == :bus
+      light_rail_route_id = Faker.Internet.slug()
+      subway_route_id = Faker.Internet.slug()
+      cr_route_id = Faker.Internet.slug()
+      bus_route_id = Faker.Internet.slug()
+
+      Routes.Repo.Mock
+      |> expect(:get, fn ^light_rail_route_id -> Route.build(:route, %{type: 0}) end)
+      |> expect(:get, fn ^subway_route_id -> Route.build(:route, %{type: 1}) end)
+      |> expect(:get, fn ^cr_route_id -> Route.build(:route, %{type: 2}) end)
+      |> expect(:get, fn ^bus_route_id -> Route.build(:route, %{type: 3}) end)
+
+      assert Fares.to_fare_atom(light_rail_route_id) == :subway
+      assert Fares.to_fare_atom(subway_route_id) == :subway
+      assert Fares.to_fare_atom(cr_route_id) == :commuter_rail
+      assert Fares.to_fare_atom(bus_route_id) == :bus
     end
 
     test "handles fare atoms" do


### PR DESCRIPTION
While cleaning up code from my (ongoing) trip planner refactoring, I realized there was some fare-calculating logic involved in `Fares.fare_for_stops/4` that is no longer relevant

- The Foxboro pilot logic is from 2019, I'm pretty sure there's no pilot effort involved anymore...
- The combo zones that were introduced in 2020 (PR #601) are no longer relevant, as there are no more `1A-2` or such zones.

This made the `trip` argument no longer needed, so I got to remove it from way too many function calls.

In the meantime I also removed the `:external` tag from a bunch of related tests to stop skipping them, and added the necessary mocks to make those tests work. 