### PR TITLE
fix: Handle single day diversions in Planned Work

### DIFF
--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -82,8 +82,8 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
   defp heading(assigns) do
     time_range_str =
       assigns.alert
-      |> alert_date_time_range()
-      |> formatted_time_range()
+      |> alert_date_range()
+      |> formatted_date_range()
 
     assigns = assign(assigns, time_range_str: time_range_str)
 
@@ -97,14 +97,14 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     """
   end
 
-  defp formatted_time_range({nil, nil}), do: nil
-  defp formatted_time_range({nil, stop}), do: "Until #{format_date(stop)}"
-  defp formatted_time_range({start, nil}), do: "#{format_date(start)} until further notice"
-  defp formatted_time_range({start, stop}), do: "#{format_date(start)} – #{format_date(stop)}"
+  defp formatted_date_range({nil, nil}), do: nil
+  defp formatted_date_range({nil, stop}), do: "Until #{format_date(stop)}"
+  defp formatted_date_range({start, nil}), do: "#{format_date(start)} until further notice"
+  defp formatted_date_range({start, stop}), do: "#{format_date(start)} – #{format_date(stop)}"
 
   # Extracts the start and stop times from the active periods of an alert.
   # We do this by sorting the active periods by start time then taking the start of the first and the stop of the last.
-  defp alert_date_time_range(%Alert{active_period: active_period}) do
+  defp alert_date_range(%Alert{active_period: active_period}) do
     sorted_active_periods =
       Enum.sort_by(
         active_period,
@@ -115,8 +115,11 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     {start, _} = List.first(sorted_active_periods)
     {_, stop} = List.last(sorted_active_periods)
 
-    {start, stop}
+    {service_date_for_display(start), service_date_for_display(stop)}
   end
+
+  defp service_date_for_display(nil), do: nil
+  defp service_date_for_display(datetime), do: service_date(datetime)
 
   # Extracts the route ids of lines and branches from the alert.
   defp alert_route_ids(%Alert{informed_entity: %{entities: entities}}) do
@@ -128,15 +131,13 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
   # Formats the date for display in the heading.
   # If the service date is on or before today, we display "Today".
   # Otherwise, we display the date like "Mon Jan 1".
-  defp format_date(datetime) do
-    service_date_datetime = service_date(datetime)
+  defp format_date(service_date_datetime) do
     service_date_today = @date_time_module.now() |> service_date()
 
-    if Timex.equal?(service_date_datetime, service_date_today) ||
-         Timex.before?(service_date_datetime, service_date_today) do
-      "Today"
-    else
+    if Timex.after?(service_date_datetime, service_date_today) do
       service_date_datetime |> Timex.format!("%a, %b %-d", :strftime)
+    else
+      "Today"
     end
   end
 end

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -100,6 +100,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
   defp formatted_date_range({nil, nil}), do: nil
   defp formatted_date_range({nil, stop}), do: "Until #{format_date(stop)}"
   defp formatted_date_range({start, nil}), do: "#{format_date(start)} until further notice"
+  defp formatted_date_range({start, stop}) when start == stop, do: "#{format_date(start)}"
   defp formatted_date_range({start, stop}), do: "#{format_date(start)} – #{format_date(stop)}"
 
   # Extracts the start and stop times from the active periods of an alert.

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -24,7 +24,9 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
     ~H"""
     <span class={[status_classes(@status), "flex items-center gap-2"]}>
       <.status_icon status={@status} />
-      {@rendered_prefix} {description(@status, @prefix, @plural)}
+      <span data-test="status-label-text">
+        {@rendered_prefix} {description(@status, @prefix, @plural)}
+      </span>
     </span>
     """
   end

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -24,7 +24,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
     ~H"""
     <span class={[status_classes(@status), "flex items-center gap-2"]}>
       <.status_icon status={@status} />
-      <span data-test="status-label-text">
+      <span data-test="status_label_text">
         {@rendered_prefix} {description(@status, @prefix, @plural)}
       </span>
     </span>

