### PR TITLE
hotfix(ContentSecurityPolicy): implement as a Plug

### DIFF
--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -4,7 +4,6 @@ defmodule DotcomWeb.Router do
   use DotcomWeb, :router
   use Plug.ErrorHandler
 
-  import DotcomWeb.ContentSecurityPolicy, only: [default_policy: 0, runtime_directives: 0]
   import KinoLiveComponent.Plug, only: [allow_insecure_connection: 2], warn: false
 
   alias DotcomWeb.ControllerHelpers
@@ -32,14 +31,12 @@ defmodule DotcomWeb.Router do
     plug(:fetch_flash)
     plug(:fetch_cookies)
     plug(:put_root_layout, {DotcomWeb.LayoutView, :root})
-    plug(ContentSecurityPolicy.Plug.Setup, default_policy: default_policy())
-    plug(ContentSecurityPolicy.Plug.AddSourceValue, runtime_directives())
-    plug(ContentSecurityPolicy.Plug.AddNonce, directives: [:script_src])
     plug(DotcomWeb.Plugs.Banner)
     plug(DotcomWeb.Plugs.CanonicalHostname)
     plug(DotcomWeb.Plugs.ClearCookies)
     plug(DotcomWeb.Plugs.Cookies)
     plug(DotcomWeb.Plugs.CommonFares)
+    plug(DotcomWeb.Plugs.ContentSecurityPolicy)
     plug(DotcomWeb.Plugs.Date)
     plug(DotcomWeb.Plugs.DateTime)
     plug(DotcomWeb.Plugs.RewriteUrls)


### PR DESCRIPTION
Right now on dev, images hosted on Drupal are being blocked by the content security policy. It's likely non-obvious things are also being blocked!

I'm giving up on using the `plug/2` macro to involve the `ContentSecurityPolicy` dependency. In this PR I am instead calling the various plugs directly via their `call/2` methods.

<img width="726" alt="image" src="https://github.com/user-attachments/assets/2fa7dbd5-f8d5-43f5-bd10-d95d40651c5d" />
