### PR TITLE
fix: Remove `paths-ignore` from CI Github Action config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,11 +3,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths-ignore:
-      - ".github/workflows/**"
-      - "*.md"
-      - "integration/**"
-      - AUTHORS
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
I've had a few PR's recently that got stuck in a state where there was a build that was required, but that was configured not to run. That has prevented those PR's from being merge-able (Cristen was able to merge them using her ~magic~ admin powers, but it's not good to rely on that).

[Documentation on required status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks) suggests that it's not a good idea to use `paths-ignore` for required checks.

Impacted PR's:
- https://github.com/mbta/dotcom/pull/2177
- https://github.com/mbta/dotcom/pull/2199