### PR TITLE
feat: Add Hi-Fi system status widget

### DIFF
--- a/lib/dotcom_web/components/route_pills.ex
+++ b/lib/dotcom_web/components/route_pills.ex
@@ -5,11 +5,24 @@ defmodule DotcomWeb.Components.RoutePills do
 
   use DotcomWeb, :component
 
-  attr :route_id, :string
-  attr :modifier_ids, :list
+  attr :route_id, :string, required: true
+  attr :modifier_ids, :list, default: []
   attr :modifier_class, :string, default: ""
 
-  def route_pill_with_modifiers(assigns) do
+  def route_pill(%{modifier_ids: []} = assigns) do
+    ~H"""
+    <div class={
+      [
+        bg_color_class(@route_id),
+        "w-[3.125rem]"
+      ] ++ shared_icon_classes()
+    }>
+      {pill_text(@route_id)}
+    </div>
+    """
+  end
+
+  def route_pill(assigns) do
     ~H"""
     <span class="flex">
       <.route_pill route_id={@route_id} />
@@ -21,19 +34,6 @@ defmodule DotcomWeb.Components.RoutePills do
         />
       </span>
     </span>
-    """
-  end
-
-  def route_pill(assigns) do
-    ~H"""
-    <div class={
-      [
-        bg_color_class(@route_id),
-        "w-[3.125rem]"
-      ] ++ shared_icon_classes()
-    }>
-      {pill_text(@route_id)}
-    </div>
     """
   end
 

--- a/lib/dotcom_web/components/route_pills.ex
+++ b/lib/dotcom_web/components/route_pills.ex
@@ -26,7 +26,7 @@ defmodule DotcomWeb.Components.RoutePills do
     ~H"""
     <span class="flex">
       <.route_pill route_id={@route_id} />
-      <span :if={Enum.any?(@modifier_ids)} class="h-6 -ml-1 flex gap-0.5">
+      <span class="h-6 -ml-1 flex gap-0.5">
         <.route_modifier
           :for={modifier_id <- @modifier_ids}
           modifier_id={modifier_id}

--- a/lib/dotcom_web/components/route_pills.ex
+++ b/lib/dotcom_web/components/route_pills.ex
@@ -1,0 +1,73 @@
+defmodule DotcomWeb.Components.RoutePills do
+  @moduledoc """
+  Reusable components for displaying subway routes.
+  """
+
+  use DotcomWeb, :component
+
+  attr :route_id, :string
+  attr :modifier_ids, :list
+  attr :modifier_class, :string, default: ""
+
+  def route_pill_with_modifiers(assigns) do
+    ~H"""
+    <span class="flex">
+      <.route_pill route_id={@route_id} />
+      <span :if={Enum.any?(@modifier_ids)} class="h-6 -ml-1 flex gap-0.5">
+        <.route_modifier
+          :for={modifier_id <- @modifier_ids}
+          modifier_id={modifier_id}
+          class={@modifier_class}
+        />
+      </span>
+    </span>
+    """
+  end
+
+  def route_pill(assigns) do
+    ~H"""
+    <div class={
+      [
+        bg_color_class(@route_id),
+        "w-[3.125rem]"
+      ] ++ shared_icon_classes()
+    }>
+      {pill_text(@route_id)}
+    </div>
+    """
+  end
+
+  defp route_modifier(assigns) do
+    ~H"""
+    <div class={
+      [bg_color_class(@modifier_id), "ring-2 ring-white w-6"] ++
+        shared_icon_classes() ++
+        [@class]
+    }>
+      {modifier_text(@modifier_id)}
+    </div>
+    """
+  end
+
+  defp pill_text(route_id) do
+    (route_id |> String.at(0)) <> "L"
+  end
+
+  defp modifier_text("Green-" <> branch_id), do: branch_id
+  defp modifier_text("Mattapan"), do: "M"
+
+  defp bg_color_class("Green-" <> _), do: bg_color_class("Green")
+  defp bg_color_class("Mattapan"), do: bg_color_class("Red")
+
+  defp bg_color_class(route_id) do
+    "bg-#{route_id |> String.downcase()}-line"
+  end
+
+  defp shared_icon_classes() do
+    [
+      "rounded-full h-6",
+      "flex items-center justify-center",
+      "text-white font-bold font-heading select-none leading-none"
+    ]
+  end
+end

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -1,0 +1,58 @@
+defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
+  @moduledoc """
+  Renders a status as a readable version of that status, along with an
+  optional prefix.
+  """
+
+  use DotcomWeb, :component
+
+  attr :prefix, :string, default: nil
+  attr :plural, :boolean, default: false
+  attr :status, :atom, required: true
+
+  def status_label(assigns) do
+    rendered_prefix =
+      case assigns.prefix do
+        nil -> ""
+        prefix -> "#{prefix}: "
+      end
+
+    assigns = assigns |> assign(:rendered_prefix, rendered_prefix)
+
+    ~H"""
+    <span class={[status_classes(@status), "flex items-center gap-2"]}>
+      <.status_icon status={@status} />
+      {@rendered_prefix} {description(@status, @plural)}
+    </span>
+    """
+  end
+
+  defp description(status, true), do: description(status) |> Inflex.pluralize()
+  defp description(status, false), do: description(status)
+
+  defp description(:normal), do: "Normal Service"
+  defp description(:station_closure), do: "Station Closure"
+  defp description(status), do: status |> Atom.to_string() |> String.capitalize()
+
+  defp status_icon(%{status: :normal} = assigns) do
+    ~H"""
+    <div class="bg-green-line h-4 w-4 rounded-full"></div>
+    """
+  end
+
+  defp status_icon(assigns) do
+    ~H"""
+    <.icon class="h-[1.125rem] w-[1.125rem]" type="icon-svg" name={status_icon_name(@status)} />
+    """
+  end
+
+  defp status_icon_name(:shuttle), do: "icon-shuttle-default"
+
+  defp status_icon_name(status) when status in [:station_closure, :suspension],
+    do: "icon-cancelled-default"
+
+  defp status_icon_name(_), do: "icon-alerts-triangle"
+
+  defp status_classes(:normal), do: ""
+  defp status_classes(_), do: "font-bold"
+end

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -1,4 +1,4 @@
-defmodule DotcomWeb.Components.SystemStatus.Widget do
+defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   @moduledoc """
   A component that renders the given `@statuses` in a table.
   """
@@ -12,7 +12,7 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
 
   attr :subway_status, :any, required: true
 
-  def system_status_widget(assigns) do
+  def subway_status(assigns) do
     assigns = assigns |> assign(:rows, status_to_rows(assigns.subway_status))
 
     ~H"""

