### PR TITLE
feedback(Components.Alerts): remove icon, make image clickable

### DIFF
--- a/lib/dotcom_web/components/alerts.ex
+++ b/lib/dotcom_web/components/alerts.ex
@@ -25,24 +25,19 @@ defmodule DotcomWeb.Components.Alerts do
         end)
       )
       |> assign(:now, @date_time_module.now())
-      |> assign(:alert_icon_type, Alerts.Alert.icon(alert))
 
     ~H"""
     <div class={"p-md c-alert-item c-alert-item--#{@alert.priority}"}>
-      <div class="flex gap-sm">
-        <span :if={@alert_icon_type != :none} class="basis-[1.75rem]">
-          {AlertView.alert_icon(@alert_icon_type)}
-        </span>
-        <span>{AlertView.format_alert_description(@header)}</span>
-      </div>
+      {AlertView.format_alert_description(@header)}
       <%= if @description do %>
         <div class="mt-sm">
-          <img
-            :if={@alert.image}
-            class="w-full mb-4"
-            src={@alert.image}
-            alt={if @alert.image_alternative_text, do: @alert.image_alternative_text, else: ""}
-          />
+          <a :if={@alert.image} href={@alert.image} target="_blank">
+            <img
+              class="w-full mb-4"
+              src={@alert.image}
+              alt={if @alert.image_alternative_text, do: @alert.image_alternative_text, else: ""}
+            />
+          </a>
           {AlertView.format_alert_description(@description)}
           <%= if @url do %>
             <hr class="my-4 border-t-[1px] border-gray-lightest" />


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [[PW/SS] Alert details changes](https://app.asana.com/0/555089885850811/1209437138451267)

- Removes icon from inside alert details
- Makes image clickable to open in a new tab. 

I adjusted a Red Line shuttle alert with an image, so we can test this out on` /preview/subway-status` in the planned disruptions section at bottom.