### PR TITLE
fix: Decrease min zoom on the map to allow riders to zoom out further

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -44,7 +44,7 @@ end
 config :mbta_metro, :map, %{
   center: [-71.0589, 42.3601],
   maxZoom: 18,
-  minZoom: 9,
+  minZoom: 8,
   style: %{
     "version" => 8,
     "sources" => %{

--- a/config/config.exs
+++ b/config/config.exs
@@ -44,7 +44,7 @@ end
 config :mbta_metro, :map, %{
   center: [-71.0589, 42.3601],
   maxZoom: 18,
-  minZoom: 12,
+  minZoom: 9,
   style: %{
     "version" => 8,
     "sources" => %{


### PR DESCRIPTION
A `minZoom` of 12 doesn't allow riders to zoom out very far at all, which means that trips over a certain distance won't fit on the screen. 

(Lower zoom corresponds to a bigger map - a zoom level of 1 is the entire planet)

## Before
<img width="391" alt="Screenshot 2025-01-09 at 12 06 04 PM" src="https://github.com/user-attachments/assets/d6f7c81b-d549-4f7c-bc9b-509aaaa1cc81" />



## After
<img width="390" alt="Screenshot 2025-01-09 at 12 04 05 PM" src="https://github.com/user-attachments/assets/b40ed4b5-330b-4a99-8371-2fbb8e1ef4ac" />

---

No ticket.

