### PR TITLE
feat(AlertController): put new features on the subway alerts page

### DIFF
--- a/lib/alerts/repo.ex
+++ b/lib/alerts/repo.ex
@@ -5,6 +5,7 @@ defmodule Alerts.Repo do
 
   @behaviour Behaviour
 
+  @impl Behaviour
   @spec all(DateTime.t()) :: [Alert.t()]
   def all(now) do
     Store.all_alerts(now)
@@ -63,6 +64,7 @@ defmodule Alerts.Repo do
     |> Store.alerts(now)
   end
 
+  @impl Behaviour
   @spec by_stop_id(String.t(), DateTime.t()) :: [Alert.t()]
   def by_stop_id(stop_id, now \\ DateTime.utc_now()) do
     stop_id

--- a/lib/alerts/repo/behaviour.ex
+++ b/lib/alerts/repo/behaviour.ex
@@ -6,7 +6,17 @@ defmodule Alerts.Repo.Behaviour do
   alias Alerts.Alert
 
   @doc """
+  Return all alerts applicable to the given datetime.
+  """
+  @callback all(DateTime.t()) :: [Alert.t()]
+
+  @doc """
   Return all alerts for the given route ids.
   """
   @callback by_route_ids([String.t()], DateTime.t()) :: [Alert.t()]
+
+  @doc """
+  Return all alerts for the given stop id.
+  """
+  @callback by_stop_id(String.t()) :: [Alert.t()]
 end

--- a/lib/dotcom/alerts/disruptions/subway.ex
+++ b/lib/dotcom/alerts/disruptions/subway.ex
@@ -113,7 +113,7 @@ defmodule Dotcom.Alerts.Disruptions.Subway do
       fn alert ->
         alert |> Map.get(:active_period, [{nil, nil}]) |> List.first() |> Kernel.elem(0)
       end,
-      :asc
+      DateTime
     )
   end
 end

--- a/lib/dotcom/utils/service_date_time.ex
+++ b/lib/dotcom/utils/service_date_time.ex
@@ -225,12 +225,17 @@ defmodule Dotcom.Utils.ServiceDateTime do
   end
 
   @doc """
-  Returns all service ranges between two datetimes, inclusive, supporting open ends.
+  Returns service ranges between two datetimes, inclusive.
+  One datetime can be given, which will return only the service range for the given datetime.
   """
   @spec service_range_range(DateTime.t() | nil, DateTime.t() | nil) :: [named_service_range()]
+  def service_range_range(nil, nil), do: []
+  def service_range_range(start, nil) when not is_nil(start), do: [service_range(start)]
+  def service_range_range(nil, stop) when not is_nil(stop), do: [service_range(stop)]
+
   def service_range_range(start, stop) do
-    start_index = if(start, do: service_range_index(start), else: 0)
-    stop_index = if(stop, do: service_range_index(stop), else: length(all_service_ranges()) - 1)
+    start_index = service_range_index(start)
+    stop_index = service_range_index(stop)
 
     all_service_ranges()
     |> Enum.with_index(&if(&2 in start_index..stop_index, do: &1))

--- a/lib/dotcom_web/components/alerts.ex
+++ b/lib/dotcom_web/components/alerts.ex
@@ -27,7 +27,7 @@ defmodule DotcomWeb.Components.Alerts do
       |> assign(:now, @date_time_module.now())
 
     ~H"""
-    <div class={"p-md c-alert-item c-alert-item--#{@alert.priority}"}>
+    <div class={"p-md c-alert-item c-alert-item--#{@alert.priority}"} data-test="alert_id:#{alert.id}">
       {AlertView.format_alert_description(@header)}
       <%= if @description do %>
         <div class="mt-sm">

--- a/lib/dotcom_web/components/alerts.ex
+++ b/lib/dotcom_web/components/alerts.ex
@@ -27,7 +27,10 @@ defmodule DotcomWeb.Components.Alerts do
       |> assign(:now, @date_time_module.now())
 
     ~H"""
-    <div class={"p-md c-alert-item c-alert-item--#{@alert.priority}"} data-test={"alert_id:#{alert.id}"}>
+    <div
+      class={"p-md c-alert-item c-alert-item--#{@alert.priority}"}
+      data-test={"alert_id:#{@alert.id}"}
+    >
       {AlertView.format_alert_description(@header)}
       <%= if @description do %>
         <div class="mt-sm">

