### PR TITLE
ui(TripPlanner): Fix alignment of route symbol icon in transit leg

### DIFF
--- a/lib/dotcom_web/components/trip_planner/transit_leg.ex
+++ b/lib/dotcom_web/components/trip_planner/transit_leg.ex
@@ -39,7 +39,7 @@ defmodule DotcomWeb.Components.TripPlanner.TransitLeg do
         alerts={@alerts.from}
       />
 
-      <div class="flex items-stretch gap-x-[0.9375rem]">
+      <div class="flex items-stretch gap-x-2">
         <div class="flex flex-col items-center">
           <div class="w-5"></div>
           <div class={["w-1 flex-grow", leg_line_class(@leg.mode.route)]}></div>
@@ -172,12 +172,14 @@ defmodule DotcomWeb.Components.TripPlanner.TransitLeg do
       |> assign(:headsign, headsign(assigns.leg.mode))
 
     ~H"""
-    <div class="flex items-start gap-1.5">
-      <.route_symbol
-        class="shrink-0"
-        route={@leg.mode.route}
-        size={route_symbol_size(@leg.mode.route)}
-      />
+    <div class="flex items-start">
+      <div class="h-6 w-[2.375rem] shrink-0 flex items-center justify-start">
+        <.route_symbol
+          class="shrink-0"
+          route={@leg.mode.route}
+          size={route_symbol_size(@leg.mode.route)}
+        />
+      </div>
 
       <div class="flex flex-col">
         <span class="font-bold">{@headsign}</span>
@@ -270,7 +272,7 @@ defmodule DotcomWeb.Components.TripPlanner.TransitLeg do
         :for={stop <- @leg.mode.intermediate_stops}
         class="inline-flex items-center gap-x-2 py-2 relative"
       >
-        <.icon name="circle" class="h-1.5 w-1.5 absolute -left-7 fill-white" />
+        <.icon name="circle" class="h-1.5 w-1.5 absolute -left-[1.3125rem] fill-white" />
         {stop.name}
       </li>
     </ul>


### PR DESCRIPTION
## Before (Train)
<img width="383" alt="Screenshot 2024-12-19 at 5 59 13 PM" src="https://github.com/user-attachments/assets/e59222e6-d30c-4918-a30f-583623bc8555" />

## After (Train)
<img width="385" alt="Screenshot 2024-12-19 at 5 57 41 PM" src="https://github.com/user-attachments/assets/4d51eec1-bc03-4688-91ae-2b07766db9a2" />

## Before (Bus)
<img width="380" alt="Screenshot 2024-12-19 at 5 59 27 PM" src="https://github.com/user-attachments/assets/ca696c24-9ebc-4dfe-861e-7a9c89d92c66" />

## After (Bus)
<img width="384" alt="Screenshot 2024-12-19 at 5 57 56 PM" src="https://github.com/user-attachments/assets/f2f84a05-8ff0-4e3f-a373-61785f95b08f" />

Screenshots above include the walking directions in order to highlight the fact that the route symbol is supposed to be aligned with the walk symbol.

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Route icon is slightly mis-aligned in itinerary-detail/transit-leg](https://app.asana.com/0/555089885850811/1209018563871715/f)

