### PR TITLE
refactor: Consolidate code for subway status row headers

### DIFF
--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -11,6 +11,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
   import DotcomWeb.Components.RouteSymbols, only: [subway_route_pill: 1]
   import DotcomWeb.Components.SystemStatus.StatusLabel, only: [status_label: 1]
+  import DotcomWeb.Components.SystemStatus.StatusRowHeading, only: [status_row_heading: 1]
 
   alias Alerts.Alert
 
@@ -88,12 +89,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     assigns = assign(assigns, time_range_str: time_range_str)
 
     ~H"""
-    <div class="pl-2 pr-sm">
-      <.subway_route_pill route_ids={@route_ids} class="group-hover/row:ring-brand-primary-lightest" />
-    </div>
-    <div class="grow py-3">
-      <.status_label status={@alert.effect} prefix={@time_range_str} />
-    </div>
+    <.status_row_heading route_ids={@route_ids} status={@alert.effect} prefix={@time_range_str} />
     """
   end
 

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -9,8 +9,6 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
   import Dotcom.Utils.ServiceDateTime, only: [service_date: 1, service_range_string: 1]
   import DotcomWeb.Components, only: [bordered_container: 1, lined_list: 1, unstyled_accordion: 1]
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
-  import DotcomWeb.Components.RouteSymbols, only: [subway_route_pill: 1]
-  import DotcomWeb.Components.SystemStatus.StatusLabel, only: [status_label: 1]
   import DotcomWeb.Components.SystemStatus.StatusRowHeading, only: [status_row_heading: 1]
 
   alias Alerts.Alert

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -1,0 +1,36 @@
+defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
+  @moduledoc """
+  Renders a status as a readable version of that status, along with an
+  optional prefix and a route pill for the given route ID's.
+  """
+
+  use DotcomWeb, :component
+
+  import DotcomWeb.Components.RouteSymbols, only: [subway_route_pill: 1]
+  import DotcomWeb.Components.SystemStatus.StatusLabel, only: [status_label: 1]
+
+  attr :hide_route_pill, :boolean, default: false
+  attr :plural, :boolean, default: false
+  attr :prefix, :string, default: nil
+  attr :route_ids, :list, required: true
+  attr :status, :atom, required: true
+
+  def status_row_heading(assigns) do
+    ~H"""
+    <div class="flex grow">
+      <div class={["px-2 py-3", @hide_route_pill && "opacity-0"]} data-route-pill>
+        <.subway_route_pill
+          class="group-hover/row:ring-brand-primary-lightest"
+          route_ids={@route_ids}
+        />
+      </div>
+      <div class={[
+        "py-3 grow",
+        @hide_route_pill && "border-t-[1px] border-gray-lightest"
+      ]}>
+        <.status_label status={@status} prefix={@prefix} plural={@plural} />
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -59,23 +59,24 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
         </div>
       </:heading>
       <.lined_list :let={row} items={@rows}>
-        <%= if row.alert do %>
-          <.unstyled_accordion
-            data-test-row-route-info={inspect(row.route_info)}
-            style={if(row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
-            summary_class="hover:bg-brand-primary-lightest cursor-pointer group/row flex items-center grow text-nowrap"
-            chevron_class={"fill-gray-dark px-2 py-3 #{row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"}"}
-          >
-            <:heading>
-              <.heading row={row} />
-            </:heading>
-            <:content>
-              <.embedded_alert alert={row.alert} />
-            </:content>
-          </.unstyled_accordion>
-        <% else %>
-          <.heading row={row} />
-        <% end %>
+        <div data-test-row-route-info={inspect(row.route_info)}>
+          <%= if row.alert do %>
+            <.unstyled_accordion
+              style={if(row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
+              summary_class="hover:bg-brand-primary-lightest cursor-pointer group/row flex items-center grow text-nowrap"
+              chevron_class={"fill-gray-dark px-2 py-3 #{row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"}"}
+            >
+              <:heading>
+                <.heading row={row} />
+              </:heading>
+              <:content>
+                <.embedded_alert alert={row.alert} />
+              </:content>
+            </.unstyled_accordion>
+          <% else %>
+            <.heading row={row} />
+          <% end %>
+        </div>
       </.lined_list>
     </.bordered_container>
     """

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -8,7 +8,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   import DotcomWeb.Components, only: [bordered_container: 1, lined_list: 1, unstyled_accordion: 1]
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
   import DotcomWeb.Components.RouteSymbols, only: [subway_route_pill: 1]
