### PR TITLE
fix: Icon location for docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule DotCom.Mixfile do
       source_url: "https://github.com/mbta/dotcom",
       homepage_url: "https://www.mbta.com/",
       # The main page in the docs
-      docs: [logo: "assets/static/images/mbta-logo-t.png"]
+      docs: [logo: "priv/static/images/mbta-logo-t.png"]
     ]
   end
 


### PR DESCRIPTION
In https://github.com/mbta/dotcom/pull/2173, we renamed a bunch of files, but didn't update the `docs` mix task to reflect the new location in the filesystem of the T logo. That was causing the docs task to fail.

This should fix that, and hopefully get the docs task publishing again.