### PR TITLE
refactor: Change itinerary-panel-view state for TripPlannerResultsSection

### DIFF
--- a/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
+++ b/lib/dotcom_web/components/live_components/trip_planner_results_section.ex
@@ -74,37 +74,6 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
     """
   end
 
-  defp itinerary_panel(%{itinerary_selection: :summary} = assigns) do
-    ~H"""
-    <div
-      :for={{%{summary: summary}, index} <- Enum.with_index(@results)}
-      class="border border-solid m-4 p-4"
-    >
-      <div
-        :if={summary.tag}
-        class="whitespace-nowrap leading-none font-bold font-heading text-sm uppercase bg-brand-primary-darkest text-white px-3 py-2 mb-3 -ml-4 -mt-4 rounded-br-lg w-min"
-      >
-        <%= summary.tag %>
-      </div>
-      <.itinerary_summary summary={summary} />
-      <div class="flex justify-end items-center">
-        <div :if={Enum.count(summary.next_starts) > 0} class="grow text-sm text-grey-dark">
-          Similar trips depart at <%= Enum.map(summary.next_starts, &format_datetime_short/1)
-          |> Enum.join(", ") %>
-        </div>
-        <button
-          class="btn-link font-semibold underline"
-          phx-click="set_itinerary_group_index"
-          phx-target={@target}
-          phx-value-index={index}
-        >
-          Details
-        </button>
-      </div>
-    </div>
-    """
-  end
-
   defp itinerary_panel(
          %{
            results: results,
@@ -140,13 +109,33 @@ defmodule DotcomWeb.Components.LiveComponents.TripPlannerResultsSection do
   end
 
   defp itinerary_panel(assigns) do
-    Sentry.capture_message("Error loading planned trips",
-      extra: %{assigns: assigns},
-      tags: %{feature: "Trip Planner"}
-    )
-
     ~H"""
-    <div>Error loading planned trips</div>
+    <div
+      :for={{%{summary: summary}, index} <- Enum.with_index(@results)}
+      class="border border-solid m-4 p-4"
+    >
+      <div
+        :if={summary.tag}
+        class="whitespace-nowrap leading-none font-bold font-heading text-sm uppercase bg-brand-primary-darkest text-white px-3 py-2 mb-3 -ml-4 -mt-4 rounded-br-lg w-min"
+      >
+        <%= summary.tag %>
+      </div>
+      <.itinerary_summary summary={summary} />
+      <div class="flex justify-end items-center">
+        <div :if={Enum.count(summary.next_starts) > 0} class="grow text-sm text-grey-dark">
+          Similar trips depart at <%= Enum.map(summary.next_starts, &format_datetime_short/1)
+          |> Enum.join(", ") %>
+        </div>
+        <button
+          class="btn-link font-semibold underline"
+          phx-click="set_itinerary_group_index"
+          phx-target={@target}
+          phx-value-index={index}
+        >
+          Details
+        </button>
+      </div>
+    </div>
     """
   end
 

--- a/lib/dotcom_web/components/trip_planner/itinerary_detail.ex
+++ b/lib/dotcom_web/components/trip_planner/itinerary_detail.ex
@@ -26,7 +26,7 @@ defmodule DotcomWeb.Components.TripPlanner.ItineraryDetail do
         <.depart_at_button
           :for={{itinerary, index} <- Enum.with_index(@itineraries)}
           active={@selected_itinerary_detail_index == index}
-          phx-click="set_selected_itinerary_detail_index"
+          phx-click="set_itinerary_index"
           phx-value-trip-index={index}
           phx-target={@target}
         >


### PR DESCRIPTION
It was bugging me that `expanded_itinerary_index` and `selected_itinerary_detail_index` were separate assigns in `TripPlannerResultsSection` (eventually will get bumped up to `TripPlanner` itself), since in reality, they're more like two parts of the same state. So I decided to try combining them into a single `itinerary_panel_view` assign instead.

Things I like: 
- It's clearer that those two bits of state are in fact related
- It's impossible to accidentally change `expanded_itinerary_index` without also resetting `selected_itinerary_detail_index` (note how those two assigns basically always have to go together in the "before" side of the diff)

Things I'm not sure about:
- With `itinerary_panel_view`, updating which specific itinerary is selected is more of a pain, because we need to keep `:expanded` and the rest of `itinerary_panel_view` the same.