### PR TITLE
fix: Don't include connecting stops when determining station accessibility

### DIFF
--- a/lib/dotcom_web/components/stops/header.ex
+++ b/lib/dotcom_web/components/stops/header.ex
@@ -32,7 +32,7 @@ defmodule DotcomWeb.Components.Stops.Header do
         <div class="flex items-end justify-items-end gap-2 flex-wrap">
           <.mode_icons routes_by_stop={@routes_by_stop} />
           <.zone stop={@stop} />
-          <.accessibility :if={accessible?(assigns)} />
+          <.accessibility :if={@accessible?} />
           <.parking :if={parking?(assigns)} />
         </div>
         <div :if={all_bus_routes?(assigns) and not @stop.station?} class="text-sm">
@@ -41,12 +41,6 @@ defmodule DotcomWeb.Components.Stops.Header do
       </div>
     </div>
     """
-  end
-
-  # A stop is accessible if it is labeled as accessible in GTFS or it doesn't have a parent stop and it serves a bus route.
-  defp accessible?(%{stop: stop, routes_by_stop: routes_by_stop}) do
-    Enum.member?(stop.accessibility, "accessible") ||
-      (is_nil(stop.parent_id) && Enum.any?(routes_by_stop, &(&1.type === 3)))
   end
 
   # All routes are bus routes if they are all type 3 or are Silver Line.

--- a/lib/dotcom_web/controllers/stop_controller.ex
+++ b/lib/dotcom_web/controllers/stop_controller.ex
@@ -60,7 +60,7 @@ defmodule DotcomWeb.StopController do
         |> redirect(to: stop_path(conn, :show, @stops_repo.get_parent(stop)))
         |> halt()
       else
-        routes_by_stop = @routes_repo.by_stop(stop_id, include: "stop.connecting_stops")
+        routes_by_stop = @routes_repo.by_stop(stop_id)
         accessible? = accessible?(stop, routes_by_stop)
 
         conn

--- a/lib/dotcom_web/controllers/stop_controller.ex
+++ b/lib/dotcom_web/controllers/stop_controller.ex
@@ -60,8 +60,8 @@ defmodule DotcomWeb.StopController do
         |> redirect(to: stop_path(conn, :show, @stops_repo.get_parent(stop)))
         |> halt()
       else
-        routes_by_stop = @routes_repo.by_stop(stop_id)
-        accessible? = accessible?(stop, routes_by_stop)
+        routes_by_stop = @routes_repo.by_stop(stop_id, include: "stop.connecting_stops")
+        accessible? = accessible?(stop)
 
         conn
         |> assign(:breadcrumbs, breadcrumbs(stop, routes_by_stop))
@@ -387,8 +387,10 @@ defmodule DotcomWeb.StopController do
   end
 
   # A stop is accessible if it is labeled as accessible in GTFS or it doesn't have a parent stop and it serves a bus route.
-  defp accessible?(stop, routes_by_stop) do
+  defp accessible?(stop) do
+    routes = @routes_repo.by_stop(stop.id)
+
     Enum.member?(stop.accessibility, "accessible") ||
-      (is_nil(stop.parent_id) && Enum.any?(routes_by_stop, &(&1.type === 3)))
+      (is_nil(stop.parent_id) && Enum.any?(routes, &(&1.type === 3)))
   end
 end

--- a/lib/dotcom_web/templates/stop/show.html.heex
+++ b/lib/dotcom_web/templates/stop/show.html.heex
@@ -2,7 +2,11 @@
 
 <div class="u-bg--gray-bordered-background">
   <div class="container">
-    <DotcomWeb.Components.Stops.Header.header stop={@stop} routes_by_stop={@routes_by_stop} accessible?={@accessible?} />
+    <DotcomWeb.Components.Stops.Header.header
+      stop={@stop}
+      routes_by_stop={@routes_by_stop}
+      accessible?={@accessible?}
+    />
   </div>
 </div>
 

--- a/lib/dotcom_web/templates/stop/show.html.heex
+++ b/lib/dotcom_web/templates/stop/show.html.heex
@@ -2,7 +2,7 @@
 
 <div class="u-bg--gray-bordered-background">
   <div class="container">
-    <DotcomWeb.Components.Stops.Header.header stop={@stop} routes_by_stop={@routes_by_stop} />
+    <DotcomWeb.Components.Stops.Header.header stop={@stop} routes_by_stop={@routes_by_stop} accessible?={@accessible?} />
   </div>
 </div>
 

--- a/test/dotcom_web/components/stops/header_test.exs
+++ b/test/dotcom_web/components/stops/header_test.exs
@@ -23,7 +23,12 @@ defmodule DotcomWeb.Components.Stops.HeaderTest do
       ]
 
       # Exercise
-      html = render_component(&header/1, %{stop: stop, routes_by_stop: routes_by_stop})
+      html =
+        render_component(&header/1, %{
+          accessible?: false,
+          stop: stop,
+          routes_by_stop: routes_by_stop
+        })
 
       # Verify
       assert html |> Floki.find("title") |> Kernel.length() == 1
@@ -45,7 +50,12 @@ defmodule DotcomWeb.Components.Stops.HeaderTest do
       ]
 
       # Exercise
-      html = render_component(&header/1, %{stop: stop, routes_by_stop: routes_by_stop})
+      html =
+        render_component(&header/1, %{
+          accessible?: false,
+          stop: stop,
+          routes_by_stop: routes_by_stop
+        })
 
       # Verify
       assert html |> Floki.find("title") |> Enum.at(-1) |> Floki.text() == "Commuter Rail"
@@ -57,19 +67,12 @@ defmodule DotcomWeb.Components.Stops.HeaderTest do
       routes_by_stop = []
 
       # Exercise
-      html = render_component(&header/1, %{stop: stop, routes_by_stop: routes_by_stop})
-
-      # Verify
-      assert html =~ "Accessible"
-    end
-
-    test "renders the accessibility icon when it is a bus-only stop" do
-      # Setup
-      stop = %Stop{parent_id: nil, accessibility: []}
-      routes_by_stop = [%Route{type: 3}]
-
-      # Exercise
-      html = render_component(&header/1, %{stop: stop, routes_by_stop: routes_by_stop})
+      html =
+        render_component(&header/1, %{
+          accessible?: true,
+          stop: stop,
+          routes_by_stop: routes_by_stop
+        })
 
       # Verify
       assert html =~ "Accessible"
@@ -81,7 +84,12 @@ defmodule DotcomWeb.Components.Stops.HeaderTest do
       routes_by_stop = []
 
       # Exercise
-      html = render_component(&header/1, %{stop: stop, routes_by_stop: routes_by_stop})
+      html =
+        render_component(&header/1, %{
+          accessible?: false,
+          stop: stop,
+          routes_by_stop: routes_by_stop
+        })
 
       # Verify
       refute html =~ "Accessible"
@@ -93,7 +101,12 @@ defmodule DotcomWeb.Components.Stops.HeaderTest do
       routes_by_stop = []
 
       # Exercise
-      html = render_component(&header/1, %{stop: stop, routes_by_stop: routes_by_stop})
+      html =
+        render_component(&header/1, %{
+          accessible?: false,
+          stop: stop,
+          routes_by_stop: routes_by_stop
+        })
 
       # Verify
       assert html =~ "Parking"
@@ -105,7 +118,12 @@ defmodule DotcomWeb.Components.Stops.HeaderTest do
       routes_by_stop = []
 
       # Exercise
-      html = render_component(&header/1, %{stop: stop, routes_by_stop: routes_by_stop})
+      html =
+        render_component(&header/1, %{
+          accessible?: false,
+          stop: stop,
+          routes_by_stop: routes_by_stop
+        })
 
       # Verify
       refute html =~ "Parking"
@@ -118,7 +136,12 @@ defmodule DotcomWeb.Components.Stops.HeaderTest do
       routes_by_stop = []
 
       # Exercise
-      html = render_component(&header/1, %{stop: stop, routes_by_stop: routes_by_stop})
+      html =
+        render_component(&header/1, %{
+          accessible?: false,
+          stop: stop,
+          routes_by_stop: routes_by_stop
+        })
 
       # Verify
       assert html =~ "Zone #{zone}"
@@ -130,7 +153,12 @@ defmodule DotcomWeb.Components.Stops.HeaderTest do
       routes_by_stop = []
 
       # Exercise
-      html = render_component(&header/1, %{stop: stop, routes_by_stop: routes_by_stop})
+      html =
+        render_component(&header/1, %{
+          accessible?: false,
+          stop: stop,
+          routes_by_stop: routes_by_stop
+        })
 
       # Verify
       refute html =~ "Zone"


### PR DESCRIPTION
Don't include `connecting_stops` when considering whether a stop/station is accessible.

This was leading to an issue where stations were being given a ♿ icon if they were connected to a bus stop (which is always considered accessible), even if the station itself is not accessible. This was impacting some Commuter Rail stations as well as a few inaccessible Green Line stations, including Hynes Convention Center and Boylston.

### Screenshots

(Before on the left; After on the right)

[Belmont](https://www.mbta.com/stops/place-FR-0064)
![Screenshot 2025-05-13 at 1 01 08 PM](https://github.com/user-attachments/assets/856d5386-4afc-43d3-a430-323d594f2d75)

[Boylston](https://﻿﻿www.mbta.com/stops/place-boyls)
![Screenshot 2025-05-13 at 1 04 43 PM](https://github.com/user-attachments/assets/1a92b601-cb88-428e-aec9-0fb0446722bb)
(This also works for stations whose names start with letters other than `B`)

---

It also fixes the `Accessibility` amenity card for affected stations.

![Screenshot 2025-05-13 at 1 02 57 PM](https://github.com/user-attachments/assets/5f0d8022-0005-4bf0-83a5-24426cf8f560)


---

No ticket.