### PR TITLE
fix: Green line grouping bug

### DIFF
--- a/lib/dotcom/system_status/subway.ex
+++ b/lib/dotcom/system_status/subway.ex
@@ -221,10 +221,7 @@ defmodule Dotcom.SystemStatus.Subway do
       MapSet.difference(@green_line_branch_id_set, affected_branches)
       |> Enum.sort()
 
-    normal_status_entry_groups =
-      normal_status_entry_groups(normal_branches)
-
-    status_entry_groups ++ normal_status_entry_groups
+    status_entry_groups ++ normal_status_entry_groups(normal_branches)
   end
 
   # Given a list of status entry groups, aggregates their branch_ids

--- a/lib/dotcom/system_status/subway.ex
+++ b/lib/dotcom/system_status/subway.ex
@@ -27,6 +27,8 @@ defmodule Dotcom.SystemStatus.Subway do
   """
   def lines(), do: @lines
 
+  @green_line_branch_id_set MapSet.new(GreenLine.branch_ids())
+
   @doc """
   Translates the given alerts into a map indicating the overall system
   status for each line.
@@ -36,7 +38,7 @@ defmodule Dotcom.SystemStatus.Subway do
       ...>   [
       ...>     %Alerts.Alert{
       ...>       effect: :shuttle,
-      ...>       informed_entity: [%Alerts.InformedEntity{route: "Orange"}],
+      ...>       informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Orange"}]),
       ...>       active_period: [{Timex.beginning_of_day(Timex.now()), nil}]
       ...>     }
       ...>   ]
@@ -64,12 +66,7 @@ defmodule Dotcom.SystemStatus.Subway do
       ...>   [
       ...>     %Alerts.Alert{
       ...>       effect: :delay,
-      ...>       informed_entity: [%Alerts.InformedEntity{route: "Green-E"}],
-      ...>       active_period: [{Timex.beginning_of_day(Timex.now()), nil}]
-      ...>     },
-      ...>     %Alerts.Alert{
-      ...>       effect: :delay,
-      ...>       informed_entity: [%Alerts.InformedEntity{route: "Green-D"}],
+      ...>       informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Green-E"}]),
       ...>       active_period: [{Timex.beginning_of_day(Timex.now()), nil}]
       ...>     }
       ...>   ]
