### PR TITLE
fix: Have vanity links point to dotcom, rather than CDN

### DIFF
--- a/lib/dotcom/map_helpers.ex
+++ b/lib/dotcom/map_helpers.ex
@@ -55,14 +55,14 @@ defmodule Dotcom.MapHelpers do
 
   @spec image(atom) :: String.t()
   def image(:subway) do
-    static_url(DotcomWeb.Endpoint, "/subway-map-image")
+    "/subway-map-image"
   end
 
   def image(:commuter_rail) do
-    static_url(DotcomWeb.Endpoint, "/cr-map-image")
+    "/cr-map-image"
   end
 
   def image(:ferry) do
-    static_url(DotcomWeb.Endpoint, "/ferry-map-image")
+    "/ferry-map-image"
   end
 end


### PR DESCRIPTION
This should fix this problem 👇 on https://www.mbta.com/schedules/subway.

<img width="498" alt="Screenshot 2024-10-29 at 10 46 48 AM" src="https://github.com/user-attachments/assets/a7601097-67d6-4b76-8428-a7298fa5cbd2">
