### PR TITLE
gravy: Animate chevron rotation for `<.unstyled_accordion />`

### DIFF
--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -199,7 +199,10 @@ defmodule DotcomWeb.Components do
       <summary class={"#{@summary_class} cursor-pointer"}>
         {render_slot(@heading)}
         <div class={"#{@chevron_class} shrink-0"}>
-          <.icon name="chevron-down" class="h-3 w-3 group-open:rotate-180" />
+          <.icon
+            name="chevron-down"
+            class="h-3 w-3 group-open:rotate-180 transition-all motion-reduce:transition-none"
+          />
         </div>
       </summary>
       {render_slot(@content)}


### PR DESCRIPTION
This is very silly and not necessary for any pressing reason, but I figured "why not have the chevrons rotate in a pleasing way?"

https://github.com/user-attachments/assets/7c6bf2de-fb44-4ced-96d6-46a270912012

