### PR TITLE
refactor: Change status row header from flex to grid

### DIFF
--- a/lib/dotcom_web/components/system_status/status_icon.ex
+++ b/lib/dotcom_web/components/system_status/status_icon.ex
@@ -1,0 +1,32 @@
+defmodule DotcomWeb.Components.SystemStatus.StatusIcon do
+  @moduledoc """
+  Renders a status as a readable version of that status, along with an
+  optional prefix.
+  """
+
+  use DotcomWeb, :component
+
+  def status_icon(%{status: :normal} = assigns) do
+    ~H"""
+    <div class="bg-green-line h-4 w-4 rounded-full shrink-0"></div>
+    """
+  end
+
+  def status_icon(assigns) do
+    ~H"""
+    <.icon
+      class="h-[1.125rem] w-[1.125rem] shrink-0"
+      type="icon-svg"
+      name={status_icon_name(@status)}
+      aria-hidden={true}
+    />
+    """
+  end
+
+  def status_icon_name(:shuttle), do: "icon-shuttle-default"
+
+  def status_icon_name(status) when status in [:station_closure, :suspension],
+    do: "icon-cancelled-default"
+
+  def status_icon_name(_), do: "icon-alerts-triangle"
+end

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -22,11 +22,8 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
     assigns = assigns |> assign(:rendered_prefix, rendered_prefix)
 
     ~H"""
-    <span class={[status_classes(@status), "flex items-center gap-2"]}>
-      <.status_icon status={@status} />
-      <span data-test="status_label_text">
-        {@rendered_prefix} {description(@status, @prefix, @plural)}
-      </span>
+    <span data-test="status_label_text" class={status_classes(@status)}>
+      {@rendered_prefix} {description(@status, @prefix, @plural)}
     </span>
     """
   end
@@ -42,30 +39,13 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
   defp description(:delay, prefix) when is_binary(prefix), do: "Expect Delay"
   defp description(status, _), do: Alert.human_effect(%Alert{effect: status})
 
-  defp status_icon(%{status: :normal} = assigns) do
-    ~H"""
-    <div class="bg-green-line h-4 w-4 rounded-full shrink-0"></div>
-    """
-  end
+  def status_icon_name(:shuttle), do: "icon-shuttle-default"
 
-  defp status_icon(assigns) do
-    ~H"""
-    <.icon
-      class="h-[1.125rem] w-[1.125rem] shrink-0"
-      type="icon-svg"
-      name={status_icon_name(@status)}
-      aria-hidden={true}
-    />
-    """
-  end
-
-  defp status_icon_name(:shuttle), do: "icon-shuttle-default"
-
-  defp status_icon_name(status) when status in [:station_closure, :suspension],
+  def status_icon_name(status) when status in [:station_closure, :suspension],
     do: "icon-cancelled-default"
 
-  defp status_icon_name(_), do: "icon-alerts-triangle"
+  def status_icon_name(_), do: "icon-alerts-triangle"
 
   defp status_classes(:normal), do: ""
-  defp status_classes(_), do: "font-bold"
+  defp status_classes(_), do: "font-bold text-lg"
 end

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -39,13 +39,6 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
   defp description(:delay, prefix) when is_binary(prefix), do: "Expect Delay"
   defp description(status, _), do: Alert.human_effect(%Alert{effect: status})
 
-  def status_icon_name(:shuttle), do: "icon-shuttle-default"
-
-  def status_icon_name(status) when status in [:station_closure, :suspension],
-    do: "icon-cancelled-default"
-
-  def status_icon_name(_), do: "icon-alerts-triangle"
-
   defp status_classes(:normal), do: ""
   defp status_classes(_), do: "font-bold text-lg"
 end

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -8,6 +8,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
 
   import DotcomWeb.Components.RouteSymbols, only: [subway_route_pill: 1]
   import DotcomWeb.Components.SystemStatus.StatusLabel, only: [status_label: 1]
