### PR TITLE
feat: Add affected stops to system status and planned work

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,7 @@
 import Config
 
+config :dotcom, :affected_stops_module, Dotcom.Alerts.AffectedStops
+
 config :dotcom, :aws_client, AwsClient.Behaviour
 
 config :dotcom, :cms_api_module, CMS.Api

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,6 +5,8 @@ config :aws_credentials,
   credential_providers: [],
   fail_if_unavailable: false
 
+config :dotcom, :affected_stops_module, Dotcom.Alerts.AffectedStops.Mock
+
 config :dotcom, :aws_client, AwsClient.Mock
 
 config :dotcom, :cache, Dotcom.Cache.TestCache

--- a/lib/dotcom/alerts/affected_stops.ex
+++ b/lib/dotcom/alerts/affected_stops.ex
@@ -12,14 +12,37 @@ defmodule Dotcom.Alerts.AffectedStops do
 
   @impl Behaviour
   def affected_stops(alerts, route_ids) do
-    stop_ids =
-      alerts
-      |> Enum.map(&(&1 |> Alert.get_entity(:stop)))
-      |> Enum.reduce(MapSet.new(), &MapSet.union/2)
+    stop_ids = alerts |> get_all_entities(:stop)
+
+    direction_ids = alerts |> get_all_direction_ids()
 
     route_ids
-    |> Enum.flat_map(&(&1 |> @stops_repo.by_route(0)))
+    |> outer_product(direction_ids)
+    |> Enum.flat_map(fn {route_id, direction_id} ->
+      @stops_repo.by_route(route_id, direction_id)
+    end)
     |> Enum.filter(&(stop_ids |> MapSet.member?(&1.id)))
     |> Enum.uniq_by(& &1.id)
+  end
+
+  @spec get_all_direction_ids([Alerts.Alert.t()]) :: [0 | 1]
+  defp get_all_direction_ids(alerts) do
+    alerts
+    |> get_all_entities(:direction_id)
+    |> Enum.reject(&Kernel.is_nil/1)
+    |> case do
+      [] -> [0]
+      direction_ids -> direction_ids
+    end
+  end
+
+  defp get_all_entities(alerts, type) do
+    alerts
+    |> Enum.map(&(&1 |> Alert.get_entity(type)))
+    |> Enum.reduce(MapSet.new(), &MapSet.union/2)
+  end
+
+  defp outer_product(enum_a, enum_b) do
+    enum_a |> Enum.flat_map(fn a -> enum_b |> Enum.map(fn b -> {a, b} end) end)
   end
 end

--- a/lib/dotcom/alerts/affected_stops.ex
+++ b/lib/dotcom/alerts/affected_stops.ex
@@ -4,9 +4,13 @@ defmodule Dotcom.Alerts.AffectedStops do
   """
 
   alias Alerts.Alert
+  alias Dotcom.Alerts.AffectedStops.Behaviour
+
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
 
-  @spec affected_stops(Alerts.Alert.t(), [Routes.Route.id_t()]) :: [Stops.Stop.t()]
+  @behaviour Behaviour
+
+  @impl Behaviour
   def affected_stops(alert, route_ids) do
     stop_ids = alert |> Alert.get_entity(:stop)
 

--- a/lib/dotcom/alerts/affected_stops.ex
+++ b/lib/dotcom/alerts/affected_stops.ex
@@ -11,8 +11,11 @@ defmodule Dotcom.Alerts.AffectedStops do
   @behaviour Behaviour
 
   @impl Behaviour
-  def affected_stops(alert, route_ids) do
-    stop_ids = alert |> Alert.get_entity(:stop)
+  def affected_stops(alerts, route_ids) do
+    stop_ids =
+      alerts
+      |> Enum.map(&(&1 |> Alert.get_entity(:stop)))
+      |> Enum.reduce(MapSet.new(), &MapSet.union/2)
 
     route_ids
     |> Enum.flat_map(&(&1 |> @stops_repo.by_route(0)))

--- a/lib/dotcom/alerts/affected_stops.ex
+++ b/lib/dotcom/alerts/affected_stops.ex
@@ -1,0 +1,18 @@
+defmodule Dotcom.Alerts.AffectedStops do
+  @moduledoc """
+  Module for determining stops affected by an alert
+  """
+
+  alias Alerts.Alert
+  @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
+
+  @spec affected_stops(Alerts.Alert.t(), [Routes.Route.id_t()]) :: [Stops.Stop.t()]
+  def affected_stops(alert, route_ids) do
+    stop_ids = alert |> Alert.get_entity(:stop)
+
+    route_ids
+    |> Enum.flat_map(&(&1 |> @stops_repo.by_route(0)))
+    |> Enum.filter(&(stop_ids |> MapSet.member?(&1.id)))
+    |> Enum.uniq_by(& &1.id)
+  end
+end

--- a/lib/dotcom/alerts/affected_stops/behaviour.ex
+++ b/lib/dotcom/alerts/affected_stops/behaviour.ex
@@ -3,5 +3,5 @@ defmodule Dotcom.Alerts.AffectedStops.Behaviour do
   Behaviour for determining stops affected by an alert
   """
 
