### PR TITLE
feat: set up deep linking for MBTA Go

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -152,6 +152,11 @@ config :dotcom, OpenTripPlanner,
   timezone: System.get_env("OPEN_TRIP_PLANNER_TIMEZONE", "America/New_York"),
   otp_url: System.get_env("OPEN_TRIP_PLANNER_URL")
 
+config :dotcom, :mbta_go,
+  android_package_name: System.get_env("MBTA_GO_ANDROID_PACKAGE_NAME"),
+  android_cert_fingerprint: System.get_env("MBTA_GO_ANDROID_CERT_FINGERPRINT"),
+  ios_appid: System.get_env("MBTA_GO_IOS_APPID")
+
 if config_env() != :test and System.get_env("OPEN_TRIP_PLANNER_URL") != "" do
   config :open_trip_planner_client,
     otp_url: System.get_env("OPEN_TRIP_PLANNER_URL")

--- a/lib/dotcom_web/controllers/mbta_go_deep_link_controller.ex
+++ b/lib/dotcom_web/controllers/mbta_go_deep_link_controller.ex
@@ -1,0 +1,38 @@
+defmodule DotcomWeb.MbtaGoDeepLinkController do
+  @moduledoc false
+
+  use DotcomWeb, :controller
+
+  def root(conn, params) do
+    DotcomWeb.AppStoreController.redirect_mbta_go(conn, params)
+  end
+
+  def apple_app_site_association(conn, _params) do
+    json(conn, %{
+      applinks: %{
+        details: [
+          %{
+            appIDs: [Util.config(:dotcom, :mbta_go, :ios_appid)],
+            components: [
+              %{/: "/go"},
+              %{/: "/go/*"}
+            ]
+          }
+        ]
+      }
+    })
+  end
+
+  def assetlinks_json(conn, _params) do
+    json(conn, [
+      %{
+        relation: ["delegate_permission/common.handle_all_urls"],
+        target: %{
+          namespace: "android_app",
+          package_name: Util.config(:dotcom, :mbta_go, :android_package_name),
+          sha256_cert_fingerprints: [Util.config(:dotcom, :mbta_go, :android_cert_fingerprint)]
+        }
+      }
+    ])
+  end
+end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -64,6 +64,14 @@ defmodule DotcomWeb.Router do
   scope "/", DotcomWeb do
     # no pipe
     get("/_health", HealthController, :index)
+
+    get(
+      "/.well-known/apple-app-site-association",
+      MbtaGoDeepLinkController,
+      :apple_app_site_association
+    )
+
+    get("/.well-known/assetlinks.json", MbtaGoDeepLinkController, :assetlinks_json)
   end
 
   scope "/cache", DotcomWeb do
@@ -243,6 +251,12 @@ defmodule DotcomWeb.Router do
     post("/search/click", SearchController, :click)
     get("/bus-stop-changes", BusStopChangeController, :show)
     get("/vote", VoteController, :show)
+  end
+
+  scope "/go", DotcomWeb do
+    pipe_through([:secure, :browser])
+
+    get("/", MbtaGoDeepLinkController, :root)
   end
 
   scope "/", DotcomWeb do

