### PR TITLE
feat: Add `endpoint_stops/2` function to get the endpoints from an alert

### DIFF
--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -298,8 +298,9 @@ defmodule Alerts.Alert do
   @spec endpoint_stops(t(), Routes.Route.id_t()) :: {Stops.Stop.t(), Stops.Stop.t()} | nil
   def endpoint_stops(alert, route_id) do
     informed_stop_ids = alert |> get_entity(:stop)
+    informed_route_ids = alert |> get_entity(:route)
 
-    if MapSet.size(informed_stop_ids) < 2 do
+    if MapSet.size(informed_stop_ids) < 2 || multiple_green_line_routes?(informed_route_ids) do
       nil
     else
       affected_stops =
@@ -308,6 +309,13 @@ defmodule Alerts.Alert do
 
       {List.first(affected_stops), List.last(affected_stops)}
     end
+  end
+
+  @spec multiple_green_line_routes?(MapSet.t()) :: boolean()
+  defp multiple_green_line_routes?(route_ids) do
+    route_ids
+    |> MapSet.intersection(MapSet.new(GreenLine.branch_ids()))
+    |> MapSet.size() > 1
   end
 
   @spec informed_direction_id(t()) :: 0 | 1

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -295,8 +295,8 @@ defmodule Alerts.Alert do
     end)
   end
 
-  @spec endpoints(t(), Routes.Route.id_t()) :: {Stops.Stop.t(), Stops.Stop.t()} | nil
-  def endpoints(alert, route_id) do
+  @spec endpoint_stops(t(), Routes.Route.id_t()) :: {Stops.Stop.t(), Stops.Stop.t()} | nil
+  def endpoint_stops(alert, route_id) do
     informed_stop_ids = alert |> get_entity(:stop)
 
     if MapSet.size(informed_stop_ids) < 2 do

--- a/test/alerts/alerts_test.exs
+++ b/test/alerts/alerts_test.exs
@@ -1,7 +1,5 @@
 defmodule AlertsTest do
   use ExUnit.Case, async: true
-  alias Test.Support.FactoryHelpers
-  alias Test.Support.Factories
   use Timex
 
   import Alerts.Alert
@@ -9,6 +7,8 @@ defmodule AlertsTest do
 
   alias Alerts.Alert
   alias Alerts.InformedEntity
+  alias Test.Support.Factories
+  alias Test.Support.FactoryHelpers
 
   setup :verify_on_exit!
 

--- a/test/alerts/alerts_test.exs
+++ b/test/alerts/alerts_test.exs
@@ -167,12 +167,12 @@ defmodule AlertsTest do
     end
   end
 
-  describe "endpoints/2" do
+  describe "endpoint_stops/2" do
     test "returns nil if an alert's informed entities don't include any stops" do
       route_id = FactoryHelpers.build(:id)
       alert = Alert.new(informed_entity: [%InformedEntity{stop: nil}])
 
-      assert Alert.endpoints(alert, route_id) == nil
+      assert Alert.endpoint_stops(alert, route_id) == nil
     end
 
     test "returns nil if an alert's informed entities includes precisely one stop" do
@@ -181,7 +181,7 @@ defmodule AlertsTest do
 
       alert = Alert.new(informed_entity: [%InformedEntity{stop: stop.id}])
 
-      assert Alert.endpoints(alert, route_id) == nil
+      assert Alert.endpoint_stops(alert, route_id) == nil
     end
 
     test "returns the first and last stops according to the order given by Stops.Repo" do
@@ -202,7 +202,7 @@ defmodule AlertsTest do
         stops
       end)
 
-      assert Alert.endpoints(alert, route_id) == {first_stop, last_stop}
+      assert Alert.endpoint_stops(alert, route_id) == {first_stop, last_stop}
     end
 
     test "does not include stops that aren't in the informed entity set" do
@@ -225,7 +225,7 @@ defmodule AlertsTest do
           Factories.Stops.Stop.build_list(2, :stop)
       end)
 
-      assert Alert.endpoints(alert, route_id) == {first_stop, last_stop}
+      assert Alert.endpoint_stops(alert, route_id) == {first_stop, last_stop}
     end
 
     test "uses a direction ID if there is one as an informed entity" do
@@ -255,7 +255,7 @@ defmodule AlertsTest do
         stops
       end)
 
-      assert Alert.endpoints(alert, route_id) == {first_stop, last_stop}
+      assert Alert.endpoint_stops(alert, route_id) == {first_stop, last_stop}
     end
   end
 end


### PR DESCRIPTION
Adds a function to get the endpoints of an alert when applicable.

Out of scope (to be done as a follow-up):
- Green Line (will just return `nil` for Green Line alerts)

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Subtask:** [[Endpoints] Add endpoints function to alerts](https://app.asana.com/1/15492006741476/project/1205718271156548/task/1210172306293799?focus=true)
**Asana Parent Ticket:** [Add endpoints of disruption to system status and planned work](https://app.asana.com/1/15492006741476/project/1205718271156548/task/1209641123314696?focus=true)