### PR TITLE
feat(Live.TripPlanner): wheelchair checkbox toggles groupings

### DIFF
--- a/lib/dotcom/trip_plan/input_form.ex
+++ b/lib/dotcom/trip_plan/input_form.ex
@@ -40,7 +40,8 @@ defmodule Dotcom.TripPlan.InputForm do
         to: to,
         datetime_type: datetime_type,
         datetime: datetime,
-        modes: modes
+        modes: modes,
+        wheelchair: wheelchair
       }) do
     %{
       fromPlace: PlanParams.to_place_param(from),
@@ -50,7 +51,7 @@ defmodule Dotcom.TripPlan.InputForm do
       numItineraries: 100,
       time: PlanParams.to_time_param(datetime),
       transportModes: __MODULE__.Modes.selected_mode_keys(modes) |> PlanParams.to_modes_param(),
-      wheelchair: true
+      wheelchair: wheelchair
     }
     |> PlanParams.new()
   end

--- a/lib/dotcom/trip_plan/input_form.ex
+++ b/lib/dotcom/trip_plan/input_form.ex
@@ -40,8 +40,7 @@ defmodule Dotcom.TripPlan.InputForm do
         to: to,
         datetime_type: datetime_type,
         datetime: datetime,
-        modes: modes,
-        wheelchair: wheelchair
+        modes: modes
       }) do
     %{
       fromPlace: PlanParams.to_place_param(from),
@@ -51,7 +50,7 @@ defmodule Dotcom.TripPlan.InputForm do
       numItineraries: 100,
       time: PlanParams.to_time_param(datetime),
       transportModes: __MODULE__.Modes.selected_mode_keys(modes) |> PlanParams.to_modes_param(),
-      wheelchair: wheelchair
+      wheelchair: true
     }
     |> PlanParams.new()
   end

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -81,7 +81,7 @@ defmodule DotcomWeb.Live.TripPlanner do
       assign(
         assigns,
         :accessible_grouping?,
-        assigns.input_form.changeset.params["wheelchair"] == "false"
+        assigns.input_form.changeset.params["wheelchair"] == "true"
       )
 
     ~H"""
@@ -376,7 +376,6 @@ defmodule DotcomWeb.Live.TripPlanner do
     case plan do
       {:ok, itineraries} ->
         itineraries
-        |> maybe_filter_accessible(data.wheelchair)
         |> ItineraryGroups.from_itineraries(take_from_end: data.datetime_type == "arrive_by")
 
       error ->
@@ -386,15 +385,6 @@ defmodule DotcomWeb.Live.TripPlanner do
 
   # If the changeset is invalid, we return an empty list of itinerary groups.
   defp get_itinerary_groups(_), do: []
-
-  # If wheelchair access is requested, limit results to accessible ones
-  defp maybe_filter_accessible(itineraries, true) do
-    Enum.filter(itineraries, & &1.accessible?)
-  end
-
-  defp maybe_filter_accessible(itineraries, _) do
-    itineraries
-  end
 
   # Convert the input form changeset to a list of pins for the map.
   # I.e., add pins for the from and to locations.

--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -77,6 +77,13 @@ defmodule DotcomWeb.Live.TripPlanner do
   - Results: Itinerary groups and itinerary details
   """
   def render(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :accessible_grouping?,
+        assigns.input_form.changeset.params["wheelchair"] == "false"
+      )
+
     ~H"""
     <h1>Trip Planner</h1>
     <div>
@@ -90,6 +97,7 @@ defmodule DotcomWeb.Live.TripPlanner do
             :if={Enum.count(@results.itinerary_groups) > 0 || @results.loading?}
             class="md:max-w-[25rem] md:sticky md:top-4"
             results={@results}
+            accessible_grouping?={@accessible_grouping?}
           />
           <.live_component
             module={MbtaMetro.Live.Map}

--- a/test/dotcom/trip_plan/itinerary_groups_test.exs
+++ b/test/dotcom/trip_plan/itinerary_groups_test.exs
@@ -5,7 +5,7 @@ defmodule Dotcom.TripPlan.ItineraryGroupsTest do
 
   import Mox
 
-  alias Dotcom.TripPlan.ItineraryGroups
+  alias Dotcom.TripPlan.{Itinerary, ItineraryGroups}
   alias Test.Support.Factories.{Stops.Stop, TripPlanner.TripPlanner}
 
   setup :verify_on_exit!
@@ -26,8 +26,8 @@ defmodule Dotcom.TripPlan.ItineraryGroupsTest do
       bus_a_b_leg = TripPlanner.build(:bus_leg, from: a, to: b)
       subway_b_c_leg = TripPlanner.build(:subway_leg, from: b, to: c)
 
-      itineraries =
-        TripPlanner.build_list(:rand.uniform(5), :itinerary, legs: [bus_a_b_leg, subway_b_c_leg])
+      itinerary = TripPlanner.build(:itinerary, legs: [bus_a_b_leg, subway_b_c_leg])
+      itineraries = Faker.Util.list(:rand.uniform(5), fn -> itinerary end)
 
       # EXERCISE
       grouped_itineraries = ItineraryGroups.from_itineraries(itineraries)
@@ -40,9 +40,8 @@ defmodule Dotcom.TripPlan.ItineraryGroupsTest do
       # SETUP
       bus_a_b_leg = TripPlanner.build(:bus_leg, from: a, to: b)
       subway_b_c_leg = TripPlanner.build(:subway_leg, from: b, to: c)
-
-      itineraries =
-        TripPlanner.build_list(10, :itinerary, legs: [bus_a_b_leg, subway_b_c_leg])
+      itinerary = TripPlanner.build(:itinerary, legs: [bus_a_b_leg, subway_b_c_leg])
+      itineraries = Faker.Util.list(10, fn -> itinerary end)
 
       # EXERCISE
       [group] = ItineraryGroups.from_itineraries(itineraries)
@@ -144,7 +143,7 @@ defmodule Dotcom.TripPlan.ItineraryGroupsTest do
     first_itinerary =
       TripPlanner.build(:itinerary, legs: [bus_a_b_leg, walk_b_c_leg, walk_c_b_leg, bus_b_a_leg])
 
-    second_itinerary = TripPlanner.build(:itinerary, legs: [bus_a_b_leg, bus_b_a_leg])
+    second_itinerary = %Itinerary{first_itinerary | legs: [bus_a_b_leg, bus_b_a_leg]}
 
     # EXERCISE
     grouped_itineraries = ItineraryGroups.from_itineraries([first_itinerary, second_itinerary])

--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -281,46 +281,6 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       assert Floki.get_by_id(document, "trip-planner-results")
     end
 
-    test "using wheelchair: true limits to accessible results", %{view: view} do
-      # Setup
-      non_bus_leg =
-        [:otp_commuter_rail_leg, :otp_ferry_leg, :otp_subway_leg]
-        |> Faker.Util.pick()
-        |> TripPlanner.build()
-
-      itineraries =
-        TripPlanner.build_list(4, :otp_itinerary,
-          accessibility_score: :rand.uniform(99) / 100,
-          legs: [non_bus_leg]
-        )
-
-      accessible_itinerary = TripPlanner.build(:otp_itinerary, accessibility_score: 1.0)
-
-      expect(OpenTripPlannerClient.Mock, :plan, fn _ ->
-        {:ok, %OpenTripPlannerClient.Plan{itineraries: [accessible_itinerary | itineraries]}}
-      end)
-
-      # Exercise
-      params = %{
-        "from" => @valid_params["from"],
-        "to" => @valid_params["to"],
-        "wheelchair" => "true"
-      }
-
-      view |> element("form") |> render_change(%{"input_form" => params})
-
-      # Verify
-      rendered = render_async(view)
-
-      assert rendered
-             |> Floki.parse_document!()
-             |> Floki.get_by_id("trip-planner-results")
-
-      refute rendered =~ "May not be accessible"
-
-      assert rendered =~ "Accessible"
-    end
-
     test "toggling wheelchair checkbox displays groupings", %{view: view} do
       # Setup
       non_bus_leg =
@@ -343,7 +303,7 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       # Exercise
       view
       |> element("form")
-      |> render_change(%{"input_form" => Map.put(@valid_params, "wheelchair", "false")})
+      |> render_change(%{"input_form" => Map.put(@valid_params, "wheelchair", "true")})
 
       # Verify
       rendered =
@@ -357,7 +317,7 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       # Exercise again
       view
       |> element("form")
-      |> render_change(%{"input_form" => Map.put(@valid_params, "wheelchair", "true")})
+      |> render_change(%{"input_form" => Map.put(@valid_params, "wheelchair", "false")})
 
       # Verify again
       rerendered =

--- a/test/support/factories/trip_planner/trip_planner.ex
+++ b/test/support/factories/trip_planner/trip_planner.ex
@@ -81,6 +81,13 @@ defmodule Test.Support.Factories.TripPlanner.TripPlanner do
     })
   end
 
+  def otp_commuter_rail_leg_factory do
+    Factory.build(:transit_leg, %{
+      agency: Factory.build(:agency, %{name: "MBTA"}),
+      route: Factory.build(:route, %{type: 2})
+    })
+  end
+
   def otp_ferry_leg_factory do
     Factory.build(:transit_leg, %{
       agency: Factory.build(:agency, %{name: "MBTA"}),


### PR DESCRIPTION
**Asana Ticket:** [Trip Planner: group results based on newly fixed accessibility score](https://app.asana.com/1/15492006741476/project/555089885850811/task/1209939784083536?focus=true) (last task in [TP | Update trip accessibility display](https://app.asana.com/1/15492006741476/project/555089885850811/task/1209572743277407?focus=true))

Mainly UI changes here:
- "Prefer accessible trips" is unchecked - show itinerary summaries grouped by "Accessible Routes" follow by "Inaccessible Routes"
- "Prefer accessible trips" is checked - show itinerary summaries in a flat list (like now), limited only to those which are accessible (this was already done in #2501)

Backend change: 
- When requesting plans from OTP, always pass `wheelchair: true` to that, regardless of what's chosen in the form. This ensures that itineraries have a computed `accessibility_score` (and doesn't significantly impact which itineraries are returned thanks to the recent changes in https://github.com/mbta/otp-deploy/pull/44)

> [!TIP] 
> **Revised PR**
>  
> Fixes some flawed assumptions, now has the following changes:
>  - "Prefer accessible trips" is unchecked -  show itinerary summaries in a flat list (like now)
>  - "Prefer accessible trips" is checked - show itinerary summaries grouped by "Accessible Routes" followed by "Inaccessible Routes"
> No changes to how we make requests to OTP.
