### PR TITLE
fix: change metro map config tile URL for prod

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,6 +30,13 @@ config :dotcom, :redix_pub_sub, Redix.PubSub
 config :dotcom, :otp_module, OpenTripPlannerClient
 config :dotcom, :req_module, Req
 
+tile_server_url =
+  if config_env() == :prod,
+    do: "https://cdn.mbta.com",
+    else: "https://mbta-map-tiles-dev.s3.amazonaws.com"
+
+config :dotcom, tile_server_url: tile_server_url
+
 config :sentry,
   enable_source_code_context: true,
   root_source_code_paths: [File.cwd!()],
@@ -50,7 +57,7 @@ config :mbta_metro, :map, %{
     "sources" => %{
       "raster-tiles" => %{
         "type" => "raster",
-        "tiles" => ["https://mbta-map-tiles-dev.s3.amazonaws.com/osm_tiles/{z}/{x}/{y}.png"],
+        "tiles" => ["#{tile_server_url}/osm_tiles/{z}/{x}/{y}.png"],
         "tileSize" => 256,
         "attribution" =>
           "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a>"

--- a/config/dotcom/dotcom.exs
+++ b/config/dotcom/dotcom.exs
@@ -8,13 +8,6 @@ config :dotcom, start_data_processes: config_env() != :test
 
 config :dotcom, Dotcom.BodyTag, mticket_header: "x-mticket"
 
-tile_server_url =
-  if config_env() == :prod,
-    do: "https://cdn.mbta.com",
-    else: "https://mbta-map-tiles-dev.s3.amazonaws.com"
-
-config :dotcom, tile_server_url: tile_server_url
-
 response_fn =
   if config_env() == :prod,
     do: {DotcomWeb.StaticFileController, :redirect_through_cdn},


### PR DESCRIPTION

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Map tiles should load on production environment](https://app.asana.com/0/555089885850811/1209117947602740/f)

Possible fix! I'm not sure we'll really know til we try it in prod.