### PR TITLE
Tell robots to ignore all pages when the domain is mbtace

### DIFF
--- a/lib/dotcom_web/templates/layout/root.html.eex
+++ b/lib/dotcom_web/templates/layout/root.html.eex
@@ -10,6 +10,11 @@
     <meta name="author" content="Massachusetts Bay Transportation Authority">
     <meta name="theme-color" content="#165c96">
 
+    <%= # hide any mbtace sub domain
+    if String.match?(@conn.host, ~r/mbtace/) do %>
+      <meta name="robots" content="noindex, nofollow">
+    <% end %>
+
     <%= # hide any page in /org directory from search engines
     if @conn.request_path == "/org" || String.slice(@conn.request_path, 0..4) == "/org/" do %>
       <meta name="robots" content="noindex, nofollow">


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1209320056067616/f

Go to dev-green and you'll see the meta tag in the html head.
