### PR TITLE
feat(Live.TripPlanner): Add switch origin/destination button

### DIFF
--- a/assets/js/test/trip-plan_test.js
+++ b/assets/js/test/trip-plan_test.js
@@ -12,11 +12,11 @@ import testConfig from "../../ts/jest.config";
 const { testURL } = testConfig;
 
 const tripPlanForm = `<form id="plan">
-        <input class="location-input" data-autocomplete="true" id="from" name="plan[from]" placeholder="Ex: 10 Park Plaza" type="text" autocomplete="off">
+        <input data-autocomplete="true" id="from" name="plan[from]" placeholder="Ex: 10 Park Plaza" type="text" autocomplete="off">
         <input type="hidden" id="from_latitude" name="plan[from_latitude]">
         <input type="hidden" id="from_longitude" name="plan[from_longitude]">
         <input type="hidden" id="from_stop_id" name="plan[from_stop_id]">
-        <input class="location-input" data-autocomplete="true" id="to" name="plan[to]" placeholder="Ex: Boston Children's Museum" type="text" autocomplete="off">
+        <input data-autocomplete="true" id="to" name="plan[to]" placeholder="Ex: Boston Children's Museum" type="text" autocomplete="off">
         <div id="trip-plan-reverse-control"></div>
         <div id="trip-plan__container--to"></div>
         <div id="trip-plan__container--from"></div>

--- a/assets/ts/ui/autocomplete/__autocomplete.d.ts
+++ b/assets/ts/ui/autocomplete/__autocomplete.d.ts
@@ -51,6 +51,7 @@ export type PopularItem = {
   url: string;
   state: string;
   municipality: string;
+  stop_id?: string;
 };
 
 export type AutocompleteItem = RouteItem | StopItem | ContentItem;

--- a/assets/ts/ui/autocomplete/index.ts
+++ b/assets/ts/ui/autocomplete/index.ts
@@ -1,6 +1,9 @@
-import { autocomplete, AutocompleteOptions } from "@algolia/autocomplete-js";
+import {
+  autocomplete,
+  AutocompleteApi,
+  AutocompleteOptions
+} from "@algolia/autocomplete-js";
 import configs from "./config";
-
 /**
  * Creates the Algolia Autocomplete instances for various search experiences on
  * MBTA.com.
@@ -9,7 +12,8 @@ function setupAlgoliaAutocomplete(
   wrapper: HTMLElement,
   pushToLiveView?: Function,
   initialState?: Function
-): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): AutocompleteApi<any> {
   const container = wrapper.querySelector<HTMLElement>(
     ".c-search-bar__autocomplete"
   );
@@ -40,6 +44,8 @@ function setupAlgoliaAutocomplete(
   document
     .querySelector("[data-nav='veil']")
     ?.addEventListener("click", () => autocompleteWidget.setIsOpen(false));
+
+  return autocompleteWidget;
 }
 
 export default setupAlgoliaAutocomplete;

--- a/assets/ts/ui/autocomplete/sources.ts
+++ b/assets/ts/ui/autocomplete/sources.ts
@@ -22,7 +22,7 @@ export const geolocationSource = (
   templates: {
     item({ item, html }) {
       return html`
-        <span class="text-brand-primary">
+        <span className="text-brand-primary">
           <i key=${item.value} className="fa fa-location-arrow fa-fw mr-xs"></i>
           ${item.value}
         </span>

--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -25,35 +25,24 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
     <section class={["rounded px-xl py-lg lg:px-2xl lg:py-xl bg-charcoal-90", @class]}>
       <.form
         :let={f}
-        class="md:grid md:grid-cols-2 gap-x-8 gap-y-2"
+        class="flex flex-col md:grid md:grid-cols-[1fr_max-content_1fr] md:gap-x-lg gap-y-sm pt-md"
         id="trip-planner-input-form"
         for={@changeset}
         method="get"
         phx-change="input_form_change"
         phx-submit="input_form_submit"
       >
-        <fieldset :for={field <- [:from, :to]} id={"trip-planner-locations-#{field}"} class="mb-sm">
-          <legend class="text-charcoal-40 m-0 py-sm">{Phoenix.Naming.humanize(field)}</legend>
-          <.algolia_autocomplete
-            config_type="trip-planner"
-            placeholder={"Enter #{if(field == :from, do: "an origin", else: "a destination")} location"}
-            id={"trip-planner-input-form--#{field}"}
+        <.location_search_box name="trip-planner-input-form--from" field={f[:from]} />
+        <div class="self-end rotate-90 -mt-xs -mb-md md:mt-0 md:mb-0 md:rotate-0">
+          <button
+            type="button"
+            class="px-xs md:py-3 bg-transparent fill-brand-primary hover:fill-black"
           >
