### PR TITLE
hotfix(TimetableController): handle no route patterns

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -264,7 +264,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
       |> with_prioritized_pattern()
       |> Enum.map(&@stops_repo.by_trip(&1.representative_trip_id))
       |> handle_ferry_stops(conn.assigns.route.id, inbound?)
-      |> Enum.reduce(&merge_stop_lists(&1, &2, inbound?))
+      |> Enum.reduce([], &merge_stop_lists(&1, &2, inbound?))
       |> remove_unused_stops(schedules)
       |> add_new_stops(schedules, inbound?)
 

--- a/test/dotcom_web/controllers/schedule/timetable_controller_test.exs
+++ b/test/dotcom_web/controllers/schedule/timetable_controller_test.exs
@@ -214,6 +214,14 @@ defmodule DotcomWeb.ScheduleController.TimetableControllerTest do
 
       assert ["1", "2", "3", "4", ^special_stop_id, "5", "6"] = Enum.map(trip_stops, & &1.id)
     end
+
+    test "doesn't crash when missing canonical route patterns", %{conn: conn} do
+      expect(RoutePatterns.Repo.Mock, :by_route_id, fn _, _ ->
+        []
+      end)
+
+      assert build_timetable(conn, @schedules)
+    end
   end
 
   describe "trip_messages/2" do


### PR DESCRIPTION
The timetable logic assumes canonical route patterns exist for every route. When that doesn't happen to be the case, we should gracefully handle that. This PR stops `Enum.EmptyError` from ruining everything, by setting an initial accumulator for `Enum.reduce/3`! 

The test is a little silly at this point but it did help me clearly see the fail vs success state!