-  @callback affected_stops(Alerts.Alert.t(), [Routes.Route.id_t()]) :: [Stops.Stop.t()]
+  @callback affected_stops([Alerts.Alert.t()], [Routes.Route.id_t()]) :: [Stops.Stop.t()]
 end

--- a/lib/dotcom/alerts/affected_stops/behaviour.ex
+++ b/lib/dotcom/alerts/affected_stops/behaviour.ex
@@ -1,0 +1,7 @@
+defmodule Dotcom.Alerts.AffectedStops.Behaviour do
+  @moduledoc """
+  Behaviour for determining stops affected by an alert
+  """
+
+  @callback affected_stops(Alerts.Alert.t(), [Routes.Route.id_t()]) :: [Stops.Stop.t()]
+end

--- a/lib/dotcom/alerts/affected_stops/behaviour.ex
+++ b/lib/dotcom/alerts/affected_stops/behaviour.ex
@@ -3,5 +3,16 @@ defmodule Dotcom.Alerts.AffectedStops.Behaviour do
   Behaviour for determining stops affected by an alert
   """
 
+  @doc """
+  Given a list of alerts and a list of routes, returns the stops on
+  the routes given that are affected by any of the alerts given. If
+  a stop shows up multiple times, either by being part of multiple
+  alerts or by being on multiple routes.
+
+  Stops on the route given are based on the affected direction ID's of
+  the alert. If the alert doesn't specify any direction ID's, then it
+  will default to just using direction ID 0.
+  """
+
   @callback affected_stops([Alerts.Alert.t()], [Routes.Route.id_t()]) :: [Stops.Stop.t()]
 end

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -89,7 +89,12 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     assigns = assign(assigns, time_range_str: time_range_str)
 
     ~H"""
-    <.status_row_heading route_ids={@route_ids} status={@alert.effect} prefix={@time_range_str} />
+    <.status_row_heading
+      alert={@alert}
+      prefix={@time_range_str}
+      route_ids={@route_ids}
+      status={@alert.effect}
+    />
     """
   end
 

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -90,7 +90,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
 
     ~H"""
     <.status_row_heading
-      alert={@alert}
+      alerts={[@alert]}
       prefix={@time_range_str}
       route_ids={@route_ids}
       status={@alert.effect}

--- a/lib/dotcom_web/components/system_status/status_label.ex
+++ b/lib/dotcom_web/components/system_status/status_label.ex
@@ -22,7 +22,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusLabel do
     assigns = assigns |> assign(:rendered_prefix, rendered_prefix)
 
     ~H"""
-    <span data-test="status_label_text" class={status_classes(@status)}>
+    <span data-test="status_label_text" class={["leading-[1.5rem]", status_classes(@status)]}>
       {@rendered_prefix} {description(@status, @prefix, @plural)}
     </span>
     """

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -20,6 +20,17 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
   attr :status, :atom, required: true
 
   def status_row_heading(assigns) do
