### PR TITLE
refactor: Green line branches and Mattapan as routes for Route Pills

### DIFF
--- a/lib/dotcom_web/components/route_pills.ex
+++ b/lib/dotcom_web/components/route_pills.ex
@@ -14,7 +14,7 @@ defmodule DotcomWeb.Components.RoutePills do
 
   def route_pill(%{route_id: route_id} = assigns) when route_id in @green_line_branches do
     ~H"""
-    <.route_pill route_id="Green" modifier_ids={[route_id]} />
+    <.route_pill route_id="Green" modifier_ids={[@route_id]} />
     """
   end
 

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -73,9 +73,13 @@ defmodule DotcomWeb.Live.SystemStatus do
     <div class="flex flex-col gap-2">
       <.route_pill route_id="Blue" />
       <.route_pill route_id="Green" />
+      <.route_pill route_id="Green-D" />
       <.route_pill route_id="Orange" />
       <.route_pill route_id="Red" />
+      <.route_pill route_id="Mattapan" />
       <.route_pill route_id="Green" modifier_ids={["Green-B", "Green-C"]} />
+      <.route_pill route_id="Lolwut" />
+      <.route_pill route_id="Green" modifier_ids={["Mattapan"]} />
     </div>
     """
   end


### PR DESCRIPTION
With this change, instead of
```elixir
~H"""
<.route_pill route_id="Green" modifier_ids={["Green-D"]} />
"""
```

You can do
```elixir
~H"""
<.route_pill route_id="Green-D" />
"""
```

Same deal for all of the green line branches and Mattapan.

---

Also, if you pass in any of
- A nonsensical `route_id` (not one of the valid subway lines or branches)
- A nonsensical `modifier_id` (not a valid branch)
- A bad `route_id`/`modifier_id` combo (Say, `route_id="Green" modifier_ids={["Mattapan"]}`) 

...then you get a nice question-mark instead of crashing the whole page.

<img width="68" alt="Screenshot 2025-02-12 at 3 05 28 PM" src="https://github.com/user-attachments/assets/77f74392-b955-4fe4-8c7c-3f8163a618ef" />

---

No ticket