### PR TITLE
fix: Alert-table line height sizes on mobile

### DIFF
--- a/lib/dotcom_web/components/alerts/subway.ex
+++ b/lib/dotcom_web/components/alerts/subway.ex
@@ -41,11 +41,7 @@ defmodule DotcomWeb.Components.Alerts.Subway do
 
     ~H"""
     <div class="m-alerts__time-filters">
-      <a
-        :for={group <- group_order()}
-        href={"#" <> anchor(group)}
-        class="m-alerts__time-filter leading-[2]"
-      >
+      <a :for={group <- group_order()} href={"#" <> anchor(group)} class="m-alerts__time-filter">
         {group}<span class="float-right"><.count count={Map.get(@grouped_counts, group, 0)} /></span>
       </a>
     </div>


### PR DESCRIPTION
Update the alert-table line height sizes so that on mobile, they're the same height on subway pages as on bus pages.

![Screenshot 2025-04-15 at 10 49 51 AM](https://github.com/user-attachments/assets/99bebb70-1a49-46f4-94f5-9e612da98572)

---
Below is a before/after comparison on mobile (Before is on the left; after is on the right)

![Screenshot 2025-04-15 at 10 50 34 AM](https://github.com/user-attachments/assets/9f0b4bc8-08f1-49e6-bc67-c74eb3a26557)

---
This also slightly shrinks the line height on desktop

(Before on the left; after on the right)
![Screenshot 2025-04-15 at 10 53 28 AM](https://github.com/user-attachments/assets/733099ca-4574-4830-b75b-36fa038dd1f2)

---

But on desktop, they're still slightly bigger on subway pages than on bus pages.

![Screenshot 2025-04-15 at 10 54 51 AM](https://github.com/user-attachments/assets/3617237d-4ad7-4319-b6b6-768799664be3)

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | Adjust subway alerts tab link height on mobile](https://app.asana.com/1/15492006741476/project/1204352509486278/task/1209775659080578?focus=true)