--- a/lib/dotcom_web/components/system_status/widget.ex
+++ b/lib/dotcom_web/components/system_status/widget.ex
@@ -10,8 +10,10 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
 
   @route_ids ["Red", "Orange", "Green", "Blue"]
 
+  attr :subway_status, :any, required: true
+
   def system_status_widget(assigns) do
-    assigns = assigns |> assign(:rows, status_to_rows(assigns.routes_with_statuses))
+    assigns = assigns |> assign(:rows, status_to_rows(assigns.subway_status))
 
     ~H"""
     <div class="px-5 py-4 border-[1px] border-gray-lightest rounded-lg w-96">
@@ -52,9 +54,9 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
     """
   end
 
-  defp status_to_rows(data) do
+  defp status_to_rows(subway_status) do
     @route_ids
-    |> Enum.map(&{&1, data |> Map.get(&1)})
+    |> Enum.map(&{&1, subway_status |> Map.get(&1)})
     |> Enum.flat_map(&rows_for_route/1)
     |> Enum.map(&add_url/1)
   end

--- a/lib/dotcom_web/components/system_status/widget.ex
+++ b/lib/dotcom_web/components/system_status/widget.ex
@@ -1,0 +1,135 @@
+defmodule DotcomWeb.Components.SystemStatus.Widget do
+  @moduledoc """
+  A component that renders the given `@statuses` in a table.
+  """
+
+  use DotcomWeb, :component
+
+  import DotcomWeb.Components.RoutePills
+  import DotcomWeb.Components.SystemStatus.StatusLabel
+
+  @route_ids ["Red", "Orange", "Green", "Blue"]
+
+  def system_status_widget(assigns) do
+    assigns = assigns |> assign(:rows, status_to_rows(assigns.routes_with_statuses))
+
+    ~H"""
+    <div class="px-5 py-4 border-[1px] border-gray-lightest rounded-lg w-96">
+      <div class="border-gray-lightest border-b-[1px] pl-2 pb-3 flex items-center gap-2">
+        <.icon type="icon-svg" name="icon-mode-subway-default" class="h-7 w-7" />
+        <span class="font-heading font-bold text-[1.75rem]">Subway Status</span>
+      </div>
+      <div
+        :for={row <- @rows}
+        class={[
+          "flex gap-2",
+          !row.style.short_bottom_border && "border-gray-lightest border-b-[1px]",
+          "hover:bg-brand-primary-lightest cursor-pointer group/row"
+        ]}
+      >
+        <div class={["pl-2 py-3", row.style.hide_route_pill && "invisible"]}>
+          <.route_pill_with_modifiers
+            route_id={row.route_info.route_id}
+            modifier_ids={row.route_info.branch_ids}
+            modifier_class="group-hover/row:ring-brand-primary-lightest"
+          />
+        </div>
+        <div class={[
+          "py-3 w-full",
+          row.style.short_bottom_border && "border-b-[1px] border-gray-lightest"
+        ]}>
+          <.status_label
+            status={row.status_entry.status}
+            prefix={row.status_entry.prefix}
+            plural={row.status_entry.plural}
+          />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def status_to_rows(data) do
+    @route_ids
+    |> Enum.map(&{&1, data |> Map.get(&1)})
+    |> Enum.flat_map(&rows_for_route/1)
+  end
+
+  defp rows_for_route({route_id, branches_with_statuses}) do
+    branches_with_statuses
+    |> Enum.flat_map(&rows_for_branch_group/1)
+    |> add_route_id(route_id)
+  end
+
+  defp rows_for_branch_group(%{branch_ids: branch_ids, status_entries: status_entries}) do
+    status_entries
+    |> rows_for_status_entries()
+    |> add_branch_ids(branch_ids)
+  end
+
+  defp rows_for_status_entries(status_entries) do
+    show_prefix = show_prefix?(status_entries)
+
+    status_entries
+    |> Enum.map(&row_for_status_entry(&1, show_prefix))
+    |> add_short_intermediate_borders()
+    |> show_first_route_pill()
+  end
+
+  defp row_for_status_entry(status_entry, show_prefix) do
+    %{status: status, time: time, multiple: multiple} = status_entry
+    prefix = if show_prefix, do: prefix(status_entry), else: nil
+
+    %{
+      route_info: %{},
+      status_entry: %{
+        status: status,
+        time: time,
+        plural: multiple,
+        prefix: prefix
+      },
+      style: %{
+        hide_route_pill: true,
+        short_bottom_border: false
+      }
+    }
+  end
+
+  defp add_branch_ids(rows, branch_ids) do
+    rows
+    |> Enum.map(fn row -> row |> put_in([:route_info, :branch_ids], branch_ids) end)
+  end
+
+  defp add_route_id(rows, route_id) do
+    rows
+    |> Enum.map(fn row -> row |> put_in([:route_info, :route_id], route_id) end)
+  end
+
+  defp show_first_route_pill([first_entry | rest_of_entries]) do
+    [
+      first_entry |> put_in([:style, :hide_route_pill], false)
+      | rest_of_entries
+    ]
+  end
+
+  defp add_short_intermediate_borders([entry]) do
+    [entry]
+  end
+
+  defp add_short_intermediate_borders([first_entry | rest_of_entries]) do
+    [
+      first_entry |> put_in([:style, :short_bottom_border], true)
+      | add_short_intermediate_borders(rest_of_entries)
+    ]
+  end
+
+  defp show_prefix?(status_entries) do
+    status_entries |> Enum.any?(&future?/1)
+  end
+
+  defp future?(%{time: {:future, _}}), do: true
+  defp future?(_), do: false
+
+  defp prefix(%{time: :current}), do: "Now"
+  defp prefix(%{time: {:future, time}}), do: Util.kitchen_downcase_time(time)
+end

--- a/lib/dotcom_web/components/system_status/widget.ex
+++ b/lib/dotcom_web/components/system_status/widget.ex
@@ -30,7 +30,7 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
         ]}
       >
         <div class={["pl-2 py-3", row.style.hide_route_pill && "invisible"]}>
-          <.route_pill_with_modifiers
+          <.route_pill
             route_id={row.route_info.route_id}
             modifier_ids={row.route_info.branch_ids}
             modifier_class="group-hover/row:ring-brand-primary-lightest"

--- a/lib/dotcom_web/components/system_status/widget.ex
+++ b/lib/dotcom_web/components/system_status/widget.ex
@@ -26,7 +26,7 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
           "flex gap-2",
           !row.style.short_bottom_border && "border-gray-lightest border-b-[1px]",
           "hover:bg-brand-primary-lightest cursor-pointer group/row",
-          "no-underline"
+          "text-black no-underline"
         ]}
       >
         <div class={["pl-2 py-3", row.style.hide_route_pill && "invisible"]}>
@@ -93,7 +93,7 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
   end
 
   defp row_for_status_entry(status_entry, show_prefix) do
-    %{status: status, time: time, multiple: multiple} = status_entry
+    %{status: status, multiple: multiple} = status_entry
     prefix = if show_prefix, do: prefix(status_entry), else: nil
 
     %{

--- a/lib/dotcom_web/components/system_status/widget.ex
+++ b/lib/dotcom_web/components/system_status/widget.ex
@@ -84,7 +84,6 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
       route_info: %{},
       status_entry: %{
         status: status,
-        time: time,
         plural: multiple,
         prefix: prefix
       },

--- a/lib/dotcom_web/components/system_status/widget.ex
+++ b/lib/dotcom_web/components/system_status/widget.ex
@@ -19,12 +19,14 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
         <.icon type="icon-svg" name="icon-mode-subway-default" class="h-7 w-7" />
         <span class="font-heading font-bold text-[1.75rem]">Subway Status</span>
       </div>
-      <div
+      <a
         :for={row <- @rows}
+        href={row.route_info.url}
         class={[
           "flex gap-2",
           !row.style.short_bottom_border && "border-gray-lightest border-b-[1px]",
-          "hover:bg-brand-primary-lightest cursor-pointer group/row"
+          "hover:bg-brand-primary-lightest cursor-pointer group/row",
+          "no-underline"
         ]}
       >
         <div class={["pl-2 py-3", row.style.hide_route_pill && "invisible"]}>
@@ -35,7 +37,7 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
           />
         </div>
         <div class={[
-          "py-3 w-full",
+          "py-3 w-full flex items-center",
           row.style.short_bottom_border && "border-b-[1px] border-gray-lightest"
         ]}>
           <.status_label
@@ -43,8 +45,9 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
             prefix={row.status_entry.prefix}
             plural={row.status_entry.plural}
           />
+          <.icon name="chevron-right" class="h-3 w-2 fill-gray-lighter ml-auto mr-3" />
         </div>
-      </div>
+      </a>
     </div>
     """
   end