-            <.inputs_for :let={location_f} field={f[field]} skip_hidden={true}>
-              <input
-                :for={subfield <- InputForm.Location.fields()}
-                type="hidden"
-                class="location-input"
-                id={location_f[subfield].id}
-                value={location_f[subfield].value}
-                name={location_f[subfield].name}
-              />
-            </.inputs_for>
-            <.error_container :for={{msg, _} <- f[field].errors}>
-              {msg}
-            </.error_container>
-          </.algolia_autocomplete>
-        </fieldset>
+            <span class="sr-only">Swap origin and destination locations</span>
+            <.icon class="h-6 w-6" name="right-left" />
+          </button>
+        </div>
+        <.location_search_box name="trip-planner-input-form--to" field={f[:to]} />
         <fieldset class="mb-sm">
           <legend class="text-charcoal-40 m-0 py-sm">When</legend>
           <.input_group
@@ -77,7 +66,7 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
             {msg}
           </.error_container>
         </fieldset>
-        <div>
+        <div class="col-start-3">
           <fieldset class="mb-sm">
             <legend class="text-charcoal-40 m-0 py-sm">Modes</legend>
             <.accordion variant="multiselect">
@@ -108,6 +97,33 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
         </div>
       </.form>
     </section>
+    """
+  end
+
+  defp location_search_box(assigns) do
+    assigns =
+      assigns
+      |> assign(:location_keys, InputForm.Location.fields())
+
+    ~H"""
+    <fieldset class="mb-sm -mt-md" id={"#{@name}-wrapper"}>
+      <legend class="text-charcoal-40 m-0 py-sm">{Phoenix.Naming.humanize(@field.field)}</legend>
+      <.algolia_autocomplete config_type="trip-planner" placeholder="Enter a location" id={@name}>
+        <.inputs_for :let={location_f} field={@field} skip_hidden={true}>
+          <input
+            :for={subfield <- @location_keys}
+            type="text"
+            class="location-input"
+            id={location_f[subfield].id}
+            value={location_f[subfield].value}
+            name={location_f[subfield].name}
+          />
+        </.inputs_for>
+        <.feedback :for={{msg, _} <- @field.errors} :if={used_input?(@field)} kind={:error}>
+          {msg}
+        </.feedback>
+      </.algolia_autocomplete>
+    </fieldset>
     """
   end
 

--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -46,7 +46,7 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
             <.icon class="h-6 w-6 rotate-90 md:rotate-0" name="right-left" />
           </button>
         </div>
-        <.location_search_box name="trip-planner-input-form--to" field={f[:to]} />
+        <.location_search_box name="trip-planner-input-form--to" field={f[:to]} placeholder="Enter a destination location" />
         <fieldset class="mb-sm">
           <legend class="text-charcoal-40 m-0 py-sm">When</legend>
           <.input_group

--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -33,14 +33,17 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
         phx-submit="input_form_submit"
       >
         <.location_search_box name="trip-planner-input-form--from" field={f[:from]} />
-        <div class="self-end rotate-90 -mt-xs -mb-md md:mt-0 md:mb-0 md:rotate-0">
+        <div class="-mb-[20px] md:-mt-md md:mb-0 self-end md:self-auto">
+          <div class="hidden md:block md:py-sm md:mb-[10px]">
+            &nbsp; <%!-- helps align the swap button on desktop--%>
+          </div>
           <button
             type="button"
             phx-click="swap_direction"
-            class="px-xs md:py-3 bg-transparent fill-brand-primary hover:fill-black"
+            class="px-xs bg-transparent fill-brand-primary hover:fill-black"
           >
             <span class="sr-only">Swap origin and destination locations</span>
-            <.icon class="h-6 w-6" name="right-left" />
+            <.icon class="h-6 w-6 rotate-90 md:rotate-0" name="right-left" />
           </button>
         </div>
         <.location_search_box name="trip-planner-input-form--to" field={f[:to]} />

--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -112,7 +112,7 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
     ~H"""
     <fieldset class="mb-sm -mt-md" id={"#{@name}-wrapper"}>
       <legend class="text-charcoal-40 m-0 py-sm">{Phoenix.Naming.humanize(@field.field)}</legend>
-      <.algolia_autocomplete config_type="trip-planner" placeholder="Enter a location" id={@name}>
+      <.algolia_autocomplete config_type="trip-planner" placeholder={@placeholder} id={@name}>
         <.inputs_for :let={location_f} field={@field} skip_hidden={true}>
           <input
             :for={subfield <- @location_keys}

