### PR TITLE
fix(Components.PlannedDisruptions): render separate accordion for each subway line

### DIFF
--- a/lib/dotcom/routes.ex
+++ b/lib/dotcom/routes.ex
@@ -5,7 +5,7 @@ defmodule Dotcom.Routes do
 
   alias Routes.Route
 
-  @subway_line_ids ["Blue", "Green", "Orange", "Red"]
+  @subway_line_ids ["Red", "Orange", "Green", "Blue"]
   @green_line_branch_ids Enum.map(["B", "C", "D", "E"], fn branch -> "Green-#{branch}" end)
   @red_line_branch_ids ["Mattapan"]
 


### PR DESCRIPTION
No ticket. 

Example can be seen with the test Station Closure alert below: 

| Before | After |
|--------|--------|
| (slightly outdated UI) <img width="569" alt="image" src="https://github.com/user-attachments/assets/88d2037b-9b35-435c-ad6b-e8e38c1ad9fc" /> | <img width="541" alt="image" src="https://github.com/user-attachments/assets/6a5fe08e-67b3-4a0d-a739-b6bb7ce00000" /> | 