### PR TITLE
fix(warnings): Unused field `params` in `LineApi`

### DIFF
--- a/lib/dotcom_web/controllers/schedule/line_api.ex
+++ b/lib/dotcom_web/controllers/schedule/line_api.ex
@@ -56,7 +56,7 @@ defmodule DotcomWeb.ScheduleController.LineApi do
     end
   end
 
-  def show(conn, params) do
+  def show(conn, _params) do
     return_invalid_arguments_error(conn)
   end
 


### PR DESCRIPTION
This fixes 👇 warning
```elixir
    warning: variable "params" is unused (if the variable is not meant to be used, prefix it with an underscore)
    │
 59 │   def show(conn, params) do
    │                  ~~~~~~
    │
    └─ lib/dotcom_web/controllers/schedule/line_api.ex:59:18: DotcomWeb.ScheduleController.LineApi.show/2
```