@@ -80,13 +77,13 @@ defmodule Dotcom.SystemStatus.Subway do
         "Red" => [%{branch_ids: [], status_entries: [%{time: :current, status: :normal, multiple: false}]}],
         "Green" => [
           %{
-            branch_ids: ["Green-D", "Green-E"],
+            branch_ids: ["Green-E"],
             status_entries: [
               %{time: :current, status: :delay, multiple: false}
             ]
           },
           %{
-            branch_ids: ["Green-B", "Green-C"],
+            branch_ids: ["Green-B", "Green-C", "Green-D"],
             status_entries: [
               %{time: :current, status: :normal, multiple: false}
             ]
@@ -102,7 +99,7 @@ defmodule Dotcom.SystemStatus.Subway do
       ...>   [
       ...>     %Alerts.Alert{
       ...>       effect: :suspension,
-      ...>       informed_entity: [%Alerts.InformedEntity{route: "Mattapan"}],
+      ...>       informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Mattapan"}]),
       ...>       active_period: [{Timex.beginning_of_day(Timex.now()), nil}]
       ...>     }
       ...>   ]
@@ -162,12 +159,7 @@ defmodule Dotcom.SystemStatus.Subway do
   defp add_nested_statuses_for_line("Green", alerts, time) do
     %{
       route_id: "Green",
-      branches_with_statuses:
-        GreenLine.branch_ids()
-        |> Enum.map(&add_statuses_for_route(&1, alerts, time))
-        |> group_by_statuses()
-        |> nest_grouped_statuses_under_branches()
-        |> sort_branches()
+      branches_with_statuses: green_line_status_entry_groups(alerts, time)
     }
   end
 
@@ -194,33 +186,86 @@ defmodule Dotcom.SystemStatus.Subway do
     }
   end
 
-  # Groups the route/status-entry combinations by their statuses so
-  # that branches with the same statuses can be combined.
-  defp group_by_statuses(status_entries) do
-    status_entries |> Enum.group_by(& &1.statuses) |> Enum.to_list()
-  end
-
-  # Nests grouped statuses under the branches_with_statuses
-  # field. Exactly how it does this depends on whether
-  # grouped_statuses has one entry or more.
-  defp nest_grouped_statuses_under_branches(grouped_statuses)
-
-  # If grouped_statuses has one entry, then that means that all of the
-  # branches have the same status, which means we don't need to
-  # specify any branches.
-  defp nest_grouped_statuses_under_branches([{statuses, _}]) do
-    [branch_with_statuses_entry(statuses)]
-  end
-
-  # If grouped_statuses has more than one entry, then we do need to
-  # specify the branches for each collection of statuses.
-  defp nest_grouped_statuses_under_branches(grouped_statuses) do
-    grouped_statuses
-    |> Enum.map(fn {statuses, entries} ->
-      branch_ids = entries |> Enum.map(& &1.route_id) |> Enum.sort()
-
-      branch_with_statuses_entry(statuses, branch_ids)
+  # Groups the alerts provided into a collection of status entries for
+  # the green line.
+  @spec green_line_status_entry_groups([Alert.t()], DateTime.t()) :: [status_entry_group()]
+  defp green_line_status_entry_groups(alerts, time) do
+    GreenLine.branch_ids()
+    |> alerts_for_routes(alerts)
+    |> Enum.group_by(&affected_green_line_branch_ids/1)
+    |> Enum.map(fn {branch_ids, alerts} ->
+      %{branch_ids: branch_ids, status_entries: alerts_to_statuses(alerts, time)}
     end)
+    |> maybe_add_normal_entry()
+    |> Enum.map(&remove_branch_ids_if_full_set/1)
+    |> sort_branches()
+  end
+
+  # Given an alert, returns a sorted list of the green line branches
+  # affected by that alert.
+  @spec affected_green_line_branch_ids([Alert.t()]) :: [Routes.Route.id_t()]
+  defp affected_green_line_branch_ids(alert) do
+    alert.informed_entity.route
+    |> MapSet.intersection(@green_line_branch_id_set)
+    |> Enum.sort()
+  end
+
+  # Given a list of status entry groups, adds an additional "normal
+  # service" entry if there are any green line branches unaccounted
+  # for.
+  @spec maybe_add_normal_entry([status_entry_group()]) :: [status_entry_group()]
+  defp maybe_add_normal_entry(status_entry_groups) do
+    affected_branches = all_affected_branches(status_entry_groups)
+
+    normal_branches =
+      MapSet.difference(@green_line_branch_id_set, affected_branches)
+      |> Enum.sort()
+
+    normal_status_entry_groups =
+      normal_status_entry_groups(normal_branches)
+
+    status_entry_groups ++ normal_status_entry_groups
+  end
+
+  # Given a list of status entry groups, aggregates their branch_ids
+  # into a MapSet and returns that.
+  @spec all_affected_branches([status_entry_group()]) :: MapSet.t()
+  defp all_affected_branches(status_entry_groups) do
+    status_entry_groups
+    |> Enum.map(& &1.branch_ids)
+    |> Enum.reduce(MapSet.new(), fn branch_ids, set ->
+      set |> MapSet.union(MapSet.new(branch_ids))
+    end)
+  end
+
+  # Given a list of branches that don't have any alerts, returns a
+  # status entry indicating normal service for those branches, or
+  # nothing if the list of branches is empty. Returns this as a list
+  # so that it can be concatenated with the alert-based status
+  # entries.
+  @spec normal_status_entry_groups([Routes.Route.id_t()]) :: [status_entry_group()]
+  defp normal_status_entry_groups([]), do: []
+
+  defp normal_status_entry_groups(normal_branches) do
+    [
+      %{
+        branch_ids: normal_branches,
+        status_entries: [normal_status()]
+      }
+    ]
+  end
+
+  # If the status entries for the group provided correspond to the
+  # entire green line (all of its branches), then replace branch_id's
+  # with an empty array to indicate that the status is for the whole
+  # line.
+  @spec remove_branch_ids_if_full_set(status_entry_group()) :: status_entry_group()
+  defp remove_branch_ids_if_full_set(status_entry_group) do
+    if status_entry_group.branch_ids == GreenLine.branch_ids() do
+      %{status_entry_group | branch_ids: []}
+    else
+      status_entry_group
+    end
   end
 
   # Sorts green line branches first by alert status (that is, "Normal
@@ -271,20 +316,6 @@ defmodule Dotcom.SystemStatus.Subway do
     end
   end
 
-  # Exchanges a route_id (a line_id or a branch_id - anything that
-  # might correspond to an alert) for a map with that route_id and the
-  # statuses affecting that route.
-  @spec add_statuses_for_route(Routes.Route.id_t(), [Alert.t()], DateTime.t()) :: %{
-          route_id: Routes.Route.id_t(),
-          statuses: [status_entry()]
-        }
-  defp add_statuses_for_route(route_id, alerts, time) do
-    %{
-      route_id: route_id,
-      statuses: statuses_for_route(route_id, alerts, time)
-    }
-  end
-
   # Returns a list of statuses corresponding to the alerts for the
   # given route.
   @spec statuses_for_route(Routes.Route.id_t(), [Alert.t()], DateTime.t()) :: [status_entry()]
@@ -321,6 +352,18 @@ defmodule Dotcom.SystemStatus.Subway do
     end)
   end
 
+  # Given `alerts` and `route_ids`, filters out only the alerts
+  # applicable to the given routes, using the alert's "informed
+  # entities".
+  @spec alerts_for_routes([Routes.Route.id_t()], [Alert.t()]) :: [Alert.t()]
+  defp alerts_for_routes(route_ids, alerts) do
+    alerts
+    |> Enum.filter(fn %Alert{informed_entity: informed_entity} ->
+      informed_entity
+      |> Enum.any?(&(&1.route in route_ids))
+    end)
+  end
+
   # Maps a list of alerts to a list of statuses that are formatted
   # according to the system status specifications:
   # - Identical alerts are grouped together and pluralized.
@@ -344,7 +387,7 @@ defmodule Dotcom.SystemStatus.Subway do
   # If there are no alerts, then we want a single status indicating
   # "Normal Service".
   defp alerts_to_statuses_naive([], _time) do
-    [%{multiple: false, status: :normal, time: :current}]
+    [normal_status()]
   end
 
   # If there are alerts, then create a starting list of statuses that
@@ -354,6 +397,11 @@ defmodule Dotcom.SystemStatus.Subway do
     |> Enum.map(fn alert ->
       alert_to_status(alert, time)
     end)
+  end
+
+  @spec normal_status() :: status_entry()
+  defp normal_status() do
+    %{multiple: false, status: :normal, time: :current}
   end
 
   # Translates an alert to a status:

--- a/lib/dotcom/system_status/subway.ex
+++ b/lib/dotcom/system_status/subway.ex
@@ -197,7 +197,7 @@ defmodule Dotcom.SystemStatus.Subway do
       %{branch_ids: branch_ids, status_entries: alerts_to_statuses(alerts, time)}
     end)
     |> maybe_add_normal_entry()
