### PR TITLE
chore: Clean up `Dotcom.Utils.Time` module and improve test coverage

### DIFF
--- a/lib/dotcom/utils/time.ex
+++ b/lib/dotcom/utils/time.ex
@@ -23,47 +23,8 @@ defmodule Dotcom.Utils.Time do
   def between?(t, start, ending, opts \\ @default_between_opts)
 
   def between?(t, start, ending, opts) do
-    inclusive_opt = opts |> Keyword.get(:inclusive, true)
-
-    in_bounds_beginning? = after?(t, start, inclusive_start?(inclusive_opt))
-    in_bounds_ending? = before?(t, ending, inclusive_end?(inclusive_opt))
-
-    in_bounds_beginning? && in_bounds_ending?
+    start = if(start, do: start, else: ~D[0000-01-01])
+    ending = if(ending, do: ending, else: ~D[9999-12-31])
+    Timex.between?(t, start, ending, Keyword.merge(@default_between_opts, opts))
   end
-
-  # A slight modification to Timex.after?/2 that takes an additional
-  # argument indicating whether the bound should be considered
-  # inclusive. If the "inclusive" argument is true, then this returns
-  # true if the given DateTime's are equal.
-  #
-  # Also, if the second argument is nil, then it's considered to be
-  # the beginning of time, which means that after? will always be true
-  # (everything is after the beginning of time, after all).
-  defp after?(_dt1, nil, _inclusive), do: true
-  defp after?(dt1, dt2, _inclusive = true) when dt1 == dt2, do: true
-  defp after?(dt1, dt2, _inclusive), do: Timex.after?(dt1, dt2)
-
-  # A slight modification to Timex.before?/2 that takes an additional
-  # argument indicating whether the bound should be considered
-  # inclusive. If the "inclusive" argument is true, then this returns
-  # true if the given DateTime's are equal.
-  #
-  # Also, if the second argument is nil, then it's considered to be
-  # the end of time, which means that before? will always be true
-  # (everything is before the end of time, after all).
-  defp before?(_dt1, nil, _inclusive), do: true
-  defp before?(dt1, dt2, _inclusive = true) when dt1 == dt2, do: true
-  defp before?(dt1, dt2, _inclusive), do: Timex.before?(dt1, dt2)
-
-  # Given a keyword arg that could be true, false, :start, or :end,
-  # returns a boolean indicating whether the start boundary should be
-  # inclusive.
-  defp inclusive_start?(opt) when opt in [true, :start], do: true
-  defp inclusive_start?(_), do: false
-
-  # Given a keyword arg that could be true, false, :start, or :end,
-  # returns a boolean indicating whether the end boundary should be
-  # inclusive.
-  defp inclusive_end?(opt) when opt in [true, :end], do: true
-  defp inclusive_end?(_), do: false
 end

--- a/lib/dotcom/utils/time.ex
+++ b/lib/dotcom/utils/time.ex
@@ -22,14 +22,48 @@ defmodule Dotcom.Utils.Time do
           boolean()
   def between?(t, start, ending, opts \\ @default_between_opts)
 
-  def between?(t, start, nil, _) when not is_nil(start) do
-    t == start or Timex.after?(t, start)
+  def between?(t, start, ending, opts) do
+    inclusive_opt = opts |> Keyword.get(:inclusive, true)
+
+    in_bounds_beginning? = after?(t, start, inclusive_start?(inclusive_opt))
+    in_bounds_ending? = before?(t, ending, inclusive_end?(inclusive_opt))
+
+    in_bounds_beginning? && in_bounds_ending?
   end
 
-  def between?(t, nil, ending, _) when not is_nil(ending) do
-    t == ending or Timex.before?(t, ending)
-  end
+  # A slight modification to Timex.after?/2 that takes an additional
+  # argument indicating whether the bound should be considered
+  # inclusive. If the "inclusive" argument is true, then this returns
+  # true if the given DateTime's are equal.
+  #
+  # Also, if the second argument is nil, then it's considered to be
+  # the beginning of time, which means that after? will always be true
+  # (everything is after the beginning of time, after all).
+  defp after?(_dt1, nil, _inclusive), do: true
+  defp after?(dt1, dt2, _inclusive = true) when dt1 == dt2, do: true
+  defp after?(dt1, dt2, _inclusive), do: Timex.after?(dt1, dt2)
 