--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -32,7 +32,11 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
         phx-change="input_form_change"
         phx-submit="input_form_submit"
       >
-        <.location_search_box name="trip-planner-input-form--from" field={f[:from]} placeholder="Enter an origin location" />
+        <.location_search_box
+          name="trip-planner-input-form--from"
+          field={f[:from]}
+          placeholder="Enter an origin location"
+        />
         <div class="-mb-[20px] md:-mt-md md:mb-0 self-end md:self-auto">
           <div class="hidden md:block md:py-sm md:mb-[10px]">
             &nbsp; <%!-- helps align the swap button on desktop--%>
@@ -46,7 +50,11 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
             <.icon class="h-6 w-6 rotate-90 md:rotate-0" name="right-left" />
           </button>
         </div>
-        <.location_search_box name="trip-planner-input-form--to" field={f[:to]} placeholder="Enter a destination location" />
+        <.location_search_box
+          name="trip-planner-input-form--to"
+          field={f[:to]}
+          placeholder="Enter a destination location"
+        />
         <fieldset class="mb-sm">
           <legend class="text-charcoal-40 m-0 py-sm">When</legend>
           <.input_group

--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -36,6 +36,7 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
         <div class="self-end rotate-90 -mt-xs -mb-md md:mt-0 md:mb-0 md:rotate-0">
           <button
             type="button"
+            phx-click="swap_direction"
             class="px-xs md:py-3 bg-transparent fill-brand-primary hover:fill-black"
           >
             <span class="sr-only">Swap origin and destination locations</span>
@@ -112,8 +113,7 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
         <.inputs_for :let={location_f} field={@field} skip_hidden={true}>
           <input
             :for={subfield <- @location_keys}
-            type="text"
-            class="location-input"
+            type="hidden"
             id={location_f[subfield].id}
             value={location_f[subfield].value}
             name={location_f[subfield].name}

--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -32,7 +32,7 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
         phx-change="input_form_change"
         phx-submit="input_form_submit"
       >
-        <.location_search_box name="trip-planner-input-form--from" field={f[:from]} />
+        <.location_search_box name="trip-planner-input-form--from" field={f[:from]} placeholder="Enter an origin location" />
         <div class="-mb-[20px] md:-mt-md md:mb-0 self-end md:self-auto">
           <div class="hidden md:block md:py-sm md:mb-[10px]">
             &nbsp; <%!-- helps align the swap button on desktop--%>

