### PR TITLE
chore(TripPlan.InputForm): change modes type from enum to map

### DIFF
--- a/lib/dotcom_web/components/live_components/trip_planner_form.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_form.ex
@@ -5,18 +5,16 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerForm do
   use DotcomWeb, :live_component
 
   import DotcomWeb.ViewHelpers, only: [svg: 1]
-  import Phoenix.HTML.Form, only: [input_name: 2, input_value: 2, input_id: 2]
-
   import MbtaMetro.Components.Feedback
   import MbtaMetro.Components.InputGroup
+  import Phoenix.HTML.Form, only: [input_name: 2, input_value: 2, input_id: 2]
 
-  alias Dotcom.TripPlan.{InputForm, OpenTripPlanner}
+  alias Dotcom.TripPlan.{InputForm, InputForm.Modes, OpenTripPlanner}
 
-  @all_modes [:RAIL, :SUBWAY, :BUS, :FERRY]
   @form_defaults %{
     "datetime_type" => :now,
     "datetime" => NaiveDateTime.local_now(),
-    "modes" => @all_modes,
+    "modes" => InputForm.initial_modes(),
     "wheelchair" => true
   }
 
@@ -130,45 +128,18 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerForm do
           <.fieldset legend="Modes">
             <.accordion>
               <:heading>
-                <%= selected_modes(input_value(@form, :modes)) %>
+                <%= Modes.selected_modes(input_value(f, :modes)) %>
               </:heading>
               <:content>
-                <div class="flex flex-col gap-1">
-                  <input
-                    type="checkbox"
-                    class="peer sr-only"
-                    name={input_name(@form, :modes) <> "[]"}
-                    value=""
-                    checked="true"
-                  />
-                  <label
-                    :for={
-                      {mode_name, mode_value} <- [
-                        {"Commuter Rail", :RAIL},
-                        {"Subway", :SUBWAY},
-                        {"Bus", :BUS},
-                        {"Ferry", :FERRY}
-                      ]
-                    }
-                    for={input_id(@form, :modes) <> "_#{mode_value}"}
-                    class="rounded border-solid border-2 border-transparent hover:bg-zinc-100 has-[:checked]:font-semibold py-1 px-2 mb-0"
-                  >
-                    <input
+                <div class="flex flex-col gap-05 px-2">
+                  <.inputs_for :let={f} field={f[:modes]}>
+                    <.input
+                      :for={subfield <- Modes.fields()}
                       type="checkbox"
-                      class="shrink-0 mr-2 rounded w-6 h-6 border-blue-500 rounded border-solid border-2 focus:border-blue-700 checked:border-blue-700 checked:bg-blue-700"
-                      id={input_id(@form, :modes)  <> "_#{mode_value}"}
-                      name={input_name(@form, :modes) <> "[]"}
-                      value={mode_value}
-                      checked={
-                        if(input_value(@form, :modes),
-                          do:
-                            mode_value in input_value(@form, :modes) ||
-                              "#{mode_value}" in input_value(@form, :modes)
-                        )
-                      }
+                      field={f[subfield]}
+                      label={Modes.mode_label(subfield)}
                     />
-                    <%= mode_name %>
-                  </label>
+                  </.inputs_for>
                 </div>
               </:content>
               <:extra :if={used_input?(f[:modes])}>
@@ -230,45 +201,5 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerForm do
     result = OpenTripPlanner.plan(data)
     _ = on_submit.(result)
     result
-  end
-
-  defp mode_atom(mode) do
-    case mode do
-      :RAIL -> :commuter_rail
-      :SUBWAY -> :subway
-      :BUS -> :bus
-      :FERRY -> :ferry
-      other when is_binary(other) and other != "" -> String.to_atom(other)
-      _ -> :unknown
-    end
-  end
-
-  defp mode_name(mode) do
-    case mode_atom(mode) do
-      :unknown ->
-        ""
-
-      other ->
-        DotcomWeb.ViewHelpers.mode_name(other)
-    end
-  end
-
-  defp selected_modes(modes) when modes == @all_modes do
-    "All modes"
-  end
-
-  defp selected_modes([]), do: "No transit modes selected"
-  defp selected_modes(nil), do: "No transit modes selected"
-
-  defp selected_modes([mode]), do: mode_name(mode) <> " Only"
-  defp selected_modes([mode1, mode2]), do: mode_name(mode1) <> " and " <> mode_name(mode2)
-
-  defp selected_modes(modes) do
-    modes
-    |> Enum.map(&mode_name/1)
-    |> Enum.reject(&(&1 == ""))
-    |> Enum.intersperse(", ")
-    |> List.insert_at(-2, "and ")
-    |> Enum.join("")
   end
 end

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -8,7 +8,7 @@ defmodule DotcomWeb.Live.TripPlanner do
   use DotcomWeb, :live_view
 
   alias DotcomWeb.Components.LiveComponents.TripPlannerForm