--- a/lib/dotcom_web/components/alerts.ex
+++ b/lib/dotcom_web/components/alerts.ex
@@ -27,7 +27,7 @@ defmodule DotcomWeb.Components.Alerts do
       |> assign(:now, @date_time_module.now())
 
     ~H"""
-    <div class={"p-md c-alert-item c-alert-item--#{@alert.priority}"} data-test="alert_id:#{alert.id}">
+    <div class={"p-md c-alert-item c-alert-item--#{@alert.priority}"} data-test={"alert_id:#{alert.id}"}>
       {AlertView.format_alert_description(@header)}
       <%= if @description do %>
         <div class="mt-sm">

--- a/lib/dotcom_web/components/layouts/alerts_layout.html.heex
+++ b/lib/dotcom_web/components/layouts/alerts_layout.html.heex
@@ -5,13 +5,13 @@
     </div>
     <div class="row">
       <div class="col-lg-3">
-        {render_slot(@sidebar_top)}
-        <div class="hidden-md-down">
+        {if(@sidebar_top, do: render_slot(@sidebar_top))}
+        <div :if={@sidebar_bottom} class="hidden-md-down">
           {render_slot(@sidebar_bottom)}
         </div>
       </div>
       <div class="col-lg-8 col-lg-offset-1">
-        <div class="m-alerts__mode-buttons">
+        <div class="m-alerts__mode-buttons mb-lg">
           <a
             :for={mode <- [:subway, :bus, :commuter_rail, :ferry, :access]}
             href={~p"/alerts/#{mode}"}
@@ -29,7 +29,7 @@
 
         {render_slot(@main_section)}
 
-        <div class="hidden-lg-up">
+        <div :if={@sidebar_bottom} class="hidden-lg-up">
           {render_slot(@sidebar_bottom)}
         </div>
       </div>

--- a/lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
+++ b/lib/dotcom_web/components/layouts/alerts_page_content_layout.html.heex
@@ -1,0 +1,38 @@
+{render_slot(@heading)}
+
+<% show_systemwide_alert? = DotcomWeb.AlertView.show_systemwide_alert?(assigns) %>
+
+<div :if={show_systemwide_alert?} class="m-alerts-header">
+  <h3 class="leading-none m-0">Systemwide</h3>
+  <div class="c-alert-group">
+    {DotcomWeb.AlertView.render("_item.html",
+      alert: %{Alerts.Repo.by_id(@alert_banner.id) | priority: :system},
+      date_time: @date_time
+    )}
+  </div>
+</div>
+
+<%= for {route_or_stop, alerts} <- @alert_groups do %>
+  <div class="m-alerts-header">
+    <%= PhoenixHTMLHelpers.Link.link to: DotcomWeb.AlertView.group_header_path(route_or_stop), class: "flex items-center gap-sm hover:no-underline" do %>
+      {render_slot(@alert_header_icon, route_or_stop)}
+      <h3 class="m-alerts-header__name">
+        {DotcomWeb.AlertView.group_header_name(route_or_stop)}
+      </h3>
+    <% end %>
+  </div>
+  <div>
+    {DotcomWeb.AlertView.group(
+      alerts: alerts,
+      route: route_or_stop,
+      date_time: @date_time
+    )}
+  </div>
+<% end %>
+
+<div
+  :if={Enum.empty?(@alert_groups) && !show_systemwide_alert?}
+  class="m-alerts__notice--no-alerts"
+>
+  {@empty_message}
+</div>

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -66,7 +66,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     <.unstyled_accordion
       :for={route_ids <- @route_ids_by_subway_line}
       summary_class="flex items-center hover:bg-brand-primary-lightest cursor-pointer group/row"
-      chevron_class="fill-gray-lighter px-2 py-3"
+      chevron_class="fill-gray-dark px-2 py-3"
     >
       <:heading>
         <.heading route_ids={route_ids} alert={@alert} />

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -99,7 +99,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
 
   defp formatted_time_range({nil, nil}), do: nil
   defp formatted_time_range({nil, stop}), do: "Until #{format_date(stop)}"
-  defp formatted_time_range({start, nil}), do: "From #{format_date(start)}"
+  defp formatted_time_range({start, nil}), do: "#{format_date(start)} until further notice"
   defp formatted_time_range({start, stop}), do: "#{format_date(start)} – #{format_date(stop)}"
 
   # Extracts the start and stop times from the active periods of an alert.

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -100,7 +100,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
   defp formatted_time_range({nil, nil}), do: nil
   defp formatted_time_range({nil, stop}), do: "Until #{format_date(stop)}"
   defp formatted_time_range({start, nil}), do: "From #{format_date(start)}"
-  defp formatted_time_range({start, stop}), do: "#{format_date(start)} - #{format_date(stop)}"
+  defp formatted_time_range({start, stop}), do: "#{format_date(start)} – #{format_date(stop)}"
 
   # Extracts the start and stop times from the active periods of an alert.
   # We do this by sorting the active periods by start time then taking the start of the first and the stop of the last.
@@ -136,7 +136,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
          Timex.before?(service_date_datetime, service_date_today) do
       "Today"
     else
-      service_date_datetime |> Timex.format!("%a %b %-d", :strftime)
+      service_date_datetime |> Timex.format!("%a, %b %-d", :strftime)
     end
   end
 end

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -27,18 +27,25 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
       |> Enum.map(fn service_range ->
         {service_range, Map.get(assigns.disruptions, service_range, [])}
       end)
+      |> Enum.reject(fn {_, disruptions} ->
+        disruptions == []
+      end)
 
     assigns = assign(assigns, :ordered_disruptions, ordered_disruptions)
 
     ~H"""
     <.bordered_container>
       <:heading>Planned Work</:heading>