--- a/lib/dotcom_web/components/trip_planner/results_summary.ex
+++ b/lib/dotcom_web/components/trip_planner/results_summary.ex
@@ -46,14 +46,19 @@ defmodule DotcomWeb.Components.TripPlanner.ResultsSummary do
     """
   end
 
-  defp submission_summary(%{from: from, to: to}) do
-    "Trips from #{from.changes.name} to #{to.changes.name}"
+  defp submission_summary(%{
+         from: %{changes: %{name: from_name}},
+         to: %{changes: %{name: to_name}}
+       }) do
+    "Trips from #{from_name} to #{to_name}"
   end
 
   defp submission_summary(_), do: nil
 
-  defp time_summary(%{datetime: datetime, datetime_type: datetime_type}) do
-    preamble = if datetime_type == "arrive_by", do: "Arriving by ", else: "Leaving at "
+  defp time_summary(%{datetime: datetime} = params) do
+    preamble =
+      if Map.get(params, :datetime_type) == "arrive_by", do: "Arriving by ", else: "Leaving at "
+
     time_description = Timex.format!(datetime, "{h12}:{m}{am}")
     date_description = Timex.format!(datetime, "{WDfull}, {Mfull} ")
     preamble <> time_description <> " on " <> date_description <> Inflex.ordinalize(datetime.day)

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -417,7 +417,7 @@ defmodule DotcomWeb.Live.TripPlanner do
   # doesn't always appear in params. When that happens, we want to set
   # "datetime" to a reasonable default.
   defp add_datetime_if_needed(%{"datetime_type" => "now"} = params),
-    do: params |> Map.put("datetime", nearest_5_minutes())
+    do: params |> Map.put("datetime", Timex.now("America/New_York"))
 
   defp add_datetime_if_needed(%{"datetime" => datetime} = params) when datetime != nil, do: params
   defp add_datetime_if_needed(params), do: params |> Map.put("datetime", nearest_5_minutes())

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -10,7 +10,7 @@ defmodule DotcomWeb.Live.TripPlanner do
   import DotcomWeb.Components.TripPlanner.{InputForm, Results, ResultsSummary}
 
   alias Dotcom.TripPlan
-  alias Dotcom.TripPlan.{AntiCorruptionLayer, InputForm, InputForm, ItineraryGroups}
+  alias Dotcom.TripPlan.{AntiCorruptionLayer, InputForm, ItineraryGroups}
 
   @state %{
     input_form: %{
@@ -157,8 +157,15 @@ defmodule DotcomWeb.Live.TripPlanner do
   # - Update the input form state with the new changeset
   # - Update the map state with the new pins
   # - Reset the results state
-  def handle_event("input_form_change", %{"input_form" => params}, socket) do
-    params_with_datetime = add_datetime_if_needed(params)
+  def handle_event(
+        "input_form_change",
+        %{"input_form" => params},
+        %{assigns: %{input_form: %{changeset: %{params: current_params}}}} = socket
+      ) do
+    params_with_datetime =
+      current_params
+      |> Map.merge(params)
+      |> add_datetime_if_needed()
 
     changeset = InputForm.changeset(params_with_datetime)
 
@@ -248,6 +255,40 @@ defmodule DotcomWeb.Live.TripPlanner do
       |> assign(:map, Map.merge(socket.assigns.map, new_map))
 
     {:noreply, new_socket}
+  end
+
+  @impl true
+  # Triggered when the user clicks the button to swap to "from" and "to" data
+  #
+  # - Creates a new changeset with the switched from and to values
+  # - Resubmits the form (which in turn updates the input form state, map, etc)
+  # - Dispatches a "set-query" event that is used by the AlgoliaAutocomplete
+  #   hook to update the displayed value of the location search box. This
+  #   reconciles a mismatch which happens when the user switches the origin and
+  #   destination values.
+  def handle_event(
+        "swap_direction",
+        _params,
+        %{assigns: %{input_form: %{changeset: changeset}}} = socket
+      ) do
+    new_to = Map.get(changeset.changes, :from) |> location_data_from_changeset()
+    new_from = Map.get(changeset.changes, :to) |> location_data_from_changeset()
+
+    if new_to != new_from do
+      changes =
+        %{}
+        |> maybe_put_change(:to, new_to)
+        |> maybe_put_change(:from, new_from)
+
+      new_socket =
+        socket
+        |> submit_changeset(Ecto.Changeset.change(changeset, changes))
+        |> push_event("set-query", changes)
+
+      {:noreply, new_socket}
+    else
+      {:noreply, socket}
+    end
   end
 
   @impl true
@@ -375,7 +416,9 @@ defmodule DotcomWeb.Live.TripPlanner do
   # on "Leave at" or "Arrive by", the actual value of "datetime"
   # doesn't always appear in params. When that happens, we want to set
   # "datetime" to a reasonable default.
-  defp add_datetime_if_needed(%{"datetime_type" => "now"} = params), do: params
+  defp add_datetime_if_needed(%{"datetime_type" => "now"} = params),
+    do: params |> Map.put("datetime", nearest_5_minutes())
+
   defp add_datetime_if_needed(%{"datetime" => datetime} = params) when datetime != nil, do: params
   defp add_datetime_if_needed(params), do: params |> Map.put("datetime", nearest_5_minutes())
 
@@ -394,4 +437,15 @@ defmodule DotcomWeb.Live.TripPlanner do
     |> assign(:results, Map.put(@state.results, :loading?, true))
     |> start_async("get_itinerary_groups", fn -> get_itinerary_groups(new_changeset) end)
   end
+
+  # Adjust the map only if value is non-nil
+  defp maybe_put_change(changes, _, nil), do: changes
+  defp maybe_put_change(changes, key, data), do: Map.put(changes, key, data)
+
+  # For the from or to fields, get the underlying location data if changed
+  defp location_data_from_changeset(%Ecto.Changeset{changes: changes}) when changes != %{} do
+    changes
+  end
+
+  defp location_data_from_changeset(_), do: %{}
 end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Add switch origin/destination button](https://app.asana.com/0/555089885850811/1208603342838393/f)

Building off of Josh's earlier work in #2231 and elsewhere, implements switching the locations on the form, thus switching the displayed markers on the map, and rerunning the trip planner with new results.

This also includes some cleanup on the `AlgoliaAutocomplete` Phoenix JS hook. Now instead of triggering 4 "change" events for each location input change, we more elegantly fire off _one_ (1) event for the LiveView to handle (just another `"input_form_change"` event, transmitting data selected from the location dropdown).