-  alias Dotcom.TripPlan.ItineraryGroups
+  alias Dotcom.TripPlan.{InputForm.Modes, ItineraryGroups}
 
   import DotcomWeb.Components.TripPlanner.ItineraryGroup, only: [itinerary_group: 1]
 
@@ -38,10 +38,21 @@ defmodule DotcomWeb.Live.TripPlanner do
         on_submit={fn data -> send(self(), {:updated_form, data}) end}
       />
       <section>
-        <p :if={@submitted_values && @groups} class="text-lg text-emerald-700">
-          <%= Enum.count(@groups) %> ways to get from <%= @submitted_values.from.name %> to <%= @submitted_values.to.name %>, using <%= inspect(
-            @submitted_values.modes
-          ) %>
+        <p :if={@submitted_values} class="text-xl">
+          Planning trips from <strong><%= @submitted_values.from.name %></strong>
+          to <strong><%= @submitted_values.to.name %></strong>
+          <br /> using <strong><%= Modes.selected_modes(@submitted_values.modes) %></strong>,
+          <strong>
+            <%= if @submitted_values.datetime_type == :arrive_by, do: "Arriving by", else: "Leaving" %> <%= @submitted_values.datetime
+            |> Timex.format!("{Mfull} {D}, {h12}:{m} {AM}") %>
+          </strong>
+        </p>
+        <p :if={@submitted_values && @groups} class="text-xl text-emerald-600">
+          Found
+          <strong>
+            <%= Enum.count(@groups) %> <%= Inflex.inflect("way", Enum.count(@groups)) %>
+          </strong>
+          to go.
         </p>
       </section>
       <section class="flex w-full border border-solid border-slate-400">

--- a/test/dotcom/trip_plan/input_form_test.exs
+++ b/test/dotcom/trip_plan/input_form_test.exs
@@ -11,13 +11,13 @@ defmodule Dotcom.TripPlan.InputFormTest do
     "latitude" => "#{Faker.Address.latitude()}",
     "longitude" => "#{Faker.Address.longitude()}"
   }
-  @mode_params InputForm.valid_modes()
+  @mode_params InputForm.initial_modes()
   @params %{
     "from" => @from_params,
     "to" => @to_params,
     "datetime_type" => Faker.Util.pick(InputForm.time_types()) |> to_string(),
     "datetime" => Faker.DateTime.forward(4) |> to_string(),
-    "modes" => @mode_params |> Enum.map(&to_string/1),
+    "modes" => @mode_params,
     "wheelchair" => Faker.Util.pick(["true", "false"])
   }
 
@@ -25,6 +25,11 @@ defmodule Dotcom.TripPlan.InputFormTest do
     changeset = InputForm.changeset(%{})
     assert {_, [validation: :required]} = changeset.errors[:from]
     assert {_, [validation: :required]} = changeset.errors[:to]
+  end
+
+  test "mode required" do
+    changeset = InputForm.changeset(%{modes: nil})
+    assert {_, [validation: :required]} = changeset.errors[:modes]
   end
 
   describe "validate_params/1" do
@@ -67,6 +72,78 @@ defmodule Dotcom.TripPlan.InputFormTest do
       expected_error = InputForm.error_message(:from_to_same)
       assert {^expected_error, _} = changeset.errors[:to]
     end
