### PR TITLE
docs: Fix formatting so that examples render nicely

### DIFF
--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -205,14 +205,15 @@ defmodule Util do
   def local_tz, do: @local_tz
 
   @doc """
-  Converts an {:error, _} tuple to a default value.
+  Converts an `{:error, _}` tuple to a default value.
 
-  # Examples
+  ## Examples
 
-    iex> Util.error_default(:value, :default)
-    :value
-    iex> Util.error_default({:error, :tuple}, :default)
-    :default
+      iex> Util.error_default(:value, :default)
+      :value
+
+      iex> Util.error_default({:error, :tuple}, :default)
+      :default
   """
   @spec error_default(value | {:error, any}, value) :: value
         when value: any
@@ -361,12 +362,12 @@ defmodule Util do
   end
 
   @doc """
-  Makes DotcomWeb.Router.Helpers available to other apps.
-  #
-  # Examples
+  Makes `DotcomWeb.Router.Helpers` available to other apps.
 
-    iex> Util.site_path(:schedule_path, [:show, "test"])
-    "/schedules/test"
+  ## Examples
+
+      iex> Util.site_path(:schedule_path, [:show, "test"])
+      "/schedules/test"
   """
   @spec site_path(atom, [any]) :: String.t()
   def site_path(helper_fn, opts) when is_list(opts) do


### PR DESCRIPTION
## Before (`error_default`)

<img width="856" alt="Screenshot 2025-01-16 at 1 23 11 PM" src="https://github.com/user-attachments/assets/6998190d-623b-4899-8a24-577f1d82f1b0" />

## After (`error_default`)
<img width="853" alt="Screenshot 2025-01-16 at 1 22 23 PM" src="https://github.com/user-attachments/assets/2194ad97-8bed-4894-b94d-c378706d5087" />

## Before (`site_path`)
<img width="854" alt="Screenshot 2025-01-16 at 1 23 01 PM" src="https://github.com/user-attachments/assets/5be3b1f4-da3f-4a55-8276-d65095395ab5" />

## After (`site_path`)
<img width="855" alt="Screenshot 2025-01-16 at 1 25 41 PM" src="https://github.com/user-attachments/assets/efca8a5f-ddee-4f4a-8a69-436604b7d9a3" />
