### PR TITLE
fix: Don't show "No trips found" message when there are other errors

### DIFF
--- a/lib/dotcom_web/components/trip_planner/results_summary.ex
+++ b/lib/dotcom_web/components/trip_planner/results_summary.ex
@@ -16,24 +16,43 @@ defmodule DotcomWeb.Components.TripPlanner.ResultsSummary do
     >
       <p class="text-lg font-semibold mb-0">{submission_summary(@changeset.changes)}</p>
       <p>{time_summary(@changeset.changes)}</p>
-      <%= if @results.loading? do %>
-        <.spinner aria_label="Waiting for results" /> Waiting for results...
-      <% else %>
-        <%= if @results.error do %>
-          <.feedback kind={:error}>{@results.error}</.feedback>
-        <% end %>
-        <%= if Enum.count(@results.itinerary_groups) == 0 do %>
-          <.feedback kind={:warning}>No trips found.</.feedback>
-        <% else %>
-          <.feedback kind={:success}>
-            Found {Enum.count(@results.itinerary_groups)} {Inflex.inflect(
-              "way",
-              Enum.count(@results.itinerary_groups)
-            )} to go.
-          </.feedback>
-        <% end %>
-      <% end %>
+      <.results_feedback results={@results} />
     </section>
+    """
+  end
+
+  defp results_feedback(%{results: %{loading?: true}} = assigns) do
+    ~H"""
+    <.spinner aria_label="Waiting for results" /> Waiting for results...
+    """
+  end
+
+  defp results_feedback(%{results: %{error: nil}} = assigns) do
+    ~H"""
+    <.itinerary_group_feedback itinerary_groups={@results.itinerary_groups} />
+    """
+  end
+
+  defp results_feedback(assigns) do
+    ~H"""
+    <.feedback kind={:error}>{@results.error}</.feedback>
+    """
+  end
+
+  defp itinerary_group_feedback(%{itinerary_groups: []} = assigns) do
+    ~H"""
+    <.feedback kind={:warning}>No trips found.</.feedback>
+    """
+  end
+
+  defp itinerary_group_feedback(assigns) do
+    ~H"""
+    <.feedback kind={:success}>
+      Found {Enum.count(@itinerary_groups)} {Inflex.inflect(
+        "way",
+        Enum.count(@itinerary_groups)
+      )} to go.
+    </.feedback>
     """
   end
 

--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -322,6 +322,17 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       refute render_async(view) =~ trip_headsign_2
     end
 
+    test "displays 'No trips found.' if given an empty list of itineraries", %{
+      conn: conn,
+      params: params
+    } do
+      stub_otp_results([])
+
+      {:ok, view, _html} = live(conn, ~p"/preview/trip-planner?#{params}")
+
+      assert render_async(view) =~ "No trips found."
+    end
+
     test "displays error message from the Open Trip Planner client", %{conn: conn, params: params} do
       error_message = Faker.Lorem.sentence()
 
@@ -332,6 +343,19 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       {:ok, view, _html} = live(conn, ~p"/preview/trip-planner?#{params}")
 
       assert render_async(view) =~ error_message
+    end
+
+    test "does not display 'No trips found.' if there's another error", %{
+      conn: conn,
+      params: params
+    } do
+      expect(OpenTripPlannerClient.Mock, :plan, fn _ ->
+        {:error, [%OpenTripPlannerClient.Error{message: Faker.Lorem.sentence()}]}
+      end)
+
+      {:ok, view, _html} = live(conn, ~p"/preview/trip-planner?#{params}")
+
+      refute render_async(view) =~ "No trips found."
     end
   end
 end


### PR DESCRIPTION
## Before
<img width="673" alt="Screenshot 2024-12-23 at 1 03 52 PM" src="https://github.com/user-attachments/assets/ed8ad523-89e8-45e3-bd76-4edf960bb4e1" />



## After
<img width="677" alt="Screenshot 2024-12-23 at 1 03 22 PM" src="https://github.com/user-attachments/assets/ebd0a1b0-55e3-48ee-b6ad-c3d7b760ba09" />

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Remove duplicate "no trips" state](https://app.asana.com/0/555089885850811/1209016991115315/f)
