### PR TITLE
feat: MBTA Go feedback form redirect endpoint

### DIFF
--- a/lib/dotcom_web/controllers/mbta_go_feedback_controller.ex
+++ b/lib/dotcom_web/controllers/mbta_go_feedback_controller.ex
@@ -1,0 +1,67 @@
+defmodule DotcomWeb.MbtaGoFeedbackController do
+  @moduledoc """
+  Redirects users to the appropriate feedback form based on their language and OS
+  """
+  use DotcomWeb, :controller
+
+  @airtable_form_url "https://airtable.com/appdYDxevMwSoOnv5/pagEeBp8XZalpGHwA/form"
+  @lang_param "lang"
+
+  def android(conn, params) do
+    feedback_redirect(conn, params[@lang_param], :android)
+  end
+
+  def android_ht(conn, _params) do
+    feedback_redirect(conn, "ht", :android)
+  end
+
+  def ios(conn, params) do
+    feedback_redirect(conn, params[@lang_param], :ios)
+  end
+
+  def ios_ht(conn, _params) do
+    feedback_redirect(conn, "ht", :ios)
+  end
+
+  defp feedback_redirect(conn, lang, os) do
+    conn
+    |> redirect(external: airtable_url(lang, os))
+    |> halt
+  end
+
+  defp airtable_url(lang, os) do
+    encoded_params =
+      URI.encode_query(
+        [
+          prefill_Language: language_param(lang),
+          "prefill_Phone Operating System": os_param(os)
+        ],
+        :rfc3986
+      )
+
+    @airtable_form_url
+    |> URI.parse()
+    |> URI.append_query(encoded_params)
+    |> URI.to_string()
+  end
+
+  defp language_param(lang) do
+    case lang do
+      "es-US" -> "Español"
+      "fr" -> "Français"
+      "ht" -> "Kreyòl Ayisyen"
+      "pt-BR" -> "Português"
+      "vi" -> "Tiếng Việt"
+      "zh-Hans" -> "中文（简体）"
+      "zh-Hant" -> "中文（繁體）"
+      _ -> "English"
+    end
+  end
+
+  defp os_param(os) do
+    case os do
+      :ios -> "iOS"
+      :android -> "Android"
+    end
+  end
+end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -166,6 +166,11 @@ defmodule DotcomWeb.Router do
     get("/menu", PageController, :menu)
 
     get("/app-store", AppStoreController, :redirect_mbta_go)
+    get("/appfeedback", MbtaGoFeedbackController, :ios)
+    get("/appfeedback-ht", MbtaGoFeedbackController, :ios_ht)
+    get("/androidappfeedback", MbtaGoFeedbackController, :android)
+    get("/androidappfeedback-ht", MbtaGoFeedbackController, :android_ht)
+
     get("/events", EventController, :index)
     get("/events/icalendar/*path_params", EventController, :icalendar)
     get("/node/icalendar/*path_params", EventController, :icalendar)

