### PR TITLE
fix(TripPlanner): Clear the map when switching back to summary view

### DIFF
--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -169,9 +169,15 @@ defmodule DotcomWeb.Live.TripPlanner do
       itinerary_selection: nil
     }
 
+    new_map = %{
+      lines: [],
+      points: []
+    }
+
     new_socket =
       socket
       |> assign(:results, Map.merge(socket.assigns.results, new_results))
+      |> assign(:map, Map.merge(socket.assigns.map, new_map))
 
     {:noreply, new_socket}
   end


### PR DESCRIPTION
## Steps to reproduce
- Plan a trip
- Select a specific itinerary
- Return to summary (By clicking "View all options")

## Before
<img width="1238" alt="Screenshot 2024-12-19 at 6 16 51 PM" src="https://github.com/user-attachments/assets/d980be21-6db7-4174-8943-97f3a0124a5f" />

## After
<img width="1247" alt="Screenshot 2024-12-19 at 6 16 08 PM" src="https://github.com/user-attachments/assets/10b10eb5-9618-4bcc-ac77-deb824665367" />

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [When navigating from details to summary view, the route diagram doesn't vanish from the map](https://app.asana.com/0/555089885850811/1208999575515975/f)

