### PR TITLE
fix(trip-planner): Nudge MA State House locations to a public entrance

### DIFF
--- a/lib/dotcom/trip_plan/location_nudger.ex
+++ b/lib/dotcom/trip_plan/location_nudger.ex
@@ -1,0 +1,49 @@
+defmodule Dotcom.TripPlan.LocationNudger do
+  @moduledoc """
+  There are some locations that are fairly close to transit stops, but
+  for which all of the OpenStreetMap paths are not public. The
+  Massachusetts State House is a good example of this. The building
+  isn't publicly accessible according to OpenStreetMaps data, and
+  that's correct, because all of the entries into it are gated with
+  security guards. That said, plenty of people need to plan trips to
+  the State House.
+
+  This location nudger is responsible for nudging locations that
+  aren't publicly accessible, but that should still be possible to
+  plan trips to and from, to a sensible lat/long that can be used in
+  trip plans, e.g. the public side of a security entrance.
+  """
+
+  @state_house_address_string "24 Beacon St"
+  @state_house_zip_codes ["02108", "02133"]
+  @state_house_location %{latitude: 42.35861, longitude: -71.06297}
+
+  def nudge(%{from: from, to: to} = data) do
+    %{data | from: nudge_location(from), to: nudge_location(to)}
+  end
+
+  def state_house_location, do: @state_house_location
+  def state_house_zip_codes(), do: @state_house_zip_codes
+
+  def nudge_location(location) do
+    if state_house?(location) do
+      location |> Map.merge(@state_house_location)
+    else
+      location
+    end
+  end
+
+  defp state_house?(%{name: name}) do
+    state_house_zip_code_and_city?(name) &&
+      state_house_street_address?(name)
+  end
+
+  defp state_house_zip_code_and_city?(name) do
+    @state_house_zip_codes
+    |> Enum.any?(fn zip_code -> name |> String.contains?("Boston, MA, #{zip_code}") end)
+  end
+
+  defp state_house_street_address?(name) do
+    name |> String.contains?(@state_house_address_string)
+  end
+end

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -360,7 +360,12 @@ defmodule DotcomWeb.Live.TripPlanner do
   defp get_itinerary_groups(%Ecto.Changeset{valid?: true} = changeset) do
     {:ok, data} = Ecto.Changeset.apply_action(changeset, :submit)
 
