### PR TITLE
fix(Alerts.Disruptions.Subway): add missing service ranges

### DIFF
--- a/lib/dotcom/utils/service_date_time.ex
+++ b/lib/dotcom/utils/service_date_time.ex
@@ -26,6 +26,12 @@ defmodule Dotcom.Utils.ServiceDateTime do
   @timezone Application.compile_env!(:dotcom, :timezone)
 
   @doc """
+  Returns an ordered list of service ranges, from earliest to latest.
+  """
+  def all_service_ranges,
+    do: [:before_today, :today, :later_this_week, :next_week, :after_next_week]
+
+  @doc """
   Returns the time at which service rolls over from 'today' to 'tomorrow'.
   """
   def service_rollover_time(), do: @service_rollover_time


### PR DESCRIPTION

#### Summary of changes

No ticket, found alerts missing under `todays_disruptions/0` and uncovered a problem which manifests for any alert which spans many service ranges. So instead of only using the service ranges for the `:active_period` starts and stops, this PR will have it also interpolate any ranges in between.