### PR TITLE
feat: Add new alert types on the stop page

### DIFF
--- a/assets/ts/stop/__tests__/StopPageTest.tsx
+++ b/assets/ts/stop/__tests__/StopPageTest.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor, within } from "@testing-library/dom";
 import { act, cleanup, RenderResult } from "@testing-library/react";
 import StopPage from "../components/StopPage";
 import * as useStop from "../../hooks/useStop";
-import { InformedEntitySet, Alert, Route } from "../../__v3api";
+import { InformedEntitySet, Alert } from "../../__v3api";
 import * as useRoute from "../../hooks/useRoute";
 import {
   TEST_LOADER_VALUE,

--- a/assets/ts/stop/__tests__/StopPageTest.tsx
+++ b/assets/ts/stop/__tests__/StopPageTest.tsx
@@ -14,7 +14,7 @@ import {
 } from "./helpers";
 import * as useSchedules from "../../hooks/useSchedules";
 import * as useAlerts from "../../hooks/useAlerts";
-import { add, formatISO } from "date-fns";
+import { add, formatISO, sub } from "date-fns";
 import { FetchStatus } from "../../helpers/use-fetch";
 import * as usePredictionsChannel from "../../hooks/usePredictionsChannel";
 import { PredictionWithTimestamp } from "../../models/predictions";
@@ -172,8 +172,8 @@ describe("StopPage", () => {
         active_period: [[dateFormatter(now), dateFormatter(future1)]],
         lifecycle: "new",
         id: "000013",
-        header: "The Elevator Is Closed",
-        effect: "elevator_closure"
+        header: "The Escalator Is Closed",
+        effect: "escalator_closure"
       },
       {
         informed_entity: {
@@ -409,6 +409,58 @@ describe("StopPage", () => {
     renderWithAct(<StopPage stopId="Test 1" />);
 
     expect(screen.queryByText("Road Is Closed")).toBeNull();
+  });
+
+  it(`should render active elevator closures, but not future or past ones`, async () => {
+    const now = new Date();
+    const future1 = add(now, { days: 1 });
+    const future2 = add(now, { days: 2 });
+    const future3 = add(now, { days: 3 });
+    const past1 = sub(now, { days: 2 });
+    const past2 = sub(now, { days: 1 });
+    const alertsForRoute: Alert[] = [
+      {
+        informed_entity: {
+          entities: [{ route: "Test Route 2" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(now), dateFormatter(future1)]],
+        lifecycle: "new",
+        id: "000001",
+        header: "The elevator is closed",
+        effect: "elevator_closure"
+      },
+      {
+        informed_entity: {
+          entities: [{ route: "Test Route 2" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(future2), dateFormatter(future3)]],
+        lifecycle: "new",
+        id: "000002",
+        header: "The elevator will be closed",
+        effect: "elevator_closure"
+      },
+      {
+        informed_entity: {
+          entities: [{ route: "Test Route 2" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(past1), dateFormatter(past2)]],
+        lifecycle: "new",
+        id: "000003",
+        header: "The elevator was closed",
+        effect: "elevator_closure"
+      }
+    ] as Alert[];
+
+    jest
+      .spyOn(useAlerts, "useAlertsByRoute")
+      .mockReturnValue({ status: FetchStatus.Data, data: alertsForRoute });
+
+    renderWithAct(<StopPage stopId="Test 1" />);
+    await waitFor(() => {
+      expect(screen.getByText(/The elevator is closed/)).toBeInTheDocument();
+      expect(screen.queryByText(/The elevator will be closed/)).toBeNull();
+      expect(screen.queryByText(/The elevator was closed before/)).toBeNull();
+    });
   });
 
   it("should only render alerts with no banner", async () => {

--- a/assets/ts/stop/__tests__/StopPageTest.tsx
+++ b/assets/ts/stop/__tests__/StopPageTest.tsx
@@ -211,7 +211,7 @@ describe("StopPage", () => {
         } as InformedEntitySet,
         active_period: [[dateFormatter(now), dateFormatter(future1)]],
         lifecycle: "new",
-        id: "000009",
+        id: "000007",
         header: "Station Closed",
         effect: "station_closure"
       },
@@ -224,6 +224,56 @@ describe("StopPage", () => {
         id: "000008",
         header: "Stop has Moved",
         effect: "stop_moved"
+      },
+      {
+        informed_entity: {
+          entities: [{ route: "Test Route 2" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(now), dateFormatter(future1)]],
+        lifecycle: "new",
+        id: "000009",
+        header: "Service has Changed",
+        effect: "service_change"
+      },
+      {
+        informed_entity: {
+          entities: [{ route: "Test Route 2" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(now), dateFormatter(future1)]],
+        lifecycle: "new",
+        id: "000010",
+        header: "Station has an Issue",
+        effect: "station_issue"
+      },
+      {
+        informed_entity: {
+          entities: [{ route: "Test Route 2" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(now), dateFormatter(future1)]],
+        lifecycle: "new",
+        id: "000011",
+        header: "Dock is Closed",
+        effect: "dock_closure"
+      },
+      {
+        informed_entity: {
+          entities: [{ route: "Test Route 2" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(now), dateFormatter(future1)]],
+        lifecycle: "new",
+        id: "000012",
+        header: "Dock has an Issue",
+        effect: "dock_issue"
+      },
+      {
+        informed_entity: {
+          entities: [{ route: "Test Route 2" }]
+        } as InformedEntitySet,
+        active_period: [[dateFormatter(now), dateFormatter(future1)]],
+        lifecycle: "new",
+        id: "000013",
+        header: "Shoveling is now Banned",
+        effect: "stop_shoveling"
       }
     ] as Alert[];
 
@@ -238,8 +288,14 @@ describe("StopPage", () => {
       expect(screen.getByText(/Stop has Moved/)).toBeInTheDocument();
       expect(screen.getByText(/Route Suspended/)).toBeInTheDocument();
       expect(screen.getByText(/Station Closed/)).toBeInTheDocument();
+      expect(screen.getByText(/Service has Changed/)).toBeInTheDocument();
+      expect(screen.getByText(/Station has an Issue/)).toBeInTheDocument();
+      expect(screen.getByText(/Dock is Closed/)).toBeInTheDocument();
+      expect(screen.getByText(/Dock has an Issue/)).toBeInTheDocument();
+      expect(screen.getByText(/Shoveling is now Banned/)).toBeInTheDocument();
+
       expect(screen.queryByText(/The Walkway has spillage/)).toBeNull();
-      expect(screen.queryByText(/The Elevator Is Closed/)).toBeNull();
+      expect(screen.queryByText(/The Escalator Is Closed/)).toBeNull();
     });
   });
 

--- a/assets/ts/stop/components/StopPage.tsx
+++ b/assets/ts/stop/components/StopPage.tsx
@@ -44,9 +44,9 @@ const isBannerAlertEffect = ({ effect }: Alert): boolean =>
   ].includes(effect);
 
 const isActiveElevatorAlert = (alert: Alert): boolean =>
-  alert.effect == "elevator_closure" && isInNextXDays(alert, 0);
+  alert.effect === "elevator_closure" && isInNextXDays(alert, 0);
 
-const isBannerAlert = (alert: Alert) =>
+const isBannerAlert = (alert: Alert): boolean =>
   (isBannerAlertEffect(alert) &&
     isInNextXDays(alert, 7) &&
     !isGlobalBannerAlert(alert)) ||

--- a/assets/ts/stop/components/StopPage.tsx
+++ b/assets/ts/stop/components/StopPage.tsx
@@ -43,10 +43,14 @@ const isBannerAlertEffect = ({ effect }: Alert): boolean =>
     "suspension"
   ].includes(effect);
 
+const isActiveElevatorAlert = (alert: Alert): boolean =>
+  alert.effect == "elevator_closure" && isInNextXDays(alert, 0);
+
 const isBannerAlert = (alert: Alert) =>
-  isBannerAlertEffect(alert) &&
-  isInNextXDays(alert, 7) &&
-  !isGlobalBannerAlert(alert);
+  (isBannerAlertEffect(alert) &&
+    isInNextXDays(alert, 7) &&
+    !isGlobalBannerAlert(alert)) ||
+  isActiveElevatorAlert(alert);
 
 const FullwidthErrorMessage = (): JSX.Element => (
   <div className="c-fullscreen-error__container">

--- a/assets/ts/stop/components/StopPage.tsx
+++ b/assets/ts/stop/components/StopPage.tsx
@@ -31,10 +31,15 @@ const isDeparturesAndMapAlert = ({ effect }: Alert): boolean =>
 
 const isBannerAlertEffect = ({ effect }: Alert): boolean =>
   [
+    "dock_closure",
+    "dock_issue",
+    "service_change",
     "shuttle",
     "station_closure",
+    "station_issue",
     "stop_closure",
     "stop_moved",
+    "stop_shoveling",
     "suspension"
   ].includes(effect);
 


### PR DESCRIPTION
New alert banners at the tops of stop pages, such as:




### Dock Issues and Closures

![Screenshot 2025-04-04 at 2 00 26 PM](https://github.com/user-attachments/assets/36f8fc32-8e91-4582-919c-7fc1f9660c36)

*if they're active or will be within the next 7 days*

### Elevator Outages

![Screenshot 2025-04-04 at 2 02 17 PM](https://github.com/user-attachments/assets/399cc10f-2ffa-4569-a353-ae8a0244ff62)

*only if they're active now*

---

... and a few other types.

Notice that none of these new alert types show up in the departures-and-map section - only as banners at the top of the page.

---

This is organized as four (base) commits, and may be easier to review commit-by-commit:
1. [refactor: Tease apart stop-page banner versus departure-and-map alerts](https://github.com/mbta/dotcom/pull/2480/commits/955cc0a122f7b56ef67d3ea663a8c675a3319fb1)
2. [feat: Add new alert types to the top of the stop page (but not the departures section)](https://github.com/mbta/dotcom/pull/2480/commits/365af26594b5107bf4aa2c2028df53274227de92)
3. [feat: Add active elevator alert banners to the stop page](https://github.com/mbta/dotcom/pull/2480/commits/3579861d314ddc353aa6ac43982db11aa3f6aeff)
4. [cleanup: Remove unused import in StopPageTest](https://github.com/mbta/dotcom/pull/2480/commits/123e61593d0720368fe028798b2d3d327dfb7f1c)

---

**Asana Ticket:** [Update list of alerts we show on stop pages as banners](https://app.asana.com/0/555089885850811/1209229373348297/f)
