### PR TITLE
fix(trip-planner): Fix rail-replacement-shuttle colors on the map

### DIFF
--- a/lib/dotcom/trip_plan/map.ex
+++ b/lib/dotcom/trip_plan/map.ex
@@ -175,6 +175,20 @@ defmodule Dotcom.TripPlan.Map do
   def stop_icon_size(_), do: %{icon_size: [22, 22], icon_anchor: [0, 0]}
 
   @spec leg_color(Leg.t()) :: String.t()
+  defp leg_color(%Leg{
+         mode: %TransitDetail{
+           route: %Route{description: :rail_replacement_bus, name: name, color: color}
+         }
+       }) do
+    case name do
+      "Blue" <> _ -> "#003DA5"
+      "Green" <> _ -> "00843D"
+      "Orange" <> _ -> "#ED8B00"
+      "Red" <> _ -> "#DA291C"
+      _ -> color
+    end
+  end
+
   defp leg_color(%Leg{mode: %TransitDetail{route: %Route{color: color}}})
        when not is_nil(color) do
     "#" <> color

--- a/lib/dotcom/trip_plan/map.ex
+++ b/lib/dotcom/trip_plan/map.ex
@@ -177,7 +177,7 @@ defmodule Dotcom.TripPlan.Map do
   @spec leg_color(Leg.t()) :: String.t()
   defp leg_color(%Leg{
          mode: %TransitDetail{
-           route: %Route{description: :rail_replacement_bus, name: name, color: color}
+           route: %Route{description: :rail_replacement_bus, name: name}
          }
        }) do
     case name do
@@ -185,7 +185,7 @@ defmodule Dotcom.TripPlan.Map do
       "Green" <> _ -> "00843D"
       "Orange" <> _ -> "#ED8B00"
       "Red" <> _ -> "#DA291C"
-      _ -> color
+      _ -> "#80276c"
     end
   end
 


### PR DESCRIPTION
### Before

![Screenshot 2025-04-09 at 11 20 13 AM](https://github.com/user-attachments/assets/6223cdaf-a0cd-4f27-9062-374d1ff1dec6)

### After
![Screenshot 2025-04-09 at 11 19 44 AM](https://github.com/user-attachments/assets/7728d7f6-1941-4a78-8105-b8b4e58d4404)




Follow-up to:
- https://github.com/mbta/dotcom/pull/2495

I had forgotten to update the line color on the map. But this is slightly complicated from the fact that we get color for the map from GTFS (while the other places we use color come from [the Rider Design System](https://github.com/mbta/rider-design-system/blob/c9589af1a5c1b6734ffb786f5f8b9ba993662f9c/dist/variables.Light.css#L62-L72)), and our GTFS sets rail-replacement-shuttles as having the bus color.

This is a _very_ inelegant solution for now. If there's a better way to do this, I am so eager for it.

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | TP | Fix shuttle icon size, line color, map color in details view](https://app.asana.com/0/555089885850811/1209501772392193/f)
