### PR TITLE
fix: Flaky test in ServiceDateTimeTest

### DIFF
--- a/test/dotcom/utils/service_date_time_test.exs
+++ b/test/dotcom/utils/service_date_time_test.exs
@@ -3,6 +3,7 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
   use ExUnitProperties
 
   import Mox
+  import Dotcom.Utils.DateTime, only: [coerce_ambiguous_date_time: 1]
   import Dotcom.Utils.ServiceDateTime
   import Test.Support.Generators.DateTime
   import Test.Support.Generators.ServiceDateTime
@@ -53,7 +54,7 @@ defmodule Dotcom.Utils.ServiceDateTimeTest do
           time_range_date_time_generator({beginning_of_day, end_of_service_day})
 
         check all(service_date_time <- date_time_generator) do
-          yesterday = service_date_time |> Timex.shift(days: -1)
+          yesterday = service_date_time |> Timex.shift(days: -1) |> coerce_ambiguous_date_time()
 
           # Exercise
           date = Timex.to_date(yesterday)


### PR DESCRIPTION
This addresses an infrequent failure that looks like

```elixir
  1) property service_date/1 returns 'yesterday' when the date_time is between midnight and the end of service (Dotcom.Utils.ServiceDateTimeTest)
     test/dotcom/utils/service_date_time_test.exs:46
     ** (ExUnitProperties.Error) failed with generated values (after 2 successful runs):

         * Clause:    date_time <- date_time_generator(:after_midnight)
           Generated: #DateTime<2033-11-06 02:00:08.766379-05:00 EST America/New_York>

     got exception:

         ** (ExUnitProperties.Error) failed with generated values (after 3 successful runs):

             * Clause:    service_date_time <- date_time_generator
               Generated: #DateTime<2033-11-07 01:54:37.904366-05:00 EST America/New_York>

         got exception:

             ** (Timex.ConvertError) unable to convert value, insufficient date/time information
     code: check all(date_time <- date_time_generator(:after_midnight)) do
     stacktrace:
       (timex 3.7.11) lib/datetime/map.ex:33: Timex.Protocol.Map.to_date/1
       test/dotcom/utils/service_date_time_test.exs:59: anonymous fn/3 in Dotcom.Utils.ServiceDateTimeTest."property service_date/1 returns 'yesterday' when the date_time is between midnight and the end of service"/1
       (stream_data 1.2.0) lib/stream_data.ex:2368: StreamData.check_all/7
       test/dotcom/utils/service_date_time_test.exs:55: anonymous fn/2 in Dotcom.Utils.ServiceDateTimeTest."property service_date/1 returns 'yesterday' when the date_time is between midnight and the end of service"/1
       (stream_data 1.2.0) lib/stream_data.ex:2368: StreamData.check_all/7
       test/dotcom/utils/service_date_time_test.exs:48: (test)
```

When I came across the error above, I was able to consistently reproduce it by running

```
mix test --seed 904499
```

(Although the precise times were different each time)

I can no longer reproduce it ☹️ 