### PR TITLE
feat: hide CR timetable in the presence of special alerts

### DIFF
--- a/lib/dotcom/timetable_blocking.ex
+++ b/lib/dotcom/timetable_blocking.ex
@@ -1,0 +1,43 @@
+defmodule Dotcom.TimetableBlocking do
+  @moduledoc """
+  Support for blocking the timetable in the presence of special alert text.
+  """
+  alias Alerts.Alert
+  alias Routes.Route
+
+  def pdf_available_text, do: "View PDF Timetable on the MBTA website."
+  def no_pdf_text, do: "Schedule will be available soon on the MBTA website."
+
+  @doc """
+  Strips the timetable blocking text from an alert header (if present)
+  """
+  @spec strip(String.t()) :: String.t()
+  def strip(header) when is_binary(header) do
+    String.replace_trailing(header, pdf_available_text(), "")
+  end
+
+  @doc """
+  Returns the alert blocking the timetable for a given route/date, or nil if there is no such alert.
+  """
+  @spec blocking_alert([Alert.t()], Route.t(), Date.t()) :: Alert.t() | nil
+  def blocking_alert(alerts, %Route{} = route, %Date{} = date) when is_list(alerts) do
+    # we do the filtering in this order to do the cheap string comparison before
+    # the more complicated informed entity/time matching
+    alerts
+    |> Enum.filter(fn alert ->
+      String.ends_with?(alert.header, pdf_available_text()) or
+        String.ends_with?(alert.header, no_pdf_text())
+    end)
+    |> Alerts.Match.match(
+      %Alerts.InformedEntity{route: route.id},
+      date
+    )
+    |> List.first()
+  end
+
+  @doc "Returns true if the given alert is blocking and has a PDF."
+  @spec pdf?(Alert.t()) :: boolean
+  def pdf?(%Alert{} = alert) do
+    String.ends_with?(alert.header, pdf_available_text()) and is_binary(alert.url)
+  end
+end

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -54,22 +54,16 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     Util.log_duration(__MODULE__, :assign_trip_schedules, [conn])
   end
 
-  @hides_timetable_pdf_available "View PDF Timetable on the MBTA website."
-  @hides_timetable_no_pdf "Schedule will be available soon on the MBTA website."
-
   def alert_blocks(conn, _) do
