### PR TITLE
Formatting date, use today for today, this week instead of later this…

### DIFF
--- a/lib/dotcom/alerts/disruptions/subway.ex
+++ b/lib/dotcom/alerts/disruptions/subway.ex
@@ -17,7 +17,7 @@ defmodule Dotcom.Alerts.Disruptions.Subway do
   """
   @spec future_disruptions() :: %{Utils.ServiceDateTime.named_service_range() => [Alert.t()]}
   def future_disruptions() do
-    disruption_groups() |> Map.take([:later_this_week, :next_week, :after_next_week])
+    disruption_groups() |> Map.take([:this_week, :next_week, :after_next_week])
   end
 
   @doc """
@@ -58,7 +58,7 @@ defmodule Dotcom.Alerts.Disruptions.Subway do
   end
 
   # An active period can span many ranges from start to stop
-  # e.g. [:before_today, :today, :later_this_week]
+  # e.g. [:before_today, :today, :this_week]
   defp service_range_range({start, stop}) do
     start_index = Enum.find_index(all_service_ranges(), &(&1 == service_range(start)))
     stop_index = Enum.find_index(all_service_ranges(), &(&1 == service_range(stop)))

--- a/lib/dotcom/utils/service_date_time.ex
+++ b/lib/dotcom/utils/service_date_time.ex
@@ -7,10 +7,10 @@ defmodule Dotcom.Utils.ServiceDateTime do
 
   The service range continuum:
 
-  <---before today---|---later this week---|---next week---|---after next week--->
-                   today
+  <---before today---|---this week---|---next week---|---after next week--->
+                     today
 
-  Before today and after next week are open intervals.
+  Before today and after next week are open intervals. Today is included in this week.
   """
 
   require Logger

--- a/lib/dotcom/utils/service_date_time.ex
+++ b/lib/dotcom/utils/service_date_time.ex
@@ -20,7 +20,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
   alias Dotcom.Utils
 
   @type named_service_range() ::
-          :before_today | :today | :later_this_week | :next_week | :after_next_week
+          :before_today | :today | :this_week | :next_week | :after_next_week
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
   @service_rollover_time Application.compile_env!(:dotcom, :service_rollover_time)
   @timezone Application.compile_env!(:dotcom, :timezone)
@@ -29,7 +29,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
   Returns an ordered list of service ranges, from earliest to latest.
   """
   def all_service_ranges,
-    do: [:before_today, :today, :later_this_week, :next_week, :after_next_week]
+    do: [:before_today, :today, :this_week, :next_week, :after_next_week]
 
   @doc """
   Returns the time at which service rolls over from 'today' to 'tomorrow'.
@@ -61,7 +61,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
       [
         &service_before_today?/1,
         &service_today?/1,
-        &service_later_this_week?/1,
+        &service_this_week?/1,
         &service_next_week?/1,
         &service_after_next_week?/1
       ],
@@ -80,9 +80,10 @@ defmodule Dotcom.Utils.ServiceDateTime do
   """
   @spec service_range_string(named_service_range()) :: String.t()
   def service_range_string(service_range) do
-    service_range
-    |> Atom.to_string()
-    |> Recase.to_title()
+    case service_range do
+      :after_next_week -> "Later"
+      _ -> service_range|> Atom.to_string() |> Recase.to_title()
+    end
   end
 
   @doc """
@@ -143,16 +144,16 @@ defmodule Dotcom.Utils.ServiceDateTime do
   Service weeks go from Monday at 03:00:00am to the following Monday at 02:59:59am.
   If today is the last day in the service week, the range will be the same as the range for today.
   """
