### PR TITLE
chore: Add `#planned` anchor tag for alerts page planned work section

### DIFF
--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -12,7 +12,7 @@
     <section class="mb-lg">
       <.alerts_subway_status subway_status={@current_status} />
     </section>
-    <section class="mb-lg">
+    <section id="planned" class="mb-lg">
       <.disruptions disruptions={@disruption_groups} />
     </section>
     <.alerts_page_content_layout


### PR DESCRIPTION
#### Summary of changes

This will allow a URL like https://www.mbta.com/alerts/subway#planned to take you directly to the planned work section.

Test locally: http://localhost:4001/alerts/subway#planned

**Asana Ticket:** [QF | PW | Add id/anchor to planned work section](https://app.asana.com/0/1205718271156548/1209703382141195/f)

