### PR TITLE
feat: Have the subway-status header link to /alerts/subway

### DIFF
--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -21,9 +21,12 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
     ~H"""
     <.bordered_container hide_divider>
       <:heading>
-        <div class="px-2 flex items-center gap-2 mb-sm">
+        <a
+          href={~p"/alerts/subway"}
+          class="px-2 flex items-center gap-2 mb-sm font-heading font-bold text-gray-dark no-underline"
+        >
           <.icon type="icon-svg" name="icon-mode-subway-default" class="h-7 w-7" /> Subway Status
-        </div>
+        </a>
       </:heading>
       <.lined_list :let={row} items={@rows}>
         <a
@@ -34,6 +37,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             "hover:bg-brand-primary-lightest cursor-pointer group/row",
             "text-black no-underline font-normal"
           ]}
+          data-test="status-row"
         >
           <div class={["pl-2 py-3", row.style.hide_route_pill && "opacity-0"]} data-route-pill>
             <.subway_route_pill

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -413,7 +413,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
 
   defp status_rows_for_alerts(alerts) do
     render_component(&homepage_subway_status/1, %{subway_status: alerts |> subway_status()})
-    |> Floki.find("a")
+    |> Floki.find("[data-test=\"status-row\"]")
   end
 
   defp for_route(rows, route_id) do


### PR DESCRIPTION
![Screenshot 2025-03-28 at 11 18 48 AM](https://github.com/user-attachments/assets/e4c61a66-bb9a-49b9-9ff3-3449eb44b9ee)

Change the `Subway Status` header to be a link that directs to `/alerts/subway`.

This change also includes a small change to the `subway_status` component tests, because, those tests were assuming that the only `<a>` tags in the component would be the status rows, but that's not true anymore.

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | Homepage subway status goes to /alerts/subway](https://app.asana.com/0/555089885850811/1209601118457610/f)

