### PR TITLE
ui(TripPlanner): Fix margins, paddings, and borders for results panel

### DIFF
--- a/lib/dotcom_web/components/trip_planner/results.ex
+++ b/lib/dotcom_web/components/trip_planner/results.ex
@@ -12,12 +12,11 @@ defmodule DotcomWeb.Components.TripPlanner.Results do
     ~H"""
     <section class={[
       "w-full",
-      "border border-solid border-slate-400",
       @class
     ]}>
       <div
         :if={Enum.count(@results.itinerary_groups) > 0 && @results.itinerary_group_selection}
-        class="h-min w-full p-4"
+        class="h-min w-full mb-3.5"
       >
         <button type="button" phx-click="reset_itinerary_group" class="btn-link">
           <span class="flex flex-row items-center">
@@ -26,7 +25,7 @@ defmodule DotcomWeb.Components.TripPlanner.Results do
           </span>
         </button>
       </div>
-      <div :if={Enum.count(@results.itinerary_groups) > 0} class="w-full p-4 row-start-2 col-start-1">
+      <div :if={Enum.count(@results.itinerary_groups) > 0} class="w-full">
         <.itinerary_panel results={@results} />
       </div>
     </section>
@@ -35,32 +34,34 @@ defmodule DotcomWeb.Components.TripPlanner.Results do
 
   defp itinerary_panel(%{results: %{itinerary_group_selection: nil}} = assigns) do
     ~H"""
-    <div
-      :for={{%{summary: summary}, index} <- Enum.with_index(@results.itinerary_groups)}
-      class="border border-solid m-4 p-4"
-    >
+    <div class="flex flex-col gap-4">
       <div
-        :if={summary.tag}
-        class="whitespace-nowrap leading-none font-bold font-heading text-sm uppercase bg-brand-primary-darkest text-white px-3 py-2 mb-3 -ml-4 -mt-4 rounded-br-lg w-min"
+        :for={{%{summary: summary}, index} <- Enum.with_index(@results.itinerary_groups)}
+        class="border border-solid border-gray-lighter p-4"
       >
-        {summary.tag}
-      </div>
-      <.itinerary_summary summary={summary} />
-      <div class="flex justify-end items-center">
-        <div :if={Enum.count(summary.next_starts) > 0} class="grow text-sm text-grey-dark">
-          Similar trips depart at {Enum.map(
-            summary.next_starts,
-            &Timex.format!(&1, "%-I:%M", :strftime)
-          )
-          |> Enum.join(", ")}
-        </div>
-        <button
-          class="btn-link font-semibold underline"
-          phx-click="select_itinerary_group"
-          phx-value-index={index}
+        <div
+          :if={summary.tag}
+          class="whitespace-nowrap leading-none font-bold font-heading text-sm uppercase bg-brand-primary-darkest text-white px-3 py-2 mb-3 -ml-4 -mt-4 rounded-br-lg w-min"
         >
-          Details
-        </button>
+          {summary.tag}
+        </div>
+        <.itinerary_summary summary={summary} />
+        <div class="flex justify-end items-center">
+          <div :if={Enum.count(summary.next_starts) > 0} class="grow text-sm text-grey-dark">
+            Similar trips depart at {Enum.map(
+              summary.next_starts,
+              &Timex.format!(&1, "%-I:%M", :strftime)
+            )
+            |> Enum.join(", ")}
+          </div>
+          <button
+            class="btn-link font-semibold underline"
+            phx-click="select_itinerary_group"
+            phx-value-index={index}
+          >
+            Details
+          </button>
+        </div>
       </div>
     </div>
     """
@@ -76,11 +77,9 @@ defmodule DotcomWeb.Components.TripPlanner.Results do
     }
 
     ~H"""
