### PR TITLE
fix: Horizontal scroll on mobile

### DIFF
--- a/lib/dotcom_web/templates/layout/_footer.html.eex
+++ b/lib/dotcom_web/templates/layout/_footer.html.eex
@@ -70,7 +70,7 @@
             </div>
           </div>
           <p class="m-footer__copyright">&copy; Massachusetts Bay Transportation Authority, all rights reserved.</p>
-          <div class="container m-footer__policy-links u-mt-16">
+          <div class="m-footer__policy-links u-mt-16">
             <%= link "Privacy Policy", to: "/policies/privacy-policy", class: "u-me-16" %>
             <%= link "Terms of Use", to: "/policies/terms-use" %>
           </div>


### PR DESCRIPTION
This fixes that bug where you can scroll a bit to the right on mobile and see this useless 16px white stripe.

<img width="384" alt="Screenshot 2025-03-03 at 8 53 35 AM" src="https://github.com/user-attachments/assets/7b2ab70d-e255-4d70-9bcc-a92b61928c5c" />

---

When we started importing the base Tailwind CSS in [this PR](https://github.com/mbta/dotcom/pull/2173), that changed the behavior of the `container` CSS class to include `width: 100%` (based on [how Tailwind defines that class](https://v3.tailwindcss.com/docs/container)). That meant that anything with a `container` class _and_ a class that had a left margin was pushed to the side, rather than shrunk. You can see that pretty clearly on desktop:

<img width="932" alt="Screenshot 2025-03-02 at 4 52 44 AM" src="https://github.com/user-attachments/assets/7f62d609-8ce4-460f-a6e8-038fcfa73bae" />

(Although it has no visible effect when you don't put red outlines around everything... `* { outline: 1px red solid; }` is pretty cool, although I would not recommend doing it in production!)

On mobile, it does have a visible effect. The `Privacy Policy` / `Terms of Use` section on the footer is kept at full width, but pushed to the right by 16px, thus forcing the page to be scrollable to the right by 16px.

Removing the `container` class from the `Privacy Policy` / `Terms of Use` section fixes that by removing `width: 100%`, and I wasn't able to see any other adverse effects (the only other effects that I saw were that the section is more closely aligned with the other sections, and the margin below it is a decent bit smaller, both of which seem like good changes.)

Before on the left, After on the right:
<img width="1397" alt="Screenshot 2025-03-03 at 9 18 54 AM" src="https://github.com/user-attachments/assets/470ea14e-41e5-4611-b46c-922b59dd441d" />


---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Horizontal scrolling on mobile devices](https://app.asana.com/0/385363666817452/1209437647061065)