### PR TITLE
fix: enable predictions on the Green Line schedule page

### DIFF
--- a/lib/dotcom/transit_near_me.ex
+++ b/lib/dotcom/transit_near_me.ex
@@ -385,6 +385,12 @@ defmodule Dotcom.TransitNearMe do
           PredictedSchedule.t()
         ]
   defp get_predicted_schedules(schedules, params, opts) do
+    params =
+      Keyword.update!(params, :route, fn
+        "Green" -> GreenLine.branch_ids() |> Enum.join(",")
+        other -> other
+      end)
+
     now = Keyword.fetch!(opts, :now)
 
     predictions = @predictions_repo.all(params)


### PR DESCRIPTION
We've known it was broken for a long time. Everything else about the code behind that functionality made sure to account for the `"Green"` route ID, _except_ for fetching predictions. The MBTA API won't give you predictions for `route: "Green"`! But it will for `route: "Green-B,Green-C,Green-D,Green-E"` :)