### PR TITLE
feat: block AI User-Agents

### DIFF
--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -12,3 +12,59 @@ Disallow: /charlie/*
 Disallow: /policies/terms-use-charlie*
 Disallow: /charlieapp
 Disallow: /learnmore-transfer
+
+# Block all known AI crawlers and assistants
+# from using content for training AI models.
+# Source: https://robotstxt.com/ai
+User-Agent: GPTBot
+User-Agent: ClaudeBot
+User-Agent: Claude-Web
+User-Agent: CCBot
+User-Agent: Googlebot-Extended
+User-Agent: Applebot-Extended
+User-Agent: Facebookbot
+User-Agent: Meta-ExternalAgent
+User-Agent: Meta-ExternalFetcher
+User-Agent: diffbot
+User-Agent: PerplexityBot
+User-Agent: Omgili
+User-Agent: Omgilibot
+User-Agent: webzio-extended
+User-Agent: ImagesiftBot
+User-Agent: Bytespider
+User-Agent: Amazonbot
+User-Agent: Youbot
+User-Agent: SemrushBot-OCOB
+User-Agent: Petalbot
+User-Agent: VelenPublicWebCrawler
+User-Agent: TurnitinBot
+User-Agent: Timpibot
+User-Agent: OAI-SearchBot
+User-Agent: ICC-Crawler
+User-Agent: AI2Bot
+User-Agent: AI2Bot-Dolma
+User-Agent: DataForSeoBot
+User-Agent: AwarioBot
+User-Agent: AwarioSmartBot
+User-Agent: AwarioRssBot
+User-Agent: Google-CloudVertexBot
+User-Agent: PanguBot
+User-Agent: Kangaroo Bot
+User-Agent: Sentibot
+User-Agent: img2dataset
+User-Agent: Meltwater
+User-Agent: Seekr
+User-Agent: peer39_crawler
+User-Agent: cohere-ai
+User-Agent: cohere-training-data-crawler
+User-Agent: DuckAssistBot
+User-Agent: Scrapy
+Disallow: /
+DisallowAITraining: /
+
+# Block any non-specified AI crawlers (e.g., new
+# or unknown bots) from using content for training
+# AI models.  This directive is still experimental
+# and may not be supported by all AI crawlers.
+User-Agent: *
+DisallowAITraining: /


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/baa19b55-720b-4146-aa34-873090099296)

[`RuntimeErrorFinch was unable to provide a connection within the timeout due to excess queuing for connections. ...`](https://mbtace.sentry.io/issues/5638477341/?environment=prod&project=4507102206820352&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=9)

After some discussion with some other engineers incl. infra we figure we may as well follow [this guide](https://robotstxt.com/ai#2) and add the known bots to our `robots.txt`