--- a/test/dotcom_web/controllers/mbta_go_deep_link_controller_test.exs
+++ b/test/dotcom_web/controllers/mbta_go_deep_link_controller_test.exs
@@ -1,0 +1,128 @@
+defmodule DotcomWeb.MbtaGoDeepLinkControllerTest do
+  use DotcomWeb.ConnCase, async: true
+  import Test.Support.EnvHelpers
+
+  describe "root" do
+    test "redirects to default project page by default, preserving params", %{conn: conn} do
+      conn = get(conn, mbta_go_deep_link_path(conn, :root, %{"param_1" => "val_1"}))
+
+      assert redirected_to(conn, 302) =~ "/goapp?param_1=val_1"
+    end
+
+    test "redirects to app store for ios browser", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header(
+          "user-agent",
+          "Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/1A542a Safari/419.3"
+        )
+        |> get(
+          mbta_go_deep_link_path(conn, :root, %{
+            "mt" => "fake-mt",
+            "ct" => "fake ct",
+            "pt" => "fake pt",
+            "extra" => "other param"
+          })
+        )
+
+      redirected_to = redirected_to(conn, 302)
+      assert redirected_to =~ "https://apps.apple.com"
+      assert redirected_to =~ "?pt=fake%20pt&ct=fake%20ct&mt=fake-mt"
+    end
+
+    test "redirects to app store for android browser", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header(
+          "user-agent",
+          "Android SDK 1.5r3: Mozilla/5.0 (Linux; U; Android 1.5; de-; sdk Build/CUPCAKE) AppleWebkit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1"
+        )
+        |> get(
+          mbta_go_deep_link_path(conn, :root, %{
+            "referrer" => "fake referrer",
+            "utm_source" => "fake utm source",
+            "utm_campaign" => "fake-utm-campaign"
+          })
+        )
+
+      redirected_to = redirected_to(conn, 302)
+      assert redirected_to =~ "https://play.google.com"
+
+      assert redirected_to =~
+               "&referrer=fake%20referrer&utm_campaign=fake-utm-campaign&utm_source=fake%20utm%20source"
+    end
+  end
+
+  defp reverse_domain_name() do
+    Faker.Internet.domain_name() |> String.split(".") |> Enum.reverse() |> Enum.join(".")
+  end
+
+  describe "Android deep link approval" do
+    test "works when configured", %{conn: conn} do
+      package_name = reverse_domain_name()
+
+      cert_fingerprint =
+        1..32
+        |> Enum.map_join(":", fn _ ->
+          Faker.random_between(0x00, 0xFF) |> Integer.to_string(16) |> String.pad_leading(2, "0")
+        end)
+
+      reassign_env(:dotcom, :mbta_go,
+        android_package_name: package_name,
+        android_cert_fingerprint: cert_fingerprint
+      )
+
+      conn = conn |> get("/.well-known/assetlinks.json")
+
+      assert json_response(conn, 200) == [
+               %{
+                 "relation" => ["delegate_permission/common.handle_all_urls"],
+                 "target" => %{
+                   "namespace" => "android_app",
+                   "package_name" => package_name,
+                   "sha256_cert_fingerprints" => [cert_fingerprint]
+                 }
+               }
+             ]
+    end
+
+    test "does not crash if not configured", %{conn: conn} do
+      reassign_env(:dotcom, :mbta_go, android_package_name: nil, android_cert_fingerprint: nil)
+
+      conn = conn |> get("/.well-known/assetlinks.json")
+
+      assert json_response(conn, 200)
+    end
+  end
+
+  describe "iOS deep link approval" do
+    test "serves iOS deep link approval", %{conn: conn} do
+      appid = "#{Faker.String.base64()}.#{reverse_domain_name()}"
+      reassign_env(:dotcom, :mbta_go, ios_appid: appid)
+
+      conn = conn |> get("/.well-known/apple-app-site-association")
+
+      assert json_response(conn, 200) == %{
+               "applinks" => %{
+                 "details" => [
+                   %{
+                     "appIDs" => [appid],
+                     "components" => [
+                       %{"/" => "/go"},
+                       %{"/" => "/go/*"}
+                     ]
+                   }
+                 ]
+               }
+             }
+    end
+
+    test "does not crash if iOS deep link approval not configured", %{conn: conn} do
+      reassign_env(:dotcom, :mbta_go, ios_appid: nil)
+
+      conn = conn |> get("/.well-known/apple-app-site-association")
+
+      assert json_response(conn, 200)
+    end
+  end
+end


### PR DESCRIPTION
<!-- 
  GitHub will automatically add a random non-busy member of the Dotcom team
  as a Required Reviewer when the PR is opened; feel free to also manually assign
  team members if a PR needs a very specific pair of eyes! -->

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Create link that opens the app if you have it installed and the store otherwise](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209949928014406?focus=true)

<!-- 
  Please include a brief description of what was changed. 
  For UI changes, screenshots are encouraged.
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

As described in the ticket, sets `/go` to redirect to the App Store / Play Store / MBTA Go project page in the same way that #2437’s `/app-store` does, and creates the `/.well-known/` files that are needed to have MBTA Go open links under `/go` if it’s installed.

It’d be theoretically possible to have every instance of dotcom attached to every instance of the mobile app, which would let this be self-contained like #2437 is, but for people with multiple instances of the app installed, that’d make it difficult to control which instance of the mobile app is actually opened. Instead, per discussion with the MBTA Go team, I’ve set this to pull information about a single MBTA Go instance from the environment, so that URLs for dotcom dev can always open in MBTA Go staging, prod can always open in prod, and dev-blue and dev-green can always open in dev-orange.

Devops PR: https://github.com/mbta/devops/pull/2894

---

#### General checks
* [ ] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [ ] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.
* [ ] **Tech debt.** Have you checked for tech debt you can address in the area you're working in? This can be a good time to address small issues, or create Asana tickets for larger issues.

<!-- More specialized checks below, remove sections that are not applicable -->

