### PR TITLE
hotfix(Alerts.Disruptions.Subway): process alerts with no end datetime

### DIFF
--- a/lib/dotcom/alerts/disruptions/subway.ex
+++ b/lib/dotcom/alerts/disruptions/subway.ex
@@ -5,7 +5,7 @@ defmodule Dotcom.Alerts.Disruptions.Subway do
 
   import Dotcom.Alerts, only: [service_impacting_alert?: 1]
   import Dotcom.Routes, only: [subway_route_ids: 0]
-  import Dotcom.Utils.ServiceDateTime, only: [all_service_ranges: 0, service_range: 1]
+  import Dotcom.Utils.ServiceDateTime, only: [service_range_range: 2]
 
   alias Alerts.Alert
   alias Dotcom.Utils
@@ -51,22 +51,11 @@ defmodule Dotcom.Alerts.Disruptions.Subway do
   defp group_alerts(alert, groups) do
     alert
     |> Map.get(:active_period)
-    |> Enum.flat_map(&service_range_range/1)
+    |> Enum.flat_map(fn {start, stop} -> service_range_range(start, stop) end)
     |> Enum.uniq()
     |> Enum.reduce(groups, fn service_range, groups ->
       Map.update(groups, service_range, [alert], &(&1 ++ [alert]))
     end)
-  end
-
-  # An active period can span many ranges from start to stop
-  # e.g. [:before_today, :today, :this_week]
-  defp service_range_range({start, stop}) do
-    start_index = Enum.find_index(all_service_ranges(), &(&1 == service_range(start)))
-    stop_index = Enum.find_index(all_service_ranges(), &(&1 == service_range(stop)))
-
-    all_service_ranges()
-    |> Enum.with_index(&if(&2 in start_index..stop_index, do: &1))
-    |> Enum.reject(&is_nil/1)
   end
 
   # Sorts alerts by the start time of the first active period.

--- a/lib/dotcom/utils/service_date_time.ex
+++ b/lib/dotcom/utils/service_date_time.ex
@@ -223,4 +223,20 @@ defmodule Dotcom.Utils.ServiceDateTime do
   def service_after_next_week?(date_time) do
     service_range_after_next_week() |> @date_time_module.in_range?(date_time)
   end
+
+  @doc """
+  Returns all service ranges between two datetimes, inclusive, supporting open ends.
+  """
+  @spec service_range_range(DateTime.t() | nil, DateTime.t() | nil) :: [named_service_range()]
+  def service_range_range(start, stop) do
+    start_index = if(start, do: service_range_index(start), else: 0)
+    stop_index = if(stop, do: service_range_index(stop), else: length(all_service_ranges()) - 1)
+
+    all_service_ranges()
+    |> Enum.with_index(&if(&2 in start_index..stop_index, do: &1))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp service_range_index(datetime),
+    do: Enum.find_index(all_service_ranges(), &(&1 == service_range(datetime)))
 end

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -73,8 +73,10 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
 
   # The heading for a disruption alert, including the route pill and status label (and active period).
   defp heading(assigns) do
-    {start, stop} = alert_date_time_range(assigns.alert)
-    time_range_str = "#{format_date(start)} - #{format_date(stop)}"
+    time_range_str =
+      assigns.alert
+      |> alert_date_time_range()
+      |> formatted_time_range()
 
     assigns = assign(assigns, time_range_str: time_range_str)
 
@@ -87,6 +89,11 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     </div>
     """
   end
+
+  defp formatted_time_range({nil, nil}), do: nil
+  defp formatted_time_range({nil, stop}), do: "Until #{format_date(stop)}"
+  defp formatted_time_range({start, nil}), do: "From #{format_date(start)}"
+  defp formatted_time_range({start, stop}), do: "#{format_date(start)} - #{format_date(stop)}"
 
   # Extracts the start and stop times from the active periods of an alert.
   # We do this by sorting the active periods by start time then taking the start of the first and the stop of the last.

--- a/test/dotcom/utils/service_date_time_test.exs
+++ b/test/dotcom/utils/service_date_time_test.exs
@@ -226,6 +226,38 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
     end
   end
 
+  describe "service_range_range/2" do
+    test "returns all service ranges between two datetimes" do
+      # Setup
+      today = service_range_day() |> random_time_range_date_time()
+      next_week = service_range_next_week() |> random_time_range_date_time()
+
+      # Exercise / Verify
+      assert service_range_range(today, next_week) == [:today, :this_week, :next_week]
+    end
+
+    test "handles open end" do
+      # Setup
+      this_week = service_range_this_week() |> random_time_range_date_time()
+
+      # Exercise / Verify
+      assert service_range_range(this_week, nil) == [:this_week, :next_week, :after_next_week]
+    end
+
+    test "handles open start" do
+      # Setup
+      next_week = service_range_next_week() |> random_time_range_date_time()
+
+      # Exercise / Verify
+      assert service_range_range(nil, next_week) == [
+               :before_today,
+               :today,
+               :this_week,
+               :next_week
+             ]
+    end
+  end
+
   # Do the two date_times share the same time information (to second granularity)?
   defp same_time?(date_time1, date_time2) do
     Map.take(date_time1, [:hour, :minute, :second]) ==

--- a/test/dotcom/utils/service_date_time_test.exs
+++ b/test/dotcom/utils/service_date_time_test.exs
@@ -236,7 +236,7 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
       assert service_range_range(today, next_week) == [:today, :this_week, :next_week]
     end
 
-    test "handles open end" do
+    test "returns all service ranges starting from a datetime" do
       # Setup
       this_week = service_range_this_week() |> random_time_range_date_time()
 
@@ -244,7 +244,7 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
       assert service_range_range(this_week, nil) == [:this_week, :next_week, :after_next_week]
     end
 
-    test "handles open start" do
+    test "returns all service ranges up to a datetime" do
       # Setup
       next_week = service_range_next_week() |> random_time_range_date_time()
 


### PR DESCRIPTION
I _think_ this is everything needed to handle alerts configured as "until further notice", but I didn't want to recreate that alert and break dev-green/blue while people were using it to review :)

- `service_range_range` has been updated to gracefully handle `nil`, and tests have been added for that
- More creative formatting has been added to handle active periods with missing start or stop times.