+    assigns =
+      assigns
+      |> assign(
+        :subheading_text,
+        subheading_text(%{
+          status: assigns.status,
+          alerts: assigns.alerts,
+          route_ids: assigns.route_ids
+        })
+      )
+
     ~H"""
     <div class="grid items-center grid-cols-[min-content_min-content_auto] items-center grow">
       <.top_padding hide_route_pill={@hide_route_pill} />
@@ -32,7 +43,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
         status={@status}
       />
 
-      <.subheading alerts={@alerts} status={@status} route_ids={@route_ids} />
+      <.subheading text={@subheading_text} />
 
       <.bottom_padding hide_route_pill={@hide_route_pill} />
     </div>
@@ -63,24 +74,13 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
     """
   end
 
-  defp subheading(%{alerts: []} = assigns), do: ~H""
-
-  defp subheading(%{status: :station_closure} = assigns) do
-    assigns =
-      assigns
-      |> assign(
-        :text,
-        @affected_stops.affected_stops(assigns.alerts, assigns.route_ids)
-        |> Enum.map(& &1.name)
-        |> humanize_stop_names()
-      )
-
-    ~H"""
-    <.text_to_subheading text={@text} />
-    """
+  defp subheading_text(%{status: :station_closure, alerts: alerts, route_ids: route_ids}) do
+    @affected_stops.affected_stops(alerts, route_ids)
+    |> Enum.map(& &1.name)
+    |> humanize_stop_names()
   end
 
-  defp subheading(assigns), do: ~H""
+  defp subheading_text(_), do: nil
 
   defp humanize_stop_names([stop_name]), do: stop_name
   defp humanize_stop_names([stop_name1, stop_name2]), do: "#{stop_name1} & #{stop_name2}"
@@ -90,9 +90,9 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
 
   defp humanize_stop_names(_stop_names), do: nil
 
-  defp text_to_subheading(%{text: nil} = assigns), do: ~H""
+  defp subheading(%{text: nil} = assigns), do: ~H""
 
-  defp text_to_subheading(assigns) do
+  defp subheading(assigns) do
     ~H"""
     <div></div>
     <div></div>

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -34,7 +34,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
       |> assign(:plural, plural)
 
     ~H"""
-    <div class="grid items-center grid-cols-[min-content_min-content_auto] items-center grow">
+    <div class="grid grid-cols-[min-content_min-content_auto] items-start grow">
       <.top_padding hide_route_pill={@hide_route_pill} />
 
       <.heading
@@ -43,9 +43,8 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
         prefix={@prefix}
         route_ids={@route_ids}
         status={@status}
+        subheading_text={@subheading_text}
       />
-
-      <.subheading text={@subheading_text} />
 
       <.bottom_padding hide_route_pill={@hide_route_pill} />
     </div>
@@ -66,12 +65,13 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
       <.subway_route_pill class="group-hover/row:ring-brand-primary-lightest" route_ids={@route_ids} />
     </div>
 
-    <div class="pr-2 flex items-center">
+    <div class="h-6 pr-2 flex items-center">
       <.status_icon status={@status} />
     </div>
 
-    <div class="grow flex items-center">
+    <div class="grow flex flex-wrap items-baseline gap-x-2">
       <.status_label status={@status} prefix={@prefix} plural={@plural} />
+      <.subheading text={@subheading_text} />
     </div>
     """
   end
@@ -102,9 +102,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
 
   defp subheading(assigns) do
     ~H"""
