### PR TITLE
fix: Styling for consolidated subway statuses

### DIFF
--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -40,9 +40,11 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
       <% else %>
         <div :for={{service_range, disruptions} <- @ordered_disruptions} class="py-3">
           <div class="mb-2 font-bold font-heading">{service_range_string(service_range)}</div>
-          <.lined_list :let={disruption} items={disruptions}>
-            <.disruption alert={disruption} />
-          </.lined_list>
+          <div class="border-b-[1px] border-gray-lightest">
+            <div :for={disruption <- disruptions}>
+              <.disruption alert={disruption} />
+            </div>
+          </div>
         </div>
       <% end %>
     </.bordered_container>
@@ -65,7 +67,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     <.unstyled_accordion
       :for={route_ids <- @route_ids_by_subway_line}
       summary_class="flex items-center hover:bg-brand-primary-lightest cursor-pointer group/row"
-      chevron_class="fill-gray-dark px-2 py-3"
+      chevron_class="border-t-[1px] border-gray-lightest fill-gray-dark px-2 py-3"
     >
       <:heading>
         <.heading route_ids={route_ids} alert={@alert} />

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -18,15 +18,22 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
   def status_row_heading(assigns) do
     ~H"""
     <div class="flex grow">
-      <div class={["px-2 py-3", @hide_route_pill && "opacity-0"]} data-route-pill>
+      <div
+        class={[
+          "px-2 py-3",
+          "flex items-center",
+          @hide_route_pill && "opacity-0",
+          !@hide_route_pill && "border-t-[1px] border-gray-lightest"
+        ]}
+        data-route-pill
+      >
         <.subway_route_pill
           class="group-hover/row:ring-brand-primary-lightest"
           route_ids={@route_ids}
         />
       </div>
       <div class={[
-        "py-3 grow",
-        @hide_route_pill && "border-t-[1px] border-gray-lightest"
+        "py-3 grow border-t-[1px] border-gray-lightest"
       ]}>
         <.status_label status={@status} prefix={@prefix} plural={@plural} />
       </div>

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -28,12 +28,12 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
           Subway Status
         </a>
       </:heading>
-      <.lined_list :let={row} items={@rows}>
+      <div class="border-b-[1px] border-gray-lightest">
         <a
+          :for={row <- @rows}
           href={row.route_info.url}
-          style={if(row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
           class={[
-            "flex gap-2 items-center",
+            "flex items-center",
             "hover:bg-brand-primary-lightest cursor-pointer group/row",
             "text-black no-underline font-normal"
           ]}
@@ -41,9 +41,11 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
         >
           <.heading row={row} />
 
-          <.icon name="chevron-right" class="h-3 w-2 fill-gray-dark ml-3 mr-2 shrink-0" />
+          <div class="border-t-[1px] border-gray-lightest self-stretch flex items-center">
+            <.icon name="chevron-right" class="h-3 w-2 fill-gray-dark ml-3 mr-2 shrink-0" />
+          </div>
         </a>
-      </.lined_list>
+      </div>
     </.bordered_container>
     """
   end
@@ -58,13 +60,13 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
           Current Status
         </div>
       </:heading>
-      <.lined_list :let={row} items={@rows}>
-        <div data-test-row-route-info={inspect(row.route_info)}>
+      <div class="border-b-[1px] border-gray-lightest">
+        <div :for={row <- @rows} data-test-row-route-info={inspect(row.route_info)}>
           <%= if row.alert do %>
             <.unstyled_accordion
               style={if(row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
               summary_class="hover:bg-brand-primary-lightest cursor-pointer group/row flex items-center grow text-nowrap"
-              chevron_class={"fill-gray-dark px-2 py-3 #{row.style.hide_route_pill && "border-t-[1px] border-gray-lightest"}"}
+              chevron_class="fill-gray-dark px-2 py-3 border-t-[1px] border-gray-lightest"
             >
               <:heading>
                 <.heading row={row} />
@@ -77,7 +79,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             <.heading row={row} />
           <% end %>
         </div>
-      </.lined_list>
+      </div>
     </.bordered_container>
     """
   end


### PR DESCRIPTION
I noticed that [this PR](https://github.com/mbta/dotcom/pull/2525) messed up some styles for when system status isn't 100% normal, with some border lines not quite lining up, and some things not being centered properly.

Screenshots below (before on the left; after on the right)

### Homepage Status
![Screenshot 2025-05-05 at 10 09 51 AM](https://github.com/user-attachments/assets/2f811e48-50c6-4e38-aaff-c078fab39e56)

### Alerts Page Status
![Screenshot 2025-05-05 at 10 12 16 AM](https://github.com/user-attachments/assets/63520106-96fa-4458-8571-f72726d72122)

### Narrow Screens
![Screenshot 2025-05-05 at 10 23 51 AM](https://github.com/user-attachments/assets/5d8e15a4-70ee-45ff-be4e-673b58317338)

---

No ticket.