### PR TITLE
fix: Wrapping behavior for stop feature icons

### DIFF
--- a/lib/dotcom_web/components/stops/header.ex
+++ b/lib/dotcom_web/components/stops/header.ex
@@ -29,7 +29,7 @@ defmodule DotcomWeb.Components.Stops.Header do
     <div class="flex items-center justify-content-space-between">
       <h1 class="text-xl mt-3 mb-3">{@stop.name}</h1>
       <div class="mt-3 mb-3">
-        <div class="flex items-end justify-items-end gap-2">
+        <div class="flex items-end justify-items-end gap-2 flex-wrap">
           <.mode_icons routes_by_stop={@routes_by_stop} />
           <.zone stop={@stop} />
           <.accessibility :if={accessible?(assigns)} />

--- a/lib/dotcom_web/components/transit_icons.ex
+++ b/lib/dotcom_web/components/transit_icons.ex
@@ -32,7 +32,7 @@ defmodule DotcomWeb.Components.TransitIcons do
   """
   def zone(assigns) when not is_nil(assigns.stop.zone) do
     ~H"""
-    <div class="border-[1px] border-commuter-rail text-commuter-rail max-h-6 rounded-sm px-1.5 font-bold inline-flex justify-center">
+    <div class="border-[1px] border-commuter-rail text-commuter-rail max-h-6 rounded-sm px-1.5 font-bold inline-flex justify-center text-nowrap">
       Zone {@stop.zone}
     </div>
     """


### PR DESCRIPTION
## Before
![Screenshot 2025-05-12 at 3 39 38 PM](https://github.com/user-attachments/assets/0545ce24-d179-4ca7-be4a-fa3fe84593ab)

## After
![Screenshot 2025-05-12 at 3 38 53 PM(2)](https://github.com/user-attachments/assets/ef746504-3b97-4525-9755-753fd5913fe5)

---

- The addition of `text-nowrap` forces `Zone 1A` to stay on one line.
- The addition of `flex-wrap` prevents that from pushing the parking icon off the edge of the screen, and allows the mode icons to give the station name some breathing room.

---

No ticket.