### PR TITLE
Update Dockerfile -Changing ADD to COPY

### DIFF
--- a/deploy/dotcom/prod/Dockerfile
+++ b/deploy/dotcom/prod/Dockerfile
@@ -19,7 +19,7 @@ RUN git config --global url.https://github.com/.insteadOf git://github.com/
 RUN mix local.hex --force && \
 	mix local.rebar --force
 
-ADD . .
+COPY . .
 
 RUN mix deps.get --only prod
 
@@ -34,8 +34,8 @@ ARG SENTRY_DSN=""
 # copy in Elixir deps required to build node modules for Phoenix
 COPY --from=elixir-builder /root/deps /root/deps
 # copy in static assets
-ADD ./priv/static /root/priv/static
-ADD ./assets /root/assets
+COPY ./priv/static /root/priv/static
+COPY ./assets /root/assets
 
 WORKDIR /root/assets
 


### PR DESCRIPTION

<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes
It is recommended to use the Copy instruction instead of the Add instruction in the Dockerfile.

See also:
https://docs.prismacloud.io/en/enterprise-edition/policy-reference/docker-policies/docker-policy-index/ensure-that-copy-is-used-instead-of-add-in-dockerfiles


@krisrjohnson21 - please review it

