### PR TITLE
Remove the subway icon on cr alerts

### DIFF
--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -17,8 +17,7 @@
       <:heading>
         <h2 class="mt-8">Station & Service Alerts</h2>
       </:heading>
-      <:alert_header_icon :let={route_or_stop}>
-        <.subway_route_pill route_ids={[route_or_stop.id]} />
+      <:alert_header_icon>
       </:alert_header_icon>
     </.alerts_page_content_layout>
   </:main_section>


### PR DESCRIPTION
I accidentally left the subway icons in CR alerts.