### PR TITLE
Remove informizely code

### DIFF
--- a/assets/js/sentry-filter.js
+++ b/assets/js/sentry-filter.js
@@ -317,7 +317,6 @@ const beforeSend = (event, hint) => {
       "localStorage", // Mobile device settings (usually coming from Android)
       "/Users/", // MacOS localhost
       "C:\\Users\\", // Windows localhost
-      "insitez.blob.core.windows" // informizely
     ].some(predicate => parsedEvent.includes(predicate));
 
     if (match) {

--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -65,7 +65,6 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
         https://www.google.com/recaptcha/api.js
         https://www.google.com/recaptcha/api/fallback
         https://www.googletagmanager.com/gtm.js
-        insitez.blob.core.windows.net
         snap.licdn.com
         translate.google.com/translate_a/element.js
         translate-pa.googleapis.com


### PR DESCRIPTION
This ended up being something we had to remove in Google Tag Manager.

https://www.informizely.com/help/installation-guides#gaTagManager

But, we should remove it from the CSP and Sentry approved list.

https://app.asana.com/1/15492006741476/project/555089885850811/task/1209981803069569?focus=true