### PR TITLE
feat(Live.TripPlanner): handle OTP timeouts

### DIFF
--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -122,7 +122,13 @@ defmodule DotcomWeb.Live.TripPlanner do
         {:ok, {:error, %Req.TransportError{reason: _reason}}},
         socket
       ) do
-    message = "Cannot connect to OpenTripPlanner. Please try again later."
+    message =
+      Application.get_env(
+        :open_trip_planner_client,
+        :fallback_error_message,
+        "Cannot connect to OpenTripPlanner. Please try again later."
+      )
+
     new_socket = assign(socket, :results, Map.put(@state.results, :error, message))
 
     {:noreply, new_socket}

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -116,10 +116,10 @@ defmodule DotcomWeb.Live.TripPlanner do
   end
 
   @impl true
-  # Triggered when we cannot connect to OTP.
+  # Triggered when we cannot connect to OTP, or we receive a timeout error.
   def handle_async(
         "get_itinerary_groups",
-        {:ok, {:error, %Req.TransportError{reason: :econnrefused}}},
+        {:ok, {:error, %Req.TransportError{reason: _reason}}},
         socket
       ) do
     message = "Cannot connect to OpenTripPlanner. Please try again later."
@@ -130,7 +130,8 @@ defmodule DotcomWeb.Live.TripPlanner do
 
   @impl true
   # Triggered by OTP errors, we combine them into a single error message and add it to the results state.
-  def handle_async("get_itinerary_groups", {:ok, {:error, errors}}, socket) do
+  def handle_async("get_itinerary_groups", {:ok, {:error, errors}}, socket)
+      when is_list(errors) do
     error =
       errors
       |> Enum.map_join(", ", &Map.get(&1, :message))

--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -203,7 +203,11 @@ defmodule DotcomWeb.Live.TripPlannerTest do
 
       document = render_async(view)
 
-      assert document =~ "Cannot connect to OpenTripPlanner. Please try again later."
+      assert document =~
+               Application.get_env(
+                 :open_trip_planner_client,
+                 :fallback_error_message
+               )
     end
 
     test "an OTP error shows up as an error message", %{view: view} do


### PR DESCRIPTION
It turns out we weren't pattern matching to handle the `%Req.TransportError{reason: :timeout}` we were receiving.