### PR TITLE
feat: Have the back button close schedule finder, rather than navigating to a different page

### DIFF
--- a/assets/ts/schedule/components/SchedulePage.tsx
+++ b/assets/ts/schedule/components/SchedulePage.tsx
@@ -35,7 +35,7 @@ const updateURL = (origin: SelectedOrigin, direction?: DirectionId): void => {
     };
     const newLoc = updateInLocation(newQuery, window.location);
     // newLoc is not a true Location, so toString doesn't work
-    window.history.replaceState({}, "", `${newLoc.pathname}${newLoc.search}`);
+    window.history.pushState({}, "", `${newLoc.pathname}${newLoc.search}`);
   }
 };
 
@@ -319,6 +319,17 @@ export const SchedulePage = ({
   });
 
   const currentState = useSelector((state: StoreProps) => state);
+
+  useEffect(() => {
+    if (currentState.modalOpen) {
+      const updateLocation = (): void => closeModal(dispatch);
+
+      window.addEventListener("popstate", updateLocation);
+      return () => window.removeEventListener("popstate", updateLocation);
+    }
+
+    return () => {};
+  }, [currentState.modalOpen, dispatch]);
 
   useEffect(() => {
     // get initial values from the store:

--- a/assets/ts/schedule/components/SchedulePage.tsx
+++ b/assets/ts/schedule/components/SchedulePage.tsx
@@ -35,11 +35,7 @@ const updateURL = (origin: SelectedOrigin, direction?: DirectionId): void => {
     };
     const newLoc = updateInLocation(newQuery, window.location);
     // newLoc is not a true Location, so toString doesn't work
-    if (origin === "") {
-      window.history.replaceState({}, "", `${newLoc.pathname}${newLoc.search}`);
-    } else {
-      window.history.pushState({}, "", `${newLoc.pathname}${newLoc.search}`);
-    }
+    window.history.pushState({}, "", `${newLoc.pathname}${newLoc.search}`);
   }
 };
 
@@ -81,6 +77,15 @@ export const changeDirection = (
   });
 };
 
