### PR TITLE
fix: Don't warn that KinoLiveComponent import is unused

### DIFF
--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -261,7 +261,7 @@ defmodule DotcomWeb.Router do
     end
   end
 
-  import KinoLiveComponent.Plug, only: [allow_insecure_connection: 2]
+  import KinoLiveComponent.Plug, only: [allow_insecure_connection: 2], warn: false
 
   if Mix.env() == :dev do
     scope "/kino-live-component", KinoLiveComponent do


### PR DESCRIPTION
Removes this warning, which shows up in any and all test output:
```
     warning: unused import KinoLiveComponent.Plug
     │
 264 │   import KinoLiveComponent.Plug, only: [allow_insecure_connection: 2]
     │   ~
     │
     └─ lib/dotcom_web/router.ex:264:3
```

The import is actually used (in `:dev` and `:dev` only), but something about the `if Mix.env() == :dev` check means that when `Mix.env()` is `:test`, it thinks that the import isn't.

---

No ticket.