--- a/test/dotcom_web/controllers/mbta_go_feedback_controller_test.exs
+++ b/test/dotcom_web/controllers/mbta_go_feedback_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule DotcomWeb.MbtaGoFeedbackControllerTest do
+  use DotcomWeb.ConnCase, async: true
+  import Test.Support.EnvHelpers
+
+  test "redirects to english by default for ios", %{conn: conn} do
+    conn = conn |> get(mbta_go_feedback_path(conn, :ios))
+    redirected_to = redirected_to(conn, 302)
+
+    assert redirected_to =~
+             "https://airtable.com/appdYDxevMwSoOnv5/pagEeBp8XZalpGHwA/form?prefill_Language=English&prefill_Phone%20Operating%20System=iOS"
+  end
+
+  test "redirects to english by default for android", %{conn: conn} do
+    conn = conn |> get(mbta_go_feedback_path(conn, :android))
+    redirected_to = redirected_to(conn, 302)
+
+    assert redirected_to =~
+             "https://airtable.com/appdYDxevMwSoOnv5/pagEeBp8XZalpGHwA/form?prefill_Language=English&prefill_Phone%20Operating%20System=Android"
+  end
+
+  test "redirects to ht for special ht url on ios", %{conn: conn} do
+    conn = conn |> get(mbta_go_feedback_path(conn, :ios_ht))
+    redirected_to = redirected_to(conn, 302)
+
+    assert redirected_to =~
+             "?prefill_Language=Krey%C3%B2l%20Ayisyen&prefill_Phone%20Operating%20System=iOS"
+  end
+
+  test "redirects to ht for special ht url on android", %{conn: conn} do
+    conn = conn |> get(mbta_go_feedback_path(conn, :android_ht))
+    redirected_to = redirected_to(conn, 302)
+
+    assert redirected_to =~
+             "?prefill_Language=Krey%C3%B2l%20Ayisyen&prefill_Phone%20Operating%20System=Android"
+  end
+
+  test "redirects to es", %{conn: conn} do
+    conn = conn |> get(mbta_go_feedback_path(conn, :ios, %{"lang" => "es-US"}))
+    redirected_to = redirected_to(conn, 302)
+
+    assert redirected_to =~
+             "?prefill_Language=Espa%C3%B1ol&prefill_Phone%20Operating%20System=iOS"
+  end
+
+  test "redirects to fr", %{conn: conn} do
+    conn = conn |> get(mbta_go_feedback_path(conn, :ios, %{"lang" => "fr"}))
+    redirected_to = redirected_to(conn, 302)
+
+    assert redirected_to =~
+             "?prefill_Language=Fran%C3%A7ais&prefill_Phone%20Operating%20System=iOS"
+  end
+
+  test "redirects to pt", %{conn: conn} do
+    conn = conn |> get(mbta_go_feedback_path(conn, :ios, %{"lang" => "pt-BR"}))
+    redirected_to = redirected_to(conn, 302)
+
+    assert redirected_to =~
+             "?prefill_Language=Portugu%C3%AAs&prefill_Phone%20Operating%20System=iOS"
+  end
+
+  test "redirects to vi", %{conn: conn} do
+    conn = conn |> get(mbta_go_feedback_path(conn, :ios, %{"lang" => "vi"}))
+    redirected_to = redirected_to(conn, 302)
+
+    assert redirected_to =~
+             "?prefill_Language=Ti%E1%BA%BFng%20Vi%E1%BB%87t&prefill_Phone%20Operating%20System=iOS"
+  end
+
+  test "redirects to zh-Hans", %{conn: conn} do
+    conn = conn |> get(mbta_go_feedback_path(conn, :ios, %{"lang" => "zh-Hans"}))
+    redirected_to = redirected_to(conn, 302)
+
+    assert redirected_to =~
+             "?prefill_Language=%E4%B8%AD%E6%96%87%EF%BC%88%E7%AE%80%E4%BD%93%EF%BC%89&prefill_Phone%20Operating%20System=iOS"
+  end
+
+  test "redirects to zh-Hant", %{conn: conn} do
+    conn = conn |> get(mbta_go_feedback_path(conn, :ios, %{"lang" => "zh-Hant"}))
+    redirected_to = redirected_to(conn, 302)
+
+    assert redirected_to =~
+             "?prefill_Language=%E4%B8%AD%E6%96%87%EF%BC%88%E7%B9%81%E9%AB%94%EF%BC%89&prefill_Phone%20Operating%20System=iOS"
+  end
+end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Redirect feedback form URLs](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209950590972399?focus=true)

Add new endpoints which replace our old vanity URLs that redirected to Microsoft forms. This replaces those URLs (which are hardcoded into the app) and redirects them instead to airtable, which prefills the language and OS.

Question for dotcom eng: Will the vanities be overridden automatically when this is deployed, or do we need to remove the vanities before this will go into effect?

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [X] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.


#### New endpoints, or non-trivial changes to current endpoints
~* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../load_tests/README.md)~
