### PR TITLE
Remove predictions that don't have a departure time

### DIFF
--- a/lib/dotcom_web/channels/predictions_channel.ex
+++ b/lib/dotcom_web/channels/predictions_channel.ex
@@ -2,8 +2,11 @@ defmodule DotcomWeb.PredictionsChannel do
   @moduledoc """
   Channel allowing clients to subscribe to streams of predictions.
   """
+
   use DotcomWeb, :channel
+
   require Routes.Route
+
   alias Routes.Route
   alias Phoenix.{Channel, Socket}
   alias Predictions.{Prediction, PredictionsPubSub}
@@ -48,9 +51,17 @@ defmodule DotcomWeb.PredictionsChannel do
     |> Enum.reject(fn prediction ->
       is_nil(prediction.trip) ||
         is_skipped_or_cancelled?(prediction) ||
+        no_departure_time?(prediction) ||
         is_in_past?(prediction) ||
         terminal_stop?(prediction)
     end)
+  end
+
+  # Used to filter out predictions that have an arrival time but no departure time.
+  # This is common when shuttles are being used at non-terminal stops.
+  defp no_departure_time?(prediction) do
+    prediction.arrival_time != nil &&
+      prediction.departure_time == nil
   end
 
   # Keeping this style until we change all of these.

--- a/test/dotcom_web/channels/predictions_channel_test.exs
+++ b/test/dotcom_web/channels/predictions_channel_test.exs
@@ -12,21 +12,6 @@ defmodule DotcomWeb.PredictionsChannelTest do
   alias Schedules.{Schedule, Trip}
   alias Stops.Stop
 
-  @route_39 "39"
-  @stop_fh "place-forhl"
-  @direction 1
-
-  @prediction39 %Prediction{
-    id: "prediction39",
-    direction_id: @direction,
-    route: %Route{id: @route_39, type: 3},
-    stop: %Stop{id: @stop_fh},
-    trip: %Trip{id: "trip_id"},
-    time: Timex.shift(Util.now(), hours: 2)
-  }
-
-  @channel_name "predictions:stop:#{@stop_fh}"
-
   setup do
     socket = socket(UserSocket, "", %{})
     {:ok, socket: socket}

--- a/test/dotcom_web/channels/predictions_channel_test.exs
+++ b/test/dotcom_web/channels/predictions_channel_test.exs
@@ -12,6 +12,21 @@ defmodule DotcomWeb.PredictionsChannelTest do
   alias Schedules.{Schedule, Trip}
   alias Stops.Stop
 
+  @route_39 "39"
+  @stop_fh "place-forhl"
+  @direction 1
+
+  @prediction39 %Prediction{
+    id: "prediction39",
+    direction_id: @direction,
+    route: %Route{id: @route_39, type: 3},
+    stop: %Stop{id: @stop_fh},
+    trip: %Trip{id: "trip_id"},
+    time: Timex.shift(Util.now(), hours: 2)
+  }
+
+  @channel_name "predictions:stop:#{@stop_fh}"
+
   setup do
     socket = socket(UserSocket, "", %{})
     {:ok, socket: socket}

--- a/test/support/factories/predictions/prediction.ex
+++ b/test/support/factories/predictions/prediction.ex
@@ -11,19 +11,19 @@ defmodule Test.Support.Factories.Predictions.Prediction do
   def prediction_factory do
     %Prediction{
       id: FactoryHelpers.build(:id),
-      trip: Trip.build(:trip) |> FactoryHelpers.nullable_item(),
-      stop: Stop.build(:stop),
+      arrival_time: Timex.now() |> Timex.shift(minutes: 10),
+      departure_time: Timex.now() |> Timex.shift(minutes: 15),
+      direction_id: FactoryHelpers.build(:direction_id),
       platform_stop_id: FactoryHelpers.build(:nullable_id),
       route: Route.build(:route),
-      vehicle_id: FactoryHelpers.build(:nullable_id),
-      direction_id: FactoryHelpers.build(:direction_id),
-      arrival_time: Faker.DateTime.forward(1),
-      departure_time: Faker.DateTime.forward(1),
-      time: Faker.DateTime.forward(1),
       schedule_relationship:
         Faker.Util.pick([:added, :unscheduled, :cancelled, :skipped, :no_data])
         |> FactoryHelpers.nullable_item(),
-      track: Faker.Util.digit() |> FactoryHelpers.nullable_item()
+      stop: Stop.build(:stop),
+      time: Faker.DateTime.forward(1),
+      track: Faker.Util.digit() |> FactoryHelpers.nullable_item(),
+      trip: Trip.build(:trip) |> FactoryHelpers.nullable_item(),
+      vehicle_id: FactoryHelpers.build(:nullable_id)
     }
   end
 end


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1207779834092092/f

Note, I am rewriting tests, but we want to get this out before this weekend's Red Line issues.