--- a/test/dotcom_web/components/planned_disruptions_test.exs
+++ b/test/dotcom_web/components/planned_disruptions_test.exs
@@ -47,6 +47,36 @@ defmodule DotcomWeb.Components.PlannedDisruptionsTest do
                "#{formatted_date_time(start_time)} – #{formatted_date_time(end_time)}"
     end
 
+    test "doesn't render as a range if the alert is on a single day" do
+      {beginning_of_week, _end_of_week} = ServiceDateTime.service_range_next_week()
+
+      start_time =
+        random_time_range_date_time(
+          {beginning_of_week, beginning_of_week |> DateTime.shift(month: 1)}
+        )
+
+      end_time =
+        random_time_range_date_time(
+          {start_time, start_time |> ServiceDateTime.end_of_service_day()}
+        )
+
+      alerts = [
+        Factories.Alerts.Alert.build(:alert, active_period: [{start_time, end_time}])
+      ]
+
+      html =
+        render_component(&disruptions/1, %{
+          disruptions: %{
+            next_week: alerts
+          }
+        })
+
+      formatted_date = date_from_status_label(html)
+
+      assert formatted_date ==
+               "#{formatted_date_time(start_time)}"
+    end
+
     test "renders a start time of today as 'Today'" do
       start_time = Dotcom.Utils.DateTime.now()
 

--- a/test/dotcom_web/components/planned_disruptions_test.exs
+++ b/test/dotcom_web/components/planned_disruptions_test.exs
@@ -185,7 +185,7 @@ defmodule DotcomWeb.Components.PlannedDisruptionsTest do
   defp date_from_status_label(html) do
     [formatted_date | _] =
       html
-      |> Floki.find("[data-test=\"status-label-text\"]")
+      |> Floki.find("[data-test=\"status_label_text\"]")
       |> Floki.text()
       |> String.trim()
       |> String.split(":")