-  import DotcomWeb.Components.SystemStatus.StatusLabel
+  import DotcomWeb.Components.SystemStatus.StatusLabel, only: [status_label: 1]
 
   @max_rows 5
   @route_ids ["Red", "Orange", "Green", "Blue"]
@@ -40,23 +40,9 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
           ]}
           data-test="status-row"
         >
-          <div class={["pl-2 py-3", row.style.hide_route_pill && "opacity-0"]} data-route-pill>
-            <.subway_route_pill
-              class="group-hover/row:ring-brand-primary-lightest"
-              route_ids={[row.route_info.route_id | row.route_info.branch_ids]}
-            />
-          </div>
-          <div class={[
-            "flex items-center justify-between grow gap-sm py-3",
-            row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
-          ]}>
-            <.status_label
-              status={row.status_entry.status}
-              prefix={row.status_entry.prefix}
-              plural={row.status_entry.plural}
-            />
-            <.icon name="chevron-right" class="h-3 w-2 fill-gray-dark ml-3 mr-2 shrink-0" />
-          </div>
+          <.status_row_header row={row} />
+
+          <.icon name="chevron-right" class="h-3 w-2 fill-gray-dark ml-3 mr-2 shrink-0" />
         </a>
       </.lined_list>
     </.bordered_container>
@@ -82,53 +68,40 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             chevron_class={"fill-gray-dark px-2 py-3 #{row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"}"}
           >
             <:heading>
-              <div class="pl-2 py-3 pr-sm">
-                <.subway_route_pill
-                  class={"group-hover/row:ring-brand-primary-lightest #{if(row.style.hide_route_pill, do: "opacity-0")}"}
-                  route_ids={[row.route_info.route_id | row.route_info.branch_ids]}
-                />
-              </div>
-              <div class={[
-                "flex items-center justify-between grow text-nowrap gap-sm py-3",
-                row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
-              ]}>
-                <.status_label
-                  status={row.status_entry.status}
-                  prefix={row.status_entry.prefix}
-                  plural={row.status_entry.plural}
-                />
-              </div>
+              <.status_row_header row={row} />
             </:heading>
             <:content>
               <.embedded_alert alert={row.alert} />
             </:content>
           </.unstyled_accordion>
         <% else %>