-      <div :for={{service_range, disruptions} <- @ordered_disruptions} class="py-3">
-        <div class="mb-2 font-bold font-heading">{service_range_string(service_range)}</div>
-        <.lined_list :let={disruption} items={disruptions}>
-          <.disruption alert={disruption} />
-        </.lined_list>
-      </div>
+      <%= if Enum.empty?(@ordered_disruptions) do %>
+        There is no planned work information at this time.
+      <% else %>
+        <div :for={{service_range, disruptions} <- @ordered_disruptions} class="py-3">
+          <div class="mb-2 font-bold font-heading">{service_range_string(service_range)}</div>
+          <.lined_list :let={disruption} items={disruptions}>
+            <.disruption alert={disruption} />
+          </.lined_list>
+        </div>
+      <% end %>
     </.bordered_container>
     """
   end

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -50,7 +50,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
               prefix={row.status_entry.prefix}
               plural={row.status_entry.plural}
             />
-            <.icon name="chevron-right" class="h-3 w-2 fill-gray-lighter ml-3 mr-2 shrink-0" />
+            <.icon name="chevron-right" class="h-3 w-2 fill-gray-dark ml-3 mr-2 shrink-0" />
           </div>
         </a>
       </.lined_list>
@@ -74,7 +74,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             data-test-row-route-info={inspect(row.route_info)}
             style={if(row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
             summary_class="hover:bg-brand-primary-lightest cursor-pointer group/row flex items-center grow text-nowrap"
-            chevron_class={"fill-gray-lighter px-2 py-3 #{row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"}"}
+            chevron_class={"fill-gray-dark px-2 py-3 #{row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"}"}
           >
             <:heading>
               <div class="pl-2 py-3 pr-sm">

--- a/lib/dotcom_web/controllers/alert_controller.ex
+++ b/lib/dotcom_web/controllers/alert_controller.ex
@@ -85,10 +85,6 @@ defmodule DotcomWeb.AlertController do
     alerts
     |> Enum.filter(&MapSet.member?(access_effects, &1.effect))
     |> Enum.reduce(%{}, &group_access_alerts_by_stop/2)
-    |> Enum.map(fn {stop_id, alerts} ->
-      stop = @stops_repo.get_parent(stop_id)
-      {stop, alerts}
-    end)
     |> Enum.sort_by(fn {stop, _} -> stop.name end)
   end
 
@@ -100,10 +96,10 @@ defmodule DotcomWeb.AlertController do
 
   defp do_group_access_alerts_by_stop(stop_id, alert, acc) do
     # stop_ids are sometimes child stops.
-    # Fetch the stop_id from the repo to get the parent id.
+    # Fetch the stop_id from the repo to get the parent stop.
     case @stops_repo.get_parent(stop_id) do
-      %Stop{id: parent_stop_id} ->
-        Map.update(acc, parent_stop_id, MapSet.new([alert]), &MapSet.put(&1, alert))
+      %Stop{} = stop ->
+        Map.update(acc, stop, MapSet.new([alert]), &MapSet.put(&1, alert))
 
       _ ->
         acc

--- a/lib/dotcom_web/controllers/alert_controller.ex
+++ b/lib/dotcom_web/controllers/alert_controller.ex
@@ -1,6 +1,6 @@
 defmodule DotcomWeb.AlertController do
   use DotcomWeb, :controller
-  alias Alerts.{Alert, InformedEntity, Match, Repo}
+  alias Alerts.{Alert, InformedEntity, Match}
   alias Stops.Stop
 
   plug(:route_type)
@@ -9,6 +9,7 @@ defmodule DotcomWeb.AlertController do
   plug(DotcomWeb.Plugs.AlertsByTimeframe)
   plug(DotcomWeb.Plug.Mticket)
 
+  @alerts_repo Application.compile_env!(:dotcom, :repo_modules)[:alerts]
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
 
@@ -35,14 +36,14 @@ defmodule DotcomWeb.AlertController do
 
   @spec show_by_stop(Plug.Conn.t(), map) :: Plug.Conn.t()
   def show_by_stop(conn, %{"stop_id" => stop_id}) do
-    alerts = Repo.by_stop_id(stop_id)
+    alerts = @alerts_repo.by_stop_id(stop_id)
     json(conn, alerts)
   end
 
   @spec show_by_routes(Plug.Conn.t(), map) :: Plug.Conn.t()
   def show_by_routes(%{query_params: %{"route_ids" => route_ids}} = conn, _) do
     route_id_array = String.split(route_ids, ",")
-    alerts = Repo.by_route_ids(route_id_array, DateTime.utc_now())
+    alerts = @alerts_repo.by_route_ids(route_id_array, DateTime.utc_now())
     json(conn, alerts)
   end
 
@@ -131,7 +132,7 @@ defmodule DotcomWeb.AlertController do
   defp routes(conn, _opts), do: conn
 
   defp alerts(%{params: %{"id" => id}} = conn, _opts) when id in @valid_ids do
-    alerts = Alerts.Repo.all(conn.assigns.date_time)
+    alerts = @alerts_repo.all(conn.assigns.date_time)
     assign(conn, :alerts, alerts)
   end
 

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -18,23 +18,26 @@ defmodule DotcomWeb.Live.SystemStatus do
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
 
   def render(assigns) do
+    now = @date_time_module.now()
+
     live_alerts =
       subway_route_ids()
-      |> Alerts.Repo.by_route_ids(@date_time_module.now())
-      |> Enum.filter(&SystemStatus.status_alert?(&1, @date_time_module.now()))
+      |> Alerts.Repo.by_route_ids(now)
+      |> Enum.filter(&SystemStatus.status_alert?(&1, now))
 
     assigns =
       assigns
       |> assign(:alerts, live_alerts)
       |> assign(:examples, alerts_examples())
+      |> assign(:now, now)
 
     ~H"""
     <h1>Live Data</h1>
