### PR TITLE
fix: Restore cache calls in LocationService, fixing some warnings

### DIFF
--- a/lib/location_service/location_service.ex
+++ b/lib/location_service/location_service.ex
@@ -6,6 +6,8 @@ defmodule LocationService do
   use Nebulex.Caching.Decorators
 
   @aws_client Application.compile_env!(:dotcom, :aws_client)
+  @cache Application.compile_env!(:dotcom, :cache)
+  @ttl :timer.hours(24)
 
   @base_options %{
     "FilterCountries" => ["USA"],
@@ -23,6 +25,7 @@ defmodule LocationService do
   @behaviour LocationService.Behaviour
 
   @impl LocationService.Behaviour
+  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   def autocomplete(text, limit, options \\ @bias_options) do
     options
     |> Map.merge(%{"Text" => text, "MaxResults" => limit})
@@ -30,6 +33,7 @@ defmodule LocationService do
     |> handle_response()
   end
 
+  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   @impl LocationService.Behaviour
   def geocode(address, options \\ @bounding_options) do
     options
@@ -38,6 +42,7 @@ defmodule LocationService do
     |> handle_response()
   end
 
+  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   @impl LocationService.Behaviour
   def reverse_geocode(latitude, longitude, options \\ @bounding_options) do
     options

--- a/lib/location_service/location_service.ex
+++ b/lib/location_service/location_service.ex
@@ -6,8 +6,6 @@ defmodule LocationService do
   use Nebulex.Caching.Decorators
 
   @aws_client Application.compile_env!(:dotcom, :aws_client)
-  @cache Application.compile_env!(:dotcom, :cache)
-  @ttl :timer.hours(24)
 
   @base_options %{
     "FilterCountries" => ["USA"],
@@ -25,7 +23,6 @@ defmodule LocationService do
   @behaviour LocationService.Behaviour
 
   @impl LocationService.Behaviour
-  # @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   def autocomplete(text, limit, options \\ @bias_options) do
     options
     |> Map.merge(%{"Text" => text, "MaxResults" => limit})
@@ -33,7 +30,6 @@ defmodule LocationService do
     |> handle_response()
   end
 
-  # @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   @impl LocationService.Behaviour
   def geocode(address, options \\ @bounding_options) do
     options
@@ -42,7 +38,6 @@ defmodule LocationService do
     |> handle_response()
   end
 
-  # @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   @impl LocationService.Behaviour
   def reverse_geocode(latitude, longitude, options \\ @bounding_options) do
     options


### PR DESCRIPTION
This removes these warnings, which show up any time we run any test

```ex
     warning: module attribute @ttl was set but never used
     │
  10 │   @ttl :timer.hours(24)
     │   ~~~~~~~~~~~~~~~~~~~~~
     │
     └─ lib/location_service/location_service.ex:10: LocationService (module)

     warning: module attribute @cache was set but never used
     │
   9 │   @cache Application.compile_env!(:dotcom, :cache)
     │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     │
     └─ lib/location_service/location_service.ex:9: LocationService (module)

```