### PR TITLE
fix: Avoid collapsing green line and Mattapan line rows unless needed

### DIFF
--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -170,8 +170,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
        when route_id1 == route_id2 and branch_ids1 == branch_ids2,
        do: true
 
-  defp combine_rows?(:identical_route_info, _row1, _row2), do: false
-
   defp combine_rows?(
          :disrupted_green_line,
          %{route_info: %{route_id: "Green"}},
@@ -186,8 +184,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
        ),
        do: true
 
-  defp combine_rows?(:disrupted_green_line, _row1, _row2), do: false
-
   defp combine_rows?(
          :all_green_line,
          %{route_info: %{route_id: "Green"}},
@@ -195,7 +191,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
        ),
        do: true
 
-  defp combine_rows?(:all_green_line, _row1, _row2), do: false
+  defp combine_rows?(_criterion, _row1, _row2), do: false
 
   defp combine_rows(
          %{route_info: %{branch_ids: branch_ids1}} = row1,

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -143,24 +143,24 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
   defp maybe_collapse_rows(rows) do
     rows
-    |> if_too_large(&collapse_rows(&1, :identical_route_info))
-    |> if_too_large(&collapse_rows(&1, :disrupted_green_line))
-    |> if_too_large(&collapse_rows(&1, :all_green_line))
+    |> if_too_large(&collapse_rows(:identical_route_info, &1))
+    |> if_too_large(&collapse_rows(:disrupted_green_line, &1))
+    |> if_too_large(&collapse_rows(:all_green_line, &1))
   end
 
   defp if_too_large(rows, collapse_fun) when length(rows) > @max_rows, do: collapse_fun.(rows)
   defp if_too_large(rows, _collapse_fun), do: rows
 
-  defp collapse_rows([row1, row2 | rest_of_rows], combine_criterion)
+  defp collapse_rows(combine_criterion, [row1, row2 | rest_of_rows])
        when is_atom(combine_criterion) do
     if combine_rows?(combine_criterion, row1, row2) do
-      collapse_rows([combine_rows(row1, row2) | rest_of_rows], combine_criterion)
+      collapse_rows(combine_criterion, [combine_rows(row1, row2) | rest_of_rows])
     else
-      [row1 | collapse_rows([row2 | rest_of_rows], combine_criterion)]
+      [row1 | collapse_rows(combine_criterion, [row2 | rest_of_rows])]
     end
   end
 
-  defp collapse_rows(rows, _combine_fun), do: rows
+  defp collapse_rows(_combine_fun, rows), do: rows
 
   defp combine_rows?(
          :identical_route_info,

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -160,7 +160,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
     end
   end
 
-  defp collapse_rows(_combine_fun, rows), do: rows
+  defp collapse_rows(_combine_criterion, rows), do: rows
 
   defp combine_rows?(
          :identical_route_info,

--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -398,6 +398,38 @@ defmodule DotcomWeb.Live.SystemStatus do
               ])
           }
         ]
+      },
+      %{
+        alerts: [
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :shuttle,
+            header:
+              "Mattapan trolleys are replaced with shuttles because the trolleys themselves wanted to explore the rest of the system",
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Mattapan"}])
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :station_closure,
+            header: "Cleveland Circle station is closed due to a Mattapan trolley on the tracks",
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Green-C"}])
+          },
+          %Alerts.Alert{
+            active_period: [
+              {Timex.beginning_of_day(Timex.now()), Timex.end_of_day(Timex.now())}
+            ],
+            effect: :station_closure,
+            header: "Reservoir station is closed due to a Mattapan trolley on the tracks",
+            informed_entity:
+              Alerts.InformedEntitySet.new([%Alerts.InformedEntity{route: "Green-D"}])
+          }
+        ]
       }
     ]
   end

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -191,12 +191,12 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
           route_id: affected_branch_id,
           effect: branch_effect
         )
-        |> Factories.Alerts.Alert.active_during(Timex.now()),
+        |> Factories.Alerts.Alert.active_now(),
         Factories.Alerts.Alert.build(:alert_for_routes,
           route_ids: GreenLine.branch_ids(),
           effect: line_effect
         )
-        |> Factories.Alerts.Alert.active_during(Timex.now())
+        |> Factories.Alerts.Alert.active_now()
       ]
 
       other_affected_route_id = Faker.Util.pick(@lines_without_branches)
