### PR TITLE
fix: Make Service.serves_date?/2 use added_stops as a full override

### DIFF
--- a/lib/services/service.ex
+++ b/lib/services/service.ex
@@ -188,9 +188,9 @@ defmodule Services.Service do
     removed_dates = parse_listed_dates(removed_dates)
 
     (dates
-     |> Enum.reject(fn date -> Enum.member?(removed_dates, date) end)
-     |> Enum.reject(fn date -> Timex.weekday(date) not in valid_days end)
-     |> Enum.map(&Timex.to_date/1)
+     |> Stream.reject(fn date -> Enum.member?(removed_dates, date) end)
+     |> Stream.reject(fn date -> Timex.weekday(date) not in valid_days end)
+     |> Stream.map(&Timex.to_date/1)
      |> Enum.uniq()) ++ parse_listed_dates(added_dates)
   end
 

--- a/lib/services/service.ex
+++ b/lib/services/service.ex
@@ -184,6 +184,7 @@ defmodule Services.Service do
         |> Interval.new()
         |> Enum.map(& &1)
       end
+      |> Enum.map(&Timex.to_date/1)
 
     removed_dates = parse_listed_dates(removed_dates)
 

--- a/lib/services/service.ex
+++ b/lib/services/service.ex
@@ -194,7 +194,6 @@ defmodule Services.Service do
       dates
       |> Stream.reject(fn date -> Enum.member?(removed_dates, date) end)
       |> Stream.reject(fn date -> Timex.weekday(date) not in valid_days end)
-      |> Stream.map(&Timex.to_date/1)
       |> Enum.uniq()
 
     explicitly_added_dates ++ valid_dates

--- a/lib/services/service.ex
+++ b/lib/services/service.ex
@@ -194,9 +194,9 @@ defmodule Services.Service do
       dates
       |> Stream.reject(fn date -> Enum.member?(removed_dates, date) end)
       |> Stream.reject(fn date -> Timex.weekday(date) not in valid_days end)
-      |> Enum.uniq()
+      |> Enum.to_list()
 
-    explicitly_added_dates ++ valid_dates
+    Enum.uniq(explicitly_added_dates ++ valid_dates)
   end
 
   @spec parse_listed_dates([String.t()]) :: [NaiveDateTime.t()]

--- a/lib/services/service.ex
+++ b/lib/services/service.ex
@@ -187,15 +187,11 @@ defmodule Services.Service do
 
     removed_dates = parse_listed_dates(removed_dates)
 
-    (dates ++ parse_listed_dates(added_dates))
-    |> Enum.reject(fn date ->
-      # if valid_days is an empty array, the service's dates are likely those in
-      # added_dates, so we can ignore evaluating the day of the week here
-      Enum.member?(removed_dates, date) ||
-        if valid_days != [], do: Timex.weekday(date) not in valid_days
-    end)
-    |> Enum.map(&Timex.to_date/1)
-    |> Enum.uniq()
+    (dates
+     |> Enum.reject(fn date -> Enum.member?(removed_dates, date) end)
+     |> Enum.reject(fn date -> Timex.weekday(date) not in valid_days end)
+     |> Enum.map(&Timex.to_date/1)
+     |> Enum.uniq()) ++ parse_listed_dates(added_dates)
   end
 
   @spec parse_listed_dates([String.t()]) :: [NaiveDateTime.t()]
@@ -204,5 +200,6 @@ defmodule Services.Service do
     |> Enum.map(&Timex.parse(&1, "{ISOdate}"))
     |> Enum.filter(&(elem(&1, 0) == :ok))
     |> Enum.map(&elem(&1, 1))
+    |> Enum.map(&Timex.to_date/1)
   end
 end

--- a/lib/services/service.ex
+++ b/lib/services/service.ex
@@ -187,11 +187,16 @@ defmodule Services.Service do
 
     removed_dates = parse_listed_dates(removed_dates)
 
-    (dates
-     |> Stream.reject(fn date -> Enum.member?(removed_dates, date) end)
-     |> Stream.reject(fn date -> Timex.weekday(date) not in valid_days end)
-     |> Stream.map(&Timex.to_date/1)
-     |> Enum.uniq()) ++ parse_listed_dates(added_dates)
+    explicitly_added_dates = parse_listed_dates(added_dates)
+
+    valid_dates =
+      dates
+      |> Stream.reject(fn date -> Enum.member?(removed_dates, date) end)
+      |> Stream.reject(fn date -> Timex.weekday(date) not in valid_days end)
+      |> Stream.map(&Timex.to_date/1)
+      |> Enum.uniq()
+
+    explicitly_added_dates ++ valid_dates
   end
 
   @spec parse_listed_dates([String.t()]) :: [NaiveDateTime.t()]