+  import DotcomWeb.Components.SystemStatus.StatusIcon, only: [status_icon: 1]
 
   attr :hide_route_pill, :boolean, default: false
   attr :plural, :boolean, default: false
@@ -17,27 +18,51 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
 
   def status_row_heading(assigns) do
     ~H"""
-    <div class="flex grow">
-      <div
-        class={[
-          "px-2 py-3",
-          "flex items-center",
-          @hide_route_pill && "opacity-0",
-          !@hide_route_pill && "border-t-[1px] border-gray-lightest"
-        ]}
-        data-route-pill
-      >
-        <.subway_route_pill
-          class="group-hover/row:ring-brand-primary-lightest"
-          route_ids={@route_ids}
-        />
-      </div>
-      <div class={[
-        "py-3 grow border-t-[1px] border-gray-lightest"
-      ]}>
-        <.status_label status={@status} prefix={@prefix} plural={@plural} />
-      </div>
+    <div class="grid items-center grid-cols-[min-content_min-content_auto] items-center grow">
+      <.top_padding hide_route_pill={@hide_route_pill} />
+
+      <.heading
+        hide_route_pill={@hide_route_pill}
+        plural={@plural}
+        prefix={@prefix}
+        route_ids={@route_ids}
+        status={@status}
+      />
+
+      <.bottom_padding hide_route_pill={@hide_route_pill} />
     </div>
+    """
+  end
+
+  defp bottom_padding(assigns) do
+    ~H"""
+    <div class="h-3"></div>
+    <div class="h-3"></div>
+    <div class="h-3"></div>
+    """
+  end
+
+  defp heading(assigns) do
+    ~H"""
+    <div class={["flex items-center pl-1 pr-2", @hide_route_pill && "opacity-0"]} data-route-pill>
+      <.subway_route_pill class="group-hover/row:ring-brand-primary-lightest" route_ids={@route_ids} />
+    </div>
+
+    <div class="pr-2 flex items-center">
+      <.status_icon status={@status} />
+    </div>
+
+    <div class="grow flex items-center">
+      <.status_label status={@status} prefix={@prefix} plural={@plural} />
+    </div>
+    """
+  end
+
+  defp top_padding(assigns) do
+    ~H"""
+    <div class={["h-3", !@hide_route_pill && "border-t-xs border-gray-lightest"]}></div>
+    <div class={["h-3", "border-t-xs border-gray-lightest"]}></div>
+    <div class={["h-3", "border-t-xs border-gray-lightest"]}></div>
     """
   end
 end

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -66,7 +66,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             <.unstyled_accordion
               style={if(row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
               summary_class="hover:bg-brand-primary-lightest cursor-pointer group/row flex items-center grow text-nowrap"
-              chevron_class="fill-gray-dark px-2 py-3 border-t-[1px] border-gray-lightest"
+              chevron_class="fill-gray-dark px-2 border-t-[1px] border-gray-lightest self-stretch flex items-center"
             >
               <:heading>
                 <.heading row={row} />


### PR DESCRIPTION
Re-implement the `<.status_row_heading />` component as a CSS `grid` instead of its previous `flex` implementation. This is in order to support the kind of layout where there is sub-heading text directly below the status description (**Shuttle** or **Station Closure** or whatever). 

This was intended to be a pure refactor, but while working on this, I noticed a few small details that I got wrong when originally implementing the subway status feature, so I went ahead and fixed those.

![Screenshot 2025-05-06 at 9 57 38 AM](https://github.com/user-attachments/assets/dea9a632-f3c5-45ec-8dcf-9a25076b9ded)

- The font size for disrupted statuses is now slightly larger, as well as being bold.
- The padding to the left of the root pills is now 4px rather than 8px.

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Subtask:** [[Endpoints] Refactor status row heading to use grid instead of flex](https://app.asana.com/1/15492006741476/project/1205718271156548/task/1210172306293798?focus=true)
**Asana Parent Ticket:** [Add endpoints of disruption to system status and planned work](https://app.asana.com/1/15492006741476/project/1205718271156548/task/1209641123314696?focus=true)