### PR TITLE
Add signup link to schedule finder

### DIFF
--- a/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -97,9 +97,7 @@ const ScheduleModalContent = ({
             href="https://forms.office.com/Pages/ResponsePage.aspx?id=meVYdQbwH0iXF7GJ5nMIYrcr-0ws2DJAoeo-oGBUIR9UOFZUVVNLTFhWWFdWV1c2UUJQNU5LTEMwQS4u"
             style={{
               color: "black",
-              display: "block",
-              height: "100%",
-              width: "100%"
+              display: "block"
             }}
             target="_blank"
           >

--- a/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -46,6 +46,13 @@ const ScheduleModalContent = ({
 }: Props): ReactElement<HTMLElement> | null => {
   const { id: routeId } = route;
 
+  const isBetaTestCandidate = (): boolean => {
+    const isIPhone = /iPhone/.test(navigator.userAgent);
+    const isRandom = Math.random() <= 0.3;
+
+    return isIPhone && isRandom;
+  };
+
   const serviceToday = services.some(service =>
     isInCurrentService(service, stringToDateObject(today))
   );
@@ -77,7 +84,29 @@ const ScheduleModalContent = ({
           stopsByDirection={stops}
         />
       </div>
-
+      {!isBetaTestCandidate() ? null : (
+        <div
+          style={{
+            background: "#DCD3E8",
+            margin: "0 -1.5rem",
+            padding: "10px",
+            textAlign: "center"
+          }}
+        >
+          <a
+            href="https://forms.office.com/Pages/ResponsePage.aspx?id=meVYdQbwH0iXF7GJ5nMIYrcr-0ws2DJAoeo-oGBUIR9UOFZUVVNLTFhWWFdWV1c2UUJQNU5LTEMwQS4u"
+            style={{
+              color: "black",
+              display: "block",
+              height: "100%",
+              width: "100%"
+            }}
+            target="_blank"
+          >
+            Sign up to test the new <strong>MBTA app &#x2192;</strong>
+          </a>
+        </div>
+      )}
       {!isSubwayRoute(route) ? null : (
         <DailyScheduleSubway
           stops={stops}


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1207936701552960/f

Simulate an iPhone. You'll see the banner show up a random 30% of the time.  Simulate on an Android device and the banner will never show.

