### PR TITLE
fix(Feedback.MockAws): use right decoder

### DIFF
--- a/lib/feedback/mock_aws.ex
+++ b/lib/feedback/mock_aws.ex
@@ -4,12 +4,12 @@ defmodule Feedback.MockAws do
   """
   require Logger
 
-  alias Mail.Parsers.RFC2822
+  alias Mail.{Encoders.Base64, Parsers.RFC2822}
 
   def send_email(%{"RawMessage" => %{"Data" => raw_message}}) do
     _ =
       raw_message
-      |> Base.decode64!()
+      |> Base64.decode()
       |> RFC2822.parse()
       |> log_email()
 

--- a/lib/feedback/mock_aws.ex
+++ b/lib/feedback/mock_aws.ex
@@ -2,7 +2,6 @@ defmodule Feedback.MockAws do
   @moduledoc """
   Mock AWS functions so that we aren't dependent on AWS in development.
   """
-  require Logger
 
   alias Mail.{Encoders.Base64, Parsers.RFC2822}
 
@@ -17,17 +16,15 @@ defmodule Feedback.MockAws do
   end
 
   defp log_email(%Mail.Message{headers: %{"to" => to}, body: body}) do
-    Logger.info(fn ->
-      """
+    IO.puts("""
 
-      MOCK EMAIL
+    MOCK EMAIL
 
-      To: #{to}
+    To: #{to}
 
-      Body:
-      #{body}
+    Body:
+    #{body}
 
-      """
-    end)
+    """)
   end
 end


### PR DESCRIPTION
No ticket, just noticed that submitting the customer support was broken when developing locally.