### PR TITLE
feat(TimetableController): Show Worcester shuttle stops

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -495,7 +495,8 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     "place-kencl" => {:after, "Boston Landing"},
     "7651" => {:before, "Newtonville"},
     "7631" => {:before, "Boston Landing"},
-    "9370044" => {:before, "Washington St @ Walnut St"}
+    "9370044" => {:before, "Washington St @ Walnut St"},
+    "place-river" => {:after, "Wellesley Hills"}
   }
   @shuttle_ids Map.keys(@shuttle_overrides)
 


### PR DESCRIPTION
[Outbound](https://dev-green.mbtace.com/schedules/CR-Worcester/timetable?date=2025-05-31&schedule_direction[direction_id]=0#direction-filter) (before to the left, after to the right)
![Screenshot 2025-05-23 at 5 18 05 PM](https://github.com/user-attachments/assets/0cb2919c-072e-4ffd-a8c8-3eab5127adbe)

[Inbound](https://dev-green.mbtace.com/schedules/CR-Worcester/timetable?date=2025-05-31&schedule_direction[direction_id]=1#direction-filter) (after only - for some reason, the shuttles weren't showing up at all.)

![Screenshot 2025-05-23 at 5 19 38 PM](https://github.com/user-attachments/assets/9d160600-afd0-4fdb-8995-c982e66c0b4b)

---

**Asana Ticket:** [[Triage] Ensure that all stops show up in timetable for oddball Worcester line shuttle](https://app.asana.com/1/15492006741476/project/1205718271156548/task/1210357255896281?focus=true)