--- a/test/dotcom_web/controllers/stop_controller_test.exs
+++ b/test/dotcom_web/controllers/stop_controller_test.exs
@@ -166,7 +166,8 @@ defmodule DotcomWeb.StopControllerTest do
             %JsonApi.Item{
               id: "",
               attributes: %{
-                "schedule_type" => "Weekday"
+                "schedule_type" => "Weekday",
+                "valid_days" => [1, 2, 3, 4, 5, 6, 7]
               },
               relationships: %{},
               type: "service"

--- a/test/services/service_test.exs
+++ b/test/services/service_test.exs
@@ -90,19 +90,19 @@ defmodule Services.ServiceTest do
   end
 
   describe "serves_date?/2" do
-    test "computes if the date is covered by a Service" do
-      # date in added_dates
+    test "returns true if the date is in added_dates" do
       assert Service.serves_date?(
                %Service{
-                 added_dates: ["2022-12-15", "2022-12-14"],
-                 start_date: ~D[2022-12-14],
-                 end_date: ~D[2022-12-15],
-                 valid_days: []
+                 added_dates: ["2022-12-15"],
+                 start_date: ~D[2022-12-01],
+                 end_date: ~D[2022-12-14],
+                 valid_days: [1, 2, 3, 5]
                },
                ~D[2022-12-15]
              )
+    end
 
-      # date in removed_dates
+    test "returns false if the date is in removed_dates" do
       refute Service.serves_date?(
                %Service{
                  removed_dates: ["2022-12-15", "2022-12-14"],
@@ -112,8 +112,9 @@ defmodule Services.ServiceTest do
                },
                ~D[2022-12-15]
              )
+    end
 
-      # date is on right valid_days
+    test "returns true if the date is on a 'valid_days' day of the week" do
       assert Service.serves_date?(
                %Service{
                  start_date: ~D[2022-12-11],
@@ -122,8 +123,9 @@ defmodule Services.ServiceTest do
                },
                ~D[2022-12-15]
              )
+    end
 
-      # date not on right valid_days
+    test "returns false if the date is not on a 'valid_days' day of the week" do
       refute Service.serves_date?(
                %Service{
                  start_date: ~D[2022-12-11],

--- a/test/services/service_test.exs
+++ b/test/services/service_test.exs
@@ -108,7 +108,7 @@ defmodule Services.ServiceTest do
                  removed_dates: ["2022-12-15", "2022-12-14"],
                  start_date: ~D[2022-12-11],
                  end_date: ~D[2022-12-22],
-                 valid_days: []
+                 valid_days: [1, 2, 3, 4, 5, 6, 7]
                },
                ~D[2022-12-15]
              )


### PR DESCRIPTION
This accommodates a very specific type of GTFS service, which looks like

      %Services.Service{
        added_dates: ["2024-12-05"],
        added_dates_notes: %{"2024-12-05" => nil},
        description: "Weekday schedule",
        end_date: ~D[2024-12-04],
        name: "Weekday",
        id: "LRV42024-hlb44011-Weekday-01",
        removed_dates: [],
        removed_dates_notes: %{},
        start_date: ~D[2024-11-27],
        type: :weekday,
        typicality: :typical_service,
        valid_days: [1, 2, 3, 5],
        rating_start_date: ~D[2024-08-25],
        rating_end_date: nil,
        rating_description: "Fall"
      }

The edge case is when the `valid_days` doesn't include the day of the week for the `added_date(s)`. When that happens, the added dates should still be considered served, but the previous version was only handling that correctly if `valid_days` was `[]`.

# Before

![Screenshot 2024-12-05 at 5 29 39 PM](https://github.com/user-attachments/assets/0b8cd409-0a93-4cf0-846e-c8c2080d435f)

# After

![Screenshot 2024-12-05 at 5 29 43 PM](https://github.com/user-attachments/assets/033d097b-c306-46bc-b3f4-016143f6a31d)
