### PR TITLE
fix(TripPlan.ItineraryGroups): enhanced grouping logic

### DIFF
--- a/lib/dotcom/trip_plan/itinerary_groups.ex
+++ b/lib/dotcom/trip_plan/itinerary_groups.ex
@@ -47,7 +47,8 @@ defmodule Dotcom.TripPlan.ItineraryGroups do
   end
 
   defp unique_leg_to_tuple(%Leg{mode: %{route: route}} = leg) do
-    {Routes.Route.type_atom(route.type), leg.from.name, leg.to.name}
+    {Routes.Route.type_atom(route.type), route.description == :rail_replacement_bus,
+     leg.from.name, leg.to.name}
   end
 
   defp limit_itinerary_count(itineraries, opts) do

--- a/lib/dotcom/trip_plan/itinerary_groups.ex
+++ b/lib/dotcom/trip_plan/itinerary_groups.ex
@@ -22,8 +22,8 @@ defmodule Dotcom.TripPlan.ItineraryGroups do
   @spec from_itineraries([Itinerary.t()], Keyword.t()) :: [ItineraryGroup.t()]
   def from_itineraries(itineraries, opts \\ []) do
     itineraries
-    |> Enum.group_by(&unique_legs_to_hash/1)
-    |> Enum.map(&drop_hash/1)
+    |> Enum.group_by(&{&1.accessible?, unique_legs_to_hash(&1)})
+    |> Enum.map(&elem(&1, 1))
     |> Enum.reject(&Enum.empty?/1)
     |> Enum.map(&to_group(&1, opts))
     |> Enum.sort_by(fn
@@ -48,10 +48,6 @@ defmodule Dotcom.TripPlan.ItineraryGroups do
 
   defp unique_leg_to_tuple(%Leg{mode: %{route: route}} = leg) do
     {Routes.Route.type_atom(route.type), leg.from.name, leg.to.name}
-  end
-
-  defp drop_hash({_hash, grouped_itineraries}) do
-    grouped_itineraries
   end
 
   defp limit_itinerary_count(itineraries, opts) do

--- a/test/dotcom/trip_plan/itinerary_groups_test.exs
+++ b/test/dotcom/trip_plan/itinerary_groups_test.exs
@@ -98,6 +98,40 @@ defmodule Dotcom.TripPlan.ItineraryGroupsTest do
       # VERIFY
       assert Kernel.length(grouped_itineraries) == 2
     end
+
+    test "does not group itineraries with different accessibility", %{stops: [a, b, _]} do
+      # SETUP
+      bus_legs = TripPlanner.build_list(3, :bus_leg, from: a, to: b)
+
+      first_itinerary = TripPlanner.build(:itinerary, accessible?: true, legs: bus_legs)
+      second_interary = TripPlanner.build(:itinerary, accessible?: false, legs: bus_legs)
+
+      # EXERCISE
+      grouped_itineraries = ItineraryGroups.from_itineraries([first_itinerary, second_interary])
+
+      # VERIFY
+      assert Kernel.length(grouped_itineraries) == 2
+    end
+
+    test "does not group bus itineraries with shuttles", %{stops: [a, b, _]} do
+      # SETUP
+      shuttle_leg = TripPlanner.build(:shuttle_leg, from: a, to: b)
+
+      bus_itineraries =
+        TripPlanner.build_list(5, :itinerary,
+          accessible?: true,
+          legs: [TripPlanner.build(:bus_leg, from: a, to: b)]
+        )
+
+      shuttle_itinerary = TripPlanner.build(:itinerary, accessible?: true, legs: [shuttle_leg])
+      many_itineraries = [shuttle_itinerary | bus_itineraries]
+
+      # EXERCISE
+      grouped_itineraries = ItineraryGroups.from_itineraries(many_itineraries)
+
+      # VERIFY
+      assert Kernel.length(grouped_itineraries) == 2
+    end
   end
 
   test "ignores short walking distances of < 0.2 miles when grouping", %{stops: [a, b, c]} do


### PR DESCRIPTION
- avoid grouping rail replacement shuttles with buses
- avoid grouping itineraries with different `accessibility?` values together
  - while that is very unlikely to be needed, it covers the case where we have a type of itinerary which is _usually_ accessible, with the exception of perhaps one trip that's affected by some sort of accessibility-impacting-outage (maybe planned work, maybe something else)