### PR TITLE
fix(TripPlan.InputForm): improve location validation + add visual error state

### DIFF
--- a/assets/css/_autocomplete-theme.scss
+++ b/assets/css/_autocomplete-theme.scss
@@ -1,12 +1,20 @@
 @import '@algolia/autocomplete-theme-classic';
 
+:root {
+  --aa-accent-color: 22, 92, 150; // $brand-primary fallback;
+}
+
 // styles that will be used for every instance
 [phx-hook='AlgoliaAutocomplete'], .aa-Detached {
+  .text-danger & {
+    --aa-accent-color: 179, 0, 15; // matches $error-text
+  }
+
   .aa-Autocomplete {
-    --aa-icon-color-rgb: 22, 92, 150; // $brand-primary;
-    --aa-primary-color-rgb: 22, 92, 150; // $brand-primary;
-    --aa-input-border-color-rgb: 22, 92, 150;
-    --aa-overlay-color-rgb: 22, 92, 150; // $brand-primary;
+    --aa-icon-color-rgb: var(--aa-accent-color);
+    --aa-primary-color-rgb: var(--aa-accent-color);
+    --aa-input-border-color-rgb: var(--aa-accent-color);
+    --aa-overlay-color-rgb: var(--aa-accent-color);
   }
 
   .aa-Label {
@@ -32,11 +40,6 @@
     &:focus-within {
       border-color: $brand-primary-light;
       box-shadow: unset;
-    }
-
-    div:has(.text-danger) > & {
-      --aa-input-border-color-rgb: 179, 0, 15;
-      --aa-icon-color-rgb: 179, 0, 15;
     }
   }
 
@@ -218,7 +221,7 @@
 
     .aa-Label {
       align-content: center;
-      color: $brand-primary;
+      color: rgb(var(--aa-icon-color-rgb));
       font-size: 1.25rem;
       font-weight: bold;
       text-align: center;

--- a/assets/ts/ui/autocomplete/config.ts
+++ b/assets/ts/ui/autocomplete/config.ts
@@ -211,9 +211,11 @@ const TRIP_PLANNER = ({
       pushToLiveView({});
     },
     onStateChange({ prevState, state }) {
-      // Send changed input text to LiveView
-      if (state.query !== prevState.query) {
-        const newInputData = state.query === "" ? {} : { name: state.query };
+      const isCleared = state.query === "";
+      const changedToClosedState = prevState.isOpen && !state.isOpen;
+      // Send changed input text to LiveView when leaving this input
+      if (changedToClosedState) {
+        const newInputData = isCleared ? {} : { name: state.query };
         pushToLiveView(newInputData);
       }
     },

--- a/assets/ts/ui/autocomplete/config.ts
+++ b/assets/ts/ui/autocomplete/config.ts
@@ -210,6 +210,13 @@ const TRIP_PLANNER = ({
     onReset: (): void => {
       pushToLiveView({});
     },
+    onStateChange({ prevState, state }) {
+      // Send changed input text to LiveView
+      if (state.query !== prevState.query) {
+        const newInputData = state.query === "" ? {} : { name: state.query };
+        pushToLiveView(newInputData);
+      }
+    },
     getSources({ query }) {
       if (!query)
         return debounced([

--- a/lib/dotcom/trip_plan/anti_corruption_layer.ex
+++ b/lib/dotcom/trip_plan/anti_corruption_layer.ex
@@ -76,16 +76,16 @@ defmodule Dotcom.TripPlan.AntiCorruptionLayer do
   defp copy_params(params) do
     %{
       "from" => %{
-        "latitude" => Map.get(params, "from_latitude"),
-        "longitude" => Map.get(params, "from_longitude"),
-        "name" => Map.get(params, "from"),
+        "latitude" => Map.get(params, "from_latitude", ""),
+        "longitude" => Map.get(params, "from_longitude", ""),
+        "name" => Map.get(params, "from", ""),
         "stop_id" => Map.get(params, "from_stop_id", "")
       },
       "modes" => Map.get(params, "modes") |> convert_modes(),
       "to" => %{
-        "latitude" => Map.get(params, "to_latitude"),
-        "longitude" => Map.get(params, "to_longitude"),
-        "name" => Map.get(params, "to"),
+        "latitude" => Map.get(params, "to_latitude", ""),
+        "longitude" => Map.get(params, "to_longitude", ""),
+        "name" => Map.get(params, "to", ""),
         "stop_id" => Map.get(params, "to_stop_id", "")
       },
       "wheelchair" => Map.get(params, "wheelchair") || "false"

--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -115,10 +115,13 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
   defp location_search_box(assigns) do
     assigns =
       assigns
-      |> assign(:location_keys, InputForm.Location.fields())
+      |> assign(%{
+        has_error?: used_input?(assigns.field) && length(assigns.field.errors) > 0,
+        location_keys: InputForm.Location.fields()
+      })
 
     ~H"""
-    <fieldset class="mb-sm -mt-md" id={"#{@name}-wrapper"}>
+    <fieldset class={"mb-sm -mt-md #{if(@has_error?, do: "text-danger")}"} id={"#{@name}-wrapper"}>
       <legend class="text-charcoal-40 m-0 py-sm">{Phoenix.Naming.humanize(@field.field)}</legend>
       <.algolia_autocomplete config_type="trip-planner" placeholder={@placeholder} id={@name}>
         <.inputs_for :let={location_f} field={@field} skip_hidden={true}>
@@ -130,7 +133,7 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
             name={location_f[subfield].name}
           />
         </.inputs_for>
-        <.feedback :for={{msg, _} <- @field.errors} :if={used_input?(@field)} kind={:error}>
+        <.feedback :for={{msg, _} <- @field.errors} :if={@has_error?} kind={:error}>
           {msg}
         </.feedback>
       </.algolia_autocomplete>

--- a/lib/dotcom_web/components/trip_planner/input_form.ex
+++ b/lib/dotcom_web/components/trip_planner/input_form.ex
@@ -43,8 +43,9 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
           </div>
           <button
             type="button"
+            disabled={disable_swap?(f)}
             phx-click="swap_direction"
-            class="px-xs bg-transparent fill-brand-primary hover:fill-black"
+            class="px-xs bg-transparent fill-brand-primary disabled:fill-gray-light hover:fill-black"
           >
             <span class="sr-only">Swap origin and destination locations</span>
             <.icon class="h-6 w-6 rotate-90 md:rotate-0" name="right-left" />
@@ -149,6 +150,12 @@ defmodule DotcomWeb.Components.TripPlanner.InputForm do
       min_date: Timex.today("America/New_York")
     }
   end
+
+  defp disable_swap?(%{errors: [_ | _] = errors}) do
+    :from in Keyword.keys(errors) or :to in Keyword.keys(errors)
+  end
+
+  defp disable_swap?(_), do: false
 
   defp show_datepicker?(f) do
     input_value(f, :datetime_type) != "now"

--- a/test/dotcom/trip_plan/input_form_test.exs
+++ b/test/dotcom/trip_plan/input_form_test.exs
@@ -60,6 +60,23 @@ defmodule Dotcom.TripPlan.InputFormTest do
       refute changeset.errors[:from]
     end
 
+    test "adds error if invalid location" do
+      changeset =
+        InputForm.changeset(%{
+          "to" => %{
+            "latitude" => "",
+            "longitude" => "",
+            "name" => Faker.Cat.breed(),
+            "stop_id" => ""
+          }
+        })
+
+      refute changeset.valid?
+
+      expected_error = InputForm.error_message(:to)
+      assert {^expected_error, _} = changeset.errors[:to]
+    end
+
     test "adds error if from & to are the same" do
       changeset =
         InputForm.changeset(%{

--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -144,6 +144,23 @@ defmodule DotcomWeb.Live.TripPlannerTest do
              ]
     end
 
+    test "disabled swap with invalid from/to", %{view: view} do
+      # Setup
+      stub(OpenTripPlannerClient.Mock, :plan, fn _ ->
+        {:ok, %OpenTripPlannerClient.Plan{itineraries: []}}
+      end)
+
+      params = Map.take(@valid_params, ["from"]) |> Map.put("to", %{"name" => Faker.Cat.breed()})
+
+      # Exercise
+      view |> element("form") |> render_change(%{"input_form" => params})
+
+      swap_button = element(view, "button[phx-click='swap_direction']") |> render()
+
+      # Verify
+      assert swap_button =~ "disabled=\"disabled\""
+    end
+
     test "selecting a time other than 'now' shows the datepicker", %{view: view} do
       # Setup
       params = %{


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** mostly [TP | Add an error state when location isn't selected](https://app.asana.com/0/1209151500209207/1209320056067619) with some [UI/UX | Trip Planner location input error state](https://app.asana.com/0/1209151500209207/1208726277099892), should fix [TP Bugs | Trip planner input location bug](https://app.asana.com/0/1209151500209207/1208025102649692) 

Will be even better with #2364 and #2361 in the mix.

## Key changes
- Validation of the `:to` and `:from` fields has been overhauled, and adds the error where needed
- The location inputs are technically themable now, and we use that to change to the error styling when that form field has errors
- Text that's pasted into the location inputs now gets sent to LiveView (as a pseudo-"selection" that's a name with no lat/lon) and proceeds through our usual pipelines

### More changes
- Fixes the default params in `Dotcom.TripPlan.AntiCorruptionLayer` to not encode missing params as `"nil"`
- Only validates whether locations A != B if each location is itself valid

