### PR TITLE
cleanup: Remove `&standardize_datetime/1` function that's now unused

### DIFF
--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -372,17 +372,6 @@ defmodule DotcomWeb.Live.TripPlanner do
   defp add_datetime_if_needed(%{"datetime" => datetime} = params) when datetime != nil, do: params
   defp add_datetime_if_needed(params), do: params |> Map.put("datetime", nearest_5_minutes())
 
-  # Convert a NaiveDateTime to a DateTime in the America/New_York timezone.
-  defp standardize_datetime(%NaiveDateTime{} = datetime) do
-    Timex.to_datetime(datetime, "America/New_York")
-  end
-
-  # The lack of a datetime means we should use the nearest 5 minutes.
-  defp standardize_datetime(nil), do: Timex.now("America/New_York")
-
-  # If the datetime is already a DateTime, we don't need to do anything.
-  defp standardize_datetime(datetime), do: datetime
-
   # Set an action on the changeset and submit it.
   #
   # - Update the input form state with the new changeset


### PR DESCRIPTION
In https://github.com/mbta/dotcom/pull/2309, we got rid of the `&maybe_round_datetime/1` function, which was the only caller of `&standardize_datetime/1`. This removes that function as well.

Follow-up to:
 - https://github.com/mbta/dotcom/pull/2309

---

No ticket, but this does clean up a warning.