-  @spec service_range_later_this_week() :: Utils.DateTime.date_time_range()
-  @spec service_range_later_this_week(DateTime.t()) :: Utils.DateTime.date_time_range()
-  def service_range_later_this_week(date_time \\ @date_time_module.now()) do
-    beginning_of_next_service_day = beginning_of_next_service_day(date_time)
+  @spec service_range_this_week() :: Utils.DateTime.date_time_range()
+  @spec service_range_this_week(DateTime.t()) :: Utils.DateTime.date_time_range()
+  def service_range_this_week(date_time \\ @date_time_module.now()) do
+    beginning_of_service_day = beginning_of_service_day(date_time)
 
-    end_of_later_this_week = date_time |> Timex.end_of_week() |> end_of_service_day()
+    end_of_this_week = date_time |> Timex.end_of_week() |> end_of_service_day()
 
-    case Timex.compare(beginning_of_next_service_day, end_of_later_this_week) do
+    case Timex.compare(beginning_of_service_day, end_of_this_week) do
       1 -> service_range_day(date_time)
-      _ -> {beginning_of_next_service_day, end_of_later_this_week}
+      _ -> {beginning_of_service_day, end_of_this_week}
     end
   end
 
@@ -162,8 +163,8 @@ defmodule Dotcom.Utils.ServiceDateTime do
   @spec service_range_next_week() :: Utils.DateTime.date_time_range()
   @spec service_range_next_week(DateTime.t()) :: Utils.DateTime.date_time_range()
   def service_range_next_week(date_time \\ @date_time_module.now()) do
-    {_, end_of_later_this_week} = service_range_later_this_week(date_time)
-    beginning_of_next_week = Timex.shift(end_of_later_this_week, microseconds: 1)
+    {_, end_of_this_week} = service_range_this_week(date_time)
+    beginning_of_next_week = Timex.shift(end_of_this_week, microseconds: 1)
 
     end_of_next_week =
       beginning_of_next_week |> Timex.end_of_week() |> end_of_service_day()
@@ -202,9 +203,9 @@ defmodule Dotcom.Utils.ServiceDateTime do
   @doc """
   Does the given date_time fall within the service range of this week?
   """
-  @spec service_later_this_week?(DateTime.t()) :: boolean
-  def service_later_this_week?(date_time) do
-    service_range_later_this_week() |> @date_time_module.in_range?(date_time)
+  @spec service_this_week?(DateTime.t()) :: boolean
+  def service_this_week?(date_time) do
+    service_range_this_week() |> @date_time_module.in_range?(date_time)
   end
 
   @doc """

--- a/lib/dotcom/utils/service_date_time.ex
+++ b/lib/dotcom/utils/service_date_time.ex
@@ -82,7 +82,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
   def service_range_string(service_range) do
     case service_range do
       :after_next_week -> "Later"
-      _ -> service_range|> Atom.to_string() |> Recase.to_title()
+      _ -> service_range |> Atom.to_string() |> Recase.to_title()
     end
   end
 

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -109,7 +109,8 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     service_date_datetime = service_date(datetime)
     service_date_today = @date_time_module.now() |> service_date()
 
-    if service_date_datetime == service_date_today do
+    if Timex.before?(service_date_datetime, service_date_today) ||
+         service_date_datetime == service_date_today do
       "Today"
     else
       service_date_datetime |> Timex.format!("%a %b %-d", :strftime)

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -22,13 +22,21 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
   Planned disruptions organized into service ranges.
   """
   def disruptions(assigns) do
