### PR TITLE
cleanup(Live.TripPlanner): even more UI polish

### DIFF
--- a/assets/ts/ui/autocomplete/__tests__/config-test.ts
+++ b/assets/ts/ui/autocomplete/__tests__/config-test.ts
@@ -150,8 +150,12 @@ describe("Trip planner configuration", () => {
 
     //@ts-ignore
     const sourcesWithQuery = await getSources(paramsWithQuery);
-    expect(sourcesWithQuery).toHaveLength(2);
-    expect(sourceIds(sourcesWithQuery)).toEqual(["algolia", "locations"]);
+    expect(sourcesWithQuery).toHaveLength(3);
+    expect(sourceIds(sourcesWithQuery)).toEqual([
+      "algolia",
+      "locations",
+      "popular"
+    ]);
   });
 
   test("sources have OnSelect handler", async () => {

--- a/assets/ts/ui/autocomplete/config.ts
+++ b/assets/ts/ui/autocomplete/config.ts
@@ -235,7 +235,11 @@ const TRIP_PLANNER = ({
           ...algoliaSource(query, { stops: { hitsPerPage: 5 } }, false),
           onSelect
         },
-        { ...locationSource(query, 5), onSelect }
+        { ...locationSource(query, 5), onSelect },
+        {
+          ...popularLocationSource(undefined, query),
+          onSelect
+        }
       ]);
     }
   };

--- a/assets/ts/ui/autocomplete/sources.ts
+++ b/assets/ts/ui/autocomplete/sources.ts
@@ -63,7 +63,8 @@ export const locationSource = (
  * Renders a list of popular locations.
  */
 export const popularLocationSource = (
-  urlType?: UrlType
+  urlType?: UrlType,
+  query?: string
 ): AutocompleteSource<PopularItem> => ({
   sourceId: "popular",
   templates: {
@@ -73,10 +74,16 @@ export const popularLocationSource = (
     return fetch("/places/popular")
       .then(res => res.json())
       .then(({ result }) =>
-        result.map(
-          (location: WithUrls<PopularItem>) =>
-            itemWithUrl(location, urlType) as PopularItem
-        )
+        result
+          .filter(
+            (location: PopularItem) =>
+              !query ||
+              location.name.toLowerCase().includes(query.toLowerCase())
+          )
+          .map(
+            (location: WithUrls<PopularItem>) =>
+              itemWithUrl(location, urlType) as PopularItem
+          )
       )
       .catch(() => []);
   },

--- a/lib/dotcom/trip_plan/input_form.ex
+++ b/lib/dotcom/trip_plan/input_form.ex
@@ -235,6 +235,8 @@ defmodule Dotcom.TripPlan.InputForm do
     def selected_modes(%{}), do: "Walking directions only"
     def selected_modes([mode]), do: mode_name(mode) <> " Only"
 
+    def selected_modes([]), do: "Walking directions only"
+
     def selected_modes(modes) do
       if fields() -- modes == [] do
         "All modes"


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [No modes selected should display "Walking only" in the select box](https://app.asana.com/0/555089885850811/1209037564056787/f) and [The special Logan result is not surfaced as a search result, only in zero state](https://app.asana.com/0/555089885850811/1209037564056804/f)
