### PR TITLE
feat(docker): Allow dotcom-1 and dotcom-2 start in parallel in docker compose

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -62,8 +62,8 @@ services:
             context: ../
             dockerfile: ./deploy/dotcom/dev/Dockerfile
         depends_on:
-            dotcom-1:
-                condition: service_healthy
+            redis-cluster-init:
+                condition: service_started
         env_file:
             - ../.env
         environment:

--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -3,6 +3,8 @@ services:
     nginx:
         image: nginx:stable-alpine3.17-slim
         depends_on:
+            dotcom-1:
+                condition: service_healthy
             dotcom-2:
                 condition: service_healthy
         volumes:


### PR DESCRIPTION
The current setup has `dotcom-2` wait for `dotcom-1` to finish starting up before it even starts trying. This PR speeds up `docker compose` startup time, since it doesn't force `dotcom-2` to wait anymore.

#### Before

```mermaid
flowchart LR
    dotcom-1 --> dotcom-2 --> nginx
```

#### After

```mermaid
flowchart LR
    dotcom-1 --> nginx
    dotcom-2 --> nginx
```


#### Historical context

- Looks like the chaining was added in https://github.com/mbta/dotcom/pull/1951 in order to keep the parallel `elixir ... mix phx.server` processes from stepping on each other. That's because they were both (under the hood) running `mix deps.compile` and writing to the same `_build` directory, which was mounted in by docker-compose.
- But with the changes introduced in https://github.com/mbta/dotcom/pull/2182, `dotcom-1` and `dotcom-2` aren't sharing the same `_build` directory anymore, and `mix deps.compile` is run as part of building the image, which means it doesn't happen again when the containers are starting up, so chaining is no longer necessary.