### PR TITLE
fixup(DotcomWeb.AlertView): remove too-big bus text

### DIFF
--- a/assets/css/_alerts.scss
+++ b/assets/css/_alerts.scss
@@ -21,9 +21,7 @@
 
 .m-alerts-header__name {
   color: $gray-dark;
-  font-weight: bold;
   margin: calc(#{$base-spacing} / 2) 0;
-  width: 90%;
 
   &:hover {
     color: $brand-primary;
@@ -32,16 +30,6 @@
   &--systemwide:hover {
     color: $gray-dark;
   }
-}
-
-.m-alerts-header__link {
-  &:hover {
-    text-decoration: none;
-  }
-}
-
-.m-alerts-header__long-name {
-  padding-left: $base-spacing;
 }
 
 .m-alerts-header__icon {

--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -28,25 +28,17 @@
       </div>
     <% end %>
     <% timeframe = format_alerts_timeframe(@alerts_timeframe) %>
-    <%= for {route_or_stop, alerts} <- @alert_groups do %>
-      <div class="m-alerts-header">
-        <%= link to: group_header_path(route_or_stop), class: "m-alerts-header__link" do %>
-          <h3 class="m-alerts-header__name">{group_header_name(route_or_stop)}</h3>
+    <div :for={{route_or_stop, alerts} <- @alert_groups} class="mb-lg">
+        <%= link to: group_header_path(route_or_stop), class: "flex items-center gap-sm hover:no-underline" do %>
+          <.route_icon :if={show_mode_icon?(route_or_stop)} route={route_or_stop} />
+          <h3 class="m-alerts-header__name text-lg">{group_header_name(route_or_stop)}</h3>
         <% end %>
-        <%= if show_mode_icon?(route_or_stop) do %>
-          <%= link to: group_header_path(route_or_stop), class: "m-alerts-header__icon" do %>
-            <.route_icon route={route_or_stop} />
-          <% end %>
-        <% end %>
-      </div>
-      <div>
         {DotcomWeb.AlertView.group(
           alerts: alerts,
           route: route_or_stop,
           date_time: @date_time
         )}
-      </div>
-    <% end %>
+    </div>
     <%= if Enum.empty?(@alert_groups) && !show_systemwide_alert? do %>
       <div class="m-alerts__notice--no-alerts">
         There are no {timeframe} {mode_name(@id)} alerts at this time.

--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -29,15 +29,15 @@
     <% end %>
     <% timeframe = format_alerts_timeframe(@alerts_timeframe) %>
     <div :for={{route_or_stop, alerts} <- @alert_groups} class="mb-lg">
-        <%= link to: group_header_path(route_or_stop), class: "flex items-center gap-sm hover:no-underline" do %>
-          <.route_icon :if={show_mode_icon?(route_or_stop)} route={route_or_stop} />
-          <h3 class="m-alerts-header__name text-lg">{group_header_name(route_or_stop)}</h3>
-        <% end %>
-        {DotcomWeb.AlertView.group(
-          alerts: alerts,
-          route: route_or_stop,
-          date_time: @date_time
-        )}
+      <%= link to: group_header_path(route_or_stop), class: "flex items-center gap-sm hover:no-underline" do %>
+        <.route_icon :if={show_mode_icon?(route_or_stop)} route={route_or_stop} />
+        <h3 class="m-alerts-header__name text-lg">{group_header_name(route_or_stop)}</h3>
+      <% end %>
+      {DotcomWeb.AlertView.group(
+        alerts: alerts,
+        route: route_or_stop,
+        date_time: @date_time
+      )}
     </div>
     <%= if Enum.empty?(@alert_groups) && !show_systemwide_alert? do %>
       <div class="m-alerts__notice--no-alerts">

--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -212,10 +212,8 @@ defmodule DotcomWeb.AlertView do
   @spec group_header_name(Route.t() | Stop.t()) :: Phoenix.HTML.Safe.t()
   defp group_header_name(%Route{long_name: long_name, name: name, type: 3}) do
     [
-      name,
-      content_tag(:span, long_name,
-        class: "font-heading font-bold mt-11 mb-3 text-2xl m-alerts-header__long-name"
-      )
+      content_tag(:span, name, class: "text-xl pr-sm"),
+      content_tag(:span, long_name, class: "text-lg")
     ]
   end
 


### PR DESCRIPTION
No ticket, just a UI improvement that Chase was cool with, that'll make it easier to implement the upcoming UI change for subway alert display (since we'll have a consistent layout for each).

The route header above each group of alerts now has icon placed on left and text on right. This also fixes a regression in the text size of bus route names.


---


![image](https://github.com/user-attachments/assets/66f98861-6edb-46c8-8730-44d762d5ac12)

![image](https://github.com/user-attachments/assets/780d348d-70dd-48ec-9362-b81dc4b7fa12)

![image](https://github.com/user-attachments/assets/de4c8b40-d0b0-4c6f-a316-29318291d3e5)
