### PR TITLE
test: check MBTA Go deep linking again

### DIFF
--- a/lib/dotcom_web/controllers/mbta_go_deep_link_test_controller.ex
+++ b/lib/dotcom_web/controllers/mbta_go_deep_link_test_controller.ex
@@ -1,0 +1,21 @@
+defmodule DotcomWeb.MbtaGoDeepLinkTestController do
+  @moduledoc false
+
+  use DotcomWeb, :controller
+
+  def redir_dotcom(conn, _params) do
+    redirect(conn, to: "/go")
+  end
+
+  def redir_backend(conn, _params) do
+    redirect(conn, external: "https://mobile-app-backend-dev-orange.mbtace.com")
+  end
+
+  def link_dotcom(conn, _params) do
+    html(conn, "<a href=\"/go\">Open MBTA Go</a>")
+  end
+
+  def link_backend(conn, _params) do
+    html(conn, "<a href=\"https://mobile-app-backend-dev-orange.mbtace.com\">Open MBTA Go</a>")
+  end
+end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -256,6 +256,11 @@ defmodule DotcomWeb.Router do
     post("/search/click", SearchController, :click)
     get("/bus-stop-changes", BusStopChangeController, :show)
     get("/vote", VoteController, :show)
+
+    get("/gotest/redir/dotcom", MbtaGoDeepLinkTestController, :redir_dotcom)
+    get("/gotest/redir/backend", MbtaGoDeepLinkTestController, :redir_backend)
+    get("/gotest/link/dotcom", MbtaGoDeepLinkTestController, :link_dotcom)
+    get("/gotest/link/backend", MbtaGoDeepLinkTestController, :link_backend)
   end
 
   scope "/go", DotcomWeb do


### PR DESCRIPTION
Now that I’ve set up deep linking on a different domain (https://github.com/mbta/mobile_app_backend/pull/318), I need to re-check #2557 with cross-domain links and redirects, on some dev environment once one is free.