### PR TITLE
tests: Add tests validating homepage-subway-status collapsing behavior

### DIFF
--- a/lib/dotcom_web/components/route_symbols.ex
+++ b/lib/dotcom_web/components/route_symbols.ex
@@ -195,11 +195,13 @@ defmodule DotcomWeb.Components.RouteSymbols do
       assign(assigns, %{
         bg_color_class: "bg-#{String.downcase(route_id)}-line",
         route_abbreviation: String.at(route_id, 0) <> "L",
+        route_id: route_id,
         route_label: route_id <> " Line"
       })
 
     ~H"""
     <div
+      data-test={"route_pill:#{@route_id}"}
       aria-label={@route_label}
       class={[
         @bg_color_class,
@@ -247,11 +249,16 @@ defmodule DotcomWeb.Components.RouteSymbols do
         ~H"""
         <span class="flex items-center">
           <.subway_route_pill route_ids={@route_ids} class={"#{@class} -mr-1"} />
-          <.route_symbol
+          <span
             :for={route_id <- @branch_ids}
-            route={%Routes.Route{id: route_id}}
-            class={"#{@class} rounded-full ring-white ring-2 mr-0.5"}
-          />
+            data-test={"route_symbol:#{route_id}"}
+            class="flex items-center"
+          >
+            <.route_symbol
+              route={%Routes.Route{id: route_id}}
+              class={"#{@class} rounded-full ring-white ring-2 mr-0.5"}
+            />
+          </span>
         </span>
         """
       end

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -24,7 +24,9 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
     ~H"""
     <span class={[status_classes(@status), "flex items-center gap-2"]}>
       <.status_icon status={@status} />
