### PR TITLE
refactor: remove React component from timetable

### DIFF
--- a/assets/css/_icons.scss
+++ b/assets/css/_icons.scss
@@ -316,19 +316,10 @@ a {
   fill: $gray-lighter;
   height: $base-spacing;
   line-height: $base-spacing;
-  margin-left: .5rem;
   width: $base-spacing;
-
-  &.c-icon__crowding--commuter-rail {
-    margin-left: 0;
-  }
 
   &--not_crowded {
     color: $crowding-not-crowded;
-
-    &.c-icon__crowding--commuter-rail {
-      color: $gray-dark;
-    }
 
     .person-left {
       fill: currentColor;
@@ -338,10 +329,6 @@ a {
   &--some_crowding {
     color: $crowding-some-crowding;
 
-    &.c-icon__crowding--commuter-rail {
-      color: $gray-dark;
-    }
-
     .person-left,
     .person-middle {
       fill: currentColor;
@@ -350,10 +337,6 @@ a {
 
   &--crowded {
     color: $crowding-crowded;
-
-    &.c-icon__crowding--commuter-rail {
-      color: $gray-dark;
-    }
 
     .person {
       fill: currentColor;
@@ -366,5 +349,9 @@ a {
     .person {
       fill: currentColor;
     }
+  }
+
+  &.monochrome {
+    color: black;
   }
 }

--- a/assets/css/_schedule-page-line-diagram.scss
+++ b/assets/css/_schedule-page-line-diagram.scss
@@ -273,8 +273,9 @@
 }
 
 .m-schedule-diagram__prediction-crowding {
-  @include icon-size-inline(1.125em, .125em);
+  @include icon-size-inline(1.125em, .15em);
   display: inline-block;
+  margin-left: .25rem;
 
   .u-no-crowding-data & {
     display: none;

--- a/assets/react_app.js
+++ b/assets/react_app.js
@@ -1,12 +1,11 @@
-import ReactServer from "react-dom/server";
 import React from "react";
+import ReactServer from "react-dom/server";
 import readline from "readline";
 
-import TransitNearMe from "../assets/ts/tnm/components/TransitNearMe";
+import ProjectsPage from "../assets/ts/projects/components/ProjectsPage";
 import AdditionalLineInfo from "../assets/ts/schedule/components/AdditionalLineInfo";
 import ScheduleFinder from "../assets/ts/schedule/components/ScheduleFinder";
-import ProjectsPage from "../assets/ts/projects/components/ProjectsPage";
-import LiveCrowdingIcon from "./ts/schedule/components/line-diagram/LiveCrowdingIcon";
+import TransitNearMe from "../assets/ts/tnm/components/TransitNearMe";
 
 const log = (title, obj) => {
   process.stdout.write(
@@ -55,8 +54,7 @@ const Components = {
   ScheduleFinder,
   AdditionalLineInfo,
   TransitNearMe,
-  ProjectsPage,
-  LiveCrowdingIcon
+  ProjectsPage
 };
 
 const encodeZeroWidthSpaceAsHtml = str => str.replace(/​/g, "&#8203;");

--- a/assets/ts/models/__tests__/vehicle-test.ts
+++ b/assets/ts/models/__tests__/vehicle-test.ts
@@ -1,4 +1,4 @@
-import { crowdingDescriptions, crCrowdingDescriptions } from "../vehicle";
+import { crowdingDescriptions } from "../vehicle";
 
 it.each`
   crowding           | description
@@ -8,14 +8,4 @@ it.each`
   ${null}            | ${""}
 `("crowdingDescriptions for $crowding", ({ crowding, description }) => {
   expect(crowdingDescriptions(crowding)).toBe(description);
-});
-
-it.each`
-  crowding           | description
-  ${"not_crowded"}   | ${"many seats available"}
-  ${"some_crowding"} | ${"some seats available"}
-  ${"crowded"}       | ${"few seats available"}
-  ${null}            | ${""}
-`("crCrowdingDescriptions for $crowding", ({ crowding, description }) => {
-  expect(crCrowdingDescriptions(crowding)).toBe(description);
 });

--- a/assets/ts/models/vehicle.ts
+++ b/assets/ts/models/vehicle.ts
@@ -11,14 +11,3 @@ export const crowdingDescriptions = (crowding: CrowdingType): string =>
         crowded: "Crowded"
       }[crowding]
     : "";
-
-export const crCrowdingDescriptions = (crowding: CrowdingType): string =>
-  crowding
-    ? {
-        // eslint-disable-next-line camelcase
-        not_crowded: "many seats available",
-        // eslint-disable-next-line camelcase
-        some_crowding: "some seats available",
-        crowded: "few seats available"
-      }[crowding]
-    : "";

--- a/assets/ts/schedule/components/line-diagram/LiveCrowdingIcon.tsx
+++ b/assets/ts/schedule/components/line-diagram/LiveCrowdingIcon.tsx
@@ -1,45 +1,30 @@
 import React from "react";
 import { TooltipWrapper, crowdingIcon } from "../../../helpers/icon";
-import {
-  crowdingDescriptions,
-  crCrowdingDescriptions
-} from "../../../models/vehicle";
+import { crowdingDescriptions } from "../../../models/vehicle";
 import { CrowdingType } from "../__schedule";
 
 interface LiveCrowdingIconProps {
   crowding: CrowdingType;
   tooltipPlacement?: "top" | "bottom" | "left" | "right";
-  isCommuterRail?: boolean;
 }
 
 const LiveCrowdingIcon = ({
   crowding,
-  tooltipPlacement,
-  isCommuterRail
+  tooltipPlacement
 }: LiveCrowdingIconProps): JSX.Element => (
   <div className="m-schedule-diagram__prediction-crowding">
     {crowding ? (
       <TooltipWrapper
-        tooltipText={
-          isCommuterRail
-            ? `This train typically has<br /><strong>${crCrowdingDescriptions(
-                crowding
-              )}</strong>`
-            : `Currently <strong>${crowdingDescriptions(
-                crowding
-              ).toLowerCase()}</strong>`
-        }
+        tooltipText={`Currently <strong>${crowdingDescriptions(
+          crowding
+        ).toLowerCase()}</strong>`}
         tooltipOptions={{
           placement: tooltipPlacement || "left",
           animation: false,
           html: true
         }}
       >
-        {crowdingIcon(
-          `c-icon__crowding--${crowding} ${
-            isCommuterRail ? "c-icon__crowding--commuter-rail" : ""
-          }`
-        )}
+        {crowdingIcon(`c-icon__crowding--${crowding}`)}
       </TooltipWrapper>
     ) : (
       crowdingIcon("c-icon__crowding--crowding_unavailable")

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LiveCrowdingIconTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LiveCrowdingIconTest.tsx.snap
@@ -5,7 +5,7 @@ exports[`LiveCrowdingIcon with crowded renders and matches snapshot 1`] = `
   <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <TooltipWrapper tooltipText=\\"Currently <strong>crowded</strong>\\" tooltipOptions={{...}}>
       <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>crowded</strong>\\">
-        <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowded \\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+        <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowded\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
       </span>
     </TooltipWrapper>
   </div>
@@ -17,7 +17,7 @@ exports[`LiveCrowdingIcon with not_crowded renders and matches snapshot 1`] = `
   <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <TooltipWrapper tooltipText=\\"Currently <strong>not crowded</strong>\\" tooltipOptions={{...}}>
       <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>not crowded</strong>\\">
-        <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--not_crowded \\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+        <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--not_crowded\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
       </span>
     </TooltipWrapper>
   </div>
@@ -29,7 +29,7 @@ exports[`LiveCrowdingIcon with some_crowding renders and matches snapshot 1`] = 
   <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <TooltipWrapper tooltipText=\\"Currently <strong>some crowding</strong>\\" tooltipOptions={{...}}>
       <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>some crowding</strong>\\">
-        <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--some_crowding \\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
+        <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--some_crowding\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
       </span>
     </TooltipWrapper>
   </div>

--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -229,4 +229,38 @@ defmodule DotcomWeb.Components do
     </details>
     """
   end
+
+  slot(:inner_block, required: true)
+  attr(:class, :string, default: "")
+
+  attr(:placement, :atom,
+    default: :left,
+    values: [:left, :right, :top, :bottom],
+    doc: "Where the tooltip appears relative to the hovered content."
+  )
+
+  attr(:title, :string,
+    doc:
+      "A preferably short bit of content which will appear on hover. Supports rendering of HTML."
+  )
+
+  @doc """
+  Basic tooltip to display content on hover.
+
+  This uses Bootstrap's JS plugin under the hood.
+  """
+  def tooltip(assigns) do
+    ~H"""
+    <span
+      class={@class}
+      data-html="true"
+      data-trigger="hover"
+      data-toggle="tooltip"
+      data-placement={@placement}
+      title={@title}
+    >
+      {render_slot(@inner_block)}
+    </span>
+    """
+  end
 end

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -106,13 +106,18 @@
                   <% else %>
                     <div class="sr-only">Bicycles not allowed</div>
                   <% end %>
-                  <%= if !is_nil(schedule.trip.occupancy) do %>
-                    {Dotcom.React.render("LiveCrowdingIcon", %{
-                      crowding: schedule.trip.occupancy,
-                      tooltipPlacement: "top",
-                      isCommuterRail: true
-                    })}
-                  <% end %>
+                  <.tooltip
+                    :if={!is_nil(schedule.trip.occupancy)}
+                    title={timetable_crowding_description(schedule.trip.occupancy)}
+                    placement={:top}
+                  >
+                    <.icon
+                      type="icon-svg"
+                      name="icon-crowding"
+                      class={"c-svg__icon c-icon__crowding c-icon__crowding--#{schedule.trip.occupancy} monochrome"}
+                      aria-hidden="true"
+                    />
+                  </.tooltip>
                 </td>
               <% end %>
             </tr>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -141,17 +141,39 @@
                     {break_text_at_slash(stop.name)}
                   <% end %>
                   <div class="m-timetable__stop-icons">
-                    {stop_parking_icon(stop)}
-                    {stop_accessibility_icon(stop)}
+                    <%= if length(stop.parking_lots) > 0 do %>
+                      <.tooltip title="Parking available" placement={:top}>
+                        <.icon
+                          name="square-parking"
+                          class="h-4 w-4 fill-gray-light"
+                          aria-hidden="true"
+                        />
+                      </.tooltip>
+                    <% else %>
+                      <span class="sr-only">No parking</span>
+                    <% end %>
+
+                    <%= if Stops.Stop.accessible?(stop) do %>
+                      <.tooltip title="Accessible" placement={:top}>
+                        <.icon
+                          type="icon-svg"
+                          name="icon-accessible-default"
+                          class="h-4 w-4 fill-gray-light"
+                          aria-hidden="true"
+                        />
+                      </.tooltip>
+                    <% else %>
+                      <%= if Stops.Stop.accessibility_known?(stop) do %>
+                        <span class="sr-only">Not accessible</span>
+                      <% else %>
+                        <span class="sr-only">May not be accessible</span>
+                      <% end %>
+                    <% end %>
+
                     <%= if Alerts.Stop.match(@alerts, stop.id, route: @route.id, time: @date, direction_id: @direction_id) != [] do %>
-                      {content_tag(
-                        :span,
-                        fa("exclamation-triangle"),
-                        aria: [hidden: "true"],
-                        class: "m-timetable__stop-alert",
-                        data: [toggle: "tooltip"],
-                        title: "Service alert or delay"
-                      )}
+                      <.tooltip title="Service alert or delay" placement={:top}>
+                        <.icon name="triangle-exclamation" class="h-4 w-4" aria-hidden="true" />
+                      </.tooltip>
                     <% end %>
                   </div>
                 </div>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -1,152 +1,204 @@
-<%= DotcomWeb.AlertView.group(alerts: @alerts, route: @route, date_time: @date_time, priority_filter: :high, always_show: List.wrap(@blocking_alert)) %>
-<%= render "_trip_view_filters.html", assigns %>
+{DotcomWeb.AlertView.group(
+  alerts: @alerts,
+  route: @route,
+  date_time: @date_time,
+  priority_filter: :high,
+  always_show: List.wrap(@blocking_alert)
+)}
+{render("_trip_view_filters.html", assigns)}
 
 <div class="calendar-covered m-timetable">
-  <%= content_tag(:div, "", [class: "calendar-cover", hidden: !@show_date_select?]) %>
+  {content_tag(:div, "", class: "calendar-cover", hidden: !@show_date_select?)}
   <%= cond do %>
-  <% @blocking_alert != nil -> %>
-      <%= render "_timetable_blocked.html", formatted_date: @formatted_date, alert: @blocking_alert %>
-  <% Enum.empty?(@header_schedules) -> %>
-    <%= render "_empty.html", date: @date, direction: Routes.Route.direction_name(@route, @direction_id), conn: @conn, error: assigns[:schedule_error] %>
-  <% true -> %>
-    <% # only show scroll controllers if we have 2 or more schedules
-        should_show_scroll_controls? = match?([_, _ | _], @header_schedules)
-    %>
-    <div class="m-timetable__header hidden-no-js">
-      <div class="m-timetable__cell m-timetable__cell--gray m-timetable__cell--first-column m-timetable__cell--first-column-header m-timetable__row-header--empty"></div>
-      <div class="m-timetable__col-headers" aria-hidden="true">
-        <%= if should_show_scroll_controls? do %>
-          <span class="m-timetable__trains-label"><%= Routes.Route.vehicle_name(@route) <> "s" %></span>
-          <button class="m-timetable__scroll-btn m-timetable__scroll-btn--left btn btn-outline-primary btn-sm" data-scroll="earlier"><%= fa "angle-left m-timetable__scroll-btn-arrow" %> Earlier <%= Routes.Route.vehicle_name(@route) <> "s" %></button>
-          <button class="m-timetable__scroll-btn m-timetable__scroll-btn--right btn btn-outline-primary btn-sm" data-scroll="later">Later <%= Routes.Route.vehicle_name(@route) <> "s" %> <%= fa "angle-right m-timetable__scroll-btn-arrow" %></button>
-        <% end %>
-      </div>
-    </div>
-    <div id="timetable" class="m-timetable__table-container" data-sticky-container>
-      <table class="m-timetable__table" aria-label={"#{@direction_name} timetable for #{@route.name}, #{@formatted_date}"}>
-        <tr class="js-timetable-train-labels">
-          <th scope="col" class="m-timetable__cell m-timetable__cell--gray m-timetable__cell--first-column m-timetable__cell--first-column-header" data-absolute>
-            <div class="m-timetable__row-header">Stops</div>
-          </th>
-          <td class="hidden-no-js">
-            <div class="m-timetable__row-header"></div>
-          </td>
-          <%= for {schedule, index} <- Enum.with_index(@header_schedules) do %>
-            <%= content_tag :th, [scope: "col", class: "m-timetable__header-cell", data: if index == @offset do [scroll: [to: true]] end] do %>
-              <span class="sr-only">Train <%= schedule.trip.name %></span>
-              <span aria-hidden="true"><%= schedule.trip.name %></span>
-              <%= if Alerts.Trip.match(@alerts, schedule.trip.id, time: @date, route: @route.id, direction_id: @direction_id) != [] do %>
-                <%= svg_icon(%SvgIcon{icon: :alert, class: "icon-small"}) %>
-              <% end %>
-            <% end %>
+    <% @blocking_alert != nil -> %>
+      {render("_timetable_blocked.html", formatted_date: @formatted_date, alert: @blocking_alert)}
+    <% Enum.empty?(@header_schedules) -> %>
+      {render("_empty.html",
+        date: @date,
+        direction: Routes.Route.direction_name(@route, @direction_id),
+        conn: @conn,
+        error: assigns[:schedule_error]
+      )}
+    <% true -> %>
+      <% # only show scroll controllers if we have 2 or more schedules
+      should_show_scroll_controls? = match?([_, _ | _], @header_schedules) %>
+      <div class="m-timetable__header hidden-no-js">
+        <div class="m-timetable__cell m-timetable__cell--gray m-timetable__cell--first-column m-timetable__cell--first-column-header m-timetable__row-header--empty">
+        </div>
+        <div class="m-timetable__col-headers" aria-hidden="true">
+          <%= if should_show_scroll_controls? do %>
+            <span class="m-timetable__trains-label">
+              {Routes.Route.vehicle_name(@route) <> "s"}
+            </span>
+            <button
+              class="m-timetable__scroll-btn m-timetable__scroll-btn--left btn btn-outline-primary btn-sm"
+              data-scroll="earlier"
+            >
+              {fa("angle-left m-timetable__scroll-btn-arrow")} Earlier {Routes.Route.vehicle_name(
+                @route
+              ) <> "s"}
+            </button>
+            <button
+              class="m-timetable__scroll-btn m-timetable__scroll-btn--right btn btn-outline-primary btn-sm"
+              data-scroll="later"
+            >
+              Later {Routes.Route.vehicle_name(@route) <> "s"} {fa(
+                "angle-right m-timetable__scroll-btn-arrow"
+              )}
+            </button>
           <% end %>
-        </tr>
-        <%= if not ferry?(@route) do %>
-          <tr>
-            <th scope="row" class="m-timetable__cell m-timetable__cell--gray m-timetable__cell--first-column m-timetable__cell--first-column-header m-timetable__bike-icon-spacer" data-absolute>
-              <div class="m-timetable__row-header">
-                <span class="sr-only">Bicycles Allowed?</span>
-                <%=
-                  # this icon is set to visibility: hidden by CSS;
-                  # it's needed to keep the absolutely positioned
-                  # header cell height consistent with the cells
-                  # that have icons in them.
-                  svg("icon-bikes-default.svg")
-                %>
-              </div>
+        </div>
+      </div>
+      <div id="timetable" class="m-timetable__table-container" data-sticky-container>
+        <table
+          class="m-timetable__table"
+          aria-label={"#{@direction_name} timetable for #{@route.name}, #{@formatted_date}"}
+        >
+          <tr class="js-timetable-train-labels">
+            <th
+              scope="col"
+              class="m-timetable__cell m-timetable__cell--gray m-timetable__cell--first-column m-timetable__cell--first-column-header"
+              data-absolute
+            >
+              <div class="m-timetable__row-header">Stops</div>
             </th>
             <td class="hidden-no-js">
               <div class="m-timetable__row-header"></div>
             </td>
-            <%= for schedule <- @header_schedules do %>
-              <td class="m-timetable__header-cell">
-                <%= if schedule.trip.bikes_allowed? do %>
-                  <%= content_tag(:span, svg("icon-bikes-default.svg"), [data: [toggle: "tooltip"], title: "Bicycles allowed", class: "bicycles-allowed-icon"]) %>
-                  <div class="sr-only">Bicycles allowed</div>
-                <% else %>
-                  <div class="sr-only">Bicycles not allowed</div>
+            <%= for {schedule, index} <- Enum.with_index(@header_schedules) do %>
+              <%= content_tag :th, [scope: "col", class: "m-timetable__header-cell", data: if index == @offset do [scroll: [to: true]] end] do %>
+                <span class="sr-only">Train {schedule.trip.name}</span>
+                <span aria-hidden="true">{schedule.trip.name}</span>
+                <%= if Alerts.Trip.match(@alerts, schedule.trip.id, time: @date, route: @route.id, direction_id: @direction_id) != [] do %>
+                  {svg_icon(%SvgIcon{icon: :alert, class: "icon-small"})}
                 <% end %>
-                <%= if !is_nil(schedule.trip.occupancy) do %>
-                  <%= Dotcom.React.render("LiveCrowdingIcon", %{
-                    crowding: schedule.trip.occupancy,
-                    tooltipPlacement: "top",
-                    isCommuterRail: true
-                  }) %>
-                <% end %>
-              </td>
+              <% end %>
             <% end %>
           </tr>
-        <% end %>
-        <%= for {stop, idx} <- @header_stops do %>
-          <% cell_background = if rem(idx, 2) == 0 do "white" else "gray" end %>
-          <%= content_tag :tr, [class: stop_row_class(idx)] do %>
-            <%= content_tag :th, [
+          <%= if not ferry?(@route) do %>
+            <tr>
+              <th
+                scope="row"
+                class="m-timetable__cell m-timetable__cell--gray m-timetable__cell--first-column m-timetable__cell--first-column-header m-timetable__bike-icon-spacer"
+                data-absolute
+              >
+                <div class="m-timetable__row-header">
+                  <span class="sr-only">Bicycles Allowed?</span>
+                  {# this icon is set to visibility: hidden by CSS;
+                  # it's needed to keep the absolutely positioned
+                  # header cell height consistent with the cells
+                  # that have icons in them.
+                  svg("icon-bikes-default.svg")}
+                </div>
+              </th>
+              <td class="hidden-no-js">
+                <div class="m-timetable__row-header"></div>
+              </td>
+              <%= for schedule <- @header_schedules do %>
+                <td class="m-timetable__header-cell">
+                  <%= if schedule.trip.bikes_allowed? do %>
+                    {content_tag(:span, svg("icon-bikes-default.svg"),
+                      data: [toggle: "tooltip"],
+                      title: "Bicycles allowed",
+                      class: "bicycles-allowed-icon"
+                    )}
+                    <div class="sr-only">Bicycles allowed</div>
+                  <% else %>
+                    <div class="sr-only">Bicycles not allowed</div>
+                  <% end %>
+                  <%= if !is_nil(schedule.trip.occupancy) do %>
+                    {Dotcom.React.render("LiveCrowdingIcon", %{
+                      crowding: schedule.trip.occupancy,
+                      tooltipPlacement: "top",
+                      isCommuterRail: true
+                    })}
+                  <% end %>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+          <%= for {stop, idx} <- @header_stops do %>
+            <% cell_background =
+              if rem(idx, 2) == 0 do
+                "white"
+              else
+                "gray"
+              end %>
+            <%= content_tag :tr, [class: stop_row_class(idx)] do %>
+              <%= content_tag :th, [
               scope: "row",
               data: [absolute: true],
               class: "js-tt-stop-name m-timetable__cell--first-column m-timetable__cell m-timetable__cell--" <>
                 cell_background
             ] do %>
-              <div class="m-timetable__row-header m-timetable__stop-name notranslate">
-                <%= link to: stop_path(@conn, :show, stop.id), class: "m-timetable__stop-link" do %>
-                  <%= break_text_at_slash(stop.name) %>
-                <% end %>
-                <div class="m-timetable__stop-icons">
-                  <%= stop_parking_icon(stop) %>
-                  <%= stop_accessibility_icon(stop) %>
-                  <%= if Alerts.Stop.match(@alerts, stop.id, route: @route.id, time: @date, direction_id: @direction_id) != [] do %>
-                    <%= content_tag(
-                      :span,
-                      fa("exclamation-triangle"),
-                      aria: [hidden: "true"],
-                      class: "m-timetable__stop-alert",
-                      data: [toggle: "tooltip"],
-                      title: "Service alert or delay"
-                    ) %>
+                <div class="m-timetable__row-header m-timetable__stop-name notranslate">
+                  <%= link to: stop_path(@conn, :show, stop.id), class: "m-timetable__stop-link" do %>
+                    {break_text_at_slash(stop.name)}
                   <% end %>
+                  <div class="m-timetable__stop-icons">
+                    {stop_parking_icon(stop)}
+                    {stop_accessibility_icon(stop)}
+                    <%= if Alerts.Stop.match(@alerts, stop.id, route: @route.id, time: @date, direction_id: @direction_id) != [] do %>
+                      {content_tag(
+                        :span,
+                        fa("exclamation-triangle"),
+                        aria: [hidden: "true"],
+                        class: "m-timetable__stop-alert",
+                        data: [toggle: "tooltip"],
+                        title: "Service alert or delay"
+                      )}
+                    <% end %>
+                  </div>
                 </div>
-              </div>
-            <% end %>
-            <td class="js-tt-cell hidden-no-js">
-              <div class="m-timetable__row-header"></div>
-            </td>
-            <%= for schedule <- @header_schedules do %>
-              <%
-                trip_id = schedule.trip.id
+              <% end %>
+              <td class="js-tt-cell hidden-no-js">
+                <div class="m-timetable__row-header"></div>
+              </td>
+              <%= for schedule <- @header_schedules do %>
+                <% trip_id = schedule.trip.id
                 trip_schedule = @trip_schedules[{trip_id, stop.id} || %{}]
                 track_change = @track_changes[{trip_id, stop.id} || nil]
                 tooltip = stop_tooltip(trip_schedule, track_change)
                 full_trip_message = @trip_messages[{schedule.trip.name}]
                 trip_message = @trip_messages[{schedule.trip.name, stop.id}]
-                tooltip_attrs = [html: "true", toggle: "tooltip"]
-              %>
-              <%= content_tag :td, [
+                tooltip_attrs = [html: "true", toggle: "tooltip"] %>
+                <%= content_tag :td, [
                 class: "js-tt-cell m-timetable__cell" <> cell_flag_class(trip_schedule) <> cell_via_class(trip_message),
                 id: "#{stop.name}-#{trip_id}-tooltip",
                 data: if tooltip do tooltip_attrs ++ [stop: raw(tooltip)] else tooltip_attrs end,
                 title: if tooltip do raw(tooltip) end
               ] do %>
-                <%= if trip_message do %>
-                  <div class="sr-only"><%= full_trip_message %></div>
-                  <div aria-hidden="true"><%= trip_message %></div>
-                <% else %>
-                  <%= render "_timetable_schedule.html",
-                  Map.merge(assigns, %{trip_schedule: trip_schedule, schedule: schedule, stop: stop, track_change: track_change}) %>
+                  <%= if trip_message do %>
+                    <div class="sr-only">{full_trip_message}</div>
+                    <div aria-hidden="true">{trip_message}</div>
+                  <% else %>
+                    {render(
+                      "_timetable_schedule.html",
+                      Map.merge(assigns, %{
+                        trip_schedule: trip_schedule,
+                        schedule: schedule,
+                        stop: stop,
+                        track_change: track_change
+                      })
+                    )}
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>
           <% end %>
-        <% end %>
-      </table>
-    </div>
+        </table>
+      </div>
   <% end %>
 </div>
-<%= timetable_note(assigns) %>
+{timetable_note(assigns)}
 <div class="m-timetable__key-and-pdfs">
-  <% show_crowding = Enum.any?(@header_schedules, fn schedule -> !is_nil(schedule.trip.occupancy) end) %>
-  <%= render "_timetable_icon_key.html", Map.merge(assigns, %{show_crowding: show_crowding}) %>
-  <%= render "_pdf_schedules.html", assigns %>
+  <% show_crowding =
+    Enum.any?(@header_schedules, fn schedule -> !is_nil(schedule.trip.occupancy) end) %>
+  {render("_timetable_icon_key.html", Map.merge(assigns, %{show_crowding: show_crowding}))}
+  {render("_pdf_schedules.html", assigns)}
 </div>
-<script type="text/plaintext" id="js-cr-vehicle-data" data-channel={@channel}></script>
+<script type="text/plaintext" id="js-cr-vehicle-data" data-channel={@channel}>
+</script>
 <script type="application/json" id="js-cr-vehicle-schedules-data">
   <%= raw Poison.encode!(@vehicle_schedules) %>
 </script>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -23,7 +23,7 @@
       </div>
     </div>
     <div id="timetable" class="m-timetable__table-container" data-sticky-container>
-      <table class="m-timetable__table" aria-label="<%= @direction_name %> timetable for <%= @route.name %>, <%= @formatted_date %>">
+      <table class="m-timetable__table" aria-label={"#{@direction_name} timetable for #{@route.name}, #{@formatted_date}"}>
         <tr class="js-timetable-train-labels">
           <th scope="col" class="m-timetable__cell m-timetable__cell--gray m-timetable__cell--first-column m-timetable__cell--first-column-header" data-absolute>
             <div class="m-timetable__row-header">Stops</div>
@@ -146,7 +146,7 @@
   <%= render "_timetable_icon_key.html", Map.merge(assigns, %{show_crowding: show_crowding}) %>
   <%= render "_pdf_schedules.html", assigns %>
 </div>
-<script type="text/plaintext" id="js-cr-vehicle-data" data-channel="<%= @channel %>"></script>
+<script type="text/plaintext" id="js-cr-vehicle-data" data-channel={@channel}></script>
 <script type="application/json" id="js-cr-vehicle-schedules-data">
   <%= raw Poison.encode!(@vehicle_schedules) %>
 </script>

--- a/lib/dotcom_web/views/schedule/timetable.ex
+++ b/lib/dotcom_web/views/schedule/timetable.ex
@@ -3,10 +3,6 @@ defmodule DotcomWeb.ScheduleView.Timetable do
   Functions for showing timetable content.
   """
 
-  import PhoenixHTMLHelpers.Tag, only: [content_tag: 3]
-
-  alias DotcomWeb.PartialView.SvgIconWithCircle
-  alias DotcomWeb.ViewHelpers, as: Helpers
   alias Routes.Route
   alias Schedules.Schedule
   alias Stops.Stop
@@ -59,43 +55,6 @@ defmodule DotcomWeb.ScheduleView.Timetable do
   @spec track_change_description(String.t(), String.t() | nil) :: String.t() | nil
   def track_change_description(station_name, track_change_stop) do
     "Train scheduled to board from #{track_change_stop.platform_name} at #{station_name}"
-  end
-
-  @spec stop_parking_icon(Stop.t()) :: [Phoenix.HTML.Safe.t()]
-  def stop_parking_icon(stop) do
-    if length(stop.parking_lots) > 0 do
-      [
-        content_tag(
-          :span,
-          Helpers.fa("square-parking"),
-          aria: [hidden: "true"],
-          class: "m-timetable__parking-icon",
-          data: [toggle: "tooltip"],
-          title: "Parking available"
-        ),
-        content_tag(:span, "Parking available", class: "sr-only")
-      ]
-    else
-      [content_tag(:span, "No parking", class: "sr-only")]
-    end
-  end
-
-  @spec stop_accessibility_icon(Stop.t()) :: [Phoenix.HTML.Safe.t()]
-  def stop_accessibility_icon(stop) do
-    cond do
-      Stop.accessible?(stop) ->
-        SvgIconWithCircle.svg_icon_with_circle(%SvgIconWithCircle{icon: :access})
-
-      Stop.accessibility_known?(stop) ->
-        [
-          content_tag(:span, "Not accessible", class: "sr-only")
-        ]
-
-      true ->
-        [
-          content_tag(:span, "May not be accessible", class: "sr-only")
-        ]
-    end
   end
 
   @spec stop_row_class(integer) :: String.t()

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -429,4 +429,19 @@ defmodule DotcomWeb.ScheduleView do
   def frequent_bus_badge(_route) do
     nil
   end
+
+  @spec timetable_crowding_description(Vehicles.Vehicle.crowding() | nil) :: String.t() | nil
+  def timetable_crowding_description(crowding) do
+    seats =
+      case crowding do
+        :not_crowded -> "many"
+        :some_crowding -> "some"
+        :crowded -> "few"
+        _ -> nil
+      end
+
+    if seats do
+      ~s(This train typically has<br /><strong>#{seats} seats available</strong>)
+    end
+  end
 end

--- a/test/dotcom_web/components_test.exs
+++ b/test/dotcom_web/components_test.exs
@@ -128,4 +128,27 @@ defmodule DotcomWeb.ComponentsTest do
       end
     end
   end
+
+  describe "tooltip" do
+    test "sets up basic tooltip" do
+      assigns = %{
+        title: Faker.Lorem.sentence(2),
+        placement: Faker.Util.pick([:left, :right, :top, :bottom]),
+        content: Faker.App.name()
+      }
+
+      tooltip =
+        rendered_to_string(~H"""
+        <.tooltip title={assigns.title} placement={assigns.placement}>
+          {assigns.content}
+        </.tooltip>
+        """)
+        |> Floki.parse_fragment!()
+
+      assert Floki.attribute(tooltip, "data-toggle") == ["tooltip"]
+      assert Floki.attribute(tooltip, "data-placement") == ["#{assigns.placement}"]
+      assert Floki.attribute(tooltip, "title") == ["#{assigns.title}"]
+      assert Floki.text(tooltip) =~ assigns.content
+    end
+  end
 end

--- a/test/dotcom_web/views/schedule/timetable_view_test.exs
+++ b/test/dotcom_web/views/schedule/timetable_view_test.exs
@@ -3,7 +3,7 @@ defmodule DotcomWeb.Schedule.TimetableViewTest do
 
   import DotcomWeb.ScheduleView.Timetable
   import Phoenix.ConnTest, only: [build_conn: 0]
-  import Phoenix.HTML, only: [safe_to_string: 1]
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
 
   alias Schedules.Schedule
 
@@ -113,8 +113,8 @@ defmodule DotcomWeb.Schedule.TimetableViewTest do
 
       assigns = Keyword.put(assigns, :header_schedules, header_schedules)
       rendered = DotcomWeb.ScheduleView.render("_timetable.html", assigns)
-      refute safe_to_string(rendered) =~ "Earlier Trains"
-      refute safe_to_string(rendered) =~ "Later Trains"
+      refute rendered_to_string(rendered) =~ "Earlier Trains"
+      refute rendered_to_string(rendered) =~ "Later Trains"
     end
 
     test "renders the earlier/later train columns when there are two or more schedules", %{
@@ -129,8 +129,8 @@ defmodule DotcomWeb.Schedule.TimetableViewTest do
 
       assigns = Keyword.put(assigns, :header_schedules, header_schedules)
       rendered = DotcomWeb.ScheduleView.render("_timetable.html", assigns)
-      assert safe_to_string(rendered) =~ "Earlier Trains"
-      assert safe_to_string(rendered) =~ "Later Trains"
+      assert rendered_to_string(rendered) =~ "Earlier Trains"
+      assert rendered_to_string(rendered) =~ "Later Trains"
     end
 
     test "should show the track change information if present", %{assigns: assigns} do
@@ -164,7 +164,7 @@ defmodule DotcomWeb.Schedule.TimetableViewTest do
         )
 
       rendered = DotcomWeb.ScheduleView.render("_timetable.html", assigns)
-      assert safe_to_string(rendered) =~ "New Track"
+      assert rendered_to_string(rendered) =~ "New Track"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Uncaught exit - {:timeout, {Task, :await, [%Task{mfa: {:erlang, :apply, 2}, owner: #PID<0.26396768.0>, pid: #PID<0.26396822.0>, ref: #Reference<0.0.425996307.1154070796.3517251586.135124>}, 5000]}}](https://app.asana.com/0/555089885850811/1209703855878428/f) (links to [this Sentry issue](https://mbtace.sentry.io/issues/5767367004/))

Since the crowding icon was initially made in React, it was later added to the timetable via `Dotcom.React.render/2`... which was cool and all but turns out performs terribly, and also contributes to many of the 500 errors we were seeing post-deploy. This PR removes that.

Also:

- Adds a simple functional component for rendering tooltips
- Refactors the React component to remove the commuter rail-specific logic that's no longer needed