### PR TITLE
fix: Fix image width in alerts

### DIFF
--- a/assets/ts/components/Alerts.tsx
+++ b/assets/ts/components/Alerts.tsx
@@ -179,7 +179,7 @@ const alertDescription = (alert: AlertType): ReactElement<HTMLElement> => (
         <img
           src={alert.image}
           alt={alert.image_alternative_text}
-          className="w-100"
+          className="w-full"
         />
       </a>
     )}


### PR DESCRIPTION
[Live example right now](https://www.mbta.com/stops/place-nqncy?route=Red&direction_id=1&headsign=Alewife) (to see the bug, or the fix, expand the shuttle alert).

### Before

![Screenshot 2025-03-13 at 2 19 59 PM](https://github.com/user-attachments/assets/6ecd44ed-b692-4816-80a7-90e20b4462da)

### After

![Screenshot 2025-03-13 at 2 18 57 PM](https://github.com/user-attachments/assets/169e74a6-99aa-49ea-8f8b-189799f75ade)

---

The bug was originally introduced in [this PR](https://github.com/mbta/dotcom/pull/2181). Turns out, there is no `w-100` tailwind utility; [the correct utility](https://v3.tailwindcss.com/docs/width#percentage-widths) to set the width to 100% is `w-full`.

---

**Asana Ticket:** [Fix dimensions for alert images on stop pages](https://app.asana.com/1/15492006741476/project/555089885850811/task/1209229373348286)

