### PR TITLE
fix: Make DOM ID's unique for trip planner search boxes

### DIFF
--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -28,7 +28,7 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
         phx-change="input_form_change"
         phx-submit="input_form_submit"
       >
-        <div :for={field <- [:from, :to]} class="mb-1" id="trip-planner-locations">
+        <div :for={field <- [:from, :to]} class="mb-1" id={"trip-planner-locations-#{field}"}>
           <.algolia_autocomplete
             config_type="trip-planner"
             placeholder="Enter a location"


### PR DESCRIPTION
No ticket, but this fixes [a bug that prevents upgrading to phoenix_live_view 1.0.1](https://github.com/phoenixframework/phoenix_live_view/blob/main/CHANGELOG.md#bug-fixes), which is necessary for https://github.com/mbta/dotcom/pull/2283.

The bug is that phoenix_live_view now raises an error if it detects duplicate DOM ID's in tests. These ID's were duplciated, [thus causing the Trip Planner tests to fail](https://github.com/mbta/dotcom/actions/runs/12421971500/job/34682970311?pr=2280).

Blocks:
- https://github.com/mbta/dotcom/pull/2283