-    |> Enum.map(&remove_branch_ids_if_full_set/1)
+    |> Enum.map(&maybe_collapse_branch_ids/1)
     |> sort_branches()
   end
 
@@ -259,8 +259,8 @@ defmodule Dotcom.SystemStatus.Subway do
   # entire green line (all of its branches), then replace branch_id's
   # with an empty array to indicate that the status is for the whole
   # line.
-  @spec remove_branch_ids_if_full_set(status_entry_group()) :: status_entry_group()
-  defp remove_branch_ids_if_full_set(status_entry_group) do
+  @spec maybe_collapse_branch_ids(status_entry_group()) :: status_entry_group()
+  defp maybe_collapse_branch_ids(status_entry_group) do
     if status_entry_group.branch_ids == GreenLine.branch_ids() do
       %{status_entry_group | branch_ids: []}
     else

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -115,9 +115,8 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :suspension,
             header: "Northbound Orange Line trains are suspended due to flooding",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Orange"}]
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Orange"}])
           },
           %Alerts.Alert{
             active_period: [
@@ -125,9 +124,8 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :delay,
             header: "Southbound Orange Line trains will be delayed due to flooding at 8:30pm",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Orange"}]
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Orange"}])
           },
           %Alerts.Alert{
             active_period: [
@@ -136,9 +134,7 @@ defmodule DotcomWeb.Live.SystemStatus do
             effect: :delay,
             header:
               "Northbound Blue line trains are delayed due to an escaped whale from the aquarium",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Blue"}]
-            }
+            informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Blue"}])
           },
           %Alerts.Alert{
             active_period: [
@@ -147,9 +143,7 @@ defmodule DotcomWeb.Live.SystemStatus do
             effect: :delay,
             header:
               "Southbound Blue line trains are delayed due to an escaped otter from the aquarium",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Blue"}]
-            }
+            informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Blue"}])
           }
         ]
       },
