### PR TITLE
fix: Bump `assert_receive_timeout` to 500ms

### DIFF
--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -328,7 +328,6 @@ defmodule DotcomWeb.Live.TripPlannerTest do
              ) != []
     end
 
-    @tag :flaky
     test "unselecting a group shows all groups", %{view: view} do
       group_count = :rand.uniform(5)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,6 +7,7 @@ Application.ensure_all_started(:ex_machina)
 Application.ensure_all_started(:mox)
 Application.ensure_all_started(:tzdata)
 
+ExUnit.configure(assert_receive_timeout: 500)
 ExUnit.configure(exclude: [external: true, flaky: true])
 ExUnit.configure(formatters: [ExUnit.CLIFormatter, ExUnitSummary.Formatter])
 


### PR DESCRIPTION
We get a lot of build failures (e.g. [this one](https://github.com/mbta/dotcom/actions/runs/14314431748/job/40117527243?pr=2484#step:5:86)) where `render_async` times out because it can't finish rendering in 100ms.  These are otherwise valuable tests, so it would be nice to not need to mark them as `@flaky`. `render_async` [respects the ExUnit setting](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveViewTest.html#render_async/2), so this should allow `render_async` more time to finish its rendering.

Hopefully this will improve test reliability.