### PR TITLE
feat(LiquidObjects): support reduced fares for the RIDE

### DIFF
--- a/lib/dotcom/content_rewriters/liquid_objects/fare.ex
+++ b/lib/dotcom/content_rewriters/liquid_objects/fare.ex
@@ -175,7 +175,7 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.Fare do
   end
 
   defp parse_token(value, good, bad) when value in @fare_ride do
-    {filter_insert(good, name: value, reduced: "senior_disabled"), bad}
+    {filter_insert(good, name: value), bad}
   end
 
   defp parse_token(value, good, bad) when value in @fare_media do

--- a/lib/dotcom/content_rewriters/liquid_objects/route.ex
+++ b/lib/dotcom/content_rewriters/liquid_objects/route.ex
@@ -5,7 +5,9 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.Route do
 
   """
 
-  alias Routes.{Repo, Route}
+  alias Routes.Route
+
+  @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
 
   @type request_error :: {:error, {:empty | :unmatched, String.t()}}
   @type request_tuple :: {:ok, String.t()}
@@ -23,7 +25,7 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.Route do
   defp compose_args(route), do: {:ok, route}
 
   @spec request_route(request_tuple | request_error) :: Route.t() | request_error | nil
-  defp request_route({:ok, route}), do: Repo.get(route)
+  defp request_route({:ok, route}), do: @routes_repo.get(route)
   defp request_route(error), do: error
 
   @spec process_results(Route.t() | request_error | nil) :: {:ok, String.t()} | request_error

--- a/lib/fares/fare_info.ex
+++ b/lib/fares/fare_info.ex
@@ -221,7 +221,13 @@ defmodule Fares.FareInfo do
       day_pass_price: "11.00",
       week_pass_price: "22.50"
     },
-    %{mode: :the_ride, ada_ride: "3.35", premium_ride: "5.60"},
+    %{
+      mode: :the_ride,
+      ada_ride: "3.35",
+      ada_ride_reduced: "1.70",
+      premium_ride: "5.60",
+      premium_ride_reduced: "2.80"
+    },
     # Logan Express Back Bay
     %{mode: :massport_shuttle, name: "Massport-32511", single_trip: "3.00"},
     # Logan Express Framingham
@@ -670,23 +676,40 @@ defmodule Fares.FareInfo do
     fares ++ reduced_fares
   end
 
-  def mapper(%{mode: :the_ride, ada_ride: ada_ride, premium_ride: premium_ride}) do
+  def mapper(%{
+        mode: :the_ride,
+        ada_ride: ada_ride,
+        premium_ride: premium_ride,
+        ada_ride_reduced: ada_ride_reduced,
+        premium_ride_reduced: premium_ride_reduced
+      }) do
     [
       %Fare{
         mode: :the_ride,
         name: :ada_ride,
-        media: [:senior_card],
-        reduced: :senior_disabled,
+        reduced: nil,
         duration: :single_trip,
         cents: dollars_to_cents(ada_ride)
       },
       %Fare{
         mode: :the_ride,
         name: :premium_ride,
-        media: [:senior_card],
-        reduced: :senior_disabled,
         duration: :single_trip,
         cents: dollars_to_cents(premium_ride)
+      },
+      %Fare{
+        mode: :the_ride,
+        name: :ada_ride,
+        reduced: :any,
+        duration: :single_trip,
+        cents: dollars_to_cents(ada_ride_reduced)
+      },
+      %Fare{
+        mode: :the_ride,
+        name: :premium_ride,
+        reduced: :any,
+        duration: :single_trip,
+        cents: dollars_to_cents(premium_ride_reduced)
       }
     ]
   end

--- a/test/dotcom/content_rewriters/liquid_objects/fare_test.exs
+++ b/test/dotcom/content_rewriters/liquid_objects/fare_test.exs
@@ -99,13 +99,23 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.FareTest do
     test "it handles the ride fare requests" do
       assert [
                name: :ada_ride,
-               reduced: :senior_disabled,
+               reduced: nil,
                duration: :single_trip
              ]
              |> Repo.all()
              |> fare_result() == "$3.35"
 
-      assert fare_request("subway:ada_ride") == {:ok, "$3.35"}
+      assert fare_request("ada_ride") == {:ok, "$3.35"}
+
+      assert [
+               name: :ada_ride,
+               reduced: :any,
+               duration: :single_trip
+             ]
+             |> Repo.all()
+             |> fare_result() == "$1.70"
+
+      assert fare_request("ada_ride:reduced") == {:ok, "$1.70"}
     end
 
     test "it handles mticket fare requests" do

--- a/test/dotcom/content_rewriters/liquid_objects_test.exs
+++ b/test/dotcom/content_rewriters/liquid_objects_test.exs
@@ -5,12 +5,13 @@ defmodule Dotcom.ContentRewriters.LiquidObjectsTest do
   import Phoenix.HTML, only: [safe_to_string: 1]
   import DotcomWeb.PartialView.SvgIconWithCircle, only: [svg_icon_with_circle: 1]
   import DotcomWeb.ViewHelpers, only: [fa: 1, svg: 1]
+  import Mox
 
   alias DotcomWeb.PartialView.SvgIconWithCircle
   alias Fares.{Format, Repo}
   alias Routes
 
-  @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
+  setup :verify_on_exit!
 
   describe "replace/1" do
     test "it replaces fa- prefixed objects" do
@@ -70,9 +71,11 @@ defmodule Dotcom.ContentRewriters.LiquidObjectsTest do
                ~s({{ <span class="text-danger">missing mode/name</span> fare:cash }})
     end
 
-    @tag :external
     test "it handles route requests" do
-      assert replace(~s(route:83)) == "83" |> @routes_repo.get() |> Map.get(:long_name)
+      route_id = Faker.Internet.slug()
+      route_name = Faker.App.name()
+      expect(Routes.Repo.Mock, :get, fn ^route_id -> %Routes.Route{long_name: route_name} end)
+      assert replace(~s(route:#{route_id})) == route_name
     end
 
     test "it returns a liquid object when not otherwise handled" do

--- a/test/dotcom/content_rewriters/liquid_objects_test.exs
+++ b/test/dotcom/content_rewriters/liquid_objects_test.exs
@@ -63,6 +63,14 @@ defmodule Dotcom.ContentRewriters.LiquidObjectsTest do
       assert replace(~s(fare:local_bus:cash)) == results |> List.first() |> Format.price()
     end
 
+    test "it handles reduced fare requests for the RIDE" do
+      ada = replace(~s(fare:ada_ride))
+      ada_reduced = replace(~s(fare:ada_ride:reduced))
+      assert ada
+      assert ada_reduced
+      assert ada != ada_reduced
+    end
+
     test "it handles bad fare requests" do
       assert replace(~s(fare:spaceship)) ==
                ~s({{ fare:<span class="text-danger">spaceship</span> }})


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Update RIDE fare cards](https://app.asana.com/0/555089885850811/1207881146339795/f)

This requires adjusting the logic for fetching The RIDE fares, which had assumed they were always reduced value and paid using senior cards... neither of which are true.