### PR TITLE
refactor feedback form category/service selection

### DIFF
--- a/config/dotcom/feedback.exs
+++ b/config/dotcom/feedback.exs
@@ -15,5 +15,6 @@ end
 
 if config_env() == :dev do
   config :dotcom,
-    send_email_fn: &Feedback.MockAws.send_email/1
+    send_email_fn: &Feedback.MockAws.send_email/1,
+    feedback_rate_limit: 50
 end

--- a/cypress/e2e/customer-support-form/support_form.cy.js
+++ b/cypress/e2e/customer-support-form/support_form.cy.js
@@ -7,7 +7,7 @@ describe("Customer Support Form", () => {
 
   it("shows an error state for missing type and comments", () => {
     cy.get("#support-submit").click();
-    cy.get(".has-danger #service").should("be.visible");
+    cy.get(".has-danger #support_subject").should("be.visible");
     cy.get(".has-danger #comments").should("be.visible");
   });
 
@@ -63,7 +63,7 @@ describe("Customer Support Form", () => {
       cy.get("#comments").type(comment);
       cy.get("#no_request_response_label").click();
       cy.fillRecaptcha();
-      cy.get('[type="submit"]').click();
+      cy.get("#support-submit").click();
 
       cy.wait("@submitForm")
         .its("response.statusCode")
@@ -95,7 +95,7 @@ describe("Customer Support Form", () => {
       cy.get("#comments").type(comment);
       cy.get("#no_request_response_label").click();
       cy.fillRecaptcha();
-      cy.get('[type="submit"]').click();
+      cy.get("#support-submit").click();
 
       cy.wait("@submitForm")
         .its("response.statusCode")
@@ -120,7 +120,7 @@ describe("Customer Support Form", () => {
       cy.get("#privacy_label").click();
       cy.get("#promotions_label").click();
       cy.fillRecaptcha();
-      cy.get('[type="submit"]').click();
+      cy.get("#support-submit").click();
 
       cy.wait("@submitForm")
         .its("response.statusCode")
@@ -159,7 +159,7 @@ describe("Customer Support Form", () => {
       cy.get("input#photo").attachFile("customer-support-form/test_image1.png");
       cy.get("#no_request_response_label").click();
       cy.fillRecaptcha();
-      cy.get('[type="submit"]').click();
+      cy.get("#support-submit").click();
 
       cy.wait("@submitForm")
         .its("response.statusCode")
@@ -198,7 +198,7 @@ describe("Customer Support Form", () => {
       cy.get("input#photo").attachFile("customer-support-form/test_image2.png");
       cy.get("#no_request_response_label").click();
       cy.fillRecaptcha();
-      cy.get('[type="submit"]').click();
+      cy.get("#support-submit").click();
 
       cy.wait("@submitForm")
         .its("response.statusCode")

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -47,25 +47,14 @@ Cypress.Commands.add("fillRecaptcha", () => {
  * Usage: `cy.selectRandomServiceAndSubject()`
  * Get values: `cy.get('@selectedService')` or `cy.get('@selectedSubject')`
  */
-const randomSelection = availableSelections =>
-  availableSelections[Cypress._.random(0, availableSelections.length - 1)];
-
 Cypress.Commands.add("selectRandomServiceAndSubject", () => {
-  cy.get("#js-subjects-by-service")
+  cy.get("#support_subject").select(Cypress._.random(0, 20));
+  cy.get("#support_subject option:selected")
     .invoke("text")
-    .then(text => {
-      const subjectsByService = JSON.parse(text);
-      const service = randomSelection(Object.keys(subjectsByService));
-      const subject = randomSelection(subjectsByService[service]);
-      cy.get(`#service-${service}`).check({ force: true });
-      cy.get("#support_subject").select(subject);
-      cy.get('[name="support[service]"]:checked')
-        .invoke("val")
-        .as("selectedService", { type: "static" });
-      cy.get("#support_subject option:selected")
-        .invoke("text")
-        .as("selectedSubject", { type: "static" });
-    });
+    .as("selectedSubject", { type: "static" });
+  cy.get("#support_subject option:selected")
+    .invoke("attr", "data-category")
+    .as("selectedService", { type: "static" });
 });
 
 /**

--- a/lib/dotcom_web/controllers/customer_support_controller.ex
+++ b/lib/dotcom_web/controllers/customer_support_controller.ex
@@ -448,7 +448,21 @@ defmodule DotcomWeb.CustomerSupportController do
   end
 
   defp set_service_options(conn, _) do
-    assign(conn, :service_options, Feedback.Message.service_options())
+    service_options =
+      Feedback.Message.service_options()
+      |> Enum.map(fn {category_label, category_value, options} ->
+        {category_label, Enum.map(options, &option(&1, category_value))}
+      end)
+
+    assign(conn, :service_options, service_options)
+  end
+
+  defp option(value, category) do
+    Keyword.new()
+    |> Keyword.put(:key, value)
+    |> Keyword.put(:value, value)
+    |> Keyword.put(:"aria-label", value)
+    |> Keyword.put(:"data-category", category)
   end
 
   defp assign_ip(conn, _) do

--- a/lib/dotcom_web/templates/customer_support/_form.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_form.html.eex
@@ -2,31 +2,15 @@
   <%= raw Poison.encode!(@all_options_per_mode) %>
 </script>
 <% form_action = "#{customer_support_path(@conn, :submit)}#support-result" %>
-<script id="js-subjects-by-service" type="text/plain">
-<%= raw Poison.encode!(subject_map(@service_options)) %>
-</script>
 
 <%= form_for @conn, form_action, [as: :support, multipart: true, method: :post, id: "support", class: "support-form"], fn f -> %>
   <h2>Email Us</h2>
   <%= preamble_text() %>
   <section>
     <h3>Message</h3>
-    <%= support_error_tag @errors, "service" %>
-    <fieldset class="form-group <%= class_for_error("service", @errors, "has-danger", "has-success") %>">
-      <legend class="form-control-label">Category*</legend>
-      <div id="service" class="service-radios">
-        <%= for {text, value, _subjects} <- @service_options do %>
-          <span class="form-check service-radio">
-            <%= radio_button f, :service, value, class: "support-form-control service c-radio", id: "service-#{value}" %>
-            <%= label f, :service, text, [for: "service-#{value}", class: "c-radio__label"] %>
-          </span>
-        <% end %>
-      </div>
-    </fieldset>
     <div id="subject" class="form-group <%= class_for_error("subject", @errors, "has-danger", "has-success") %>">
-      <%= label f, :subject, "Subject*", [for: "support_subject", class: "form-control-label"] %>
-      <%= select f, :subject, [], prompt: "Please choose a subject", value: "", required: "required", class: "form-control c-select", "aria-describedby": "subjectHelp" %>
-      <small id="subjectHelp" class="form-text">Please choose a Category to view available Subject values.</small>
+      <%= label f, :subject, "Category and Subject*", [for: "support_subject", class: "form-control-label"] %>
+      <%= select f, :subject, @service_options, prompt: "Please choose a subject", value: "", required: "required", class: "form-control c-select" %>
     </div>
     <div id="charlie-card-or-ticket-number" class="form-group">
       <%= label f, :ticket_number, "CharlieCard or Ticket number (optional)", [class: "form-control-label"] %>


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Feedback form | Form refresh breaks subject selection](https://app.asana.com/0/555089885850811/1208914203038402/f)

After consultation with some design-savvy folk, I've decided to adjust the form this way. 

Instead of a dynamically-populated `<select>`, which was subject to data loss on refresh and probably wasn't particularly accessible anyway, we use a simpler static `<select>` with `<optgroup>` to separate the groups.

<img width="901" alt="image" src="https://github.com/user-attachments/assets/a9920815-c523-404d-8d1f-322c7529d344" />

It's a bit long, but this was agreed upon to be the least bad quick option.

One side effect is that we can remove the "Category" radio buttons, since we can now infer the selected category from this big dropdown.

And this all needed some downstream changes, to ensure validation still works and that the right data is sent.

> [!CAUTION]
> The Cypress test only mostly works: the mechanism for retrieving the "sent" data is flawed when many tests are happening together, I think. But I think fixing this is out of scope 👀  