### PR TITLE
ui(TripPlanner): Use small bus icons in trip planner transit legs

### DIFF
--- a/lib/dotcom_web/components/route_symbols.ex
+++ b/lib/dotcom_web/components/route_symbols.ex
@@ -16,7 +16,7 @@ defmodule DotcomWeb.Components.RouteSymbols do
   variant(
     :size,
     [
-      small: "rounded-[3px] px-[2px] py-[2px] min-w-6 text-sm",
+      small: "rounded-[3px] px-[2px] py-[2px] min-w-8 text-sm",
       default: "rounded-[4px] px-[4px] py-[4px] min-w-10"
     ],
     default: :default

--- a/lib/dotcom_web/components/trip_planner/transit_leg.ex
+++ b/lib/dotcom_web/components/trip_planner/transit_leg.ex
@@ -173,7 +173,11 @@ defmodule DotcomWeb.Components.TripPlanner.TransitLeg do
 
     ~H"""
     <div class="flex items-start gap-1.5">
-      <.route_symbol class="shrink-0" route={@leg.mode.route} />
+      <.route_symbol
+        class="shrink-0"
+        route={@leg.mode.route}
+        size={route_symbol_size(@leg.mode.route)}
+      />
 
       <div class="flex flex-col">
         <span class="font-bold">{@headsign}</span>
@@ -188,6 +192,9 @@ defmodule DotcomWeb.Components.TripPlanner.TransitLeg do
     </div>
     """
   end
+
+  defp route_symbol_size(%Route{type: 3} = route) when not is_external?(route), do: "small"
+  defp route_symbol_size(_), do: "default"
 
   # Massport trips might not have headsigns, so use the route names instead
   defp headsign(%{route: %Route{} = route}) when is_external?(route) do


### PR DESCRIPTION
## Before
<img width="420" alt="Screenshot 2024-12-19 at 3 22 14 PM" src="https://github.com/user-attachments/assets/9bb84e50-a264-471e-bc8b-de5886353d7c" />


## After
<img width="415" alt="Screenshot 2024-12-19 at 3 21 37 PM" src="https://github.com/user-attachments/assets/0c95b601-10a5-4dc6-b338-bd3d2370730b" />

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Bus icon should be smaller in itinerary-detail/transit-leg](https://app.asana.com/0/555089885850811/1209018563871717/f)

