### PR TITLE
feat: Add /route/{id} endpoint for T-Alerts texts

### DIFF
--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -232,6 +232,7 @@ defmodule DotcomWeb.Router do
     get("/schedules/:route", ScheduleController, :show, as: :schedule)
     get("/schedules/:route/pdf", ScheduleController.Pdf, :pdf, as: :route_pdf)
     get("/schedules/:route/*path", Plugs.ScheduleRedirector, [])
+    get("/route/*path", ScheduleController, :route_redirect)
     get("/style-guide", StyleGuideController, :index)
     get("/style-guide/principles", Redirector, to: "/style-guide")
     get("/style-guide/about", Redirector, to: "/style-guide")

--- a/test/dotcom_web/controllers/schedule_controller_test.exs
+++ b/test/dotcom_web/controllers/schedule_controller_test.exs
@@ -453,4 +453,30 @@ defmodule DotcomWeb.ScheduleControllerTest do
       end
     end
   end
+
+  describe "route redirects" do
+    test "redirect with tracking params", %{conn: conn} do
+      conn = conn |> get("/route/66")
+      redirected_to = redirected_to(conn, 302)
+
+      assert redirected_to =~
+               "/schedules/66?utm_campaign=TAlertsDotcom&utm_source=TAlerts"
+    end
+
+    test "passes through provided params", %{conn: conn} do
+      conn = conn |> get("/route/1?test_param=value&utm_source=bad_source")
+      redirected_to = redirected_to(conn, 302)
+
+      assert redirected_to =~
+               "/schedules/1?test_param=value&utm_campaign=TAlertsDotcom&utm_source=TAlerts"
+    end
+
+    test "route ids that don't exist are still passed", %{conn: conn} do
+      conn = conn |> get("/route/Green")
+      redirected_to = redirected_to(conn, 302)
+
+      assert redirected_to =~
+               "/schedules/Green?utm_campaign=TAlertsDotcom&utm_source=TAlerts"
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Create dotcom schedule redirect URLs](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209949928014410?focus=true)

This adds a `/route/{id}` endpoint which will be used in T-Alerts texts as a shortcut to the schedule page. This is done partly to conserve characters, and partly so that we can use the redirect to include a GA campaign so that we know that the requests are coming from the alerts.

Instead of using the Route plug, this passes through whatever URL param is provided as the route id, so that it can handle cases like the Green line schedule page.

---

#### General checks
* [x] **Are the changes organized into self-contained commits with descriptive and well-formatted commit messages?** This is a good practice that can facilitate easier reviews.
* [x] **Testing.** Do the changes include relevant passing updates to tests? This includes updating screenshots. Preferably tests are run locally to verify that there are no test failures created by these changes, before opening a PR.

#### New endpoints, or non-trivial changes to current endpoints
~* [ ] **Have we load-tested** any new pages or internal API endpoints that will receive significant traffic? [See load testing docs](./../load_tests/README.md)~
* [x] **If this change involves routes,** does it work correctly with pertinent "unusual" routes such as the combined Green Line, Silver Line, Foxboro commuter rail, and single-direction bus routes like the 170?

