### PR TITLE
feat: Remove "fifteen minutes or more" badge

### DIFF
--- a/lib/dotcom_web/templates/schedule/_line_header.html.eex
+++ b/lib/dotcom_web/templates/schedule/_line_header.html.eex
@@ -4,7 +4,6 @@
       <%= route_header_text(@route) %>
     </h1>
     <%= route_header_description(@route) %>
-    <%= frequent_bus_badge(@route) %>
     <div class="schedule__header-tabs">
       <%= route_header_tabs(@conn) %>
     </div>

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -413,23 +413,6 @@ defmodule DotcomWeb.ScheduleView do
     stop.station?
   end
 
-  @spec frequent_bus_badge(Route.t()) :: Safe.t() | nil
-  def frequent_bus_badge(%Route{description: :frequent_bus_route}) do
-    content_tag :div,
-      class: "bg-white rounded-full h-8 w-fit flex gap-2 items-center py-1 pl-1 pr-3 mb-6" do
-      [
-        svg("icon-frequent-bus.svg"),
-        content_tag :span, class: "text-sm font-bold text-black" do
-          "Service every 15 minutes or better"
-        end
-      ]
-    end
-  end
-
-  def frequent_bus_badge(_route) do
-    nil
-  end
-
   @spec timetable_crowding_description(Vehicles.Vehicle.crowding() | nil) :: String.t() | nil
   def timetable_crowding_description(crowding) do
     seats =

--- a/test/dotcom_web/views/schedule_view_test.exs
+++ b/test/dotcom_web/views/schedule_view_test.exs
@@ -456,14 +456,4 @@ defmodule DotcomWeb.ScheduleViewTest do
       assert station?(%Stop{id: "11257", station?: false}) == false
     end
   end
-
-  describe "frequent_bus_badge/1" do
-    test "returns a badge for frequent bus routes" do
-      refute frequent_bus_badge(%Route{type: 3, description: :frequent_bus_route}) == nil
-    end
-
-    test "returns nothing otherwise" do
-      assert frequent_bus_badge(%Route{type: 3, description: :community_bus}) == nil
-    end
-  end
 end


### PR DESCRIPTION
Removing 👇 this 👇 from the schedule pages where they're currently present.

![Screenshot 2025-04-07 at 12 15 07 PM](https://github.com/user-attachments/assets/3e8795bd-3420-41e4-b237-f9188a3a6b47)

Having the 15-minute badges caused a bit of a kerfuffle because not all of the routes that got tagged as `Frequent Bus` actually had headways of 15 minutes - some had headways of 20 instead.

Since these badges don't solve a pressing rider need (although they do look very nice), and there isn't a good way to get more precise information, we're going to drop them for now.

**Asana Ticket:** [Remove the 15 minute icon from all bus schedule pages](https://app.asana.com/0/385363666817452/1209864928234317/f)

