### PR TITLE
feat(DotcomWeb.Components): add two components

### DIFF
--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -92,4 +92,103 @@ defmodule DotcomWeb.Components do
     </div>
     """
   end
+
+  slot(:heading, required: false, doc: "Large title shown at top of container.")
+  slot(:inner_block, required: true)
+  attr(:show_divider?, :boolean, required: false, default: true)
+
+  @doc """
+  A generic "card" sort of component, with an optional large header block.
+
+  Example usage:
+
+  ```elixir
+  <.bordered_container>
+    <:heading>Title on Top</:heading>
+    <p class="text-yellow-600">
+      <strong>Whatever</strong> else inside.
+    </p>
+  </.bordered_container>
+  ```
+
+  Can omit the divider between the heading and content using
+  `show_divider?={false}`.
+
+  ```elixir
+  <.bordered_container show_divider?={false}>
+    <:heading>
+      <div class="flex justify-between">
+        Slightly elaborate
+        <mark>Thing</mark>
+      </div>
+    </:heading>
+    <p class="border-t-4 border-t-brand-primary p-6 bg-brand-primary-lightest">
+      Got my own dividing line
+    </p>
+  </.bordered_container>
+  ```
+  """
+  def bordered_container(assigns) do
+    ~H"""
+    <div class="px-5 py-4 border-[1px] bg-white border-gray-lightest rounded-lg">
+      <div :if={@heading} class="font-heading font-bold text-[1.75rem] text-nowrap">
+        {render_slot(@heading)}
+      </div>
+      <hr :if={@show_divider?} class="h-px my-2 bg-gray-lightest border-0" />
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+
+  slot(:inner_block, required: true)
+  attr(:items, :list, required: true)
+
+  @doc """
+  Generic list with a faint dividing line between list items. The `@inner_block`
+  gets repeated for every list item.
+
+  Example usage:
+
+  ```elixir
+  <.lined_list :let={stop} items={@stops}>
+    <p class="p-1 m-0 text-xl">
+      {stop.name} @ {stop.address}
+    </p>
+  </.lined_list>
+  ```
+
+  Not recommended but possible: Removing or altering the dividing line can be
+  done on a per-line basis by wrapping the line with an element which redefines
+  the Tailwind CSS properties affecting the `divide-y` helper.
+
+  ```elixir
+  <.lined_list :let={thing} items={@things}>
+    <%= if thing.important do %>
+      <div style="--tw-divide-y-reverse: 10">
+        {stop.name} has larger bottom border width
+      </div>
+    <% else %>
+      <%= if thing.sequence > 1 do %>
+        <div style="--tw-divide-opacity: 0" class="border-dashed border-t-2">
+          {stop.name} has custom top border
+        </div>
+      <% else %>
+        {stop.name} has default border
+      <% end %>
+    <% end %>
+  </.lined_list>
+  ```
+
+  Not recommended for simple lists which should use `<ul>` or `<ol>`, as this
+  does not implement the ARIA role for "list".
+  """
+  def lined_list(assigns) do
+    ~H"""
+    <div class="border-gray-lightest border-y-[1px] divide-gray-lightest divide-y-[1px]">
+      <%= for item <- @items do %>
+        {render_slot(@inner_block, item)}
+      <% end %>
+    </div>
+    """
+  end
 end

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -5,6 +5,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
   use DotcomWeb, :component
 
+  import DotcomWeb.Components, only: [bordered_container: 1, lined_list: 1]
   import DotcomWeb.Components.RoutePills
   import DotcomWeb.Components.SystemStatus.StatusLabel
 
@@ -16,41 +17,43 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
     assigns = assigns |> assign(:rows, status_to_rows(assigns.subway_status))
 
     ~H"""
-    <div class="px-5 py-4 border-[1px] border-gray-lightest rounded-lg w-96">
-      <div class="border-gray-lightest border-b-[1px] pl-2 pb-3 flex items-center gap-2">
-        <.icon type="icon-svg" name="icon-mode-subway-default" class="h-7 w-7" />
-        <span class="font-heading font-bold text-[1.75rem]">Subway Status</span>
-      </div>
-      <a
-        :for={row <- @rows}
-        href={row.route_info.url}
-        class={[
-          "flex gap-2",
-          !row.style.short_bottom_border && "border-gray-lightest border-b-[1px]",
-          "hover:bg-brand-primary-lightest cursor-pointer group/row",
-          "text-black no-underline"
-        ]}
-      >
-        <div class={["pl-2 py-3", row.style.hide_route_pill && "invisible"]}>
-          <.route_pill
-            route_id={row.route_info.route_id}
-            modifier_ids={row.route_info.branch_ids}
-            modifier_class="group-hover/row:ring-brand-primary-lightest"
-          />
+    <.bordered_container show_divider?={false}>
+      <:heading>
+        <div class="px-2 flex items-center gap-2 mb-sm">
+          <.icon type="icon-svg" name="icon-mode-subway-default" class="h-7 w-7" /> Subway Status
         </div>
-        <div class={[
-          "py-3 w-full flex items-center",
-          row.style.short_bottom_border && "border-b-[1px] border-gray-lightest"
-        ]}>
-          <.status_label
-            status={row.status_entry.status}
-            prefix={row.status_entry.prefix}
-            plural={row.status_entry.plural}
-          />
-          <.icon name="chevron-right" class="h-3 w-2 fill-gray-lighter ml-auto mr-3" />
-        </div>
-      </a>
-    </div>
+      </:heading>
+      <.lined_list :let={row} items={@rows}>
+        <a
+          href={row.route_info.url}
+          style={if(row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
+          class={[
+            "flex gap-2",
+            "hover:bg-brand-primary-lightest cursor-pointer group/row",
+            "text-black no-underline"
+          ]}
+        >
+          <div class={["pl-2 py-3", row.style.hide_route_pill && "invisible"]}>
+            <.route_pill
+              route_id={row.route_info.route_id}
+              modifier_ids={row.route_info.branch_ids}
+              modifier_class="group-hover/row:ring-brand-primary-lightest"
+            />
+          </div>
+          <div class={[
+            "flex items-center justify-between grow text-nowrap gap-sm",
+            row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
+          ]}>
+            <.status_label
+              status={row.status_entry.status}
+              prefix={row.status_entry.prefix}
+              plural={row.status_entry.plural}
+            />
+            <.icon name="chevron-right" class="h-3 w-2 fill-gray-lighter ml-3 mr-2" />
+          </div>
+        </a>
+      </.lined_list>
+    </.bordered_container>
     """
   end
 
