### PR TITLE
Only reject service impacting alerts from today

### DIFF
--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -3,6 +3,8 @@ defmodule Dotcom.Alerts do
   A collection of functions that help to work with alerts in a unified way.
   """
 
+  import Dotcom.Utils.ServiceDateTime, only: [service_today?: 1]
+
   alias Alerts.Alert
   alias Stops.Stop
 
@@ -88,8 +90,7 @@ defmodule Dotcom.Alerts do
   @spec in_effect_today?(Alerts.Alert.t()) :: boolean()
   def in_effect_today?(%Alerts.Alert{active_period: active_period}) do
     Enum.any?(active_period, fn {start, stop} ->
-      Dotcom.Utils.ServiceDateTime.service_today?(start) ||
-        Dotcom.Utils.ServiceDateTime.service_today?(stop)
+      service_today?(start) || service_today?(stop)
     end)
   end
 

--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -83,6 +83,17 @@ defmodule Dotcom.Alerts do
   end
 
   @doc """
+  Returns a boolean indicating whether or not the alert is in effect for the service day.
+  """
+  @spec in_effect_today?(Alerts.Alert.t()) :: boolean()
+  def in_effect_today?(%Alerts.Alert{active_period: active_period}) do
+    Enum.any?(active_period, fn {start, stop} ->
+      Dotcom.Utils.ServiceDateTime.service_today?(start) ||
+        Dotcom.Utils.ServiceDateTime.service_today?(stop)
+    end)
+  end
+
+  @doc """
   Returns a keyword list of the alert effects that are considered service-impacting and their severity levels.
   """
   @spec service_impacting_effects() :: [{service_effect_t(), integer()}]

--- a/lib/dotcom/system_status/commuter_rail.ex
+++ b/lib/dotcom/system_status/commuter_rail.ex
@@ -5,7 +5,7 @@ defmodule Dotcom.SystemStatus.CommuterRail do
   or whether there are alerts that impact service.
   """
 
-  import Dotcom.Alerts, only: [service_impacting_alert?: 1]
+  import Dotcom.Alerts, only: [in_effect_today?: 1, service_impacting_alert?: 1]
 
   alias Routes.Route
 
@@ -64,15 +64,6 @@ defmodule Dotcom.SystemStatus.CommuterRail do
       {effect, Kernel.length(alerts)}
     end)
     |> Map.new()
-  end
-
-  # Returns a boolean indicating whether or not the alert is in effect for the service day.
-  @spec in_effect_today?(Alerts.Alert.t()) :: boolean()
-  defp in_effect_today?(%Alerts.Alert{active_period: active_period}) do
-    Enum.any?(active_period, fn {start, stop} ->
-      Dotcom.Utils.ServiceDateTime.service_today?(start) ||
-        Dotcom.Utils.ServiceDateTime.service_today?(stop)
-    end)
   end
 
   # Returns a boolean indicating whether or not the route has a schedule

--- a/lib/dotcom_web/controllers/alert_controller.ex
+++ b/lib/dotcom_web/controllers/alert_controller.ex
@@ -3,6 +3,8 @@ defmodule DotcomWeb.AlertController do
 
   use DotcomWeb, :controller
 
+  import Dotcom.Alerts, only: [in_effect_today?: 1, service_impacting_alert?: 1]
+
   alias Alerts.{Alert, InformedEntity, Match}
   alias Dotcom.Alerts.Subway.Disruptions
   alias Stops.Stop
@@ -31,12 +33,14 @@ defmodule DotcomWeb.AlertController do
   end
 
   def show(conn, %{"id" => "commuter-rail"}) do
+    alerts =
+      Enum.reject(conn.assigns.alerts, fn alert ->
+        service_impacting_alert?(alert) && in_effect_today?(alert)
+      end)
+
     conn
     |> assign(:commuter_rail_status, Dotcom.SystemStatus.CommuterRail.commuter_rail_status())
-    |> assign(
-      :alerts,
-      Enum.reject(conn.assigns.alerts, &Dotcom.Alerts.service_impacting_alert?/1)
-    )
+    |> assign(:alerts, alerts)
     |> render_routes()
   end
 


### PR DESCRIPTION
Hotfix to only reject service impacting alerts that are in effect today.