### PR TITLE
fix(AlertsController): don't filter by timeframe

### DIFF
--- a/lib/dotcom_web/controllers/schedule/alerts_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/alerts_controller.ex
@@ -1,13 +1,17 @@
 defmodule DotcomWeb.ScheduleController.AlertsController do
+  @moduledoc """
+  Used in the alerts tab on schedule pages.
+  """
+
   use DotcomWeb, :controller
 
-  alias DotcomWeb.ScheduleView
+  alias DotcomWeb.{Plugs, ScheduleView}
   alias Routes.Route
 
   plug(DotcomWeb.Plugs.Route)
   plug(DotcomWeb.ScheduleController.Defaults)
   plug(:alerts)
-  plug(DotcomWeb.Plugs.AlertsByTimeframe)
+  plug(:alerts_by_timeframe)
   plug(DotcomWeb.ScheduleController.RouteBreadcrumbs)
   plug(:tab_name)
 
@@ -45,5 +49,15 @@ defmodule DotcomWeb.ScheduleController.AlertsController do
     route
     |> Route.type_atom()
     |> Route.type_name()
+  end
+
+  # The alert timeframe filter is being phased out of schedule pages
+  # Adjust this condition as we update more route alert page layouts
+  defp alerts_by_timeframe(%{assigns: %{route: %Route{id: route_id}}} = conn, _) do
+    if route_id in Dotcom.Routes.subway_route_ids() do
+      conn
+    else
+      Plugs.AlertsByTimeframe.call(conn, [])
+    end
   end
 end


### PR DESCRIPTION
Having the `alerts_timeframe=` URL parameter present was still filtering away alerts on pages where we've taken away from timeframe filtering from the UI! This PR avoids that from happening on subway schedule pages.

Before at https://dev.mbtace.com/schedules/Red/alerts?alerts_timeframe=current - No service alerts
<img width="1256" alt="image" src="https://github.com/user-attachments/assets/a6a7efa7-2bad-4d18-b2f1-96daf619eb77" />

Now with this PR - Upcoming service alerts visible
<img width="1258" alt="image" src="https://github.com/user-attachments/assets/a7891811-1794-4dd1-bd87-0f3b8e318530" />