@@ -211,7 +211,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
             route_id: other_affected_route_id,
             effect: effect
           )
-          |> Factories.Alerts.Alert.active_during(Timex.now())
+          |> Factories.Alerts.Alert.active_now()
         end)
 
       # Exercise
@@ -233,17 +233,17 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
           route_id: Faker.Util.pick(GreenLine.branch_ids()),
           effect: Faker.Util.pick(service_impacting_effects())
         )
-        |> Factories.Alerts.Alert.active_during(Timex.now()),
+        |> Factories.Alerts.Alert.active_now(),
         Factories.Alerts.Alert.build(:alert_for_routes,
           route_ids: GreenLine.branch_ids(),
           effect: Faker.Util.pick(service_impacting_effects())
         )
-        |> Factories.Alerts.Alert.active_during(Timex.now()),
+        |> Factories.Alerts.Alert.active_now(),
         Factories.Alerts.Alert.build(:alert_for_route,
           route_id: "Mattapan",
           effect: Faker.Util.pick(service_impacting_effects())
         )
-        |> Factories.Alerts.Alert.active_during(Timex.now())
+        |> Factories.Alerts.Alert.active_now()
       ]
 
       # Exercise
@@ -264,12 +264,12 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
           route_id: Faker.Util.pick(GreenLine.branch_ids()),
           effect: Faker.Util.pick(service_impacting_effects())
         )
-        |> Factories.Alerts.Alert.active_during(Timex.now()),
+        |> Factories.Alerts.Alert.active_now(),
         Factories.Alerts.Alert.build(:alert_for_route,
           route_id: "Mattapan",
           effect: Faker.Util.pick(service_impacting_effects())
         )
-        |> Factories.Alerts.Alert.active_during(Timex.now())
+        |> Factories.Alerts.Alert.active_now()
       ]
 
       # Exercise
@@ -292,17 +292,17 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
           route_id: Faker.Util.pick(GreenLine.branch_ids()),
           effect: Faker.Util.pick(service_impacting_effects())
         )
-        |> Factories.Alerts.Alert.active_during(Timex.now()),
+        |> Factories.Alerts.Alert.active_now(),
         Factories.Alerts.Alert.build(:alert_for_routes,
           route_ids: GreenLine.branch_ids(),
           effect: Faker.Util.pick(service_impacting_effects())
         )
-        |> Factories.Alerts.Alert.active_during(Timex.now()),
+        |> Factories.Alerts.Alert.active_now(),
         Factories.Alerts.Alert.build(:alert_for_route,
           route_id: "Mattapan",
           effect: mattapan_effect
         )
-        |> Factories.Alerts.Alert.active_during(Timex.now())
+        |> Factories.Alerts.Alert.active_now()
       ]
 
       # Exercise


### PR DESCRIPTION
This PR fixes a few edge cases in the homepage subway status component where it was unnecessarily collapsing green line rows together, or collapsing Mattapan alerts into Red line (which we decided it should never do).

### Two Green line rows when other data would cause a collapse (Green line shouldn't be collapsed, but other rows should be)

#### Before
<img width="1218" alt="Screenshot 2025-03-05 at 11 50 27 AM" src="https://github.com/user-attachments/assets/dfba4459-b471-4728-8fa4-5a3811c07699" />

#### After
<img width="1218" alt="Screenshot 2025-03-05 at 11 47 38 AM" src="https://github.com/user-attachments/assets/90b9f8c8-462c-42b7-b0cb-00ca6ae71e29" />


### Green line and Mattapan both have extra rows (Green should be collapsed / Mattapan should remain visible)

#### Before
<img width="1217" alt="Screenshot 2025-03-05 at 11 49 54 AM" src="https://github.com/user-attachments/assets/2c71d973-5dc3-40a7-92e3-e085ebf5a7f7" />


#### After
<img width="1217" alt="Screenshot 2025-03-05 at 11 49 11 AM" src="https://github.com/user-attachments/assets/424faa96-39b2-4c21-9c4e-e29aa958c92a" />


### Asana Tickets
- [System Status | 🐞 Don't needlessly collapse Mattapan alerts into Red](https://app.asana.com/0/555089885850811/1209412979464965)
- [System Status | 🐞 Don't needlessly collapse GL alerts](https://app.asana.com/0/555089885850811/1209412979464963)

Blocked by:
- https://github.com/mbta/dotcom/pull/2404
