### PR TITLE
fix(layout): Shrink margin-top for schedule headers

### DIFF
--- a/assets/css/_schedule.scss
+++ b/assets/css/_schedule.scss
@@ -6,6 +6,7 @@
 .schedule__route-name {
   display: inline-block;
   margin-bottom: calc(#{$base-spacing} / 2);
+  margin-top: 1.75rem;
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
No ticket.

I happened to notice that the layout looked funky, especially on mobile, with what seemed like a huge amount of dead space above the route pill. And sure enough, the Figma showed 28 pixels, while reality showed 44. 

# Desktop

## Before
![Screenshot 2024-12-09 at 1 48 26 PM](https://github.com/user-attachments/assets/2cf802a0-9eed-4498-9490-63d44ccfc56d)

## After
![Screenshot 2024-12-09 at 1 48 06 PM](https://github.com/user-attachments/assets/2f010a36-52bb-4569-9549-6aa2922558e5)

# Mobile

## Before
![Screenshot 2024-12-09 at 1 49 30 PM](https://github.com/user-attachments/assets/6d913b0c-788c-4101-818b-d2f846517d5f)

## After
![Screenshot 2024-12-09 at 1 50 08 PM](https://github.com/user-attachments/assets/9b168f9c-3efb-479c-b935-71d7973919d7)
