### PR TITLE
Take trip planner query params into account in the new trip planner

### DIFF
--- a/lib/dotcom/trip_plan/anti_corruption_layer.ex
+++ b/lib/dotcom/trip_plan/anti_corruption_layer.ex
@@ -1,0 +1,46 @@
+defmodule Dotcom.TripPlan.AntiCorruptionLayer do
+  @moduledoc false
+
+  def convert(%{"plan" => params}) do
+    %{
+      "datetime" => Map.get(params, "date_time") |> convert_datetime(),
+      "datetime_type" => Map.get(params, "time", "now"),
+      "from" => %{
+        "latitude" => Map.get(params, "from_latitude"),
+        "longitude" => Map.get(params, "from_longitude"),
+        "name" => Map.get(params, "from"),
+        "stop_id" => Map.get(params, "from_stop_id", "")
+      },
+      "modes" => Map.get(params, "modes") |> convert_modes(),
+      "to" => %{
+        "latitude" => Map.get(params, "to_latitude"),
+        "longitude" => Map.get(params, "to_longitude"),
+        "name" => Map.get(params, "to"),
+        "stop_id" => Map.get(params, "to_stop_id", "")
+      },
+      "wheelchair" => Map.get(params, "wheelchair") || "false"
+    }
+  end
+
+  def convert(_), do: convert(%{"plan" => %{}})
+
+  defp convert_datetime(datetime) when is_binary(datetime) do
+    case Timex.parse(datetime, "%Y-%m-%d %H:%M %p", :strftime) do
+      {:ok, naivedatetime} -> naivedatetime |> Timex.to_datetime("America/New_York")
+      {:error, _} -> Timex.now("America/New_York")
+    end
+  end
+
+  defp convert_datetime(_), do: Timex.now("America/New_York")
+
+  defp convert_modes(modes) when is_map(modes) do
+    default_modes = for {k, _} <- Dotcom.TripPlan.InputForm.initial_modes(), into: %{}, do: {k, "false"}
+
+    modes
+    |> Enum.reduce(default_modes, fn {key, value}, acc ->
+      Map.put(acc, String.upcase(key), value)
+    end)
+  end
+
+  defp convert_modes(_), do: Dotcom.TripPlan.InputForm.initial_modes()
+end

