### PR TITLE
feat(DotcomWeb.ScheduleView): add track changes

### DIFF
--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -5,6 +5,9 @@
   priority_filter: :high,
   always_show: List.wrap(@blocking_alert)
 )}
+
+<.track_changes track_changes={Enum.filter(@alerts, &(&1.effect == :track_change))} />
+
 <%= if !assigns[:suppress_timetable?] do %>
   {render("_trip_view_filters.html", assigns)}
 <% end %>

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -450,4 +450,35 @@ defmodule DotcomWeb.ScheduleView do
       ~s(This train typically has<br /><strong>#{seats} seats available</strong>)
     end
   end
+
+  attr :track_changes, :list, required: true
+
+  def track_changes(assigns) do
+    assigns = assign(assigns, :count, Enum.count(assigns.track_changes))
+
+    ~H"""
+    <.unstyled_accordion
+      :if={@count > 0}
+      class="rounded-lg border border-[1px] border-gray-lighter"
+      summary_class="bg-gray-lightest rounded-lg group-open:rounded-none group-open:rounded-t-lg p-3 font-bold flex justify-between"
+    >
+      <:heading>
+        <div class="flex items-center gap-sm">
+          <.icon type="icon-svg" name="icon-alerts-triangle" class="h-4 w-4" aria-hidden="true" />
+          <span>{@count} Additional Track {Inflex.inflect("Change", @count)}</span>
+        </div>
+      </:heading>
+      <:content>
+        <div class="px-3 py-xs leading-snug">
+          <div
+            :for={change <- @track_changes}
+            class="py-sm [&:not(:last-child)]:border-b-[1px] border-gray-lightest"
+          >
+            {change.header}
+          </div>
+        </div>
+      </:content>
+    </.unstyled_accordion>
+    """
+  end
 end

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -464,8 +464,8 @@ defmodule DotcomWeb.ScheduleView do
     >
       <:heading>
         <div class="flex items-center gap-sm">
-          <.icon type="icon-svg" name="icon-alerts-triangle" class="h-4 w-4" aria-hidden="true" />
-          <span>{@count} Temporary Track {Inflex.inflect("Change", @count)}</span>
+          <.icon name="shuffle" class="h-4 w-4" aria-hidden="true" />
+          <span>{@count} Unscheduled Track {Inflex.inflect("Change", @count)}</span>
         </div>
       </:heading>
       <:content>

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -465,7 +465,7 @@ defmodule DotcomWeb.ScheduleView do
       <:heading>
         <div class="flex items-center gap-sm">
           <.icon type="icon-svg" name="icon-alerts-triangle" class="h-4 w-4" aria-hidden="true" />
-          <span>{@count} Additional Track {Inflex.inflect("Change", @count)}</span>
+          <span>{@count} Temporary Track {Inflex.inflect("Change", @count)}</span>
         </div>
       </:heading>
       <:content>

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -460,7 +460,7 @@ defmodule DotcomWeb.ScheduleView do
     <.unstyled_accordion
       :if={@count > 0}
       class="rounded-lg border border-[1px] border-gray-lighter"
-      summary_class="bg-gray-lightest rounded-lg group-open:rounded-none group-open:rounded-t-lg p-3 font-bold flex justify-between"
+      summary_class="bg-gray-lightest rounded-lg group-open:rounded-b-none p-3 font-bold flex justify-between"
     >
       <:heading>
         <div class="flex items-center gap-sm">

--- a/test/alerts/priority_test.exs
+++ b/test/alerts/priority_test.exs
@@ -1,12 +1,11 @@
 defmodule Alerts.PriorityTest do
   use ExUnit.Case, async: true
-  use Timex
 
   import Alerts.Priority
   alias Alerts.Alert
   alias Alerts.InformedEntity
 
-  @now Util.to_local_time(~N[2018-01-15T12:00:00])
+  @now Dotcom.Utils.DateTime.now()
 
   describe "priority_levels/0" do
     test "returns a list" do
@@ -116,9 +115,9 @@ defmodule Alerts.PriorityTest do
     end
 
     test "severe alerts updated within the last week are always high" do
-      updated = Timex.shift(@now, days: -6, hours: -23)
-      period_start = Timex.shift(@now, days: -8)
-      period_end = Timex.shift(@now, days: 8)
+      updated = DateTime.shift(@now, day: -6, hour: -23)
+      period_start = DateTime.shift(@now, day: -8)
+      period_end = DateTime.shift(@now, day: 8)
       assert within_one_week(@now, updated) == true
 
       for type <- types_which_can_be_notices() do
@@ -140,9 +139,9 @@ defmodule Alerts.PriorityTest do
     end
 
     test "severe alerts not updated in the last week are high within a week of the start date" do
-      updated = Timex.shift(@now, days: -10)
-      period_start = Timex.shift(@now, days: -5)
-      period_end = Timex.shift(@now, days: 15)
+      updated = DateTime.shift(@now, day: -10)
+      period_start = DateTime.shift(@now, day: -5)
+      period_end = DateTime.shift(@now, day: 15)
 
       for type <- types_which_can_be_notices() do
         params = %{
@@ -157,9 +156,9 @@ defmodule Alerts.PriorityTest do
     end
 
     test "severe alerts not updated in the last week are high within a week of the end date" do
-      updated = Timex.shift(@now, days: -8)
-      period_start = Timex.shift(@now, days: -20)
-      period_end = Timex.shift(@now, days: 6)
+      updated = DateTime.shift(@now, day: -8)
+      period_start = DateTime.shift(@now, day: -20)
+      period_end = DateTime.shift(@now, day: 6)
 
       for type <- types_which_can_be_notices() do
         params = %{
@@ -178,8 +177,8 @@ defmodule Alerts.PriorityTest do
         params = %{
           effect: type,
           severity: 7,
-          updated_at: Timex.shift(@now, days: -7, hours: -1),
-          active_period: [{Timex.shift(@now, days: -6, hours: -20), nil}]
+          updated_at: DateTime.shift(@now, day: -7, hour: -1),
+          active_period: [{DateTime.shift(@now, day: -6, hour: -20), nil}]
         }
 
         assert {type, priority(params, @now)} == {type, :high}
@@ -191,8 +190,10 @@ defmodule Alerts.PriorityTest do
         params = %{
           effect: type,
           severity: 7,
-          updated_at: Timex.shift(@now, days: -7, hours: -1),
-          active_period: [{Timex.shift(@now, days: -14), Timex.shift(@now, days: 6, hours: 23)}]
+          updated_at: DateTime.shift(@now, day: -7, hour: -1),
+          active_period: [
+            {DateTime.shift(@now, day: -14), DateTime.shift(@now, day: 6, hour: 23)}
+          ]
         }
 
         assert {type, priority(params, @now)} == {type, :high}
@@ -204,8 +205,8 @@ defmodule Alerts.PriorityTest do
         params = %{
           effect: type,
           severity: 7,
-          updated_at: Timex.shift(@now, days: -7, hours: -1),
-          active_period: [{nil, Timex.shift(@now, days: 6, hours: 23)}]
+          updated_at: DateTime.shift(@now, day: -7, hour: -1),
+          active_period: [{nil, DateTime.shift(@now, day: 6, hour: 23)}]
         }
 
         assert {type, priority(params, @now)} == {type, :high}
@@ -217,9 +218,9 @@ defmodule Alerts.PriorityTest do
         params = %{
           effect: type,
           severity: 7,
-          updated_at: Timex.shift(@now, days: -7, hours: -1),
+          updated_at: DateTime.shift(@now, day: -7, hour: -1),
           active_period: [
-            {Timex.shift(@now, days: -7, hours: -1), Timex.shift(@now, days: 7, hours: 1)}
+            {DateTime.shift(@now, day: -7, hour: -1), DateTime.shift(@now, day: 7, hour: 1)}
           ]
         }
 
@@ -234,9 +235,9 @@ defmodule Alerts.PriorityTest do
         params = %{
           effect: type,
           severity: 7,
-          updated_at: Timex.shift(@now, days: -6, hours: -20),
+          updated_at: DateTime.shift(@now, day: -6, hour: -20),
           active_period: [
-            {Timex.shift(@now, days: -7, hours: -1), Timex.shift(@now, days: 7, hours: 1)}
+            {DateTime.shift(@now, day: -7, hour: -1), DateTime.shift(@now, day: 7, hour: 1)}
           ]
         }
 
@@ -249,10 +250,10 @@ defmodule Alerts.PriorityTest do
         params = %{
           effect: type,
           severity: 7,
-          updated_at: Timex.shift(@now, days: -6, hours: -1),
+          updated_at: DateTime.shift(@now, day: -6, hour: -1),
           active_period: [
-            {Timex.shift(@now, days: -7, hours: -1), Timex.shift(@now, days: 7, hours: 1)},
-            {Timex.shift(@now, days: -6, hours: -23), Timex.shift(@now, days: 6, hours: 23)}
+            {DateTime.shift(@now, day: -7, hour: -1), DateTime.shift(@now, day: 7, hour: 1)},
+            {DateTime.shift(@now, day: -6, hour: -23), DateTime.shift(@now, day: 6, hour: 23)}
           ]
         }
 
@@ -265,11 +266,11 @@ defmodule Alerts.PriorityTest do
         params = %{
           effect: type,
           severity: 7,
-          updated_at: Timex.shift(@now, days: -7, hours: -1),
+          updated_at: DateTime.shift(@now, day: -7, hour: -1),
           active_period: [
-            {Timex.shift(@now, days: 10, hours: -1), Timex.shift(@now, days: 11, hours: 1)},
-            {nil, Timex.shift(@now, days: -10, hours: 1)},
-            {Timex.shift(@now, days: 10, hours: 1), nil}
+            {DateTime.shift(@now, day: 10, hour: -1), DateTime.shift(@now, day: 11, hour: 1)},
+            {nil, DateTime.shift(@now, day: -10, hour: 1)},
+            {DateTime.shift(@now, day: 10, hour: 1), nil}
           ]
         }
 
@@ -288,7 +289,7 @@ defmodule Alerts.PriorityTest do
     test "Current non-minor Service Change is high" do
       params = %{
         effect: :service_change,
-        active_period: [{Timex.shift(@now, days: -1), nil}]
+        active_period: [{DateTime.shift(@now, day: -1), nil}]
       }
 
       assert priority(params, @now) == :high
@@ -297,32 +298,28 @@ defmodule Alerts.PriorityTest do
     test "Future non-minor Service Change is low" do
       params = %{
         effect: :service_change,
-        active_period: [{Timex.shift(@now, days: 5), nil}]
+        active_period: [{DateTime.shift(@now, day: 5), nil}]
       }
 
       assert priority(params, @now)
     end
 
     test "Shuttle is high if it's active and not Ongoing" do
-      today = Timex.now("America/New_York")
-
       shuttle = %{
         effect: :shuttle,
-        active_period: [{Timex.shift(today, days: -1), nil}],
+        active_period: [{DateTime.shift(@now, day: -1), nil}],
         lifecycle: :new
       }
 
-      assert priority(shuttle, today) == :high
-      assert priority(shuttle, Timex.shift(today, days: -2)) == :low
-      assert priority(shuttle, today |> Timex.shift(days: -2) |> DateTime.to_date()) == :low
+      assert priority(shuttle, @now) == :high
+      assert priority(shuttle, DateTime.shift(@now, day: -2)) == :low
+      assert priority(shuttle, @now |> DateTime.shift(day: -2) |> DateTime.to_date()) == :low
     end
 
     test "Shuttle is low if it's Ongoing" do
-      today = Timex.now("America/New_York")
-
       shuttle = %{
         effect: :shuttle,
-        active_period: [{Timex.shift(today, days: -1), nil}],
+        active_period: [{DateTime.shift(@now, day: -1), nil}],
         lifecycle: :ongoing
       }
 
@@ -330,38 +327,35 @@ defmodule Alerts.PriorityTest do
     end
 
     test "Non on-going alerts are notices if they arent happening now" do
-      today = ~N[2017-01-01T12:00:00]
-      tomorrow = Timex.shift(today, days: 1)
+      tomorrow = DateTime.shift(@now, day: 1)
       shuttle = %{effect: :shuttle, active_period: [{tomorrow, nil}], lifecycle: :upcoming}
-      assert priority(shuttle, today) == :low
+      assert priority(shuttle, @now) == :low
     end
 
     test "Cancellation is high if it's today" do
       # NOTE: this will fail around 11:55pm, since future will switch to a different day
-      future = Timex.shift(@now, minutes: 5)
+      today = DateTime.shift(@now, minute: 5)
 
       cancellation = %{
         effect: :cancellation,
-        active_period: [{future, future}],
+        active_period: [{today, today}],
         lifecycle: :new
       }
 
-      today = future |> DateTime.to_date()
-      yesterday = future |> Timex.shift(days: -1) |> DateTime.to_date()
+      yesterday = today |> DateTime.shift(day: -1)
       assert priority(cancellation, today) == :high
       assert priority(cancellation, yesterday) == :low
     end
 
     test "Cancellation with multiple periods are notices if today is within on of the periods" do
       # NOTE: this will fail around 11:55pm, since future will switch to a different day
-      future = Timex.shift(@now, minutes: 5)
-      today = future |> DateTime.to_date()
-      yesterday = future |> Timex.shift(days: -1) |> DateTime.to_date()
-      tomorrow = future |> Timex.shift(days: 1) |> DateTime.to_date()
+      today = DateTime.shift(@now, minute: 5)
+      yesterday = today |> DateTime.shift(day: -1)
+      tomorrow = today |> DateTime.shift(day: 1)
 
       cancellation = %{
         effect: :cancellation,
-        active_period: [{future, future}, {tomorrow, tomorrow}],
+        active_period: [{today, today}, {tomorrow, tomorrow}],
         lifecycle: :new
       }
 
@@ -371,10 +365,10 @@ defmodule Alerts.PriorityTest do
   end
 
   test "within_one_week/2" do
-    assert within_one_week(~N[2018-01-01T12:00:00], ~N[2018-01-08T12:00:00]) == false
-    assert within_one_week(~N[2018-01-08T12:00:00], ~N[2018-01-01T12:00:00]) == false
-    assert within_one_week(~N[2018-01-01T12:00:00], ~N[2018-01-07T11:59:00]) == true
-    assert within_one_week(~N[2018-01-07T11:59:00], ~N[2018-01-01T12:00:00]) == true
+    assert within_one_week(@now, DateTime.shift(@now, day: -7)) == false
+    assert within_one_week(@now, DateTime.shift(@now, day: 7)) == false
+    assert within_one_week(@now, DateTime.shift(@now, day: -6)) == true
+    assert within_one_week(@now, DateTime.shift(@now, day: 6)) == true
   end
 
   describe "urgent_period?/2" do
@@ -384,32 +378,32 @@ defmodule Alerts.PriorityTest do
 
     test "severe alerts within 1 week of end date are urgent" do
       now = ~N[2018-01-15T12:00:00] |> Util.to_local_time()
-      start_date = Timex.shift(now, days: -10)
-      end_date = Timex.shift(now, days: 6)
+      start_date = DateTime.shift(now, day: -10)
+      end_date = DateTime.shift(now, day: 6)
       assert urgent_period?({nil, end_date}, now) == true
       assert urgent_period?({start_date, end_date}, now) == true
     end
 
     test "severe alerts beyond 1 week of end date are not urgent" do
       now = ~N[2018-01-15T12:00:00] |> Util.to_local_time()
-      start_date = Timex.shift(now, days: -10)
-      end_date = Timex.shift(now, days: 14)
+      start_date = DateTime.shift(now, day: -10)
+      end_date = DateTime.shift(now, day: 14)
       assert urgent_period?({nil, end_date}, now) == false
       assert urgent_period?({start_date, end_date}, now) == false
     end
 
     test "severe alerts within 1 week of start date are urgent" do
       now = ~N[2018-01-15T12:00:00] |> Util.to_local_time()
-      start_date = Timex.shift(now, days: -6)
-      end_date = Timex.shift(now, days: 10)
+      start_date = DateTime.shift(now, day: -6)
+      end_date = DateTime.shift(now, day: 10)
       assert urgent_period?({start_date, nil}, now) == true
       assert urgent_period?({start_date, end_date}, now) == true
     end
 
     test "severe alerts beyond 1 week of start date are not urgent" do
       now = ~N[2018-01-15T12:00:00] |> Util.to_local_time()
-      start_date = Timex.shift(now, days: -14)
-      end_date = Timex.shift(now, days: 10)
+      start_date = DateTime.shift(now, day: -14)
+      end_date = DateTime.shift(now, day: 10)
       assert urgent_period?({start_date, nil}, now) == false
       assert urgent_period?({start_date, end_date}, now) == false
     end
@@ -431,7 +425,7 @@ defmodule Alerts.PriorityTest do
              %{
                effect: type,
                severity: 7,
-               updated_at: Timex.shift(@now, days: -30),
+               updated_at: DateTime.shift(@now, day: -30),
                active_period: []
              },
              @now
@@ -446,7 +440,7 @@ defmodule Alerts.PriorityTest do
         params = %{
           effect: type,
           severity: 7,
-          updated_at: Timex.shift(@now, days: -6),
+          updated_at: DateTime.shift(@now, day: -6),
           active_period: [{nil, nil}]
         }
 
@@ -459,5 +453,6 @@ defmodule Alerts.PriorityTest do
     Alert.all_types()
     |> List.delete(:delay)
     |> List.delete(:suspension)
+    |> List.delete(:track_change)
   end
 end

--- a/test/dotcom_web/views/schedule_view_test.exs
+++ b/test/dotcom_web/views/schedule_view_test.exs
@@ -482,7 +482,7 @@ defmodule DotcomWeb.ScheduleViewTest do
         )
 
       assert one =~ "<details"
-      assert one =~ "1 Temporary Track Change"
+      assert one =~ "1 Unscheduled Track Change"
     end
 
     test "with 2+ changes" do
@@ -492,7 +492,7 @@ defmodule DotcomWeb.ScheduleViewTest do
         Phoenix.LiveViewTest.render_component(&track_changes/1, track_changes: changes)
 
       assert more =~ "<details"
-      assert more =~ "#{Enum.count(changes)} Temporary Track Changes"
+      assert more =~ "#{Enum.count(changes)} Unscheduled Track Changes"
 
       for header <- Enum.map(changes, & &1.header) do
         header_text = html_escape(header) |> safe_to_string()

--- a/test/dotcom_web/views/schedule_view_test.exs
+++ b/test/dotcom_web/views/schedule_view_test.exs
@@ -1,10 +1,13 @@
 defmodule DotcomWeb.ScheduleViewTest do
   use DotcomWeb.ConnCase
 
+  require Phoenix.LiveViewTest
+
   import DotcomWeb.ScheduleView
   import Mox
   import PhoenixHTMLHelpers.Tag, only: [content_tag: 3]
-  import Phoenix.HTML, only: [safe_to_string: 1]
+  import Phoenix.HTML, only: [html_escape: 1, safe_to_string: 1]
+  import Test.Support.Factories.Alerts.Alert
 
   alias CMS.Partial.RoutePdf
   alias Routes.Route
@@ -463,6 +466,38 @@ defmodule DotcomWeb.ScheduleViewTest do
 
     test "returns nothing otherwise" do
       assert flag_stop_badge(%Route{id: "39"}) == nil
+    end
+  end
+
+  describe "track_changes/1 shows alert headers" do
+    test "no content with no changes" do
+      none = Phoenix.LiveViewTest.render_component(&track_changes/1, track_changes: [])
+      assert none == ""
+    end
+
+    test "with 1 change" do
+      one =
+        Phoenix.LiveViewTest.render_component(&track_changes/1,
+          track_changes: build_list(1, :alert)
+        )
+
+      assert one =~ "<details"
+      assert one =~ "1 Temporary Track Change"
+    end
+
+    test "with 2+ changes" do
+      changes = Faker.random_between(2, 200) |> build_list(:alert)
+
+      more =
+        Phoenix.LiveViewTest.render_component(&track_changes/1, track_changes: changes)
+
+      assert more =~ "<details"
+      assert more =~ "#{Enum.count(changes)} Temporary Track Changes"
+
+      for header <- Enum.map(changes, & &1.header) do
+        header_text = html_escape(header) |> safe_to_string()
+        assert more =~ header_text
+      end
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [SS | Track Changes on CR /timetable pages](https://app.asana.com/1/15492006741476/project/555089885850811/task/1210331726103787?focus=true)

Adjusted the priority logic to always make track change alerts low priority, which removes them from showing in the top banner on timetable pages.