-    <div class="mt-30">
-      <div class="border-b-[1px] border-gray-lighter">
-        <.itinerary_summary summary={@summary} />
-        <.itinerary_detail results={@results} />
-      </div>
+    <div>
+      <.itinerary_summary summary={@summary} />
+      <.itinerary_detail results={@results} />
     </div>
     """
   end

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -67,14 +67,13 @@ defmodule DotcomWeb.Live.TripPlanner do
       <.input_form changeset={@input_form.changeset} />
       <.results_summary changeset={@input_form.changeset} results={@results} />
       <div class={[
-        "flex flex-col md:grid",
-        Enum.count(@results.itinerary_groups) > 0 && "md:grid-cols-2",
-        Enum.count(@results.itinerary_groups) == 0 && "md:grid-cols-1"
+        "flex flex-col gap-4 md:flex-row md:gap-7"
       ]}>
         <.live_component
           module={MbtaMetro.Live.Map}
           id="trip-planner-map"
           class={[
+            "md:order-last",
             "h-64 md:h-96 w-full",
             @results.itinerary_group_selection == nil && "hidden md:block",
             @results.itinerary_group_selection != nil && "block"
@@ -84,7 +83,11 @@ defmodule DotcomWeb.Live.TripPlanner do
           pins={@map.pins}
           points={@map.points}
         />
-        <.results class="row-start-1 col-start-1" results={@results} />
+        <.results
+          :if={Enum.count(@results.itinerary_groups) > 0}
+          class="md:max-w-[25rem]"
+          results={@results}
+        />
       </div>
     </div>
     """

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -74,7 +74,7 @@ defmodule DotcomWeb.Live.TripPlanner do
           id="trip-planner-map"
           class={[
             "md:order-last",
-            "h-64 md:h-96 w-full",
+            "h-64 md:h-[32rem] w-full",
             @results.itinerary_group_selection == nil && "hidden md:block",
             @results.itinerary_group_selection != nil && "block"
           ]}


### PR DESCRIPTION
<details>
<summary>Screenshots</summary>

## Before (Summary / Mobile)
<img width="418" alt="Screenshot 2024-12-18 at 5 05 44 PM" src="https://github.com/user-attachments/assets/fe6d4407-e993-4f4e-8180-f3d632e5ecce" />

## After (Summary / Mobile)
<img width="420" alt="Screenshot 2024-12-18 at 5 04 40 PM" src="https://github.com/user-attachments/assets/acdcfc5d-914e-48b2-8305-fe937d6b1e73" />

## Before (Summay / Desktop)

<img width="1234" alt="Screenshot 2024-12-18 at 5 05 28 PM" src="https://github.com/user-attachments/assets/8a5fe516-7148-4c4c-b692-98e878e946f8" />

## After (Summary / Desktop)
<img width="1231" alt="Screenshot 2024-12-18 at 5 04 50 PM" src="https://github.com/user-attachments/assets/8297df91-15a8-4b1e-b97f-2f77e8d7fd44" />

(Note: The fact that the route is drawn on the map is because of an unrelated bug and has to do with the order in which I took the screenshots, and has nothing to do with this PR)

## Before (Detail / Mobile)
<img width="422" alt="Screenshot 2024-12-18 at 5 06 20 PM" src="https://github.com/user-attachments/assets/9b79f74b-cd9a-4379-b4b3-d9f8723ca48e" />

## After (Detail / Mobile)
<img width="412" alt="Screenshot 2024-12-18 at 5 04 02 PM" src="https://github.com/user-attachments/assets/3a111f2c-69c2-4506-9d05-c3ee9c880a5f" />

## Before (Detail / Desktop)
<img width="1222" alt="Screenshot 2024-12-18 at 5 06 05 PM" src="https://github.com/user-attachments/assets/7c2bbe1f-b3bd-459a-8a7b-d01c45cd8c5a" />

## After (Detail / Desktop)
<img width="1231" alt="Screenshot 2024-12-18 at 5 04 16 PM" src="https://github.com/user-attachments/assets/fbdbaa98-2000-4977-b73b-0ed2cb9e8825" />

</details>

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Fix margins, padding, and borders for the panel to the left of the map](https://app.asana.com/0/555089885850811/1209002105863143/f)

Changes:
- Removed border and margins around the results panel
- Removed a border at the bottom of itinerary details
- Replaced `grid` with `flex` as an implementation for arranging the results panel next to the map
- Made the results panel grow to no more than 500px on desktop

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [ ] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [ ] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [ ] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../load_tests/README.md)
* [ ] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

