### PR TITLE
fix: Three more instances of expanding `text-2xl`'s

### DIFF
--- a/lib/dotcom_web/templates/bus_stop_change/index.html.eex
+++ b/lib/dotcom_web/templates/bus_stop_change/index.html.eex
@@ -16,7 +16,7 @@
     <h1>Bus Stop Changes</h1>
     <div class="row">
       <div class="col-lg-3">
-        <div class="font-heading font-bold mt-11 mb-3 text-2xl">Filter by type</div>
+        <div class="font-heading font-bold mt-11 mb-3 text-xl">Filter by type</div>
         <%= time_filter_buttons(@conn) %>
       </div>
       <div class="col-lg-8 col-lg-offset-1" style="padding-top: 1rem;">

--- a/lib/dotcom_web/templates/news_entry/show.html.eex
+++ b/lib/dotcom_web/templates/news_entry/show.html.eex
@@ -24,7 +24,7 @@
         <%= if NewsEntry.contact?(@news_entry) do %>
           <div class="page-section">
             <div class="callout">
-              <h2 class="text-2xl callout-heading">Media Contact Information</h2>
+              <h2 class="text-xl callout-heading">Media Contact Information</h2>
               <p>For all queries and comments, please contact:</p>
 
               <%= if (contact = @news_entry.media_contact) do %>

--- a/lib/dotcom_web/templates/search/index.html.eex
+++ b/lib/dotcom_web/templates/search/index.html.eex
@@ -21,7 +21,7 @@
       <div id="close-facets-modal" class="c-search__close-modal-button">
         CLOSE
       </div>
-      <h2 class="text-2xl c-search__filter-label">
+      <h2 class="text-xl c-search__filter-label">
         Filter by type
       </h2>
       <div id="search-facets"></div>


### PR DESCRIPTION
A few more font-size fixes (follow-up to https://github.com/mbta/dotcom/pull/2477)

(**Before** is on the left. **After** is on the right.)

---

![Screenshot 2025-04-03 at 7 10 29 PM](https://github.com/user-attachments/assets/651bb0aa-8557-47cb-8e77-e3f06434e7ff)
On [news pages](https://www.mbta.com/news/2025-04-01/mbta-offers-increased-service-ma250-celebrations-april-19-20)
---

![Screenshot 2025-04-03 at 7 12 57 PM](https://github.com/user-attachments/assets/211945f3-31cc-44b1-a269-11b34c37a445)
On [bus stop changes pages](https://www.mbta.com/bus-stop-changes?alerts_timeframe=current)
---

![Screenshot 2025-04-03 at 7 29 56 PM](https://github.com/user-attachments/assets/a02911bb-58c6-45bc-ba5a-e9347a987b93)
On the [search page](https://www.mbta.com/search)
---

No ticket, or maybe this is part of [Style issues | Text size](https://app.asana.com/0/555089885850811/1209162421069228/f).