### PR TITLE
fix: Remove invocation of @target from <.itinerary_detail />

### DIFF
--- a/lib/dotcom_web/components/trip_planner/itinerary_detail.ex
+++ b/lib/dotcom_web/components/trip_planner/itinerary_detail.ex
@@ -25,7 +25,6 @@ defmodule DotcomWeb.Components.TripPlanner.ItineraryDetail do
       <.depart_at_buttons
         selected_itinerary_detail_index={@selected_itinerary_detail_index}
         itineraries={@itineraries}
-        target={@target}
       />
       <.specific_itinerary_detail itinerary={@selected_itinerary} />
     </div>
@@ -34,7 +33,6 @@ defmodule DotcomWeb.Components.TripPlanner.ItineraryDetail do
 
   attr :itineraries, :list
   attr :selected_itinerary_detail_index, :integer
-  attr :target, :string
 
   defp depart_at_buttons(assigns) do
     ~H"""


### PR DESCRIPTION
The build is currently failing because of this, and trip planner is broken in dev, so this would be good to merge, assuming that it fixes the problem! 😅 

The change in this PR was missed in [this change](https://github.com/mbta/dotcom/pull/2252/files#diff-305f62bdf1a6c169554d660ab991cb2351a808186609f2fdf0acfe1281b59290)

No ticket.