### PR TITLE
fix: Don't call `item.focus()` for all variants in dropdown

### DIFF
--- a/assets/ts/schedule/components/direction/BusMenu.tsx
+++ b/assets/ts/schedule/components/direction/BusMenu.tsx
@@ -66,7 +66,6 @@ const RoutePatternItem = ({
       role="menuitem"
       className={`m-schedule-direction__menu-item${selectedClass}`}
       onClick={handleClick}
-      ref={item => item && item.focus()}
       onKeyUp={(e: ReactKeyboardEvent) => {
         handleReactEnterKeyPress(e, () => {
           handleClick();


### PR DESCRIPTION
### Before

![Screenshot 2025-03-25 at 10 36 47 AM](https://github.com/user-attachments/assets/cb1a84a4-4597-48bf-b70c-2f02fb8ded33)

### After

![Screenshot 2025-03-25 at 10 36 54 AM](https://github.com/user-attachments/assets/42ea62d2-c7e4-4f62-94ef-887bedbfac3b)

---

No ticket