### PR TITLE
Set up dev preview page for Trip Planner WIP

### DIFF
--- a/assets/css/_autocomplete-theme.scss
+++ b/assets/css/_autocomplete-theme.scss
@@ -142,6 +142,15 @@
   @extend %shared-autocomplete;
 }
 
+#trip-from,
+#trip-to {
+  @extend %shared-autocomplete;
+
+  .aa-InputWrapper {
+    padding-left: .5rem;
+  }
+}
+
 %large-autocomplete {
   --aa-search-input-height: 2.5rem;
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -43,8 +43,7 @@ import pslPageSetup from "./psl-page-setup.js";
 import tabbedNav from "./tabbed-nav.js";
 import { accordionInit } from "../ts/ui/accordion";
 import initializeSentry from "../ts/sentry";
-import setupAlgoliaAutocomplete from "../ts/ui/autocomplete/index";
-import setupTripPlannerForm from "./trip-planner-form.js";
+import Hooks from "../ts/phoenix-hooks/index.ts";
 
 // Establish Phoenix Socket and LiveView configuration.
 import { Socket } from "phoenix";
@@ -53,26 +52,6 @@ import { LiveSocket } from "phoenix_live_view";
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")
   .getAttribute("content");
-
-let Hooks = {};
-
-Hooks.AlgoliaAutocomplete = {
-  mounted() {
-    setupAlgoliaAutocomplete(this.el);
-  }
-};
-
-Hooks.ScrollIntoView = {
-  mounted() {
-    this.el.scrollIntoView({ behavior: "smooth" });
-  }
-};
-
-Hooks.TripPlannerForm = {
-  mounted() {
-    setupTripPlannerForm(this.el);
-  }
-};
 
 let liveSocket = new LiveSocket("/live", Socket, {
   params: { _csrf_token: csrfToken },

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -72,6 +72,7 @@
         "@types/jest": "^27.0.1",
         "@types/lodash": "^4.14.168",
         "@types/phoenix": "^1.4.0",
+        "@types/phoenix_live_view": "^0.18.5",
         "@types/react": "^16.8.25",
         "@types/react-dom": "^16.8.5",
         "@types/react-leaflet": "^2.5.2",
@@ -5671,6 +5672,15 @@
       "version": "1.5.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/phoenix_live_view": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@types/phoenix_live_view/-/phoenix_live_view-0.18.5.tgz",
+      "integrity": "sha512-mxj3KVkp+wX+hLFAILTbfIx5Q890TBgs/jxc6nmmVv6bW6Z9qer/5tZtGOcL3IES75QqqOHSTrjwwz0iZBs0lw==",
+      "dev": true,
+      "dependencies": {
+        "@types/phoenix": "*"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -67,6 +67,7 @@
     "@types/jest": "^27.0.1",
     "@types/lodash": "^4.14.168",
     "@types/phoenix": "^1.4.0",
+    "@types/phoenix_live_view": "^0.18.5",
     "@types/react": "^16.8.25",
     "@types/react-dom": "^16.8.5",
     "@types/react-leaflet": "^2.5.2",

--- a/assets/ts/jest.config.js
+++ b/assets/ts/jest.config.js
@@ -15,7 +15,8 @@ module.exports = {
     "!./sentry.ts",
     "!**/*.d.ts",
     "!./ie-warning/**",
-    "!./ui/autocomplete/templates/**"
+    "!./ui/autocomplete/templates/**",
+    "!./phoenix-hooks/**"
   ],
   coverageReporters: ["html"],
   coverageThreshold: {

--- a/assets/ts/phoenix-hooks/algolia-autocomplete.ts
+++ b/assets/ts/phoenix-hooks/algolia-autocomplete.ts
@@ -1,0 +1,12 @@
+import { ViewHook } from "phoenix_live_view";
+import setupAlgoliaAutocomplete from "../ui/autocomplete";
+
+const AlgoliaAutocomplete: Partial<ViewHook> = {
+  mounted() {
+    if (this.el) {
+      setupAlgoliaAutocomplete(this.el);
+    }
+  }
+};
+
+export default AlgoliaAutocomplete;

--- a/assets/ts/phoenix-hooks/index.ts
+++ b/assets/ts/phoenix-hooks/index.ts
@@ -1,0 +1,11 @@
+import AlgoliaAutocomplete from "./algolia-autocomplete";
+import ScrollIntoView from "./scroll-into-view";
+import TripPlannerForm from "./trip-planner-form";
+
+const Hooks = {
+  AlgoliaAutocomplete,
+  ScrollIntoView,
+  TripPlannerForm
+};
+
+export default Hooks;

--- a/assets/ts/phoenix-hooks/index.ts
+++ b/assets/ts/phoenix-hooks/index.ts
@@ -3,6 +3,14 @@ import LeafletMap from "./leaflet-map";
 import ScrollIntoView from "./scroll-into-view";
 import TripPlannerForm from "./trip-planner-form";
 
+/**
+ * Configurations for usage with [Phoenix LiveView's
+ * phx-hook](https://hexdocs.pm/phoenix_live_view/js-interop.html#client-hooks-via-phx-hook)
+ *
+ * The functionality written for the various life-cycle callbacks should be
+ * defined in other modules which have their own test coverage, as Phoenix hooks
+ * themselves are not tested via Jest unit tests.
+ */
 const Hooks = {
   AlgoliaAutocomplete,
   LeafletMap,

--- a/assets/ts/phoenix-hooks/index.ts
+++ b/assets/ts/phoenix-hooks/index.ts
@@ -1,9 +1,11 @@
 import AlgoliaAutocomplete from "./algolia-autocomplete";
+import LeafletMap from "./leaflet-map";
 import ScrollIntoView from "./scroll-into-view";
 import TripPlannerForm from "./trip-planner-form";
 
 const Hooks = {
   AlgoliaAutocomplete,
+  LeafletMap,
   ScrollIntoView,
   TripPlannerForm
 };

--- a/assets/ts/phoenix-hooks/leaflet-map.ts
+++ b/assets/ts/phoenix-hooks/leaflet-map.ts
@@ -1,0 +1,17 @@
+import { ViewHook } from "phoenix_live_view";
+import L from "leaflet";
+import "../../js/leaflet-css";
+
+const LeafletMap: Partial<ViewHook> = {
+  mounted() {
+    if (this.el) {
+      const mapid = this.el.id;
+      const map = L.map(mapid).setView([42.360718, -71.05891], 14);
+      L.tileLayer("https://cdn.mbta.com/osm_tiles/{z}/{x}/{y}.png", {}).addTo(
+        map
+      );
+    }
+  }
+};
+
+export default LeafletMap;

--- a/assets/ts/phoenix-hooks/scroll-into-view.ts
+++ b/assets/ts/phoenix-hooks/scroll-into-view.ts
@@ -1,0 +1,11 @@
+import { ViewHook } from "phoenix_live_view";
+
+const ScrollIntoView: Partial<ViewHook> = {
+  mounted() {
+    if (this.el) {
+      this.el.scrollIntoView({ behavior: "smooth" });
+    }
+  }
+};
+
+export default ScrollIntoView;

--- a/assets/ts/phoenix-hooks/trip-planner-form.ts
+++ b/assets/ts/phoenix-hooks/trip-planner-form.ts
@@ -1,0 +1,12 @@
+import { ViewHook } from "phoenix_live_view";
+import setupTripPlannerForm from "../../js/trip-planner-form";
+
+const TripPlannerForm: Partial<ViewHook> = {
+  mounted() {
+    if (this.el) {
+      setupTripPlannerForm(this.el);
+    }
+  }
+};
+
+export default TripPlannerForm;

--- a/assets/ts/ui/autocomplete/index.ts
+++ b/assets/ts/ui/autocomplete/index.ts
@@ -47,13 +47,15 @@ function setupAlgoliaAutocomplete(wrapper: HTMLElement): void {
     ".c-search-bar__autocomplete-results"
   );
   if (!container || !panelContainer) throw new Error("container needed");
+
+  const INPUT_CLASSNAME = "c-form__input-container";
   const options: AutocompleteOptions<Item> = {
     id: container.id || "search",
     container,
     panelContainer,
     detachedMediaQuery: "none",
     classNames: {
-      input: "c-form__input-container"
+      input: INPUT_CLASSNAME
     },
     initialState: {
       query:
@@ -69,7 +71,16 @@ function setupAlgoliaAutocomplete(wrapper: HTMLElement): void {
     plugins: getPlugins(container.dataset),
     renderer: reactRenderer
   };
-  setupVeilCloseListener(autocomplete(options));
+  const autocompleteWidget = autocomplete(options);
+  setupVeilCloseListener(autocompleteWidget);
+
+  // close on blur too
+  const input = container.querySelector(`.${INPUT_CLASSNAME}`);
+  if (input) {
+    input.addEventListener("blur", () => {
+      autocompleteWidget.setIsOpen(false);
+    });
+  }
 }
 
 export default setupAlgoliaAutocomplete;

--- a/lib/dotcom_web/live/trip_planner/index.ex
+++ b/lib/dotcom_web/live/trip_planner/index.ex
@@ -1,4 +1,10 @@
 defmodule DotcomWeb.Live.TripPlanner do
+  @moduledoc """
+  The entire Trip Planner experience, including submitting and validating user
+  input, querying and parsing results from OpenTripPlanner, and rendering the
+  results in a list and map format.
+  """
+
   use DotcomWeb, :live_view
 
   def mount(_params, _session, socket) do

--- a/lib/dotcom_web/live/trip_planner/index.ex
+++ b/lib/dotcom_web/live/trip_planner/index.ex
@@ -1,0 +1,43 @@
+defmodule DotcomWeb.Live.TripPlanner do
+  use DotcomWeb, :live_view
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+      <h1>Trip Planner</h1>
+      <p>(develop the <a href="https://knowyourmeme.com/memes/how-to-draw-an-owl">rest of the owl</a> here)</p>
+      <div style="display: grid; grid-template-columns: 1fr 3fr; gap: .5rem;">
+        <section>
+          <label>From
+          <.algolia_autocomplete
+            id="trip-from"
+            algolia_indexes={[:stops]}
+            geolocation={true}
+            locations_count={5}
+            placeholder="Enter a location"
+            popular_locations={true}
+            initial_state={true}
+          />
+          </label>
+          <label>To
+          <.algolia_autocomplete
+            id="trip-to"
+            algolia_indexes={[:stops]}
+            geolocation={true}
+            locations_count={5}
+            placeholder="Enter a location"
+            popular_locations={true}
+            initial_state={true}
+          />
+          </label>
+        </section>
+        <div id="trip-planner-map-wrapper" phx-update="ignore">
+          <div style="height: 400px;" id="trip-planner-map" phx-hook="LeafletMap" />
+        </div>
+      </div>
+    """
+  end
+end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -247,6 +247,7 @@ defmodule DotcomWeb.Router do
     pipe_through([:browser, :browser_live, :basic_auth])
 
     live_session :rider, layout: {DotcomWeb.LayoutView, :preview} do
+      live("/trip-planner", Live.TripPlanner)
     end
   end
 

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -242,6 +242,14 @@ defmodule DotcomWeb.Router do
     end
   end
 
+  scope "/preview", DotcomWeb do
+    import Phoenix.LiveView.Router
+    pipe_through([:browser, :browser_live, :basic_auth])
+
+    live_session :rider, layout: {DotcomWeb.LayoutView, :preview} do
+    end
+  end
+
   scope "/api", DotcomWeb do
     pipe_through([:secure, :browser])
 

--- a/lib/dotcom_web/templates/layout/preview.html.heex
+++ b/lib/dotcom_web/templates/layout/preview.html.heex
@@ -1,0 +1,3 @@
+<div style="margin: 0; padding: .5rem; text-align: center; background-color: #00ffce; background-image: linear-gradient(45deg, #00ffce 25%, #FFFAE9 25%, #FFFAE9 50%, #00ffce 50%, #00ffce 75%, #fff 75%, #FFFAE9 100%); background-size: 56.57px 56.57px; font-weight: bold;">Preview Version</div>
+<div class="container"><%= @inner_content %></div>
+<div style="transform: translateY(2rem); margin: 0; padding: .5rem; text-align: center; background-color: #00ffce; background-image: linear-gradient(45deg, #00ffce 25%, #FFFAE9 25%, #FFFAE9 50%, #00ffce 50%, #00ffce 75%, #fff 75%, #FFFAE9 100%); background-size: 56.57px 56.57px; font-weight: bold;">Preview Version</div>


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Set up dev preview page for Trip Planner WIP](https://app.asana.com/0/385363666817452/1207763166362686/f)

Instead of hacking at the current trip planner incrementally, we'll use a fresh view to start implementing the desired UX/UI changes. This page will be shared across the team for iterative feedback while we explore new ways of grouping and displaying itineraries.

> [!Tip]
>
> Visit `/preview/trip-planner` using the basic auth username/password (this is in 1Password under "Dotcom Basic Auth" in the Website Dev vault for prod/dev/dev-blue/dev-green, or locally with `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` environment variables)

<img width="1463" alt="image" src="https://github.com/mbta/dotcom/assets/2136286/0af657f2-a85d-493f-9994-66c4daeb05a7">
