### PR TITLE
feat: Add logging to debug iOS app store redirect

### DIFF
--- a/lib/dotcom_web/controllers/app_store_controller.ex
+++ b/lib/dotcom_web/controllers/app_store_controller.ex
@@ -5,6 +5,8 @@ defmodule DotcomWeb.AppStoreController do
   """
   use DotcomWeb, :controller
 
+  require Logger
+
   @android_store_base_url "https://play.google.com/store/apps/details?id=com.mbta.tid.mbta_app"
   @ios_store_base_url "https://apps.apple.com/app/apple-store/id6472726821?"
   @default_project_page "/goapp"
@@ -18,7 +20,7 @@ defmodule DotcomWeb.AppStoreController do
   defp redirect_to_app_store(conn, params) do
     cond do
       Browser.ios?(conn) ->
-        redirect(conn, external: campaign_url(@ios_store_base_url, params))
+        redirect(conn, external: log_and_return(campaign_url(@ios_store_base_url, params)))
 
       Browser.android?(conn) ->
         redirect(conn, external: campaign_url(@android_store_base_url, params))
@@ -35,5 +37,10 @@ defmodule DotcomWeb.AppStoreController do
     |> URI.parse()
     |> URI.append_query(encoded_params)
     |> URI.to_string()
+  end
+
+  defp log_and_return(url) do
+    Logger.info("app-store redirect", %{url: url})
+    url
   end
 end


### PR DESCRIPTION
#### Summary of changes

#2437 added this redirect logic for sending people to the right app store for their current platform. We've now added a marketing campaign using this redirect, and it's working fine on Android, but on iOS, we're not seeing any metrics on their dashboards which are registered as coming through the campaign. This logs the redirect URL that we're generating for iOS, so that we can verify that we're sending people to the right place.

I don't have dotcom set up locally, and trying to run `mix phx.server` gives me a hackney error, so I haven't tested this myself, if a dotcom engineer could help me out with that I'd appreciate it. 🙏 

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [x] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.
