### PR TITLE
fix: show mobile app banner in schedule finder for additional modes

### DIFF
--- a/assets/ts/hooks/useMobileAppBanner.ts
+++ b/assets/ts/hooks/useMobileAppBanner.ts
@@ -1,0 +1,25 @@
+import { createElement, ReactHTMLElement, useEffect, useState } from "react";
+
+/**
+ * If there's a banner for the mobile app present in the DOM, copy it for use
+ * with React components.
+ *
+ * @return {JSX.Element | null} - the banner HTML, if present
+ */
+export default function useMobileAppBanner(): ReactHTMLElement<
+  HTMLElement
+> | null {
+  const [banner, setBanner] = useState<ReactHTMLElement<HTMLElement> | null>(
+    null
+  );
+  useEffect(() => {
+    const el = document.querySelector<HTMLElement>("#mobile-app-banner");
+    if (el && el.style.display === "block") {
+      const element = createElement("div", {
+        dangerouslySetInnerHTML: { __html: el.outerHTML }
+      });
+      setBanner(element);
+    }
+  }, []);
+  return banner;
+}

--- a/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
+++ b/assets/ts/schedule/components/schedule-finder/ScheduleModalContent.tsx
@@ -2,20 +2,21 @@ import React, { ReactElement } from "react";
 import { Dispatch } from "redux";
 import { DirectionId, Route } from "../../../__v3api";
 import { routeToModeName } from "../../../helpers/css";
+import formattedDate, { stringToDateObject } from "../../../helpers/date";
+import { isInAddedDates, isInCurrentService } from "../../../helpers/service";
+import useMobileAppBanner from "../../../hooks/useMobileAppBanner";
+import { isSubwayRoute } from "../../../models/route";
 import {
-  SimpleStopMap,
   RoutePatternsByDirection,
-  ServiceInSelector,
+  ScheduleNote,
   SelectedOrigin,
-  ScheduleNote
+  ServiceInSelector,
+  SimpleStopMap
 } from "../__schedule";
 import ScheduleFinderForm from "./ScheduleFinderForm";
 import DailySchedule from "./daily-schedule/DailySchedule";
-import UpcomingDepartures from "./upcoming-departures/UpcomingDepartures";
-import { isSubwayRoute } from "../../../models/route";
 import DailyScheduleSubway from "./daily-schedule/DailyScheduleSubway";
