### PR TITLE
cleanup: We only need to alias PersonalDetail once

### DIFF
--- a/test/fares/fares_test.exs
+++ b/test/fares/fares_test.exs
@@ -4,7 +4,7 @@ defmodule FaresTest do
 
   import Mox
 
-  alias Dotcom.TripPlan.{NamedPosition, Leg, PersonalDetail, TransitDetail}
+  alias Dotcom.TripPlan.{Leg, NamedPosition, PersonalDetail, TransitDetail}
   alias Test.Support.Factories.{Routes.Route, Stops.Stop}
 
   setup :verify_on_exit!

--- a/test/fares/fares_test.exs
+++ b/test/fares/fares_test.exs
@@ -4,7 +4,7 @@ defmodule FaresTest do
 
   import Mox
 
-  alias Dotcom.TripPlan.{NamedPosition, Leg, PersonalDetail, PersonalDetail, TransitDetail}
+  alias Dotcom.TripPlan.{NamedPosition, Leg, PersonalDetail, TransitDetail}
   alias Test.Support.Factories.{Routes.Route, Stops.Stop}
 
   setup :verify_on_exit!


### PR DESCRIPTION
No ticket. Just happened to notice that we were _really_ making sure that we imported the `PersonalDetail` module.