### PR TITLE
fix: Call `item.focus()` on the selected variant

### DIFF
--- a/assets/ts/schedule/components/direction/BusMenu.tsx
+++ b/assets/ts/schedule/components/direction/BusMenu.tsx
@@ -66,6 +66,7 @@ const RoutePatternItem = ({
       role="menuitem"
       className={`m-schedule-direction__menu-item${selectedClass}`}
       onClick={handleClick}
+      ref={item => selected && item && item.focus()}
       onKeyUp={(e: ReactKeyboardEvent) => {
         handleReactEnterKeyPress(e, () => {
           handleClick();


### PR DESCRIPTION
On the bus variant dropdown, automatically focus the selected variant.

Follow-up to:
- https://github.com/mbta/dotcom/pull/2446