### PR TITLE
feat(autocomplete): in trip planner, auto-select first result on enter

### DIFF
--- a/assets/ts/ui/autocomplete/config.ts
+++ b/assets/ts/ui/autocomplete/config.ts
@@ -210,6 +210,15 @@ const TRIP_PLANNER = ({
     onReset: (): void => {
       pushToLiveView({});
     },
+    onSubmit({ state, setQuery }) {
+      // Triggered by pressing enter on the input: selects the first result.
+      const results = state.collections.flatMap(collection => collection.items);
+      if (results.length > 0) {
+        const item = results[0];
+        // @ts-ignore
+        onSelect({ item, setQuery });
+      }
+    },
     getSources({ query }) {
       if (!query)
         return debounced([


### PR DESCRIPTION
Inspired by [this thread](https://mbta.slack.com/archives/C911LQH2N/p1738766422999089). This PR will simulate selecting the first result if a user presses enter in a location search box. This actually replicates old Trip Planner behavior, which [searches AWS Location Service using the name](https://github.com/mbta/dotcom/blob/main/lib/dotcom/trip_plan/location.ex#L118) in cases when geographic coordinates weren't already provided.
 
We don't necessarily want this exact same configuration in other usages of the autocomplete component, since some have implemented different behavior. For example, pressing `Enter` in the top nav search bar actually takes you to the search page. :) So this change only affects trip planner as written here. 