### PR TITLE
fix(tripPlanner): Restore error message if from and to are the same

### DIFF
--- a/lib/dotcom/trip_plan/input_form.ex
+++ b/lib/dotcom/trip_plan/input_form.ex
@@ -12,8 +12,6 @@ defmodule Dotcom.TripPlan.InputForm do
   alias OpenTripPlannerClient.PlanParams
 
   @error_messages %{
-    from: "Please specify an origin location.",
-    to: "Please add a destination.",
     from_to_same: "Please select a destination at a different location from the origin.",
     modes: "Please select at least one mode of transit.",
     datetime: "Please specify a date and time in the future or select 'Now'."
@@ -68,8 +66,6 @@ defmodule Dotcom.TripPlan.InputForm do
     |> cast_embed(:modes, required: true)
     |> update_change(:from, &update_location_change/1)
     |> update_change(:to, &update_location_change/1)
-    |> validate_required(:from, message: error_message(:from))
-    |> validate_required(:to, message: error_message(:to))
     |> validate_required(:modes, message: error_message(:modes))
     |> validate_required([:datetime_type, :wheelchair])
     |> validate_same_locations()

--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -49,6 +49,9 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
                 name={location_f[subfield].name}
               />
             </.inputs_for>
+            <.error_container :for={{msg, _} <- f[field].errors}>
+              {msg}
+            </.error_container>
           </.algolia_autocomplete>
         </fieldset>
         <fieldset class="mb-sm">

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -54,7 +54,7 @@ defmodule DotcomWeb.Live.TripPlanner do
       socket
       |> assign(@state)
       |> assign(:input_form, Map.put(@state.input_form, :changeset, changeset))
-      |> maybe_submit_form()
+      |> submit_changeset(changeset)
 
     {:ok, new_socket}
   end
@@ -315,15 +315,6 @@ defmodule DotcomWeb.Live.TripPlanner do
 
   defp update_datepicker(socket, %{}) do
     socket
-  end
-
-  # Check the input form change set for validity and submit the form if it is.
-  defp maybe_submit_form(socket) do
-    if socket.assigns.input_form.changeset.valid? do
-      submit_changeset(socket, socket.assigns.input_form.changeset)
-    else
-      socket
-    end
   end
 
   # Round the current time to the nearest 5 minutes.

--- a/test/dotcom/trip_plan/input_form_test.exs
+++ b/test/dotcom/trip_plan/input_form_test.exs
@@ -38,7 +38,7 @@ defmodule Dotcom.TripPlan.InputFormTest do
       assert changeset.valid?
     end
 
-    test "adds from & to errors" do
+    test "does not add from & to errors" do
       changeset =
         InputForm.changeset(%{
           "from" => %{
@@ -56,8 +56,8 @@ defmodule Dotcom.TripPlan.InputFormTest do
         })
 
       refute changeset.valid?
-      assert changeset.errors[:to]
-      assert changeset.errors[:from]
+      refute changeset.errors[:to]
+      refute changeset.errors[:from]
     end
 
     test "adds error if from & to are the same" do


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/mbta/dotcom/pull/2309 (oops!)

## Before

<img width="1223" alt="Screenshot 2025-01-08 at 1 07 17 PM" src="https://github.com/user-attachments/assets/ea4e92f6-419f-491c-905f-6904ba392881" />
(Note the lack of error message, but also the lack of actually doing a trip plan)

## After

<img width="1231" alt="Screenshot 2025-01-08 at 1 05 55 PM" src="https://github.com/user-attachments/assets/2ed4558e-46f5-4481-ae80-b0d88af10e26" />

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Trip Planner | Restore error state for origin == destination](https://app.asana.com/0/555089885850811/1209091204225425/f)

Follow-up to:
 - https://github.com/mbta/dotcom/pull/2309