### PR TITLE
hotfix: Only show `<OtherStopList />` for bus routes

### DIFF
--- a/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -149,6 +149,7 @@ const LineDiagram = ({
             alerts={alerts}
             handleStopClick={handleStopClick}
             otherRouteStops={filteredOtherStops}
+            route={route}
             searchQuery={query}
             stopTree={stopTree}
           />

--- a/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
+++ b/assets/ts/schedule/components/line-diagram/LineDiagramWithStops.tsx
@@ -332,6 +332,7 @@ const LineDiagramWithStops = ({
           alerts={alerts}
           handleStopClick={handleStopClick}
           otherRouteStops={otherRouteStops}
+          route={route}
           stopTree={stopTree}
         />
       </div>

--- a/assets/ts/schedule/components/line-diagram/OtherStopList.tsx
+++ b/assets/ts/schedule/components/line-diagram/OtherStopList.tsx
@@ -1,12 +1,14 @@
 import React, { ReactElement } from "react";
 import { RouteStop, StopTree } from "../__schedule";
 import StopCard from "./StopCard";
-import { Alert } from "../../../__v3api";
+import { Alert, Route } from "../../../__v3api";
+import { isABusRoute } from "../../../models/route";
 
 interface Props {
   alerts: Alert[];
   handleStopClick: (stop: RouteStop) => void;
   otherRouteStops: RouteStop[];
+  route: Route;
   searchQuery?: string;
   stopTree: StopTree | null;
 }
@@ -18,10 +20,11 @@ const OtherStopList = ({
   alerts,
   handleStopClick,
   otherRouteStops,
+  route,
   searchQuery,
   stopTree
 }: Props): ReactElement<HTMLElement> | null =>
-  (otherRouteStops.length > 0 && (
+  (otherRouteStops.length > 0 && isABusRoute(route) && (
     <details className="group/other-stops">
       <summary className="flex justify-between w-full bg-charcoal-90 border-x-[1px] border-b-[1px] group-open/other-stops:border-b-0 border-charcoal-80 cursor-pointer p-3 font-medium">
         <span>

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -549,7 +549,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
           </NextStopOrBranch>
         </NextStopOrBranch>
       </ol>
-      <OtherStopList alerts={{...}} handleStopClick={[Function: handleStopClick]} otherRouteStops={{...}} stopTree={{...}} />
+      <OtherStopList alerts={{...}} handleStopClick={[Function: handleStopClick]} otherRouteStops={{...}} route={{...}} stopTree={{...}} />
     </div>
   </LineDiagramWithStops>
 </Provider>"


### PR DESCRIPTION
This should fix the fact that https://www.mbta.com/schedules/CR-Providence/line (and some other commuter rail line-diagram pages) aren't loading right now.

---

No ticket.