### PR TITLE
fix(StationInformation): show bike/parking info even for non-stations

### DIFF
--- a/assets/ts/stop/__tests__/components/StationInformationTest.tsx
+++ b/assets/ts/stop/__tests__/components/StationInformationTest.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import StationInformation from "../../components/StationInformation";
 import { customStop } from "../helpers";
-import { Facility } from "../../../__v3api";
+import { Facility, ParkingLot } from "../../../__v3api";
 
 const stationStop = customStop({
   name: "First Station",
@@ -14,7 +14,8 @@ const stationStop = customStop({
 const busStop = customStop({
   name: "Second Pl",
   "station?": false,
-  bike_storage: ["bike_storage_rack"],
+  bike_storage: [],
+  parking_lots: [],
   accessibility: ["accessible"],
   "has_fare_machine?": false
 });
@@ -66,5 +67,22 @@ describe("StationInformation", () => {
     expect(
       screen.queryByRole("heading", { name: "Purchasing fares" })
     ).not.toBeInTheDocument();
+  });
+
+  it("shows parking/bike heading for bus stops which have those facilities", () => {
+    const busStopWithParking = {
+      ...busStop,
+      parking_lots: [{ name: "Parking" } as ParkingLot]
+    };
+    render(
+      <StationInformation
+        stop={busStopWithParking}
+        alerts={[]}
+        facilities={[]}
+      />
+    );
+    expect(
+      screen.queryByRole("heading", { name: "Bringing your car or bike" })
+    ).toBeInTheDocument();
   });
 });

--- a/assets/ts/stop/components/StationInformation.tsx
+++ b/assets/ts/stop/components/StationInformation.tsx
@@ -29,6 +29,8 @@ const StationInformation = ({
   const escalators = facilities.filter(
     ({ attributes }) => attributes.type === "ESCALATOR"
   );
+  const showBikeInfo = isStation || stop.bike_storage.length > 0;
+  const showParkingInfo = isStation || stop.parking_lots.length > 0;
 
   return (
     <div>
@@ -41,19 +43,21 @@ const StationInformation = ({
         longitude={stop.longitude}
       />
       <div className="station-amenities u-mt-24">
-        {isStation && (
-          <>
-            <h3 className="hidden-md-up">Bringing your car or bike</h3>
-            <ParkingAmenityCard
-              stop={stop}
-              alertsForParking={filterParkingAlerts(alerts)}
-            />
-            <BikeStorageAmenityCard
-              stopName={stop.name}
-              bikeStorage={stop.bike_storage}
-              alerts={alertsByActivity(alerts, "store_bike")}
-            />
-          </>
+        {(showBikeInfo || showParkingInfo) && (
+          <h3 className="hidden-md-up">Bringing your car or bike</h3>
+        )}
+        {showParkingInfo && (
+          <ParkingAmenityCard
+            stop={stop}
+            alertsForParking={filterParkingAlerts(alerts)}
+          />
+        )}
+        {showBikeInfo && (
+          <BikeStorageAmenityCard
+            stopName={stop.name}
+            bikeStorage={stop.bike_storage}
+            alerts={alertsByActivity(alerts, "store_bike")}
+          />
         )}
         {isStation && (
           <>


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

**Asana Ticket:** [Stop pages missing facility information](https://app.asana.com/0/555089885850811/1208613560085954/f)

Before, parking info and bike facility info would be suppressed on stop pages representing bus stops or other "not station" stops. Adjusted the logic so this is no longer the case.

Now we can see...
- Parking and bike storage at ferry docks such as Hingham
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/83eff5b8-2c1b-46ff-9ea1-2bc5069c5867" />
- Parking and bike storage at this bus stop near Watertown Yard
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/d351ba46-61b4-4eb1-b17d-6dd20dc55d32" />
- Covered bike racks at Arlington Heights Busway
<img width="1331" alt="image" src="https://github.com/user-attachments/assets/2a35ab5f-0727-4b4b-b5b2-340d373fdf26" />