-      {@rendered_prefix} {description(@status, @prefix, @plural)}
+      <span data-test="status_label_text">
+        {@rendered_prefix} {description(@status, @prefix, @plural)}
+      </span>
     </span>
     """
   end

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -34,7 +34,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             "hover:bg-brand-primary-lightest cursor-pointer group/row",
             "text-black no-underline font-normal"
           ]}
-          data-route-info={route_info_to_string(row.route_info)}
         >
           <div class={["pl-2 py-3", row.style.hide_route_pill && "opacity-0"]} data-route-pill>
             <.subway_route_pill
@@ -322,8 +321,4 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   defp prefix(%{time: {:future, time}}), do: Util.narrow_time(time)
 
   defp see_alerts_status(), do: %{status: :see_alerts, prefix: nil, plural: false}
-
-  defp route_info_to_string(route_info) do
-    [route_info.route_id | route_info.branch_ids] |> Enum.join("_")
-  end
 end

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -34,17 +34,21 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             "hover:bg-brand-primary-lightest cursor-pointer group/row",
             "text-black no-underline font-normal"
           ]}
+          data-route-info={route_info_to_string(row.route_info)}
         >
-          <div class="pl-2 py-3">
+          <div class={["pl-2 py-3", row.style.hide_route_pill && "opacity-0"]} data-route-pill>
             <.subway_route_pill
-              class={"group-hover/row:ring-brand-primary-lightest #{if(row.style.hide_route_pill, do: "opacity-0")}"}
+              class="group-hover/row:ring-brand-primary-lightest"
               route_ids={[row.route_info.route_id | row.route_info.branch_ids]}
             />
           </div>
-          <div class={[
-            "flex items-center justify-between grow gap-sm py-3",
-            row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
-          ]}>
+          <div
+            class={[
+              "flex items-center justify-between grow gap-sm py-3",
+              row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
+            ]}
+            data-status-label
+          >
             <.status_label
               status={row.status_entry.status}
               prefix={row.status_entry.prefix}
@@ -330,4 +334,8 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   defp prefix(%{time: {:future, time}}), do: Util.narrow_time(time)
 
   defp see_alerts_status(), do: %{status: :see_alerts, prefix: nil, plural: false}
+
+  defp route_info_to_string(route_info) do
+    [route_info.route_id | route_info.branch_ids] |> Enum.join("_")
+  end
 end

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -168,7 +168,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
         (branch_ids1 ++ branch_ids2)
         |> Enum.uniq()
         |> Enum.sort()
-        |> collapse_if_all_green_line()
       end
 
     combined_row =
@@ -197,14 +196,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
   defp collapse_rows([]) do
     []
-  end
-
-  defp collapse_if_all_green_line(branch_ids) do
-    if branch_ids == GreenLine.branch_ids() do
-      []
-    else
-      branch_ids
-    end
   end
 
   defp add_url(row) do

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -42,13 +42,10 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
               route_ids={[row.route_info.route_id | row.route_info.branch_ids]}
             />
           </div>
-          <div
-            class={[
-              "flex items-center justify-between grow gap-sm py-3",
-              row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
-            ]}
-            data-status-label
-          >
+          <div class={[
+            "flex items-center justify-between grow gap-sm py-3",
+            row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
+          ]}>
             <.status_label
               status={row.status_entry.status}
               prefix={row.status_entry.prefix}

--- a/test/dotcom_web/components/route_symbols_test.exs
+++ b/test/dotcom_web/components/route_symbols_test.exs
@@ -125,7 +125,8 @@ defmodule DotcomWeb.Components.RouteSymbolsTest do
         |> Floki.parse_fragment!()
         |> List.first()
 
-      assert [{"div", _, _}, {"svg", _, _}] = Floki.children(html, include_text: false)
+      assert [{"div", _, _}, {"span", _, [{"svg", _, _}]}] =
+               Floki.children(html, include_text: false)
     end
 
     test "Multiple branches render pill + multiple icons" do
@@ -139,7 +140,7 @@ defmodule DotcomWeb.Components.RouteSymbolsTest do
         |> List.first()
 
       assert [{"div", _, _} | icons] = Floki.children(html, include_text: false)
-      assert [{"svg", _, _} | _] = icons
+      assert [{"span", _, [{"svg", _, _}]} | _] = icons
       assert Enum.count(icons) == num_branches
     end
 

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -282,11 +282,8 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
 
   defp status_label_text_for_row(row) do
     row
-    |> Floki.find("[data-status-label]")
+    |> Floki.find("[data-test=\"status_label_text\"]")
     |> Floki.text()
-    |> String.trim()
-    |> String.split("\n")
-    |> List.last()
     |> String.trim()
   end
 end

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -71,7 +71,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
                [:visible, :invisible]
     end
 
-    test "collapses alerts for non-branched lines if there would otherwise be too many rows" do
+    test "collapses alerts for non-branched lines if there would otherwise be more than five rows" do
       # Setup
       [affected_line_1, affected_line_2] =
         Faker.Util.sample_uniq(2, fn -> Faker.Util.pick(@lines_without_branches) end)
@@ -115,7 +115,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
              ]
     end
 
-    test "collapses Green line alerts if there would otherwise be too many rows" do
+    test "collapses Green line alerts if there would otherwise be more than five rows" do
       # Setup
       affected_branches =
         Faker.Util.sample_uniq(2, fn -> Faker.Util.pick(GreenLine.branch_ids()) end)

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -168,27 +168,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
              |> for_route("Green_#{normal_branch_1}_#{normal_branch_2}")
              |> Enum.map(&status_label_text_for_row/1) == ["Normal Service"]
     end
-
-    test "collapses the Green line if the whole line is disrupted by different alerts" do
-      # Setup
-      alerts =
-        GreenLine.branch_ids()
-        |> Enum.map(fn branch_id ->
-          Factories.Alerts.Alert.build(:alert_for_route,
-            route_id: branch_id,
-            effect: Faker.Util.pick(service_impacting_effects())
-          )
-          |> Factories.Alerts.Alert.active_during(Timex.now())
-        end)
-
-      # Exercise
-      rows = status_rows_for_alerts(alerts)
-
-      # Verify
-      assert rows
-             |> for_route("Green")
-             |> Enum.map(&status_label_text_for_row/1) == ["See Alerts"]
-    end
   end
 
   describe "alerts_subway_status/1" do

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -27,10 +27,10 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
       rows = status_rows_for_alerts(alerts)
 
       # Verify
-      assert rows
-             |> Enum.each(fn row ->
-               assert status_label_text_for_row(row) == "Normal Service"
-             end)
+      rows
+      |> Enum.each(fn row ->
+        assert status_label_text_for_row(row) == "Normal Service"
+      end)
     end
 
     test "shows all of the route pills by default" do

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -58,7 +58,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
         effects
         |> Enum.map(
           &(Factories.Alerts.Alert.build(:alert_for_route, route_id: affected_line, effect: &1)
-            |> Factories.Alerts.Alert.active_during(Timex.now()))
+            |> Factories.Alerts.Alert.active_now())
         )
 
       # Exercise
@@ -89,7 +89,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
               route_id: affected_line_1,
               effect: &1
             )
-            |> Factories.Alerts.Alert.active_during(Timex.now()))
+            |> Factories.Alerts.Alert.active_now())
         )
 
       alerts_for_affected_line_2 =
@@ -99,7 +99,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
               route_id: affected_line_2,
               effect: &1
             )
-            |> Factories.Alerts.Alert.active_during(Timex.now()))
+            |> Factories.Alerts.Alert.active_now())
         )
 
       # Exercise
@@ -127,7 +127,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
             route_id: branch_id,
             effect: Faker.Util.pick(service_impacting_effects())
           )
-          |> Factories.Alerts.Alert.active_during(Timex.now())
+          |> Factories.Alerts.Alert.active_now()
         end)
 
       # Exercise
@@ -154,7 +154,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
             route_id: branch_id,
             effect: Faker.Util.pick(service_impacting_effects())
           )
-          |> Factories.Alerts.Alert.active_during(Timex.now())
+          |> Factories.Alerts.Alert.active_now()
         end)
 
       # Exercise

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -293,7 +293,4 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
     |> List.last()
     |> String.trim()
   end
-
-  # defp status_label_text_for_effect(:station_closure), do: "Station Closure"
-  # defp status_label_text_for_effect(effect), do: effect |> Atom.to_string() |> String.capitalize()
 end

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -136,9 +136,17 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
       # Verify
       [affected_branch_1, affected_branch_2] = affected_branches |> Enum.sort()
 
-      assert rows
-             |> for_route("Green_#{affected_branch_1}_#{affected_branch_2}")
-             |> Enum.map(&status_label_text_for_row/1) == ["See Alerts"]
+      [affected_row, _normal_row] =
+        rows
+        |> for_route("Green")
+
+      assert affected_row |> Floki.find("[data-test=\"route_symbol:#{affected_branch_1}\"]") !=
+               []
+
+      assert affected_row |> Floki.find("[data-test=\"route_symbol:#{affected_branch_2}\"]") !=
+               []
+
+      assert status_label_text_for_row(affected_row) == "See Alerts"
     end
 
     test "includes normal-status Green line row for non-affected Green line branches when rows are collapsed" do
@@ -164,9 +172,17 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
       [normal_branch_1, normal_branch_2] =
         GreenLine.branch_ids() -- affected_branches
 
-      assert rows
-             |> for_route("Green_#{normal_branch_1}_#{normal_branch_2}")
-             |> Enum.map(&status_label_text_for_row/1) == ["Normal Service"]
+      [_disrupted_row, normal_row] =
+        rows
+        |> for_route("Green")
+
+      assert normal_row |> Floki.find("[data-test=\"route_symbol:#{normal_branch_1}\"]") !=
+               []
+
+      assert normal_row |> Floki.find("[data-test=\"route_symbol:#{normal_branch_2}\"]") !=
+               []
+
+      assert status_label_text_for_row(normal_row) == "Normal Service"
     end
   end
 
@@ -262,7 +278,10 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
   end
 
   defp for_route(rows, route_id) do
-    rows |> Floki.find("[data-route-info=#{route_id}]")
+    rows
+    |> Enum.filter(fn row ->
+      row |> Floki.find("[data-test=\"route_pill:#{route_id}\"]") != []
+    end)
   end
 
   defp route_pill_visibility_for_row(row) do

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -257,11 +257,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
   end
 
   defp status_rows_for_alerts(alerts) do
-    subway_status =
-      alerts
-      |> Dotcom.SystemStatus.Subway.subway_status(Timex.now())
-
-    render_component(&homepage_subway_status/1, %{subway_status: subway_status})
+    render_component(&homepage_subway_status/1, %{subway_status: alerts |> subway_status()})
     |> Floki.find("a")
   end
 

--- a/test/support/factories/alerts/alert.ex
+++ b/test/support/factories/alerts/alert.ex
@@ -61,6 +61,10 @@ defmodule Test.Support.Factories.Alerts.Alert do
     %{alert | active_period: [{time_before(time), time_after(time)}]}
   end
 
+  def active_now(alert) do
+    alert |> active_during(Dotcom.Utils.DateTime.now())
+  end
+
   def active_starting_at(alert, start_time) do
     %{alert | active_period: [{start_time, time_after(start_time)}]}
   end


### PR DESCRIPTION
[This PR](https://github.com/mbta/dotcom/pull/2385) was introduced without tests for the homepage component, but upon further reflection, there's enough non-trivial stuff going on in there, that it does deserve some tests.

I'm doing this for two reasons:
- It's better to have this test coverage late than never
- There are tickets that I'm about to work on that affect how to collapse [Mattapan trolley status](https://app.asana.com/0/555089885850811/1209412979464965) and [green line status](https://app.asana.com/0/555089885850811/1209412979464963), which I think will involve substantially changing the collapsing logic, so I want to reduce the risk of introducing a regression.

---

No ticket.

---

Follow-up to:
- https://github.com/mbta/dotcom/pull/2385

Blocking:
- https://github.com/mbta/dotcom/pull/2415