-import formattedDate, { stringToDateObject } from "../../../helpers/date";
-import { isInAddedDates, isInCurrentService } from "../../../helpers/service";
+import UpcomingDepartures from "./upcoming-departures/UpcomingDepartures";
 
 interface Props {
   handleChangeDirection: (direction: DirectionId) => void;
@@ -65,6 +66,7 @@ const ScheduleModalContent = ({
         There are no scheduled trips for {formattedDate(today)}.
       </div>
     );
+  const mobileAppBanner = useMobileAppBanner();
 
   return (
     <>
@@ -79,6 +81,7 @@ const ScheduleModalContent = ({
           stopsByDirection={stops}
         />
       </div>
+      {mobileAppBanner && <div className="-mx-lg">{mobileAppBanner}</div>}
       {!isSubwayRoute(route) ? null : (
         <DailyScheduleSubway
           stops={stops}

--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/DailyScheduleSubway.tsx
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/DailyScheduleSubway.tsx
@@ -9,26 +9,26 @@ import {
 } from "date-fns";
 import { find, toLower } from "lodash";
 import React, { ReactElement, useEffect, useState } from "react";
-import ExpandableBlock from "../../../../components/ExpandableBlock";
-import {
-  formatToBostonTime,
-  stringToDateObject
-} from "../../../../helpers/date";
-import { useHoursOfOperationByStop } from "../../../../hooks/useHoursOfOperation";
-import RouteIcon from "../../../../projects/components/RouteIcon";
 import {
   DirectionId,
   Route,
   StopHours,
   StopHoursByStop
 } from "../../../../__v3api";
+import ExpandableBlock from "../../../../components/ExpandableBlock";
+import {
+  formatToBostonTime,
+  stringToDateObject
+} from "../../../../helpers/date";
+import { useHoursOfOperationByStop } from "../../../../hooks/useHoursOfOperation";
+import { useStop } from "../../../../hooks/useStop";
+import RouteIcon from "../../../../projects/components/RouteIcon";
 import {
   ScheduleNote,
   ServiceInSelector,
   SimpleStopMap
 } from "../../__schedule";
 import SelectContainer from "../SelectContainer";
-import { useStop } from "../../../../hooks/useStop";
 
 const findStopName = (
   stopId: string,
@@ -196,24 +196,6 @@ const DailyScheduleSubway = ({
 
   return (
     <div>
-      <div
-        style={{
-          backgroundColor: "#DCD3E8",
-          display: "block",
-          margin: "0 -1.5rem",
-          padding: "10px",
-          textAlign: "center"
-        }}
-      >
-        <a
-          href="https://mbta.com/app-store?pt=117998862&ct=Dotcom%20Banners&mt=8&referrer=utm_source%3Ddotcom%26utm_campaign%3Dbanners"
-          rel="noreferrer"
-          style={{ color: "black", display: "block" }}
-          target="_blank"
-        >
-          Download <strong>MBTA Go</strong> to track your trip &#x2192;
-        </a>
-      </div>
       <div className="u-highlight-gray u-m-n24">
         <div className="u-m-24">
           <div className="d-flex u-pt-10">

--- a/integration/e2e_tests/mobile-app-banner.spec.js
+++ b/integration/e2e_tests/mobile-app-banner.spec.js
@@ -1,0 +1,69 @@
+const { expect, test } = require("@playwright/test");
+
+const baseURL = process.env.HOST
+  ? `https://${process.env.HOST}`
+  : "http://localhost:4001";
+
+test.use({ baseURL, headless: true, screenshot: { mode: "only-on-failure" }, video: "off" });
+
+/**
+ * One-off test suite to verify the mobile app banner is configured to show where it's supposed to.
+ * 
+ * Defaults to running against localhost, but can run against any site using
+ * the HOST environment variable, e.g.
+ * 
+ * HOST=dev.mbtace.com npx playwright test mobile-app-banner
+ */
+
+[
+  ["subway", "Blue", ["/line", "/alerts"]],
+  ["bus", "111", ["/line", "/alerts"]],
+  ["commuter rail", "CR-Fitchburg", ["/timetable", "/line", "/alerts"]],
+].forEach(modeTest => {
+  const [modeName, routeId, tabs] = modeTest;
+  test.describe(`${modeName} schedule`, () => {
+    tabs.forEach(tabPath => {
+      test(tabPath, async ({ page, isMobile }) => {
+        await page.goto(`/schedules/${routeId}${tabPath}`);
+        await checkBannerVisibility(page, isMobile);
+        if (tabPath == "/line") {
+          const scheduleFinderLinkName = modeName == "subway" ? "View upcoming departures" : "View schedule";
+          await page.getByRole("button", { name: scheduleFinderLinkName }).first().click();
+          const modal = await page.getByRole("dialog");
+          await checkBannerVisibility(modal, isMobile);
+        }
+      });
+    });
+  });
+});
+
+test("does not show on schedule page (ferry)", async ({ page }) => {
+  await page.goto("/schedules/Boat-F1");
+  await bannerIsNotVisible(page);
+});
+test("shows in Transit Near Me", async ({ page, isMobile }) => {
+  await page.goto("/transit-near-me");
+  await checkBannerVisibility(page, isMobile);
+});
+test("shows on stop pages", async ({ page, isMobile }) => {
+  await page.goto("/stops/1");
+  await checkBannerVisibility(page, isMobile);
+});
+
+async function bannerIsVisible(locator) {
+  const banner = locator.locator("#mobile-app-banner");
+  await expect(banner).toBeVisible();
+}
+
+async function bannerIsNotVisible(locator) {
+  const banner = locator.locator("#mobile-app-banner");
+  await expect(banner).toBeHidden();
+}
+
+async function checkBannerVisibility(locator, isMobile) {
+  if (isMobile) {
+    await bannerIsVisible(locator);
+  } else {
+    await bannerIsNotVisible(locator);
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -27,15 +27,15 @@ module.exports = defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-    /* We'll eventually want other browsers and devices, but for now, we'll just use Chrome
     {
       name: 'Mobile Chrome',
-      use: { ...devices['Pixel 5'] },
+      testMatch: /mobile-app-banner.spec.js/,
+      use: { ...devices['Pixel 7'] },
     },
     {
       name: 'Mobile Safari',
-      use: { ...devices['iPhone 12'] },
-    },
-    */
+      testMatch: /mobile-app-banner.spec.js/,
+      use: { ...devices['iPhone SE'] },
+    }
   ]
 });


### PR DESCRIPTION
- moves rendering the banner into the `<ScheduleModalContent />` component so it could potentially render in any mode (instead of just subway)
- instead of hard-coding the banner in the React component, copies it from the DOM (thus leveraging the logic used in `js/mobile-app-banner.js`). Thereby, if the banner isn't on the schedule page anyway, it doesn't get copied and rendered in the schedule finder, either.
- adds a new Playwright test! This tests against our expectations, and also runs the tests in triplicate - on desktop, iPhone, and Android - so we can verify presence on mobile and absence on desktop.