@@ -53,7 +56,20 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
     @route_ids
     |> Enum.map(&{&1, data |> Map.get(&1)})
     |> Enum.flat_map(&rows_for_route/1)
+    |> Enum.map(&add_url/1)
   end
+
+  defp add_url(row) do
+    route_id = route_id_from_route_info(row.route_info)
+    sub_page = if is_normal?(row.status_entry), do: "line", else: "alerts"
+    row |> put_in([:route_info, :url], ~p"/schedules/#{route_id}/#{sub_page}")
+  end
+
+  defp is_normal?(%{status: :normal}), do: true
+  defp is_normal?(%{}), do: false
+
+  defp route_id_from_route_info(%{branch_ids: [branch_id]}), do: branch_id
+  defp route_id_from_route_info(%{route_id: route_id}), do: route_id
 
   defp rows_for_route({route_id, branches_with_statuses}) do
     branches_with_statuses

--- a/lib/dotcom_web/components/system_status/widget.ex
+++ b/lib/dotcom_web/components/system_status/widget.ex
@@ -49,7 +49,7 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
     """
   end
 
-  def status_to_rows(data) do
+  defp status_to_rows(data) do
     @route_ids
     |> Enum.map(&{&1, data |> Map.get(&1)})
     |> Enum.flat_map(&rows_for_route/1)

--- a/lib/dotcom_web/components/system_status/widget.ex
+++ b/lib/dotcom_web/components/system_status/widget.ex
@@ -63,12 +63,12 @@ defmodule DotcomWeb.Components.SystemStatus.Widget do
 
   defp add_url(row) do
     route_id = route_id_from_route_info(row.route_info)
-    sub_page = if is_normal?(row.status_entry), do: "line", else: "alerts"
+    sub_page = if normal?(row.status_entry), do: "line", else: "alerts"
     row |> put_in([:route_info, :url], ~p"/schedules/#{route_id}/#{sub_page}")
   end
 
-  defp is_normal?(%{status: :normal}), do: true
-  defp is_normal?(%{}), do: false
+  defp normal?(%{status: :normal}), do: true
+  defp normal?(%{}), do: false
 
   defp route_id_from_route_info(%{branch_ids: [branch_id]}), do: branch_id
   defp route_id_from_route_info(%{route_id: route_id}), do: route_id

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -75,7 +75,7 @@ defmodule DotcomWeb.Live.SystemStatus do
       <.route_pill route_id="Green" />
       <.route_pill route_id="Orange" />
       <.route_pill route_id="Red" />
-      <.route_pill_with_modifiers route_id="Green" modifier_ids={["Green-B", "Green-C"]} />
+      <.route_pill route_id="Green" modifier_ids={["Green-B", "Green-C"]} />
     </div>
     """
   end

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -17,23 +17,38 @@ defmodule DotcomWeb.Live.SystemStatus do
 
     statuses = SystemStatus.subway_status()
 
