### PR TITLE
hotfix: Increase default Finch connection pool size

### DIFF
--- a/lib/cms/api.ex
+++ b/lib/cms/api.ex
@@ -50,7 +50,8 @@ defmodule CMS.Api do
 
     @req.new(
       base_url: config[:base_url],
-      headers: config[:headers] ++ headers
+      headers: config[:headers] ++ headers,
+      finch: Dotcom.Finch
     )
   end
 

--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -31,7 +31,7 @@ defmodule Dotcom.Application do
       ] ++
         if Application.get_env(:dotcom, :env) != :test do
           [
-            {Finch, name: Telemetry.Finch},
+            {Finch, name: Telemetry.Finch, pools: %{default: [size: 200]}},
             {Dotcom.Telemetry, []},
             {Dotcom.Cache.Telemetry, []},
             {DotcomWeb.Telemetry, []},

--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -27,7 +27,8 @@ defmodule Dotcom.Application do
     children =
       [
         {Application.get_env(:dotcom, :cache, Dotcom.Cache.Multilevel), []},
-        {Dotcom.RateLimit, [clean_period: 60_000 * 10]}
+        {Dotcom.RateLimit, [clean_period: 60_000 * 10]},
+        {Finch, name: Dotcom.Finch, pools: %{default: [size: 300, count: 10]}}
       ] ++
         if Application.get_env(:dotcom, :env) != :test do
           [

--- a/lib/dotcom_web/controllers/helpers.ex
+++ b/lib/dotcom_web/controllers/helpers.ex
@@ -138,7 +138,8 @@ defmodule DotcomWeb.ControllerHelpers do
 
     @req.new(
       base_url: config[:base_url],
-      headers: config[:headers] ++ headers
+      headers: config[:headers] ++ headers,
+      finch: Dotcom.Finch
     )
   end
 

--- a/lib/mbta/api.ex
+++ b/lib/mbta/api.ex
@@ -24,7 +24,8 @@ defmodule MBTA.Api do
 
     @req.new(
       base_url: config[:base_url],
-      headers: config[:headers]
+      headers: config[:headers],
+      finch: Dotcom.Finch
     )
   end
 end


### PR DESCRIPTION
No ticket.

We saw some issues that included error messages like

```
** (RuntimeError) Finch was unable to provide a connection
within the timeout due to excess queuing for connections.
Consider adjusting the pool size, count, timeout or reducing
the rate of requests if it is possible that the downstream
service is unable to keep up with the current rate.
```

So we figured we would bump the Finch pool size from its default of 50 up to 200.

[Finch docs.](https://hexdocs.pm/finch/Finch.html#module-usage)