@@ -90,7 +93,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
     status_entries
     |> Enum.map(&row_for_status_entry(&1, show_prefix))
-    |> add_short_intermediate_borders()
     |> show_first_route_pill()
   end
 
@@ -106,8 +108,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
         prefix: prefix
       },
       style: %{
-        hide_route_pill: true,
-        short_bottom_border: false
+        hide_route_pill: true
       }
     }
   end
@@ -126,17 +127,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
     [
       first_entry |> put_in([:style, :hide_route_pill], false)
       | rest_of_entries
-    ]
-  end
-
-  defp add_short_intermediate_borders([entry]) do
-    [entry]
-  end
-
-  defp add_short_intermediate_borders([first_entry | rest_of_entries]) do
-    [
-      first_entry |> put_in([:style, :short_bottom_border], true)
-      | add_short_intermediate_borders(rest_of_entries)
     ]
   end
 

--- a/test/dotcom_web/components_test.exs
+++ b/test/dotcom_web/components_test.exs
@@ -55,4 +55,66 @@ defmodule DotcomWeb.ComponentsTest do
              """) =~ assigns.content
     end
   end
+
+  describe "bordered_container" do
+    test "optionally shows a dividing line" do
+      assigns = %{
+        title: Faker.Lorem.sentence(1..3),
+        content: Faker.Lorem.sentence(3..5)
+      }
+
+      str =
+        rendered_to_string(~H"""
+        <.bordered_container>
+          <:heading>
+            <span>{assigns.title}</span>
+          </:heading>
+          {assigns.content}
+        </.bordered_container>
+        """)
+
+      assert str =~ assigns.title
+      assert str =~ assigns.content
+
+      assert Floki.parse_fragment!(str)
+             |> Floki.find("hr")
+
+      str_without_divider =
+        rendered_to_string(~H"""
+        <.bordered_container show_divider?={false}>
+          <:heading>
+            <span>{assigns.title}</span>
+          </:heading>
+          {assigns.content}
+        </.bordered_container>
+        """)
+
+      assert Floki.parse_fragment!(str_without_divider)
+             |> Floki.find("hr") == []
+    end
+  end
+
+  describe "lined_list" do
+    test "shows inner block for each item" do
+      assigns = %{
+        items: Faker.Lorem.sentences()
+      }
+
+      rendered_items =
+        rendered_to_string(~H"""
+        <.lined_list :let={sentence} items={@items}>
+          <p>{sentence}</p>
+        </.lined_list>
+        """)
+        |> Floki.parse_fragment!()
+        |> Floki.find("p")
+
+      assert Enum.count(rendered_items) == Enum.count(assigns.items)
+      rendered_content = Enum.flat_map(rendered_items, fn {"p", _, content} -> content end)
+
+      for sentence <- assigns.items do
+        assert sentence in rendered_content
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes

Add/documents/tests two new generic components that can be reused between the Subway Status & Planned Work components (and uses them for the current subway status component).

1. `<.bordered_container />` is a lightly bordered rounded box with a heading. Keeping it simple. The dividing line between heading and content is toggleable since subway status doesn't need it but I think planned work will.
2. `<.lined_list />` is a "list" with faint lines between items, structured in such a way that it's possible to adjust the lines per-item, mostly because of the exception needed by the subway status. I know there's a similar component in Metro, but this one is more bare-bones (doesn't even dictate padding or other styling) and doesn't even handle proper unordered or ordered lists (wrapping each child in a `<li>` would remove our ability to easily control those line-styles between items). This component probably won't see much use perhaps.

With the exception of the subway status component now expanding to fill its container width, this should visually be a no-op — let me know if I missed anything.

<img width="1313" alt="image" src="https://github.com/user-attachments/assets/9a02d0dd-96d9-4564-bee9-f20143ae3432" />

