### PR TITLE
feat: Remove local-dev Content Security Policy

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -229,21 +229,10 @@ case config_env() do
              "; "
            )
 
+  # Dev is only used for local development, so we don't need, and in
+  # fact actively do not want, a restrictive CSP
   :dev ->
-    config :dotcom,
-           :content_security_policy_definition,
-           Enum.join(
-             [
-               "default-src 'none'",
-               "img-src 'self' cdn.mbta.com #{System.get_env("CMS_API_BASE_URL", "")} *.google.com *.googleapis.com *.gstatic.com mbta-map-tiles-dev.s3.amazonaws.com data: i.ytimg.com www.googletagmanager.com",
-               "style-src 'self' 'unsafe-inline' localhost:* www.gstatic.com cdn.jsdelivr.net",
-               "script-src 'self' 'unsafe-eval' 'unsafe-inline' localhost:* www.instagram.com *.google.com www.gstatic.com www.googletagmanager.com www.google-analytics.com *.googleapis.com data.mbta.com",
-               "font-src 'self' localhost:*",
-               "connect-src 'self' localhost:* ws://localhost:* *.googleapis.com",
-               "frame-src 'self' localhost:* data.mbta.com www.youtube.com www.google.com cdn.knightlab.com livestream.com www.instagram.com"
-             ],
-             "; "
-           )
+    config :dotcom, :content_security_policy_definition, "*"
 
   :test ->
     config :dotcom, :content_security_policy_definition, ""


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

*This affects only local dev, or any environment that uses `MIX_ENV=dev`.*

The CSP was preventing a wide variety of images from being loaded when running locally. The local-dev CSP doesn't protect us from anything, since it's not used in prod, and it doesn't make use of any re-usable config either, so it's really not serving any purpose aside from creating some challenging local-only issues that are tough to debug.

#### Before
<img width="1294" alt="Screenshot 2024-10-01 at 12 54 42 PM" src="https://github.com/user-attachments/assets/07c01a5e-c325-4c3c-a393-c20c40068f6f">

#### After

<img width="1295" alt="Screenshot 2024-10-01 at 12 51 36 PM" src="https://github.com/user-attachments/assets/ac38a140-627e-4eac-8e39-1d141494fed1">

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [x] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [x] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [x] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [x] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../load_tests/README.md)
* [x] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

