### PR TITLE
feat(Live.TripPlanner): support /from and /to shortcuts

### DIFF
--- a/lib/dotcom/trip_plan/anti_corruption_layer.ex
+++ b/lib/dotcom/trip_plan/anti_corruption_layer.ex
@@ -8,6 +8,30 @@ defmodule Dotcom.TripPlan.AntiCorruptionLayer do
   We ignore datetime_type and datetime and allow those to be set to 'now' and the current time respectively.
   """
 
+  @location_service Application.compile_env!(:dotcom, :location_service)
+
+  @doc """
+  Given a query for the old trip planner /to or /from actions, replicate the old
+  behavior by searching for a location and using the first result. Convert this
+  to the new trip planner form values.
+  """
+  def convert_old_action(action) do
+    with [key] when key in [:from, :to] <- Map.keys(action),
+         query when is_binary(query) <- Map.get(action, key),
+         {:ok, [%LocationService.Address{} = geocoded | _]} <- @location_service.geocode(query) do
+      %{
+        "plan" => %{
+          "#{key}_latitude" => geocoded.latitude,
+          "#{key}_longitude" => geocoded.longitude,
+          "#{key}" => geocoded.formatted
+        }
+      }
+    else
+      _ ->
+        %{"plan" => %{}}
+    end
+  end
+
   @doc """
   Given the params from the old trip planner, convert them to the new trip planner form values.
 

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -269,6 +269,8 @@ defmodule DotcomWeb.Router do
 
     live_session :rider, layout: {DotcomWeb.LayoutView, :preview} do
       live("/trip-planner", Live.TripPlanner)
+      live("/trip-planner/from/:place", Live.TripPlanner, :from)
+      live("/trip-planner/to/:place", Live.TripPlanner, :to)
     end
   end
 

--- a/test/dotcom/trip_plan/anti_corruption_layer_test.exs
+++ b/test/dotcom/trip_plan/anti_corruption_layer_test.exs
@@ -1,7 +1,54 @@
 defmodule Dotcom.TripPlan.AntiCorruptionLayerTest do
   use ExUnit.Case
 
-  import Dotcom.TripPlan.AntiCorruptionLayer, only: [convert_old_params: 1]
+  import Dotcom.TripPlan.AntiCorruptionLayer, only: [convert_old_action: 1, convert_old_params: 1]
+  import Mox
+  import Test.Support.Factories.LocationService.LocationService
+
+  setup :verify_on_exit!
+
+  describe "convert_old_action/1" do
+    test "returns all defaults when no params are given" do
+      assert convert_old_action(%{}) == convert_old_action(%{"plan" => %{}})
+    end
+
+    test "returns params representing successfully geocoded result" do
+      query = Faker.Address.street_address()
+      geocoded_result = build(:address)
+
+      expect(LocationService.Mock, :geocode, fn ^query ->
+        {:ok, [geocoded_result]}
+      end)
+
+      assert convert_old_action(%{from: query}) == %{
+               "plan" => %{
+                 "from" => geocoded_result.formatted,
+                 "from_latitude" => geocoded_result.latitude,
+                 "from_longitude" => geocoded_result.longitude
+               }
+             }
+    end
+
+    test "returns all defaults when no address found" do
+      query = Faker.Address.street_address()
+
+      expect(LocationService.Mock, :geocode, fn _ ->
+        {:ok, []}
+      end)
+
+      assert convert_old_action(%{from: query}) == %{"plan" => %{}}
+    end
+
+    test "returns all defaults for geocoding error" do
+      query = Faker.Address.street_address()
+
+      expect(LocationService.Mock, :geocode, fn _ ->
+        {:error, :internal_error}
+      end)
+
+      assert convert_old_action(%{from: query}) == %{"plan" => %{}}
+    end
+  end
 
   describe "convert_old_params/1" do
     test "returns all defaults when no params are given" do


### PR DESCRIPTION
#### Summary of changes

Last week we discussed whether to port over the old trip planner's feature of geocoding and pre-filling a "From" or "To" destination using the `/to/` and `/from/` URLs. I wanted to see if this could potentially be a quick thing, and this is what I came up with. 