### PR TITLE
hotfix(departureInfo): handle missing departure time

### DIFF
--- a/assets/ts/helpers/__tests__/departureInfoTest.tsx
+++ b/assets/ts/helpers/__tests__/departureInfoTest.tsx
@@ -1,19 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { add } from "date-fns";
+import React from "react";
+import { DepartureInfo } from "../../models/departureInfo";
 import { PredictionWithTimestamp } from "../../models/predictions";
 import { ScheduleWithTimestamp } from "../../models/schedules";
+import { baseRoute, customStop } from "../../stop/__tests__/helpers";
 import {
   COMMUTER_RAIL,
   SUBWAY,
+  departureInfoToTime,
   departuresListFromInfos,
   isAtDestination,
   mergeIntoDepartureInfo
 } from "../departureInfo";
-import { baseRoute, customStop } from "../../stop/__tests__/helpers";
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import { DepartureInfo } from "../../models/departureInfo";
-import { add } from "date-fns";
 
 describe("departureInfo", () => {
+  describe("departureInfoToTime", () => {
+    const predictionTime = new Date("2022-04-27T11:15:00-04:00");
+    const scheduleTime = new Date("2025-04-27T11:15:00-04:00");
+    const departureInfo = {
+      prediction: { time: predictionTime } as PredictionWithTimestamp,
+      schedule: { time: scheduleTime } as ScheduleWithTimestamp
+    } as DepartureInfo;
+    test("should prefer prediction time", () => {
+      const time = departureInfoToTime(departureInfo);
+      expect(time).toEqual(predictionTime);
+    });
+    test("should use schedule time otherwise", () => {
+      const time = departureInfoToTime({
+        ...departureInfo,
+        prediction: undefined
+      });
+      expect(time).toEqual(scheduleTime);
+    });
+    test("should return undefined if neither exist", () => {
+      const time = departureInfoToTime({
+        ...departureInfo,
+        prediction: undefined,
+        schedule: undefined
+      });
+      expect(time).toEqual(undefined);
+    });
+  });
+
   describe("mergeIntoDepartureInfo", () => {
     it("should match schedules and predictions", () => {
       const schedules = [

--- a/assets/ts/helpers/departureInfo.tsx
+++ b/assets/ts/helpers/departureInfo.tsx
@@ -43,11 +43,10 @@ const toRouteMode = (
   return FERRY;
 };
 
-const departureInfoToTime = (departureInfo: DepartureInfo): Date => {
-  // If there isn't a prediction there should be a schedule
-  return departureInfo.prediction && departureInfo.prediction.time
-    ? departureInfo.prediction.time
-    : departureInfo.schedule!.time;
+const departureInfoToTime = (
+  departureInfo: DepartureInfo
+): Date | undefined => {
+  return departureInfo.prediction?.time || departureInfo.schedule?.time;
 };
 
 const getNextUnCancelledDeparture = (

--- a/assets/ts/stop/__tests__/DepartureCardTest.tsx
+++ b/assets/ts/stop/__tests__/DepartureCardTest.tsx
@@ -61,7 +61,7 @@ const schedule = {
   "last_stop?": true,
   stop_sequence: 1,
   stop_headsign: "Foo",
-  pickup_type: 1,
+  pickup_type: 1
 } as ScheduleWithTimestamp;
 
 const departure = {

--- a/assets/ts/stop/components/DisplayTime.tsx
+++ b/assets/ts/stop/components/DisplayTime.tsx
@@ -67,6 +67,8 @@ const DisplayTime = ({
   } = departure;
   const isDelayedAndDisplayed = isDelayed && routeMode !== "subway";
   const time = departureInfoToTime(departure);
+  if (!time) return null;
+
   const track = prediction?.track;
   const trackName = isCR && !!track && `Track ${track}`;
   const tomorrow = !isSameDayInBoston(targetDate, time);


### PR DESCRIPTION
#2406 makes it possible to have departures (prediction+schedule pairs) which have _no_ valid time associated with them. This was handled in most places, except this place. This PR handles that.