### PR TITLE
fix(StopPageHeader): improve mode and accessibility icons

### DIFF
--- a/assets/ts/stop/__tests__/components/icons/AccessibilityIconTest.tsx
+++ b/assets/ts/stop/__tests__/components/icons/AccessibilityIconTest.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { Route, Stop } from "../../../../__v3api";
+import { Stop } from "../../../../__v3api";
 import AccessibilityIcon from "../../../components/icons/AccessibilityIcon";
 
 describe("AccessibilityIcon", () => {
   it("should return an empty element for non accessilbe stops", () => {
-    const stop = { accessibility: ["none"] };
+    const stop = ({ accessibility: [] } as unknown) as Stop;
     render(
       <div data-testid="empty">
-        <AccessibilityIcon stop={stop as Stop} routes={[]} />
+        <AccessibilityIcon stop={stop} />
       </div>
     );
     expect(screen.getByTestId("empty")).toBeEmptyDOMElement();
@@ -18,18 +18,7 @@ describe("AccessibilityIcon", () => {
     const stop = { accessibility: ["accessible"] };
     render(
       <div data-testid="empty">
-        <AccessibilityIcon stop={stop as Stop} routes={[]} />
-      </div>
-    );
-    expect(screen.getByTestId("empty")).not.toBeEmptyDOMElement();
-  });
-
-  it("should return an icon for a bus stop", () => {
-    const stop = { accessibility: ["none"] };
-    const routes = [{ type: 3 }];
-    render(
-      <div data-testid="empty">
-        <AccessibilityIcon stop={stop as Stop} routes={routes as Route[]} />
+        <AccessibilityIcon stop={stop as Stop} />
       </div>
     );
     expect(screen.getByTestId("empty")).not.toBeEmptyDOMElement();

--- a/assets/ts/stop/components/icons/AccessibilityIcon.tsx
+++ b/assets/ts/stop/components/icons/AccessibilityIcon.tsx
@@ -1,23 +1,13 @@
 import React, { ReactElement } from "react";
-import { some } from "lodash";
-import { Route, Stop } from "../../../__v3api";
+import { Stop } from "../../../__v3api";
 import { accessibleIcon } from "../../../helpers/icon";
-import { isABusRoute } from "../../../models/route";
 
 const AccessibilityIcon = ({
-  stop,
-  routes
+  stop
 }: {
   stop: Stop;
-  routes: Route[];
-}): ReactElement<HTMLElement> => {
-  // NOTE: Bus stops are always considered accessible, see
-  // https://app.asana.com/0/1201653980996886/1201894234147725/f
-  const isBusStop = some(routes, r => isABusRoute(r));
-  if (!isBusStop && !stop.accessibility.includes("accessible")) {
-    return <></>;
-  }
-
+}): ReactElement<HTMLElement> | null => {
+  if (stop.accessibility.length === 0) return null;
   return (
     <div className="m-stop-page__access-icon">
       <span className="m-stop-page__icon">

--- a/assets/ts/stop/components/icons/StopFeatures.tsx
+++ b/assets/ts/stop/components/icons/StopFeatures.tsx
@@ -14,7 +14,11 @@ const StopFeatures = ({
 }): ReactElement<HTMLElement> => {
   return (
     <span className="m-stop-page__header-features mb-6">
-      <ModeIcons routes={routes} />
+      <ModeIcons
+        routes={routes.filter(
+          route => route.description !== "rail_replacement_bus"
+        )}
+      />
       <CommuterRailZoneIcon zoneNumber={stop.zone} />
       <AccessibilityIcon stop={stop} routes={routes} />
       <ParkingIcon stop={stop} />

--- a/assets/ts/stop/components/icons/StopFeatures.tsx
+++ b/assets/ts/stop/components/icons/StopFeatures.tsx
@@ -20,7 +20,7 @@ const StopFeatures = ({
         )}
       />
       <CommuterRailZoneIcon zoneNumber={stop.zone} />
-      <AccessibilityIcon stop={stop} routes={routes} />
+      <AccessibilityIcon stop={stop} />
       <ParkingIcon stop={stop} />
     </span>
   );


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Inaccurate accessibility icon for station pages](https://app.asana.com/0/385363666817452/1208024340326629/f)

- Removes extra logic in `<AccessibilityIcon />` in favor of reading from the stop's `accessible` attribute, which looks pretty correct to me. Some stops I checked and verified:
  - Concord, the offending stop cited in the ticket
  - Holbrook/Randolph, a commuter rail stop that's actually served by buses and is marked as accessible on the commuter rail map
  - Washington St opp Ruggles St, a bus stop, to verify that it's still being marked as accessible
  - note: as far as I can tell, there are no commuter rail + bus stations which are marked inaccessible on the map
- Added logic to remove the shuttle routes from being assessed in `<ModeIcons />`. Still not great (these ought to be computed and assigned to the stop in the backend) but improves the page, and doesn't show buses at stations not typically serviced by standard bus routes. So, this removes the bus icon from Concord, but doesn't bring true consistency with the `/stops` page as they're still using different rendering logic.