-    <.example_table alerts={@alerts} />
+    <.example_table alerts={@alerts} now={@now} />
 
     <h1>Examples</h1>
     <div :for={example <- @examples} class="mb-4">
-      <.example_table alerts={example.alerts} />
+      <.example_table alerts={example.alerts} now={@now} />
     </div>
 
     <h1>Misc Components</h1>
@@ -73,7 +76,7 @@ defmodule DotcomWeb.Live.SystemStatus do
 
   defp example_table(assigns) do
     subway_status =
-      SystemStatus.Subway.subway_status(assigns.alerts, Timex.now() |> Timex.set(hour: 12))
+      SystemStatus.Subway.subway_status(assigns.alerts, assigns.now)
 
     assigns = assign(assigns, :subway_status, subway_status)
 
@@ -92,7 +95,7 @@ defmodule DotcomWeb.Live.SystemStatus do
           <.alerts_subway_status subway_status={@subway_status} />
         </td>
         <td class="bg-slate-600 p-2 w-1/3 align-top">
-          {Phoenix.View.render_many(@alerts, DotcomWeb.AlertView, "_item.html", date_time: Util.now())}
+          {Phoenix.View.render_many(@alerts, DotcomWeb.AlertView, "_item.html", date_time: @now)}
         </td>
       </tr>
     </table>

