### PR TITLE
feat: Suppress timetables for "loopy" ferries `Boat-F6` and `Boat-F7`

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -14,6 +14,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   @route_patterns_repo Application.compile_env!(:dotcom, :repo_modules)[:route_patterns]
   @spring_2025_rating_date ~D[2025-03-24]
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
+  @loop_ferries ["Boat-F6", "Boat-F7"]
 
   plug(DotcomWeb.Plugs.Route)
   plug(DotcomWeb.Plugs.DateInRating)
@@ -23,6 +24,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   plug(DotcomWeb.ScheduleController.DatePicker)
   plug(DotcomWeb.ScheduleController.Core)
   plug(:alert_blocks)
+  plug(:suppress_loop_ferries)
   plug(:do_assign_trip_schedules)
   plug(DotcomWeb.ScheduleController.Offset)
   plug(DotcomWeb.ScheduleController.ScheduleError)
@@ -66,6 +68,10 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
         conn.assigns.date
       )
     )
+  end
+
+  def suppress_loop_ferries(conn, _) do
+    assign(conn, :suppress_timetable?, Enum.member?(@loop_ferries, conn.assigns.route.id))
   end
 
   def assign_trip_schedules(

--- a/lib/dotcom_web/templates/schedule/_pdf_schedules.html.eex
+++ b/lib/dotcom_web/templates/schedule/_pdf_schedules.html.eex
@@ -5,7 +5,7 @@
   end
 %>
 <%= unless Enum.empty?(pdfs) do %>
-  <div class="pdf-schedules-container">
+  <div class="pdf-schedules-container" id="pdf-schedules">
     <h2 class="pdf-schedules-header">PDF Schedules</h2>
     <%= route_pdf_link(pdfs, @route, @date) %>
   </div>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -5,11 +5,15 @@
   priority_filter: :high,
   always_show: List.wrap(@blocking_alert)
 )}
-{render("_trip_view_filters.html", assigns)}
+<%= if !@suppress_timetable? do %>
+  {render("_trip_view_filters.html", assigns)}
+<% end %>
 
 <div class="calendar-covered m-timetable">
   {content_tag(:div, "", class: "calendar-cover", hidden: !@show_date_select?)}
   <%= cond do %>
+    <% @suppress_timetable? -> %>
+      {render("_timetable_suppressed.html")}
     <% @blocking_alert != nil -> %>
       {render("_timetable_blocked.html", formatted_date: @formatted_date, alert: @blocking_alert)}
     <% Enum.empty?(@header_schedules) -> %>

--- a/lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
@@ -1,0 +1,6 @@
+<div class="callout schedule-empty">
+  <div>
+    <%= link "View PDF Timetable", to: "#pdf-schedules" %>
+  </div>
+</div>
+

--- a/test/dotcom_web/views/schedule/timetable_view_test.exs
+++ b/test/dotcom_web/views/schedule/timetable_view_test.exs
@@ -96,7 +96,8 @@ defmodule DotcomWeb.Schedule.TimetableViewTest do
         date_time: ~N[2017-03-01T07:29:00],
         direction_name: "Southeastbound",
         formatted_date: "March 1, 2017",
-        blocking_alert: nil
+        blocking_alert: nil,
+        suppress_timetable?: false
       ]
 
       {:ok, %{assigns: assigns}}


### PR DESCRIPTION
(Before on the left; After on the right)
![Screenshot 2025-04-23 at 10 50 21 PM](https://github.com/user-attachments/assets/ff92ca52-90d7-4aae-9871-788a607941b1)

---

**Asana Ticket:** [Disable the timetable on the Winthrop and Quincy ferry pages](https://app.asana.com/1/15492006741476/project/555089885850811/task/1210057792979807?focus=true)
