### PR TITLE
fix: Remove padding from `Current Status` title

### DIFF
--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -56,7 +56,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
     ~H"""
     <.bordered_container hide_divider>
       <:heading>
-        <div class="px-2 mb-sm">
+        <div class="mb-sm">
           Current Status
         </div>
       </:heading>


### PR DESCRIPTION
Very small and subtle, but when I fixed the padding for subway status rows, I forgot to update the padding for the `Current Status` header on the [alerts page](https://www.mbta.com/alerts/subway). As a result, the header is a bit to the right of the content below it, which looks a bit wrong.

This change shifts it to be a bit to the left of the content below, and aligns it with `Planned Work` below.

(Before is to the left; After is to the right)
![Screenshot 2025-05-14 at 5 37 36 PM](https://github.com/user-attachments/assets/26e0968c-5375-4098-a3e2-2822bbd51d16)
