### PR TITLE
When we decode a datetime, we have to cast it to the timezone

### DIFF
--- a/lib/dotcom/trip_plan/anti_corruption_layer.ex
+++ b/lib/dotcom/trip_plan/anti_corruption_layer.ex
@@ -98,7 +98,9 @@ defmodule Dotcom.TripPlan.AntiCorruptionLayer do
         datetime_in_timezone = Timex.to_datetime(datetime, "America/New_York")
 
         Map.put(params, "datetime", datetime_in_timezone)
-      _ -> params
+
+      _ ->
+        params
     end
   end
 

--- a/lib/dotcom/trip_plan/anti_corruption_layer.ex
+++ b/lib/dotcom/trip_plan/anti_corruption_layer.ex
@@ -94,7 +94,10 @@ defmodule Dotcom.TripPlan.AntiCorruptionLayer do
 
   defp decode_datetime(%{"datetime" => datetime} = params) do
     case DateTime.from_iso8601(datetime) do
-      {:ok, datetime, _} -> Map.put(params, "datetime", datetime)
+      {:ok, datetime, _} ->
+        datetime_in_timezone = Timex.to_datetime(datetime, "America/New_York")
+
+        Map.put(params, "datetime", datetime_in_timezone)
       _ -> params
     end
   end

--- a/test/dotcom/trip_plan/anti_corruption_layer_test.exs
+++ b/test/dotcom/trip_plan/anti_corruption_layer_test.exs
@@ -1,10 +1,24 @@
 defmodule Dotcom.TripPlan.AntiCorruptionLayerTest do
   use ExUnit.Case
 
-  import Dotcom.TripPlan.AntiCorruptionLayer, only: [convert_old_params: 1]
+  import Dotcom.TripPlan.AntiCorruptionLayer, only: [convert_old_params: 1, decode: 1, encode: 1]
   import Mox
 
   setup :verify_on_exit!
+
+  describe "decode/1" do
+    test "maintains timezone information when decoding datetimes" do
+      # Setup
+      datetime = Timex.now("America/New_York")
+      encoded = encode(%{"datetime" => datetime})
+
+      # Exercise
+      decoded = decode(encoded)
+
+      # Verify
+      assert decoded["datetime"] == datetime
+    end
+  end
 
   describe "convert_old_params/1" do
     test "returns all defaults when no params are given" do


### PR DESCRIPTION
Even though the timezone information is in the ISO8601 string, it doesn't get decoded by DateTime.

```
DATETIME: #DateTime<2025-01-30 18:01:34.508539-05:00 EST America/New_York>
ENCODED: "2025-01-30T18:01:34.508539-05:00"
DECODED: ~U[2025-01-30 23:01:34.508539Z]
```

So, we have to convert it to a datetime with Timex and specify the timezone.