+    examples =
+      alerts_examples()
+      |> Enum.map(fn %{alerts: alerts} = example ->
+        example |> Map.put(:statuses, SystemStatus.Subway.subway_status(alerts, Timex.now()))
+      end)
+
     assigns =
       assigns
       |> assign(:alerts, alerts)
       |> assign(:statuses, statuses)
+      |> assign(:examples, examples)
 
     Widget
 
     ~H"""
-    <h1>System Status</h1>
+    <h1>Live Data</h1>
     <.system_status_widget routes_with_statuses={@statuses} />
 
-    <h1>Examples</h1>
-    <.system_status_widget routes_with_statuses={fake_statuses_1()} />
-
-    <h1>Alerts</h1>
+    <h2>Alerts</h2>
     <div class="flex flex-col gap-2">
       <.alert :for={alert <- @alerts} alert={alert} />
+    </div>
+
+    <h1>Examples</h1>
+    <div :for={example <- @examples} class="mb-4">
+      <div class="flex gap-5">
+        <.system_status_widget routes_with_statuses={example.statuses} />
+        <div class="flex flex-col gap-5">
+          <span class="text-lg font-bold">Alerts</span>
+          <.alert :for={alert <- example.alerts} alert={alert} />
+        </div>
+      </div>
     </div>
 
     <h1>Misc Components</h1>
@@ -43,7 +58,7 @@ defmodule DotcomWeb.Live.SystemStatus do
       <.status_label status={:shuttle} />
       <.status_label status={:shuttle} plural />
       <.status_label status={:shuttle} prefix="8:30pm" />
-      <.status_label status={:shuttle} prefix="Wed, Feb 12 - Fri, Feb 14" />
+      <.status_label status={:shuttle} prefix="Wed Feb 12 - Fri Feb 14" />
       <.status_label status={:station_closure} />
       <.status_label status={:delay} />
     </div>
@@ -63,7 +78,17 @@ defmodule DotcomWeb.Live.SystemStatus do
     ~H"""
     <details class="border border-gray-lighter p-2">
       <summary>
