### PR TITLE
fix: Warning about unused `handle_revision/1` clause in tests

### DIFF
--- a/lib/cms/api/static.ex
+++ b/lib/cms/api/static.ex
@@ -485,6 +485,7 @@ defmodule CMS.Api.Static do
   def preview(3480, vid), do: {:ok, do_preview(Enum.at(project_repo(), 1), vid)}
   def preview(3174, vid), do: {:ok, do_preview(Enum.at(project_update_repo(), 1), vid)}
   def preview(6, vid), do: {:ok, do_preview(basic_page_response(), vid)}
+  def preview(_, _vid), do: {:error, :not_found}
 
   defp filter_by(map, key, value) do
     Enum.filter(map, &match?(%{^key => [%{"value" => ^value}]}, &1))

--- a/lib/cms/api/static.ex
+++ b/lib/cms/api/static.ex
@@ -482,7 +482,6 @@ defmodule CMS.Api.Static do
   def preview(node_id, revision_id)
   def preview(3518, vid), do: {:ok, do_preview(Enum.at(news_repo(), 1), vid)}
   def preview(5, vid), do: {:ok, do_preview(Enum.at(events_response(), 1), vid)}
-  def preview(3480, vid), do: {:ok, do_preview(Enum.at(project_repo(), 1), vid)}
   def preview(3174, vid), do: {:ok, do_preview(Enum.at(project_update_repo(), 1), vid)}
   def preview(6, vid), do: {:ok, do_preview(basic_page_response(), vid)}
   def preview(_, _vid), do: {:error, :not_found}

--- a/test/dotcom_web/controllers/cms_controller_test.exs
+++ b/test/dotcom_web/controllers/cms_controller_test.exs
@@ -54,6 +54,16 @@ defmodule DotcomWeb.CMSControllerTest do
       assert html_response(conn, 200) =~ "Arts on the T 112"
     end
 
+    test "returns a 404 if the given node is missing", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          "/basic_page_no_sidebar?preview&vid=112&nid=#{Faker.random_between(9000, 9999)}"
+        )
+
+      assert html_response(conn, 404)
+    end
+
     test "renders a basic page without sidebar", %{conn: conn} do
       conn = get(conn, "/basic_page_no_sidebar")
       rendered = html_response(conn, 200)

--- a/test/dotcom_web/controllers/event_controller_test.exs
+++ b/test/dotcom_web/controllers/event_controller_test.exs
@@ -103,6 +103,19 @@ defmodule DotcomWeb.EventControllerTest do
       assert %{"preview" => "", "vid" => "112", "nid" => "5"} == conn.query_params
     end
 
+    test "returns a 404 if the given node is missing", %{conn: conn} do
+      event = event_factory(1)
+
+      conn =
+        get(
+          conn,
+          event_path(conn, :show, event) <>
+            "?preview&vid=112&nid=#{Faker.random_between(9000, 9999)}"
+        )
+
+      assert html_response(conn, 404)
+    end
+
     test "retains params (except _format) and redirects when CMS returns a native redirect", %{
       conn: conn
     } do

--- a/test/dotcom_web/controllers/news_entry_controller_test.exs
+++ b/test/dotcom_web/controllers/news_entry_controller_test.exs
@@ -75,6 +75,19 @@ defmodule DotcomWeb.NewsEntryControllerTest do
                "Between Forge Park/495 and Readville Stations for 8 Weekends 112"
     end
 
+    test "returns a 404 if the given node is missing", %{conn: conn} do
+      news_entry = news_entry_factory(1)
+
+      conn =
+        get(
+          conn,
+          news_entry_path(conn, :show, news_entry) <>
+            "?preview&vid=112&nid=#{Faker.random_between(9000, 9999)}"
+        )
+
+      assert html_response(conn, 404)
+    end
+
     test "includes Recent News suggestions", %{conn: conn} do
       news_entry = news_entry_factory(1)
 

--- a/test/dotcom_web/controllers/project_controller_test.exs
+++ b/test/dotcom_web/controllers/project_controller_test.exs
@@ -152,6 +152,19 @@ defmodule DotcomWeb.ProjectControllerTest do
       assert %{"preview" => "", "vid" => "112", "nid" => "3174"} == conn.query_params
     end
 
+    test "returns a 404 if the given node is missing", %{conn: conn} do
+      project_update = project_update_factory(1)
+
+      conn =
+        get(
+          conn,
+          project_update_path(conn, :project_update, project_update) <>
+            "?preview&vid=112&nid=#{Faker.random_between(9000, 9999)}"
+        )
+
+      assert conn.status == 404
+    end
+
     test "doesn't redirect update when project part of path would by itself return a native redirect",
          %{conn: conn} do
       conn =


### PR DESCRIPTION
No ticket.

When we did [the Elixir 1.18 upgrade](https://github.com/mbta/dotcom/pull/2539), that introduced a new type of warning to alert us to certain types of unused code. One of the offenders was this:
```
     warning: this clause of defp handle_revision/1 is never used
     │
 287 │   defp handle_revision({:error, err}), do: {:error, err}
     │        ~
     │
     └─ lib/cms/repo.ex:287:8: CMS.Repo.handle_revision/1
```

Triggered by [this code here](https://github.com/mbta/dotcom/blob/bf440f87f575faba294b9f68263abb955715e36f/lib/cms/repo.ex#L286-L287).

The wacky thing is - that code actually is used! `handle_revision/1` is called [here](https://github.com/mbta/dotcom/blob/bf440f87f575faba294b9f68263abb955715e36f/lib/cms/repo.ex#L265-L266), with the value [returned from](https://github.com/mbta/dotcom/blob/bf440f87f575faba294b9f68263abb955715e36f/lib/cms/api.ex#L11-L22) `CMS.Api.preview/2`, whose return value comes from `CMS.Api.handle_response/1`, which [does return](https://github.com/mbta/dotcom/blob/bf440f87f575faba294b9f68263abb955715e36f/lib/cms/api.ex#L41-L42) `{:error, err}` when it gets either a 404 or a 500.

...

Turns out, that warning only appears during test runs - `mix compile` runs clean (once you get past all the warnings in the dependencies 😩), which suggests that this is test-specific. And sure enough, `CMS.Api` is not the module used in tests - that's [configured](https://github.com/mbta/dotcom/blob/bf440f87f575faba294b9f68263abb955715e36f/config/test.exs#L14) to be `CMS.Api.Static`, which defines its own `preview/2` function. And sure enough, [that preview implementation](https://github.com/mbta/dotcom/blob/bf440f87f575faba294b9f68263abb955715e36f/lib/cms/api/static.ex#L481-L487) does not return `{:error, _}` under any circumstances, meaning that in the test environment, `CMS.Repo.handle_revision/1` really can't ever be called with `{:error, _}`.

---

This PR is divided into three commits:
1. The first commit just adds a match to `CMS.Api.Static.preview/2` so that it can return `{:error, _}`, thus making the warning go away.
2. But that's a clue that there was some missing test coverage - if that match couldn't have been triggered at the compiled level in the test env, then it certainly wasn't being executed by any tests. So the second commit adds those missing tests.
3. One of the patterns that was matched by `CMS.Api.Static` isn't being used, so I figured we could get rid of it.
