### PR TITLE
fix: Top border alignment on planned work rows

### DIFF
--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -67,7 +67,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
     <.unstyled_accordion
       :for={route_ids <- @route_ids_by_subway_line}
       summary_class="flex items-center hover:bg-brand-primary-lightest cursor-pointer group/row"
-      chevron_class="border-t-[1px] border-gray-lightest fill-gray-dark px-2 py-3"
+      chevron_class="border-t-[1px] border-gray-lightest fill-gray-dark px-2 py-3 self-stretch flex items-center"
     >
       <:heading>
         <.heading route_ids={route_ids} alert={@alert} />


### PR DESCRIPTION
Just noticed this while working on subheading layout.

This actually is broken on both mobile and desktop, but it's easier to see the problem for narrower screen widths.

(Before on the left; After on the right)
![Screenshot 2025-05-14 at 11 25 58 AM](https://github.com/user-attachments/assets/06ea1428-2da3-408e-b323-cdc10b839a12)

No ticket.