### PR TITLE
refactor: Make `<.status_label />` component more re-usable

### DIFF
--- a/lib/dotcom_web/live/system_status.ex
+++ b/lib/dotcom_web/live/system_status.ex
@@ -43,13 +43,19 @@ defmodule DotcomWeb.Live.SystemStatus do
     <h1>Misc Components</h1>
     <h2>Status Labels</h2>
     <div class="flex flex-col gap-2">
-      <.status_label status={:normal} />
-      <.status_label status={:shuttle} />
-      <.status_label status={:shuttle} plural />
-      <.status_label status={:shuttle} prefix="8:30pm" />
-      <.status_label status={:shuttle} prefix="Wed Feb 12 - Fri Feb 14" />
-      <.status_label status={:station_closure} />
-      <.status_label status={:delay} />
+      <.status_label status={:normal} description="Normal Service" />
+      <.status_label status={:no_scheduled_service} description="No Scheduled Service" />
+      <.status_label status={:shuttle} description="Shuttles" />
+      <.status_label status={:suspension} description="Suspension" />
+      <.status_label status={:shuttle} description="8:30pm: Shuttles" />
+      <.status_label status={:shuttle} description="Wed Feb 12 - Fri Feb 14: Shuttles" />
+      <.status_label status={:delay} description="Delay" />
+      <.status_label
+        status={:shuttle}
+        description="Shuttles"
+        subheading_text={"Forest Hills" <> " \u2194 " <> "Back Bay"}
+        subheading_aria_label="between Forest Hills and Back Bay"
+      />
     </div>
 
     <h2>Route Pills</h2>


### PR DESCRIPTION
Two major changes:
- Move icon and subheading layout and logic into the component for consistency
- Move prefix and plural logic out of the component for flexibility

So now `<.status_label />` will render with an icon, and will take text as an argument, as well as an optional subheading. Below are some example `<.status_label />` components on the preview page, before on the left, after on the right.

![Screenshot 2025-06-03 at 10 12 45 AM](https://github.com/user-attachments/assets/e88e98ef-e364-44ef-a62a-287c08b69ec6)

Some additional thoughts:
- From a rider perspective, this should be a pure refactor. The change is entirely in what components are available to `<.status_row_header />` and other possible consumers of `<.status_label />`.
- CR system status doesn't use this yet - that will be a follow-up (there's some fiddling with wrapping behavior that needs to happen in order for that to be fully right, and nothing is blocked on CR system status using this.)

---

No ticket, but in anticipation for adding detailed status on the CR timetable pages.