+    ordered_disruptions =
+      [:this_week, :next_week, :after_next_week]
+      |> Enum.map(fn service_range ->
+        {service_range, Map.get(assigns.disruptions, service_range, [])}
+      end)
+
+    assigns = assign(assigns, :ordered_disruptions, ordered_disruptions)
+
     ~H"""
     <.bordered_container>
       <:heading>Planned Work</:heading>
-      <div :for={{service_range, alerts} <- @disruptions} class="py-3">
+      <div :for={{service_range, disruptions} <- @ordered_disruptions} class="py-3">
         <div class="mb-2 font-bold font-heading">{service_range_string(service_range)}</div>
-        <.lined_list :let={alert} items={alerts}>
-          <.disruption alert={alert} />
+        <.lined_list :let={disruption} items={disruptions}>
+          <.disruption alert={disruption} />
         </.lined_list>
       </div>
     </.bordered_container>

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -85,7 +85,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     periods =
       Enum.sort_by(
         active_period,
-        &Kernel.elem(&1, 0),
+        fn {start, _} -> start end,
         DateTime
       )
 

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -82,11 +82,12 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
 
   # Extracts the start and stop times from the active period of an alert.
   defp alert_date_time_range(%Alert{active_period: active_period}) do
-    periods = Enum.sort_by(
-      active_period,
-      &Kernel.elem(&1, 0),
-      DateTime
-    )
+    periods =
+      Enum.sort_by(
+        active_period,
+        &Kernel.elem(&1, 0),
+        DateTime
+      )
 
     {start, _} = List.first(periods)
     {_, stop} = List.last(periods)

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -103,7 +103,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
   end
 
   # Formats the date for display in the heading.
-  # If the service date is today, we display "Today".
+  # If the service date is on or before today, we display "Today".
   # Otherwise, we display the date like "Mon Jan 1".
   defp format_date(datetime) do
     service_date_datetime = service_date(datetime)

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -109,8 +109,8 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     service_date_datetime = service_date(datetime)
     service_date_today = @date_time_module.now() |> service_date()
 
-    if Timex.before?(service_date_datetime, service_date_today) ||
-         service_date_datetime == service_date_today do
+    if Timex.equal?(service_date_datetime, service_date_today) ||
+         Timex.before?(service_date_datetime, service_date_today) do
       "Today"
     else
       service_date_datetime |> Timex.format!("%a %b %-d", :strftime)

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -80,17 +80,18 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     """
   end
 
-  # Extracts the start and stop times from the active period of an alert.
+  # Extracts the start and stop times from the active periods of an alert.
+  # We do this by sorting the active periods by start time then taking the start of the first and the stop of the last.
   defp alert_date_time_range(%Alert{active_period: active_period}) do
-    periods =
+    sorted_active_periods =
       Enum.sort_by(
         active_period,
         fn {start, _} -> start end,
         DateTime
       )
 
-    {start, _} = List.first(periods)
-    {_, stop} = List.last(periods)
+    {start, _} = List.first(sorted_active_periods)
+    {_, stop} = List.last(sorted_active_periods)
 
     {start, stop}
   end

--- a/test/dotcom/alerts/disruptions/subway_test.exs
+++ b/test/dotcom/alerts/disruptions/subway_test.exs
@@ -7,7 +7,7 @@ defmodule Dotcom.Alerts.Disruptions.SubwayTest do
   import Dotcom.Utils.ServiceDateTime,
     only: [
       service_range_day: 0,
-      service_range_later_this_week: 0,
+      service_range_this_week: 0,
       service_range_next_week: 0,
       service_range_after_next_week: 0
     ]
@@ -37,7 +37,7 @@ defmodule Dotcom.Alerts.Disruptions.SubwayTest do
     test "returns alerts for later this week, next week, and after next week" do
       # Setup
       alert_today = service_range_day() |> disruption_alert()
-      alert_later_this_week = service_range_later_this_week() |> disruption_alert()
+      alert_this_week = service_range_this_week() |> disruption_alert()
       alert_next_week = service_range_next_week() |> disruption_alert()
 
       {alert_after_next_week_start, _} = service_range_after_next_week()
@@ -47,12 +47,12 @@ defmodule Dotcom.Alerts.Disruptions.SubwayTest do
         |> disruption_alert()
 
       expect(Alerts.Repo.Mock, :by_route_ids, fn _route_ids, _now ->
-        [alert_today, alert_later_this_week, alert_next_week, alert_after_next_week]
+        [alert_today, alert_this_week, alert_next_week, alert_after_next_week]
       end)
 
       # Exercise/Verify
       assert %{
-               later_this_week: [^alert_later_this_week],
+               this_week: [^alert_this_week],
                next_week: [^alert_next_week],
                after_next_week: [^alert_after_next_week]
              } = future_disruptions()
