### PR TITLE
fix: De-duplicate start and end locations when they're next to transit segments

### DIFF
--- a/lib/dotcom/trip_plan/leg_to_segment_helper.ex
+++ b/lib/dotcom/trip_plan/leg_to_segment_helper.ex
@@ -25,11 +25,19 @@ defmodule Dotcom.TripPlan.LegToSegmentHelper do
     {:transit_segment, leg}
   end
 
+  defp prepend_start_location([{:transit_segment, _} | _] = segments) do
+    segments
+  end
+
   defp prepend_start_location([{_, leg} | _] = segments) do
     [
       {:location_segment, %{time: leg.start, place: leg.from}}
       | segments
     ]
+  end
+
+  defp append_end_location([{:transit_segment, _} = last_segment]) do
+    [last_segment]
   end
 
   defp append_end_location([{_, leg} = last_segment]) do

--- a/test/dotcom/trip_plan/leg_to_segment_helper_test.exs
+++ b/test/dotcom/trip_plan/leg_to_segment_helper_test.exs
@@ -44,4 +44,13 @@ defmodule Dotcom.TripPlan.LegToSegmentHelperTest do
                %Leg{mode: %TransitDetail{}}
              ])
   end
+
+  test "works if there is just one transit leg" do
+    assert [
+             {:transit_segment, _}
+           ] =
+             LegToSegmentHelper.legs_to_segments([
+               %Leg{mode: %TransitDetail{}}
+             ])
+  end
 end

--- a/test/dotcom/trip_plan/leg_to_segment_helper_test.exs
+++ b/test/dotcom/trip_plan/leg_to_segment_helper_test.exs
@@ -20,4 +20,28 @@ defmodule Dotcom.TripPlan.LegToSegmentHelperTest do
                %Leg{mode: %PersonalDetail{}}
              ])
   end
+
+  test "does not prepend location if the first segment is transit" do
+    assert [
+             {:transit_segment, _},
+             {:walking_segment, _},
+             {:location_segment, _}
+           ] =
+             LegToSegmentHelper.legs_to_segments([
+               %Leg{mode: %TransitDetail{}},
+               %Leg{mode: %PersonalDetail{}}
+             ])
+  end
+
+  test "does not append location if the last segment is transit" do
+    assert [
+             {:location_segment, _},
+             {:walking_segment, _},
+             {:transit_segment, _}
+           ] =
+             LegToSegmentHelper.legs_to_segments([
+               %Leg{mode: %PersonalDetail{}},
+               %Leg{mode: %TransitDetail{}}
+             ])
+  end
 end


### PR DESCRIPTION
## Before

![Screenshot 2024-12-11 at 2 11 49 PM](https://github.com/user-attachments/assets/f7108cf5-018b-4516-906b-c1e7d9ad147c)

## After

![Screenshot 2024-12-11 at 2 11 11 PM](https://github.com/user-attachments/assets/a83db01e-1900-4389-b7da-0965868fd3b1)

---

**Asana Ticket:** [🐞 Trip Planner Preview | Details: Duplicate end-location if there's no walking leg at the beginning or end of an itinerary](https://app.asana.com/0/555089885850811/1208939733320494/f)