### PR TITLE
fix(DailySchedule): improve identification of today's service

### DIFF
--- a/assets/ts/helpers/service.ts
+++ b/assets/ts/helpers/service.ts
@@ -24,7 +24,7 @@ export const serviceStartDateComparator = (
 const isInRemovedDates = (service: Service, currentDate: Date): boolean =>
   service.removed_dates.includes(dateObjectToString(currentDate));
 
-const isInAddedDates = (service: Service, currentDate: Date): boolean =>
+export const isInAddedDates = (service: Service, currentDate: Date): boolean =>
   service.added_dates.includes(dateObjectToString(currentDate));
 
 const isOnValidDay = (service: Service, currentDate: Date): boolean => {
@@ -40,10 +40,7 @@ export const isInCurrentService = (
 ): boolean => {
   const serviceStartDate = stringToDateObject(service.start_date);
   const serviceEndDate = stringToDateObject(service.end_date);
-  return (
-    isInAddedDates(service, currentDate) ||
-    (currentDate >= serviceStartDate && currentDate <= serviceEndDate)
-  );
+  return currentDate >= serviceStartDate && currentDate <= serviceEndDate;
 };
 
 export const isInCurrentRating = (
@@ -155,6 +152,7 @@ export const groupServicesByDateRating = (
     // additionally, prioritize current service/rating in grouping
     if (!service.rating_end_date) {
       if (
+        isInAddedDates(service, currentDate) ||
         isInCurrentService(service, currentDate) ||
         isInCurrentRating(service, currentDate)
       ) {

--- a/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -15,7 +15,7 @@ import UpcomingDepartures from "./upcoming-departures/UpcomingDepartures";
 import { isSubwayRoute } from "../../../models/route";
 import DailyScheduleSubway from "./daily-schedule/DailyScheduleSubway";
 import formattedDate, { stringToDateObject } from "../../../helpers/date";
-import { isInCurrentService } from "../../../helpers/service";
+import { isInAddedDates, isInCurrentService } from "../../../helpers/service";
 
 interface Props {
   handleChangeDirection: (direction: DirectionId) => void;
@@ -46,8 +46,10 @@ const ScheduleModalContent = ({
 }: Props): ReactElement<HTMLElement> | null => {
   const { id: routeId } = route;
 
-  const serviceToday = services.some(service =>
-    isInCurrentService(service, stringToDateObject(today))
+  const serviceToday = services.some(
+    service =>
+      isInCurrentService(service, stringToDateObject(today)) ||
+      isInAddedDates(service, stringToDateObject(today))
   );
 
   const renderUpcomingDepartures = (): ReactElement<HTMLElement> =>

--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/DailySchedule.tsx
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/DailySchedule.tsx
@@ -163,11 +163,11 @@ export const DailySchedule = ({
   const currentServices = sortedServices.filter(service =>
     isCurrentValidService(service, todayDate)
   );
-  const todayServiceId =
-    currentServices.length > 0 ? currentServices[0].id : "";
-  const [defaultSelectedService] = currentServices.length
-    ? currentServices
-    : sortedServices;
+  const todayService =
+    currentServices.find(service => !!service["default_service?"]) ||
+    currentServices[0];
+  const todayServiceId = todayService?.id || "";
+  const defaultSelectedService = todayService || sortedServices[0];
 
   const [selectedService, setSelectedService] = useState(
     defaultSelectedService

--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
@@ -5,6 +5,7 @@ import { shortDate, stringToDateObject } from "../../../../helpers/date";
 import {
   ServiceGroupNames,
   dedupeServices,
+  isInAddedDates,
   isInCurrentService
 } from "../../../../helpers/service";
 
@@ -57,7 +58,10 @@ const ServiceOptGroup = ({
         if (service.id === todayServiceId) {
           // if it's the only service this rating, this service might not
           // technically be now - adjust text for that
-          if (isInCurrentService(service, nowDate)) {
+          if (
+            isInCurrentService(service, nowDate) ||
+            isInAddedDates(service, nowDate)
+          ) {
             optionText += " (now)";
           } else {
             optionText += ` (Starting ${format(startDate, "MMMM d, y")})`;


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Schedule finder "Daily Schedule" selection doesn't match current date](https://app.asana.com/0/555089885850811/1208990596026312/f)

- The logic for "is this service current?" founders in the face of this rating's weekday schedule, which features added dates which are outside of the start/end date range. We improve this by disentangling the added date check from the start/end date check
- The current logic picked the first of today's valid services as the 'default' selection. We improve this by first checking for the `"default_service?"` flag on the service.