### PR TITLE
Get stops info so that we know what zone a cr stop is in for fare cal…

### DIFF
--- a/lib/trip_planner/parser.ex
+++ b/lib/trip_planner/parser.ex
@@ -10,9 +10,11 @@ defmodule Dotcom.TripPlanner.Parser do
      MBTA system.
   """
 
-  alias TripPlan.{Itinerary, Leg, NamedPosition, PersonalDetail, TransitDetail}
   alias Dotcom.TripPlanner.FarePasses
   alias OpenTripPlannerClient.Schema
+  alias TripPlan.{Itinerary, Leg, NamedPosition, PersonalDetail, TransitDetail}
+
+  @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
 
   @spec parse(Schema.Itinerary.t()) :: Itinerary.t()
   def parse(
@@ -166,15 +168,11 @@ defmodule Dotcom.TripPlanner.Parser do
 
   defp build_stop(
          %Schema.Stop{
-           gtfs_id: "mbta-ma-us:" <> gtfs_id,
-           name: name
+           gtfs_id: "mbta-ma-us:" <> gtfs_id
          },
          attributes
        ) do
-    %Stops.Stop{
-      id: gtfs_id,
-      name: name
-    }
+    @stops_repo.get(gtfs_id)
     |> struct(attributes)
   end
 

--- a/test/dotcom/trip_plan/itinerary_row_test.exs
+++ b/test/dotcom/trip_plan/itinerary_row_test.exs
@@ -3,15 +3,22 @@ defmodule TripPlan.ItineraryRowTest do
 
   import Dotcom.TripPlan.ItineraryRow
   import Mox
-  import Test.Support.Factories.TripPlanner.TripPlanner
 
+  alias Alerts.{Alert, InformedEntity}
   alias Dotcom.TripPlan.ItineraryRow
   alias Routes.Route
-  alias Alerts.{Alert, InformedEntity}
-  alias Test.Support.Factories.MBTA.Api
+  alias Test.Support.Factories.{MBTA.Api, Stops.Stop, TripPlanner.TripPlanner}
   alias TripPlan.{Leg, NamedPosition, PersonalDetail}
 
   setup :verify_on_exit!
+
+  setup do
+    stub(Stops.Repo.Mock, :get, fn _ ->
+      Stop.build(:stop)
+    end)
+
+    :ok
+  end
 
   describe "route_id/1" do
     test "returns the route id when a route is present" do
@@ -318,8 +325,12 @@ defmodule TripPlan.ItineraryRowTest do
   end
 
   describe "from_leg/3" do
-    @personal_leg build(:walking_leg)
-    @transit_leg build(:transit_leg)
+    stub(Stops.Repo.Mock, :get, fn _ ->
+      Stop.build(:stop)
+    end)
+
+    @personal_leg TripPlanner.build(:walking_leg)
+    @transit_leg TripPlanner.build(:transit_leg)
 
     setup do
       stub(MBTA.Api.Mock, :get_json, fn path, _ ->
@@ -339,7 +350,7 @@ defmodule TripPlan.ItineraryRowTest do
     end
 
     test "returns an itinerary row from a Leg" do
-      leg = build(:transit_leg)
+      leg = TripPlanner.build(:transit_leg)
 
       stub(Stops.Repo.Mock, :get_parent, fn id ->
         %Stops.Stop{id: id}

--- a/test/dotcom/trip_plan/related_link_test.exs
+++ b/test/dotcom/trip_plan/related_link_test.exs
@@ -12,6 +12,10 @@ defmodule Dotcom.TripPlan.RelatedLinkTest do
   setup :verify_on_exit!
 
   setup do
+    stub(Stops.Repo.Mock, :get, fn _ ->
+      Stop.build(:stop)
+    end)
+
     itinerary =
       build(:itinerary,
         legs: [build(:transit_leg)]

--- a/test/dotcom_web/views/trip_plan_view_test.exs
+++ b/test/dotcom_web/views/trip_plan_view_test.exs
@@ -8,7 +8,7 @@ defmodule DotcomWeb.TripPlanViewTest do
 
   alias Fares.Fare
   alias Dotcom.TripPlan.{IntermediateStop, ItineraryRow, Query}
-  alias Test.Support.Factories.TripPlanner.TripPlanner
+  alias Test.Support.Factories.{Stops.Stop, TripPlanner.TripPlanner}
   alias TripPlan.{Itinerary, Leg, NamedPosition, TransitDetail}
 
   @highest_one_way_fare %Fares.Fare{
@@ -77,6 +77,10 @@ defmodule DotcomWeb.TripPlanViewTest do
   setup :verify_on_exit!
 
   setup do
+    stub(Stops.Repo.Mock, :get, fn _ ->
+      Stop.build(:stop)
+    end)
+
     stub(MBTA.Api.Mock, :get_json, fn "/schedules/", [route: "Red", date: "1970-01-01"] ->
       {:error,
        [

--- a/test/trip_plan/itinerary_test.exs
+++ b/test/trip_plan/itinerary_test.exs
@@ -2,19 +2,24 @@ defmodule TripPlan.ItineraryTest do
   use ExUnit.Case, async: true
 
   import Mox
-  import Test.Support.Factories.TripPlanner.TripPlanner
   import TripPlan.Itinerary
 
-  alias TripPlan.{TransitDetail, Leg, PersonalDetail, TransitDetail}
+  alias Test
+  alias Test.Support.Factories.{Stops.Stop, TripPlanner.TripPlanner}
+  alias TripPlan.{Leg, PersonalDetail, TransitDetail}
 
-  @from build(:stop_named_position)
-  @to build(:stop_named_position)
-  @transit_leg build(:transit_leg, from: @from, to: @to)
+  @from TripPlanner.build(:stop_named_position)
+  @to TripPlanner.build(:stop_named_position)
 
   setup :verify_on_exit!
 
   setup do
-    itinerary = build(:itinerary, legs: [@transit_leg])
+    stub(Stops.Repo.Mock, :get, fn _ ->
+      Stop.build(:stop)
+    end)
+
+    transit_leg = TripPlanner.build(:transit_leg, from: @from, to: @to)
+    itinerary = TripPlanner.build(:itinerary, legs: [transit_leg])
     %{itinerary: itinerary}
   end
 
@@ -75,8 +80,8 @@ defmodule TripPlan.ItineraryTest do
   describe "positions/1" do
     test "returns all named positions for the itinerary" do
       itinerary =
-        build(:itinerary,
-          legs: build_list(3, :walking_leg, from: @from, to: @to)
+        TripPlanner.build(:itinerary,
+          legs: TripPlanner.build_list(3, :walking_leg, from: @from, to: @to)
         )
 
       [first, second, third] = itinerary.legs

--- a/test/trip_plan/transfer_test.exs
+++ b/test/trip_plan/transfer_test.exs
@@ -3,20 +3,28 @@ defmodule TransferTest do
 
   import Mox
   import TripPlan.Transfer
-  import Test.Support.Factories.TripPlanner.TripPlanner
 
+  alias Test.Support.Factories.{Stops.Stop, TripPlanner.TripPlanner}
   alias TripPlan.{Leg, NamedPosition, PersonalDetail, TransitDetail}
 
   setup :verify_on_exit!
 
+  setup do
+    stub(Stops.Repo.Mock, :get, fn _ ->
+      Stop.build(:stop)
+    end)
+
+    :ok
+  end
+
   describe "maybe_transfer?/1 correctly identifies the potential presence of a transfer [assumes single ride media]" do
-    defp bus_leg, do: build(:bus_leg)
-    defp subway_leg, do: build(:subway_leg)
-    defp cr_leg, do: build(:cr_leg)
-    defp ferry_leg, do: build(:ferry_leg)
-    defp xp_leg, do: build(:express_bus_leg)
-    defp sl_rapid_leg, do: build(:sl_rapid_leg)
-    defp shuttle_leg, do: build(:shuttle_leg)
+    defp bus_leg, do: TripPlanner.build(:bus_leg)
+    defp subway_leg, do: TripPlanner.build(:subway_leg)
+    defp cr_leg, do: TripPlanner.build(:cr_leg)
+    defp ferry_leg, do: TripPlanner.build(:ferry_leg)
+    defp xp_leg, do: TripPlanner.build(:express_bus_leg)
+    defp sl_rapid_leg, do: TripPlanner.build(:sl_rapid_leg)
+    defp shuttle_leg, do: TripPlanner.build(:shuttle_leg)
 
     test "if from or to is nil" do
       refute [nil, nil] |> maybe_transfer?


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1207827448713211/f

Looks like we tried to remove the call to the `Stops.Repo`, but we need the stop zone so that we can calculate the fare for commuter rail. So, I added the call back and then added a stub for all tests that rely on the trip plan parser.

https://github.com/mbta/dotcom/pull/2123

