### PR TITLE
fix(DotcomWeb.PredictionsChannel): let skipped/cancelled with no departure times through

### DIFF
--- a/lib/dotcom_web/channels/predictions_channel.ex
+++ b/lib/dotcom_web/channels/predictions_channel.ex
@@ -72,12 +72,9 @@ defmodule DotcomWeb.PredictionsChannel do
   end
 
   # For predictions which have a departure time, filter out ones that are past
-  defp departure_exists_in_past?(prediction) do
-    if prediction.departure_time do
-      Timex.before?(prediction.departure_time, now())
-    else
-      # it doesn't exist
-      false
-    end
+  defp departure_exists_in_past?(%{departure_time: nil}), do: false
+
+  defp departure_exists_in_past?(%{departure_time: departure_time}) do
+    Timex.before?(departure_time, now())
   end
 end

--- a/lib/dotcom_web/channels/predictions_channel.ex
+++ b/lib/dotcom_web/channels/predictions_channel.ex
@@ -7,6 +7,8 @@ defmodule DotcomWeb.PredictionsChannel do
 
   require Routes.Route
 
+  import Dotcom.Utils.DateTime, only: [now: 0]
+
   alias Routes.Route
   alias Phoenix.{Channel, Socket}
   alias Predictions.Prediction
@@ -46,24 +48,36 @@ defmodule DotcomWeb.PredictionsChannel do
     predictions
     |> Enum.reject(fn prediction ->
       no_trip?(prediction) ||
-        no_departure_time?(prediction) ||
-        skipped_or_cancelled?(prediction)
+        missing_departure_time?(prediction) ||
+        skipped_or_cancelled_subway?(prediction) ||
+        departure_exists_in_past?(prediction)
     end)
-    |> Enum.filter(&in_future_seconds?/1)
   end
 
   defp no_trip?(prediction), do: is_nil(prediction.trip)
 
-  # Used to filter out predictions that have no departure time.
-  # This is common when shuttles are being used at non-terminal stops and at terminal stops.
-  defp no_departure_time?(prediction), do: is_nil(prediction.departure_time)
+  # Used to filter out predictions that have no departure time. This is common
+  # when shuttles are being used at non-terminal stops and at terminal stops.
+  # However, cancelled/skipped predictions are expected to have nil
+  # departure_times, so don't flag those.
+  defp missing_departure_time?(prediction) do
+    is_nil(prediction.departure_time) and
+      prediction.schedule_relationship not in [:cancelled, :skipped]
+  end
 
-  defp skipped_or_cancelled?(prediction) do
+  # Filter out all cancelled/skipped predictions if it's for subway
+  defp skipped_or_cancelled_subway?(prediction) do
     Route.subway?(prediction.route.type, prediction.route.id) &&
       prediction.schedule_relationship in [:cancelled, :skipped]
   end
 
-  defp in_future_seconds?(prediction) do
-    Timex.compare(prediction.departure_time, Util.now(), :seconds) >= 0
+  # For predictions which have a departure time, filter out ones that are past
+  defp departure_exists_in_past?(prediction) do
+    if prediction.departure_time do
+      Timex.before?(prediction.departure_time, now())
+    else
+      # it doesn't exist
+      false
+    end
   end
 end

--- a/test/dotcom_web/channels/predictions_channel_test.exs
+++ b/test/dotcom_web/channels/predictions_channel_test.exs
@@ -1,8 +1,8 @@
 defmodule DotcomWeb.PredictionsChannelTest do
   use DotcomWeb.ChannelCase, async: false
 
-  import Mox
   import Dotcom.Utils.DateTime, only: [now: 0]
+  import Mox
 
   alias DotcomWeb.{PredictionsChannel, UserSocket}
   alias Test.Support.Factories
@@ -114,12 +114,11 @@ defmodule DotcomWeb.PredictionsChannelTest do
 
     test "filters out past predictions", context do
       # Setup
-      now = now() |> DateTime.shift(second: 1)
-      past = DateTime.shift(now, second: -15)
-      future = DateTime.shift(now, second: 15)
+      past = DateTime.shift(now(), second: -1)
+      future = DateTime.shift(now(), second: 1)
 
       predictions =
-        [past, now, future]
+        [past, future]
         |> Enum.map(
           &Factories.Predictions.Prediction.build(:canonical_prediction, %{departure_time: &1})
         )

