### PR TITLE
refactor(autocomplete): consistent URL handling for source.getItemUrl

### DIFF
--- a/assets/js/mobile-app-banner.js
+++ b/assets/js/mobile-app-banner.js
@@ -15,10 +15,7 @@ const isNotFerry = url => {
 };
 
 const isSchedulePage = url => {
-  return (
-    isNotFerry(url) &&
-    /\/schedules\/[\w.-]+\//.test(url)
-  );
+  return isNotFerry(url) && /\/schedules\/[\w.-]+\//.test(url);
 };
 
 const isStopPage = url => {
@@ -34,7 +31,7 @@ const isIncludedPage = url => {
     return fn(url);
   });
 };
-  
+
 /**
  * If the user is on a mobile device,
  * and the page is one of the pages we want to show the banner on,
@@ -50,10 +47,12 @@ export default function mobileAppBanner() {
     const mobileAppBanner = document.querySelector("#mobile-app-banner");
 
     if (mobileAppBanner) {
-      const text = isTransitNearMe(url) ? "find transit near you" : "track your trip";
+      const text = isTransitNearMe(url)
+        ? "find transit near you"
+        : "track your trip";
 
       mobileAppBanner.querySelector("span").textContent = text;
       mobileAppBanner.style.display = "block";
     }
   }
-};
+}

--- a/assets/ts/ui/autocomplete/sources.ts
+++ b/assets/ts/ui/autocomplete/sources.ts
@@ -1,13 +1,13 @@
 import { AutocompleteSource } from "@algolia/autocomplete-js";
 import { SearchResponse } from "@algolia/client-search";
-import { LocationItem, PopularItem, AutocompleteItem } from "./__autocomplete";
-import { UrlType, WithUrls, itemWithUrl } from "./helpers";
-import AlgoliaItemTemplate from "./templates/algolia";
-import { templateWithLink } from "./templates/helpers";
-import LocationItemTemplate from "./templates/location";
-import PopularItemTemplate from "./templates/popular";
 import geolocationPromise from "../../../js/geolocation-promise";
 import { fetchJsonOrThrow } from "../../helpers/fetch-json";
+import { AutocompleteItem, LocationItem, PopularItem } from "./__autocomplete";
+import { UrlType, WithUrls, itemWithUrl } from "./helpers";
+import AlgoliaItemTemplate from "./templates/algolia";
+import { itemURL, templateWithLink } from "./templates/helpers";
+import LocationItemTemplate from "./templates/location";
+import PopularItemTemplate from "./templates/popular";
 
 /**
  * Renders a simple UI for requesting the browser's location.
@@ -184,9 +184,6 @@ export const algoliaSource = (
       .catch(() => []);
   },
   ...(withLink && {
-    getItemUrl: ({ item }) => {
-      const { url, _content_url } = item as AutocompleteItem;
-      return (url || _content_url) as string;
-    }
+    getItemUrl: ({ item }) => itemURL(item)
   })
 });

--- a/assets/ts/ui/autocomplete/templates/algolia.tsx
+++ b/assets/ts/ui/autocomplete/templates/algolia.tsx
@@ -1,20 +1,20 @@
 /* eslint-disable no-underscore-dangle */
-import React from "react";
-import { get, uniqueId } from "lodash";
 import { SourceTemplates, VNode } from "@algolia/autocomplete-js";
-import { AutocompleteItem } from "../__autocomplete";
-import {
-  getTitleAttribute,
-  isContentItem,
-  isRouteItem,
-  isSearchResultItem,
-  isStopItem
-} from "../helpers";
+import { get, uniqueId } from "lodash";
+import React from "react";
 import {
   contentIcon,
   getFeatureIcons,
   getIcon
 } from "../../../../js/algolia-result";
+import { AutocompleteItem } from "../__autocomplete";
+import {
+  getTitleAttribute,
+  isContentItem,
+  isRouteItem,
+  isStopItem
+} from "../helpers";
+import { itemURL } from "./helpers";
 
 // parse this from a stop's address until we can get it as a stop field
 const stateAbbr = (address: string): string =>
@@ -26,16 +26,7 @@ export function LinkForItem(props: {
   children: string | VNode | VNode[];
 }): React.ReactElement {
   const { item, query, children } = props;
-
-  let url = isContentItem(item) ? item._content_url : item.url;
-
-  // Search result items are a subset of content items that point to a different URL
-  if (isSearchResultItem(item)) {
-    url = item._search_result_url.replace(/(internal|entity):/g, "/");
-  }
-
-  // Strip extra forward slashes as they break relative links
-  url = url.replace(/\/\//g, "/");
+  const url = itemURL(item);
 
   // Special case: When the matching text isn't part of the page title, help the
   // user locate the matching text by linking directly to / scrolling to the

--- a/assets/ts/ui/autocomplete/templates/helpers.tsx
+++ b/assets/ts/ui/autocomplete/templates/helpers.tsx
@@ -1,13 +1,27 @@
 /* eslint-disable import/prefer-default-export */
-
+/* eslint-disable no-underscore-dangle */
 import { SourceTemplates } from "@algolia/autocomplete-js";
 import React from "react";
 import { AutocompleteItem } from "../__autocomplete";
-import { isAlgoliaItem } from "../helpers";
+import { isAlgoliaItem, isContentItem, isSearchResultItem } from "../helpers";
 import { LinkForItem } from "./algolia";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ItemTemplate = SourceTemplates<any>["item"];
+
+export const itemURL = (item: AutocompleteItem): string => {
+  let url = isContentItem(item) ? item._content_url : item.url;
+
+  // Search result items are a subset of content items that point to a different URL
+  if (isSearchResultItem(item)) {
+    url = item._search_result_url.replace(/(internal|entity):/g, "/");
+  }
+
+  // Strip extra forward slashes as they break relative links
+  url = url.replace(/\/\//g, "/");
+
+  return url;
+};
 
 export const templateWithLink = (
   childTemplate: ItemTemplate


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Search results takes you to node instead of actual page when you hit enter](https://app.asana.com/0/555089885850811/1207505625020797/f)

We already have good logic for figuring out the URL you go to when you click the result. Now this PR applies this same logic to the source's `getItemUrl` property, which is what autocomplete.js uses to identify the URL that _keyboard navigation_ takes you to.