### PR TITLE
feat: Allow schedule finder to load (short) trips for terminals

### DIFF
--- a/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -180,22 +180,21 @@ const StopCard = ({
           )}
         </div>
 
-        {!isEnd &&
-          (stopTree
-            ? hasUpcomingDeparturesIfSubway(stopTree, stopId, liveData)
-            : true) && (
-            <footer className="m-schedule-diagram__footer">
-              <button
-                className="btn btn-link"
-                type="button"
-                onClick={() => onClick(routeStop)}
-              >
-                {schedulesButtonLabel(
-                  stopTree ? routeForStop(stopTree, stopId) : routeStop.route
-                )}
-              </button>
-            </footer>
-          )}
+        {(stopTree
+          ? hasUpcomingDeparturesIfSubway(stopTree, stopId, liveData)
+          : true) && (
+          <footer className="m-schedule-diagram__footer">
+            <button
+              className="btn btn-link"
+              type="button"
+              onClick={() => onClick(routeStop)}
+            >
+              {schedulesButtonLabel(
+                stopTree ? routeForStop(stopTree, stopId) : routeStop.route
+              )}
+            </button>
+          </footer>
+        )}
       </section>
     </li>
   );

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -445,6 +445,11 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                 <div className=\\"m-schedule-diagram__stop-details\\">
                                   <div className=\\"m-schedule-diagram__connections\\" />
                                 </div>
+                                <footer className=\\"m-schedule-diagram__footer\\">
+                                  <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+                                    View schedule
+                                  </button>
+                                </footer>
                               </section>
                             </li>
                           </StopCard>
@@ -502,6 +507,11 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                     <div className=\\"m-schedule-diagram__stop-details\\">
                                       <div className=\\"m-schedule-diagram__connections\\" />
                                     </div>
+                                    <footer className=\\"m-schedule-diagram__footer\\">
+                                      <button className=\\"btn btn-link\\" type=\\"button\\" onClick={[Function: onClick]}>
+                                        View schedule
+                                      </button>
+                                    </footer>
                                   </section>
                                 </li>
                               </StopCard>