-  def between?(t, start, ending, opts),
-    do: Timex.between?(t, start, ending, Keyword.merge(@default_between_opts, opts))
+  # A slight modification to Timex.before?/2 that takes an additional
+  # argument indicating whether the bound should be considered
+  # inclusive. If the "inclusive" argument is true, then this returns
+  # true if the given DateTime's are equal.
+  #
+  # Also, if the second argument is nil, then it's considered to be
+  # the end of time, which means that before? will always be true
+  # (everything is before the beginning of time, after all).
+  defp before?(_dt1, nil, _inclusive), do: true
+  defp before?(dt1, dt2, _inclusive = true) when dt1 == dt2, do: true
+  defp before?(dt1, dt2, _inclusive), do: Timex.before?(dt1, dt2)
+
+  # Given a keyword arg that could be true, false, :start, or :end,
+  # returns a boolean indicating whether the start boundary should be
+  # inclusive.
+  defp inclusive_start?(opt) when opt in [true, :start], do: true
+  defp inclusive_start?(_), do: false
+
+  # Given a keyword arg that could be true, false, :start, or :end,
+  # returns a boolean indicating whether the end boundary should be
+  # inclusive.
+  defp inclusive_end?(opt) when opt in [true, :end], do: true
+  defp inclusive_end?(_), do: false
 end

--- a/lib/dotcom/utils/time.ex
+++ b/lib/dotcom/utils/time.ex
@@ -50,7 +50,7 @@ defmodule Dotcom.Utils.Time do
   #
   # Also, if the second argument is nil, then it's considered to be
   # the end of time, which means that before? will always be true
-  # (everything is before the beginning of time, after all).
+  # (everything is before the end of time, after all).
   defp before?(_dt1, nil, _inclusive), do: true
   defp before?(dt1, dt2, _inclusive = true) when dt1 == dt2, do: true
   defp before?(dt1, dt2, _inclusive), do: Timex.before?(dt1, dt2)

--- a/test/dotcom/utils/time_test.exs
+++ b/test/dotcom/utils/time_test.exs
@@ -12,40 +12,76 @@ defmodule Dotcom.Utils.TimeTest do
   end
 
   describe "between?/0" do
-    property "returns false when the date_time is not within the range" do
+    property "returns false when the date_time is before the beginning of the range" do
       check all(date_time <- date_time_generator()) do
-        start = DateTime.shift(date_time, second: 1)
-        stop = DateTime.shift(start, year: 1)
+        start = random_date_time_after(date_time)
+        stop = random_date_time_after(start)
         refute between?(date_time, start, stop)
+        refute between?(date_time, start, nil)
+      end
+    end
+
+    property "returns false when the date_time is after the end of the range" do
+      check all(date_time <- date_time_generator()) do
+        stop = random_date_time_before(date_time)
+        start = random_date_time_before(stop)
+        refute between?(date_time, start, stop)
+        refute between?(date_time, nil, stop)
       end
     end
 
     property "returns true when the date_time is within the range" do
       check all(date_time <- date_time_generator()) do
-        start = DateTime.shift(date_time, day: -400)
-        stop = DateTime.shift(start, day: 400)
+        start = random_date_time_before(date_time)
+        stop = random_date_time_after(date_time)
+        assert between?(date_time, start, stop)
+        assert between?(date_time, nil, stop)
+        assert between?(date_time, start, nil)
+      end
+    end
 
-        cond do
-          date_time == stop ->
-            refute between?(date_time, start, stop, inclusive: :start)
-            assert between?(date_time, start, stop, inclusive: true)
+    property "returns true when date_time is at the beginning of the range when inclusive is true or :start" do
+      check all(date_time <- date_time_generator()) do
+        stop = random_date_time_after(date_time)
+        assert between?(date_time, date_time, stop, inclusive: true)
+        assert between?(date_time, date_time, nil, inclusive: true)
+        assert between?(date_time, date_time, stop, inclusive: :start)
+        assert between?(date_time, date_time, nil, inclusive: :start)
+      end
+    end
 
