### PR TITLE
Fix flaky test

### DIFF
--- a/test/dotcom/system_status/commuter_rail_test.exs
+++ b/test/dotcom/system_status/commuter_rail_test.exs
@@ -61,7 +61,8 @@ defmodule Dotcom.SystemStatus.CommuterRailTest do
           # Service impacting alert
           Factories.Alerts.Alert.build(:alert,
             active_period: active_period,
-            effect: random_service_impacting_effect
+            effect: random_service_impacting_effect,
+            severity: 3
           ),
           # Non-service impacting alert
           Factories.Alerts.Alert.build(:alert, effect: :summary)


### PR DESCRIPTION
We had a flaky test (written by me) where it was failing in the off chance that the alert effect was service change but the severity wasn't 3. Just set the severity to 3 and it works.