### PR TITLE
fix: Remove wheelchair icon from non-accessible stop pages

### DIFF
--- a/assets/ts/stop/__tests__/components/icons/AccessibilityIconTest.tsx
+++ b/assets/ts/stop/__tests__/components/icons/AccessibilityIconTest.tsx
@@ -23,4 +23,14 @@ describe("AccessibilityIcon", () => {
     );
     expect(screen.getByTestId("empty")).not.toBeEmptyDOMElement();
   });
+
+  it("should not return an icon for an accessible stop", () => {
+    const stop = { accessibility: ["escalator_up"] };
+    render(
+      <div data-testid="empty">
+        <AccessibilityIcon stop={stop as Stop} />
+      </div>
+    );
+    expect(screen.getByTestId("empty")).toBeEmptyDOMElement();
+  });
 });

--- a/assets/ts/stop/components/icons/AccessibilityIcon.tsx
+++ b/assets/ts/stop/components/icons/AccessibilityIcon.tsx
@@ -7,7 +7,7 @@ const AccessibilityIcon = ({
 }: {
   stop: Stop;
 }): ReactElement<HTMLElement> | null => {
-  if (stop.accessibility.length === 0) return null;
+  if (!stop.accessibility.includes("accessible")) return null;
   return (
     <div className="m-stop-page__access-icon">
       <span className="m-stop-page__icon">


### PR DESCRIPTION
# Context

**[Slack Thread](https://mbta.slack.com/archives/C076FBBC21K/p1733238074242899)**
**[Notion Doc](https://www.notion.so/mbta-downtown-crossing/Accessibility-Inconsistencies-151f5d8d11ea8097ac79d213a592d635?pvs=4)**

# Before 
<img width="415" alt="Screenshot 2024-12-03 at 4 36 26 PM" src="https://github.com/user-attachments/assets/b34ccd3f-0070-4fc3-b42c-4862d8638393">
<img width="413" alt="Screenshot 2024-12-03 at 4 36 33 PM" src="https://github.com/user-attachments/assets/0ff57fa1-0edd-48f3-a929-8c3b383514cb">

# After
<img width="413" alt="Screenshot 2024-12-03 at 4 34 57 PM" src="https://github.com/user-attachments/assets/f1eb9515-a34d-41d7-b28d-ff5ccaf7f39d">
<img width="413" alt="Screenshot 2024-12-03 at 4 35 04 PM" src="https://github.com/user-attachments/assets/bd22366d-1563-4eb5-9c5d-dd92b752b0ff">