--- a/test/dotcom_web/components/planned_disruptions_test.exs
+++ b/test/dotcom_web/components/planned_disruptions_test.exs
@@ -1,0 +1,169 @@
+defmodule DotcomWeb.Components.PlannedDisruptionsTest do
+  use ExUnit.Case
+
+  import DotcomWeb.Components.PlannedDisruptions, only: [disruptions: 1]
+  import Mox
+  import Phoenix.LiveViewTest
+  import Test.Support.Generators.DateTime, only: [random_time_range_date_time: 1]
+
+  alias Dotcom.Utils.ServiceDateTime
+  alias Test.Support.Factories
+
+  setup :verify_on_exit!
+
+  setup do
+    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+    :ok
+  end
+
+  describe "disruptions/1" do
+    test "formats the start and end dates as dates separated with an endash" do
+      {beginning_of_week, _end_of_week} = ServiceDateTime.service_range_next_week()
+
+      start_time =
+        random_time_range_date_time(
+          {beginning_of_week, beginning_of_week |> DateTime.shift(month: 1)}
+        )
+
+      end_time =
+        random_time_range_date_time(
+          {start_time |> DateTime.shift(day: 2), start_time |> DateTime.shift(month: 1)}
+        )
+
+      alerts = [
+        Factories.Alerts.Alert.build(:alert, active_period: [{start_time, end_time}])
+      ]
+
+      html =
+        render_component(&disruptions/1, %{
+          disruptions: %{
+            next_week: alerts
+          }
+        })
+
+      formatted_date = date_from_status_label(html)
+
+      assert formatted_date ==
+               "#{formatted_date_time(start_time)} – #{formatted_date_time(end_time)}"
+    end
+
+    test "renders a start time of today as 'Today'" do
+      start_time = Dotcom.Utils.DateTime.now()
+
+      end_time =
+        random_time_range_date_time(
+          {start_time |> DateTime.shift(day: 2), start_time |> DateTime.shift(month: 1)}
+        )
+
+      alerts = [
+        Factories.Alerts.Alert.build(:alert, active_period: [{start_time, end_time}])
+      ]
+
+      html =
+        render_component(&disruptions/1, %{
+          disruptions: %{
+            next_week: alerts
+          }
+        })
+
+      formatted_date = date_from_status_label(html)
+
+      assert formatted_date ==
+               "Today – #{formatted_date_time(end_time)}"
+    end
+
+    test "renders a start time before today as 'Today'" do
+      start_time = Faker.DateTime.backward(10)
+
+      end_time =
+        random_time_range_date_time(
+          {Dotcom.Utils.DateTime.now() |> DateTime.shift(day: 2),
+           start_time |> DateTime.shift(month: 1)}
+        )
+
+      alerts = [
+        Factories.Alerts.Alert.build(:alert, active_period: [{start_time, end_time}])
+      ]
+
+      html =
+        render_component(&disruptions/1, %{
+          disruptions: %{
+            next_week: alerts
+          }
+        })
+
+      formatted_date = date_from_status_label(html)
+
+      assert formatted_date ==
+               "Today – #{formatted_date_time(end_time)}"
+    end
+
+    test "renders a nil start time as 'Until'" do
+      start_time = nil
+
+      end_time =
+        random_time_range_date_time(
+          {Dotcom.Utils.DateTime.now() |> DateTime.shift(day: 2),
+           Dotcom.Utils.DateTime.now() |> DateTime.shift(month: 1)}
+        )
+
+      alerts = [
+        Factories.Alerts.Alert.build(:alert, active_period: [{start_time, end_time}])
+      ]
+
+      html =
+        render_component(&disruptions/1, %{
+          disruptions: %{
+            next_week: alerts
+          }
+        })
+
+      formatted_date = date_from_status_label(html)
+
+      assert formatted_date ==
+               "Until #{formatted_date_time(end_time)}"
+    end
+
+    test "renders a nil end time as 'until further notice'" do
+      {beginning_of_week, _end_of_week} = ServiceDateTime.service_range_next_week()
+
+      start_time =
+        random_time_range_date_time(
+          {beginning_of_week, beginning_of_week |> DateTime.shift(month: 1)}
+        )
+
+      end_time = nil
+
+      alerts = [
+        Factories.Alerts.Alert.build(:alert, active_period: [{start_time, end_time}])
+      ]
+
+      html =
+        render_component(&disruptions/1, %{
+          disruptions: %{
+            next_week: alerts
+          }
+        })
+
+      formatted_date = date_from_status_label(html)
+
+      assert formatted_date ==
+               "#{formatted_date_time(start_time)} until further notice"
+    end
+  end
+
+  defp date_from_status_label(html) do
+    [formatted_date | _] =
+      html
+      |> Floki.find("[data-test=\"status-label-text\"]")
+      |> Floki.text()
+      |> String.trim()
+      |> String.split(":")
+
+    formatted_date
+  end
+
+  defp formatted_date_time(datetime) do
+    datetime |> ServiceDateTime.service_date() |> Timex.format!("%a, %b %-d", :strftime)
+  end
+end


### PR DESCRIPTION
#### Before

<img width="467" alt="Screenshot 2025-03-04 at 1 39 11 PM" src="https://github.com/user-attachments/assets/a084f756-be56-46c7-95ac-816f55cf0205" />

#### After

<img width="408" alt="Screenshot 2025-03-04 at 1 38 12 PM" src="https://github.com/user-attachments/assets/2b3d0be0-49fa-4777-b66d-963c809b4fb6" />

#### Summary of changes

Three main changes, grouped by commit:
1. Add tests for planned disruptions
2. Refactor so that the planned disruptions component passes around alert `Date`'s rather than alert `DateTime`'s
3. Fix the bug (in a way that's a lot easier given 2 ☝️ than it would have been without, hence the refactor)

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Handle single day diversions in Planned Work](https://app.asana.com/0/555089885850811/1209557314856998)

