### PR TITLE
fix(trip-planner): Render itinerary details for rail replacement shuttles correctly

### DIFF
--- a/lib/dotcom_web/components/trip_planner/transit_leg.ex
+++ b/lib/dotcom_web/components/trip_planner/transit_leg.ex
@@ -210,7 +210,10 @@ defmodule DotcomWeb.Components.TripPlanner.TransitLeg do
     """
   end
 
-  defp route_symbol_size(%Route{type: 3} = route) when not is_external?(route), do: "small"
+  defp route_symbol_size(%Route{type: 3} = route)
+       when not is_external?(route) and not is_shuttle?(route),
+       do: "small"
+
   defp route_symbol_size(_), do: "default"
 
   defp headsign(%{stop_headsign: stop_headsign}) when not is_nil(stop_headsign) do

--- a/lib/dotcom_web/components/trip_planner/transit_leg.ex
+++ b/lib/dotcom_web/components/trip_planner/transit_leg.ex
@@ -123,6 +123,13 @@ defmodule DotcomWeb.Components.TripPlanner.TransitLeg do
     "bg-logan-express-#{name}"
   end
 
+  defp leg_line_class(%Route{name: name} = route) when is_shuttle?(route) do
+    %Route{id: name |> String.split(" ") |> List.first()}
+    |> Route.icon_atom()
+    |> CSSHelpers.atom_to_class()
+    |> route_background_class()
+  end
+
   defp leg_line_class(%Route{} = route) do
     route
     |> Route.to_naive()


### PR DESCRIPTION
### Before 

![Screenshot 2025-04-08 at 4 07 13 PM](https://github.com/user-attachments/assets/5630e308-d7a1-4921-9066-147a49f5308e)

### After

![Screenshot 2025-04-08 at 4 04 27 PM](https://github.com/user-attachments/assets/e1fa2a8a-8333-43d4-a8a2-c041a5d44392)

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | TP | Fix shuttle icon size, line color, map color in details view](https://app.asana.com/0/1205718271156548/1209501772392193/f)

