### PR TITLE
fix: Extra duplication of duplicate stops when filtered

### DIFF
--- a/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useState } from "react";
 import { Provider, useDispatch, useSelector } from "react-redux";
 import { updateInLocation } from "use-query-params";
+import { uniqBy } from "lodash";
 import SearchBox from "../../../components/SearchBox";
 import { stopForId, stopIds } from "../../../helpers/stop-tree";
 import useRealtime from "../../../hooks/useRealtime";
@@ -18,7 +19,6 @@ import LineDiagramWithStops from "./LineDiagramWithStops";
 import StopCard from "./StopCard";
 import { alertsByStop } from "../../../models/alert";
 import OtherStopList from "./OtherStopList";
-import { uniqBy } from "lodash";
 
 interface Props {
   alerts: Alert[];

--- a/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -18,6 +18,7 @@ import LineDiagramWithStops from "./LineDiagramWithStops";
 import StopCard from "./StopCard";
 import { alertsByStop } from "../../../models/alert";
 import OtherStopList from "./OtherStopList";
+import { uniqBy } from "lodash";
 
 interface Props {
   alerts: Alert[];
@@ -66,11 +67,17 @@ const LineDiagram = ({
   const allStops: RouteStop[] = stopTree
     ? stopIds(stopTree).map(stopId => stopForId(stopTree, stopId))
     : routeStopList;
-  const filteredStops: RouteStop[] = allStops.filter(stop =>
-    stop.name.toLowerCase().includes(query.toLowerCase())
+  const filteredStops: RouteStop[] = uniqBy(
+    allStops.filter(stop =>
+      stop.name.toLowerCase().includes(query.toLowerCase())
+    ),
+    rs => rs.id
   );
-  const filteredOtherStops: RouteStop[] = otherRouteStops.filter(stop =>
-    stop.name.toLowerCase().includes(query.toLowerCase())
+  const filteredOtherStops: RouteStop[] = uniqBy(
+    otherRouteStops.filter(stop =>
+      stop.name.toLowerCase().includes(query.toLowerCase())
+    ),
+    rs => rs.id
   );
 
   const changeOrigin = (origin: SelectedOrigin): void => {


### PR DESCRIPTION
(Before on the left; After on the right)

[Route 217](https://www.mbta.com/schedules/217/line?schedule_direction%5Bdirection_id%5D=0&schedule_direction%5Bvariant%5D=217-1-0)
![Screenshot 2025-04-15 at 11 57 30 AM](https://github.com/user-attachments/assets/4e47c015-9b59-4dab-b4c1-4ddc690c481e)

[Route 37](https://www.mbta.com/schedules/37/line?schedule_direction%5Bdirection_id%5D=1&schedule_direction%5Bvariant%5D=37-3-1)
![Screenshot 2025-04-15 at 12 02 44 PM](https://github.com/user-attachments/assets/e70caf75-be33-4b1d-adfc-07e6f9610b73)

Turns out: Both of these bugs are examples of some of the bizarre non-deterministic behavior that React does when child elements have duplicate `key` values.

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Inaccurate stop search results for routes which visit a stop twice ](https://app.asana.com/1/15492006741476/project/555089885850811/task/1206537132113542?focus=true)
**Asana Ticket 2:** [Weird stop search results for "Lagrange St @ Vermont St"](https://app.asana.com/1/15492006741476/project/385363666817452/task/1209646743059749?focus=true)

