### PR TITLE
fix(TripPlanner): Restore A and B on desktop in search boxes

### DIFF
--- a/assets/css/_autocomplete-theme.scss
+++ b/assets/css/_autocomplete-theme.scss
@@ -231,7 +231,7 @@
   }
 
   // hide default search magnifying glass icon
-  .aa-SubmitIcon {
+  .aa-SubmitButton, .aa-SubmitIcon {
     display: none;
   }
 
@@ -242,10 +242,12 @@
   }
 }
 
+#trip-planner-input-form--from .aa-Label::before,
 #trip-planner-input-form--from .aa-DetachedSearchButtonIcon::before {
   content: "A"
 }
 
+#trip-planner-input-form--to .aa-Label::before,
 #trip-planner-input-form--to .aa-DetachedSearchButtonIcon::before {
   content: "B"
 }


### PR DESCRIPTION
## Before

<img width="980" alt="Screenshot 2025-01-09 at 2 16 33 PM" src="https://github.com/user-attachments/assets/5fa78778-39df-4f6a-b6f8-6e39b40185af" />

## After

<img width="989" alt="Screenshot 2025-01-09 at 2 15 49 PM" src="https://github.com/user-attachments/assets/340b7707-eb58-450d-b0f5-b292edb51293" />

---
No ticket.