-          date_time == start ->
-            refute between?(date_time, start, stop, inclusive: :end)
-            assert between?(date_time, start, stop, inclusive: true)
+    property "returns false when date_time is at the beginning of the range when inclusive is false or :end" do
+      check all(date_time <- date_time_generator()) do
+        stop = random_date_time_after(date_time)
+        refute between?(date_time, date_time, stop, inclusive: false)
+        refute between?(date_time, date_time, nil, inclusive: false)
+        refute between?(date_time, date_time, stop, inclusive: :end)
+        refute between?(date_time, date_time, nil, inclusive: :end)
+      end
+    end
 
-          true ->
-            assert between?(date_time, start, stop, inclusive: true)
-            assert between?(date_time, start, stop)
-            assert between?(date_time, start, nil)
-            assert between?(date_time, nil, stop)
-            assert between?(date_time, nil, nil)
-        end
+    property "returns true when date_time is at the end of the range when inclusive is true or :end" do
+      check all(date_time <- date_time_generator()) do
+        start = random_date_time_before(date_time)
+        assert between?(date_time, start, date_time, inclusive: true)
+        assert between?(date_time, nil, date_time, inclusive: true)
+        assert between?(date_time, start, date_time, inclusive: :end)
+        assert between?(date_time, nil, date_time, inclusive: :end)
+      end
+    end
+
+    property "returns false when date_time is at the end of the range when inclusive is false or :start" do
+      check all(date_time <- date_time_generator()) do
+        start = random_date_time_before(date_time)
+        refute between?(date_time, start, date_time, inclusive: false)
+        refute between?(date_time, nil, date_time, inclusive: false)
+        refute between?(date_time, start, date_time, inclusive: :start)
+        refute between?(date_time, nil, date_time, inclusive: :start)
       end
     end
 
     test "raises error for invalid inputs" do
-      assert_raise Protocol.UndefinedError, fn ->
+      assert_raise ArgumentError, fn ->
         between?(random_date_time(), random_date_time(), "2025-12-12")
       end
 

--- a/test/dotcom/utils/time_test.exs
+++ b/test/dotcom/utils/time_test.exs
@@ -81,7 +81,7 @@ defmodule Dotcom.Utils.TimeTest do
     end
 
     test "raises error for invalid inputs" do
-      assert_raise ArgumentError, fn ->
+      assert_raise Protocol.UndefinedError, fn ->
         between?(random_date_time(), random_date_time(), "2025-12-12")
       end
 

--- a/test/support/generators/date_time.ex
+++ b/test/support/generators/date_time.ex
@@ -28,9 +28,24 @@ defmodule Test.Support.Generators.DateTime do
     time_range_date_time_generator({start, stop}) |> Enum.take(1) |> List.first()
   end
 
+  @doc "Get a random date_time after the date_time provided"
+  def random_date_time_after(date_time) do
+    random_time_range_date_time({date_time, nil})
+  end
+
+  @doc "Get a random date_time before the date_time provided"
+  def random_date_time_before(date_time) do
+    random_time_range_date_time({nil, date_time})
+  end
+
   @doc "Generate a random date_time between the beginning and end of the time range."
   def time_range_date_time_generator({start, nil}) do
     stop = Timex.shift(start, years: 10) |> @date_time_module.coerce_ambiguous_date_time()
+    time_range_date_time_generator({start, stop})
+  end
+
+  def time_range_date_time_generator({nil, stop}) do
+    start = Timex.shift(stop, years: -10) |> @date_time_module.coerce_ambiguous_date_time()
     time_range_date_time_generator({start, stop})
   end
 


### PR DESCRIPTION
This ensures that the `Dotcom.Utils.Time` module is always paying attention to its `inclusive` opt, and that its test coverage is keeping it honest.

---

No ticket.