### PR TITLE
Tooltip offset

### DIFF
--- a/assets/ts/leaflet/components/Map.tsx
+++ b/assets/ts/leaflet/components/Map.tsx
@@ -134,11 +134,7 @@ const Component = ({
             keyboard={false}
             onclick={marker.onClick}
           >
-            {marker.tooltip && (
-              <Popup offset={[0, 40]}>
-                {marker.tooltip}
-              </Popup>
-            )}
+            {marker.tooltip && <Popup offset={[0, 40]}>{marker.tooltip}</Popup>}
           </Marker>
         ))}
       </Map>

--- a/assets/ts/leaflet/components/Map.tsx
+++ b/assets/ts/leaflet/components/Map.tsx
@@ -135,7 +135,7 @@ const Component = ({
             onclick={marker.onClick}
           >
             {marker.tooltip && (
-              <Popup maxHeight={0} offset={[0, 40]}>
+              <Popup offset={[0, 40]}>
                 {marker.tooltip}
               </Popup>
             )}

--- a/assets/ts/leaflet/components/Map.tsx
+++ b/assets/ts/leaflet/components/Map.tsx
@@ -134,7 +134,11 @@ const Component = ({
             keyboard={false}
             onclick={marker.onClick}
           >
-            {marker.tooltip && <Popup maxHeight={0} offset={[0,40]}>{marker.tooltip}</Popup>}
+            {marker.tooltip && (
+              <Popup maxHeight={0} offset={[0, 40]}>
+                {marker.tooltip}
+              </Popup>
+            )}
           </Marker>
         ))}
       </Map>

--- a/assets/ts/leaflet/components/Map.tsx
+++ b/assets/ts/leaflet/components/Map.tsx
@@ -134,7 +134,7 @@ const Component = ({
             keyboard={false}
             onclick={marker.onClick}
           >
-            {marker.tooltip && <Popup maxHeight={175}>{marker.tooltip}</Popup>}
+            {marker.tooltip && <Popup maxHeight={0} offset={[0,40]}>{marker.tooltip}</Popup>}
           </Marker>
         ))}
       </Map>

--- a/assets/ts/schedule/components/__tests__/__snapshots__/MapTest.tsx.snap
+++ b/assets/ts/schedule/components/__tests__/__snapshots__/MapTest.tsx.snap
@@ -11,8 +11,8 @@ exports[`Schedule Map renders and matches snapshot 1`] = `
           </ForwardRef(Leaflet(TileLayer))>
           <ForwardRef(Leaflet(Marker)) icon={{...}} alt=\\"Marker\\" position={{...}} zIndexOffset={[undefined]} keyboard={false} onclick={[undefined]}>
             <Marker icon={{...}} alt=\\"Marker\\" position={{...}} zIndexOffset={[undefined]} keyboard={false} onclick={[undefined]} leaflet={{...}}>
-              <ForwardRef(Leaflet(Popup)) maxHeight={0} offset={{...}}>
-                <Popup maxHeight={0} offset={{...}} leaflet={{...}} pane=\\"popupPane\\" />
+              <ForwardRef(Leaflet(Popup)) offset={{...}}>
+                <Popup offset={{...}} leaflet={{...}} pane=\\"popupPane\\" />
               </ForwardRef(Leaflet(Popup))>
             </Marker>
           </ForwardRef(Leaflet(Marker))>

--- a/assets/ts/schedule/components/__tests__/__snapshots__/MapTest.tsx.snap
+++ b/assets/ts/schedule/components/__tests__/__snapshots__/MapTest.tsx.snap
@@ -11,8 +11,8 @@ exports[`Schedule Map renders and matches snapshot 1`] = `
           </ForwardRef(Leaflet(TileLayer))>
           <ForwardRef(Leaflet(Marker)) icon={{...}} alt=\\"Marker\\" position={{...}} zIndexOffset={[undefined]} keyboard={false} onclick={[undefined]}>
             <Marker icon={{...}} alt=\\"Marker\\" position={{...}} zIndexOffset={[undefined]} keyboard={false} onclick={[undefined]} leaflet={{...}}>
-              <ForwardRef(Leaflet(Popup)) maxHeight={175}>
-                <Popup maxHeight={175} leaflet={{...}} pane=\\"popupPane\\" />
+              <ForwardRef(Leaflet(Popup)) maxHeight={0} offset={{...}}>
+                <Popup maxHeight={0} offset={{...}} leaflet={{...}} pane=\\"popupPane\\" />
               </ForwardRef(Leaflet(Popup))>
             </Marker>
           </ForwardRef(Leaflet(Marker))>


### PR DESCRIPTION
Moves the tooltip down 40px so that it sits on top of the marker. I'm not sure why this is necessary. My guess is that it has something to do with the map's CSS positioning within the page.

https://app.asana.com/0/555089885850811/1209641407424374/f

![Screenshot Capture - 2025-03-27 - 09-35-54](https://github.com/user-attachments/assets/8149dde1-3d49-4a9e-a517-81a60914d56d)

