### PR TITLE
hotfix(ContentSecurityPolicy): corrected websocket host for iOS15

### DIFF
--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -61,6 +61,7 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
         *.tableau.com
         connect.facebook.net
         data.mbta.com
+        edge.fullstory.com
         https://www.google.com/recaptcha/api.js
         https://www.google.com/recaptcha/api/fallback
         https://www.googletagmanager.com/gtm.js

--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -107,13 +107,20 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
   end
 
   defp sentry(directives, dsn) do
-    if dsn do
+    if is_binary(dsn) do
       [
-        {:connect_src, dsn},
-        {:connect_src, Util.config(:sentry, :js_dsn)}
+        {:connect_src, sentry_host(dsn)},
+        {:connect_src, Util.config(:sentry, :js_dsn) |> sentry_host()}
       ] ++ directives
     else
       directives
+    end
+  end
+
+  defp sentry_host(dsn) do
+    case Regex.run(~r/@(.*)\//, dsn, capture: :all_but_first) do
+      nil -> ""
+      [match | _] -> match
     end
   end
 

--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -98,6 +98,7 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
 
     [
       {:connect_src, "ws://#{websocket_url}"},
+      {:connect_src, "wss://#{websocket_url}"},
       {:img_src, drupal_url}
     ]
     |> static_host(Keyword.get(endpoint_config, :static_url))


### PR DESCRIPTION
Well, I'm hoping that works -- will deploy and test.
Also adds a missing directive for Fullstory, and fixes the Sentry URL (which was broken :()