### PR TITLE
feat(autocomplete): add zero state

### DIFF
--- a/assets/ts/ui/autocomplete/sources.ts
+++ b/assets/ts/ui/autocomplete/sources.ts
@@ -95,7 +95,16 @@ export const locationSource = (
   templates: {
     item: urlType
       ? templateWithLink(LocationItemTemplate)
-      : LocationItemTemplate
+      : LocationItemTemplate,
+    noResults({ html }) {
+      return html`
+        <i
+          class="fa fa-fw fa-circle-exclamation text-firebrick-50 mr-sm"
+          aria-hidden="true"
+        ></i>
+        No results found
+      `;
+    }
   },
   getItems() {
     return fetch(`/places/search/${encodeURIComponent(query)}/${number}`)


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
Related to [TP | Add an error state when location isn't selected](https://app.asana.com/0/555089885850811/1209320056067619) but not technically that! Chase and I decided to split this into two parts, here's one of those parts.

This PR both:
1. Changes the behavior of this input to keep the dropdown open until an item is selected (or the input is cleared).
2. Adds a display for when there're no results.

Both changes apply to this input generally, not just in the trip planner.