### PR TITLE
fix: Swap the sense of the Regex.match? call in route_symbols_test

### DIFF
--- a/test/dotcom_web/components/route_symbols_test.exs
+++ b/test/dotcom_web/components/route_symbols_test.exs
@@ -103,11 +103,14 @@ defmodule DotcomWeb.Components.RouteSymbolsTest do
   end
 
   defp matches_title?(html, text) do
-    html
-    |> Floki.find("title")
-    |> Floki.text()
-    |> String.trim()
+    title =
+      html
+      |> Floki.find("title")
+      |> Floki.text()
+      |> String.trim()
+
+    text
     |> Regex.compile!("i")
-    |> Regex.match?(text)
+    |> Regex.match?(title)
   end
 end


### PR DESCRIPTION
This makes assertions less picky. For instance:

```elixir
    "Massport Route 55" |> Regex.compile!("i") |> Regex.match?("Massport")
```

is `false`, but

```elixir
    "Massport" |> Regex.compile!("i") |> Regex.match?("Massport Route 55")
```

is `true`.

This should hopefully fix the [build that's currently failing](https://github.com/mbta/dotcom/actions/runs/11939144123/job/33279345358).