+const closeModal = (dispatch: Dispatch): void => {
+  dispatch({
+    type: "CLOSE_MODAL",
+    newStoreValues: {}
+  });
+  // clear parameters from URL when closing the modal:
+  updateURL("");
+};
+
 export const handleOriginSelectClick = (dispatch: Dispatch): void => {
   dispatch({
     type: "OPEN_MODAL",
@@ -94,8 +99,7 @@ const getDirectionAndMap = (
   schedulePageData: SchedulePageData,
   mapData: MapData,
   staticMapData: StaticMapData | undefined,
-  directionId: DirectionId,
-  closeModal: (dispatch: Dispatch) => void
+  directionId: DirectionId
 ): JSX.Element => {
   const {
     route,
@@ -166,8 +170,7 @@ const getDirectionAndMap = (
 
 const getScheduleFinder = (
   schedulePageData: SchedulePageData,
-  directionId: DirectionId,
-  closeModal: (dispatch: Dispatch) => void
+  directionId: DirectionId
 ): JSX.Element | undefined => {
   const {
     route,
@@ -197,8 +200,7 @@ const getScheduleFinder = (
 const getScheduleNote = (
   schedulePageData: SchedulePageData,
   directionId: DirectionId,
-  modalOpen: boolean,
-  closeModal: (dispatch: Dispatch) => void
+  modalOpen: boolean
 ): JSX.Element => {
   const {
     pdfs,
@@ -318,20 +320,6 @@ export const SchedulePage = ({
 
   const currentState = useSelector((state: StoreProps) => state);
 
-  const closeModal = (dispatch: Dispatch): void => {
-    console.log("MODAL CLOSE THE MODAL");
-    dispatch({
-      type: "CLOSE_MODAL",
-      newStoreValues: {}
-    });
-    // clear parameters from URL when closing the modal:
-    if (currentState.modalCameFromSchedulePage) {
-      window.history.back();
-    } else {
-      updateURL("");
-    }
-  };
-
   useEffect(() => {
     if (currentState.modalOpen) {
       const updateLocation = (): void => closeModal(dispatch);
@@ -384,7 +372,6 @@ export const SchedulePage = ({
     : "col-lg-offset-1";
   const ferry = isFerryRoute(route) ? "ferry" : "";
   const title = getPageTitle(route);
-
   if (!!currentState && Object.keys(currentState).length !== 0) {
     const {
       selectedDirection: currentDirection,
@@ -419,8 +406,7 @@ export const SchedulePage = ({
                   schedulePageData,
                   mapData,
                   staticMapData,
-                  readjustedDirectionId,
-                  closeModal
+                  readjustedDirectionId
                 )}
               </div>
             </div>
@@ -434,16 +420,11 @@ export const SchedulePage = ({
             getScheduleNote(
               schedulePageData,
               readjustedDirectionId,
-              currentState.modalOpen,
-              closeModal
+              currentState.modalOpen
             )}
           {schedulePageData.schedule_note === null &&
             !isFerryRoute(route) &&
-            getScheduleFinder(
-              schedulePageData,
-              readjustedDirectionId,
-              closeModal
-            )}
+            getScheduleFinder(schedulePageData, readjustedDirectionId)}
         </div>
         <div
           className={`col-md-5 col-lg-4 ${offset} m-schedule-page__side-content`}

--- a/assets/ts/schedule/components/SchedulePage.tsx
+++ b/assets/ts/schedule/components/SchedulePage.tsx
@@ -27,15 +27,19 @@ import HoursOfOperation from "./HoursOfOperation";
 const updateURL = (origin: SelectedOrigin, direction?: DirectionId): void => {
   /* istanbul ignore else  */
   if (window) {
-    // eslint-disable-next-line camelcase
-    const newQuery = {
-      "schedule_finder[direction_id]":
-        direction !== undefined ? direction.toString() : "",
-      "schedule_finder[origin]": origin
-    };
-    const newLoc = updateInLocation(newQuery, window.location);
-    // newLoc is not a true Location, so toString doesn't work
-    window.history.pushState({}, "", `${newLoc.pathname}${newLoc.search}`);
+    if (origin === "") {
+      window.history.back();
+    } else {
+      // eslint-disable-next-line camelcase
+      const newQuery = {
+        "schedule_finder[direction_id]":
+          direction !== undefined ? direction.toString() : "",
+        "schedule_finder[origin]": origin
+      };
+      const newLoc = updateInLocation(newQuery, window.location);
+      // newLoc is not a true Location, so toString doesn't work
+      window.history.pushState({}, "", `${newLoc.pathname}${newLoc.search}`);
+    }
   }
 };
 

--- a/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
+++ b/assets/ts/schedule/components/line-diagram/LineDiagram.tsx
@@ -43,7 +43,7 @@ const updateURL = (origin: SelectedOrigin, direction?: DirectionId): void => {
     };
     const newLoc = updateInLocation(newQuery, window.location);
     // newLoc is not a true Location, so toString doesn't work
-    window.history.replaceState({}, "", `${newLoc.pathname}${newLoc.search}`);
+    window.history.pushState({}, "", `${newLoc.pathname}${newLoc.search}`);
   }
 };
 

--- a/assets/ts/schedule/store/ScheduleStore.tsx
+++ b/assets/ts/schedule/store/ScheduleStore.tsx
@@ -9,7 +9,6 @@ export interface StoreProps {
   selectedOrigin: SelectedOrigin | "";
   modalOpen: boolean;
   modalMode: ModalMode;
-  modalCameFromSchedulePage?: boolean;
 }
 
 interface ActionData {
@@ -17,7 +16,6 @@ interface ActionData {
   selectedOrigin?: SelectedOrigin | "";
   modalOpen?: boolean;
   modalMode?: ModalMode;
-  modalCameFromSchedulePage?: boolean;
 }
 
 export interface Action {
@@ -34,8 +32,7 @@ export const scheduleStoreReducer: Reducer<StoreProps, Action> = (
       selectedDirection: undefined,
       selectedOrigin: undefined,
       modalOpen: false,
-      modalMode: "schedule",
-      modalCameFromSchedulePage: false
+      modalMode: "schedule"
     },
     state
   );
@@ -61,8 +58,7 @@ export const scheduleStoreReducer: Reducer<StoreProps, Action> = (
       return {
         ...newState,
         modalMode: action.newStoreValues.modalMode!,
-        modalOpen: true,
-        modalCameFromSchedulePage: true
+        modalOpen: true
       };
     case "CLOSE_MODAL":
       return {

--- a/assets/ts/schedule/store/ScheduleStore.tsx
+++ b/assets/ts/schedule/store/ScheduleStore.tsx
@@ -9,6 +9,7 @@ export interface StoreProps {
   selectedOrigin: SelectedOrigin | "";
   modalOpen: boolean;
   modalMode: ModalMode;
+  modalCameFromSchedulePage?: boolean;
 }
 
 interface ActionData {
@@ -16,6 +17,7 @@ interface ActionData {
   selectedOrigin?: SelectedOrigin | "";
   modalOpen?: boolean;
   modalMode?: ModalMode;
+  modalCameFromSchedulePage?: boolean;
 }
 
 export interface Action {
@@ -32,7 +34,8 @@ export const scheduleStoreReducer: Reducer<StoreProps, Action> = (
       selectedDirection: undefined,
       selectedOrigin: undefined,
       modalOpen: false,
-      modalMode: "schedule"
+      modalMode: "schedule",
+      modalCameFromSchedulePage: false
     },
     state
   );
@@ -58,7 +61,8 @@ export const scheduleStoreReducer: Reducer<StoreProps, Action> = (
       return {
         ...newState,
         modalMode: action.newStoreValues.modalMode!,
-        modalOpen: true
+        modalOpen: true,
+        modalCameFromSchedulePage: true
       };
     case "CLOSE_MODAL":
       return {


### PR DESCRIPTION
This fixes a bug/weird-UX where if you open schedule finder from a schedule page, and then hit the back button, instead of closing the schedule finder, it navigates to whatever page you were on _before_ schedule finder was opened. On desktop, that's _fine_ (maybe not ideal, but not awful), but on mobile, schedule finder takes up the whole screen and looks like a separate page, so it looks from the user's perspective like hitting the back button takes you back two pages.

This fix comes in two parts:
- Use `pushState` instead of `replaceState` when opening the schedule finder modal.
  - This is what allows the back button to do something _other_ than navigate to the pre-schedule-page part of your history.
- Add a `popstate` event listener whenever `modalOpen` is true.
  - Without this, because the only thing that changes is query params, the browser won't actually reload the page, which means that we need to manually handle closing the modal when it's open.

---

**Asana Ticket:** [SR | Fix Schedule Finder close/back behavior](https://app.asana.com/1/15492006741476/project/555089885850811/task/1209964790389162?focus=true)