-    case Dotcom.TripPlan.OpenTripPlanner.plan(data) do
+    plan =
+      data
+      |> Dotcom.TripPlan.LocationNudger.nudge()
+      |> Dotcom.TripPlan.OpenTripPlanner.plan()
+
+    case plan do
       {:ok, itineraries} ->
         ItineraryGroups.from_itineraries(itineraries,
           take_from_end: data.datetime_type == "arrive_by"

--- a/test/dotcom/trip_plan/location_nudger_test.exs
+++ b/test/dotcom/trip_plan/location_nudger_test.exs
@@ -1,0 +1,178 @@
+defmodule Dotcom.TripPlan.LocationNudgerTest do
+  alias Dotcom.TripPlan.LocationNudger
+  alias Test.Support.Generators
+  use ExUnit.Case
+
+  import Dotcom.TripPlan.LocationNudger, only: [nudge: 1, nudge_location: 1]
+
+  @state_house_address_strings ["24 Beacon St", "24 Beacon Street"]
+  @state_house_location LocationNudger.state_house_location()
+  @state_house_zip_codes LocationNudger.state_house_zip_codes()
+
+  describe "nudge_location/1" do
+    test "does not alter a typical location" do
+      # Setup
+      location = %{
+        name: Generators.Address.address(),
+        latitude: Faker.Address.latitude(),
+        longitude: Faker.Address.longitude()
+      }
+
+      # Exercise / Verify
+      assert nudge_location(location) == location
+    end
+
+    test "nudges addresses associated with the MA State House to the MA State House lat and long" do
+      street_address = Faker.Util.pick(@state_house_address_strings)
+      zip_code = Faker.Util.pick(@state_house_zip_codes)
+
+      # Setup
+      location = %{
+        name: "#{Faker.Company.name()}, #{street_address}, Boston, MA, #{zip_code}, USA",
+        latitude: Faker.Address.latitude(),
+        longitude: Faker.Address.longitude()
+      }
+
+      # Exercise
+      nudged_location = nudge_location(location)
+
+      # Verify
+      assert @state_house_location = nudged_location
+    end
+
+    test "does not nudge addresses to the State House if the zip code isn't one of the State House zip codes" do
+      street_address = Faker.Util.pick(@state_house_address_strings)
+
+      non_state_house_zip_code =
+        fake_with_blocklist(
+          fn -> Faker.Address.zip_code() end,
+          @state_house_zip_codes
+        )
+
+      # Setup
+      location = %{
+        name:
+          "#{Faker.Company.name()}, #{street_address}, Boston, MA, #{non_state_house_zip_code}, USA",
+        latitude: Faker.Address.latitude(),
+        longitude: Faker.Address.longitude()
+      }
+
+      # Exercise
+      nudged_location = nudge_location(location)
+
+      # Verify
+      assert nudged_location == location
+    end
+
+    test "does not nudge addresses to the State House if they're not in Boston" do
+      # Setup
+      street_address = Faker.Util.pick(@state_house_address_strings)
+      zip_code = Faker.Util.pick(@state_house_zip_codes)
+
+      non_boston_city =
+        fake_with_blocklist(
+          fn -> Faker.Address.city() end,
+          ["Boston"]
+        )
+
+      location = %{
+        name:
+          "#{Faker.Company.name()}, #{street_address}, #{non_boston_city}, MA, #{zip_code}, USA",
+        latitude: Faker.Address.latitude(),
+        longitude: Faker.Address.longitude()
+      }
+
+      # Exercise
+      nudged_location = nudge_location(location)
+
+      # Verify
+      assert nudged_location == location
+    end
+  end
+
+  describe "nudge/1" do
+    test "keeps the 'to' and 'from' fields the same for typical addresses" do
+      # Setup
+      form_data = %{
+        from: %{
+          name: Generators.Address.address(),
+          latitude: Faker.Address.latitude(),
+          longitude: Faker.Address.longitude()
+        },
+        to: %{
+          name: Generators.Address.address(),
+          latitude: Faker.Address.latitude(),
+          longitude: Faker.Address.longitude()
+        }
+      }
+
+      # Exercise
+      nudged_form_data = nudge(form_data)
+
+      # Verify
+      assert nudged_form_data == form_data
+    end
+
+    test "nudges the 'from' field when needed" do
+      street_address = Faker.Util.pick(@state_house_address_strings)
+      zip_code = Faker.Util.pick(@state_house_zip_codes)
+
+      # Setup
+      form_data = %{
+        from: %{
+          name: "#{Faker.Company.name()}, #{street_address}, Boston, MA, #{zip_code}, USA",
+          latitude: Faker.Address.latitude(),
+          longitude: Faker.Address.longitude()
+        },
+        to: %{
+          name: Generators.Address.address(),
+          latitude: Faker.Address.latitude(),
+          longitude: Faker.Address.longitude()
+        }
+      }
+
+      # Exercise
+      nudged_form_data = nudge(form_data)
+
+      # Verify
+      assert @state_house_location = nudged_form_data.from
+      assert nudged_form_data.to == form_data.to
+    end
+
+    test "nudges the 'to' field when needed" do
+      street_address = Faker.Util.pick(@state_house_address_strings)
+      zip_code = Faker.Util.pick(@state_house_zip_codes)
+
+      # Setup
+      form_data = %{
+        from: %{
+          name: Generators.Address.address(),
+          latitude: Faker.Address.latitude(),
+          longitude: Faker.Address.longitude()
+        },
+        to: %{
+          name: "#{Faker.Company.name()}, #{street_address}, Boston, MA, #{zip_code}, USA",
+          latitude: Faker.Address.latitude(),
+          longitude: Faker.Address.longitude()
+        }
+      }
+
+      # Exercise
+      nudged_form_data = nudge(form_data)
+
+      # Verify
+      assert @state_house_location = nudged_form_data.to
+      assert nudged_form_data.from == form_data.from
+    end
+  end
+
+  defp fake_with_blocklist(fake_fun, blocklist) do
+    value = fake_fun.()
+
+    if blocklist |> Enum.member?(value) do
+      fake_with_blocklist(fake_fun, blocklist)
+    else
+      value
+    end
+  end
+end

--- a/test/support/generators/address.ex
+++ b/test/support/generators/address.ex
@@ -1,0 +1,12 @@
+defmodule Test.Support.Generators.Address do
+  @moduledoc """
+  Generators to help generate fully-formatted addresses for testing.
+  """
+
+  @doc """
+  Generate a random fully-formatted address
+  """
+  def address() do
+    "#{Faker.Address.street_address()}, #{Faker.Address.city()}, #{Faker.Address.state()}, #{Faker.Address.zip_code()}"
+  end
+end


### PR DESCRIPTION
## Summary

This is a very hacky stop-gap solution to a kind of thorny problem. The problem is that updating OSM data isn't an option, because then OSM will tell people that the inside of the State House is publicly accessible, which it's not. And we don't have fine-grained control over what lat/long corresponds to specific search terms.

The solution here is that any location in the `To` or `From` fields in trip planner whose name/address indicates that its address is `24 Beacon St, Boston, MA` with a zip code of either `02133` or `02108` will be nudged to the security booth where visiting members of the public can actually go.

## Example

[Local testing link](http://localhost:4001/trip-planner?plan=hsQVX3VudXNlZF9kYXRldGltZV90eXBlxADEEl91bnVzZWRfd2hlZWxjaGFpcsQAxAhkYXRldGltZcQgMjAyNS0wMy0yMVQxNDozNTo1Ny4zNjQ3NjgtMDQ6MDDEBGZyb22ExAhsYXRpdHVkZctARSy0jTrmhsQJbG9uZ2l0dWRly8BRxQQtjCpFxARuYW1lxC5Cb3N0b24gUHVibGljIExpYnJhcnksIENpdHkgb2YgQm9zdG9uLCBNQSwgVVNBxAdzdG9wX2lkxADEBW1vZGVzicQDQlVTxAR0cnVlxAVGRVJSWcQEdHJ1ZcQEUkFJTMQEdHJ1ZcQGU1VCV0FZxAR0cnVlxA5fcGVyc2lzdGVudF9pZMQBMMQLX3VudXNlZF9CVVPEAMQNX3VudXNlZF9GRVJSWcQAxAxfdW51c2VkX1JBSUzEAMQOX3VudXNlZF9TVUJXQVnEAMQCdG-ExAhsYXRpdHVkZctARS3sgMc6vcQJbG9uZ2l0dWRly8BRxBV-7UXpxARuYW1lxD9NYXNzYWNodXNldHRzIFN0YXRlIEhvdXNlLCAyNCBCZWFjb24gU3QsIEJvc3RvbiwgTUEsIDAyMTA4LCBVU0HEB3N0b3BfaWTEAA==)

### Before
![Screenshot 2025-03-21 at 2 35 16 PM](https://github.com/user-attachments/assets/e56a14cf-03b6-49ea-99b5-885f27cac9af)

### After
![Screenshot 2025-03-21 at 2 34 02 PM](https://github.com/user-attachments/assets/adabba7b-d8b9-4ed3-bfac-b88695756ac1)

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [TP Bugs | 🐞 Trip Planner (New and Old) | Can't plan trips to Massachusetts State House](https://app.asana.com/0/555089885850811/1208887683514495/f)

