### PR TITLE
refactor: initial adjustments to subway alerts

### DIFF
--- a/assets/css/_alerts.scss
+++ b/assets/css/_alerts.scss
@@ -40,10 +40,6 @@
   }
 }
 
-.m-alerts-header__long-name {
-  padding-left: $base-spacing;
-}
-
 .m-alerts-header__icon {
   margin-top: calc(#{$base-spacing} / 2);
   position: absolute;

--- a/lib/dotcom_web/components/layouts/alerts_layout.html.heex
+++ b/lib/dotcom_web/components/layouts/alerts_layout.html.heex
@@ -5,13 +5,13 @@
     </div>
     <div class="row">
       <div class="col-lg-3">
-        {render_slot(@sidebar_top)}
-        <div class="hidden-md-down">
+        {if(@sidebar_top, do: render_slot(@sidebar_top))}
+        <div :if={@sidebar_bottom} class="hidden-md-down">
           {render_slot(@sidebar_bottom)}
         </div>
       </div>
       <div class="col-lg-8 col-lg-offset-1">
-        <div class="m-alerts__mode-buttons">
+        <div class="m-alerts__mode-buttons mb-lg">
           <a
             :for={mode <- [:subway, :bus, :commuter_rail, :ferry, :access]}
             href={~p"/alerts/#{mode}"}
@@ -29,7 +29,7 @@
 
         {render_slot(@main_section)}
 
-        <div class="hidden-lg-up">
+        <div :if={@sidebar_bottom} class="hidden-lg-up">
           {render_slot(@sidebar_bottom)}
         </div>
       </div>

--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -1,6 +1,5 @@
-<% show_systemwide_alert? = show_systemwide_alert?(assigns) %>
 <.alerts_layout mode={@id}>
-  <:sidebar_top>
+  <:sidebar_top :if={@id != :subway}>
     {DotcomWeb.PartialView.alert_time_filters(@alerts_timeframe,
       method: :alert_path,
       item: @id
@@ -10,47 +9,64 @@
     {render("_t-alerts.html")}
   </:sidebar_bottom>
   <:main_section>
-    <%= if show_systemwide_alert? do %>
-      <div class="m-alerts-header">
-        <h2 class="m-alerts-header__name--systemwide">Systemwide</h2>
-        <span class="m-alerts-header__icon">
-          {DotcomWeb.PartialView.SvgIconWithCircle.svg_icon_with_circle(%SvgIconWithCircle{
-            icon: :t_logo,
-            aria_hidden?: true
-          })}
-        </span>
+    <section :if={@id == :subway} class="border-[1px] border-gray-lightest rounded-lg mb-xl p-md">
+      <h2 class="leading-none mt-0 mb-md">Subway Status</h2>
+      <div class="p-28 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-2xl text-center rounded-xl opacity-15">
+        TBD
       </div>
-      <div class="c-alert-group">
-        {render("_item.html",
-          alert: %{Alerts.Repo.by_id(@alert_banner.id) | priority: :system},
-          date_time: @date_time
-        )}
+    </section>
+    <section :if={@id == :subway} class="border-[1px] border-gray-lightest rounded-lg mb-xl p-md">
+      <h2 class="leading-none mt-0 mb-md">Planned Work</h2>
+      <div class="p-28 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-2xl text-center rounded-xl opacity-15">
+        TBD
       </div>
-    <% end %>
-    <% timeframe = format_alerts_timeframe(@alerts_timeframe) %>
-    <%= for {route_or_stop, alerts} <- @alert_groups do %>
-      <div class="m-alerts-header">
-        <%= link to: group_header_path(route_or_stop), class: "m-alerts-header__link" do %>
-          <h3 class="m-alerts-header__name">{group_header_name(route_or_stop)}</h3>
-        <% end %>
-        <%= if show_mode_icon?(route_or_stop) do %>
-          <%= link to: group_header_path(route_or_stop), class: "m-alerts-header__icon" do %>
-            <.route_icon route={route_or_stop} />
+    </section>
+    <section>
+      <h2 :if={@id == :subway} class="mt-0 mb-0">Station & Service Alerts</h2>
+      <h2 :if={@id != :subway} class="sr-only">All Alerts</h2>
+      <% show_systemwide_alert? = show_systemwide_alert?(assigns) %>
+      <%= if show_systemwide_alert? do %>
+        <div class="m-alerts-header">
+          <h3 class="leading-none m-0">Systemwide</h3>
+        </div>
+        <div class="c-alert-group">
+          {render("_item.html",
+            alert: %{Alerts.Repo.by_id(@alert_banner.id) | priority: :system},
+            date_time: @date_time
+          )}
+        </div>
+      <% end %>
+      <% timeframe = format_alerts_timeframe(@alerts_timeframe) %>
+      <%= for {route_or_stop, alerts} <- @alert_groups do %>
+        <div :if={@id != :subway} class="m-alerts-header">
+          <%= link to: group_header_path(route_or_stop), class: "m-alerts-header__link" do %>
+            <h3 class="m-alerts-header__name">{group_header_name(route_or_stop)}</h3>
           <% end %>
-        <% end %>
-      </div>
-      <div>
-        {DotcomWeb.AlertView.group(
-          alerts: alerts,
-          route: route_or_stop,
-          date_time: @date_time
-        )}
-      </div>
-    <% end %>
-    <%= if Enum.empty?(@alert_groups) && !show_systemwide_alert? do %>
-      <div class="m-alerts__notice--no-alerts">
-        There are no {timeframe} {mode_name(@id)} alerts at this time.
-      </div>
-    <% end %>
+          <%= if show_mode_icon?(route_or_stop) do %>
+            <%= link to: group_header_path(route_or_stop), class: "m-alerts-header__icon" do %>
+              <.route_icon route={route_or_stop} />
+            <% end %>
+          <% end %>
+        </div>
+        <div :if={@id == :subway} class="m-alerts-header">
+          <%= link to: group_header_path(route_or_stop), class: "inline-flex align-items-center no-underline text-black gap-sm py-xs hover:text-brand-primary" do %>
+            <.route_icon route={route_or_stop} />
+            <h3 class="m-0">{group_header_name(route_or_stop)}</h3>
+          <% end %>
+        </div>
+        <div>
+          {DotcomWeb.AlertView.group(
+            alerts: alerts,
+            route: route_or_stop,
+            date_time: @date_time
+          )}
+        </div>
+      <% end %>
+      <%= if Enum.empty?(@alert_groups) && !show_systemwide_alert? do %>
+        <div class="m-alerts__notice--no-alerts">
+          There are no {timeframe} {mode_name(@id)} alerts at this time.
+        </div>
+      <% end %>
+    </section>
   </:main_section>
 </.alerts_layout>

--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -9,13 +9,11 @@
     {render("_t-alerts.html")}
   </:sidebar_bottom>
   <:main_section>
-    <section :if={@id == :subway} class="border-[1px] border-gray-lightest rounded-lg mb-xl p-md">
-      <h2 class="leading-none mt-0 mb-md">Subway Status</h2>
-      <div class="p-28 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-2xl text-center rounded-xl opacity-15">
-        TBD
-      </div>
-    </section>
-    <section :if={@id == :subway} class="border-[1px] border-gray-lightest rounded-lg mb-xl p-md">
+    <.subway_status
+      :if={@id == :subway && assigns[:subway_status]}
+      subway_status={@subway_status}
+    />
+    <section :if={@id == :subway} class="border-[1px] border-gray-lightest rounded-lg my-xl p-md">
       <h2 class="leading-none mt-0 mb-md">Planned Work</h2>
       <div class="p-28 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-2xl text-center rounded-xl opacity-15">
         TBD

--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -48,7 +48,12 @@
         </div>
         <div :if={@id == :subway} class="m-alerts-header">
           <%= link to: group_header_path(route_or_stop), class: "inline-flex align-items-center no-underline text-black gap-sm py-xs hover:text-brand-primary" do %>
-            <.route_icon route={route_or_stop} />
+            <.route_pill
+              route_id={route_or_stop.id}
+              modifier_ids={
+                if(route_or_stop.id in GreenLine.branch_ids(), do: [route_or_stop.id], else: [])
+              }
+            />
             <h3 class="m-0">{group_header_name(route_or_stop)}</h3>
           <% end %>
         </div>

--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -4,6 +4,7 @@ defmodule DotcomWeb.AlertView do
   use DotcomWeb, :view
 
   import DotcomWeb.ViewHelpers
+  import DotcomWeb.Components.SystemStatus.SubwayStatus, only: [subway_status: 1]
   import PhoenixHTMLHelpers.Tag, only: [content_tag: 3]
 
   alias Alerts.{Alert, InformedEntity, InformedEntitySet, URLParsingHelpers}

--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -4,6 +4,7 @@ defmodule DotcomWeb.AlertView do
   use DotcomWeb, :view
 
   import DotcomWeb.ViewHelpers
+  import DotcomWeb.Components.RoutePills, only: [route_pill: 1]
   import DotcomWeb.Components.SystemStatus.SubwayStatus, only: [subway_status: 1]
   import PhoenixHTMLHelpers.Tag, only: [content_tag: 3]
 

--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -7,7 +7,6 @@ defmodule DotcomWeb.AlertView do
   import PhoenixHTMLHelpers.Tag, only: [content_tag: 3]
 
   alias Alerts.{Alert, InformedEntity, InformedEntitySet, URLParsingHelpers}
-  alias DotcomWeb.PartialView.SvgIconWithCircle
   alias Routes.Route
   alias Stops.Stop
 
@@ -213,9 +212,7 @@ defmodule DotcomWeb.AlertView do
   defp group_header_name(%Route{long_name: long_name, name: name, type: 3}) do
     [
       name,
-      content_tag(:span, long_name,
-        class: "font-heading font-bold mt-11 mb-3 text-2xl m-alerts-header__long-name"
-      )
+      content_tag(:span, long_name, class: "pl-md text-lg")
     ]
   end
 

--- a/test/dotcom_web/controllers/alert_controller_test.exs
+++ b/test/dotcom_web/controllers/alert_controller_test.exs
@@ -92,12 +92,13 @@ defmodule DotcomWeb.AlertControllerTest do
     end
 
     test "are shown on subway alerts", %{conn: conn, alerts: alerts} do
+      route_id = get_route(:subway) |> Map.get(:id)
       response = render_alerts_page(conn, :subway, alerts)
 
       expected =
         render_component(
-          &DotcomWeb.Components.RouteSymbols.route_symbol/1,
-          %{route: get_route(:subway), size: :default}
+          &DotcomWeb.Components.RoutePills.route_pill/1,
+          %{route_id: route_id}
         )
 
       assert response =~ expected

--- a/test/dotcom_web/controllers/alert_controller_test.exs
+++ b/test/dotcom_web/controllers/alert_controller_test.exs
@@ -19,6 +19,10 @@ defmodule DotcomWeb.AlertControllerTest do
     cache = Application.get_env(:dotcom, :cache)
     cache.flush()
 
+    stub(Alerts.Repo.Mock, :by_route_ids, fn _ids, _date ->
+      []
+    end)
+
     stub(Routes.Repo.Mock, :by_type, fn route_type ->
       build_list(2, :route, %{type: route_type})
     end)


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** another part of [Service Alerts page | Refine Station and Service Alerts section](https://app.asana.com/0/555089885850811/1209323323089304)

- added placeholder sections for the subway status and planned work
- remove timeframe buttons for subway
- New h2 for Station & Service alerts, everything else gets h3
- refactored group header link for subway, with icon at left of text / also fixes text sizing for the bus here

> [!WARNING]
> Two pieces of this goal remain outstanding:
> - Use the `<.route_pill />` component to display the subway route icons
> - Remove alerts that are in the subway status and planned work section from the list of alerts under Station & Service alerts

![localhost_4001_alerts_subway](https://github.com/user-attachments/assets/76bed710-f1a3-4396-b13f-fb952a5dc4ef)

Some other modes:

![localhost_4001_alerts_commuter-rail](https://github.com/user-attachments/assets/7684bcbe-3553-4654-a81a-b16e39705db3)
![localhost_4001_alerts_bus](https://github.com/user-attachments/assets/69ce5296-2bb8-48bd-996a-739809944a63)

