### PR TITLE
cleanup: Remove unused aliases

### DIFF
--- a/lib/dotcom_web/components/trip_planner/start_or_end_place.ex
+++ b/lib/dotcom_web/components/trip_planner/start_or_end_place.ex
@@ -7,9 +7,6 @@ defmodule DotcomWeb.Components.TripPlanner.StartOrEndPlace do
 
   import DotcomWeb.Components.TripPlanner.Place, only: [place: 1]
 
-  alias Routes.Route
-  alias Stops.Stop
-
   attr :place, :map, required: true
   attr :time, :any, required: true
   attr :route, :map, default: nil


### PR DESCRIPTION
No ticket.

Added [here](https://github.com/mbta/dotcom/pull/2275/files#diff-7cdebfe6554316ff59636ce0c4ed299e9e2cc8104f7a823992c1196a9f5dfe28R10-R11), but I guess I forgot to remove them when they become unnecessary.