### PR TITLE
fix(TripPlan.ItineraryGroups): correct representative itinerary

### DIFF
--- a/lib/dotcom/trip_plan/itinerary_groups.ex
+++ b/lib/dotcom/trip_plan/itinerary_groups.ex
@@ -71,7 +71,7 @@ defmodule Dotcom.TripPlan.ItineraryGroups do
       if(opts[:take_from_end], do: Enum.count(limited_itineraries) - 1, else: 0)
 
     summary =
-      grouped_itineraries
+      limited_itineraries
       |> Enum.at(representative_index)
       |> to_summary(grouped_itineraries)
 


### PR DESCRIPTION
For the "arrive by" situation, actually chooses the representative itinerary correctly (after limiting the itineraries in the group).

<img width="1241" alt="image" src="https://github.com/user-attachments/assets/d977f2ed-9dd4-4ae9-8903-4aff57cff727" />