### PR TITLE
When we have predictions show those over alerts

### DIFF
--- a/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
+++ b/assets/ts/stop/__tests__/components/DepartureTimesTest.tsx
@@ -218,7 +218,7 @@ describe("DepartureTimes", () => {
       />
     );
     await waitFor(() => {
-      expect(screen.getByText("Detour")).toBeDefined();
+      expect(screen.getByText("Delayed")).toBeDefined();
       expect(screen.getByText("45 min")).toBeDefined();
       expect(screen.queryByText("See alternatives")).toBeNull();
     });

--- a/assets/ts/stop/components/DepartureTimes.tsx
+++ b/assets/ts/stop/components/DepartureTimes.tsx
@@ -75,6 +75,7 @@ const DepartureTimes = ({
           <DeparturesWithBadge
             alerts={alertsForDirection}
             departuresLength={departures.length}
+            timeListLength={timeList.length}
           >
             {timeList.length > 0 ? (
               <div className="departure-card__times">{timeList}</div>

--- a/assets/ts/stop/components/DeparturesWithBadge.tsx
+++ b/assets/ts/stop/components/DeparturesWithBadge.tsx
@@ -48,6 +48,8 @@ const DeparturesWithBadge = ({
   if (!(priorityBadge || secondaryBadge)) return <>{children}</>;
   const displayBadge = (priorityBadge || secondaryBadge)!;
 
+  // if the priority badge is present and there is only one departure, show the badge
+  // this is because we check for predictions and return a single time list if there are none
   return (
     <>
       {priorityBadge && timeListLength === 1 ? (

--- a/assets/ts/stop/components/DeparturesWithBadge.tsx
+++ b/assets/ts/stop/components/DeparturesWithBadge.tsx
@@ -29,24 +29,15 @@ const toInformativeAlertBadge = (alerts: Alert[]): JSX.Element | undefined => {
   return undefined;
 };
 
-const alertBadgeWrapper = (alertBadge: JSX.Element): JSX.Element => {
-  return (
-    <div
-      className="departure-card__alert"
-      style={{ float: "right", whiteSpace: "nowrap", marginTop: "0.25rem" }}
-    >
-      {alertBadge}
-    </div>
-  );
-};
-
 const DeparturesWithBadge = ({
   alerts,
   departuresLength,
+  timeListLength,
   children
 }: {
   alerts: Alert[];
   departuresLength: number;
+  timeListLength: number;
   children: ReactNode;
 }): ReactElement | null => {
   const suppressiveAlerts = alerts.filter(alert =>
@@ -59,14 +50,19 @@ const DeparturesWithBadge = ({
 
   return (
     <>
-      {priorityBadge ? (
-        <div className="font-helvetica-neue fs-14" style={{ float: "right" }}>
-          See alternatives
+      {priorityBadge && timeListLength === 1 ? (
+        <div>
+          <div className="font-helvetica-neue fs-14">See alternatives</div>
+          <div
+            className="departure-card__alert"
+            style={{ whiteSpace: "nowrap", marginTop: "0.25rem" }}
+          >
+            {displayBadge}
+          </div>
         </div>
       ) : (
         children
       )}
-      {alertBadgeWrapper(displayBadge)}
     </>
   );
 };


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1207562164283201/f

This will work in most cases, but there is one case where it will present incorrect information. If there are one or fewer predictions *and* there is an alert then it will say there is no service. I can see this happening at the end of service for the day. But, it is still better than it saying there is no service for the entire day.

![Screenshot Capture - 2024-07-05 - 09-10-42](https://github.com/mbta/dotcom/assets/155012/5b88b756-6991-4724-8fe1-7696f432f4cc)