-        <span class="font-bold">{@alert.severity} {@alert.effect}:</span> {@alert.header}
+        <div>
+          <span class="font-bold">{@alert.effect}:</span>
+          <span class="italic">
+            {@alert.informed_entity
+            |> Enum.map(& &1.route)
+            |> Enum.uniq()
+            |> Enum.sort()
+            |> Enum.join(", ")}
+          </span>
+        </div>
+        <span>{@alert.header}</span>
       </summary>
       <details>
         <summary>Raw alert</summary>
@@ -73,53 +98,153 @@ defmodule DotcomWeb.Live.SystemStatus do
     """
   end
 
-  defp fake_statuses_1() do
-    %{
-      "Blue" => [
-        %{
-          branch_ids: [],
-          status_entries: [%{time: :current, status: :normal, multiple: false}]
-        }
-      ],
-      "Orange" => [
-        %{
-          branch_ids: [],
-          status_entries: [
-            %{time: :current, status: :delay, multiple: false},
-            %{
-              time: {:future, Timex.now() |> Timex.set(hour: 20, minute: 30)},
-              status: :shuttle,
-              multiple: false
+  defp alerts_examples() do
+    [
+      %{alerts: []},
+      %{
+        alerts: [
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :suspension,
+            header: "Northbound Orange Line trains are suspended due to flooding",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Orange"}]
             }
-          ]
-        }
-      ],
-      "Red" => [
-        %{
-          branch_ids: [],
-          status_entries: [%{time: :current, status: :normal, multiple: false}]
-        },
-        %{
-          branch_ids: ["Mattapan"],
-          status_entries: [%{time: :current, status: :suspension, multiple: false}]
-        }
-      ],
-      "Green" => [
-        %{
-          branch_ids: ["Green-D", "Green-E"],
-          status_entries: [
-            %{
-              time: {:future, Timex.now() |> Timex.set(hour: 18, minute: 0)},
-              status: :station_closure,
-              multiple: true
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header: "Southbound Orange Line trains are delayed due to flooding",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Orange"}]
             }
-          ]
-        },
-        %{
-          branch_ids: ["Green-B", "Green-C"],
-          status_entries: [%{time: :current, status: :normal, multiple: false}]
-        }
-      ]
-    }
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header:
+              "Northbound Blue line trains are delayed due to an escaped whale from the aquarium",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Blue"}]
+            }
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header:
+              "Southbound Blue line trains are delayed due to an escaped otter from the aquarium",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Blue"}]
+            }
+          }
+        ]
+      },
+      %{
+        alerts: [
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :shuttle,
+            header:
+              "Mattapan trains are replaced with shuttles that are just driving on the tracks",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Mattapan"}]
+            }
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :station_closure,
+            header: "Copley Station is closed due to an overabundance of books",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: GreenLine.branch_ids() |> Enum.map(&%Alerts.InformedEntity{route: &1})
+            }
+          }
+        ]
+      },
+      %{
+        alerts: [
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header: "Green line B branch is delayed due to protests at BU",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Green-B"}]
+            }
+          }
+        ]
+      },
+      %{
+        alerts: [
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header: "Green line B branch is delayed due to protests at BU",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Green-B"}]
+            }
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :station_closure,
+            header: "Copley Station is closed due to an over-abundance of books",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: GreenLine.branch_ids() |> Enum.map(&%Alerts.InformedEntity{route: &1})
+            }
+          }
+        ]
+      },
+      %{
+        alerts: [
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :suspension,
+            header: "Northbound Orange Line trains are suspended due to flooding",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Orange"}]
+            }
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header: "Southbound Orange Line trains are delayed due to flooding",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Orange"}]
+            }
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :shuttle,
+            header:
+              "Mattapan trains are replaced with shuttles that are just driving on the tracks",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Mattapan"}]
+            }
+          }
+        ]
+      }
+    ]
   end
 end

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -47,7 +47,9 @@ defmodule DotcomWeb.Live.SystemStatus do
     <h1>Examples</h1>
     <div :for={example <- @examples} class="mb-4">
       <div class="flex gap-5">
-        <.system_status_widget routes_with_statuses={example.statuses} />
+        <div>
+          <.system_status_widget routes_with_statuses={example.statuses} />
+        </div>
         <div class="flex flex-col gap-5">
           <span class="text-lg font-bold">Alerts</span>
           <.alert :for={alert <- example.alerts} alert={alert} />

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -6,6 +6,10 @@ defmodule DotcomWeb.Live.SystemStatus do
 
   use DotcomWeb, :live_view
 
+  import DotcomWeb.Components.RoutePills
+  import DotcomWeb.Components.SystemStatus.StatusLabel
+  import DotcomWeb.Components.SystemStatus.Widget
+
   alias Dotcom.SystemStatus
 
   def render(assigns) do
@@ -18,21 +22,40 @@ defmodule DotcomWeb.Live.SystemStatus do
       |> assign(:alerts, alerts)
       |> assign(:statuses, statuses)
 
+    Widget
+
     ~H"""
     <h1>System Status</h1>
