### PR TITLE
refactor(TripPlanner.Results): component for a group of summaries

### DIFF
--- a/lib/dotcom_web/components/trip_planner/results.ex
+++ b/lib/dotcom_web/components/trip_planner/results.ex
@@ -50,35 +50,7 @@ defmodule DotcomWeb.Components.TripPlanner.Results do
   # optionally displaying a tag and description of alternate times
   defp itinerary_panel(%{results: %{itinerary_group_selection: nil}} = assigns) do
     ~H"""
-    <div class="flex flex-col gap-4">
-      <div
-        :for={{group, index} <- Enum.with_index(@results.itinerary_groups)}
-        class="border border-solid border-gray-lighter p-4"
-        phx-click="select_itinerary_group"
-        phx-value-index={index}
-        data-test={"results:itinerary_group:#{index}"}
-      >
-        <div
-          :if={group.summary.tag}
-          class="whitespace-nowrap leading-none font-bold font-heading text-sm uppercase bg-brand-primary-darkest text-white px-3 py-2 mb-3 -ml-4 -mt-4 rounded-br-lg w-min"
-        >
-          {Phoenix.Naming.humanize(group.summary.tag)}
-        </div>
-        <.itinerary_summary summary={group.summary} />
-        <div class="flex justify-end items-center">
-          <div :if={ItineraryGroup.options_text(group)} class="grow text-sm text-grey-dark">
-            {ItineraryGroup.options_text(group)}
-          </div>
-          <button
-            class="btn-link font-semibold underline"
-            phx-click="select_itinerary_group"
-            phx-value-index={index}
-          >
-            Details
-          </button>
-        </div>
-      </div>
-    </div>
+    <.itinerary_groups indexed_groups={Enum.with_index(@results.itinerary_groups)} />
     """
   end
 
@@ -130,6 +102,42 @@ defmodule DotcomWeb.Components.TripPlanner.Results do
         </div>
       </div>
       <.itinerary_detail itinerary={@itinerary} />
+    </div>
+    """
+  end
+
+  attr(:indexed_groups, :list, required: true, doc: "Indexed list of `%ItineraryGroup{}`")
+
+  defp itinerary_groups(assigns) do
+    ~H"""
+    <div class="flex flex-col gap-4">
+      <div
+        :for={{group, index} <- @indexed_groups}
+        class="border border-solid border-gray-lighter p-4"
+        phx-click="select_itinerary_group"
+        phx-value-index={index}
+        data-test={"results:itinerary_group:#{index}"}
+      >
+        <div
+          :if={group.summary.tag}
+          class="whitespace-nowrap leading-none font-bold font-heading text-sm uppercase bg-brand-primary-darkest text-white px-3 py-2 mb-3 -ml-4 -mt-4 rounded-br-lg w-min"
+        >
+          {Phoenix.Naming.humanize(group.summary.tag)}
+        </div>
+        <.itinerary_summary summary={group.summary} />
+        <div class="flex justify-end items-center">
+          <div :if={ItineraryGroup.options_text(group)} class="grow text-sm text-grey-dark">
+            {ItineraryGroup.options_text(group)}
+          </div>
+          <button
+            class="btn-link font-semibold underline"
+            phx-click="select_itinerary_group"
+            phx-value-index={index}
+          >
+            Details
+          </button>
+        </div>
+      </div>
     </div>
     """
   end


### PR DESCRIPTION
This is a no-op. This'll make things easier once we start rendering several groups like so:

<img width="694" alt="image" src="https://github.com/user-attachments/assets/ef01baea-b787-47e7-9906-78b9b8b28a15" />

The reason the new component takes already-indexed groups, instead of handling the indexing itself, is so that we don't run into collisions based on index (e.g. if we're showing multiple groups of itinerary summaries, the first item in each shouldn't open the same view).