### PR TITLE
fix: Comment out comment explaining readonly basic auth creds

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -28,6 +28,6 @@ REDIS_STANDALONE=true
 # BASIC_AUTH_PASSWORD=
 
 # These credentials control access to read-only resources, such as the Live
-Dashboard, the admin page, and features under the /preview path.
+# Dashboard, the admin page, and features under the /preview path.
 # BASIC_AUTH_READONLY_USERNAME=
 # BASIC_AUTH_READONLY_PASSWORD=


### PR DESCRIPTION
This causes an error if `.env.template` is copied directly into `.env`.