-    <div>
-      <.status :for={status <- @statuses} status={status} />
-    </div>
+    <.system_status_widget routes_with_statuses={@statuses} />
+
+    <h1>Examples</h1>
+    <.system_status_widget routes_with_statuses={fake_statuses_1()} />
+
     <h1>Alerts</h1>
     <div class="flex flex-col gap-2">
       <.alert :for={alert <- @alerts} alert={alert} />
     </div>
-    """
-  end
 
-  defp status(assigns) do
-    ~H"""
-    <pre>{inspect @status, pretty: true}</pre>
+    <h1>Misc Components</h1>
+    <h2>Status Labels</h2>
+    <div class="flex flex-col gap-2">
+      <.status_label status={:normal} />
+      <.status_label status={:shuttle} />
+      <.status_label status={:shuttle} plural />
+      <.status_label status={:shuttle} prefix="8:30pm" />
+      <.status_label status={:shuttle} prefix="Wed, Feb 12 - Fri, Feb 14" />
+      <.status_label status={:station_closure} />
+      <.status_label status={:delay} />
+    </div>
+
+    <h2>Route Pills</h2>
+    <div class="flex flex-col gap-2">
+      <.route_pill route_id="Blue" />
+      <.route_pill route_id="Green" />
+      <.route_pill route_id="Orange" />
+      <.route_pill route_id="Red" />
+      <.route_pill_with_modifiers route_id="Green" modifier_ids={["Green-B", "Green-C"]} />
+    </div>
     """
   end
 
@@ -48,5 +71,55 @@ defmodule DotcomWeb.Live.SystemStatus do
       </details>
     </details>
     """
