### PR TITLE
fix: Don't have `<Modal />` component auto-close itself

### DIFF
--- a/assets/ts/components/Modal.tsx
+++ b/assets/ts/components/Modal.tsx
@@ -62,14 +62,6 @@ const ModalContent = ({
     }
   }, [children]);
 
-  useEffect(() => {
-    document.addEventListener("DOMContentLoaded", closeModal, {
-      passive: true
-    });
-
-    return () => document.removeEventListener("DOMContentLoaded", closeModal);
-  }, [closeModal]);
-
   useLayoutEffect(() => {
     // Activate trap and disable scroll on background body
     const trap = createFocusTrap("#modal-cover", {


### PR DESCRIPTION
[Local link](http://localhost:4001/schedules/39/line?schedule_finder%5Bdirection_id%5D=0&schedule_finder%5Borigin%5D=41391)
[Prod link](https://www.mbta.com/schedules/39/line?schedule_finder%5Bdirection_id%5D=0&schedule_finder%5Borigin%5D=41391)

The current behavior is that whenever there is a `Modal` present in the DOM on page-load, it adds a listener that closes the modal as soon as the DOM's content is loaded. You can see this if you copy the prod link above into a browser - you'll see the modal flicker briefly before vanishing. This leads to a few annoying UX'es:
- If you refresh with schedule finder open, it won't be open anymore.
- If you copy a schedule page link with the schedule finder query params and open that link in another browser window, those query params will erase themselves and schedule finder will be closed.

The only two places `Modal` is currently used are [Schedule Finder](https://github.com/mbta/dotcom/blob/66aa161153b6599e0a1a657931750461e8505bf1/assets/ts/schedule/components/schedule-finder/ScheduleFinderModal.tsx#L118-L141) and the [Amenity Cards](https://github.com/mbta/dotcom/blob/66aa161153b6599e0a1a657931750461e8505bf1/assets/ts/stop/components/amenities/AmenityCard.tsx#L19-L28). This change fixes an issue with Schedule Finder, and doesn't appear to have any effect on Amenity Cards, so I'm pretty sure it's safe 🤞.

---

No ticket. Uncovered while I was working on #2522, because I thought they might be related, but now I don't think they are.