### PR TITLE
fix: Shrink font sizes on accordions

### DIFF
--- a/lib/dotcom_web/templates/partial/_accordion_ui.html.eex
+++ b/lib/dotcom_web/templates/partial/_accordion_ui.html.eex
@@ -4,7 +4,7 @@
   <%= for section <- @sections do %>
     <div class="panel">
       <div class="c-accordion-ui__heading<%= if assigns[:sticky] do %> fixedsticky sticky-top<% end %>" role="heading" aria-level="3">
-        <button class="c-accordion-ui__trigger font-headings text-lg collapsed"
+        <button class="c-accordion-ui__trigger font-headings collapsed"
             data-target="#<%= section.prefix %>-section"
             aria-expanded="false"
             aria-controls="<%= section.prefix %>-section"

--- a/lib/dotcom_web/templates/partial/_accordion_ui_no_bootstrap.html.eex
+++ b/lib/dotcom_web/templates/partial/_accordion_ui_no_bootstrap.html.eex
@@ -4,7 +4,7 @@
   <%= for section <- @sections do %>
     <% expanded = Map.get(section, :expanded?, false) |> to_string() %>
     <h3 class="c-accordion-ui__heading<%= if assigns[:sticky] do %> fixedsticky sticky-top<% end %>" data-accordion-expanded="<%= expanded %>">
-      <button class="c-accordion-ui__trigger c-accordion-ui__title font-headings text-lg"
+      <button class="c-accordion-ui__trigger c-accordion-ui__title font-headings"
         id="<%= section.prefix %>-title"
         aria-expanded="<%= expanded %>"
         aria-controls="<%= section.prefix %>-section">


### PR DESCRIPTION
This has effects in two places that I was able to find:

(In both screenshots below, **before** is on the left, and **after** is on the right)

### Holiday Service Schedules Page
![Screenshot 2025-04-03 at 6 25 10 PM](https://github.com/user-attachments/assets/6841fbf5-8e24-49b5-9bde-905101464ee8)

### Commuter Rail Icon Legend

![Screenshot 2025-04-03 at 6 25 58 PM](https://github.com/user-attachments/assets/d8b7ce28-af3e-4ba0-9487-b0d7acae9243)

(The font size is the change. The fact that seat availability is missing is a data discrepancy between local and prod.)

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Style issues | Text size](https://app.asana.com/0/555089885850811/1209162421069228/f)

(This only addresses the second issue - text size getting larger on accordions)

