### PR TITLE
fix(TimetableController): Foxboro route pattern sorting

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -368,6 +368,11 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     |> with_prioritized_pattern("Fall River")
   end
 
+  defp with_prioritized_pattern([%RoutePattern{route_id: "CR-Foxboro"} | _] = route_patterns) do
+    route_patterns
+    |> with_prioritized_pattern("South Station - Foxboro")
+  end
+
   defp with_prioritized_pattern(route_patterns), do: route_patterns
 
   defp with_prioritized_pattern(route_patterns, pattern_name) do


### PR DESCRIPTION
When iterating through canonical route patterns and their associated trips/stops, sometimes we need to help it pick the right route pattern to look through first. Here we add the Foxboro route to this logic!

[Before](https://dev.mbtace.com/schedules/CR-Foxboro/timetable?date=2025-05-04&schedule_direction[direction_id]=0#direction-filter)
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/255e9dc1-598a-40cc-a97b-99ec14418464" />

After
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/b78963d4-1c27-4ea2-ab99-8928a25427d9" />

