### PR TITLE
Group commuter rail alerts

### DIFF
--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -12,7 +12,7 @@ defmodule Dotcom.Alerts do
           :detour | :service_change | :shuttle | :station_closure | :stop_closure | :suspension
 
   @typedoc "Service alerts which typically impact rider experience."
-  @type service_effect_t() :: :delay | :service_change | :shuttle | :suspension | :station_closure
+  @type service_effect_t() :: :cancellation | :delay | :service_change | :shuttle | :suspension | :station_closure
 
   # A keyword list of effects and the severity level necessary to make an alert a 'diversion.'
   @diversion_effects [
@@ -26,6 +26,7 @@ defmodule Dotcom.Alerts do
 
   # A keyword list of effects and the severity level necessary to make an alert 'service impacting.'
   @service_impacting_effects [
+    cancellation: 1,
     delay: 1,
     service_change: 3,
     shuttle: 1,

--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -12,7 +12,8 @@ defmodule Dotcom.Alerts do
           :detour | :service_change | :shuttle | :station_closure | :stop_closure | :suspension
 
   @typedoc "Service alerts which typically impact rider experience."
-  @type service_effect_t() :: :cancellation | :delay | :service_change | :shuttle | :suspension | :station_closure
+  @type service_effect_t() ::
+          :cancellation | :delay | :service_change | :shuttle | :suspension | :station_closure
 
   # A keyword list of effects and the severity level necessary to make an alert a 'diversion.'
   @diversion_effects [

--- a/lib/dotcom/alerts/commuter_rail.ex
+++ b/lib/dotcom/alerts/commuter_rail.ex
@@ -8,22 +8,14 @@ defmodule Dotcom.Alerts.CommuterRail do
   import import Dotcom.Alerts, only: [service_impacting_effects: 0]
 
   @impl Dotcom.Alerts.Group
-  def effects do
-    %{
-      "Bike" => [bike_issue: 1],
-      "Elevator & Escalator" => [
-        elevator_closure: 1,
-        escalator_closure: 1
-      ],
-      "Other" => [],
-      "Parking" => [parking_issue: 1],
-      "Service" => service_impacting_effects(),
-      "Track Change" => [track_change: 1]
-    }
-  end
-
-  @impl Dotcom.Alerts.Group
-  def group_order do
-    ["Service", "Track Change", "Elevator & Escalator", "Bike", "Parking", "Other"]
+  def effect_groups do
+    [
+      {"Service", service_impacting_effects()},
+      {"Track Change", [track_change: 1]},
+      {"Elevator & Escalator", [elevator_closure: 1, escalator_closure: 1]},
+      {"Bike", [bike_issue: 1]},
+      {"Parking", [parking_issue: 1]},
+      {"Other", []}
+    ]
   end
 end

--- a/lib/dotcom/alerts/commuter_rail.ex
+++ b/lib/dotcom/alerts/commuter_rail.ex
@@ -1,5 +1,6 @@
 defmodule Dotcom.Alerts.CommuterRail do
   @moduledoc """
+  Implements `Dotcom.Alerts.Group` for Commuter Rail alerts.
   """
 
   use Dotcom.Alerts.Group

--- a/lib/dotcom/alerts/commuter_rail.ex
+++ b/lib/dotcom/alerts/commuter_rail.ex
@@ -1,5 +1,6 @@
-defmodule Dotcom.Alerts.Subway do
-  @moduledoc false
+defmodule Dotcom.Alerts.CommuterRail do
+  @moduledoc """
+  """
 
   use Dotcom.Alerts.Group
 
@@ -15,12 +16,13 @@ defmodule Dotcom.Alerts.Subway do
       ],
       "Other" => [],
       "Parking" => [parking_issue: 1],
-      "Service" => service_impacting_effects()
+      "Service" => service_impacting_effects(),
+      "Track Change" => [track_change: 1]
     }
   end
 
   @impl Dotcom.Alerts.Group
   def group_order do
-    ["Service", "Elevator & Escalator", "Bike", "Parking", "Other"]
+    ["Service", "Track Change", "Elevator & Escalator", "Bike", "Parking", "Other"]
   end
 end

--- a/lib/dotcom/alerts/group.ex
+++ b/lib/dotcom/alerts/group.ex
@@ -1,0 +1,96 @@
+defmodule Dotcom.Alerts.Group do
+  @moduledoc """
+  TODO
+  """
+
+  @callback effects() :: %{String.t() => [{atom(), byte()}]}
+  @callback group_order() :: [String.t()]
+
+  defmacro __using__(_) do
+    quote do
+      import Dotcom.Alerts,
+        only: [
+          effects_match?: 2,
+          sort_by_start_time_sorter: 2,
+          sort_by_station_sorter: 2
+        ]
+
+      alias Alerts.Alert
+
+      @behaviour Dotcom.Alerts.Group
+
+      @doc """
+      Given an effect and severity of an Alert, find the group it belongs to.
+      Checks all effects in the group and returns the first group that contains the effect.
+      If the effects list is empty, we know it belongs in "Other".
+      """
+      @spec find_group(atom()) :: String.t()
+      def find_group(alert) do
+        groups()
+        |> Enum.find(&group_match?(&1, alert))
+        |> Kernel.elem(0)
+      end
+
+      @doc """
+      Given a list of alerts, return a map of groups and their associated alerts.
+      We merge the empty alerts map with the grouped alerts to ensure all groups are present.
+      """
+      @spec group_alerts([Alert.t()]) :: %{String.t() => [Alert.t()]}
+      def group_alerts(alerts) do
+        grouped_alerts =
+          Enum.group_by(alerts, fn alert ->
+            find_group(alert)
+          end)
+
+        Map.merge(empty_alerts(), grouped_alerts)
+      end
+
+      @doc """
+      Given a list of alerts, return a map of groups and their associated alert counts.
+      Because this uses `group_alerts/1`, we can be sure that all groups are present.
+      """
+      @spec group_counts([Alert.t()]) :: %{String.t() => integer()}
+      def group_counts(alerts) do
+        alerts
+        |> group_alerts()
+        |> Enum.map(fn {group, alerts} -> {group, Enum.count(alerts)} end)
+        |> Enum.into(%{})
+      end
+
+      @doc """
+      Get an ordered list of groups and their associated effects.
+      """
+      @spec groups() :: [{String.t(), [atom()]}]
+      def groups() do
+        Enum.map(__MODULE__.group_order(), fn group ->
+          {group, __MODULE__.effects()[group]}
+        end)
+      end
+
+      @doc """
+      Sort alerts by station and then by start time.
+      """
+      @spec sort_alerts([Alert.t()]) :: [Alert.t()]
+      def sort_alerts(alerts) do
+        alerts
+        |> Enum.sort(&sort_by_station_sorter/2)
+        |> Enum.sort(&sort_by_start_time_sorter/2)
+      end
+
+      # Does the alert match the group?
+      defp group_match?({_, []}, _), do: true
+
+      defp group_match?({_, effects}, alert) do
+        effects_match?(effects, alert)
+      end
+
+      # Return a map of groups with no alerts.
+      defp empty_alerts() do
+        Enum.map(__MODULE__.group_order(), fn group ->
+          {group, []}
+        end)
+        |> Enum.into(%{})
+      end
+    end
+  end
+end

--- a/lib/dotcom/alerts/group.ex
+++ b/lib/dotcom/alerts/group.ex
@@ -1,6 +1,14 @@
 defmodule Dotcom.Alerts.Group do
   @moduledoc """
-  TODO
+  This module defines a behaviour for grouping alerts by their effects.
+
+  Implementations must provide a list of effects and the order of the groups.
+  Combined, the two approximate an ordered map.
+
+  The `effects/0` function should return a map where the keys are group names
+  and the values are lists of tuples. Each tuple contains an effect name and
+  its severity. The severity is a number that indicates the importance of the
+  effect. The higher the number, the more important the effect is.
   """
 
   @callback effects() :: %{String.t() => [{atom(), byte()}]}

--- a/lib/dotcom/alerts/subway.ex
+++ b/lib/dotcom/alerts/subway.ex
@@ -8,21 +8,13 @@ defmodule Dotcom.Alerts.Subway do
   import import Dotcom.Alerts, only: [service_impacting_effects: 0]
 
   @impl Dotcom.Alerts.Group
-  def effects do
-    %{
-      "Bike" => [bike_issue: 1],
-      "Elevator & Escalator" => [
-        elevator_closure: 1,
-        escalator_closure: 1
-      ],
-      "Other" => [],
-      "Parking" => [parking_issue: 1],
-      "Service" => service_impacting_effects()
-    }
-  end
-
-  @impl Dotcom.Alerts.Group
-  def group_order do
-    ["Service", "Elevator & Escalator", "Bike", "Parking", "Other"]
+  def effect_groups do
+    [
+      {"Service", service_impacting_effects()},
+      {"Elevator & Escalator", [elevator_closure: 1, escalator_closure: 1]},
+      {"Bike", [bike_issue: 1]},
+      {"Parking", [parking_issue: 1]},
+      {"Other", []}
+    ]
   end
 end

--- a/lib/dotcom/alerts/subway.ex
+++ b/lib/dotcom/alerts/subway.ex
@@ -1,5 +1,7 @@
 defmodule Dotcom.Alerts.Subway do
-  @moduledoc false
+  @moduledoc """
+  Implements `Dotcom.Alerts.Group` for Subway alerts.
+  """
 
   use Dotcom.Alerts.Group
 

--- a/lib/dotcom_web/components/alerts/grouped.ex
+++ b/lib/dotcom_web/components/alerts/grouped.ex
@@ -1,18 +1,17 @@
-defmodule DotcomWeb.Components.Alerts.Subway do
+defmodule DotcomWeb.Components.Alerts.Grouped do
   @moduledoc false
 
   use DotcomWeb, :component
-
-  import Dotcom.Alerts.Subway,
-    only: [group_alerts: 1, group_counts: 1, group_order: 0, sort_alerts: 1]
 
   import DotcomWeb.Components, only: [count: 1]
 
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
 
-  def alerts_by_effect(%{alerts: alerts} = assigns) do
-    grouped_alerts = group_alerts(alerts)
-    grouped_counts = group_counts(alerts)
+  def alerts_by_effect(%{alerts: alerts, mode: mode} = assigns) do
+    module = mode_to_module(mode)
+
+    grouped_alerts = module.group_alerts(alerts)
+    grouped_counts = module.group_counts(alerts)
     now = @date_time_module.now()
 
     assigns =
@@ -20,13 +19,13 @@ defmodule DotcomWeb.Components.Alerts.Subway do
 
     ~H"""
     <div>
-      <div :for={group <- group_order()}>
+      <div :for={group <- apply(module, :group_order, [])}>
         <h3 id={anchor(group)}>{group}</h3>
         <%= if Map.get(@grouped_counts, group, 0) == 0 do %>
           <p>No {String.downcase(group)} alerts</p>
         <% else %>
           {Phoenix.View.render(DotcomWeb.AlertView, "group.html",
-            alerts: @grouped_alerts |> Map.get(group, []) |> sort_alerts(),
+            alerts: @grouped_alerts |> Map.get(group, []) |> module.sort_alerts(),
             date_time: @now
           )}
         <% end %>
@@ -35,13 +34,20 @@ defmodule DotcomWeb.Components.Alerts.Subway do
     """
   end
 
-  def titles_by_effect(%{alerts: alerts} = assigns) do
-    grouped_counts = group_counts(alerts)
+  def titles_by_effect(%{alerts: alerts, mode: mode} = assigns) do
+    module = mode_to_module(mode)
+
+    grouped_counts = module.group_counts(alerts)
+
     assigns = assign(assigns, grouped_counts: grouped_counts)
 
     ~H"""
     <div class="m-alerts__time-filters">
-      <a :for={group <- group_order()} href={"#" <> anchor(group)} class="m-alerts__time-filter">
+      <a
+        :for={group <- module.group_order()}
+        href={"#" <> anchor(group)}
+        class="m-alerts__time-filter"
+      >
         {group}<span class="float-right"><.count count={Map.get(@grouped_counts, group, 0)} /></span>
       </a>
     </div>
@@ -49,4 +55,8 @@ defmodule DotcomWeb.Components.Alerts.Subway do
   end
 
   defp anchor(group), do: Recase.to_kebab(group)
+
+  defp mode_to_module(mode) do
+    "Elixir.Dotcom.Alerts.#{Recase.to_pascal(mode)}" |> String.to_atom()
+  end
 end

--- a/lib/dotcom_web/components/alerts/grouped.ex
+++ b/lib/dotcom_web/components/alerts/grouped.ex
@@ -75,6 +75,12 @@ defmodule DotcomWeb.Components.Alerts.Grouped do
   defp anchor(group), do: Recase.to_kebab(group)
 
   defp mode_to_module(mode) do
-    "Elixir.Dotcom.Alerts.#{Recase.to_pascal(mode)}" |> String.to_atom()
+    mode
+    |> Atom.to_string()
+    |> Recase.to_pascal()
+    |> Kernel.then(fn mode ->
+      "Elixir.Dotcom.Alerts.#{mode}"
+    end)
+    |> String.to_atom()
   end
 end

--- a/lib/dotcom_web/components/alerts/grouped.ex
+++ b/lib/dotcom_web/components/alerts/grouped.ex
@@ -1,5 +1,12 @@
 defmodule DotcomWeb.Components.Alerts.Grouped do
-  @moduledoc false
+  @moduledoc """
+  Displays alerts grouped by their effect. Two compoenents are provided:
+
+  - `alerts_by_effect/1`: Renders the alerts grouped by their effect.
+  - `titles_by_effect/1`: Renders the titles of the alerts grouped by their effect.
+
+  In both cases, the `mode` assigns is used to determine the module to use for grouping and sorting the alerts.
+  """
 
   use DotcomWeb, :component
 
@@ -7,6 +14,9 @@ defmodule DotcomWeb.Components.Alerts.Grouped do
 
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
 
+  @doc """
+  Renders the alerts grouped by their effect.
+  """
   def alerts_by_effect(%{alerts: alerts, mode: mode} = assigns) do
     module = mode_to_module(mode)
 
@@ -15,17 +25,22 @@ defmodule DotcomWeb.Components.Alerts.Grouped do
     now = @date_time_module.now()
 
     assigns =
-      assign(assigns, grouped_alerts: grouped_alerts, grouped_counts: grouped_counts, now: now)
+      assign(assigns,
+        module: module,
+        grouped_alerts: grouped_alerts,
+        grouped_counts: grouped_counts,
+        now: now
+      )
 
     ~H"""
     <div>
-      <div :for={group <- apply(module, :group_order, [])}>
+      <div :for={group <- @module.group_order()}>
         <h3 id={anchor(group)}>{group}</h3>
         <%= if Map.get(@grouped_counts, group, 0) == 0 do %>
           <p>No {String.downcase(group)} alerts</p>
         <% else %>
           {Phoenix.View.render(DotcomWeb.AlertView, "group.html",
-            alerts: @grouped_alerts |> Map.get(group, []) |> module.sort_alerts(),
+            alerts: @grouped_alerts |> Map.get(group, []) |> @module.sort_alerts(),
             date_time: @now
           )}
         <% end %>
@@ -34,17 +49,20 @@ defmodule DotcomWeb.Components.Alerts.Grouped do
     """
   end
 
+  @doc """
+  Renders the titles of the alerts (with a count of alerts in the group) grouped by their effect.
+  """
   def titles_by_effect(%{alerts: alerts, mode: mode} = assigns) do
     module = mode_to_module(mode)
 
     grouped_counts = module.group_counts(alerts)
 
-    assigns = assign(assigns, grouped_counts: grouped_counts)
+    assigns = assign(assigns, module: module, grouped_counts: grouped_counts)
 
     ~H"""
     <div class="m-alerts__time-filters">
       <a
-        :for={group <- module.group_order()}
+        :for={group <- @module.group_order()}
         href={"#" <> anchor(group)}
         class="m-alerts__time-filter"
       >

--- a/lib/dotcom_web/controllers/schedule/alerts_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/alerts_controller.ex
@@ -15,9 +15,8 @@ defmodule DotcomWeb.ScheduleController.AlertsController do
     mode =
       conn
       |> Map.get(:assigns, %{})
-      |> Map.get(:breadcrumbs, %{})
-      |> Enum.at(1, %{})
-      |> Map.get(:text)
+      |> Map.get(:route)
+      |> Routes.Route.type_atom()
 
     conn
     |> assign(:meta_description, route_description(conn.assigns.route))

--- a/lib/dotcom_web/controllers/schedule/alerts_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/alerts_controller.ex
@@ -12,8 +12,16 @@ defmodule DotcomWeb.ScheduleController.AlertsController do
   plug(:tab_name)
 
   def show(conn, _) do
+    mode =
+      conn
+      |> Map.get(:assigns, %{})
+      |> Map.get(:breadcrumbs, %{})
+      |> Enum.at(1, %{})
+      |> Map.get(:text)
+
     conn
     |> assign(:meta_description, route_description(conn.assigns.route))
+    |> assign(:mode, mode)
     |> put_view(ScheduleView)
     |> render("show.html", [])
   end

--- a/lib/dotcom_web/templates/schedule/_alerts.html.heex
+++ b/lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -1,12 +1,10 @@
 <div class="page-section m-schedule-line">
-  <% subway? =
-    Map.get(@conn.assigns, :breadcrumbs, [])
-    |> Enum.any?(fn %{text: text} -> text === "Subway" end) %>
+  <% group_alerts? = Enum.member?(["Commuter Rail", "Subway"], @mode) %>
   <div class="row">
     <div class="col-xs-12 col-lg-3">
-      <%= if subway? do %>
+      <%= if group_alerts? do %>
         <h3>Jump to</h3>
-        <DotcomWeb.Components.Alerts.Subway.titles_by_effect alerts={@alerts} />
+        <DotcomWeb.Components.Alerts.Grouped.titles_by_effect alerts={@alerts} mode={@mode} />
       <% else %>
         {DotcomWeb.PartialView.alert_time_filters(@alerts_timeframe,
           method: :alerts_path,
@@ -16,8 +14,8 @@
     </div>
     <div class="col-xs-12 col-lg-8 col-lg-offset-1">
       <h2>Alerts</h2>
-      <%= if subway? do %>
-        <DotcomWeb.Components.Alerts.Subway.alerts_by_effect alerts={@alerts} />
+      <%= if group_alerts? do %>
+        <DotcomWeb.Components.Alerts.Grouped.alerts_by_effect alerts={@alerts} mode={@mode} />
       <% else %>
         {DotcomWeb.AlertView.group(
           alerts: @alerts,

--- a/lib/dotcom_web/templates/schedule/_alerts.html.heex
+++ b/lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -1,5 +1,5 @@
 <div class="page-section m-schedule-line">
-  <% group_alerts? = Enum.member?(["Commuter Rail", "Subway"], @mode) %>
+  <% group_alerts? = Enum.member?([:commuter_rail, :subway], @mode) %>
   <div class="row">
     <div class="col-xs-12 col-lg-3">
       <%= if group_alerts? do %>

--- a/test/dotcom/alerts/group_test.exs
+++ b/test/dotcom/alerts/group_test.exs
@@ -56,7 +56,8 @@ defmodule Dotcom.Alerts.GroupTest do
       random_group = Enum.random(effect_groups) |> Kernel.elem(0)
 
       effects =
-        Enum.find(effect_groups, fn {group, _effects} -> group == random_group end) |> Kernel.elem(1)
+        Enum.find(effect_groups, fn {group, _effects} -> group == random_group end)
+        |> Kernel.elem(1)
 
       {random_effect, random_severity} =
         if Enum.empty?(effects), do: {:foo, 0}, else: Enum.random(effects)
@@ -106,7 +107,8 @@ defmodule Dotcom.Alerts.GroupTest do
       random_group = Enum.random(effect_groups) |> Kernel.elem(0)
 
       effects =
-        Enum.find(effect_groups, fn {group, _effects} -> group == random_group end) |> Kernel.elem(1)
+        Enum.find(effect_groups, fn {group, _effects} -> group == random_group end)
+        |> Kernel.elem(1)
 
       {random_effect, random_severity} =
         if Enum.empty?(effects), do: {:foo, 0}, else: Enum.random(effects)
@@ -165,7 +167,8 @@ defmodule Dotcom.Alerts.GroupTest do
       random_group = Enum.random(effect_groups) |> Kernel.elem(0)
 
       effects =
-        Enum.find(effect_groups, fn {group, _effects} -> group == random_group end) |> Kernel.elem(1)
+        Enum.find(effect_groups, fn {group, _effects} -> group == random_group end)
+        |> Kernel.elem(1)
 
       {random_effect, random_severity} = Enum.random(effects)
 

--- a/test/dotcom/alerts/group_test.exs
+++ b/test/dotcom/alerts/group_test.exs
@@ -1,4 +1,4 @@
-defmodule Dotcom.Alerts.SubwayTest do
+defmodule Dotcom.Alerts.GroupTest do
   use ExUnit.Case
 
   import Dotcom.Alerts.Subway

--- a/test/dotcom/alerts/group_test.exs
+++ b/test/dotcom/alerts/group_test.exs
@@ -25,7 +25,7 @@ defmodule Dotcom.Alerts.GroupTest do
   end
 
   describe "group_alerts/1" do
-    test "all groups are present" do
+    test "all effect_groups are present" do
       # Setup
       group_order = group_order()
       alerts = []
@@ -52,11 +52,11 @@ defmodule Dotcom.Alerts.GroupTest do
 
     test "alerts get grouped by effect and severity" do
       # Setup
-      groups = groups()
-      random_group = Enum.random(groups) |> Kernel.elem(0)
+      effect_groups = effect_groups()
+      random_group = Enum.random(effect_groups) |> Kernel.elem(0)
 
       effects =
-        Enum.find(groups, fn {group, _effects} -> group == random_group end) |> Kernel.elem(1)
+        Enum.find(effect_groups, fn {group, _effects} -> group == random_group end) |> Kernel.elem(1)
 
       {random_effect, random_severity} =
         if Enum.empty?(effects), do: {:foo, 0}, else: Enum.random(effects)
@@ -75,7 +75,7 @@ defmodule Dotcom.Alerts.GroupTest do
   end
 
   describe "group_counts/1" do
-    test "all groups are present" do
+    test "all effect_groups are present" do
       # Setup
       group_order = group_order()
       alerts = []
@@ -102,11 +102,11 @@ defmodule Dotcom.Alerts.GroupTest do
 
     test "alerts get counted by effect" do
       # Setup
-      groups = groups()
-      random_group = Enum.random(groups) |> Kernel.elem(0)
+      effect_groups = effect_groups()
+      random_group = Enum.random(effect_groups) |> Kernel.elem(0)
 
       effects =
-        Enum.find(groups, fn {group, _effects} -> group == random_group end) |> Kernel.elem(1)
+        Enum.find(effect_groups, fn {group, _effects} -> group == random_group end) |> Kernel.elem(1)
 
       {random_effect, random_severity} =
         if Enum.empty?(effects), do: {:foo, 0}, else: Enum.random(effects)
@@ -131,17 +131,17 @@ defmodule Dotcom.Alerts.GroupTest do
     end
   end
 
-  describe "groups/0" do
+  describe "effect_groups/0" do
     test "returns an ordered list" do
       # Setup
       group_order = group_order()
 
       # Exercise
-      groups = groups()
+      effect_groups = effect_groups()
 
       # Verify
-      assert groups |> List.first() |> Kernel.elem(0) == Enum.at(group_order, 0)
-      assert groups |> List.last() |> Kernel.elem(0) == Enum.at(group_order, -1)
+      assert effect_groups |> List.first() |> Kernel.elem(0) == Enum.at(group_order, 0)
+      assert effect_groups |> List.last() |> Kernel.elem(0) == Enum.at(group_order, -1)
     end
   end
 
@@ -161,11 +161,11 @@ defmodule Dotcom.Alerts.GroupTest do
 
     test "returns the correct group for grouped effects" do
       # Setup
-      groups = groups() |> Enum.reject(fn {group, _effects} -> group == "Other" end)
-      random_group = Enum.random(groups) |> Kernel.elem(0)
+      effect_groups = effect_groups() |> Enum.reject(fn {group, _effects} -> group == "Other" end)
+      random_group = Enum.random(effect_groups) |> Kernel.elem(0)
 
       effects =
-        Enum.find(groups, fn {group, _effects} -> group == random_group end) |> Kernel.elem(1)
+        Enum.find(effect_groups, fn {group, _effects} -> group == random_group end) |> Kernel.elem(1)
 
       {random_effect, random_severity} = Enum.random(effects)
 


### PR DESCRIPTION
Group commuter rail alerts nearly like subway, but with some small differences. I pulled the logic from subway into a behaviour module and now you just have to define the grouping and sorting and it just works.

https://app.asana.com/1/15492006741476/project/555089885850811/task/1210070462275466?focus=true

