### PR TITLE
fix alignment of icons on Safari

### DIFF
--- a/assets/css/_schedule-page-line-diagram.scss
+++ b/assets/css/_schedule-page-line-diagram.scss
@@ -114,6 +114,7 @@
 }
 
 .m-schedule-diagram__stop-details {
+  align-items: flex-start;
   display: flex;
   flex-wrap: wrap;
 }

--- a/assets/css/_schedule-page-line-diagram.scss
+++ b/assets/css/_schedule-page-line-diagram.scss
@@ -124,10 +124,10 @@
 .m-schedule-diagram__connections {
   @include icon-size-inline($base-spacing);
 
-  a {
-    margin-right: calc(#{$base-spacing} / 4);
-    vertical-align: top;
-  }
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: calc(#{$base-spacing} / 4);
+  line-height: initial;
 
   .m-schedule-diagram__connection {
     vertical-align: middle;


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Style issues | Icons misaligned](https://app.asana.com/0/555089885850811/1209237709550399/f)

This is for the line diagram, where connections show a mix of round icons + pills.