### PR TITLE
chore(Plugs.CanonicalHostname): remove mTicket exception

### DIFF
--- a/lib/dotcom_web/plugs/canonical_hostname.ex
+++ b/lib/dotcom_web/plugs/canonical_hostname.ex
@@ -2,22 +2,12 @@ defmodule DotcomWeb.Plugs.CanonicalHostname do
   @moduledoc """
   Plug to ensure that the site is only accessed via the canonical hostname.
   In particular, this will prevent users going to www.mbtace.com.
-
-  There is an exception for the hostname that the mTicket app uses, since
-  we detect that elsewhere in the code to produce some mTicket-specific
-  effects when the site is loaded in mTicket's webview.
   """
-
-  @mticket_hostname "mticket.mbtace.com"
 
   import Plug.Conn
   import Phoenix.Controller, only: [redirect: 2]
 
   def init(_) do
-  end
-
-  def call(%Plug.Conn{host: @mticket_hostname} = conn, _) do
-    conn
   end
 
   def call(%Plug.Conn{host: requested_hostname} = conn, _) do

--- a/test/dotcom_web/plugs/canonical_hostname_test.exs
+++ b/test/dotcom_web/plugs/canonical_hostname_test.exs
@@ -5,14 +5,6 @@ defmodule DotcomWeb.Plugs.CanonicalHostnameTest do
   alias DotcomWeb.Plugs.CanonicalHostname
 
   describe "call/2" do
-    test "with the special mTicket hostname, does nothing" do
-      conn = %Plug.Conn{default_conn() | host: "mticket.mbtace.com"}
-      assert conn.status != 301
-
-      conn = CanonicalHostname.call(conn, nil)
-      assert conn.status != 301
-    end
-
     test "with a local IP address, does nothing" do
       # Class A
       conn = %Plug.Conn{default_conn() | host: "10.127.127.127"}


### PR DESCRIPTION

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** Related to [Get rid of mticket.mbtace.com](https://app.asana.com/0/555089885850811/1209322293648193)

This lets mticket.mbtace.com-based visitors get a 301 response and get redirected to mbta.com.
