### PR TITLE
fix(trip-planner): Datepicker bug on mount

### DIFF
--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -43,10 +43,17 @@ defmodule DotcomWeb.Live.TripPlanner do
   def mount(%{"plan" => plan}, _session, socket) when is_binary(plan) do
     changeset = plan |> AntiCorruptionLayer.decode() |> InputForm.changeset()
 
+    %{params: previous_params} = changeset
+
+    params_with_datetime =
+      previous_params
+      |> add_datetime_if_needed(previous_params)
+
     new_socket =
       socket
       |> assign(@state)
       |> assign(:input_form, Map.put(@state.input_form, :changeset, changeset))
+      |> update_datepicker(params_with_datetime)
       |> submit_changeset(changeset)
 
     {:ok, new_socket}

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -43,11 +43,11 @@ defmodule DotcomWeb.Live.TripPlanner do
   def mount(%{"plan" => plan}, _session, socket) when is_binary(plan) do
     changeset = plan |> AntiCorruptionLayer.decode() |> InputForm.changeset()
 
-    %{params: previous_params} = changeset
+    %{params: params} = changeset
 
     params_with_datetime =
-      previous_params
-      |> add_datetime_if_needed(previous_params)
+      params
+      |> add_datetime_if_needed(params)
 
     new_socket =
       socket


### PR DESCRIPTION
[Example Trip](https://www.mbta.com/trip-planner?plan=hsQSX3VudXNlZF93aGVlbGNoYWlyxADECGRhdGV0aW1lxBkyMDI1LTA0LTAxVDEyOjAwOjAwLTA0OjAwxA1kYXRldGltZV90eXBlxAhsZWF2ZV9hdMQEZnJvbYTECGxhdGl0dWRlxAk0Mi4zNjUzOTbECWxvbmdpdHVkZcQKLTcxLjAxNzU0N8QEbmFtZcQUQm9zdG9uIExvZ2FuIEFpcnBvcnTEB3N0b3BfaWTEAMQFbW9kZXOJxANCVVPEBHRydWXEBUZFUlJZxAR0cnVlxARSQUlMxAR0cnVlxAZTVUJXQVnEBHRydWXEDl9wZXJzaXN0ZW50X2lkxAEwxAtfdW51c2VkX0JVU8QAxA1fdW51c2VkX0ZFUlJZxADEDF91bnVzZWRfUkFJTMQAxA5fdW51c2VkX1NVQldBWcQAxAJ0b4TECGxhdGl0dWRlxAk0Mi4zNjU1NzfECWxvbmdpdHVkZcQJLTcxLjA2MTI5xARuYW1lxA1Ob3J0aCBTdGF0aW9uxAdzdG9wX2lkxAtwbGFjZS1ub3J0aA==) (this link will be valid until April 1)

### Before
![Screenshot 2025-03-13 at 12 53 04 PM](https://github.com/user-attachments/assets/2d021b7e-2444-406c-9f56-72c73984d9e2)


(Note the mismatch between what's in the datepicker and what's in the results summary - the trip is planned based on the time in the URL, which is displayed in the results summary, but the datepicker renders with the time that the page is loaded)

### After
![Screenshot 2025-03-13 at 12 50 38 PM](https://github.com/user-attachments/assets/e4bbb2d5-ac3a-47fd-a2a7-17a3016ebf93)

(Note that the datepicker and the results summary now align 🎉)

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Trip Planner | Time/date selection should show the right thing if you reload or copy/paste URL](https://app.asana.com/1/15492006741476/project/385363666817452/task/1209437631293601)