--- a/assets/ts/schedule/components/schedule-finder/OriginListItem.tsx
+++ b/assets/ts/schedule/components/schedule-finder/OriginListItem.tsx
@@ -8,16 +8,14 @@ interface OriginListItemProps {
   changeOrigin: Function;
   stop: SimpleStop;
   selectedOrigin: SelectedOrigin;
-  lastStop: SimpleStop;
 }
 
 const OriginListItem = ({
   changeOrigin,
   stop,
-  selectedOrigin,
-  lastStop
+  selectedOrigin
 }: OriginListItemProps): ReactElement<HTMLElement> => {
-  const isDisabled = stop.is_closed || stop.id === lastStop.id;
+  const isDisabled = stop.is_closed;
   const handleClick = (): void => {
     if (isDisabled) return;
     changeOrigin(stop.id);

--- a/assets/ts/schedule/components/schedule-finder/OriginModalContent.tsx
+++ b/assets/ts/schedule/components/schedule-finder/OriginModalContent.tsx
@@ -52,7 +52,6 @@ const OriginModalContent = ({
             stop={stop}
             changeOrigin={handleChangeOrigin}
             selectedOrigin={selectedOrigin}
-            lastStop={stops[stops.length - 1]}
           />
         ))}
       </div>

--- a/assets/ts/schedule/components/schedule-finder/__tests__/OriginListItemTest.tsx
+++ b/assets/ts/schedule/components/schedule-finder/__tests__/OriginListItemTest.tsx
@@ -45,7 +45,6 @@ describe("<OriginListItem />", () => {
     renderWithProvider(
       <OriginListItem
         stop={stopWithZone}
-        lastStop={lastStop}
         selectedOrigin="456"
         changeOrigin={() => {}}
       />
@@ -57,25 +56,10 @@ describe("<OriginListItem />", () => {
     ).toBeTruthy();
   });
 
-  test("disabled for last stop", () => {
-    renderWithProvider(
-      <OriginListItem
-        stop={lastStop}
-        lastStop={lastStop}
-        selectedOrigin="456"
-        changeOrigin={() => {}}
-      />
-    );
-
-    const btn = screen.getByRole("button");
-    expect(btn.classList.contains("disabled")).toBeTruthy();
-  });
-
   test("disabled for closed stop", () => {
     renderWithProvider(
       <OriginListItem
         stop={closedStop}
-        lastStop={lastStop}
         selectedOrigin="456"
         changeOrigin={() => {}}
       />
@@ -89,7 +73,6 @@ describe("<OriginListItem />", () => {
     renderWithProvider(
       <OriginListItem
         stop={stopWithZone}
-        lastStop={lastStop}
         selectedOrigin="741"
         changeOrigin={() => {}}
       />
@@ -102,7 +85,6 @@ describe("<OriginListItem />", () => {
     renderWithProvider(
       <OriginListItem
         stop={stopWithZone}
-        lastStop={lastStop}
         selectedOrigin="456"
         changeOrigin={spy}
       />
@@ -118,7 +100,6 @@ describe("<OriginListItem />", () => {
     renderWithProvider(
       <OriginListItem
         stop={stopWithZone}
-        lastStop={lastStop}
         selectedOrigin="456"
         changeOrigin={spy}
       />

--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/TripDetails.tsx
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/TripDetails.tsx
@@ -10,6 +10,9 @@ interface Props {
   showFare: boolean;
 }
 
+const tripStopCountWords = (stopCount: number): string =>
+  stopCount === 1 ? "1 stop" : `${stopCount} stops`;
+
 const TripSummary = ({
   tripInfo,
   showFare
@@ -44,9 +47,6 @@ const TripSummary = ({
     </td>
   </tr>
 );
-
-const tripStopCountWords = (stopCount: number): string =>
-  stopCount === 1 ? "1 stop" : `${stopCount} stops`;
 
 const allTimesHaveSchedule = (tripInfo: TripInfo): boolean =>
   tripInfo.times.every(time => !!time.schedule);

--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/TripDetails.tsx
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/TripDetails.tsx
@@ -23,7 +23,8 @@ const TripSummary = ({
         <span className="trip-details-table__title u-small-caps font-bold">
           Trip length
         </span>
-        {tripInfo.times.length} stops, {tripInfo.duration} minutes total
+        {tripStopCountWords(tripInfo.times.length)}, {tripInfo.duration} minutes
+        total
       </div>
       {showFare && (
         <div>
@@ -43,6 +44,9 @@ const TripSummary = ({
     </td>
   </tr>
 );
+
+const tripStopCountWords = (stopCount: number): string =>
+  stopCount === 1 ? "1 stop" : `${stopCount} stops`;
 
 const allTimesHaveSchedule = (tripInfo: TripInfo): boolean =>
   tripInfo.times.every(time => !!time.schedule);

--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/__tests__/__snapshots__/TripDetailsTest.tsx.snap
@@ -18,8 +18,8 @@ exports[`TripDetails displays both scheduled and predicted times for CR if there
           >
             Trip length
           </span>
-          7
-           stops, 
+          7 stops
+          , 
           56
            minutes total
         </div>
@@ -229,8 +229,8 @@ exports[`TripDetails it renders trip details for a CR trip 1`] = `
           >
             Trip length
           </span>
-          10
-           stops, 
+          10 stops
+          , 
           69
            minutes total
         </div>
@@ -524,8 +524,8 @@ exports[`TripDetails it renders trip details for a bus trip 1`] = `
           >
             Trip length
           </span>
-          11
-           stops, 
+          11 stops
+          , 
           14
            minutes total
         </div>
@@ -767,8 +767,8 @@ exports[`TripDetails uses a predicted departure time in preference to a schedule
           >
             Trip length
           </span>
-          39
-           stops, 
+          39 stops
+          , 
           32
            minutes total
         </div>

--- a/lib/trip_info.ex
+++ b/lib/trip_info.ex
@@ -88,7 +88,7 @@ defmodule TripInfo do
   end
 
   defp do_from_list(
-         [time, _ | _] = times,
+         [time | _] = times,
          [origin_id | _],
          destination_id,
          vehicle_stop_name,

--- a/test/dotcom_web/trip_info_test.exs
+++ b/test/dotcom_web/trip_info_test.exs
@@ -165,8 +165,8 @@ defmodule TripInfoTest do
                Enum.drop_while(@time_list, &(PredictedSchedule.stop(&1).id != "place-north"))
     end
 
-    test "if there are not enough times, returns an error" do
-      actual = @time_list |> Enum.take(1) |> from_list
+    test "if there are no times, returns an error" do
+      actual = from_list([])
       assert {:error, _} = actual
     end
 


### PR DESCRIPTION
### Before

![Screenshot 2025-03-31 at 4 37 51 PM](https://github.com/user-attachments/assets/6fdae879-7a2e-4d17-bfdc-a8d3f4e7572b)

(*Context: Route 39, Outbound. Note the lack of a `View Schedule` link for Forest Hills, the terminal station for this variant.*)

![Screenshot 2025-03-31 at 4 40 19 PM](https://github.com/user-attachments/assets/4061baae-9e4a-4bf4-acb4-353e561663bd)

(*Before-ish: This is why the `View Schedule` link is suppressed - expanding the trip produces an error rather than a table.*)

### After

![Screenshot 2025-03-31 at 4 41 36 PM](https://github.com/user-attachments/assets/26d8e859-d1c5-4d93-aef6-ecda5e600058)


![Screenshot 2025-03-31 at 5 14 26 PM](https://github.com/user-attachments/assets/a87dc4aa-bf38-497e-8fec-4d5354a05cf6)


---

- This doesn't change the display for subway pages - only bus and commuter rail.
- No ticket explicitly, but it's closely related to (and blocking) https://github.com/mbta/dotcom/pull/2454.

---

Blocking:
- https://github.com/mbta/dotcom/pull/2454