+  end
+
+  defp fake_statuses_1() do
+    %{
+      "Blue" => [
+        %{
+          branch_ids: [],
+          status_entries: [%{time: :current, status: :normal, multiple: false}]
+        }
+      ],
+      "Orange" => [
+        %{
+          branch_ids: [],
+          status_entries: [
+            %{time: :current, status: :delay, multiple: false},
+            %{
+              time: {:future, Timex.now() |> Timex.set(hour: 20, minute: 30)},
+              status: :shuttle,
+              multiple: false
+            }
+          ]
+        }
+      ],
+      "Red" => [
+        %{
+          branch_ids: [],
+          status_entries: [%{time: :current, status: :normal, multiple: false}]
+        },
+        %{
+          branch_ids: ["Mattapan"],
+          status_entries: [%{time: :current, status: :suspension, multiple: false}]
+        }
+      ],
+      "Green" => [
+        %{
+          branch_ids: ["Green-D", "Green-E"],
+          status_entries: [
+            %{
+              time: {:future, Timex.now() |> Timex.set(hour: 18, minute: 0)},
+              status: :station_closure,
+              multiple: true
+            }
+          ]
+        },
+        %{
+          branch_ids: ["Green-B", "Green-C"],
+          status_entries: [%{time: :current, status: :normal, multiple: false}]
+        }
+      ]
+    }
   end
 end

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -37,7 +37,7 @@ defmodule DotcomWeb.Live.SystemStatus do
 
     ~H"""
     <h1>Live Data</h1>
-    <.system_status_widget routes_with_statuses={@statuses} />
+    <.system_status_widget subway_status={@statuses} />
 
     <h2>Alerts</h2>
     <div class="flex flex-col gap-2">
@@ -48,7 +48,7 @@ defmodule DotcomWeb.Live.SystemStatus do
     <div :for={example <- @examples} class="mb-4">
       <div class="flex gap-5">
         <div>
-          <.system_status_widget routes_with_statuses={example.statuses} />
+          <.system_status_widget subway_status={example.statuses} />
         </div>
         <div class="flex flex-col gap-5">
           <span class="text-lg font-bold">Alerts</span>

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -8,7 +8,7 @@ defmodule DotcomWeb.Live.SystemStatus do
 
   import DotcomWeb.Components.RoutePills
   import DotcomWeb.Components.SystemStatus.StatusLabel
-  import DotcomWeb.Components.SystemStatus.Widget
+  import DotcomWeb.Components.SystemStatus.SubwayStatus
 
   alias Dotcom.SystemStatus
 
@@ -37,7 +37,7 @@ defmodule DotcomWeb.Live.SystemStatus do
 
     ~H"""
     <h1>Live Data</h1>
