### PR TITLE
fix(TripPlanner/ui): Decrease padding on the input form for tiny screens

### DIFF
--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -22,7 +22,7 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
 
   def input_form(assigns) do
     ~H"""
-    <section class={["rounded px-xl py-lg lg:px-2xl lg:py-xl bg-charcoal-90", @class]}>
+    <section class={["rounded px-2 py-3 sm:px-8 sm:py-6 lg:px-12 lg:py-8 bg-charcoal-90", @class]}>
       <.form
         :let={f}
         class="md:grid md:grid-cols-2 gap-x-8 gap-y-2"


### PR DESCRIPTION
## Before

<img width="356" alt="Screenshot 2025-01-09 at 1 43 38 PM" src="https://github.com/user-attachments/assets/d74c524d-2db4-4765-9b6e-aca052ca77e7" />

## After

<img width="358" alt="Screenshot 2025-01-09 at 1 42 06 PM" src="https://github.com/user-attachments/assets/c4f97401-3b28-47e2-9cfd-8aeb28553875" />

---

No Ticket.