### PR TITLE
test: explore if certain paths into MBTA Go deep link work

### DIFF
--- a/lib/dotcom_web/controllers/mbta_go_deep_link_test_controller.ex
+++ b/lib/dotcom_web/controllers/mbta_go_deep_link_test_controller.ex
@@ -1,0 +1,13 @@
+defmodule DotcomWeb.MbtaGoDeepLinkTestController do
+  @moduledoc false
+
+  use DotcomWeb, :controller
+
+  def redir(conn, _params) do
+    redirect(conn, to: "/go")
+  end
+
+  def link(conn, _params) do
+    html(conn, "<a href=\"/go\">Open MBTA Go</a>")
+  end
+end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -251,6 +251,9 @@ defmodule DotcomWeb.Router do
     post("/search/click", SearchController, :click)
     get("/bus-stop-changes", BusStopChangeController, :show)
     get("/vote", VoteController, :show)
+
+    get("/gotest/redir", MbtaGoDeepLinkTestController, :redir)
+    get("/gotest/link", MbtaGoDeepLinkTestController, :link)
   end
 
   scope "/go", DotcomWeb do


### PR DESCRIPTION
Apparently, opening links from other apps to the `/go` URL established in #2555 will correctly open MBTA Go, but manually entering that URL in a Web browser will open that URL in the Web browser instead of opening MBTA Go, on both Android and iOS. As such, we need to figure out how we can get people from a manually entered URL to the deep link, and there are some things that may work differently when they’re on the same domain vs moving across domains, so we need to test a redirect and a link that are from dotcom to dotcom, rather than redirecting or linking from some other domain to dotcom.

If I can borrow a dotcom dev environment for a couple of minutes, I should be able to figure out which things work and which things don’t. This isn’t urgent, but there are a couple of different things that it’s blocking.