### PR TITLE
hotfix(schedule-finder): Check whether `added_dates` has more than 0 elements

### DIFF
--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/ServiceOptGroup.tsx
@@ -38,6 +38,7 @@ const ServiceOptGroup = ({
         } else if (
           ["extra_service", "holiday_service"].includes(service.typicality) &&
           service.added_dates &&
+          service.added_dates.length > 0 &&
           service.added_dates_notes
         ) {
           const addedDate = service.added_dates[0];


### PR DESCRIPTION
## Problem

Schedule finder crashes the page for certain bus routes, including [Route 111](https://www.mbta.com/schedules/111/line), [Route 61](https://www.mbta.com/schedules/61/line), [Route 96](https://www.mbta.com/schedules/96/line) and several others.

The current code checks `service.added_dates` for truthiness before pulling the first item out as `addedDate`. Javascript treats `[]` as truthy, so that check still passes even if `service.added_dates` is `[]`. This PR fixes that by also checking to make sure that `service.added_dates` isn't empty.

---

No Ticket.