### PR TITLE
feat: Suppress "Depart at" buttons when there's only one itinerary

### DIFF
--- a/lib/dotcom_web/components/trip_planner/itinerary_detail.ex
+++ b/lib/dotcom_web/components/trip_planner/itinerary_detail.ex
@@ -36,14 +36,9 @@ defmodule DotcomWeb.Components.TripPlanner.ItineraryDetail do
   attr :selected_itinerary_detail_index, :integer
   attr :target, :string
 
-  defp depart_at_buttons(%{itineraries: [_]} = assigns) do
-    ~H"""
-    """
-  end
-
   defp depart_at_buttons(assigns) do
     ~H"""
-    <div>
+    <div :if={Enum.count(@itineraries) > 1}>
       <p class="text-sm mb-2 mt-3">Depart at</p>
       <div class="flex">
         <.depart_at_button

--- a/lib/dotcom_web/components/trip_planner/itinerary_detail.ex
+++ b/lib/dotcom_web/components/trip_planner/itinerary_detail.ex
@@ -22,6 +22,28 @@ defmodule DotcomWeb.Components.TripPlanner.ItineraryDetail do
 
     ~H"""
     <div>
+      <.depart_at_buttons
+        selected_itinerary_detail_index={@selected_itinerary_detail_index}
+        itineraries={@itineraries}
+        target={@target}
+      />
+      <.specific_itinerary_detail itinerary={@selected_itinerary} />
+    </div>
+    """
+  end
+
+  attr :itineraries, :list
+  attr :selected_itinerary_detail_index, :integer
+  attr :target, :string
+
+  defp depart_at_buttons(%{itineraries: [_]} = assigns) do
+    ~H"""
+    """
+  end
+
+  defp depart_at_buttons(assigns) do
+    ~H"""
+    <div>
       <p class="text-sm mb-2 mt-3">Depart at</p>
       <div class="flex">
         <.depart_at_button
@@ -34,7 +56,6 @@ defmodule DotcomWeb.Components.TripPlanner.ItineraryDetail do
           {Timex.format!(itinerary.start, "%-I:%M%p", :strftime)}
         </.depart_at_button>
       </div>
-      <.specific_itinerary_detail itinerary={@selected_itinerary} />
     </div>
     """
   end

--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -20,7 +20,7 @@ defmodule DotcomWeb.Live.TripPlannerTest do
     stub_otp_results(itineraries)
   end
 
-  defp update_trip_details(itinerary, trip_id: trip_id, start_time: start_time) do
+  defp update_trip_id(itinerary, trip_id) do
     updated_transit_leg =
       itinerary.legs
       |> Enum.at(1)
@@ -28,6 +28,10 @@ defmodule DotcomWeb.Live.TripPlannerTest do
 
     itinerary
     |> Map.update!(:legs, &List.replace_at(&1, 1, updated_transit_leg))
+  end
+
+  defp update_start_time(itinerary, start_time) do
+    itinerary
     |> Map.put(:start, DateTime.new!(Date.utc_today(), start_time, "America/New_York"))
   end
 
@@ -212,8 +216,8 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       # should update these updates and the assertions below to use
       # the headsign instead of the trip ID.
       stub_otp_results([
-        update_trip_details(base_itinerary, trip_id: trip_id_1, start_time: trip_time_1),
-        update_trip_details(base_itinerary, trip_id: trip_id_2, start_time: trip_time_2)
+        base_itinerary |> update_trip_id(trip_id_1) |> update_start_time(trip_time_1),
+        base_itinerary |> update_trip_id(trip_id_2) |> update_start_time(trip_time_2)
       ])
 
       {:ok, view, _html} = live(conn, ~p"/preview/trip-planner?#{params}")
@@ -252,8 +256,8 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       # should update these updates and the assertions below to use
       # the headsign instead of the trip ID.
       stub_otp_results([
-        update_trip_details(base_itinerary, trip_id: trip_id_1, start_time: trip_time_1),
-        update_trip_details(base_itinerary, trip_id: trip_id_2, start_time: trip_time_2)
+        base_itinerary |> update_trip_id(trip_id_1) |> update_start_time(trip_time_1),
+        base_itinerary |> update_trip_id(trip_id_2) |> update_start_time(trip_time_2)
       ])
 
       {:ok, view, _html} = live(conn, ~p"/preview/trip-planner?#{params}")

--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -235,6 +235,28 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       refute render_async(view) =~ trip_id_1
     end
 
+    test "'Depart At' buttons don't appear if there would only be one", %{
+      conn: conn,
+      params: params
+    } do
+      trip_time_1 = Faker.DateTime.forward(2) |> DateTime.to_time()
+      trip_time_display_1 = trip_time_1 |> Timex.format!("%-I:%M", :strftime)
+
+      base_itinerary = TripPlannerFactory.build(:otp_itinerary)
+
+      stub_otp_results([
+        base_itinerary |> update_start_time(trip_time_1)
+      ])
+
+      {:ok, view, _html} = live(conn, ~p"/preview/trip-planner?#{params}")
+
+      render_async(view)
+
+      view |> element("button", "Details") |> render_click()
+
+      refute view |> element("button", trip_time_display_1) |> has_element?()
+    end
+
     test "'Depart At' button state is not preserved when leaving details view", %{
       conn: conn,
       params: params


### PR DESCRIPTION
# Before

![Screenshot 2024-12-06 at 2 59 28 PM](https://github.com/user-attachments/assets/e7a13a83-90d9-4146-be7d-23f8cf236ae0)

# After
![Screenshot 2024-12-06 at 2 58 53 PM](https://github.com/user-attachments/assets/21beebab-3817-45df-84a0-ebb59973857f)

**Asana Ticket:** [Trip Planner Preview | Suppress "Depart At" buttons if only one itinerary is surfaced in an itinerary group](https://app.asana.com/0/555089885850811/1208923455785213/f)

