### PR TITLE
fix(tests): Guarantee that TripPlannerTest headsigns are different from each other

### DIFF
--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -226,8 +226,8 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       conn: conn,
       params: params
     } do
-      trip_headsign_1 = "Headsign:#{Faker.App.name()}"
-      trip_headsign_2 = "Headsign:#{Faker.App.name()}"
+      trip_headsign_1 = "Headsign1"
+      trip_headsign_2 = "Headsign2"
 
       expect(OpenTripPlannerClient.Mock, :plan, fn _ ->
         {:ok,
@@ -291,8 +291,8 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       conn: conn,
       params: params
     } do
-      trip_headsign_1 = "Headsign:#{Faker.App.name()}"
-      trip_headsign_2 = "Headsign:#{Faker.App.name()}"
+      trip_headsign_1 = "Headsign1"
+      trip_headsign_2 = "Headsign2"
 
       expect(OpenTripPlannerClient.Mock, :plan, fn _ ->
         {:ok,


### PR DESCRIPTION
Turns out, sometimes `Faker.App.name()` will return the exact same value twice in a row!

When that happens, `trip_headsign_1` and `trip_headsign_2` are the same as each other, which the test assumes is not true.