### PR TITLE
fix: don't set default fontWeight on links

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -95,9 +95,6 @@ module.exports = {
     ),
     plugin(({ addBase, theme }) =>
       addBase({
-        a: {
-          fontWeight: theme("fontWeight.medium")
-        },
         "h1, h2, h3, h4, h5, h6": {
           fontFamily: theme("fontFamily.heading"),
           fontWeight: theme("fontWeight.bold"),


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Style issues | Link bolding](https://app.asana.com/0/555089885850811/1209237709550402/f)

This reverts the Tailwind-related change.

I feel like this might unbold some links that we might want more weight on, but I figure we can find and fix those on a case-by-case basis.