### PR TITLE
cleanup: Remove unused `lined_list` imports

### DIFF
--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -171,58 +171,6 @@ defmodule DotcomWeb.Components do
     """
   end
 
-  slot(:inner_block, required: true)
-  attr(:items, :list, required: true)
-
-  @doc """
-  Generic list with a faint dividing line between list items. The `@inner_block`
-  gets repeated for every list item.
-
-  Example usage:
-
-  ```elixir
-  <.lined_list :let={stop} items={@stops}>
-    <p class="p-1 m-0 text-xl">
-      {stop.name} @ {stop.address}
-    </p>
-  </.lined_list>
-  ```
-
-  Not recommended but possible: Removing or altering the dividing line can be
-  done on a per-line basis by wrapping the line with an element which redefines
-  the Tailwind CSS properties affecting the `divide-y` helper.
-
-  ```elixir
-  <.lined_list :let={thing} items={@things}>
-    <%= if thing.important do %>
-      <div style="--tw-divide-y-reverse: 10">
-        {stop.name} has larger bottom border width
-      </div>
-    <% else %>
-      <%= if thing.sequence > 1 do %>
-        <div style="--tw-divide-opacity: 0" class="border-dashed border-t-2">
-          {stop.name} has custom top border
-        </div>
-      <% else %>
-        {stop.name} has default border
-      <% end %>
-    <% end %>
-  </.lined_list>
-  ```
-
-  Not recommended for simple lists which should use `<ul>` or `<ol>`, as this
-  does not implement the ARIA role for "list".
-  """
-  def lined_list(assigns) do
-    ~H"""
-    <div class="border-gray-lightest border-y-[1px] divide-gray-lightest divide-y-[1px]">
-      <%= for item <- @items do %>
-        {render_slot(@inner_block, item)}
-      <% end %>
-    </div>
-    """
-  end
-
   slot(:content, required: true)
   slot(:heading, required: true)
   attr(:class, :string, default: "")

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -7,7 +7,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
 
   import Dotcom.Routes, only: [line_name_for_subway_route: 1, subway_line_ids: 0]
   import Dotcom.Utils.ServiceDateTime, only: [service_date: 1, service_range_string: 1]
-  import DotcomWeb.Components, only: [bordered_container: 1, lined_list: 1, unstyled_accordion: 1]
+  import DotcomWeb.Components, only: [bordered_container: 1, unstyled_accordion: 1]
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
   import DotcomWeb.Components.SystemStatus.StatusRowHeading, only: [status_row_heading: 1]
 

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -5,7 +5,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
   use DotcomWeb, :component
 
-  import DotcomWeb.Components, only: [bordered_container: 1, lined_list: 1, unstyled_accordion: 1]
+  import DotcomWeb.Components, only: [bordered_container: 1, unstyled_accordion: 1]
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
   import DotcomWeb.Components.SystemStatus.StatusRowHeading, only: [status_row_heading: 1]
 

--- a/test/dotcom_web/components_test.exs
+++ b/test/dotcom_web/components_test.exs
@@ -105,30 +105,6 @@ defmodule DotcomWeb.ComponentsTest do
     end
   end
 
-  describe "lined_list" do
-    test "shows inner block for each item" do
-      assigns = %{
-        items: Faker.Lorem.sentences()
-      }
-
-      rendered_items =
-        rendered_to_string(~H"""
-        <.lined_list :let={sentence} items={@items}>
-          <p>{sentence}</p>
-        </.lined_list>
-        """)
-        |> Floki.parse_fragment!()
-        |> Floki.find("p")
-
-      assert Enum.count(rendered_items) == Enum.count(assigns.items)
-      rendered_content = Enum.flat_map(rendered_items, fn {"p", _, content} -> content end)
-
-      for sentence <- assigns.items do
-        assert sentence in rendered_content
-      end
-    end
-  end
-
   describe "tooltip" do
     test "sets up basic tooltip" do
       assigns = %{


### PR DESCRIPTION
Oops - [missed these](https://github.com/mbta/dotcom/pull/2534).

These were actually the last usages of `lined_list`, so we could, in theory, remove that entire component as well. Thoughts?