### PR TITLE
fix(warnings): Format EEx comment correctly

### DIFF
--- a/lib/dotcom_web/templates/news_entry/show.html.eex
+++ b/lib/dotcom_web/templates/news_entry/show.html.eex
@@ -39,7 +39,7 @@
                 <div class="contact-element-phone"><%= tel_link phone %></div>
               <% end %>
 
-              <% # This emails is hardcoded on purpose; the email can differ from the #{email} value. %>
+              <% # This email is hardcoded on purpose; the email can differ from the #{email} value. %>
               <p>Members of the press can request to join our media list by emailing <a href="mailto:MediaRelations@mbta.com">MediaRelations@mbta.com</a>. We'll send you MBTA press releases and media advisories directly.</p>
             </div>
           </div>

--- a/lib/dotcom_web/templates/news_entry/show.html.eex
+++ b/lib/dotcom_web/templates/news_entry/show.html.eex
@@ -39,7 +39,7 @@
                 <div class="contact-element-phone"><%= tel_link phone %></div>
               <% end %>
 
-              <%# This emails is hardcoded on purpose; the email can differ from the #{email} value. %>
+              <% # This emails is hardcoded on purpose; the email can differ from the #{email} value. %>
               <p>Members of the press can request to join our media list by emailing <a href="mailto:MediaRelations@mbta.com">MediaRelations@mbta.com</a>. We'll send you MBTA press releases and media advisories directly.</p>
             </div>
           </div>


### PR DESCRIPTION
This clears up 👇 warning (and fixes a typo).

```
    warning: <%# is deprecated, use <%!-- or add a space between <% and # instead
    │
 42 │               <%# This emails is hardcoded on purpose; the email can differ from the #{email} value. %>
    │               ~
    │
    └─ lib/dotcom_web/templates/news_entry/show.html.eex:42: (file)
```