-    <.system_status_widget subway_status={@statuses} />
+    <.subway_status subway_status={@statuses} />
 
     <h2>Alerts</h2>
     <div class="flex flex-col gap-2">
@@ -48,7 +48,7 @@ defmodule DotcomWeb.Live.SystemStatus do
     <div :for={example <- @examples} class="mb-4">
       <div class="flex gap-5">
         <div>
-          <.system_status_widget subway_status={example.statuses} />
+          <.subway_status subway_status={example.statuses} />
         </div>
         <div class="flex flex-col gap-5">
           <span class="text-lg font-bold">Alerts</span>

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -20,7 +20,11 @@ defmodule DotcomWeb.Live.SystemStatus do
     examples =
       alerts_examples()
       |> Enum.map(fn %{alerts: alerts} = example ->
-        example |> Map.put(:statuses, SystemStatus.Subway.subway_status(alerts, Timex.now()))
+        example
+        |> Map.put(
+          :statuses,
+          SystemStatus.Subway.subway_status(alerts, Timex.now() |> Timex.set(hour: 12))
+        )
       end)
 
     assigns =
@@ -115,10 +119,10 @@ defmodule DotcomWeb.Live.SystemStatus do
           },
           %Alerts.Alert{
             active_period: [
-              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+              {Timex.now() |> Timex.set(hour: 20, minute: 30), Timex.end_of_day(Timex.now())}
             ],
             effect: :delay,
-            header: "Southbound Orange Line trains are delayed due to flooding",
+            header: "Southbound Orange Line trains will be delayed due to flooding at 8:30pm",
             informed_entity: %Alerts.InformedEntitySet{
               entities: [%Alerts.InformedEntity{route: "Orange"}]
             }
@@ -241,6 +245,40 @@ defmodule DotcomWeb.Live.SystemStatus do
               "Mattapan trains are replaced with shuttles that are just driving on the tracks",
             informed_entity: %Alerts.InformedEntitySet{
               entities: [%Alerts.InformedEntity{route: "Mattapan"}]
+            }
+          }
+        ]
+      },
+      %{
+        alerts: [
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header: "Green line B branch is delayed due to protests at BU",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Green-B"}]
+            }
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :station_closure,
+            header: "Riverside station is closed due to a red line train on the tracks",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Green-D"}]
+            }
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :station_closure,
+            header: "Alewife station is closed due to a green line train on the tracks",
+            informed_entity: %Alerts.InformedEntitySet{
+              entities: [%Alerts.InformedEntity{route: "Red"}]
             }
           }
         ]


### PR DESCRIPTION
## Examples

<img width="399" alt="Screenshot 2025-02-10 at 2 24 09 PM" src="https://github.com/user-attachments/assets/787219c8-7e2e-4448-8ec7-701ebac20329" />

<img width="398" alt="Screenshot 2025-02-10 at 2 24 18 PM" src="https://github.com/user-attachments/assets/ac466306-2a8f-4591-8cf2-9356d2b09535" />

<img width="396" alt="Screenshot 2025-02-10 at 2 24 31 PM" src="https://github.com/user-attachments/assets/5bf54491-1cfa-4061-bb2e-08ec6f5e851d" />

---

**Asana Ticket:** [System Status | [Hi-Fi] Component that renders grouped statuses/alerts](https://app.asana.com/0/555089885850811/1209091199210570)