### PR TITLE
feat: Add `endpoints/2` function to get the endpoints from an alert

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,3 +6,5 @@ config :kino_live_component,
   css_path: "http://localhost:8090/app.css",
   endpoint: "http://localhost:4001/kino-live-component",
   js_path: nil
+
+config :phoenix_live_view, debug_heex_annotations: true

--- a/lib/dotcom_web/components/system_status/status_icon.ex
+++ b/lib/dotcom_web/components/system_status/status_icon.ex
@@ -1,0 +1,32 @@
+defmodule DotcomWeb.Components.SystemStatus.StatusIcon do
+  @moduledoc """
+  Renders a status as a readable version of that status, along with an
+  optional prefix.
+  """
+
+  use DotcomWeb, :component
+
+  def status_icon(%{status: :normal} = assigns) do
+    ~H"""
+    <div class="bg-green-line h-4 w-4 rounded-full shrink-0"></div>
+    """
+  end
+
+  def status_icon(assigns) do
+    ~H"""
+    <.icon
+      class="h-[1.125rem] w-[1.125rem] shrink-0"
+      type="icon-svg"
+      name={status_icon_name(@status)}
+      aria-hidden={true}
+    />
+    """
+  end
+
+  def status_icon_name(:shuttle), do: "icon-shuttle-default"
+
+  def status_icon_name(status) when status in [:station_closure, :suspension],
+    do: "icon-cancelled-default"
+
+  def status_icon_name(_), do: "icon-alerts-triangle"
+end

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -22,11 +22,8 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
     assigns = assigns |> assign(:rendered_prefix, rendered_prefix)
 
     ~H"""
-    <span class={[status_classes(@status), "flex items-center gap-2"]}>
-      <.status_icon status={@status} />
-      <span data-test="status_label_text">
-        {@rendered_prefix} {description(@status, @prefix, @plural)}
-      </span>
+    <span data-test="status_label_text" class={status_classes(@status)}>
+      {@rendered_prefix} {description(@status, @prefix, @plural)}
     </span>
     """
   end
@@ -42,30 +39,13 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
   defp description(:delay, prefix) when is_binary(prefix), do: "Expect Delay"
   defp description(status, _), do: Alert.human_effect(%Alert{effect: status})
 
-  defp status_icon(%{status: :normal} = assigns) do
-    ~H"""
-    <div class="bg-green-line h-4 w-4 rounded-full shrink-0"></div>
-    """
-  end
+  def status_icon_name(:shuttle), do: "icon-shuttle-default"
 
-  defp status_icon(assigns) do
-    ~H"""
-    <.icon
-      class="h-[1.125rem] w-[1.125rem] shrink-0"
-      type="icon-svg"
-      name={status_icon_name(@status)}
-      aria-hidden={true}
-    />
-    """
-  end
-
-  defp status_icon_name(:shuttle), do: "icon-shuttle-default"
-
-  defp status_icon_name(status) when status in [:station_closure, :suspension],
+  def status_icon_name(status) when status in [:station_closure, :suspension],
     do: "icon-cancelled-default"
 
-  defp status_icon_name(_), do: "icon-alerts-triangle"
+  def status_icon_name(_), do: "icon-alerts-triangle"
 
   defp status_classes(:normal), do: ""
-  defp status_classes(_), do: "font-bold"
+  defp status_classes(_), do: "font-bold text-lg"
 end

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -8,6 +8,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
 
   import DotcomWeb.Components.RouteSymbols, only: [subway_route_pill: 1]
   import DotcomWeb.Components.SystemStatus.StatusLabel, only: [status_label: 1]
+  import DotcomWeb.Components.SystemStatus.StatusIcon, only: [status_icon: 1]
 
   attr :hide_route_pill, :boolean, default: false
   attr :plural, :boolean, default: false
@@ -17,11 +18,10 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
 
   def status_row_heading(assigns) do
     ~H"""
-    <div class="flex grow">
+    <div class="grid items-center grid-cols-[min-content_min-content_auto] items-stretch grow">
       <div
         class={[
-          "px-2 py-3",
-          "flex items-center",
+          "flex items-center py-3 pl-1 pr-2",
           @hide_route_pill && "opacity-0",
           !@hide_route_pill && "border-t-[1px] border-gray-lightest"
         ]}
@@ -33,7 +33,14 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
         />
       </div>
       <div class={[
-        "py-3 grow border-t-[1px] border-gray-lightest"
+        "pr-2",
+        "flex items-center",
+        "border-t-[1px] border-gray-lightest"
+      ]}>
+        <.status_icon status={@status} />
+      </div>
+      <div class={[
+        "grow border-t-[1px] border-gray-lightest flex items-center"
       ]}>
         <.status_label status={@status} prefix={@prefix} plural={@plural} />
       </div>

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -66,7 +66,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             <.unstyled_accordion
               style={if(row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
               summary_class="hover:bg-brand-primary-lightest cursor-pointer group/row flex items-center grow text-nowrap"
-              chevron_class="fill-gray-dark px-2 py-3 border-t-[1px] border-gray-lightest"
+              chevron_class="fill-gray-dark px-2 border-t-[1px] border-gray-lightest self-stretch flex items-center"
             >
               <:heading>
                 <.heading row={row} />


### PR DESCRIPTION
TODO:
- [ ] Put endpoints into the system status backend
- [ ] Put endpoints into the planned work backend
- [ ] Draw endpoints on the screen when available
- [ ] Make sure that endpoint logic works for Green Line edge cases

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Add endpoints of disruption to system status and planned work](https://app.asana.com/1/15492006741476/project/555089885850811/task/1209641123314696?focus=true)