-          <div
-            data-test-row-route-info={inspect(row.route_info)}
-            class="flex gap-sm"
-            style={if(row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
-          >
-            <div class="pl-2 py-3">
-              <.subway_route_pill
-                class={"group-hover/row:ring-brand-primary-lightest #{if(row.style.hide_route_pill, do: "opacity-0")}"}
-                route_ids={[row.route_info.route_id | row.route_info.branch_ids]}
-              />
-            </div>
-            <div class={[
-              "flex items-center justify-between grow text-nowrap gap-sm",
-              row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
-            ]}>
-              <.status_label
-                status={row.status_entry.status}
-                prefix={row.status_entry.prefix}
-                plural={row.status_entry.plural}
-              />
-            </div>
-          </div>
+          <.status_row_header row={row} />
         <% end %>
       </.lined_list>
     </.bordered_container>
+    """
+  end
+
+  defp status_row_header(assigns) do
+    ~H"""
+    <div class="flex grow">
+      <div class={["px-2 py-3", @row.style.hide_route_pill && "opacity-0"]} data-route-pill>
+        <.subway_route_pill
+          class="group-hover/row:ring-brand-primary-lightest"
+          route_ids={[@row.route_info.route_id | @row.route_info.branch_ids]}
+        />
+      </div>
+      <div class={[
+        "py-3 grow",
+        @row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
+      ]}>
+        <.status_label
+          status={@row.status_entry.status}
+          prefix={@row.status_entry.prefix}
+          plural={@row.status_entry.plural}
+        />
+      </div>
+    </div>
     """
   end
 

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -7,8 +7,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
   import DotcomWeb.Components, only: [bordered_container: 1, lined_list: 1, unstyled_accordion: 1]
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
-  import DotcomWeb.Components.RouteSymbols, only: [subway_route_pill: 1]
-  import DotcomWeb.Components.SystemStatus.StatusLabel, only: [status_label: 1]
   import DotcomWeb.Components.SystemStatus.StatusRowHeading, only: [status_row_heading: 1]
 
   @max_rows 5

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -9,6 +9,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
   import DotcomWeb.Components.RouteSymbols, only: [subway_route_pill: 1]
   import DotcomWeb.Components.SystemStatus.StatusLabel, only: [status_label: 1]
+  import DotcomWeb.Components.SystemStatus.StatusRowHeading, only: [status_row_heading: 1]
 
   @max_rows 5
   @route_ids ["Red", "Orange", "Green", "Blue"]
@@ -40,7 +41,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
           ]}
           data-test="status-row"
         >
-          <.status_row_header row={row} />
+          <.heading row={row} />
 
           <.icon name="chevron-right" class="h-3 w-2 fill-gray-dark ml-3 mr-2 shrink-0" />
         </a>
@@ -68,40 +69,29 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             chevron_class={"fill-gray-dark px-2 py-3 #{row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"}"}
           >
             <:heading>
-              <.status_row_header row={row} />
+              <.heading row={row} />
             </:heading>
             <:content>
               <.embedded_alert alert={row.alert} />
             </:content>
           </.unstyled_accordion>
         <% else %>
-          <.status_row_header row={row} />
+          <.heading row={row} />
         <% end %>
       </.lined_list>
     </.bordered_container>
     """
   end
 
-  defp status_row_header(assigns) do
+  defp heading(assigns) do
     ~H"""
-    <div class="flex grow">
-      <div class={["px-2 py-3", @row.style.hide_route_pill && "opacity-0"]} data-route-pill>
-        <.subway_route_pill
-          class="group-hover/row:ring-brand-primary-lightest"
-          route_ids={[@row.route_info.route_id | @row.route_info.branch_ids]}
-        />
-      </div>
-      <div class={[
-        "py-3 grow",
-        @row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"
-      ]}>
-        <.status_label
-          status={@row.status_entry.status}
-          prefix={@row.status_entry.prefix}
-          plural={@row.status_entry.plural}
-        />
-      </div>
-    </div>
+    <.status_row_heading
+      hide_route_pill={@row.style.hide_route_pill}
+      status={@row.status_entry.status}
+      prefix={@row.status_entry.prefix}
+      plural={@row.status_entry.plural}
+      route_ids={[@row.route_info.route_id | @row.route_info.branch_ids]}
+    />
     """
   end
 

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -375,7 +375,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
       route = Dotcom.Routes.subway_route_ids() |> Faker.Util.pick()
       alerts = subway_status_alerts(route)
       html = render_component(&alerts_subway_status/1, %{subway_status: subway_status(alerts)})
-      details = Floki.find(html, "details[data-test-row-route-info*=\"#{route}\"]")
+      details = Floki.find(html, "[data-test-row-route-info*=\"#{route}\"]")
 
       [
         %Alerts.Alert{


### PR DESCRIPTION
No ticket, but it's been bugging me for a while that there were three (slightly different, but fundamentally the same) implementations of the same route-pill-plus-status-label concept. So I extracted that to a component that's shared between the various subway status components.

~There may be an opportunity here to re-use this for planned work as well and extracting this further (if we do that, we'll want to clean up the interface a bit more 😅). I'm open to doing that as part of this PR, or as a follow-up.~ *I did it as part of this PR 😇*

![Screenshot 2025-04-24 at 2 55 28 PM](https://github.com/user-attachments/assets/788321da-7133-4da5-ae4f-5bf97479f895)