-    <div></div>
-    <div></div>
-    <div class="text-sm" data-test="status_subheading">
+    <div class="text-sm leading-[1.5rem]" data-test="status_subheading">
       {@text}
     </div>
     """

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -20,16 +20,18 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
   attr :status, :atom, required: true
 
   def status_row_heading(assigns) do
+    %{subheading_text: subheading_text, plural: plural} =
+      subheading_text(%{
+        status: assigns.status,
+        alerts: assigns.alerts,
+        plural: assigns.plural,
+        route_ids: assigns.route_ids
+      })
+
     assigns =
       assigns
-      |> assign(
-        :subheading_text,
-        subheading_text(%{
-          status: assigns.status,
-          alerts: assigns.alerts,
-          route_ids: assigns.route_ids
-        })
-      )
+      |> assign(:subheading_text, subheading_text)
+      |> assign(:plural, plural)
 
     ~H"""
     <div class="grid items-center grid-cols-[min-content_min-content_auto] items-center grow">
@@ -75,12 +77,18 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
   end
 
   defp subheading_text(%{status: :station_closure, alerts: alerts, route_ids: route_ids}) do
-    @affected_stops.affected_stops(alerts, route_ids)
-    |> Enum.map(& &1.name)
-    |> humanize_stop_names()
+    affected_stops = @affected_stops.affected_stops(alerts, route_ids)
+
+    %{
+      plural: affected_stops |> Enum.count() > 1,
+      subheading_text:
+        affected_stops
+        |> Enum.map(& &1.name)
+        |> humanize_stop_names()
+    }
   end
 
-  defp subheading_text(_), do: nil
+  defp subheading_text(%{plural: plural}), do: %{plural: plural, subheading_text: nil}
 
   defp humanize_stop_names([stop_name]), do: stop_name
   defp humanize_stop_names([stop_name1, stop_name2]), do: "#{stop_name1} & #{stop_name2}"

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -10,6 +10,9 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
   import DotcomWeb.Components.SystemStatus.StatusLabel, only: [status_label: 1]
   import DotcomWeb.Components.SystemStatus.StatusIcon, only: [status_icon: 1]
 
+  @affected_stops Application.compile_env!(:dotcom, :affected_stops_module)
+
+  attr :alert, Alerts.Alert, default: nil
   attr :hide_route_pill, :boolean, default: false
   attr :plural, :boolean, default: false
   attr :prefix, :string, default: nil
@@ -28,6 +31,8 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
         route_ids={@route_ids}
         status={@status}
       />
+
+      <.subheading alert={@alert} status={@status} route_ids={@route_ids} />
 
       <.bottom_padding hide_route_pill={@hide_route_pill} />
     </div>
@@ -54,6 +59,45 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
 
     <div class="grow flex items-center">
       <.status_label status={@status} prefix={@prefix} plural={@plural} />