+
+    test "at least one mode required" do
+      changeset =
+        InputForm.validate_params(%{
+          @params
+          | "modes" => %{RAIL: false, BUS: false, FERRY: false, SUBWAY: false}
+        })
+
+      refute changeset.valid?
+
+      expected_error = InputForm.error_message(:modes)
+      assert {^expected_error, _} = changeset.errors[:modes]
+    end
+
+    test "adds datetime if using datetime_type == now" do
+      changeset =
+        InputForm.validate_params(%{
+          @params
+          | "datetime_type" => "now",
+            "datetime" => nil
+        })
+
+      assert changeset.valid?
+      assert %DateTime{} = changeset.changes[:datetime]
+    end
+
+    test "datetime required if using datetime_type != now" do
+      expected_error = InputForm.error_message(:datetime)
+
+      changeset =
+        InputForm.validate_params(%{
+          @params
+          | "datetime_type" => "arrive_by",
+            "datetime" => nil
+        })
+
+      refute changeset.valid?
+      assert {^expected_error, _} = changeset.errors[:datetime]
+
+      changeset =
+        InputForm.validate_params(%{
+          @params
+          | "datetime_type" => "leave_at",
+            "datetime" => nil
+        })
+
+      refute changeset.valid?
+      assert {^expected_error, _} = changeset.errors[:datetime]
+    end
+
+    test "requires date to be in the future" do
+      changeset =
+        InputForm.validate_params(%{
+          @params
+          | "datetime_type" => "arrive_by",
+            "datetime" => Faker.DateTime.forward(1)
+        })
+
+      assert changeset.valid?
+
+      expected_error = InputForm.error_message(:datetime)
+
+      changeset =
+        InputForm.validate_params(%{
+          @params
+          | "datetime_type" => "arrive_by",
+            "datetime" => Faker.DateTime.backward(1)
+        })
+
+      refute changeset.valid?
+      assert {^expected_error, _} = changeset.errors[:datetime]
+    end
   end
 
   describe "Location" do
@@ -87,6 +164,35 @@ defmodule Dotcom.TripPlan.InputFormTest do
         })
 
       assert changeset.changes.name == "#{lat}, #{lon}"
+    end
+  end
+
+  describe "Modes" do
+    test "selected_modes/1 summarizes two values" do
+      changeset =
+        InputForm.Modes.changeset(%InputForm.Modes{}, %{
+          "RAIL" => "true",
+          "SUBWAY" => "true",
+          "BUS" => "false",
+          "FERRY" => "false"
+        })
+
+      assert "Commuter Rail and Subway" = InputForm.Modes.selected_modes(changeset)
+    end
+
+    test "selected_modes/1 summarizes one value" do
+      data = %InputForm.Modes{RAIL: false, SUBWAY: false, BUS: true, FERRY: false}
+      assert "Bus Only" = InputForm.Modes.selected_modes(data)
+    end
+
+    test "selected_modes/1 summarizes many values" do
+      data = %InputForm.Modes{RAIL: true, SUBWAY: false, BUS: true, FERRY: true}
+      assert "Commuter Rail, Bus, and Ferry" = InputForm.Modes.selected_modes(data)
+    end
+
+    test "selected_modes/1 summarizes all values" do
+      data = %InputForm.Modes{RAIL: true, SUBWAY: true, BUS: true, FERRY: true}
+      assert "All modes" = InputForm.Modes.selected_modes(data)
     end
   end
 end

--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -51,7 +51,7 @@ defmodule DotcomWeb.Live.TripPlannerTest do
         |> element("form")
         |> render_change(%{
           _target: ["input_form", "modes"],
-          input_form: %{modes: [:commuter_rail, :subway, :ferry]}
+          input_form: %{modes: %{RAIL: true, SUBWAY: true, FERRY: true, BUS: false}}
         })
 
       assert html =~ "Commuter Rail, Subway, and Ferry"
@@ -59,7 +59,10 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       html =
         view
         |> element("form")
-        |> render_change(%{_target: ["input_form", "modes"], input_form: %{modes: [:subway]}})
+        |> render_change(%{
+          _target: ["input_form", "modes"],
+          input_form: %{modes: %{SUBWAY: true, BUS: false, RAIL: false, FERRY: false}}
+        })
 
       assert html =~ "Subway Only"
 
@@ -68,7 +71,7 @@ defmodule DotcomWeb.Live.TripPlannerTest do
         |> element("form")
         |> render_change(%{
           _target: ["input_form", "modes"],
-          input_form: %{modes: [:subway, :bus]}
+          input_form: %{modes: %{SUBWAY: true, BUS: true, RAIL: false, FERRY: false}}
         })
 
       assert html =~ "Subway and Bus"


### PR DESCRIPTION
While polishing up the mode selector I struggled to reconcile the current form field values (for modes, initially a list of atoms, e.g. `[:RAIL, :BUS]`) with how the default checkboxes work (each setting a true/false value). Rather than devise some new checkbox group component, I decided to keep the traditional checkboxes and change the form schema. So now modes is a map, where each key is a mode and each value is a boolean. It works great.

I also moved some display logic outside of the form live component. This let me render the selected modes summary outside the form like so :) 

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/ca9e6e87-2906-49d1-86e4-fafd76b5873c">

Finally added some missing tests around form validation mostly.