### PR TITLE
feat: Arrange map and plan results correctly on desktop and mobile

### DIFF
--- a/assets/css/_events.scss
+++ b/assets/css/_events.scss
@@ -181,10 +181,6 @@ $mobile-control-height: 73px;
   cursor: pointer;
 }
 
-.hidden {
-  display: none !important;
-}
-
 .m-event {
   padding: 16px;
   @include media-breakpoint-down(xs) {

--- a/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
@@ -16,27 +16,61 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
 
   @impl true
   def render(assigns) do
+    grid_column_layout = "md:grid-cols-[1fr_1fr]"
+
+    grid_column_layout =
+      case assigns.results.result do
+        nil -> "md:grid-cols-[1fr]"
+        _ -> "md:grid-cols-[1fr_1fr]"
+      end
+
+    assigns = assign(assigns, :grid_column_layout, grid_column_layout)
+
     ~H"""
-    <section class="flex w-full border border-solid border-slate-400">
-      <div :if={@error} class="w-full p-4 text-rose-400">
-        <%= inspect(@error) %>
-      </div>
-      <.async_result :let={results} assign={@results}>
-        <div :if={results} class="w-full p-4">
-          <.itinerary_panel
-            results={results}
-            details_index={@expanded_itinerary_index}
-            target={@myself}
-          />
+    <div>
+      <section class={"flex flex-col md:grid #{@grid_column_layout} md:grid-rows-[min-content_1fr] w-full border border-solid border-slate-400"}>
+        <div :if={@error} class="w-full p-4 text-rose-400">
+          <%= inspect(@error) %>
         </div>
-      </.async_result>
-      <.map
-        map_config={@map_config}
-        from={@from}
-        to={@to}
-        hide_on_mobile={@expanded_itinerary_index == nil}
-      />
-    </section>
+        <.async_result :let={results} assign={@results}>
+          <div
+            :if={results && @expanded_itinerary_index}
+            class="row-start-1 col-start-1 h-min w-full p-4"
+          >
+            <button
+              type="button"
+              phx-click="set_expanded_itinerary_index"
+              phx-value-index="nil"
+              phx-target={@myself}
+              class="btn-link"
+            >
+              <span class="flex flex-row items-center">
+                <.icon class="fill-brand-primary h-4 mr-2" name="chevron-left" />
+                <span class="font-medium">View All Options</span>
+              </span>
+            </button>
+          </div>
+        </.async_result>
+
+        <.map
+          map_config={@map_config}
+          from={@from}
+          to={@to}
+          hide_on_mobile={@expanded_itinerary_index == nil}
+          class="row-span-2"
+        />
+
+        <.async_result :let={results} assign={@results}>
+          <div :if={results} class="w-full p-4 row-start-2 col-start-1">
+            <.itinerary_panel
+              results={results}
+              details_index={@expanded_itinerary_index}
+              target={@myself}
+            />
+          </div>
+        </.async_result>
+      </section>
+    </div>
     """
   end
 
@@ -62,19 +96,6 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
 
     ~H"""
     <div class="mt-30">
-      <button
-        type="button"
-        phx-click="set_expanded_itinerary_index"
-        phx-value-index="nil"
-        phx-target={@target}
-        class="btn-link"
-      >
-        <p class="flex flex-row items-center">
-          <.icon class="fill-brand-primary h-4 mr-2" name="chevron-left" />
-          <span class="font-medium">View All Options</span>
-        </p>
-      </button>
-
       <div class="border-b-[1px] border-gray-lighter">
         <.itinerary_summary summary={@summary} />
       </div>
@@ -98,7 +119,7 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
     <.live_component
       module={MbtaMetro.Live.Map}
       id="trip-planner-map"
-      class={["h-96 w-full relative overflow-none", @display_classes]}
+      class={["h-64 md:h-96 w-full relative overflow-none", @display_classes, @class]}
       config={@map_config}
       pins={[@from, @to]}
     />

--- a/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
@@ -16,8 +16,6 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
 
   @impl true
   def render(assigns) do
-    grid_column_layout = "md:grid-cols-[1fr_1fr]"
-
     grid_column_layout =
       case assigns.results.result do
         nil -> "md:grid-cols-[1fr]"

--- a/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
@@ -30,12 +30,10 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
           />
         </div>
       </.async_result>
-      <.live_component
-        module={MbtaMetro.Live.Map}
-        id="trip-planner-map"
-        class="h-96 w-full relative overflow-none"
-        config={@map_config}
-        pins={[@from, @to]}
+      <.map
+        map_config={@map_config}
+        from={@from}
+        to={@to}
       />
     </section>
     """
@@ -82,6 +80,18 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
 
       <.itinerary_detail :for={itinerary <- @itineraries} itinerary={itinerary} />
     </div>
+    """
+  end
+
+  defp map(assigns) do
+    ~H"""
+    <.live_component
+      module={MbtaMetro.Live.Map}
+      id="trip-planner-map"
+      class="h-96 w-full relative overflow-none"
+      config={@map_config}
+      pins={[@from, @to]}
+    />
     """
   end
 

--- a/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
@@ -25,50 +25,48 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
     assigns = assign(assigns, :grid_column_layout, grid_column_layout)
 
     ~H"""
-    <div>
-      <section class={"flex flex-col md:grid #{@grid_column_layout} md:grid-rows-[min-content_1fr] w-full border border-solid border-slate-400"}>
-        <div :if={@error} class="w-full p-4 text-rose-400">
-          <%= inspect(@error) %>
-        </div>
-        <.async_result :let={results} assign={@results}>
-          <div
-            :if={results && @expanded_itinerary_index}
-            class="row-start-1 col-start-1 h-min w-full p-4"
+    <section class={"flex flex-col md:grid #{@grid_column_layout} md:grid-rows-[min-content_1fr] w-full border border-solid border-slate-400"}>
+      <div :if={@error} class="w-full p-4 text-rose-400">
+        <%= inspect(@error) %>
+      </div>
+      <.async_result :let={results} assign={@results}>
+        <div
+          :if={results && @expanded_itinerary_index}
+          class="row-start-1 col-start-1 h-min w-full p-4"
+        >
+          <button
+            type="button"
+            phx-click="set_expanded_itinerary_index"
+            phx-value-index="nil"
+            phx-target={@myself}
+            class="btn-link"
           >
-            <button
-              type="button"
-              phx-click="set_expanded_itinerary_index"
-              phx-value-index="nil"
-              phx-target={@myself}
-              class="btn-link"
-            >
-              <span class="flex flex-row items-center">
-                <.icon class="fill-brand-primary h-4 mr-2" name="chevron-left" />
-                <span class="font-medium">View All Options</span>
-              </span>
-            </button>
-          </div>
-        </.async_result>
+            <span class="flex flex-row items-center">
+              <.icon class="fill-brand-primary h-4 mr-2" name="chevron-left" />
+              <span class="font-medium">View All Options</span>
+            </span>
+          </button>
+        </div>
+      </.async_result>
 
-        <.map
-          map_config={@map_config}
-          from={@from}
-          to={@to}
-          hide_on_mobile={@expanded_itinerary_index == nil}
-          class="row-span-2"
-        />
+      <.map
+        map_config={@map_config}
+        from={@from}
+        to={@to}
+        hide_on_mobile={@expanded_itinerary_index == nil}
+        class="row-span-2"
+      />
 
-        <.async_result :let={results} assign={@results}>
-          <div :if={results} class="w-full p-4 row-start-2 col-start-1">
-            <.itinerary_panel
-              results={results}
-              details_index={@expanded_itinerary_index}
-              target={@myself}
-            />
-          </div>
-        </.async_result>
-      </section>
-    </div>
+      <.async_result :let={results} assign={@results}>
+        <div :if={results} class="w-full p-4 row-start-2 col-start-1">
+          <.itinerary_panel
+            results={results}
+            details_index={@expanded_itinerary_index}
+            target={@myself}
+          />
+        </div>
+      </.async_result>
+    </section>
     """
   end
 

--- a/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
@@ -34,6 +34,7 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
         map_config={@map_config}
         from={@from}
         to={@to}
+        hide_on_mobile={@expanded_itinerary_index == nil}
       />
     </section>
     """
@@ -83,12 +84,21 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
     """
   end
 
-  defp map(assigns) do
+  defp map(%{hide_on_mobile: hide_on_mobile} = assigns) do
+    display_classes =
+      if hide_on_mobile do
+        "hidden md:block"
+      else
+        ""
+      end
+
+    assigns = assign(assigns, :display_classes, display_classes)
+
     ~H"""
     <.live_component
       module={MbtaMetro.Live.Map}
       id="trip-planner-map"
-      class="h-96 w-full relative overflow-none"
+      class={["h-96 w-full relative overflow-none", @display_classes]}
       config={@map_config}
       pins={[@from, @to]}
     />

--- a/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
@@ -16,16 +16,15 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
 
   @impl true
   def render(assigns) do
-    grid_column_layout =
-      case assigns.results.result do
-        nil -> "md:grid-cols-[1fr]"
-        _ -> "md:grid-cols-[1fr_1fr]"
-      end
-
-    assigns = assign(assigns, :grid_column_layout, grid_column_layout)
-
     ~H"""
-    <section class={"flex flex-col md:grid #{@grid_column_layout} md:grid-rows-[min-content_1fr] w-full border border-solid border-slate-400"}>
+    <section class={[
+      "flex flex-col",
+      "md:grid md:grid-rows-[min-content_1fr]",
+      @results.result == nil && "md:grid-cols-[1fr]",
+      @results.result != nil && "md:grid-cols-[1fr_1fr]",
+      "w-full",
+      "border border-solid border-slate-400"
+    ]}>
       <div :if={@error} class="w-full p-4 text-rose-400">
         <%= inspect(@error) %>
       </div>

--- a/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
@@ -48,12 +48,16 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
         </div>
       </.async_result>
 
-      <.map
-        map_config={@map_config}
-        from={@from}
-        to={@to}
-        hide_on_mobile={@expanded_itinerary_index == nil}
-        class="row-span-2"
+      <.live_component
+        module={MbtaMetro.Live.Map}
+        id="trip-planner-map"
+        class={[
+          "h-64 md:h-96 w-full",
+          "relative overflow-none row-span-2",
+          @expanded_itinerary_index == nil && "hidden md:block"
+        ]}
+        config={@map_config}
+        pins={[@from, @to]}
       />
 
       <.async_result :let={results} assign={@results}>
@@ -97,27 +101,6 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
 
       <.itinerary_detail :for={itinerary <- @itineraries} itinerary={itinerary} />
     </div>
-    """
-  end
-
-  defp map(%{hide_on_mobile: hide_on_mobile} = assigns) do
-    display_classes =
-      if hide_on_mobile do
-        "hidden md:block"
-      else
-        ""
-      end
-
-    assigns = assign(assigns, :display_classes, display_classes)
-
-    ~H"""
-    <.live_component
-      module={MbtaMetro.Live.Map}
-      id="trip-planner-map"
-      class={["h-64 md:h-96 w-full relative overflow-none", @display_classes, @class]}
-      config={@map_config}
-      pins={[@from, @to]}
-    />
     """
   end
 


### PR DESCRIPTION
# Mobile

## Before
<img width="393" alt="Screenshot 2024-11-29 at 12 51 00 PM" src="https://github.com/user-attachments/assets/84b3d26d-a471-4197-9772-9c4703355e76">

<img width="393" alt="Screenshot 2024-11-29 at 12 51 09 PM" src="https://github.com/user-attachments/assets/4307da4a-e32f-43b7-ac47-c5d28f007daa">


## After
<img width="397" alt="Screenshot 2024-11-29 at 12 47 43 PM" src="https://github.com/user-attachments/assets/3c029812-cbd2-421f-9fb3-157524591e8f">
<img width="399" alt="Screenshot 2024-11-29 at 12 48 03 PM" src="https://github.com/user-attachments/assets/d67fa1a2-7a93-4310-ad9a-6f4e841ab6a9">


# Desktop

Looks pretty much the same

---

**Asana Ticket:** [Trip Planner Preview | Scaffold out the responsive mobile/desktop layout](https://app.asana.com/0/555089885850811/1208788271277297/f)

