### PR TITLE
Make sure Rancher Desktop works

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,40 @@ For details on environment configuration, including optional variables, see
 
 The easiest way to develop MBTA dotcom is to use Docker Compose.
 
+### Installing Rancher Desktop
+
+We have tested this setup using [Rancher Desktop](https://rancherdesktop.io) on Mac.
+
+Install Rancher Desktop and then download the [docker-credential-osxkeychain](https://github.com/docker/docker-credential-helpers/releases) binary.
+Add it to your `$PATH`.
+
+Install docker and docker compose:
+
+```
+brew install docker docker-compose
+```
+
+Make sure your `~/.docker/config.json` looks like the following:
+
+```json
+{
+  "auths": {},
+  "cliPluginsExtraDirs": [
+    "/opt/homebrew/lib/docker/cli-plugins"
+  ],
+  "credsStore": "osxkeychain",
+  "currentContext": "rancher-desktop"
+}
+```
+
+Login to docker:
+
+```
+docker login
+```
+
+### Run docker compose
+
 ```
 docker compose -f deploy/dev.yml up -d --build
 ```

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Login to Docker:
 docker login
 ```
 
+Start Rancher Desktop.
+
 ### Run Docker Compose
 
 ```

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Login to docker:
 docker login
 ```
 
-### Run docker compose
+### Run Docker Compose
 
 ```
 docker compose -f deploy/dev.yml up -d --build

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ We have tested this setup using [Rancher Desktop](https://rancherdesktop.io) on 
 Install Rancher Desktop and then download the [docker-credential-osxkeychain](https://github.com/docker/docker-credential-helpers/releases) binary.
 Add it to your `$PATH`.
 
-Install docker and docker compose:
+Install Docker and Docker Compose:
 
 ```
 brew install docker docker-compose
@@ -149,7 +149,7 @@ Make sure your `~/.docker/config.json` looks like the following:
 }
 ```
 
-Login to docker:
+Login to Docker:
 
 ```
 docker login

--- a/deploy/monitor/Dockerfile
+++ b/deploy/monitor/Dockerfile
@@ -7,9 +7,9 @@ RUN useradd -m runner
 USER runner
 WORKDIR /home/runner
 
-COPY package*.json .
+COPY package.json .
 
-RUN npm ci --ignore-scripts
+RUN npm install --omit=optional --audit false --fund false --loglevel verbose --ignore-scripts
 
 RUN ./node_modules/pm2/bin/pm2 install pm2-logrotate
 RUN ./node_modules/pm2/bin/pm2 set pm2-logrotate:max_size 1M


### PR DESCRIPTION
We want to make sure that we can run the Docker Compose setup w/out using Docker Desktop in case the bootjacks come for us in the night. Copying over the package lock in the monitor image was failing because it was requiring some Mac-only deps.

