### PR TITLE
fix: Failing "publish docs" build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/configure-pages@v5
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.2
-          elixir-version: 1.16.1
+          otp-version: 27.0
+          elixir-version: 1.17.0
       - run: mix deps.get
       - run: mix docs --formatter html
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
The `Publish docs` action has been failing consistently for a few weeks with this message:

```
** (Mix) You're trying to run :dotcom on Elixir v1.16.1 but it has declared in its mix.exs file it supports only Elixir ~> 1.17
Error: Process completed with exit code 1.
```

This should fix that.

Example: https://github.com/mbta/dotcom/actions/runs/11371895399/job/31634982030