### PR TITLE
fix: `SystemStatus` QA improvements 

### DIFF
--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -82,7 +82,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     <div class="pl-2 pr-sm">
       <.subway_route_pill route_ids={@route_ids} class="group-hover/row:ring-brand-primary-lightest" />
     </div>
-    <div class="flex items-center justify-between grow text-nowrap gap-sm py-3">
+    <div class="grow py-3">
       <.status_label status={@alert.effect} prefix={@time_range_str} />
     </div>
     """

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -37,13 +37,17 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
 
   defp status_icon(%{status: :normal} = assigns) do
     ~H"""
-    <div class="bg-green-line h-4 w-4 rounded-full"></div>
+    <div class="bg-green-line h-4 w-4 rounded-full shrink-0"></div>
     """
   end
 
   defp status_icon(assigns) do
     ~H"""
-    <.icon class="h-[1.125rem] w-[1.125rem]" type="icon-svg" name={status_icon_name(@status)} />
+    <.icon
+      class="h-[1.125rem] w-[1.125rem] shrink-0"
+      type="icon-svg"
+      name={status_icon_name(@status)}
+    />
     """
   end
 

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -22,10 +22,13 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
     ~H"""
     <span class={[status_classes(@status), "flex items-center gap-2"]}>
       <.status_icon status={@status} />
-      {@rendered_prefix} {description(@status, @plural)}
+      {@rendered_prefix} {expectation(@status, @prefix)} {description(@status, @plural)}
     </span>
     """
   end
+
+  defp expectation(:delay, prefix) when is_binary(prefix), do: "Expect"
+  defp expectation(_, _), do: nil
 
   defp description(status, true), do: description(status) |> Inflex.pluralize()
   defp description(status, false), do: description(status)

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -47,6 +47,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
       class="h-[1.125rem] w-[1.125rem] shrink-0"
       type="icon-svg"
       name={status_icon_name(@status)}
+      aria-hidden={true}
     />
     """
   end

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -50,7 +50,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
               prefix={row.status_entry.prefix}
               plural={row.status_entry.plural}
             />
-            <.icon name="chevron-right" class="h-3 w-2 fill-gray-lighter ml-3 mr-2" />
+            <.icon name="chevron-right" class="h-3 w-2 fill-gray-lighter ml-3 mr-2 shrink-0" />
           </div>
         </a>
       </.lined_list>

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -327,7 +327,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   defp future?(_), do: false
 
   defp prefix(%{time: :current}), do: "Now"
-  defp prefix(%{time: {:future, time}}), do: Util.kitchen_downcase_time(time)
+  defp prefix(%{time: {:future, time}}), do: Util.narrow_time(time)
 
   defp see_alerts_status(), do: %{status: :see_alerts, prefix: nil, plural: false}
 end

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -30,7 +30,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
           href={row.route_info.url}
           style={if(row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
           class={[
-            "flex gap-2",
+            "flex gap-2 items-center",
             "hover:bg-brand-primary-lightest cursor-pointer group/row",
             "text-black no-underline font-normal"
           ]}
@@ -42,7 +42,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             />
           </div>
           <div class={[
-            "flex items-center justify-between grow text-nowrap gap-sm",
+            "flex items-center justify-between grow gap-sm py-3",
             row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
           ]}>
             <.status_label

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -226,6 +226,36 @@ defmodule Util do
   end
 
   @doc """
+  A very concise representation of time, with period (AM/PM).
+
+  ## Examples
+      iex> Util.narrow_time(~T[08:30:00])
+      "8:30 AM"
+
+      iex> Util.narrow_time(~T[20:30:00])
+      "8:30 PM"
+
+      # Works for DateTime and NaiveDateTime inputs as well
+      iex> Util.narrow_time(~N[2018-01-17T20:30:00])
+      "8:30 PM"
+
+      # Hides minutes at top of the hour
+      iex> Util.narrow_time(~T[08:00:00])
+      "8 AM"
+
+      iex> Util.narrow_time(~T[00:00:00])
+      "12 AM"
+  """
+  @spec narrow_time(DateTime.t() | NaiveDateTime.t() | Time.t()) :: String.t()
+  def narrow_time(%{minute: 0} = time) do
+    Timex.format!(time, "{h12} {AM}")
+  end
+
+  def narrow_time(time) do
+    Timex.format!(time, "{h12}:{m} {AM}")
+  end
+
+  @doc """
   Converts an `{:error, _}` tuple to a default value.
 
   ## Examples


### PR DESCRIPTION
#### Summary of changes

In order:

<!-- Link to relevant Asana task; remove if not applicable -->
1. **Asana Ticket:** [[PW/SS] Fix text wrapping](https://app.asana.com/0/555089885850811/1209437138451266)
2. Hiding the status icon from screen readers, as the text alone is sufficient
3. _Part_ of [Tweaks to delay handling, homepage + /alerts/subway system status](https://app.asana.com/0/555089885850811/1209498039973244)
  - Add "Expect " to all future delays (`Expect Delay`)
  - For all future alerts, adjust time display:
    - Capitalize AM/PM 
    - Add space between time & AM/PM
    - Hide :00 if even hour
    - `8:00pm → 8 PM`

