### PR TITLE
fix: Don't call non-existent function in `ScheduleControllerTest`

### DIFF
--- a/test/dotcom_web/controllers/schedule_controller_test.exs
+++ b/test/dotcom_web/controllers/schedule_controller_test.exs
@@ -77,7 +77,7 @@ defmodule DotcomWeb.ScheduleControllerTest do
 
       assert conn.assigns.header_schedules ==
                conn.assigns.timetable_schedules
-               |> Sort.sort_by_first_times()
+               |> Sort.sort_by_first_shared_stop()
                |> Enum.map(&List.first/1)
     end
   end


### PR DESCRIPTION
Fix warning associated with calling a non-existent function in `ScheduleControllerTest`. This wasn't causing the build to fail because those tests were already marked as `external`, which means they're not getting run.

---

No ticket.