### PR TITLE
fix: Format long trip durations with hr/min instead of just min

### DIFF
--- a/lib/dotcom_web/components/trip_planner/itinerary_summary.ex
+++ b/lib/dotcom_web/components/trip_planner/itinerary_summary.ex
@@ -15,7 +15,7 @@ defmodule DotcomWeb.Components.TripPlanner.ItinerarySummary do
           {Util.kitchen_downcase_time(@summary.start)} - {Util.kitchen_downcase_time(@summary.stop)}
         </div>
         <div>
-          {@summary.duration} min
+          {Util.format_minutes_duration(@summary.duration)}
         </div>
       </div>
       <div class="flex flex-wrap gap-1 items-center content-center mb-3">

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -256,6 +256,29 @@ defmodule Util do
   end
 
   @doc """
+
+  Formats a number of minutes as a string. If the number of minutes is
+  greater than 60, then split it out into hours and minutes
+
+  ## Examples
+      iex> Util.format_minutes_duration(59)
+      "59 min"
+
+      iex> Util.format_minutes_duration(61)
+      "1 hr 1 min"
+  """
+  @spec format_minutes_duration(integer) :: String.t()
+  def format_minutes_duration(duration) do
+    case duration do
+      duration when duration >= 60 ->
+        "#{div(duration, 60)} hr #{rem(duration, 60)} min"
+
+      _ ->
+        "#{duration} min"
+    end
+  end
+
+  @doc """
   Converts an `{:error, _}` tuple to a default value.
 
   ## Examples


### PR DESCRIPTION
## Before

![Screenshot 2025-04-03 at 6 22 06 PM](https://github.com/user-attachments/assets/4ada665f-113e-49da-a965-d5de0aaeec7d)

## After

![Screenshot 2025-04-03 at 6 21 46 PM](https://github.com/user-attachments/assets/b6851791-1646-4cbe-9d1e-de0960c3a7f4)


---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | TP | Reformat trip time for times > 1 hour to show hr/min](https://app.asana.com/0/385363666817452/1209391396072991/f)

