### PR TITLE
fix: Make the first "Depart at" button active when selecting an itinerary group

### DIFF
--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -203,9 +203,11 @@ defmodule DotcomWeb.Live.TripPlanner do
       points: itinerary_groups_to_points(socket.assigns.results.itinerary_groups, index)
     }
 
+    new_results = %{itinerary_group_selection: index, itinerary_selection: 0}
+
     new_socket =
       socket
-      |> assign(:results, Map.put(socket.assigns.results, :itinerary_group_selection, index))
+      |> assign(:results, Map.merge(socket.assigns.results, new_results))
       |> assign(:map, Map.merge(socket.assigns.map, new_map))
 
     {:noreply, new_socket}


### PR DESCRIPTION
## Before

<img width="408" alt="Screenshot 2024-12-19 at 6 10 33 PM" src="https://github.com/user-attachments/assets/d5d2e2f0-5f49-4913-bd58-69f771951c0c" />


## After
<img width="413" alt="Screenshot 2024-12-19 at 6 09 30 PM" src="https://github.com/user-attachments/assets/648c8ac2-82ea-44e5-b900-81d6b497e563" />

---


<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Itinerary detail should show active state on first "Depart at" button](https://app.asana.com/0/555089885850811/1209016991115335/f)

