### PR TITLE
fix: assorted CSP issues

### DIFF
--- a/lib/dotcom_web/plugs/secure_headers.ex
+++ b/lib/dotcom_web/plugs/secure_headers.ex
@@ -12,6 +12,7 @@ defmodule DotcomWeb.Plugs.SecureHeaders do
       *.googleapis.com
       *.s3.amazonaws.com
       analytics.google.com
+      cdn.mbta.com
       px.ads.linkedin.com
       stats.g.doubleclick.net
       www.google-analytics.com

--- a/lib/dotcom_web/plugs/secure_headers.ex
+++ b/lib/dotcom_web/plugs/secure_headers.ex
@@ -31,6 +31,7 @@ defmodule DotcomWeb.Plugs.SecureHeaders do
       www.google.com
       www.googletagmanager.com
       www.instagram.com
+      *.soundcloud.com
     ],
     img: ~w[
       img-src

--- a/lib/dotcom_web/plugs/secure_headers.ex
+++ b/lib/dotcom_web/plugs/secure_headers.ex
@@ -29,6 +29,7 @@ defmodule DotcomWeb.Plugs.SecureHeaders do
       livestream.com
       www.youtube.com
       www.google.com
+      www.googletagmanager.com
       www.instagram.com
     ],
     img: ~w[

--- a/lib/dotcom_web/templates/layout/root.html.eex
+++ b/lib/dotcom_web/templates/layout/root.html.eex
@@ -27,7 +27,6 @@
     <link rel="apple-touch-icon" href="<%= static_url(@conn, "/apple-touch-icon.png") %>" type="image/png">
     <link rel="icon" href="<%= static_url(@conn, "/images/mbta-logo-t-favicon.png") %>" sizes="32x32" type="image/png">
     <link rel="icon" href="<%= static_url(@conn, "/favicon.ico") %>" sizes="16x16" type="image/vnd.microsoft.icon">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
 
     <%= if google_tag_manager_id() do %>
       <link rel="preconnect" href="//www.google-analytics.com">


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Add Soundcloud to CSP list so we can embed it](https://app.asana.com/0/555089885850811/1209117971448504/f) and [Map tiles should load on production environment](https://app.asana.com/0/555089885850811/1209117947602740/f)

- After #2322 the map tiles couldn't load as they were blocked by the CSP! So the first commit should fix that.
- The second commit adds a missing Google Tag Manager URL that I noticed logged in the console on mbta.com
- The third commit removes an old link from the root template that I only noticed because the CSP yelled about it 😅 The flatpickr library code is distributed with Metro now anyway.
- The fourth commit goes ahead and adds the Soundcloud URL.

