### PR TITLE
fix(subway-status): Don't show "Expect Delay" when the prefix is "Now"

### DIFF
--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -120,7 +120,10 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
   defp description(:see_alerts, _), do: "See Alerts"
 
   # Special case for delays - when displayed with a future date, say 
-  # "Expect Delay" (or Expect Delays) rather than simply "Delay"
+  # "Expect Delay" (or Expect Delays) rather than simply "Delay". A
+  # prefix of "Now" should still display as "Delay", rather than
+  # "Expect Delay".
+  defp description(:delay, "Now"), do: "Delay"
   defp description(:delay, prefix) when is_binary(prefix), do: "Expect Delay"
   defp description(:shuttle, _), do: "Shuttles"
   defp description(status, _), do: Alert.human_effect(%Alert{effect: status})


### PR DESCRIPTION
Before on the left; After on the right

![Screenshot 2025-06-05 at 1 27 58 PM](https://github.com/user-attachments/assets/02bb37a7-859c-4134-baea-dee442de25eb)

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Show "Now: Delay" on homepage and /alerts/subway status](https://app.asana.com/1/15492006741476/project/555089885850811/task/1209634655431456?focus=true)

