### PR TITLE
refactor: alerts page layout

### DIFF
--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -6,6 +6,12 @@ defmodule DotcomWeb.Components do
   """
   use Phoenix.Component
 
+  use Phoenix.VerifiedRoutes,
+    endpoint: DotcomWeb.Endpoint,
+    router: DotcomWeb.Router
+
+  embed_templates "layouts/*"
+
   attr(:id, :string, required: true, doc: "A unique identifier for this search input.")
 
   attr(:placeholder, :string,

--- a/lib/dotcom_web/components/layouts/alerts_layout.html.heex
+++ b/lib/dotcom_web/components/layouts/alerts_layout.html.heex
@@ -1,0 +1,38 @@
+<div class="container">
+  <div class="page-section">
+    <div class="page-header">
+      <h1>Alerts</h1>
+    </div>
+    <div class="row">
+      <div class="col-lg-3">
+        {render_slot(@sidebar_top)}
+        <div class="hidden-md-down">
+          {render_slot(@sidebar_bottom)}
+        </div>
+      </div>
+      <div class="col-lg-8 col-lg-offset-1">
+        <div class="m-alerts__mode-buttons">
+          <a
+            :for={mode <- [:subway, :bus, :commuter_rail, :ferry, :access]}
+            href={~p"/alerts/#{mode}"}
+            class="m-alerts__mode-button-container"
+          >
+            <div class={[
+              "m-alerts__mode-button",
+              if(@mode == mode, do: "m-alerts__mode-button--selected")
+            ]}>
+              <div class="m-alerts__mode-icon">{DotcomWeb.AlertView.type_icon(mode)}</div>
+              <div class="m-alerts__mode-name">{DotcomWeb.AlertView.type_name(mode)}</div>
+            </div>
+          </a>
+        </div>
+
+        {render_slot(@main_section)}
+
+        <div class="hidden-lg-up">
+          {render_slot(@sidebar_bottom)}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/dotcom_web/templates/alert/inline.html.eex
+++ b/lib/dotcom_web/templates/alert/inline.html.eex
@@ -1,6 +1,0 @@
-<% unique_id = Integer.to_string(:erlang.unique_integer) %>
-<ul class="c-alert-group">
-  <%= for alert <- @alerts do %>
-    <%= render "_item.html", alert: alert, extra_id: unique_id, time: @time %>
-  <% end %>
-</ul>

--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -1,72 +1,56 @@
 <% show_systemwide_alert? = show_systemwide_alert?(assigns) %>
-
-<div class="container">
-  <div class="page-section">
-    <div class="page-header">
-      <h1>Alerts</h1>
-    </div>
-    <div class="row">
-      <div class="col-lg-3">
-        {DotcomWeb.PartialView.alert_time_filters(@alerts_timeframe,
-          method: :alert_path,
-          item: @id
+<.alerts_layout mode={@id}>
+  <:sidebar_top>
+    {DotcomWeb.PartialView.alert_time_filters(@alerts_timeframe,
+      method: :alert_path,
+      item: @id
+    )}
+  </:sidebar_top>
+  <:sidebar_bottom>
+    {render("_t-alerts.html")}
+  </:sidebar_bottom>
+  <:main_section>
+    <%= if show_systemwide_alert? do %>
+      <div class="m-alerts-header">
+        <h2 class="m-alerts-header__name--systemwide">Systemwide</h2>
+        <span class="m-alerts-header__icon">
+          {DotcomWeb.PartialView.SvgIconWithCircle.svg_icon_with_circle(%SvgIconWithCircle{
+            icon: :t_logo,
+            aria_hidden?: true
+          })}
+        </span>
+      </div>
+      <div class="c-alert-group">
+        {render("_item.html",
+          alert: %{Alerts.Repo.by_id(@alert_banner.id) | priority: :system},
+          date_time: @date_time
         )}
-        <div class="hidden-md-down">
-          {render("_t-alerts.html")}
-        </div>
       </div>
-      <div class="col-lg-8 col-lg-offset-1">
-        <div class="m-alerts__mode-buttons">
-          {mode_buttons(@id)}
-        </div>
-
-        <%= if show_systemwide_alert? do %>
-          <div class="m-alerts-header">
-            <h2 class="m-alerts-header__name--systemwide">Systemwide</h2>
-            <span class="m-alerts-header__icon">
-              {DotcomWeb.PartialView.SvgIconWithCircle.svg_icon_with_circle(%SvgIconWithCircle{
-                icon: :t_logo,
-                aria_hidden?: true
-              })}
-            </span>
-          </div>
-          <div class="c-alert-group">
-            {render("_item.html",
-              alert: %{Alerts.Repo.by_id(@alert_banner.id) | priority: :system},
-              date_time: @date_time
-            )}
-          </div>
+    <% end %>
+    <% timeframe = format_alerts_timeframe(@alerts_timeframe) %>
+    <%= for {route_or_stop, alerts} <- @alert_groups do %>
+      <div class="m-alerts-header">
+        <%= link to: group_header_path(route_or_stop), class: "m-alerts-header__link" do %>
+          <h3 class="m-alerts-header__name">{group_header_name(route_or_stop)}</h3>
         <% end %>
-
-        <% timeframe = format_alerts_timeframe(@alerts_timeframe) %>
-        <%= for {route_or_stop, alerts} <- @alert_groups do %>
-          <div class="m-alerts-header">
-            <%= link to: group_header_path(route_or_stop), class: "m-alerts-header__link" do %>
-              <h2 class="m-alerts-header__name">{group_header_name(route_or_stop)}</h2>
-            <% end %>
-            <%= if show_mode_icon?(route_or_stop) do %>
-              <%= link to: group_header_path(route_or_stop), class: "m-alerts-header__icon" do %>
-                <.route_icon route={route_or_stop} />
-              <% end %>
-            <% end %>
-          </div>
-          <div>
-            {DotcomWeb.AlertView.group(
-              alerts: alerts,
-              route: route_or_stop,
-              date_time: @date_time
-            )}
-          </div>
+        <%= if show_mode_icon?(route_or_stop) do %>
+          <%= link to: group_header_path(route_or_stop), class: "m-alerts-header__icon" do %>
+            <.route_icon route={route_or_stop} />
+          <% end %>
         <% end %>
-        <%= if Enum.empty?(@alert_groups) && !show_systemwide_alert? do %>
-          <div class="m-alerts__notice--no-alerts">
-            There are no {timeframe} {mode_name(@id)} alerts at this time.
-          </div>
-        <% end %>
-        <div class="hidden-lg-up">
-          {render("_t-alerts.html")}
-        </div>
       </div>
-    </div>
-  </div>
-</div>
+      <div>
+        {DotcomWeb.AlertView.group(
+          alerts: alerts,
+          route: route_or_stop,
+          date_time: @date_time
+        )}
+      </div>
+    <% end %>
+    <%= if Enum.empty?(@alert_groups) && !show_systemwide_alert? do %>
+      <div class="m-alerts__notice--no-alerts">
+        There are no {timeframe} {mode_name(@id)} alerts at this time.
+      </div>
+    <% end %>
+  </:main_section>
+</.alerts_layout>

--- a/lib/dotcom_web/templates/alert/tooltip.html.eex
+++ b/lib/dotcom_web/templates/alert/tooltip.html.eex
@@ -1,5 +1,0 @@
-<% text = "There is an alert for this service that may affect your trip" %>
-<span class="alert-icon">
-  <%= fa "exclamation-triangle", title: text, "data-toggle": "tooltip" %>
-</span>
-<span class="sr-only"><%= text %></span>

--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -232,31 +232,6 @@ defmodule DotcomWeb.AlertView do
 
   defp show_mode_icon?(%Route{}), do: true
 
-  @spec mode_buttons(atom) :: [Phoenix.HTML.Safe.t()]
-  def mode_buttons(selected) do
-    for mode <- [:subway, :bus, :commuter_rail, :ferry, :access] do
-      link(
-        [
-          content_tag(
-            :div,
-            [
-              content_tag(:div, type_icon(mode), class: "m-alerts__mode-icon"),
-              content_tag(:div, type_name(mode), class: "m-alerts__mode-name")
-            ],
-            class:
-              if mode == selected do
-                "m-alerts__mode-button m-alerts__mode-button--selected"
-              else
-                "m-alerts__mode-button"
-              end
-          )
-        ],
-        to: alert_path(DotcomWeb.Endpoint, :show, mode),
-        class: "m-alerts__mode-button-container"
-      )
-    end
-  end
-
   @spec show_systemwide_alert?(map) :: boolean
   def show_systemwide_alert?(%{
         alert_banner: alert_banner,
@@ -278,12 +253,12 @@ defmodule DotcomWeb.AlertView do
   end
 
   @spec type_name(atom) :: String.t()
-  defp type_name(:commuter_rail), do: "Rail"
-  defp type_name(mode), do: mode_name(mode)
+  def type_name(:commuter_rail), do: "Rail"
+  def type_name(mode), do: mode_name(mode)
 
   @spec type_icon(atom) :: Phoenix.HTML.Safe.t()
-  defp type_icon(:access), do: svg("icon-accessible-default.svg")
-  defp type_icon(mode), do: mode_icon(mode, :default)
+  def type_icon(:access), do: svg("icon-accessible-default.svg")
+  def type_icon(mode), do: mode_icon(mode, :default)
 
   @spec alert_icon(Alert.icon_type()) :: Phoenix.HTML.Safe.t()
   defp alert_icon(:shuttle), do: svg("icon-shuttle-default.svg")

--- a/test/dotcom_web/views/alert_view_test.exs
+++ b/test/dotcom_web/views/alert_view_test.exs
@@ -444,19 +444,6 @@ defmodule DotcomWeb.AlertViewTest do
     end
   end
 
-  test "mode_buttons" do
-    assert [subway | rest] =
-             :subway
-             |> mode_buttons()
-             |> Enum.map(&safe_to_string/1)
-
-    assert subway =~ "m-alerts__mode-button--selected"
-
-    for mode <- rest do
-      refute mode =~ "m-alerts__mode-button--selected"
-    end
-  end
-
   describe "show_systemwide_alert?/1" do
     setup do
       banner_template = "_alert_announcement.html"


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** Precursor to [Service Alerts page | Refine Station and Service Alerts section](https://app.asana.com/0/555089885850811/1209323323089304)

Refactored the alerts "show" template into a layout. I used named slots to control what goes into the sidebar, since this will change for the subway service alerts (the timeframe filters will be removed). Anyways, I'm hoping it'll make it easier to swap in/out the differing content between subway and the other modes (which will remain the same). Visually, this should be a no-op.