### PR TITLE
cleanup: Sort props in LineDiagram code

### DIFF
--- a/assets/ts/schedule/components/ScheduleDirection.tsx
+++ b/assets/ts/schedule/components/ScheduleDirection.tsx
@@ -22,15 +22,15 @@ import LineDiagram from "./line-diagram/LineDiagram";
 import { fromStopTreeData } from "./SchedulePage";
 
 export interface Props {
-  route: EnhancedRoute;
-  directionId: DirectionId;
-  routePatternsByDirection: RoutePatternsByDirection;
-  mapData?: MapData;
-  staticMapData?: StaticMapData;
-  stopTree: StopTree | null;
-  routeStopLists: RouteStop[][] | null;
   alerts: Alert[];
   busVariantId: string | null;
+  directionId: DirectionId;
+  mapData?: MapData;
+  route: EnhancedRoute;
+  routePatternsByDirection: RoutePatternsByDirection;
+  routeStopLists: RouteStop[][] | null;
+  staticMapData?: StaticMapData;
+  stopTree: StopTree | null;
 }
 
 export const fetchMapData = (
@@ -98,15 +98,15 @@ export const fetchLineData = (
 };
 
 const ScheduleDirection = ({
-  route,
-  directionId,
-  routePatternsByDirection,
-  mapData,
-  staticMapData,
-  stopTree: initialStopTree,
-  routeStopLists: initialRouteStopLists,
   alerts,
-  busVariantId
+  busVariantId,
+  directionId,
+  mapData,
+  route,
+  routePatternsByDirection,
+  routeStopLists: initialRouteStopLists,
+  staticMapData,
+  stopTree: initialStopTree
 }: Props): ReactElement<HTMLElement> => {
   const routePatternsInCurrentDirection = routePatternsByDirection[directionId];
   const defaultRoutePattern =
@@ -190,8 +190,8 @@ const ScheduleDirection = ({
 
   const [lineState, dispatchLineData] = useReducer(fetchReducer, {
     data: {
-      stopTree: initialStopTree,
-      routeStopLists: initialRouteStopLists
+      routeStopLists: initialRouteStopLists,
+      stopTree: initialStopTree
     },
     isLoading: false,
     error: false
@@ -218,12 +218,12 @@ const ScheduleDirection = ({
           {route.direction_names[state.directionId]}
         </div>
         <ScheduleDirectionMenu
-          route={route}
           directionId={state.directionId}
+          dispatch={dispatch}
+          menuOpen={state.routePatternMenuOpen}
+          route={route}
           routePatternsByDirection={routePatternsByDirection}
           selectedRoutePatternId={state.routePattern.id}
-          menuOpen={state.routePatternMenuOpen}
-          dispatch={dispatch}
         />
         {directionIsChangeable ? (
           <ScheduleDirectionButton dispatch={dispatch} />
@@ -231,32 +231,32 @@ const ScheduleDirection = ({
       </div>
       {isSubwayRoute(route) && lineState.data && (
         <LineDiagram
-          stopTree={lineState.data.stopTree}
-          routeStopList={routeStopList}
-          route={route}
-          directionId={state.directionId}
           alerts={alerts}
+          directionId={state.directionId}
+          route={route}
+          routeStopList={routeStopList}
+          stopTree={lineState.data.stopTree}
         />
       )}
       {!staticMapData && mapState.data && (
         <Map
           channel={`vehicles:${route.id}:${state.directionId}`}
-          data={mapState.data}
           currentShapes={currentShapes}
           currentStops={currentStops}
+          data={mapState.data}
         />
       )}
       {staticMapData && (
         <>
           <img
-            src={staticMapData.img_src}
             alt={`${route.name} route map`}
             className="img-fluid"
+            src={staticMapData.img_src}
           />
           <a
             href={staticMapData.pdf_url}
-            target="_blank"
             rel="noopener noreferrer"
+            target="_blank"
           >
             <i className="fa fa-search-plus" aria-hidden="true" />
             View map as a PDF
@@ -265,11 +265,11 @@ const ScheduleDirection = ({
       )}
       {!isSubwayRoute(route) && (
         <LineDiagram
-          stopTree={lineState.data && lineState.data.stopTree}
-          routeStopList={routeStopList}
-          route={route}
-          directionId={state.directionId}
           alerts={alerts}
+          directionId={state.directionId}
+          route={route}
+          routeStopList={routeStopList}
+          stopTree={lineState.data && lineState.data.stopTree}
         />
       )}
     </>

--- a/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -19,11 +19,11 @@ import StopCard from "./StopCard";
 import { alertsByStop } from "../../../models/alert";
 
 interface Props {
-  stopTree: StopTree | null;
+  alerts: Alert[];
+  directionId: DirectionId;
   route: Route;
   routeStopList: IndexedRouteStop[];
-  directionId: DirectionId;
-  alerts: Alert[];
+  stopTree: StopTree | null;
 }
 
 const stationsOrStops = (routeType: number): string =>
@@ -45,11 +45,11 @@ const updateURL = (origin: SelectedOrigin, direction?: DirectionId): void => {
 };
 
 const LineDiagram = ({
-  stopTree,
-  routeStopList,
-  route,
+  alerts,
   directionId,
-  alerts
+  route,
+  routeStopList,
+  stopTree
 }: Props): ReactElement<HTMLElement> => {
   const stopTreeCoordStore = stopTree
     ? createStopTreeCoordStore(stopTree)
@@ -119,14 +119,14 @@ const LineDiagram = ({
           {filteredStops.length ? (
             filteredStops.map((stop: RouteStop) => (
               <StopCard
-                key={stop.id}
-                stopTree={stopTree}
-                stopId={stop.id}
-                routeStopList={routeStopList}
                 alerts={alertsByStop(alerts, stop.id)}
-                onClick={handleStopClick}
+                key={stop.id}
                 liveData={liveData?.[stop.id]}
+                onClick={handleStopClick}
+                routeStopList={routeStopList}
                 searchQuery={query}
+                stopId={stop.id}
+                stopTree={stopTree}
               />
             ))
           ) : (
@@ -141,13 +141,13 @@ const LineDiagram = ({
       ) : (
         <Provider store={stopTreeCoordStore}>
           <LineDiagramWithStops
-            stopTree={stopTree}
-            routeStopList={routeStopList}
-            route={route}
-            directionId={directionId}
             alerts={alerts}
+            directionId={directionId}
             handleStopClick={handleStopClick}
             liveData={liveData}
+            route={route}
+            routeStopList={routeStopList}
+            stopTree={stopTree}
           />
         </Provider>
       )}

--- a/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
+++ b/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
@@ -17,13 +17,13 @@ import { LiveDataByStop } from "./__line-diagram";
 import { alertsByStop } from "../../../models/alert";
 
 interface Props {
-  stopTree: StopTree | null;
-  routeStopList: IndexedRouteStop[];
-  route: Route;
-  directionId: DirectionId;
   alerts: Alert[];
+  directionId: DirectionId;
   handleStopClick: (stop: RouteStop) => void;
   liveData?: LiveDataByStop;
+  route: Route;
+  routeStopList: IndexedRouteStop[];
+  stopTree: StopTree | null;
 }
 
 export const StopRefContext = React.createContext<[RefMap, () => void]>([
@@ -51,21 +51,21 @@ const nextPrimaryAndBranches = (
 };
 
 const NextStopOrBranch = ({
-  stopTree,
-  stopId,
   alerts,
+  handleStopClick,
+  liveData,
   mergingInBranches,
   splittingOffBranches,
-  handleStopClick,
-  liveData
+  stopId,
+  stopTree
 }: {
-  stopTree: StopTree;
-  stopId: StopId;
   alerts: Alert[];
-  mergingInBranches: StopId[][];
-  splittingOffBranches: StopId[];
   handleStopClick: (stop: RouteStop) => void;
   liveData?: LiveDataByStop;
+  mergingInBranches: StopId[][];
+  splittingOffBranches: StopId[];
+  stopId: StopId;
+  stopTree: StopTree;
 }): ReactElement<HTMLElement> => {
   // Splitting off branch
   if (splittingOffBranches.length) {
@@ -134,36 +134,35 @@ const NextStopOrBranch = ({
     const expandableBranch = nonStartingStops.length
       ? [
           <ExpandableBranch
-            key={`branch-${startingId}`}
-            stopTree={stopTree}
-            // Strip the merge stop
-            stopIds={nonStartingStops}
             alerts={alerts}
             handleStopClick={handleStopClick}
+            key={`branch-${startingId}`}
             liveData={liveData}
+            stopIds={nonStartingStops} // Strip the merge stop
+            stopTree={stopTree}
           />
         ]
       : [];
     const children = [
       <StopCard
+        alerts={alertsByStop(alerts, startingId)}
         key={`stop-card-${startingId}`}
-        stopTree={stopTree}
+        liveData={liveData?.[startingId]}
+        onClick={handleStopClick}
         routeStopList={[]}
         stopId={startingId}
-        alerts={alertsByStop(alerts, startingId)}
-        onClick={handleStopClick}
-        liveData={liveData?.[startingId]}
+        stopTree={stopTree}
       />,
       ...expandableBranch,
       <NextStopOrBranch
-        key={`tail-${startingId}`}
-        stopTree={stopTree}
-        stopId={stopId}
         alerts={alerts}
+        handleStopClick={handleStopClick}
+        key={`tail-${startingId}`}
+        liveData={liveData}
         mergingInBranches={remainingMergingInBranches}
         splittingOffBranches={splittingOffBranches}
-        handleStopClick={handleStopClick}
-        liveData={liveData}
+        stopId={stopId}
+        stopTree={stopTree}
       />
     ];
 
@@ -182,23 +181,23 @@ const NextStopOrBranch = ({
       // Display splitting off branches before any next stops on the primary branch
       const children = [
         <StopCard
+          alerts={alertsByStop(alerts, stopId)}
           key={stopId}
-          stopTree={stopTree}
+          liveData={liveData?.[stopId]}
+          onClick={handleStopClick}
           routeStopList={[]}
           stopId={stopId}
-          alerts={alertsByStop(alerts, stopId)}
-          onClick={handleStopClick}
-          liveData={liveData?.[stopId]}
+          stopTree={stopTree}
         />,
         <NextStopOrBranch
-          key={`${stopId}-${nextId}`}
-          stopTree={stopTree}
-          stopId={nextId}
           alerts={alerts}
+          handleStopClick={handleStopClick}
+          key={`${stopId}-${nextId}`}
+          liveData={liveData}
           mergingInBranches={mergingInBranches}
           splittingOffBranches={newSplittingOffBranches}
-          handleStopClick={handleStopClick}
-          liveData={liveData}
+          stopId={nextId}
+          stopTree={stopTree}
         />
       ];
 
@@ -212,23 +211,23 @@ const NextStopOrBranch = ({
 
     const children = [
       <StopCard
+        alerts={alertsByStop(alerts, stopId)}
         key={stopId}
-        stopTree={stopTree}
+        liveData={liveData?.[stopId]}
+        onClick={handleStopClick}
         routeStopList={[]}
         stopId={stopId}
-        alerts={alertsByStop(alerts, stopId)}
-        onClick={handleStopClick}
-        liveData={liveData?.[stopId]}
+        stopTree={stopTree}
       />,
       <NextStopOrBranch
-        key={`${stopId}-${nextId}`}
-        stopTree={stopTree}
-        stopId={nextId}
         alerts={alerts}
+        handleStopClick={handleStopClick}
+        key={`${stopId}-${nextId}`}
+        liveData={liveData}
         mergingInBranches={mergingInBranchesWithNext}
         splittingOffBranches={[]}
-        handleStopClick={handleStopClick}
-        liveData={liveData}
+        stopId={nextId}
+        stopTree={stopTree}
       />
     ];
 
@@ -237,25 +236,25 @@ const NextStopOrBranch = ({
 
   return (
     <StopCard
+      alerts={alertsByStop(alerts, stopId)}
       key={stopId}
-      stopTree={stopTree}
+      liveData={liveData?.[stopId]}
+      onClick={handleStopClick}
       routeStopList={[]}
       stopId={stopId}
-      alerts={alertsByStop(alerts, stopId)}
-      onClick={handleStopClick}
-      liveData={liveData?.[stopId]}
+      stopTree={stopTree}
     />
   );
 };
 
 const LineDiagramWithStops = ({
-  stopTree,
-  routeStopList,
-  route,
-  directionId,
   alerts,
+  directionId,
   handleStopClick,
-  liveData
+  liveData,
+  route,
+  routeStopList,
+  stopTree
 }: Props): ReactElement<HTMLElement> => {
   // create a ref for each stop - we will use this to track the location of the stop so we can place the line diagram bubbles
   const [stopRefsMap, updateAllStopCoords] = useTreeStopPositions(
@@ -284,43 +283,43 @@ const LineDiagramWithStops = ({
       >
         {stopTree ? (
           <Diagram
-            stopTree={stopTree}
-            route={route}
-            directionId={directionId}
             alerts={alerts}
+            directionId={directionId}
             liveData={liveData}
+            route={route}
+            stopTree={stopTree}
           />
         ) : (
           <SimpleDiagram
-            routeStopList={routeStopList}
-            route={route}
-            directionId={directionId}
             alerts={alerts}
+            directionId={directionId}
             liveData={liveData}
+            route={route}
+            routeStopList={routeStopList}
           />
         )}
         <ol>
           {stopTree ? (
             <NextStopOrBranch
-              stopTree={stopTree}
-              stopId={longestPathStartingId(stopTree)}
               alerts={alerts}
-              mergingInBranches={[]}
-              splittingOffBranches={[]}
               handleStopClick={handleStopClick}
               liveData={liveData}
+              mergingInBranches={[]}
+              splittingOffBranches={[]}
+              stopId={longestPathStartingId(stopTree)}
+              stopTree={stopTree}
             />
           ) : (
             <>
               {routeStopList.map(routeStop => (
                 <StopCard
+                  alerts={alertsByStop(alerts, routeStop.id)}
                   key={`stop-card-${routeStop.routeIndex}`}
-                  stopTree={null}
+                  liveData={liveData?.[routeStop.id]}
+                  onClick={handleStopClick}
                   routeStopList={routeStopList}
                   stopId={routeStop.id}
-                  alerts={alertsByStop(alerts, routeStop.id)}
-                  onClick={handleStopClick}
-                  liveData={liveData?.[routeStop.id]}
+                  stopTree={null}
                 />
               ))}
             </>

--- a/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -30,13 +30,13 @@ import { StopRefContext } from "./LineDiagramWithStops";
 import { LiveData } from "./__line-diagram";
 
 interface Props {
-  stopTree: StopTree | null;
-  routeStopList: RouteStop[];
-  stopId: StopId;
   alerts: Alert[];
-  onClick: (stop: RouteStop) => void;
   liveData?: LiveData;
+  onClick: (stop: RouteStop) => void;
+  routeStopList: RouteStop[];
   searchQuery?: string;
+  stopId: StopId;
+  stopTree: StopTree | null;
 }
 
 const width = (stopTree: StopTree, stopId: StopId): number =>
@@ -112,13 +112,13 @@ const Alert = (): JSX.Element => (
 );
 
 const StopCard = ({
-  stopTree,
-  stopId,
-  routeStopList,
   alerts,
-  onClick,
   liveData,
-  searchQuery
+  onClick,
+  routeStopList,
+  searchQuery,
+  stopId,
+  stopTree
 }: Props): ReactElement<HTMLElement> => {
   const refs = useContext(StopRefContext)[0];
   const routeStop = stopTree

--- a/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
+++ b/assets/ts/schedule/components/line-diagram/__tests__/LineDiagramWithStopsTest.tsx
@@ -189,13 +189,13 @@ describe("LineDiagramWithStops", () => {
     wrapper = mount(
       <redux.Provider store={store}>
         <LineDiagramWithStops
-          stopTree={stopTree}
-          routeStopList={testRouteStopList}
-          route={route}
-          directionId={1}
           alerts={[]}
+          directionId={1}
           handleStopClick={handleStopClick}
           liveData={liveDataWithCrowding}
+          route={route}
+          routeStopList={testRouteStopList}
+          stopTree={stopTree}
         />
       </redux.Provider>
     );
@@ -217,12 +217,12 @@ describe("LineDiagramWithStops", () => {
     const wrapperWithoutCrowding = mount(
       <redux.Provider store={store}>
         <LineDiagramWithStops
-          stopTree={stopTree}
-          routeStopList={testRouteStopList}
-          route={route}
-          directionId={1}
           alerts={[]}
+          directionId={1}
           handleStopClick={handleStopClick}
+          route={route}
+          routeStopList={testRouteStopList}
+          stopTree={stopTree}
         />
       </redux.Provider>
     );
@@ -243,12 +243,12 @@ describe("LineDiagramWithStops", () => {
     const { container } = render(
       <redux.Provider store={store}>
         <LineDiagramWithStops
-          stopTree={stopTree}
-          routeStopList={testRouteStopList}
-          route={route}
-          directionId={1}
           alerts={[currentDiversionAlert]}
+          directionId={1}
           handleStopClick={handleStopClick}
+          route={route}
+          routeStopList={testRouteStopList}
+          stopTree={stopTree}
         />
       </redux.Provider>
     );

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
 "<Provider store={{...}}>
-  <LineDiagramWithStops stopTree={{...}} routeStopList={{...}} route={{...}} directionId={1} alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
+  <LineDiagramWithStops alerts={{...}} directionId={1} handleStopClick={[Function: handleStopClick]} liveData={{...}} route={{...}} routeStopList={{...}} stopTree={{...}}>
     <div className=\\"m-schedule-diagram \\">
-      <Diagram stopTree={{...}} route={{...}} directionId={1} alerts={{...}} liveData={{...}}>
+      <Diagram alerts={{...}} directionId={1} liveData={{...}} route={{...}} stopTree={{...}}>
         <LiveVehicleIconSet isStart={true} stop={{...}} liveData={{...}} />
         <LiveVehicleIconSet isStart={false} stop={{...}} liveData={{...}} />
         <LiveVehicleIconSet isStart={true} stop={{...}} liveData={{...}} />
@@ -110,8 +110,8 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
         </svg>
       </Diagram>
       <ol>
-        <NextStopOrBranch stopTree={{...}} stopId=\\"b1\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-          <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"b1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+        <NextStopOrBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} stopId=\\"b1\\" stopTree={{...}}>
+          <StopCard alerts={{...}} liveData={[undefined]} onClick={[Function: handleStopClick]} routeStopList={{...}} stopId=\\"b1\\" stopTree={{...}}>
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -141,8 +141,8 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
               </section>
             </li>
           </StopCard>
-          <NextStopOrBranch stopTree={{...}} stopId=\\"b2\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-            <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"b2\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+          <NextStopOrBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} stopId=\\"b2\\" stopTree={{...}}>
+            <StopCard alerts={{...}} liveData={[undefined]} onClick={[Function: handleStopClick]} routeStopList={{...}} stopId=\\"b2\\" stopTree={{...}}>
               <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                 <section className=\\"m-schedule-diagram__content\\">
                   <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -172,8 +172,8 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                 </section>
               </li>
             </StopCard>
-            <NextStopOrBranch stopTree={{...}} stopId=\\"b3\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-              <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"b3\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+            <NextStopOrBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} stopId=\\"b3\\" stopTree={{...}}>
+              <StopCard alerts={{...}} liveData={[undefined]} onClick={[Function: handleStopClick]} routeStopList={{...}} stopId=\\"b3\\" stopTree={{...}}>
                 <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                   <section className=\\"m-schedule-diagram__content\\">
                     <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -203,8 +203,8 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                   </section>
                 </li>
               </StopCard>
-              <NextStopOrBranch stopTree={{...}} stopId=\\"m1\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"a1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+              <NextStopOrBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} stopId=\\"m1\\" stopTree={{...}}>
+                <StopCard alerts={{...}} liveData={[undefined]} onClick={[Function: handleStopClick]} routeStopList={{...}} stopId=\\"a1\\" stopTree={{...}}>
                   <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                     <section className=\\"m-schedule-diagram__content\\">
                       <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -234,7 +234,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                     </section>
                   </li>
                 </StopCard>
-                <ExpandableBranch stopTree={{...}} stopIds={{...}} alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
+                <ExpandableBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} stopIds={{...}} stopTree={{...}}>
                   <div className=\\"m-schedule-diagram__expander\\">
                     <ExpandableBlock header={{...}} initiallyExpanded={false} notifyExpanded={[Function: notifyExpanded]} preventScroll={true} id=\\"undefined\\">
                       <h3 className=\\"c-expandable-block__header \\" tabIndex={0} id=\\"header-undefined\\" aria-expanded={false} aria-controls=\\"panel-undefined\\" role=\\"button\\" onClick={[Function: onClick]} onKeyPress={[Function: onKeyPress]}>
@@ -266,8 +266,8 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                     </ExpandableBlock>
                   </div>
                 </ExpandableBranch>
-                <NextStopOrBranch stopTree={{...}} stopId=\\"m1\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                  <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"m1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                <NextStopOrBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} stopId=\\"m1\\" stopTree={{...}}>
+                  <StopCard alerts={{...}} liveData={[undefined]} onClick={[Function: handleStopClick]} routeStopList={{...}} stopId=\\"m1\\" stopTree={{...}}>
                     <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                       <section className=\\"m-schedule-diagram__content\\">
                         <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -297,8 +297,8 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                       </section>
                     </li>
                   </StopCard>
-                  <NextStopOrBranch stopTree={{...}} stopId=\\"m2\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                    <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"c1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                  <NextStopOrBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} stopId=\\"m2\\" stopTree={{...}}>
+                    <StopCard alerts={{...}} liveData={[undefined]} onClick={[Function: handleStopClick]} routeStopList={{...}} stopId=\\"c1\\" stopTree={{...}}>
                       <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                         <section className=\\"m-schedule-diagram__content\\">
                           <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -328,7 +328,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                         </section>
                       </li>
                     </StopCard>
-                    <ExpandableBranch stopTree={{...}} stopIds={{...}} alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
+                    <ExpandableBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} stopIds={{...}} stopTree={{...}}>
                       <div className=\\"m-schedule-diagram__expander\\">
                         <ExpandableBlock header={{...}} initiallyExpanded={false} notifyExpanded={[Function: notifyExpanded]} preventScroll={true} id=\\"undefined\\">
                           <h3 className=\\"c-expandable-block__header \\" tabIndex={0} id=\\"header-undefined\\" aria-expanded={false} aria-controls=\\"panel-undefined\\" role=\\"button\\" onClick={[Function: onClick]} onKeyPress={[Function: onKeyPress]}>
@@ -360,8 +360,8 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                         </ExpandableBlock>
                       </div>
                     </ExpandableBranch>
-                    <NextStopOrBranch stopTree={{...}} stopId=\\"m2\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                      <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"m2\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                    <NextStopOrBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} stopId=\\"m2\\" stopTree={{...}}>
+                      <StopCard alerts={{...}} liveData={[undefined]} onClick={[Function: handleStopClick]} routeStopList={{...}} stopId=\\"m2\\" stopTree={{...}}>
                         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                           <section className=\\"m-schedule-diagram__content\\">
                             <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -391,8 +391,8 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                           </section>
                         </li>
                       </StopCard>
-                      <NextStopOrBranch stopTree={{...}} stopId=\\"m3\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                        <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"m3\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                      <NextStopOrBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} stopId=\\"m3\\" stopTree={{...}}>
+                        <StopCard alerts={{...}} liveData={[undefined]} onClick={[Function: handleStopClick]} routeStopList={{...}} stopId=\\"m3\\" stopTree={{...}}>
                           <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                             <section className=\\"m-schedule-diagram__content\\">
                               <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -422,7 +422,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                             </section>
                           </li>
                         </StopCard>
-                        <NextStopOrBranch stopTree={{...}} stopId=\\"x1\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
+                        <NextStopOrBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} stopId=\\"x1\\" stopTree={{...}}>
                           <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"y1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
                             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                               <section className=\\"m-schedule-diagram__content\\">
@@ -449,7 +449,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                             </li>
                           </StopCard>
                           <NextStopOrBranch stopTree={{...}} stopId=\\"x1\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                            <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"x1\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                            <StopCard alerts={{...}} liveData={[undefined]} onClick={[Function: handleStopClick]} routeStopList={{...}} stopId=\\"x1\\" stopTree={{...}}>
                               <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                                 <section className=\\"m-schedule-diagram__content\\">
                                   <header className=\\"m-schedule-diagram__stop-heading\\">
@@ -479,8 +479,8 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                 </section>
                               </li>
                             </StopCard>
-                            <NextStopOrBranch stopTree={{...}} stopId=\\"x2\\" alerts={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}}>
-                              <StopCard stopTree={{...}} routeStopList={{...}} stopId=\\"x2\\" alerts={{...}} onClick={[Function: handleStopClick]} liveData={[undefined]}>
+                            <NextStopOrBranch alerts={{...}} handleStopClick={[Function: handleStopClick]} liveData={{...}} mergingInBranches={{...}} splittingOffBranches={{...}} stopId=\\"x2\\" stopTree={{...}}>
+                              <StopCard alerts={{...}} liveData={[undefined]} onClick={[Function: handleStopClick]} routeStopList={{...}} stopId=\\"x2\\" stopTree={{...}}>
                                 <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                                   <section className=\\"m-schedule-diagram__content\\">
                                     <header className=\\"m-schedule-diagram__stop-heading\\">


### PR DESCRIPTION
This is a code-cosmetic change that I'm intending to merge _before_ https://github.com/mbta/dotcom/pull/2454. 

As I was working on https://github.com/mbta/dotcom/pull/2454, I noticed that a bunch of components had props that weren't sorted, which made it a bit confusing to decide where to put the new props that I was adding. For some of those prop-lists, I sorted them while working on it, but that expands the diff and makes it harder to see what the real change is, versus just the cosmetic prop-ordering. Also I missed some.

This change is a more systematic run-through of all of the prop-lists in the files touched by https://github.com/mbta/dotcom/pull/2454 in order to get all of those lists into sorted order. Once this is merged, then https://github.com/mbta/dotcom/pull/2454 can be updated so that it's a pure addition, making the diff easier to read, and leaving the props in sorted order.