### PR TITLE
fix: show paragraphs on events

### DIFF
--- a/lib/dotcom_web/templates/event/show.html.eex
+++ b/lib/dotcom_web/templates/event/show.html.eex
@@ -22,6 +22,9 @@
           <div class="m-event-section">
             <h2 class="u-mt-0">Event Description</h2>
             <%= Dotcom.ContentRewriter.rewrite(@event.body, @conn) %>
+            <%= for paragraph <- @event.paragraphs do %>
+              <%= DotcomWeb.CMS.ParagraphView.render_paragraph(paragraph, @conn) %>
+            <% end %>
             <%= if has_related_files do %>
               <h3>Related Files</h3>
               <%= if @event.agenda_file do %>


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Before 4/17, Allow Vimeo embeds to be full width on event pages](https://app.asana.com/0/555089885850811/1209459897950318/f)

Per discussion described in the ticket, we can already add a code embed to events... and now with this PR we can actually show them too.

Now here's the thing, I think we had a flawed bit of Vimeo embed code. This one didn't work:
```html
<div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://vimeo.com/event/4867722/embed" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;"></iframe></div>
```

But this one did (while super similar, there's a difference!):

```html
<div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://vimeo.com/event/4867722/embed" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media" style="position:absolute;top:0;left:0;width:100%;height:100%;"></iframe></div>
```

I came upon the working version by using Benji's oEmbed suggestion -- going to `https://vimeo.com/api/oembed.json?url=https://vimeo.com/event/4867722/` gave me the better embed code.