### PR TITLE
fix(TripPlan.Parser): interpret MBTA buses as accessible

### DIFF
--- a/test/dotcom/trip_plan/parser_test.exs
+++ b/test/dotcom/trip_plan/parser_test.exs
@@ -1,0 +1,56 @@
+defmodule Dotcom.TripPlan.ParserTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+  import Dotcom.TripPlan.Parser
+
+  alias Dotcom.TripPlan.Itinerary
+  alias Test.Support.Factories.{Stops.Stop, TripPlanner.TripPlanner}
+
+  setup :verify_on_exit!
+
+  setup do
+    stub(Stops.Repo.Mock, :get, fn _ ->
+      Stop.build(:stop)
+    end)
+
+    :ok
+  end
+
+  describe "parse/1" do
+    test "outputs an %Itinerary{}" do
+      unparsed = TripPlanner.build(:otp_itinerary)
+      assert %Itinerary{} = parse(unparsed)
+    end
+
+    test "uses accessibility_score to mark itinerary as accessible" do
+      unparsed = TripPlanner.build(:otp_itinerary, accessibility_score: 1.0)
+      assert %Itinerary{accessible?: true} = parse(unparsed)
+    end
+
+    test "marks bus-only itineraries as accessible" do
+      unparsed =
+        TripPlanner.build(:otp_itinerary,
+          accessibility_score: :rand.uniform(99) / 100,
+          legs: TripPlanner.build_list(3, :otp_bus_leg)
+        )
+
+      assert %Itinerary{accessible?: true} = parse(unparsed)
+    end
+
+    test "marks other itineraries as inaccessible" do
+      non_bus_leg =
+        [:otp_commuter_rail_leg, :otp_ferry_leg, :otp_subway_leg]
+        |> Faker.Util.pick()
+        |> TripPlanner.build()
+
+      unparsed =
+        TripPlanner.build(:otp_itinerary,
+          accessibility_score: :rand.uniform(99) / 100,
+          legs: [non_bus_leg | TripPlanner.build_list(2, :otp_transit_leg)]
+        )
+
+      assert %Itinerary{accessible?: false} = parse(unparsed)
+    end
+  end
+end

--- a/test/support/factories/trip_planner/trip_planner.ex
+++ b/test/support/factories/trip_planner/trip_planner.ex
@@ -81,6 +81,13 @@ defmodule Test.Support.Factories.TripPlanner.TripPlanner do
     })
   end
 
+  def otp_commuter_rail_leg_factory do
+    Factory.build(:transit_leg, %{
+      agency: Factory.build(:agency, %{name: "MBTA"}),
+      route: Factory.build(:route, %{type: 2})
+    })
+  end
+
   def otp_ferry_leg_factory do
     Factory.build(:transit_leg, %{
       agency: Factory.build(:agency, %{name: "MBTA"}),
@@ -97,6 +104,11 @@ defmodule Test.Support.Factories.TripPlanner.TripPlanner do
 
   def otp_itinerary_factory do
     Factory.build(:itinerary)
+    |> limit_route_types()
+  end
+
+  def otp_transit_leg_factory do
+    Factory.build(:transit_leg)
     |> limit_route_types()
   end
 


### PR DESCRIPTION
From a recent discussion during my work towards [TP | Update trip accessibility display](https://app.asana.com/1/15492006741476/project/555089885850811/task/1209572743277407?focus=true) it's come to light that we'd like MBTA buses to be considered accessible in the trip planner! So, we can now account for that while parsing OTP output.