### PR TITLE
fix: Line-wrapping on alerts-page subway status

### DIFF
--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -75,7 +75,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
     ~H"""
     <.unstyled_accordion
       style={if(@row.style.hide_route_pill, do: "--tw-divide-opacity: 0")}
-      summary_class="hover:bg-brand-primary-lightest cursor-pointer group/row flex items-center grow text-nowrap"
+      summary_class="hover:bg-brand-primary-lightest cursor-pointer group/row flex items-center grow"
       chevron_class="fill-gray-dark px-2 border-t-[1px] border-gray-lightest self-stretch flex items-center"
     >
       <:heading>


### PR DESCRIPTION
Before on the left; After on the right.
![Screenshot 2025-06-05 at 10 26 34 AM](https://github.com/user-attachments/assets/85f91956-f947-444e-9763-d704f010f9a9)

---

**Asana Ticket:** [QF | Fix endpoint wrapping on /alerts current status](https://app.asana.com/1/15492006741476/project/385363666817452/task/1210474743226557?focus=true)
