### PR TITLE
feat: add another basic auth credential

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -26,3 +26,8 @@ REDIS_STANDALONE=true
 # But, they'll need to match those on the Drupal side if you're doing CMS development.
 # BASIC_AUTH_USERNAME=
 # BASIC_AUTH_PASSWORD=
+
+# These credentials control access to read-only resources, such as the Live
+Dashboard, the admin page, and features under the /preview path.
+# BASIC_AUTH_READONLY_USERNAME=
+# BASIC_AUTH_READONLY_PASSWORD=

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -101,12 +101,20 @@ if config_env() == :test do
     basic_auth: [
       username: "username",
       password: "password"
+    ],
+    basic_auth_readonly: [
+      username: "username",
+      password: "password"
     ]
 else
   config :dotcom, DotcomWeb.Router,
     basic_auth: [
       username: System.get_env("BASIC_AUTH_USERNAME"),
       password: System.get_env("BASIC_AUTH_PASSWORD")
+    ],
+    basic_auth_readonly: [
+      username: System.get_env("BASIC_AUTH_READONLY_USERNAME"),
+      password: System.get_env("BASIC_AUTH_READONLY_PASSWORD")
     ]
 end
 

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -248,13 +248,13 @@ defmodule DotcomWeb.Router do
   scope "/", DotcomWeb do
     import Phoenix.LiveDashboard.Router
 
-    pipe_through([:browser, :browser_live, :basic_auth])
+    pipe_through([:browser, :browser_live, :basic_auth_readonly])
     live_dashboard("/dashboard")
   end
 
   scope "/admin", DotcomWeb do
     import Phoenix.LiveView.Router
-    pipe_through([:browser, :browser_live, :basic_auth])
+    pipe_through([:browser, :browser_live, :basic_auth_readonly])
 
     live_session :admin, layout: {DotcomWeb.LayoutView, :admin} do
       get("/trip-planner/feedback/download", TripPlan.Feedback, :download)
@@ -265,7 +265,7 @@ defmodule DotcomWeb.Router do
 
   scope "/preview", DotcomWeb do
     import Phoenix.LiveView.Router
-    pipe_through([:browser, :browser_live, :basic_auth])
+    pipe_through([:browser, :browser_live, :basic_auth_readonly])
 
     live_session :rider, layout: {DotcomWeb.LayoutView, :preview} do
       live("/trip-planner", Live.TripPlanner)
@@ -331,6 +331,12 @@ defmodule DotcomWeb.Router do
 
   defp basic_auth(conn, _) do
     opts = Application.get_env(:dotcom, DotcomWeb.Router)[:basic_auth]
+
+    Plug.BasicAuth.basic_auth(conn, opts)
+  end
+
+  defp basic_auth_readonly(conn, _) do
+    opts = Application.get_env(:dotcom, DotcomWeb.Router)[:basic_auth_readonly]
 
     Plug.BasicAuth.basic_auth(conn, opts)
   end

--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -73,7 +73,7 @@ defmodule DotcomWeb.Live.TripPlannerTest do
   describe "Trip Planner" do
     setup %{conn: conn} do
       [username: username, password: password] =
-        Application.get_env(:dotcom, DotcomWeb.Router)[:basic_auth]
+        Application.get_env(:dotcom, DotcomWeb.Router)[:basic_auth_readonly]
 
       {:ok, view, html} =
         conn
@@ -130,7 +130,7 @@ defmodule DotcomWeb.Live.TripPlannerTest do
   describe "Trip Planner with no results" do
     setup %{conn: conn} do
       [username: username, password: password] =
-        Application.get_env(:dotcom, DotcomWeb.Router)[:basic_auth]
+        Application.get_env(:dotcom, DotcomWeb.Router)[:basic_auth_readonly]
 
       %{
         conn:
@@ -163,7 +163,7 @@ defmodule DotcomWeb.Live.TripPlannerTest do
   describe "Trip Planner with results" do
     setup %{conn: conn} do
       [username: username, password: password] =
-        Application.get_env(:dotcom, DotcomWeb.Router)[:basic_auth]
+        Application.get_env(:dotcom, DotcomWeb.Router)[:basic_auth_readonly]
 
       stub(Stops.Repo.Mock, :get, fn _ ->
         Test.Support.Factories.Stops.Stop.build(:stop)


### PR DESCRIPTION
Goes with https://github.com/mbta/devops/pull/2400

There might be a better way to organize it? Anyways, this keeps the existing credential for the `/cache` scope but changes the environment variables for the others.