### PR TITLE
Ignore params when caching cms pages

### DIFF
--- a/lib/cms/repo.ex
+++ b/lib/cms/repo.ex
@@ -221,36 +221,11 @@ defmodule CMS.Repo do
   @behaviour Nebulex.Caching.KeyGenerator
 
   @impl true
-  def generate(_, _, [path, %Plug.Conn.Unfetched{aspect: :query_params}]) do
+  def generate(_, _, [path, _]) do
     key = path |> String.trim("/") |> String.replace(~r/\//, "|")
 
     "cms.repo|#{key}"
   end
-
-  def generate(_, _, [path, params]) do
-    key = path |> String.trim("/") |> String.replace(~r/\//, "|")
-
-    "cms.repo|#{key}" <> params_to_string(params)
-  end
-
-  defp params_to_string(params) when params == %{}, do: ""
-  defp params_to_string(params) when is_binary(params), do: params
-
-  defp params_to_string(params) when is_map(params) do
-    case params
-         |> Enum.reduce([], &CMS.Api.stringify_params/2)
-         |> Enum.map(fn {k, v} -> "#{k}=#{v}" end) do
-      [head | tail] ->
-        ["?#{head}", "#{Enum.join(tail, "&")}"]
-        |> Enum.reject(&(&1 == ""))
-        |> Enum.join("&")
-
-      _ ->
-        ""
-    end
-  end
-
-  defp params_to_string(_), do: ""
 
   @spec view_or_preview(String.t(), map) :: {:ok, map} | {:error, API.error()}
   defp view_or_preview(path, %{"preview" => _, "vid" => "latest"} = params) do

--- a/test/cms/repo_test.exs
+++ b/test/cms/repo_test.exs
@@ -29,36 +29,12 @@ defmodule CMS.RepoTest do
       assert Repo.generate(nil, nil, [path, %{}]) == "cms.repo" <> String.replace(path, "/", "|")
     end
 
-    test "generates the correct key for /**/*?*=*" do
-      path = "/foo/bar"
-      params = %{"baz" => "bop"}
-
-      assert Repo.generate(nil, nil, [path, params]) ==
-               "cms.repo" <> String.replace(path, "/", "|") <> "?baz=bop"
-    end
-
-    test "generates the correct key for /**/*?*=*&*=*" do
-      path = "/foo/bar"
-      params = %{"bam" => "bop", "baz" => "qux"}
-
-      assert Repo.generate(nil, nil, [path, params]) ==
-               "cms.repo" <> String.replace(path, "/", "|") <> "?baz=qux&bam=bop"
-    end
-
-    test "ignores nested maps if it is an unsupported key" do
+    test "ignores params" do
       path = "/foo/bar"
       params = %{"data" => %{"some" => "map"}}
 
       assert Repo.generate(nil, nil, [path, params]) ==
                "cms.repo" <> String.replace(path, "/", "|")
-    end
-
-    test "adds nested maps if it is a supported key" do
-      path = "/foo/bar"
-      params = %{"biz" => "bang", "data" => %{"latitude" => "123"}}
-
-      assert Repo.generate(nil, nil, [path, params]) ==
-               "cms.repo" <> String.replace(path, "/", "|") <> "?biz=bang&data[latitude]=123"
     end
   end
 end


### PR DESCRIPTION
We don't want to treat params when deciding whether or not a cms page is the same or different.

https://app.asana.com/1/15492006741476/project/555089885850811/task/1210137852727427?focus=true