### PR TITLE
fix: Update module name for ItineraryGroupTest to fix warning

### DIFF
--- a/test/dotcom/trip_plan/itinerary_group_test.exs
+++ b/test/dotcom/trip_plan/itinerary_group_test.exs
@@ -1,4 +1,4 @@
-defmodule Dotcom.TripPlan.ItineraryTest do
+defmodule Dotcom.TripPlan.ItineraryGroupTest do
   @moduledoc false
 
   use ExUnit.Case, async: true


### PR DESCRIPTION
This fixes the warning 👇 that shows up when running `mix test`:

```
warning: redefining module Dotcom.TripPlan.ItineraryTest (current version defined in memory)
```