### PR TITLE
fix(warnings): Fix expect/assert mismatch that guaranteed test failure

### DIFF
--- a/test/schedules/parser_test.exs
+++ b/test/schedules/parser_test.exs
@@ -59,7 +59,7 @@ defmodule Schedules.ParserTest do
 
     assert {"CR-Lowell", "31174458-CR_MAY2016-hxl16011-Weekday-01", "Lowell", nil,
             Timex.to_datetime({{2016, 6, 8}, {5, 35, 0}}, "Etc/GMT-4"),
-            Timex.to_datetime({{2016, 6, 8}, {5, 35, 0}}, "Etc/GMT-4"), true, true, false, 0,
+            Timex.to_datetime({{2016, 6, 8}, {5, 35, 0}}, "Etc/GMT-4"), true, true, false, 0, nil,
             3} == actual
   end
 


### PR DESCRIPTION
This fixes 👇 warning:

```elixir
    warning: comparison between distinct types found:

        left == right

    given types:

        dynamic(
          {binary(), binary(), binary(), nil, term(), term(), true, true, false, integer(), integer()}
        ) ==
          dynamic(
            {term(), term(), term(), term(), term(), term(), boolean(), boolean(), boolean(), term(),
             term(), term()}
          )

    where "left" (context ExUnit.Assertions) was given the type:

        # type: dynamic(
          {binary(), binary(), binary(), nil, term(), term(), true, true, false, integer(), integer()}
        )
        # from: test/schedules/parser_test.exs:60
        left =
          {"CR-Lowell", "31174458-CR_MAY2016-hxl16011-Weekday-01", "Lowell", nil,
           Timex.to_datetime({{2016, 6, 8}, {5, 35, 0}}, "Etc/GMT-4"),
           Timex.to_datetime({{2016, 6, 8}, {5, 35, 0}}, "Etc/GMT-4"), true, true, false, 0, 3}

    where "right" (context ExUnit.Assertions) was given the type:

        # type: dynamic(
          {term(), term(), term(), term(), term(), term(), boolean(), boolean(), boolean(), term(),
           term(), term()}
        )
        # from: test/schedules/parser_test.exs:60
        right = actual

    While Elixir can compare across all types, you are comparing across types which are always disjoint, and the result is either always true or always false

    typing violation found at:
    │
 63 │             3} == actual
    │                ~
    │
    └─ test/schedules/parser_test.exs:63:16: Schedules.ParserTest."test parse converts a JsonApi.Item into a tuple"/1
```