+    </div>
+    """
+  end
+
+  defp subheading(%{alert: nil} = assigns), do: ~H""
+
+  defp subheading(%{status: :station_closure} = assigns) do
+    assigns =
+      assigns
+      |> assign(
+        :text,
+        @affected_stops.affected_stops(assigns.alert, assigns.route_ids)
+        |> Enum.map(& &1.name)
+        |> humanize_stop_names()
+      )
+
+    ~H"""
+    <.text_to_subheading text={@text} />
+    """
+  end
+
+  defp subheading(assigns), do: ~H""
+
+  defp humanize_stop_names([stop_name]), do: stop_name
+  defp humanize_stop_names([stop_name1, stop_name2]), do: "#{stop_name1} & #{stop_name2}"
+
+  defp humanize_stop_names([stop_name1, stop_name2, stop_name3]),
+    do: "#{stop_name1}, #{stop_name2} & #{stop_name3}"
+
+  defp humanize_stop_names(_stop_names), do: nil
+
+  defp text_to_subheading(%{text: nil} = assigns), do: ~H""
+
+  defp text_to_subheading(assigns) do
+    ~H"""
+    <div></div>
+    <div></div>
+    <div class="text-sm">
+      {@text}
     </div>
     """
   end

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -84,13 +84,14 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
 
   defp decorations(%{plural: plural}), do: %{plural: plural, subheading_text: nil}
 
+  defp humanize_stop_names([]), do: nil
   defp humanize_stop_names([stop_name]), do: stop_name
   defp humanize_stop_names([stop_name1, stop_name2]), do: "#{stop_name1} & #{stop_name2}"
 
   defp humanize_stop_names([stop_name1, stop_name2, stop_name3]),
     do: "#{stop_name1}, #{stop_name2} & #{stop_name3}"
 
-  defp humanize_stop_names(_stop_names), do: nil
+  defp humanize_stop_names(stop_names), do: "#{Enum.count(stop_names)} Stops"
 
   defp subheading(%{text: nil} = assigns), do: ~H""
 

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -20,13 +20,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
   attr :status, :atom, required: true
 
   def status_row_heading(assigns) do
-    %{subheading_text: subheading_text, plural: plural} =
-      subheading_text(%{
-        status: assigns.status,
-        alerts: assigns.alerts,
-        plural: assigns.plural,
-        route_ids: assigns.route_ids
-      })
+    %{subheading_text: subheading_text, plural: plural} = decorations(assigns)
 
     assigns =
       assigns
@@ -76,7 +70,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
     """
   end
 
-  defp subheading_text(%{status: :station_closure, alerts: alerts, route_ids: route_ids}) do
+  defp decorations(%{status: :station_closure, alerts: alerts, route_ids: route_ids}) do
     affected_stops = @affected_stops.affected_stops(alerts, route_ids)
 
     %{
@@ -88,7 +82,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
     }
   end
 
-  defp subheading_text(%{plural: plural}), do: %{plural: plural, subheading_text: nil}
+  defp decorations(%{plural: plural}), do: %{plural: plural, subheading_text: nil}
 
   defp humanize_stop_names([stop_name]), do: stop_name
   defp humanize_stop_names([stop_name1, stop_name2]), do: "#{stop_name1} & #{stop_name2}"

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -96,7 +96,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
     ~H"""
     <div></div>
     <div></div>
-    <div class="text-sm">
+    <div class="text-sm" data-test="status_subheading">
       {@text}
     </div>
     """

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -12,7 +12,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
 
   @affected_stops Application.compile_env!(:dotcom, :affected_stops_module)
 
-  attr :alert, Alerts.Alert, default: nil
+  attr :alerts, :list, default: []
   attr :hide_route_pill, :boolean, default: false
   attr :plural, :boolean, default: false
   attr :prefix, :string, default: nil
@@ -32,7 +32,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
         status={@status}
       />
 
-      <.subheading alert={@alert} status={@status} route_ids={@route_ids} />
+      <.subheading alerts={@alerts} status={@status} route_ids={@route_ids} />
 
       <.bottom_padding hide_route_pill={@hide_route_pill} />
     </div>
@@ -63,14 +63,14 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
     """
   end
 
-  defp subheading(%{alert: nil} = assigns), do: ~H""
+  defp subheading(%{alerts: []} = assigns), do: ~H""
 
   defp subheading(%{status: :station_closure} = assigns) do
     assigns =
       assigns
       |> assign(
         :text,
-        @affected_stops.affected_stops(assigns.alert, assigns.route_ids)
+        @affected_stops.affected_stops(assigns.alerts, assigns.route_ids)
         |> Enum.map(& &1.name)
         |> humanize_stop_names()
       )

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -87,6 +87,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   defp heading(assigns) do
     ~H"""
     <.status_row_heading
+      alert={@row |> Map.get(:alert)}
       hide_route_pill={@row.style.hide_route_pill}
       status={@row.status_entry.status}
       prefix={@row.status_entry.prefix}

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -285,25 +285,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
     end
   end
 
