### PR TITLE
feat(TripPlanner): Show more itineraries

### DIFF
--- a/lib/dotcom/trip_plan/input_form.ex
+++ b/lib/dotcom/trip_plan/input_form.ex
@@ -48,6 +48,7 @@ defmodule Dotcom.TripPlan.InputForm do
       toPlace: PlanParams.to_place_param(to),
       arriveBy: datetime_type == "arrive_by",
       date: PlanParams.to_date_param(datetime),
+      numItineraries: 100,
       time: PlanParams.to_time_param(datetime),
       transportModes: __MODULE__.Modes.selected_mode_keys(modes) |> PlanParams.to_modes_param(),
       wheelchair: wheelchair

--- a/test/dotcom/trip_plan/itinerary_groups_test.exs
+++ b/test/dotcom/trip_plan/itinerary_groups_test.exs
@@ -34,6 +34,21 @@ defmodule Dotcom.TripPlan.ItineraryGroupsTest do
       assert Kernel.length(grouped_itineraries) == 1
     end
 
+    test "only includes the first five itineraries in a group", %{stops: [a, b, c]} do
+      # SETUP
+      bus_a_b_leg = TripPlanner.build(:bus_leg, from: a, to: b)
+      subway_b_c_leg = TripPlanner.build(:subway_leg, from: b, to: c)
+
+      itineraries =
+        TripPlanner.build_list(10, :itinerary, legs: [bus_a_b_leg, subway_b_c_leg])
+
+      # EXERCISE
+      [group] = ItineraryGroups.from_itineraries(itineraries)
+
+      # VERIFY
+      assert Kernel.length(group.itineraries) == 5
+    end
+
     test "does not group itineraries with different modes", %{stops: [a, b, c]} do
       # SETUP
       bus_a_b_leg = TripPlanner.build(:bus_leg, from: a, to: b)


### PR DESCRIPTION
<img width="1230" alt="Screenshot 2024-12-19 at 2 58 11 PM" src="https://github.com/user-attachments/assets/42b55f52-b3de-4e21-9368-982c47b12662" />

#### Summary of changes

**Before**
- We retrieved 5 itineraries from OTP, then grouped them, and returned them however they were grouped.
- This sometimes led to all of the itineraries being shown as one group, or two groups, and sometimes left out certain itineraries.
  - For instance, Logan Airport to North Station can easily be done with the Back Bay Logan Express shuttle, followed by an OL transfer, but if that wasn't in the next 5 trips, then it wouldn't show up.

**After**
- We retrieve 100 itineraries from OTP, group those, and then within each group, surface the next five itineraries (so as not to overwhelm).


<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Increase number of itineraries returned from 5 ](https://app.asana.com/0/555089885850811/1208975267675615/f)

