### PR TITLE
fix: Use cdn.mbta.com as the tileserver for MapLibre maps for all envs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,11 +37,7 @@ config :dotcom, :service_rollover_time, ~T[03:00:00]
 
 config :dotcom, :timezone, "America/New_York"
 
-tile_server_url =
-  if config_env() == :prod,
-    do: "https://cdn.mbta.com",
-    else: "https://mbta-map-tiles-dev.s3.amazonaws.com"
-
+tile_server_url = "https://cdn.mbta.com"
 config :dotcom, tile_server_url: tile_server_url
 
 config :elixir, ansi_enabled: true


### PR DESCRIPTION
This only affects local dev, since deployed environments were already using cdn.mbta.com for this.

### Before

![Screenshot 2025-03-18 at 10 26 00 PM](https://github.com/user-attachments/assets/672f74dd-1ee7-41fd-aee7-a41c1d4d5c1d)

### After

![Screenshot 2025-03-18 at 10 23 14 PM](https://github.com/user-attachments/assets/b9790823-5bd2-4f17-a9a1-7e22308cab05)


---

No ticket