### PR TITLE
fix(LocationService): handle :unexpected_response

### DIFF
--- a/lib/location_service/location_service.ex
+++ b/lib/location_service/location_service.ex
@@ -56,6 +56,10 @@ defmodule LocationService do
     |> handle_response()
   end
 
+  defp handle_response({:error, {:unexpected_response, error}}) do
+    handle_response({:error, error})
+  end
+
   defp handle_response({:error, error}) do
     error |> inspect() |> Sentry.capture_message()
     {:error, :internal_error}


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | {:unexpected_response, ...](https://app.asana.com/0/555089885850811/1209661472945582/f) ([Sentry ticket](https://mbtace.sentry.io/issues/6387119168/?project=4507102206820352))

I was wise enough to even acknowledge the `{:unexpected_response, error}` response format when defining the `AWSClient.Behaviou` (https://github.com/mbta/dotcom/blob/main/lib/aws_client/behaviour.ex#L6-L28), but hadn't implemented any code to handle that, until now...