--- a/lib/dotcom/trip_plan/anti_corruption_layer.ex
+++ b/lib/dotcom/trip_plan/anti_corruption_layer.ex
@@ -3,8 +3,6 @@ defmodule Dotcom.TripPlan.AntiCorruptionLayer do
 
   def convert(%{"plan" => params}) do
     %{
-      "datetime" => Map.get(params, "date_time") |> convert_datetime(),
-      "datetime_type" => Map.get(params, "time", "now"),
       "from" => %{
         "latitude" => Map.get(params, "from_latitude"),
         "longitude" => Map.get(params, "from_longitude"),
@@ -23,15 +21,6 @@ defmodule Dotcom.TripPlan.AntiCorruptionLayer do
   end
 
   def convert(_), do: convert(%{"plan" => %{}})
-
-  defp convert_datetime(datetime) when is_binary(datetime) do
-    case Timex.parse(datetime, "%Y-%m-%d %H:%M %p", :strftime) do
-      {:ok, naivedatetime} -> naivedatetime |> Timex.to_datetime("America/New_York")
-      {:error, _} -> Timex.now("America/New_York")
-    end
-  end
-
-  defp convert_datetime(_), do: Timex.now("America/New_York")
 
   defp convert_modes(modes) when is_map(modes) do
     default_modes = for {k, _} <- Dotcom.TripPlan.InputForm.initial_modes(), into: %{}, do: {k, "false"}

--- a/lib/dotcom_web/components/live_components/trip_planner_form.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_form.ex
@@ -13,20 +13,29 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerForm do
 
   @impl true
   def mount(socket) do
-    form_defaults = %{
+    {:ok, socket}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    form_defaults = Map.get(assigns, :form_values, %{
       "datetime_type" => "now",
       "datetime" => Timex.now("America/New_York"),
       "modes" => InputForm.initial_modes(),
       "wheelchair" => true
-    }
+    })
 
     defaults = %{
       form: %InputForm{} |> InputForm.changeset(form_defaults) |> to_form(),
       location_keys: InputForm.Location.fields(),
       show_datepicker: false
     }
+    new_socket =
+      socket
+      |> assign(assigns)
+      |> assign(defaults)
 
-    {:ok, assign(socket, defaults)}
+    {:ok, new_socket}
   end
 
   @impl true
@@ -40,7 +49,6 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerForm do
         for={@form}
         method="get"
         phx-submit="save_form"
-        phx-change="handle_change"
         phx-target={@myself}
       >
         <div :for={field <- [:from, :to]} class="mb-1" id="trip-planner-locations" phx-update="ignore">
@@ -136,6 +144,10 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerForm do
           </.button>
         </div>
       </.form>
+      <div>
+        <code><%= inspect(@form[:datetime_type].value) %></code>
+        <code><%= inspect(@form[:datetime].value) %></code>
+      </div>
     </section>
     """
   end

--- a/lib/dotcom_web/components/live_components/trip_planner_form.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_form.ex
@@ -53,6 +53,7 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerForm do
         for={@form}
         method="get"
         phx-submit="save_form"
+        phx-change="handle_change"
         phx-target={@myself}
       >
         <div :for={field <- [:from, :to]} class="mb-1" id="trip-planner-locations" phx-update="ignore">

--- a/lib/dotcom_web/components/live_components/trip_planner_form.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_form.ex
@@ -18,12 +18,16 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerForm do
 
   @impl true
   def update(assigns, socket) do
-    form_defaults = Map.get(assigns, :form_values, %{
-      "datetime_type" => "now",
-      "datetime" => Timex.now("America/New_York"),
-      "modes" => InputForm.initial_modes(),
-      "wheelchair" => true
-    })
+    form_defaults =
+      assigns
+      |> Map.get(:form_values, %{
+        "modes" => InputForm.initial_modes(),
+        "wheelchair" => true
+      })
+      |> Map.merge(%{
+        "datetime_type" => "now",
+        "datetime" => Timex.now("America/New_York"),
+      })
 
     defaults = %{
       form: %InputForm{} |> InputForm.changeset(form_defaults) |> to_form(),
@@ -144,10 +148,6 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerForm do
           </.button>
         </div>
       </.form>
-      <div>
-        <code><%= inspect(@form[:datetime_type].value) %></code>
-        <code><%= inspect(@form[:datetime].value) %></code>
-      </div>
     </section>
     """
   end

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -18,11 +18,12 @@ defmodule DotcomWeb.Live.TripPlanner do
   @map_config Application.compile_env!(:mbta_metro, :map)
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     socket =
       socket
       |> assign(:error, nil)
       |> assign(:form_name, @form_id)
+      |> assign(:form_values, Dotcom.TripPlan.AntiCorruptionLayer.convert(params))
       |> assign(:map_config, @map_config)
       |> assign(:from, [])
       |> assign(:to, [])
@@ -39,7 +40,7 @@ defmodule DotcomWeb.Live.TripPlanner do
     ~H"""
     <h1>Trip Planner <mark style="font-weight: 400">Preview</mark></h1>
     <div style="row">
-      <.live_component module={TripPlannerForm} id={@form_name} form_name={@form_name} />
+      <.live_component module={TripPlannerForm} id={@form_name} form_name={@form_name} form_values={@form_values} />
       <section :if={@submitted_values} class="mt-2 mb-6">
         <p class="text-lg font-semibold mb-0"><%= submission_summary(@submitted_values) %></p>
         <p><%= time_summary(@submitted_values) %></p>


### PR DESCRIPTION
The time selection is a little trickier because of the change and hide/show behavior. But, we decided to just set it to 'now' since links generated in the past won't work anyway. All other selections are reflected. You can test this by planning a trip with selections and then just switching to `/preview/trip-planner`.