-    blocking_alert =
-      conn.assigns.alerts
-      |> Alerts.Match.match(
-        %Alerts.InformedEntity{route: conn.assigns.route.id},
+    assign(
+      conn,
+      :blocking_alert,
+      Dotcom.TimetableBlocking.blocking_alert(
+        conn.assigns.alerts,
+        conn.assigns.route,
         conn.assigns.date
       )
-      |> Enum.find(fn alert ->
-        String.ends_with?(alert.header, @hides_timetable_pdf_available) or
-          String.ends_with?(alert.header, @hides_timetable_no_pdf)
-      end)
-
-    assign(conn, :blocking_alert, blocking_alert)
+    )
   end
 
   def assign_trip_schedules(

--- a/lib/dotcom_web/templates/alert/_item.html.eex
+++ b/lib/dotcom_web/templates/alert/_item.html.eex
@@ -17,10 +17,9 @@
         end %>
       </div>
       <div class="c-alert-item__content">
-        <% timetable_pdf_available = "View PDF Timetable on the MBTA website." %>
-        <%= replace_urls_with_links(String.replace_trailing(@alert.header, timetable_pdf_available, "")) %>
+        <%= replace_urls_with_links(Dotcom.TimetableBlocking.strip(@alert.header)) %>
         <%= if @alert.url != nil && @alert.url != "" && !Map.get(assigns, :hide_url, false) do %>
-          <%= if String.ends_with?(@alert.header, timetable_pdf_available) do %>
+          <%= if Dotcom.TimetableBlocking.pdf?(@alert) do %>
             <%= link "View PDF Timetable", to: @alert.url %>
           <% else %>
             <%= replace_urls_with_links(@alert.url) %>

--- a/lib/dotcom_web/templates/alert/_item.html.eex
+++ b/lib/dotcom_web/templates/alert/_item.html.eex
@@ -17,9 +17,14 @@
         end %>
       </div>
       <div class="c-alert-item__content">
-        <%= replace_urls_with_links(@alert.header) %>
+        <% timetable_pdf_available = "View PDF Timetable on the MBTA website." %>
+        <%= replace_urls_with_links(String.replace_trailing(@alert.header, timetable_pdf_available, "")) %>
         <%= if @alert.url != nil && @alert.url != "" && !Map.get(assigns, :hide_url, false) do %>
-          <%= replace_urls_with_links(@alert.url) %>
+          <%= if String.ends_with?(@alert.header, timetable_pdf_available) do %>
+            <%= link "View PDF Timetable", to: @alert.url %>
+          <% else %>
+            <%= replace_urls_with_links(@alert.url) %>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.eex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.eex
@@ -1,4 +1,4 @@
-<%= DotcomWeb.AlertView.group(alerts: @alerts, route: @route, date_time: @date_time, priority_filter: :high) %>
+<%= DotcomWeb.AlertView.group(alerts: @alerts, route: @route, date_time: @date_time, priority_filter: :high, always_show: List.wrap(@blocking_alert)) %>
 <%= render "_trip_view_filters.html", assigns %>
 
 <div class="calendar-covered m-timetable">

--- a/lib/dotcom_web/templates/schedule/_timetable.html.eex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.eex
@@ -3,9 +3,10 @@
 
 <div class="calendar-covered m-timetable">
   <%= content_tag(:div, "", [class: "calendar-cover", hidden: !@show_date_select?]) %>
-  <%= if Enum.empty?(@header_schedules) do %>
+  <%= cond do %>
+  <% Enum.empty?(@header_schedules) -> %>
     <%= render "_empty.html", date: @date, direction: Routes.Route.direction_name(@route, @direction_id), conn: @conn, error: assigns[:schedule_error] %>
-  <% else %>
+  <% true -> %>
     <% # only show scroll controllers if we have 2 or more schedules
         should_show_scroll_controls? = match?([_, _ | _], @header_schedules)
     %>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.eex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.eex
@@ -4,6 +4,8 @@
 <div class="calendar-covered m-timetable">
   <%= content_tag(:div, "", [class: "calendar-cover", hidden: !@show_date_select?]) %>
   <%= cond do %>
+  <% @blocking_alert != nil -> %>
+      <%= render "_timetable_blocked.html", formatted_date: @formatted_date, alert: @blocking_alert %>
   <% Enum.empty?(@header_schedules) -> %>
     <%= render "_empty.html", date: @date, direction: Routes.Route.direction_name(@route, @direction_id), conn: @conn, error: assigns[:schedule_error] %>
   <% true -> %>

--- a/lib/dotcom_web/templates/schedule/_timetable_blocked.html.eex
+++ b/lib/dotcom_web/templates/schedule/_timetable_blocked.html.eex
@@ -1,0 +1,10 @@
+<div class="callout schedule-empty">
+  The interactive timetable for <%= @formatted_date %> is temporarily unavailable due to a service change.
+  <div>
+    <%= if @alert.url do %>
+      <%= link "View PDF Timetable", to: @alert.url %>
+    <% else %>
+      PDF Upcoming
+    <% end %>
+  </div>
+</div>

--- a/test/dotcom/timetable_blocking_test.exs
+++ b/test/dotcom/timetable_blocking_test.exs
@@ -1,0 +1,58 @@
+defmodule Dotcom.TimetableBlockingTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  alias Dotcom.TimetableBlocking
+
+  @date ~D[2025-01-01]
+  @route %Routes.Route{id: "CR-route"}
+
+  describe "blocking_alert/3" do
+    test "returns an alert if there's a specially tagged alert without a PDF" do
+      alert =
+        Alerts.Alert.new(
+          header: "No timetable. #{TimetableBlocking.no_pdf_text()}",
+          informed_entity: [%Alerts.InformedEntity{route: @route.id}],
+          active_period: [{~U[2025-01-01T00:00:00Z], nil}]
+        )
+
+      assert TimetableBlocking.blocking_alert([alert], @route, @date) == alert
+    end
+
+    test "returns an alert if there's a specially tagged alert with a PDF" do
+      alert =
+        Alerts.Alert.new(
+          header: "No timetable. #{TimetableBlocking.pdf_available_text()}",
+          informed_entity: [%Alerts.InformedEntity{route: @route.id}],
+          active_period: [{~U[2025-01-01T00:00:00Z], nil}],
+          url: "https://www.mbta.com/pdf-link"
+        )
+
+      assert TimetableBlocking.blocking_alert([alert], @route, @date) == alert
+    end
+
+    test "returns nil if there's no special alert" do
+      ie = %Alerts.InformedEntity{route: "CR-route"}
+      active_period = {~U[2025-01-01T00:00:00Z], ~U[2025-01-01T23:59:59Z]}
+
+      alerts = [
+        Alerts.Alert.new(
+          header: "Regular alert.",
+          informed_entity: [ie],
+          active_period: [active_period]
+        ),
+        Alerts.Alert.new(
+          header: "Not active. #{TimetableBlocking.no_pdf_text()}",
+          informed_entity: [ie],
+          active_period: [{~U[2025-06-06T00:00:00Z], nil}]
+        ),
+        Alerts.Alert.new(
+          header: "Different route. #{TimetableBlocking.no_pdf_text()}",
+          informed_entity: [%Alerts.InformedEntity{route: "bus"}],
+          active_period: [active_period]
+        )
+      ]
+
+      assert TimetableBlocking.blocking_alert(alerts, @route, @date) == nil
+    end
+  end
+end

--- a/test/dotcom_web/controllers/schedule/timetable_controller_test.exs
+++ b/test/dotcom_web/controllers/schedule/timetable_controller_test.exs
@@ -3,6 +3,7 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
   use DotcomWeb.ConnCase, async: true
   import DotcomWeb.ScheduleController.TimetableController
   import Mox
+  alias Dotcom.TimetableBlocking
   alias Routes.Route
   alias Stops.Stop
   alias Schedules.{Schedule, Trip}
@@ -347,8 +348,8 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
     test "assigns @blocking_alert if there's a specially tagged alert", %{conn: conn} do
       alert =
         Alerts.Alert.new(
-          header: "No timetable. Schedule will be available soon on the MBTA website.",
-          informed_entity: [%Alerts.InformedEntity{route: "CR-route"}],
+          header: "No timetable. #{TimetableBlocking.no_pdf_text()}",
+          informed_entity: [%Alerts.InformedEntity{route: conn.assigns.route.id}],
           active_period: [{~U[2025-01-01T00:00:00Z], nil}]
         )
 
@@ -361,7 +362,7 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
     end
 
     test "assigns @blocking_alert to nil if there's no special alert", %{conn: conn} do
-      ie = %Alerts.InformedEntity{route: "CR-route"}
+      ie = %Alerts.InformedEntity{route: conn.assigns.route.id}
       active_period = {~U[2025-01-01T00:00:00Z], ~U[2025-01-01T23:59:59Z]}
 
       alerts = [
@@ -371,12 +372,12 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
           active_period: [active_period]
         ),
         Alerts.Alert.new(
-          header: "Not active. Schedule will be available soon on the MBTA website.",
+          header: "Not active. #{TimetableBlocking.no_pdf_text()}",
           informed_entity: [ie],
           active_period: [{~U[2025-06-06T00:00:00Z], nil}]
         ),
         Alerts.Alert.new(
-          header: "Different route. Schedule will be available soon on the MBTA website.",
+          header: "Different route. #{TimetableBlocking.no_pdf_text()}",
           informed_entity: [%Alerts.InformedEntity{route: "bus"}],
           active_period: [active_period]
         )

--- a/test/dotcom_web/views/alert_view_test.exs
+++ b/test/dotcom_web/views/alert_view_test.exs
@@ -185,6 +185,29 @@ defmodule DotcomWeb.AlertViewTest do
       text = safe_to_string(response)
       assert text =~ "There are no alerts on the Name at this time."
     end
+
+    test "text for an CR alert which is blocking the timetable (but has a PDF available)" do
+      alert = %Alerts.Alert{
+        header: "Blocked timetable. View PDF Timetable on the MBTA website.",
+        url: "https://www.mbta.com/pdf-timetable",
+        updated_at: DateTime.utc_now()
+      }
+
+      response =
+        group(
+          alerts: [alert],
+          route: @route,
+          stop?: false,
+          show_empty?: false,
+          date_time: DateTime.utc_now()
+        )
+
+      text = safe_to_string(response)
+
+      refute text =~ "View PDF Timetable on the MBTA website."
+      assert text =~ ~s["https://www.mbta.com/pdf-timetable"]
+      assert text =~ ">View PDF Timetable</a>"
+    end
   end
 
   describe "no_alerts_message/3" do

--- a/test/dotcom_web/views/alert_view_test.exs
+++ b/test/dotcom_web/views/alert_view_test.exs
@@ -204,7 +204,7 @@ defmodule DotcomWeb.AlertViewTest do
 
       text = safe_to_string(response)
 
-      refute text =~ "View PDF Timetable on the MBTA website."
+      refute text =~ Dotcom.TimetableBlocking.pdf_available_text()
       assert text =~ ~s["https://www.mbta.com/pdf-timetable"]
       assert text =~ ">View PDF Timetable</a>"
     end

--- a/test/dotcom_web/views/schedule/timetable_view_test.exs
+++ b/test/dotcom_web/views/schedule/timetable_view_test.exs
@@ -93,7 +93,8 @@ defmodule DotcomWeb.Schedule.TimetableViewTest do
         track_changes: %{},
         date_time: ~N[2017-03-01T07:29:00],
         direction_name: "Southeastbound",
-        formatted_date: "March 1, 2017"
+        formatted_date: "March 1, 2017",
+        blocking_alert: nil
       ]
 
       {:ok, %{assigns: assigns}}


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [CR disruption timetable improvements](https://app.asana.com/0/116562505129567/1208217281866205/f)

This adds special-case handling for two types of alerts where we want to hide the timetable from view. One case is expected to have a PDF as the URL for the alert, and the other does not. In the PDF case, we hide the timetable and provide the link to the PDF. In the other, we hide the timetable and say "PDF upcoming."

This also changes the rendering of the alert to drop the special-case text, and to say "View PDF schedule" if the PDF link is available.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

#### New UI, or substantial UI changes
* [x] **Cross-browser compatibility** is less of an issue now that we're no longer supporting IE, but changes still need to work as expected in Safari, Chrome, and Firefox.
* [x] **Are interactive elements accessible?** This includes at minimum having [relevant keyboard interactions](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#keyboard-interaction) and [visible focus](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus), but can also include verification with screen reader testing.
* [x] **Other accessibility checks** such as sufficient [color constrast](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#color-contrast), or whether the layout holds up at 200% [zoom level](https://thinkdobecreate.com/articles/4-required-tests-before-shipping-new-features/#visible-focus).

#### New endpoints, or non-trivial changes to current endpoints
* [x] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../load_tests/README.md)
* [x] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