@@ -162,9 +156,8 @@ defmodule DotcomWeb.Live.SystemStatus do
             effect: :shuttle,
             header:
               "Mattapan trains are replaced with shuttles that are just driving on the tracks",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Mattapan"}]
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Mattapan"}])
           },
           %Alerts.Alert{
             active_period: [
@@ -172,9 +165,11 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :station_closure,
             header: "Copley Station is closed due to an overabundance of books",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: GreenLine.branch_ids() |> Enum.map(&%Alerts.InformedEntity{route: &1})
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new(
+                GreenLine.branch_ids()
+                |> Enum.map(&%Alerts.InformedEntity{route: &1})
+              )
           }
         ]
       },
@@ -186,9 +181,8 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :delay,
             header: "Green line B branch is delayed due to protests at BU",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Green-B"}]
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Green-B"}])
           }
         ]
       },
@@ -200,9 +194,8 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :delay,
             header: "Green line B branch is delayed due to protests at BU",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Green-B"}]
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Green-B"}])
           },
           %Alerts.Alert{
             active_period: [
@@ -210,9 +203,20 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :station_closure,
             header: "Copley Station is closed due to an over-abundance of books",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: GreenLine.branch_ids() |> Enum.map(&%Alerts.InformedEntity{route: &1})
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new(
+                GreenLine.branch_ids()
+                |> Enum.map(&%Alerts.InformedEntity{route: &1})
+              )
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header: "Green line B branch is delayed due to protests on Comm Ave",
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Green-B"}])
           }
         ]
       },
@@ -224,9 +228,8 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :suspension,
             header: "Northbound Orange Line trains are suspended due to flooding",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Orange"}]
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Orange"}])
           },
           %Alerts.Alert{
             active_period: [
@@ -234,9 +237,8 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :delay,
             header: "Southbound Orange Line trains are delayed due to flooding",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Orange"}]
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Orange"}])
           },
           %Alerts.Alert{
             active_period: [
@@ -245,9 +247,8 @@ defmodule DotcomWeb.Live.SystemStatus do
             effect: :shuttle,
             header:
               "Mattapan trains are replaced with shuttles that are just driving on the tracks",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Mattapan"}]
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Mattapan"}])
           }
         ]
       },
@@ -259,9 +260,8 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :delay,
             header: "Green line B branch is delayed due to protests at BU",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Green-B"}]
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Green-B"}])
           },
           %Alerts.Alert{
             active_period: [
@@ -269,9 +269,8 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :station_closure,
             header: "Riverside station is closed due to a red line train on the tracks",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Green-D"}]
-            }
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Green-D"}])
           },
           %Alerts.Alert{
             active_period: [
@@ -279,9 +278,7 @@ defmodule DotcomWeb.Live.SystemStatus do
             ],
             effect: :station_closure,
             header: "Alewife station is closed due to a green line train on the tracks",
-            informed_entity: %Alerts.InformedEntitySet{
-              entities: [%Alerts.InformedEntity{route: "Red"}]
-            }
+            informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Red"}])
           }
         ]
       }

--- a/test/support/factories/alerts/alert.ex
+++ b/test/support/factories/alerts/alert.ex
@@ -44,6 +44,19 @@ defmodule Test.Support.Factories.Alerts.Alert do
     )
   end
 
+  def alert_for_routes_factory(attrs) do
+    {route_ids, attrs} = Map.pop(attrs, :route_ids)
+
+    entities =
+      route_ids |> Enum.map(&Factories.Alerts.InformedEntity.build(:informed_entity, route: &1))
+
+    build(
+      :alert,
+      attrs
+      |> Map.put(:informed_entity, InformedEntitySet.new(entities))
+    )
+  end
+
   def active_during(alert, time) do
     %{alert | active_period: [{time_before(time), time_after(time)}]}
   end


### PR DESCRIPTION
Changes the way that green line statuses get grouped, so that they line up more closely with the alerts themselves. Previously, branches would only be grouped together if their full set of alerts was the same. Now, branches will be grouped together if they're impacted by the same alert, even if they also have other statuses.

## Before
<img width="402" alt="Screenshot 2025-02-12 at 9 21 05 PM" src="https://github.com/user-attachments/assets/b3d2bc23-530f-4525-b394-302292a1a08f" />

## After
<img width="401" alt="Screenshot 2025-02-12 at 9 21 19 PM" src="https://github.com/user-attachments/assets/cc7b1ad4-fdc8-47fe-9027-acef4bbf5c64" />

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [System Status | 🐞 Green line grouping bug](https://app.asana.com/0/555089885850811/1209323504575454)

---

Depends on:
- #2347 