--- a/test/dotcom_web/channels/predictions_channel_test.exs
+++ b/test/dotcom_web/channels/predictions_channel_test.exs
@@ -5,7 +5,7 @@ defmodule DotcomWeb.PredictionsChannelTest do
   import Mox
 
   alias DotcomWeb.{PredictionsChannel, UserSocket}
-  alias Test.Support.Factories
+  alias Test.Support.Factories.{Predictions.Prediction, Routes.Route, Schedules.Trip}
 
   @predictions_pub_sub Application.compile_env!(:dotcom, :predictions_pub_sub)
 
@@ -31,7 +31,7 @@ defmodule DotcomWeb.PredictionsChannelTest do
   describe "join/3" do
     test "filters skipped or cancelled predictions", context do
       # Setup
-      canonical_prediction = Factories.Predictions.Prediction.build(:canonical_prediction)
+      canonical_prediction = Prediction.build(:canonical_prediction)
 
       filtered_prediction =
         canonical_prediction
@@ -51,7 +51,7 @@ defmodule DotcomWeb.PredictionsChannelTest do
 
     test "filters predictions with no departure time", context do
       # Setup
-      canonical_prediction = Factories.Predictions.Prediction.build(:canonical_prediction)
+      canonical_prediction = Prediction.build(:canonical_prediction)
 
       filtered_prediction =
         canonical_prediction
@@ -71,14 +71,14 @@ defmodule DotcomWeb.PredictionsChannelTest do
 
     test "doesn't filter skipped or cancelled non-subway predictions", context do
       # Setup
-      canonical_prediction = Factories.Predictions.Prediction.build(:canonical_prediction)
+      canonical_prediction = Prediction.build(:canonical_prediction)
 
       not_filtered_cancelled_prediction =
-        Factories.Predictions.Prediction.build(:prediction,
+        Prediction.build(:prediction,
           departure_time: nil,
-          route: Factories.Routes.Route.build(:route, type: 3),
+          route: Route.build(:route, type: 3),
           schedule_relationship: :cancelled,
-          trip: Factories.Schedules.Trip.build(:trip)
+          trip: Trip.build(:trip)
         )
 
       expect(@predictions_pub_sub, :subscribe, fn _ ->
@@ -97,7 +97,7 @@ defmodule DotcomWeb.PredictionsChannelTest do
   describe "handle_info/2" do
     test "pushes predictions to the channel", context do
       # Setup
-      predictions = Factories.Predictions.Prediction.build_list(3, :canonical_prediction)
+      predictions = Prediction.build_list(3, :canonical_prediction)
 
       expect(@predictions_pub_sub, :subscribe, fn _ ->
         predictions
@@ -119,9 +119,7 @@ defmodule DotcomWeb.PredictionsChannelTest do
 
       predictions =
         [past, future]
-        |> Enum.map(
-          &Factories.Predictions.Prediction.build(:canonical_prediction, %{departure_time: &1})
-        )
+        |> Enum.map(&Prediction.build(:canonical_prediction, %{departure_time: &1}))
 
       expect(@predictions_pub_sub, :subscribe, fn _ ->
         predictions
@@ -142,7 +140,7 @@ defmodule DotcomWeb.PredictionsChannelTest do
   describe "terminate/2" do
     test "casts a closed channel message", context do
       # Setup
-      predictions = Factories.Predictions.Prediction.build_list(3, :canonical_prediction)
+      predictions = Prediction.build_list(3, :canonical_prediction)
 
       expect(@predictions_pub_sub, :subscribe, fn _ ->
         predictions

--- a/test/dotcom_web/controllers/alert_controller_test.exs
+++ b/test/dotcom_web/controllers/alert_controller_test.exs
@@ -7,7 +7,6 @@ defmodule DotcomWeb.AlertControllerTest do
   import DotcomWeb.AlertController, only: [excluding_banner: 2, group_access_alerts: 1]
   import Mox
   import Phoenix.LiveViewTest
-  import Test.Support.Factories.Routes.Route
 
   alias Alerts.Alert
   alias Dotcom.Utils


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Stop Pages don't display cancelled trips with strikethrough](https://app.asana.com/0/555089885850811/1207956121805040)

...it turns out that skipped/cancelled predictions without departure times (e.g. probably all of them) were never making it to the stops page in the first place (on account of we were rejecting every prediction having `nil` departure_time). This PR should fix that. 

And this should be enough to resolve the cited issue, as everything's in place in the frontend to give skipped/cancelled trips the strikethrough treatment they deserve.

