### PR TITLE
feat: Add badge on bus route pages for routes 714 and 716

### DIFF
--- a/lib/dotcom_web/templates/schedule/_line_header.html.eex
+++ b/lib/dotcom_web/templates/schedule/_line_header.html.eex
@@ -5,6 +5,7 @@
     </h1>
     <%= route_header_description(@route) %>
     <%= frequent_bus_badge(@route) %>
+    <%= flag_stop_badge(@route) %>
     <div class="schedule__header-tabs">
       <%= route_header_tabs(@conn) %>
     </div>

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -2,12 +2,14 @@ defmodule DotcomWeb.ScheduleView do
   @moduledoc false
 
   use DotcomWeb, :view
+  use DotcomWeb, :component
 
   require Routes.Route
 
   import DotcomWeb.ScheduleView.StopList
   import DotcomWeb.ScheduleView.Timetable
   import DotcomWeb.ViewHelpers
+  import MbtaMetro.Components.Icon, only: [icon: 1]
 
   alias CMS.Partial.RoutePdf
   alias Dotcom.MapHelpers
@@ -27,6 +29,8 @@ defmodule DotcomWeb.ScheduleView do
     "Blue",
     "Mattapan"
   ]
+
+  @flag_stop_routes ["714", "716"]
 
   defdelegate update_schedule_url(conn, opts), to: UrlHelpers, as: :update_url
 
@@ -427,6 +431,24 @@ defmodule DotcomWeb.ScheduleView do
   end
 
   def frequent_bus_badge(_route) do
+    nil
+  end
+
+  @spec flag_stop_badge(Route.t()) :: Safe.t() | nil
+  def flag_stop_badge(%Route{id: route_id}) when route_id in @flag_stop_routes do
+    assigns = %{}
+
+    ~H"""
+    <div class="bg-white rounded-full min-h-8 w-fit flex gap-2 items-center py-1 pl-1 pr-3 mb-6">
+      <div class="bg-brand-bus h-6 w-6 rounded-full flex items-center justify-center shrink-0">
+        <.icon class="h-3.5 w-3.5" name="flag" />
+      </div>
+      <span class="text-sm font-bold text-black">Flag the bus in any safe place along the route</span>
+    </div>
+    """
+  end
+
+  def flag_stop_badge(_route) do
     nil
   end
 

--- a/test/dotcom_web/views/schedule_view_test.exs
+++ b/test/dotcom_web/views/schedule_view_test.exs
@@ -457,6 +457,17 @@ defmodule DotcomWeb.ScheduleViewTest do
     end
   end
 
+  describe "flag_stop_badge/1" do
+    test "returns a badge for the flag stop routes" do
+      refute flag_stop_badge(%Route{id: "714"}) == nil
+      refute flag_stop_badge(%Route{id: "716"}) == nil
+    end
+
+    test "returns nothing otherwise" do
+      assert flag_stop_badge(%Route{id: "39"}) == nil
+    end
+  end
+
   describe "frequent_bus_badge/1" do
     test "returns a badge for frequent bus routes" do
       refute frequent_bus_badge(%Route{type: 3, description: :frequent_bus_route}) == nil


### PR DESCRIPTION
Different wrapping at different screen sizes and font sizes.

![Screenshot 2025-04-10 at 4 19 48 PM](https://github.com/user-attachments/assets/38c98f7c-5351-4b1b-8e80-f4010eb5593c)
![Screenshot 2025-04-10 at 4 15 04 PM](https://github.com/user-attachments/assets/fa145416-7aea-41e4-a583-fea30bcdb6e5)
![Screenshot 2025-04-10 at 4 20 34 PM](https://github.com/user-attachments/assets/6a58b811-b606-424c-9da3-fba3eb4480ea)

---

**Asana Ticket:** [Add flag stops badge to 714, 716 bus schedule pages](https://app.asana.com/1/15492006741476/project/555089885850811/task/1209916369431916?focus=true)

