### PR TITLE
feat(Live.TripPlanner): custom meta description and title

### DIFF
--- a/lib/dotcom_web/live/trip_planner.ex
+++ b/lib/dotcom_web/live/trip_planner.ex
@@ -52,6 +52,11 @@ defmodule DotcomWeb.Live.TripPlanner do
 
     new_socket =
       socket
+      |> assign(
+        :meta_description,
+        "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
+      )
+      |> assign(:breadcrumbs, [%Util.Breadcrumb{url: "/trip-planner", text: "Trip Planner"}])
       |> assign(@state)
       |> assign(:input_form, Map.put(@state.input_form, :changeset, changeset))
       |> update_datepicker(params_with_datetime)


### PR DESCRIPTION

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | TP | Update Trip Planner <title> and content](https://app.asana.com/1/15492006741476/project/385363666817452/task/1209294962719705?focus=true)

Turns out adding breadcrumbs gives you the right title for free, and that assigning `:meta_description` directly just works.