### PR TITLE
docs: Update function name in SystemStatus.Alerts docs to be linkable

### DIFF
--- a/lib/dotcom/system_status/alerts.ex
+++ b/lib/dotcom/system_status/alerts.ex
@@ -66,8 +66,7 @@ defmodule Dotcom.SystemStatus.Alerts do
   end
 
   @doc """
-  Given a list of alerts, filters only the ones that are active today, as defined in `&active_on_day?/2`.
-  See that function for details
+  Given a list of alerts, filters only the ones that are active today, as defined in `active_on_day?/2`.
   """
   def for_day(alerts, datetime) do
     Enum.filter(alerts, &active_on_day?(&1, datetime))


### PR DESCRIPTION
Elixir docs will add a link to a function's docs if it's referenced like `active_on_day?/2`, but not if it's referenced like `&active_on_day?/2`. Thus, what I had thought was a link wasn't. This fixes that.

No ticket.