### PR TITLE
fix(tests): Prevent router_test.exs from running async

### DIFF
--- a/test/dotcom_web/router_test.exs
+++ b/test/dotcom_web/router_test.exs
@@ -1,5 +1,5 @@
 defmodule Phoenix.Router.RoutingTest do
-  use DotcomWeb.ConnCase, async: true
+  use DotcomWeb.ConnCase
 
   @canonical_host "www.mbta.com"
 


### PR DESCRIPTION
Most tests rely on the `HOST` environment variable to be set to `nil`, so that it defaults to `localhost`. If `HOST` is set to `www.mbta.com`, that causes a redirect. `router_test.exs` has a test that validates that redirect, by setting `HOST` to `www.mbta.com`, validating the redirect, and then setting it back to `nil`.

This is what that normally looks like in context:
```mermaid
sequenceDiagram
  RouterTest->>Env: set_env("HOST", "www.mbta.com")
  RouterTest->>Env: get_env("HOST")
  Env-->>RouterTest: "www.mbta.com"
  RouterTest->>Env: set_env("HOST", nil)
  OtherTest->>Env: get_env("HOST")
  Env-->>OtherTest: nil
```
(Note the existence of `OtherTest`, which also retrieves `HOST`, and relies on `HOST` being `nil`.)

BUT, when `router_test.exs`'s execution is interleaved with other tests, then sometimes another test will try to retrieve `HOST` (well, another test will invoke a `conn`, which then invokes `HOST` through [the CanonicalHostname plug](https://github.com/mbta/dotcom/blob/f7db31e89a2523eec2402fc7994f59f5a1b51171/lib/dotcom_web/plugs/canonical_hostname.ex#L24)) before `router_test.exs` has set `HOST` back to `nil`.


```mermaid
sequenceDiagram
  RouterTest->>Env: set_env("HOST", "www.mbta.com")
  RouterTest->>Env: get_env("HOST")
  Env-->>RouterTest: "www.mbta.com"
  OtherTest->>Env: get_env("HOST")
  Env-->>OtherTest: "www.mbta.com"
  RouterTest->>Env: set_env("HOST", nil)
```

The `conn` invoked by `OtherTest` gets the `www.mbta.com` `HOST` and does a redirect, which the other test wasn't expecting, and fails.

This creates a very challenging debugging environment, because, in this context, `OtherTest` could refer to literally any other test that makes an HTTP request or does anything with a `conn`. This bug was causing very rare non-deterministic failures in every other HTTP-related test.

The solution here is to remove the `async: true` flag from `router_test.exs`, preventing it from interleaving itself with other tests.

Hat-tip to @thecristen for helping me figure out that this CanonicalHostname plug was the culprit.