### PR TITLE
Use bias options for autocomplete

### DIFF
--- a/lib/location_service/location_service.ex
+++ b/lib/location_service/location_service.ex
@@ -15,25 +15,16 @@ defmodule LocationService do
 
   @behaviour LocationService.Behaviour
 
-  @default_options %{
+  @bias_options %{
+    BiasPosition: [-71.0660, 42.3548],
+    MaxResults: 50
+  }
+  @bounding_options %{
     FilterBBox: [-71.9380, 41.3193, -69.6189, 42.8266],
     MaxResults: 50
   }
 
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  def geocode(address, options \\ @default_options) when is_binary(address) do
-    Request.new(address, options)
-    |> Result.handle_response(address)
-  end
-
-  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  def reverse_geocode(latitude, longitude, options \\ @default_options)
-      when is_float(latitude) and is_float(longitude) do
-    Request.new([latitude, longitude], options)
-    |> Result.handle_response([latitude, longitude])
-  end
-
-  def autocomplete(text, limit, options \\ @default_options)
+  def autocomplete(text, limit, options \\ @bias_options)
 
   @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   def autocomplete(text, limit, options) when 1 <= limit and limit <= 15 do
@@ -42,4 +33,17 @@ defmodule LocationService do
   end
 
   def autocomplete(_, _, _), do: {:error, :invalid_arguments}
+
+  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
+  def geocode(address, options \\ @bounding_options) when is_binary(address) do
+    Request.new(address, options)
+    |> Result.handle_response(address)
+  end
+
+  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
+  def reverse_geocode(latitude, longitude, options \\ @bounding_options)
+      when is_float(latitude) and is_float(longitude) do
+    Request.new([latitude, longitude], options)
+    |> Result.handle_response([latitude, longitude])
+  end
 end


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1207746606618659/f

A previous ticket made it simple to change options for AWS locations. This ticket just makes bias the default option for autocomplete while retaining bounding box as the default option for geocode and reverse geocode.

