### PR TITLE
fix(ControllerHelpers): add valid response headers

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -23,8 +23,6 @@
   {"lib/dotcom_web/controllers/cms_controller.ex", :unknown_type},
   {"lib/dotcom_web/controllers/event_controller.ex", :unknown_type},
   {"lib/dotcom_web/controllers/fare_controller.ex", :unknown_type},
-  {"lib/dotcom_web/controllers/helpers.ex", :call},
-  {"lib/dotcom_web/controllers/helpers.ex", :invalid_contract},
   {"lib/dotcom_web/controllers/map_config_controller.ex", :unknown_type},
   {"lib/dotcom_web/controllers/mode/hub_behavior.ex", :unknown_type},
   {"lib/dotcom_web/controllers/schedule/line/maps.ex", :unknown_type},

--- a/lib/dotcom_web/controllers/helpers.ex
+++ b/lib/dotcom_web/controllers/helpers.ex
@@ -186,14 +186,15 @@ defmodule DotcomWeb.ControllerHelpers do
     end)
   end
 
-  @spec add_headers_if_valid(Conn.t(), [{String.t(), String.t()}]) :: Conn.t()
+  @spec add_headers_if_valid(Conn.t(), %{optional(binary()) => [binary()]}) :: Conn.t()
   defp add_headers_if_valid(conn, headers) do
-    Enum.reduce(headers, conn, fn {key, value}, conn ->
-      if key in @valid_resp_headers && is_binary(value) do
+    Enum.reduce(headers, conn, fn
+      {key, [value]}, conn
+      when key in @valid_resp_headers and is_binary(value) ->
         Conn.put_resp_header(conn, key, value)
-      else
+
+      _, conn ->
         conn
-      end
     end)
   end
 

--- a/test/dotcom_web/controllers/helpers_test.exs
+++ b/test/dotcom_web/controllers/helpers_test.exs
@@ -324,10 +324,10 @@ defmodule DotcomWeb.ControllerHelpersTest do
 
     test "returns the body and headers from the response if it's a 200" do
       headers = [
-        {"content-type", "text/plain"},
-        {"etag", "tag"},
-        {"content-length", "6"},
-        {"date", "Tue, 13 Nov 2018 00:00:00 EST"}
+        {"content-type", ["text/plain"]},
+        {"etag", ["tag"]},
+        {"content-length", ["6"]},
+        {"date", ["Tue, 13 Nov 2018 00:00:00 EST"]}
       ]
 
       expect(Req.Mock, :new, fn _ ->


### PR DESCRIPTION
actually use the format returned by Req, as described by https://hexdocs.pm/req/0.5.1/Req.Response.html#t:t/0

This happens to fix a few links when accessed locally, for example `http://localhost:4001/sites/default/files/media/route_pdfs/batch_7426/2025-03-25-cr-spring-summer-fairmount-line-schedule.pdf`

Click Fairmount line schedule PDF from its timetable page, before (Firefox): 
<img width="915" alt="image" src="https://github.com/user-attachments/assets/3545e71e-de8d-473e-858a-1a1f5682b47b" />


After: 
<img width="1457" alt="image" src="https://github.com/user-attachments/assets/c358487c-0679-41e8-9063-c2c8b065180a" />
