### PR TITLE
fix(warnings): Change non-empty-list assertion to fix match warning

### DIFF
--- a/test/schedules/repo_test.exs
+++ b/test/schedules/repo_test.exs
@@ -51,7 +51,7 @@ defmodule Schedules.RepoTest do
           stop_sequences: ["first"]
         )
 
-      assert response != []
+      refute response |> Enum.empty?()
 
       assert %{stop: %{id: "place-alfcl", name: "Alewife"}, platform_stop_id: platform_stop_id} =
                first_schedule


### PR DESCRIPTION
This fixes 👇 warning
```elixir

    warning: comparison between distinct types found:

        left != right

    given types:

        dynamic(non_empty_list(term(), term())) != empty_list()

    where "left" (context ExUnit.Assertions) was given the type:

        # type: dynamic(non_empty_list(term(), term()))
        # from: test/schedules/repo_test.exs:54
        left = response

    where "right" (context ExUnit.Assertions) was given the type:

        # type: empty_list()
        # from: test/schedules/repo_test.exs:54
        right = []

    While Elixir can compare across all types, you are comparing across types which are always disjoint, and the result is either always true or always false

    typing violation found at:
    │
 54 │       assert response != []
    │                       ~
    │
    └─ test/schedules/repo_test.exs:54:23: Schedules.RepoTest."test by_route_ids/2 returns the parent station as the stop and keeps raw stop id"/1

```