--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -1,5 +1,5 @@
 <.alerts_layout mode={@id}>
-  <:sidebar_top>
+  <:sidebar_top :if={@id != :subway}>
     {DotcomWeb.PartialView.alert_time_filters(@alerts_timeframe,
       method: :alert_path,
       item: @id
@@ -8,7 +8,26 @@
   <:sidebar_bottom>
     {render("_t-alerts.html")}
   </:sidebar_bottom>
-  <:main_section>
+  <:main_section :if={@id == :subway}>
+    <section class="mb-lg">
+      <.alerts_subway_status subway_status={@current_status} />
+    </section>
+    <section class="mb-lg">
+      <.disruptions disruptions={@disruption_groups} />
+    </section>
+    <.alerts_page_content_layout
+      {assigns}
+      empty_message={"There are no other #{format_alerts_timeframe(@alerts_timeframe)} #{mode_name(@id)} alerts at this time."}
+    >
+      <:heading>
+        <h2 class="mt-0">Station & Service Alerts</h2>
+      </:heading>
+      <:alert_header_icon :let={route_or_stop}>
+        <.subway_route_pill route_ids={[route_or_stop.id]} />
+      </:alert_header_icon>
+    </.alerts_page_content_layout>
+  </:main_section>
+  <:main_section :if={@id != :subway}>
     <.alerts_page_content_layout
       {assigns}
       empty_message={"There are no #{format_alerts_timeframe(@alerts_timeframe)} #{mode_name(@id)} alerts at this time."}

--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -1,4 +1,3 @@
-<% show_systemwide_alert? = show_systemwide_alert?(assigns) %>
 <.alerts_layout mode={@id}>
   <:sidebar_top>
     {DotcomWeb.PartialView.alert_time_filters(@alerts_timeframe,
@@ -10,39 +9,16 @@
     {render("_t-alerts.html")}
   </:sidebar_bottom>
   <:main_section>
-    <%= if show_systemwide_alert? do %>
-      <div class="m-alerts-header">
-        <h2 class="m-alerts-header__name--systemwide">Systemwide</h2>
-        <span class="m-alerts-header__icon">
-          {DotcomWeb.PartialView.SvgIconWithCircle.svg_icon_with_circle(%SvgIconWithCircle{
-            icon: :t_logo,
-            aria_hidden?: true
-          })}
-        </span>
-      </div>
-      <div class="c-alert-group">
-        {render("_item.html",
-          alert: %{Alerts.Repo.by_id(@alert_banner.id) | priority: :system},
-          date_time: @date_time
-        )}
-      </div>
-    <% end %>
-    <% timeframe = format_alerts_timeframe(@alerts_timeframe) %>
-    <div :for={{route_or_stop, alerts} <- @alert_groups} class="mb-lg">
-      <%= link to: group_header_path(route_or_stop), class: "flex items-center gap-sm hover:no-underline" do %>
+    <.alerts_page_content_layout
+      {assigns}
+      empty_message={"There are no #{format_alerts_timeframe(@alerts_timeframe)} #{mode_name(@id)} alerts at this time."}
+    >
+      <:heading>
+        <h2 class="sr-only">All Alerts</h2>
+      </:heading>
+      <:alert_header_icon :let={route_or_stop}>
         <.route_icon :if={show_mode_icon?(route_or_stop)} route={route_or_stop} />
-        <h3 class="m-alerts-header__name text-lg">{group_header_name(route_or_stop)}</h3>
-      <% end %>
-      {DotcomWeb.AlertView.group(
-        alerts: alerts,
-        route: route_or_stop,
-        date_time: @date_time
-      )}
-    </div>
-    <%= if Enum.empty?(@alert_groups) && !show_systemwide_alert? do %>
-      <div class="m-alerts__notice--no-alerts">
-        There are no {timeframe} {mode_name(@id)} alerts at this time.
-      </div>
-    <% end %>
+      </:alert_header_icon>
+    </.alerts_page_content_layout>
   </:main_section>
 </.alerts_layout>

--- a/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+++ b/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
@@ -13,7 +13,7 @@
         <span aria-hidden="true">
           {svg("icon-map-default.svg")}
         </span>
-        <span href="/schedules" class="m-tabbed-nav__icon-text">Schedules</span>
+        <span href="/schedules" class="m-tabbed-nav__icon-text">Routes</span>
       </a>
     </div>
     <div class="m-tabbed-nav__item-container">

--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -4,10 +4,12 @@ defmodule DotcomWeb.AlertView do
   use DotcomWeb, :view
 
   import DotcomWeb.ViewHelpers
+  import DotcomWeb.Components.PlannedDisruptions, only: [disruptions: 1]
+  import DotcomWeb.Components.RouteSymbols
+  import DotcomWeb.Components.SystemStatus.SubwayStatus, only: [alerts_subway_status: 1]
   import PhoenixHTMLHelpers.Tag, only: [content_tag: 3]
 
   alias Alerts.{Alert, InformedEntity, InformedEntitySet, URLParsingHelpers}
-  alias DotcomWeb.PartialView.SvgIconWithCircle
   alias Routes.Route
   alias Stops.Stop
 

--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -210,18 +210,18 @@ defmodule DotcomWeb.AlertView do
   end
 
   @spec group_header_name(Route.t() | Stop.t()) :: Phoenix.HTML.Safe.t()
-  defp group_header_name(%Route{long_name: long_name, name: name, type: 3}) do
+  def group_header_name(%Route{long_name: long_name, name: name, type: 3}) do
     [
       content_tag(:span, name, class: "text-xl pr-sm"),
       content_tag(:span, long_name, class: "text-lg")
     ]
   end
 
-  defp group_header_name(%Route{name: name}) do
+  def group_header_name(%Route{name: name}) do
     [name]
   end
 
-  defp group_header_name(%Stops.Stop{name: name}) do
+  def group_header_name(%Stops.Stop{name: name}) do
     [name]
   end
 

--- a/test/dotcom/utils/service_date_time_test.exs
+++ b/test/dotcom/utils/service_date_time_test.exs
@@ -238,10 +238,10 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
 
     test "returns all service ranges starting from a datetime" do
       # Setup
-      this_week = service_range_this_week() |> random_time_range_date_time()
+      next_week = service_range_next_week() |> random_time_range_date_time()
 
       # Exercise / Verify
-      assert service_range_range(this_week, nil) == [:this_week, :next_week, :after_next_week]
+      assert service_range_range(next_week, nil) == [:next_week, :after_next_week]
     end
 
     test "returns all service ranges up to a datetime" do

--- a/test/dotcom/utils/service_date_time_test.exs
+++ b/test/dotcom/utils/service_date_time_test.exs
@@ -236,25 +236,20 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
       assert service_range_range(today, next_week) == [:today, :this_week, :next_week]
     end
 
-    test "returns all service ranges starting from a datetime" do
+    test "returns one service range when given only one start datetime" do
       # Setup
       next_week = service_range_next_week() |> random_time_range_date_time()
 
       # Exercise / Verify
-      assert service_range_range(next_week, nil) == [:next_week, :after_next_week]
+      assert service_range_range(next_week, nil) == [:next_week]
     end
 
-    test "returns all service ranges up to a datetime" do
+    test "returns one service range when given only one stop datetime" do
       # Setup
       next_week = service_range_next_week() |> random_time_range_date_time()
 
       # Exercise / Verify
-      assert service_range_range(nil, next_week) == [
-               :before_today,
-               :today,
-               :this_week,
-               :next_week
-             ]
+      assert service_range_range(nil, next_week) == [:next_week]
     end
   end
 


### PR DESCRIPTION

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Service Alerts page | Refine Station and Service Alerts section](https://app.asana.com/0/555089885850811/1209323323089304) and [Service Alerts page | Add "Current Status" section for subway](https://app.asana.com/0/555089885850811/1209323323089299)

<img width="1347" alt="image" src="https://github.com/user-attachments/assets/cd83f862-9336-471c-9f63-c1d03181b727" />


Most of the changes here were adding an additional sub-layout for the content of the alert page. Everything's the same between modes except for: 
- the icon shown next to each route (for subway it's the `subway_route_pill`, all others `route_icon`)
- the `<h2>` shown above the list of alerts, as there's no heading shown for non-subway
- I changed the verbiage of the "no alerts here" message for subway to read more like "no other alerts here", since there might be other alerts covered by the Current Status or Planned Disruptions sections
- and of course, the new sections are only included for subway

Outside of the main content, the timeframe filters are also omitted from the sidebar for subway only.

Hopefully the structure is clear enough. Please omit the first commit from review, as it is already covered in #2388 