### PR TITLE
feat(TripPlanner): filter itineraries if wheelchair: true set

### DIFF
--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -367,9 +367,15 @@ defmodule DotcomWeb.Live.TripPlanner do
 
     case plan do
       {:ok, itineraries} ->
-        ItineraryGroups.from_itineraries(itineraries,
-          take_from_end: data.datetime_type == "arrive_by"
-        )
+        itineraries
+        |> then(fn all_itineraries ->
+          if data.wheelchair do
+            Enum.filter(all_itineraries, & &1.accessible?)
+          else
+            all_itineraries
+          end
+        end)
+        |> ItineraryGroups.from_itineraries(take_from_end: data.datetime_type == "arrive_by")
 
       error ->
         error


### PR DESCRIPTION
#### Summary of changes

Offshoot of this PR, which will let OTP start returning inaccessible results.

- https://github.com/mbta/otp-deploy/pull/44

Before OTP is changed, this will be a no-op (currently OTP itself removes inaccessible results when `wheelchair: true`).