### PR TITLE
feat: add tile server URL to CSP

### DIFF
--- a/lib/dotcom_web/plugs/secure_headers.ex
+++ b/lib/dotcom_web/plugs/secure_headers.ex
@@ -4,6 +4,7 @@ defmodule DotcomWeb.Plugs.SecureHeaders do
   content security policy directives at funtime.
   """
 
+  @tile_url Application.compile_env!(:dotcom, :tile_server_url)
   @base_csp_directives %{
     connect: ~w[
       connect-src
@@ -11,6 +12,7 @@ defmodule DotcomWeb.Plugs.SecureHeaders do
       *.arcgis.com
       *.googleapis.com
       *.s3.amazonaws.com
+      #{@tile_url}
       analytics.google.com
       cdn.mbta.com
       px.ads.linkedin.com


### PR DESCRIPTION
No ticket

Technically our existing tile server URLs are already in the Content Security Policy directives, via cdn.mbta.com and *.s3.amazonaws.com. But I found this approach helpful when testing out a different URL here.