### PR TITLE
fix(VehicleMapMarkerChannel): prediction for rail only

### DIFF
--- a/lib/dotcom_web/channels/vehicle_map_marker_channel.ex
+++ b/lib/dotcom_web/channels/vehicle_map_marker_channel.ex
@@ -49,12 +49,15 @@ defmodule DotcomWeb.VehicleMapMarkerChannel do
     stop_name = get_stop_name(vehicle.stop_id)
     trip = Schedules.Repo.trip(vehicle.trip_id)
 
+    # We need the prediction's status and track number to display on tooltips text such as "All aboard on track 9"
     prediction =
-      @predictions_repo.all(
-        route: vehicle.route_id,
-        direction_id: vehicle.direction_id
-      )
-      |> Enum.find(&(&1.vehicle_id == vehicle.id))
+      if route.type == 2 do
+        @predictions_repo.all(
+          route: vehicle.route_id,
+          direction_id: vehicle.direction_id
+        )
+        |> Enum.find(&(&1.vehicle_id == vehicle.id))
+      end
 
     %{
       data: %{vehicle: vehicle, stop_name: stop_name},

--- a/lib/vehicle_helpers.ex
+++ b/lib/vehicle_helpers.ex
@@ -174,7 +174,7 @@ defmodule VehicleHelpers do
   defp realtime_status_text(:in_transit), do: " is on the way to "
 
   @spec display_trip_name(Route.t(), Trip.t() | nil) :: iodata
-  defp display_trip_name(%{type: 2}, %{name: name}), do: [" ", name]
+  defp display_trip_name(%{type: 2}, %{name: name}) when is_binary(name), do: [" ", name]
   defp display_trip_name(_, _), do: ""
 
   @spec build_tooltip(iodata, iodata) :: String.t()

--- a/test/dotcom_web/channels/vehicle_map_marker_channel_test.exs
+++ b/test/dotcom_web/channels/vehicle_map_marker_channel_test.exs
@@ -106,8 +106,8 @@ defmodule DotcomWeb.VehicleMapMarkerChannelTest do
     assert_push("data", _)
   end
 
-  test "fetches and processes vehicle prediction when buliding tooltip_text" do
-    route = %Routes.Route{id: "CR-Lowell"}
+  test "fetches and processes vehicle prediction when building tooltip_text" do
+    route = %Routes.Route{id: "CR-Lowell", type: 2}
 
     trip = %Schedules.Trip{
       id: "trip",


### PR DESCRIPTION
Looking at our excessive number of V3 API requests to `/predictions` in particular, I figured out we re-request predictions after every change in `/vehicles`... it's too much. Since we only use the prediction in that location to show tooltip text with commuter rail status and track, I added this `if` statement to only request the prediction if we're on a commuter rail route.

The whole everything should probably be rearchitected, really.

No ticket.