### PR TITLE
cleanup: Make `<StopConnections />` a real component and remove unused prop

### DIFF
--- a/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -163,7 +163,7 @@ const StopCard = ({
         </header>
 
         <div className="m-schedule-diagram__stop-details">
-          {StopConnections(stopId, connections)}
+          <StopConnections connections={connections} />
           {hasLivePredictions(liveData) && !isEnd ? (
             <StopPredictions
               headsigns={liveData!.headsigns}

--- a/assets/ts/schedule/components/line-diagram/StopConnections.tsx
+++ b/assets/ts/schedule/components/line-diagram/StopConnections.tsx
@@ -42,10 +42,11 @@ const connectionName = (connection: Route): string => {
   return connection.name;
 };
 
-const StopConnections = (
-  route_id: string,
-  connections: Route[]
-): JSX.Element => (
+const StopConnections = ({
+  connections
+}: {
+  connections: Route[];
+}): JSX.Element => (
   <div className="m-schedule-diagram__connections">
     {filteredConnections(connections).map((connectingRoute: Route) => (
       <TooltipWrapper

--- a/assets/ts/schedule/components/line-diagram/__tests__/StopConnectionsTest.tsx
+++ b/assets/ts/schedule/components/line-diagram/__tests__/StopConnectionsTest.tsx
@@ -17,7 +17,7 @@ describe("StopConnections", () => {
         expect(params.tooltipText).toEqual("Commuter Rail");
         return <div>Test</div>;
       });
-    render(StopConnections("a", [commuterRailRoute as any]));
+    render(<StopConnections connections={[commuterRailRoute as any]} />);
     expect(wrapperSpy).toHaveBeenCalled();
   });
 
@@ -29,7 +29,9 @@ describe("StopConnections", () => {
         return <div>Test</div>;
       });
     render(
-      StopConnections("a", [{ type: 3, name: "SL-Test", id: "SL" } as any])
+      <StopConnections
+        connections={[{ type: 3, name: "SL-Test", id: "SL" } as any]}
+      />
     );
     expect(wrapperSpy).toHaveBeenCalled();
   });
@@ -42,7 +44,9 @@ describe("StopConnections", () => {
         return <div>Test</div>;
       });
     render(
-      StopConnections("a", [{ type: 3, name: "Bus-Test", id: "Bus" } as any])
+      <StopConnections
+        connections={[{ type: 3, name: "Bus-Test", id: "Bus" } as any]}
+      />
     );
     expect(wrapperSpy).toHaveBeenCalled();
   });
@@ -55,9 +59,9 @@ describe("StopConnections", () => {
         return <div>Test</div>;
       });
     render(
-      StopConnections("a", [
-        { type: 1, name: "Line-Test", id: "Test-Line" } as any
-      ])
+      <StopConnections
+        connections={[{ type: 1, name: "Line-Test", id: "Test-Line" } as any]}
+      />
     );
     expect(wrapperSpy).toHaveBeenCalled();
   });

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -131,7 +131,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                   </div>
                 </header>
                 <div className=\\"m-schedule-diagram__stop-details\\">
-                  <div className=\\"m-schedule-diagram__connections\\" />
+                  <StopConnections connections={{...}}>
+                    <div className=\\"m-schedule-diagram__connections\\" />
+                  </StopConnections>
                 </div>
                 <footer className=\\"m-schedule-diagram__footer\\">
                   <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -162,7 +164,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                     </div>
                   </header>
                   <div className=\\"m-schedule-diagram__stop-details\\">
-                    <div className=\\"m-schedule-diagram__connections\\" />
+                    <StopConnections connections={{...}}>
+                      <div className=\\"m-schedule-diagram__connections\\" />
+                    </StopConnections>
                   </div>
                   <footer className=\\"m-schedule-diagram__footer\\">
                     <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -193,7 +197,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                       </div>
                     </header>
                     <div className=\\"m-schedule-diagram__stop-details\\">
-                      <div className=\\"m-schedule-diagram__connections\\" />
+                      <StopConnections connections={{...}}>
+                        <div className=\\"m-schedule-diagram__connections\\" />
+                      </StopConnections>
                     </div>
                     <footer className=\\"m-schedule-diagram__footer\\">
                       <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -224,7 +230,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                         </div>
                       </header>
                       <div className=\\"m-schedule-diagram__stop-details\\">
-                        <div className=\\"m-schedule-diagram__connections\\" />
+                        <StopConnections connections={{...}}>
+                          <div className=\\"m-schedule-diagram__connections\\" />
+                        </StopConnections>
                       </div>
                       <footer className=\\"m-schedule-diagram__footer\\">
                         <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -287,7 +295,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                           </div>
                         </header>
                         <div className=\\"m-schedule-diagram__stop-details\\">
-                          <div className=\\"m-schedule-diagram__connections\\" />
+                          <StopConnections connections={{...}}>
+                            <div className=\\"m-schedule-diagram__connections\\" />
+                          </StopConnections>
                         </div>
                         <footer className=\\"m-schedule-diagram__footer\\">
                           <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -318,7 +328,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                             </div>
                           </header>
                           <div className=\\"m-schedule-diagram__stop-details\\">
-                            <div className=\\"m-schedule-diagram__connections\\" />
+                            <StopConnections connections={{...}}>
+                              <div className=\\"m-schedule-diagram__connections\\" />
+                            </StopConnections>
                           </div>
                           <footer className=\\"m-schedule-diagram__footer\\">
                             <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -381,7 +393,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                               </div>
                             </header>
                             <div className=\\"m-schedule-diagram__stop-details\\">
-                              <div className=\\"m-schedule-diagram__connections\\" />
+                              <StopConnections connections={{...}}>
+                                <div className=\\"m-schedule-diagram__connections\\" />
+                              </StopConnections>
                             </div>
                             <footer className=\\"m-schedule-diagram__footer\\">
                               <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -412,7 +426,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                 </div>
                               </header>
                               <div className=\\"m-schedule-diagram__stop-details\\">
-                                <div className=\\"m-schedule-diagram__connections\\" />
+                                <StopConnections connections={{...}}>
+                                  <div className=\\"m-schedule-diagram__connections\\" />
+                                </StopConnections>
                               </div>
                               <footer className=\\"m-schedule-diagram__footer\\">
                                 <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -443,7 +459,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                   </div>
                                 </header>
                                 <div className=\\"m-schedule-diagram__stop-details\\">
-                                  <div className=\\"m-schedule-diagram__connections\\" />
+                                  <StopConnections connections={{...}}>
+                                    <div className=\\"m-schedule-diagram__connections\\" />
+                                  </StopConnections>
                                 </div>
                               </section>
                             </li>
@@ -469,7 +487,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                     </div>
                                   </header>
                                   <div className=\\"m-schedule-diagram__stop-details\\">
-                                    <div className=\\"m-schedule-diagram__connections\\" />
+                                    <StopConnections connections={{...}}>
+                                      <div className=\\"m-schedule-diagram__connections\\" />
+                                    </StopConnections>
                                   </div>
                                   <footer className=\\"m-schedule-diagram__footer\\">
                                     <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
@@ -500,7 +520,9 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                       </div>
                                     </header>
                                     <div className=\\"m-schedule-diagram__stop-details\\">
-                                      <div className=\\"m-schedule-diagram__connections\\" />
+                                      <StopConnections connections={{...}}>
+                                        <div className=\\"m-schedule-diagram__connections\\" />
+                                      </StopConnections>
                                     </div>
                                   </section>
                                 </li>

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
@@ -29,15 +29,17 @@ exports[`StopCard renders and matches snapshot 1`] = `
           </div>
         </header>
         <div className=\\"m-schedule-diagram__stop-details\\">
-          <div className=\\"m-schedule-diagram__connections\\">
-            <TooltipWrapper href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
-              <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Orange Line\\">
-                <span className=\\"m-schedule-diagram__connection\\">
-                  <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
-                </span>
-              </a>
-            </TooltipWrapper>
-          </div>
+          <StopConnections connections={{...}}>
+            <div className=\\"m-schedule-diagram__connections\\">
+              <TooltipWrapper href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
+                <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Orange Line\\">
+                  <span className=\\"m-schedule-diagram__connection\\">
+                    <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
+                  </span>
+                </a>
+              </TooltipWrapper>
+            </div>
+          </StopConnections>
           <div className=\\"m-schedule-diagram__alert\\">
             Detour
           </div>


### PR DESCRIPTION
Just a minor code-cleanup thing that I noticed while working on https://github.com/mbta/dotcom/pull/2454 - `<StopConnections />` wasn't using its first argument (called `route_id`, though the value that was passed in was actually a stop ID), and also that it was defined in a way that made it impossible to invoke as a normal React component.