### PR TITLE
fix: Set headers to `text-xl` instead of `text-2xl`

### DIFF
--- a/assets/ts/components/RouteCardHeader.tsx
+++ b/assets/ts/components/RouteCardHeader.tsx
@@ -13,7 +13,7 @@ const RouteCardHeader = ({
   alerts: Alert[];
 }): ReactElement<HTMLElement> => (
   <div
-    className={`c-link-block font-heading font-bold mt-11 mb-3 text-2xl m-tnm-sidebar__route-name ${routeBgClass(
+    className={`c-link-block font-heading font-bold mt-11 mb-3 text-xl m-tnm-sidebar__route-name ${routeBgClass(
       route
     )}`}
   >

--- a/assets/ts/stop/components/amenities/AccessibilityAmenityCard.tsx
+++ b/assets/ts/stop/components/amenities/AccessibilityAmenityCard.tsx
@@ -23,7 +23,7 @@ const accessibilityNames: {
 
 const StationFeatures = (features: AccessibilityType[]): JSX.Element => (
   <>
-    <h2 className="text-2xl">Station Features</h2>
+    <h2 className="text-xl">Station Features</h2>
     {features.length > 0 ? (
       <ul>
         {features.map(
@@ -44,7 +44,7 @@ const StationFeatures = (features: AccessibilityType[]): JSX.Element => (
 
 const StopFeatures = (
   <>
-    <h2 className="text-2xl">Bus Features</h2>
+    <h2 className="text-xl">Bus Features</h2>
     <ul>
       <li>Buses that can be lowered for easier boarding and exiting</li>
       <li>Onboard ramps at the front door of each bus</li>
@@ -100,7 +100,7 @@ const AccessibilityAmenityCard = ({
               url="/customer-support"
             />
             {AccessibilityLink(isStation)}
-            <h2 className="text-2xl">Accessibility Resources</h2>
+            <h2 className="text-xl">Accessibility Resources</h2>
             <ul>
               <li>
                 <a href="/accessibility/trip-planning">

--- a/assets/ts/stop/components/amenities/BikeStorageAmenityCard.tsx
+++ b/assets/ts/stop/components/amenities/BikeStorageAmenityCard.tsx
@@ -60,7 +60,7 @@ const BikeStorageAmenityCard = ({
         hasBikeStorage && (
           <AmenityModal headerText={`Bike Storage at ${stopName}`}>
             {hasBikeFacilityAlert && <Alerts alerts={alerts} />}
-            <h2 className="text-2xl">Facility Information</h2>
+            <h2 className="text-xl">Facility Information</h2>
             {hasPedalAndPark && (
               <AmenityImage
                 className="u-mt-8 u-mb-1"

--- a/assets/ts/stop/components/amenities/FareSalesAmenityCard.tsx
+++ b/assets/ts/stop/components/amenities/FareSalesAmenityCard.tsx
@@ -12,7 +12,7 @@ import Loading from "../../../components/Loading";
 
 const FareRetailLocations = (stop: Stop): JSX.Element => (
   <>
-    <h2 className="text-2xl u-mb-8">Fare Retail Locations</h2>
+    <h2 className="text-xl u-mb-8">Fare Retail Locations</h2>
     <p className="u-mt-0">
       This stop does not have fare vending machines, but you can purchase fares
       at a{" "}
@@ -28,7 +28,7 @@ const FareRetailLocations = (stop: Stop): JSX.Element => (
 
 const FareVendingMachines = (): JSX.Element => (
   <>
-    <h2 className="text-2xl u-mb-8">Fare Vending Machines</h2>
+    <h2 className="text-xl u-mb-8">Fare Vending Machines</h2>
     <AmenityImage
       src="https://cdn.mbta.com/sites/default/files/styles/max_2600x2600/public/media/2021-11/Fare-Transformation-new-fvms-Nov2021.jpg"
       altText="MBTA fare vending machines"
@@ -52,7 +52,7 @@ const FareVendingMachines = (): JSX.Element => (
 
 const fareTable = (tableData: [string, string][]): React.ReactElement => (
   <>
-    <h2 id="fare-types" className="text-2xl">
+    <h2 id="fare-types" className="text-xl">
       Fare Types
     </h2>
     <table aria-labelledby="fare-types" className="fare-sales-table">

--- a/assets/ts/stop/components/amenities/ParkingAmenityCard.tsx
+++ b/assets/ts/stop/components/amenities/ParkingAmenityCard.tsx
@@ -84,7 +84,7 @@ const getModalContent = (
 
             return (
               <div key={park.name}>
-                <h2 className="u-mt-6">{park.name}</h2>
+                <h2 className="text-xl u-mt-6">{park.name}</h2>
                 <h3>Parking Rates</h3>
                 <ul>
                   {park.payment?.daily_rate && (

--- a/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+++ b/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
@@ -61,7 +61,7 @@
         routes: Map.get(assigns, :recently_visited, []),
         alerts: @alerts,
         date_time: @date_time,
-        header_class: "text-2xl"
+        header_class: "text-xl"
       )}
       <%= unless Enum.empty?(Map.get(assigns, :recently_visited, [])) do %>
         <hr />

--- a/lib/dotcom_web/templates/project/updates.html.eex
+++ b/lib/dotcom_web/templates/project/updates.html.eex
@@ -9,7 +9,7 @@
       <div class="c-cms__body">
         <%= for update <- @updates do
           text_content = [
-                content_tag(:h2, update.title, class: "text-2xl m-project-updates__title"),
+                content_tag(:h2, update.title, class: "text-xl m-project-updates__title"),
                 content_tag(:p, Timex.format!(update.date, "{Mfull} {D}, {YYYY}"), class: "text-lg font-heading font-bold mt-11 mb-3")
               ]
 


### PR DESCRIPTION
(Note: In all screenshots below, **Before** is on the left, and **After** is on the right)

### Homepage `Recently Visited Schedules`

![Screenshot 2025-04-03 at 6 45 59 PM](https://github.com/user-attachments/assets/ee4803f0-20b9-4a57-9e38-6b1caf2ada33)

### Station Info Cards on the Stop/Station Page
[Prod](https://www.mbta.com/stops/place-sstat)
[Local](http://localhost:4001/stops/place-sstat)

![Screenshot 2025-04-03 at 6 48 50 PM](https://github.com/user-attachments/assets/eb6515e5-855e-46f1-8f55-6b28a41341b7)
![Screenshot 2025-04-03 at 6 51 07 PM](https://github.com/user-attachments/assets/a17ea359-8567-4fcb-a3f3-6053de24b2d5)
![Screenshot 2025-04-03 at 6 52 02 PM](https://github.com/user-attachments/assets/7cd3f3a4-3ee5-4d7e-a8e1-f99f52abb273)

### Accessibility Improvements Updates Page
[Prod](https://www.mbta.com/projects/accessibility-improvements/updates)
[Local](http://localhost:4001/projects/accessibility-improvements/updates)

![Screenshot 2025-04-03 at 6 54 54 PM](https://github.com/user-attachments/assets/98cef6ef-efab-4751-af34-fc080b18dad0)

### Transit Near Me Route Pills

[Prod](https://www.mbta.com/transit-near-me?address=1+Bow+Market+Way&longitude=-71.098132380796&latitude=42.381266906104)
[Local](http://localhost:4001/transit-near-me?address=1+Bow+Market+Way&longitude=-71.098132380796&latitude=42.381266906104)

![Screenshot 2025-04-03 at 7 00 57 PM](https://github.com/user-attachments/assets/56e96088-c30a-46ad-8461-0dc0b42cfcdc)


---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Style issues | Text size](https://app.asana.com/0/555089885850811/1209162421069228/f)

(This only addresses the first issue - accordion text-size is handled in https://github.com/mbta/dotcom/pull/2475)