### PR TITLE
feat: Collapse subway status component if it has more than five lines

### DIFF
--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -31,6 +31,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
   defp description(status, false), do: description(status)
 
   defp description(:normal), do: "Normal Service"
+  defp description(:see_alerts), do: "See Alerts"
   defp description(:station_closure), do: "Station Closure"
   defp description(status), do: status |> Atom.to_string() |> String.capitalize()
 

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -9,6 +9,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   import DotcomWeb.Components.RoutePills
   import DotcomWeb.Components.SystemStatus.StatusLabel
 
+  @max_rows 5
   @route_ids ["Red", "Orange", "Green", "Blue"]
 
   attr :subway_status, :any, required: true
@@ -62,6 +63,62 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
     |> Enum.map(&{&1, subway_status |> Map.get(&1)})
     |> Enum.flat_map(&rows_for_route/1)
     |> Enum.map(&add_url/1)
+    |> maybe_collapse_rows()
+  end
+
+  defp maybe_collapse_rows(rows) when length(rows) > @max_rows, do: collapse_rows(rows)
+  defp maybe_collapse_rows(rows), do: rows
+
+  defp collapse_rows([
+         %{route_info: %{route_id: "Green"}} = row1,
+         %{route_info: %{route_id: "Green"}, status_entry: %{status: :normal}} = row2
+         | rest_of_rows
+       ]) do
+    [row1 | collapse_rows([row2 | rest_of_rows])]
+  end
+
+  defp collapse_rows([
+         %{route_info: %{route_id: "Green", branch_ids: branch_ids1}} = row1,
+         %{route_info: %{route_id: "Green", branch_ids: branch_ids2}}
+         | rest_of_rows
+       ]) do
+    combined_branch_ids =
+      (branch_ids1 ++ branch_ids2) |> Enum.uniq() |> Enum.sort() |> collapse_if_all_green_line()
+
+    combined_row =
+      row1
+      |> Map.put(:status_entry, see_alerts_status())
+      |> put_in([:route_info, :branch_ids], combined_branch_ids)
+
+    [combined_row | rest_of_rows] |> collapse_rows()
+  end
+
+  defp collapse_rows([
+         %{route_info: %{route_id: route_id1}} = row1,
+         %{route_info: %{route_id: route_id2}} = _row2
+         | rest_of_rows
+       ])
+       when route_id1 == route_id2 do
+    combined_row =
+      row1 |> Map.put(:status_entry, see_alerts_status())
+
+    [combined_row | rest_of_rows] |> collapse_rows()
+  end
+
+  defp collapse_rows([row1 | rest_of_rows]) do
+    [row1 | collapse_rows(rest_of_rows)]
+  end
+
+  defp collapse_rows([]) do
+    []
+  end
+
+  defp collapse_if_all_green_line(branch_ids) do
+    if branch_ids == GreenLine.branch_ids() do
+      []
+    else
+      branch_ids
+    end
   end
 
   defp add_url(row) do
@@ -139,4 +196,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
   defp prefix(%{time: :current}), do: "Now"
   defp prefix(%{time: {:future, time}}), do: Util.kitchen_downcase_time(time)
+
+  defp see_alerts_status(), do: %{status: :see_alerts, prefix: nil, plural: false}
 end

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -279,6 +279,69 @@ defmodule DotcomWeb.Live.SystemStatus do
             effect: :station_closure,
             header: "Alewife station is closed due to a green line train on the tracks",
             informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Red"}])
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :suspension,
+            header:
+              "Northbound Blue line trains are suspended due to an escaped whale from the aquarium",
+            informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Blue"}])
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header:
+              "Southbound Blue line trains are delayed due to an escaped otter from the aquarium",
+            informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Blue"}])
+          }
+        ]
+      },
+      %{
+        alerts: [
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :suspension,
+            header:
+              "Northbound Blue line trains are suspended due to an escaped whale from the aquarium",
+            informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Blue"}])
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header:
+              "Southbound Blue line trains are delayed due to an escaped otter from the aquarium",
+            informed_entity: Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Blue"}])
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :station_closure,
+            header: "Heath St station is closed due to an escaped shark from the aquarium",
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Green-E"}])
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :delay,
+            header:
+              "Delays at Hynes Convention Center due to a gathering of escaped sea creatures",
+            informed_entity:
+              Alerts.InformedEntitySet.new([
+                %Alerts.InformedEntity{route: "Green-B"},
+                %Alerts.InformedEntity{route: "Green-C"},
+                %Alerts.InformedEntity{route: "Green-D"}
+              ])
           }
         ]
       }


### PR DESCRIPTION
## Before
<img width="347" alt="Screenshot 2025-02-13 at 4 05 53 PM" src="https://github.com/user-attachments/assets/04062425-444a-4bba-88d9-e7edaa2b5a7c" />

## After
<img width="348" alt="Screenshot 2025-02-13 at 4 06 20 PM" src="https://github.com/user-attachments/assets/1f3c1240-80ce-4a6a-865f-de9a391e41fc" />

---
<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [System Status | Collapse if total widget size is >5 lines](https://app.asana.com/0/home/1205718271156544/1209345596450257)

