### PR TITLE
fix(PredictionsChannel): filter out past predictions

### DIFF
--- a/lib/dotcom_web/channels/predictions_channel.ex
+++ b/lib/dotcom_web/channels/predictions_channel.ex
@@ -49,6 +49,7 @@ defmodule DotcomWeb.PredictionsChannel do
         no_departure_time?(prediction) ||
         skipped_or_cancelled?(prediction)
     end)
+    |> Enum.filter(&is_in_future_seconds?/1)
   end
 
   defp no_trip?(prediction), do: is_nil(prediction.trip)
@@ -60,5 +61,9 @@ defmodule DotcomWeb.PredictionsChannel do
   defp skipped_or_cancelled?(prediction) do
     Route.subway?(prediction.route.type, prediction.route.id) &&
       prediction.schedule_relationship in [:cancelled, :skipped]
+  end
+
+  defp is_in_future_seconds?(prediction) do
+    Timex.compare(prediction.departure_time, Util.now(), :seconds) >= 0
   end
 end

--- a/lib/dotcom_web/channels/predictions_channel.ex
+++ b/lib/dotcom_web/channels/predictions_channel.ex
@@ -49,7 +49,7 @@ defmodule DotcomWeb.PredictionsChannel do
         no_departure_time?(prediction) ||
         skipped_or_cancelled?(prediction)
     end)
-    |> Enum.filter(&is_in_future_seconds?/1)
+    |> Enum.filter(&in_future_seconds?/1)
   end
 
   defp no_trip?(prediction), do: is_nil(prediction.trip)
@@ -63,7 +63,7 @@ defmodule DotcomWeb.PredictionsChannel do
       prediction.schedule_relationship in [:cancelled, :skipped]
   end
 
-  defp is_in_future_seconds?(prediction) do
+  defp in_future_seconds?(prediction) do
     Timex.compare(prediction.departure_time, Util.now(), :seconds) >= 0
   end
 end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Fix: Extraneous <1 minute predictions appearing on Stop Pages](https://app.asana.com/0/555089885850811/1208505215613687/f)

Some facts:
- because the backend endpoint that gives the stop page its schedules is cached, the frontend component refreshes every 15s, filtering out the past schedules. 
  - these get merged with the predictions. but plenty of predictions have no corresponding schedule. 
  - and apparently there's no frontend mechanism to filter out stale predictions
- in the backend, past predictions get culled out of our in-memory storage every 5 minutes (gotta keep the ETS table size low)
- the streaming connection we have to the V3 API tells us when to add/remove/update/reset our predictions

Filtering the predictions here in `DotcomWeb.PredictionsChannel`, right before we publish the predictions to stop pages, seems to work ok. My guess is that this logic wasn't included previously because we thought (a) we'd get timely "remove" events from the streaming predictions or (b) something else in our logic would filter these out before making it to the UI.

