### PR TITLE
fix(autocomplete): adjust clear button width only in detached mode

### DIFF
--- a/assets/css/_autocomplete-theme.scss
+++ b/assets/css/_autocomplete-theme.scss
@@ -227,7 +227,6 @@
 
   .aa-InputWrapperSuffix {
     order: 3;
-    width: calc(var(--aa-spacing) + var(--aa-icon-size) - 1px);
   }
 
   // hide default search magnifying glass icon
@@ -252,6 +251,12 @@
   content: "B"
 }
 
-.aa-DetachedOverlay .aa-InputWrapper {
-  padding-left: calc(var(--aa-spacing));
+.aa-DetachedOverlay {
+  .aa-InputWrapper {
+    padding-left: calc(var(--aa-spacing));
+  }
+  
+  .aa-InputWrapperSuffix {
+    width: calc(var(--aa-spacing) + var(--aa-icon-size) - 1px);
+  }
 }


### PR DESCRIPTION
No ticket, just a very minor repositioning of the "x" icon to clear the input. This regressed in #2300

Before
<img width="538" alt="image" src="https://github.com/user-attachments/assets/3c912fe6-b89a-46e9-a1d8-b6353d72bc01" />
After
<img width="535" alt="image" src="https://github.com/user-attachments/assets/e8e860e9-ca09-4eef-83ad-f8ead2ec6395" />