@@ -73,7 +73,7 @@ defmodule Dotcom.Alerts.Disruptions.SubwayTest do
 
       # Exercise/Verify
       assert %{
-               later_this_week: [^long_alert],
+               this_week: [^long_alert],
                next_week: [^long_alert],
                after_next_week: [^long_alert]
              } = future_disruptions()
@@ -82,7 +82,7 @@ defmodule Dotcom.Alerts.Disruptions.SubwayTest do
     test "handles alert with more than one active_period" do
       # Setup
       long_alert =
-        [service_range_later_this_week(), service_range_next_week()] |> disruption_alert()
+        [service_range_this_week(), service_range_next_week()] |> disruption_alert()
 
       expect(Alerts.Repo.Mock, :by_route_ids, fn _route_ids, _now ->
         [long_alert]
@@ -90,7 +90,7 @@ defmodule Dotcom.Alerts.Disruptions.SubwayTest do
 
       # Exercise/Verify
       assert %{
-               later_this_week: [^long_alert],
+               this_week: [^long_alert],
                next_week: [^long_alert]
              } = future_disruptions()
     end
@@ -128,7 +128,7 @@ defmodule Dotcom.Alerts.Disruptions.SubwayTest do
       alert_today_and_other_dates =
         [
           service_range_day(),
-          service_range_later_this_week(),
+          service_range_this_week(),
           service_range_next_week()
         ]
         |> disruption_alert()

--- a/test/dotcom/utils/service_date_time_test.exs
+++ b/test/dotcom/utils/service_date_time_test.exs
@@ -90,7 +90,7 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
         Dotcom.Utils.DateTime.now() |> Timex.beginning_of_week() |> beginning_of_service_day()
       end)
 
-      {_, end_of_service_week} = service_range_later_this_week()
+      {_, end_of_service_week} = service_range_this_week()
 
       expect(Dotcom.Utils.DateTime.Mock, :now, 1, fn ->
         end_of_service_week
@@ -100,19 +100,19 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
       assert service_range(end_of_service_week) == :today
     end
 
-    test "returns :later_this_week for later this week" do
+    test "returns :this_week for this week" do
       # Setup
-      {beginning_of_service_week, end_of_service_week} = service_range_later_this_week()
+      {beginning_of_service_week, end_of_service_week} = service_range_this_week()
 
       stub(Dotcom.Utils.DateTime.Mock, :now, fn ->
         beginning_of_service_week
       end)
 
       second_service_day = beginning_of_service_week |> beginning_of_next_service_day()
-      later_this_week = random_time_range_date_time({second_service_day, end_of_service_week})
+      this_week = random_time_range_date_time({second_service_day, end_of_service_week})
 
       # Exercise / Verify
-      assert service_range(later_this_week) == :later_this_week
+      assert service_range(this_week) == :this_week
     end
 
     test "returns :next_week for next week" do
@@ -192,17 +192,17 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
     end
   end
 
-  describe "service_later_this_week?/1" do
+  describe "service_this_week?/1" do
     test "returns true when the date_time is in this week's service" do
       # Setup
-      {_, end_of_current_service_week} = service_range_later_this_week()
+      {_, end_of_current_service_week} = service_range_this_week()
       beginning_of_next_service_day = beginning_of_next_service_day()
 
       service_range_date_time =
         random_time_range_date_time({end_of_current_service_week, beginning_of_next_service_day})
 
       # Exercise / Verify
-      assert service_later_this_week?(service_range_date_time)
+      assert service_this_week?(service_range_date_time)
     end
   end
 


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1209437138451263/f
https://app.asana.com/0/555089885850811/1209437138451264/f
https://app.asana.com/0/555089885850811/1209437138451268/f

I also fixed the date sorting and changed 'later this week' to 'this week'.

