### PR TITLE
fix: various styling things

### DIFF
--- a/assets/css/_accordion-ui.scss
+++ b/assets/css/_accordion-ui.scss
@@ -138,3 +138,18 @@
     @include fa-icon-solid($fa-var-angle-up);
   }
 }
+
+// Remove top margin from first heading element inside the accordion panel
+.c-expandable-block__panel, .c-accordion-ui__content {
+  // when the heading is directly the first child element
+  > :first-child:is(h1, h2, h3, h4) {
+    margin-top: 0;
+  }
+
+  // when the heading is NOT directly the first child element
+  // markup structure varies widely, precluding the use of a simpler selector,
+  // but this finds a first heading element inside the first child of the panel
+  :first-child:has(> h1, > h2, > h3, > h4) :is(h1, h2, h3, h4) {
+    margin-top: 0;
+  }
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -11,8 +11,12 @@
   --tw-content: '' !important;
 }
 
-@import "../../deps/mbta_metro/priv/static/assets/variables.light.css" (prefers-color-scheme: light);
-@import "../../deps/mbta_metro/priv/static/assets/variables.dark.css" (prefers-color-scheme: dark);
+// MBTA Metro components can support light or dark mode, and includes CSS
+// variable definitions for both. However, Dotcom itself does not support dark
+// mode, so we only include the light mode variables here.
+// @import "../../deps/mbta_metro/priv/static/assets/variables.light.css" (prefers-color-scheme: light);
+// @import "../../deps/mbta_metro/priv/static/assets/variables.dark.css" (prefers-color-scheme: dark);
+@import "../../deps/mbta_metro/priv/static/assets/variables.light.css";
 @import '../../deps/mbta_metro/priv/static/assets/default.css';
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -101,24 +101,6 @@ module.exports = {
             marginBottom: theme("spacing.1")
           }
         },
-        h1: {
-          fontSize: theme("fontSize.4xl")
-        },
-        h2: {
-          fontSize: theme("fontSize.3xl")
-        },
-        h3: {
-          fontSize: theme("fontSize.2xl")
-        },
-        h4: {
-          fontSize: theme("fontSize.lg")
-        },
-        h5: {
-          fontSize: theme("fontSize.base")
-        },
-        h6: {
-          fontSize: theme("fontSize.sm")
-        },
         "h1 + h2, h2 + h3, h3 + h4, h4 + h5, h5 + h6, p + h3, p + h4, p + h5, p + h6": {
           marginTop: theme("spacing.4")
         },

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -92,6 +92,9 @@ module.exports = {
     ),
     plugin(({ addBase, theme }) =>
       addBase({
+        a: {
+          fontWeight: theme("fontWeight.medium")
+        },
         "h1, h2, h3, h4, h5, h6": {
           fontFamily: theme("fontFamily.heading"),
           fontWeight: theme("fontWeight.bold"),


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Clean up Trip Planner dark mode issues](https://app.asana.com/0/555089885850811/1209078786966517/f)

Before (with system dark mode on)
<img width="486" alt="image" src="https://github.com/user-attachments/assets/01ac88f3-5fd9-411e-bb10-5f327a3ba351" />

After (with system dark mode STILL on). No dark mode states for anyone!
<img width="484" alt="image" src="https://github.com/user-attachments/assets/57d0601e-ec5b-4aa6-ade5-a21ce7707c58" />

(same is reflected in the secondary buttons used in the trip planner results)

## Additional improvements

### Fixes incorrect heading sizes

Before (left) and after (right)

<img width="1223" alt="image" src="https://github.com/user-attachments/assets/23506d19-9545-4eef-b831-bfff93d87700" />

### Restores the bolder font weight for links

Before (left) and after (right) is subtle, but the links are no longer the regular font weight

<img width="622" alt="image" src="https://github.com/user-attachments/assets/85ab280e-e98d-45c8-aac2-b03d66417a36" />


### Improves headings within accordions

Before (left) and after (right)

<img width="657" alt="image" src="https://github.com/user-attachments/assets/93c4bdc8-2b9e-4f8f-ae83-a1d97aa9207a" />

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/8bd7dbbc-8a70-492f-9134-6efec770bd25" />