-  defp rows_for_status_entry(status_entry, show_prefix, _) do
-    %{status: status, multiple: multiple} = status_entry
-    prefix = if show_prefix, do: prefix(status_entry), else: nil
-
-    [
-      %{
-        route_info: %{},
-        status_entry: %{
-          status: status,
-          plural: multiple,
-          prefix: prefix
-        },
-        style: %{
-          hide_route_pill: true
-        }
-      }
-    ]
-  end
-
   defp add_branch_ids(rows, branch_ids) do
     rows
     |> Enum.map(fn row -> row |> put_in([:route_info, :branch_ids], branch_ids) end)

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -270,7 +270,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
       [
         %{
-          alerts: [],
+          alerts: alerts,
           route_info: %{},
           status_entry: %{
             status: status,

--- a/test/dotcom/alerts/affected_stops_test.exs
+++ b/test/dotcom/alerts/affected_stops_test.exs
@@ -7,6 +7,8 @@ defmodule Dotcom.Alerts.AffectedStopsTest do
   alias Dotcom.Alerts.AffectedStops
   alias Test.Support.{Factories.Stops.Stop, FactoryHelpers}
 
+  setup :verify_on_exit!
+
   describe "affected_stops/1" do
     test "returns an empty list if there are no informed-entity stops" do
       # Setup
@@ -101,7 +103,7 @@ defmodule Dotcom.Alerts.AffectedStopsTest do
       overlap_stops = build_random_size_non_empty_stop_list()
 
       Stops.Repo.Mock
-      |> stub(:by_route, fn
+      |> expect(:by_route, fn
         ^route_id, 0 ->
           build_random_size_stop_list() ++
             stops1 ++ stops2 ++ overlap_stops ++ build_random_size_stop_list()

--- a/test/dotcom/alerts/affected_stops_test.exs
+++ b/test/dotcom/alerts/affected_stops_test.exs
@@ -51,6 +51,29 @@ defmodule Dotcom.Alerts.AffectedStopsTest do
       assert affected_stops == stops
     end
 
+    test "uses the direction in the alert if present" do
+      # Setup
+      route_id = FactoryHelpers.build(:id)
+      stops = build_random_size_non_empty_stop_list()
+
+      Stops.Repo.Mock
+      |> stub(:by_route, fn
+        ^route_id, 1 -> build_random_size_stop_list() ++ stops ++ build_random_size_stop_list()
+        _, 1 -> build_random_size_stop_list()
+      end)
+
+      informed_entities = stops |> Enum.map(&%InformedEntity{stop: &1.id})
+      alert = Alert.new(informed_entity: informed_entities ++ [%InformedEntity{direction_id: 1}])
+
+      # Exercise
+      queried_route_ids = build_random_size_id_list() ++ [route_id] ++ build_random_size_id_list()
+
+      affected_stops = AffectedStops.affected_stops([alert], queried_route_ids)
+
+      # Verify
+      assert affected_stops == stops
+    end
+
     test "dedupes stops that are part of multiple routes given" do
       # Setup
       route_id1 = FactoryHelpers.build(:id)

--- a/test/dotcom/alerts/affected_stops_test.exs
+++ b/test/dotcom/alerts/affected_stops_test.exs
@@ -9,7 +9,7 @@ defmodule Dotcom.Alerts.AffectedStopsTest do
 
   setup :verify_on_exit!
 
-  describe "affected_stops/1" do
+  describe "affected_stops/2" do
     test "returns an empty list if there are no informed-entity stops" do
       # Setup
       route_id = FactoryHelpers.build(:id)

--- a/test/dotcom/alerts/affected_stops_test.exs
+++ b/test/dotcom/alerts/affected_stops_test.exs
@@ -1,0 +1,106 @@
+defmodule Dotcom.Alerts.AffectedStopsTest do
+  use ExUnit.Case
+
+  import Mox
+
+  alias Alerts.{Alert, InformedEntity}
+  alias Dotcom.Alerts.AffectedStops
+  alias Test.Support.{Factories.Stops.Stop, FactoryHelpers}
+
+  describe "affected_stops/1" do
+    test "returns an empty list if there are no informed-entity stops" do
+      # Setup
+      route_id = FactoryHelpers.build(:id)
+
+      Stops.Repo.Mock
+      |> expect(:by_route, fn ^route_id, 0 ->
+        build_random_size_non_empty_stop_list()
+      end)
+
+      alert = Alert.new(informed_entity: [%InformedEntity{stop: nil}])
+
+      # Exercise
+      affected_stops = AffectedStops.affected_stops(alert, [route_id])
+
+      # Verify
+      assert affected_stops == []
+    end
+
+    test "returns stops that are part of the informed entities and part of the route given" do
+      # Setup
+      route_id = FactoryHelpers.build(:id)
+      stops = build_random_size_non_empty_stop_list()
+
+      Stops.Repo.Mock
+      |> stub(:by_route, fn
+        ^route_id, 0 -> build_random_size_stop_list() ++ stops ++ build_random_size_stop_list()
+        _, 0 -> build_random_size_stop_list()
+      end)
+
+      informed_entities = stops |> Enum.map(&%InformedEntity{stop: &1.id})
+      alert = Alert.new(informed_entity: informed_entities)
+
+      # Exercise
+      queried_route_ids = build_random_size_id_list() ++ [route_id] ++ build_random_size_id_list()
+
+      affected_stops = AffectedStops.affected_stops(alert, queried_route_ids)
+
+      # Verify
+      assert affected_stops == stops
+    end
+
+    test "dedupes stops that are part of multiple routes given" do
+      # Setup
+      route_id1 = FactoryHelpers.build(:id)
+      stops1 = build_random_size_non_empty_stop_list()
+
+      route_id2 = FactoryHelpers.build(:id)
+      stops2 = build_random_size_non_empty_stop_list()
+
+      overlap_stops = build_random_size_non_empty_stop_list()
+
+      Stops.Repo.Mock
+      |> stub(:by_route, fn
+        ^route_id1, 0 ->
+          build_random_size_stop_list() ++
+            stops1 ++ overlap_stops ++ build_random_size_stop_list()
+
+        ^route_id2, 0 ->
+          build_random_size_stop_list() ++
+            stops2 ++ overlap_stops ++ build_random_size_stop_list()
+
+        _, 0 ->
+          build_random_size_stop_list()
+      end)
+
+      informed_entities =
+        (stops1 ++ stops2 ++ overlap_stops) |> Enum.map(&%InformedEntity{stop: &1.id})
+
+      alert = Alert.new(informed_entity: informed_entities)
+
+      # Exercise
+      queried_route_ids =
+        (build_random_size_id_list() ++ [route_id1, route_id2] ++ build_random_size_id_list())
+        |> Enum.shuffle()
+
+      affected_stops_count =
+        AffectedStops.affected_stops(alert, queried_route_ids) |> Enum.count()
+
+      # Verify
+      total_stops_count = (stops1 ++ stops2 ++ overlap_stops) |> Enum.count()
+      assert affected_stops_count == total_stops_count
+    end
+  end
+
+  defp build_random_size_stop_list(), do: Stop.build_list(Faker.random_between(0, 10), :stop)
+
+  defp build_random_size_id_list() do
+    count = Faker.random_between(0, 10)
+    FactoryHelpers.build_list(count, :id)
+  end
+
+  defp build_random_size_non_empty_stop_list() do
+    count = Faker.random_between(1, 10)
+    Stop.build_list(count, :stop)
+  end
+end

--- a/test/dotcom_web/components/planned_disruptions_test.exs
+++ b/test/dotcom_web/components/planned_disruptions_test.exs
@@ -12,6 +12,7 @@ defmodule DotcomWeb.Components.PlannedDisruptionsTest do
   setup :verify_on_exit!
 
   setup do
+    stub(Dotcom.Alerts.AffectedStops.Mock, :affected_stops, fn _, _ -> [] end)
     stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
     :ok
   end

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -424,7 +424,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
                ["#{stop1.name}, #{stop2.name} & #{stop3.name}"]
     end
 
-    test "does not show a subheading for four or more stop closures" do
+    test "does not show individual stop names when four or more stops are closed" do
       # Setup
       affected_line = Faker.Util.pick(@lines_without_branches)
 
@@ -435,7 +435,8 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
         )
         |> Factories.Alerts.Alert.active_now()
 
-      stops = Factories.Stops.Stop.build_list(Faker.random_between(4, 10), :stop)
+      count = Faker.random_between(4, 10)
+      stops = Factories.Stops.Stop.build_list(count, :stop)
 
       expect(Dotcom.Alerts.AffectedStops.Mock, :affected_stops, fn _, _ -> stops end)
 
@@ -446,7 +447,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
       assert rows
              |> for_route(affected_line)
              |> Enum.map(&status_subheading_for_row/1) ==
-               [""]
+               ["#{count} Stops"]
     end
 
     test "does not attempt to find affected stops when the status isn't station_closure" do

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -14,6 +14,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
   setup :verify_on_exit!
 
   setup do
+    stub(Dotcom.Alerts.AffectedStops.Mock, :affected_stops, fn _, _ -> [] end)
     stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
     :ok
   end

--- a/test/dotcom_web/controllers/alert_controller_test.exs
+++ b/test/dotcom_web/controllers/alert_controller_test.exs
@@ -19,6 +19,7 @@ defmodule DotcomWeb.AlertControllerTest do
     cache = Application.get_env(:dotcom, :cache)
     cache.flush()
 
+    stub(Dotcom.Alerts.AffectedStops.Mock, :affected_stops, fn _, _ -> [] end)
     stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
 
     stub(Alerts.Repo.Mock, :all, fn _date ->

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -7,6 +7,7 @@ Mox.defmock(Req.Mock, for: Req.Behaviour)
 
 # Internal
 Mox.defmock(CMS.Api.Mock, for: CMS.Api.Behaviour)
+Mox.defmock(Dotcom.Alerts.AffectedStops.Mock, for: Dotcom.Alerts.AffectedStops.Behaviour)
 Mox.defmock(Dotcom.Redis.Mock, for: Dotcom.Redis.Behaviour)
 Mox.defmock(Dotcom.Redix.Mock, for: Dotcom.Redix.Behaviour)
 Mox.defmock(Dotcom.Redix.PubSub.Mock, for: Dotcom.Redix.PubSub.Behaviour)


### PR DESCRIPTION
### Homepage, with alerts combined
![Screenshot 2025-05-14 at 2 43 12 PM](https://github.com/user-attachments/assets/885f10b2-0eee-4880-956a-c28c3e105d26)

### Alerts page / System Status
![Screenshot 2025-05-14 at 2 43 22 PM](https://github.com/user-attachments/assets/26c498eb-e62c-4199-b247-e3c7f7b54fc7)

### Alerts Page / Planned Work
![Screenshot 2025-05-14 at 2 43 28 PM](https://github.com/user-attachments/assets/f1ba4c2c-600e-4aee-86d1-5c4baa8142e8)


### TODO
- [x] Fix pluralizing (should be based on number of stops closed for Station Closures, not number of alerts).
- [x] Fix layout (could be a follow-up)

---

**Asana Subtask:** [[Endpoints] Add affected stops subheadings to system status and planned work](https://app.asana.com/1/15492006741476/project/555089885850811/task/1210239131757949?focus=true)
**Asana Parent Ticket:** [Add endpoints of disruption to system status and planned work](https://app.asana.com/1/15492006741476/project/1205718271156548/task/1209641123314696?focus=true)

