### PR TITLE
fix: Make "Depart at" buttons wrap rather than overflow

### DIFF
--- a/lib/dotcom_web/components/trip_planner/itinerary_detail.ex
+++ b/lib/dotcom_web/components/trip_planner/itinerary_detail.ex
@@ -23,7 +23,7 @@ defmodule DotcomWeb.Components.TripPlanner.ItineraryDetail do
     ~H"""
     <div>
       <p class="text-sm mb-2 mt-3">Depart at</p>
-      <div class="flex">
+      <div class="flex flex-wrap gap-2">
         <.depart_at_button
           :for={{itinerary, index} <- Enum.with_index(@itineraries)}
           active={@selected_itinerary_detail_index == index}
@@ -50,7 +50,7 @@ defmodule DotcomWeb.Components.TripPlanner.ItineraryDetail do
     <button
       type="button"
       class={[
-        "border border-brand-primary rounded px-2.5 py-1.5 mr-2 text-brand-primary text-lg",
+        "border border-brand-primary rounded px-2.5 py-1.5 text-brand-primary text-lg",
         "hover:bg-brand-primary-lightest #{@background_class}"
       ]}
       {@rest}


### PR DESCRIPTION
No ticket.

Maybe the Right™ answer here is to limit to show no more than some reasonable number of "Depart at" buttons, but I also think we should wrap responsibly, in case whatever limiting we try to do still leads to an overflow.

## Before

![Screenshot 2024-12-10 at 11 37 46 AM](https://github.com/user-attachments/assets/e839561a-5e3d-4f99-a3c4-51ce22bed599)

## After
![Screenshot 2024-12-10 at 11 40 27 AM](https://github.com/user-attachments/assets/b45115f2-6f5e-4b7c-b4a0-b59f69ab5d4d)
