### PR TITLE
fix(TransitLeg): collapse for any non-zero number of intermediate stops

### DIFF
--- a/lib/dotcom_web/components/trip_planner/transit_leg.ex
+++ b/lib/dotcom_web/components/trip_planner/transit_leg.ex
@@ -45,7 +45,7 @@ defmodule DotcomWeb.Components.TripPlanner.TransitLeg do
           <div class={["w-1 flex-grow", leg_line_class(@leg.mode.route)]}></div>
         </div>
 
-        <%= if Enum.count(@leg.mode.intermediate_stops) < 2 do %>
+        <%= if Enum.count(@leg.mode.intermediate_stops) == 0 do %>
           <div class="w-full my-3">
             <.leg_summary leg={@leg} alerts={@alerts.route} />
             <.leg_details leg={@leg} />
@@ -54,7 +54,6 @@ defmodule DotcomWeb.Components.TripPlanner.TransitLeg do
           <details class="w-full my-3 group/stops">
             <summary class="flex items-start cursor-pointer">
               <.leg_summary leg={@leg} alerts={@alerts.route} />
-
               <.icon
                 name="chevron-down"
                 class="ml-auto shrink-0 w-4 h-4 fill-brand-primary group-open/stops:rotate-180"


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Transit legs with 2 stops should be collapsed](https://app.asana.com/0/555089885850811/1209037564056803/f)

(noting here the leg `intermediate_stops` is just the stops between start and end, so it shows "take X for 2 stops" for 1 intermediate stop + the end stop)