### PR TITLE
sentry: add console integration

### DIFF
--- a/assets/ts/sentry.ts
+++ b/assets/ts/sentry.ts
@@ -15,9 +15,10 @@ export default function initializeSentry(): void {
     Sentry.init({
       dsn: window.sentry.dsn,
       environment: window.sentry.environment,
+      integrations: [Sentry.captureConsoleIntegration()],
       beforeSend,
       autoSessionTracking: false,
-      sampleRate: 0.6, // error sampling - might increase later
+      sampleRate: 0.8, // error sampling - might increase later
       initialScope: {
         tags: { "dotcom.application": "frontend" }
       },


### PR DESCRIPTION
No ticket, but I'm trying to see if I can collect more info for that [one persistent stop page error](https://mbtace.sentry.io/issues/5255754689/?project=194344&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0) that Sentry logs. It linked to some [guidance](https://sentry.io/answers/load-failed-javascript/) suggesting that adding this integration might help!

While I'm here I also figured I'd increase the sample rate and maybe collect more errors.