### PR TITLE
hotfix(Cache.KeyGenerator): don't hash single binaries

### DIFF
--- a/lib/dotcom/cache/key_generator.ex
+++ b/lib/dotcom/cache/key_generator.ex
@@ -17,7 +17,7 @@ defmodule Dotcom.Cache.KeyGenerator do
   end
 
   def generate(mod, fun, args) do
-    "#{clean_mod(mod)}|#{fun}|#{:erlang.phash2(args)}"
+    "#{clean_mod(mod)}|#{fun}|#{:erlang.phash2(args, 2 ** 32)}"
   end
 
   defp clean_mod(mod) do

--- a/lib/dotcom/cache/key_generator.ex
+++ b/lib/dotcom/cache/key_generator.ex
@@ -12,8 +12,8 @@ defmodule Dotcom.Cache.KeyGenerator do
     "#{clean_mod(mod)}|#{fun}"
   end
 
-  def generate(mod, fun, [arg]) do
-    "#{clean_mod(mod)}|#{fun}|#{:erlang.phash2(arg)}"
+  def generate(mod, fun, [arg]) when is_binary(arg) do
+    "#{clean_mod(mod)}|#{fun}|#{arg}"
   end
 
   def generate(mod, fun, args) do


### PR DESCRIPTION
Minor note: this changes handling of a single argument which _isn't_ a binary - instead of hashing it directly it'll be wrapped in a list (e.g. `:erlang.phash2([arg])` instead of `:erlang.phash2(arg)`)

But I also took the suggestion to increase the range via the second argument of `:erlang.phash2/2`
