### PR TITLE
fix(TripPlanner.Results): various small things

### DIFF
--- a/lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+++ b/lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -51,11 +51,11 @@ defmodule DotcomWeb.Components.TripPlanner.ItinerarySummary do
   attr(:routes, :list, required: true, doc: "List of %Routes.Route{}")
   attr(:walk_minutes, :integer, required: true)
 
-  # No routes
+  # No routes: this is a walking leg
   defp leg_icon(%{routes: [], walk_minutes: _} = assigns) do
     ~H"""
     <span class={[
-      "flex items-center gap-1 text-sm font-semibold leading-none whitespace-nowrap py-1 px-2 rounded-full border border-solid border-gray-light",
+      "flex items-center gap-1 text-sm font-semibold leading-none whitespace-nowrap py-1 px-2 rounded-full border-[1px] border-gray-light",
       @class
     ]}>
       <.icon name="person-walking" class="h-4 w-4" />

--- a/lib/dotcom_web/components/trip_planner/results.ex
+++ b/lib/dotcom_web/components/trip_planner/results.ex
@@ -42,6 +42,8 @@ defmodule DotcomWeb.Components.TripPlanner.Results do
       <div
         :for={{%{summary: summary}, index} <- Enum.with_index(@results.itinerary_groups)}
         class="border border-solid border-gray-lighter p-4"
+        phx-click="select_itinerary_group"
+        phx-value-index={index}
       >
         <div
           :if={summary.tag}

--- a/lib/dotcom_web/components/trip_planner/results.ex
+++ b/lib/dotcom_web/components/trip_planner/results.ex
@@ -52,7 +52,10 @@ defmodule DotcomWeb.Components.TripPlanner.Results do
         <.itinerary_summary summary={summary} />
         <div class="flex justify-end items-center">
           <div :if={Enum.count(summary.next_starts) > 0} class="grow text-sm text-grey-dark">
-            Similar trips depart at {Enum.map(
+            Similar {if(Enum.count(summary.next_starts) == 1,
+              do: "trip departs",
+              else: "trips depart"
+            )} at {Enum.map(
               summary.next_starts,
               &Timex.format!(&1, "%-I:%M", :strftime)
             )

--- a/lib/dotcom_web/components/trip_planner/results_summary.ex
+++ b/lib/dotcom_web/components/trip_planner/results_summary.ex
@@ -56,7 +56,7 @@ defmodule DotcomWeb.Components.TripPlanner.ResultsSummary do
   defp time_summary(%{datetime: datetime, datetime_type: datetime_type}) do
     preamble = if datetime_type == "arrive_by", do: "Arriving by ", else: "Leaving at "
     time_description = Timex.format!(datetime, "{h12}:{m}{am}")
-    date_description = Timex.format!(datetime, "{WDfull}, {Mfull} {D}")
-    preamble <> time_description <> " on " <> date_description
+    date_description = Timex.format!(datetime, "{WDfull}, {Mfull} ")
+    preamble <> time_description <> " on " <> date_description <> Inflex.ordinalize(datetime.day)
   end
 end


### PR DESCRIPTION
#### Summary of changes

Tickets completed as individual commits.

**Asana Ticket:** [Walking pills should have a 1px border radius](https://app.asana.com/0/555089885850811/1209085415061427/f)

Pretty sure he meant 1px border _width_.

**Asana Ticket:** [Correctly pluralize similar trips](https://app.asana.com/0/555089885850811/1209085415061417/f)

Adds the correct phrasing.

**Bonus:** I figured out how to display ordinal dates to match the Figma mock.

So now it says "January 6**th**" instead of "January 6".

**Asana Ticket:** [Clicking anywhere on a result card should open the details view](https://app.asana.com/0/555089885850811/1209085415061423/f)

I decided to leave the relevant Phoenix data attributes on the "Details" button despite the fact they're duplicating the functionality of clicking on the `<div>`... it felt more "right" to me, makes clicking around in tests easier, Phoenix complains if you try to click a thing which doesn't have those attributes... and it doesn't seem to hurt anything to have the `phx-click` on both the "Details" link and the overall div.
