### PR TITLE
hotfix: Only show delays in system status of severity 2 or higher

### DIFF
--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -32,7 +32,7 @@ defmodule Dotcom.Alerts do
   # A keyword list of effects and the severity level necessary to make an alert 'service impacting.'
   @service_impacting_effects [
     cancellation: 1,
-    delay: 1,
+    delay: 2,
     service_change: 3,
     shuttle: 1,
     station_closure: 1,

--- a/test/dotcom/system_status/commuter_rail_test.exs
+++ b/test/dotcom/system_status/commuter_rail_test.exs
@@ -134,8 +134,16 @@ defmodule Dotcom.SystemStatus.CommuterRailTest do
 
       stub(Alerts.Repo.Mock, :by_route_ids, fn _, _ ->
         [
-          Factories.Alerts.Alert.build(:alert, active_period: active_period, effect: :delay),
-          Factories.Alerts.Alert.build(:alert, active_period: active_period, effect: :delay),
+          Factories.Alerts.Alert.build(:alert,
+            active_period: active_period,
+            effect: :delay,
+            severity: 2
+          ),
+          Factories.Alerts.Alert.build(:alert,
+            active_period: active_period,
+            effect: :delay,
+            severity: 2
+          ),
           Factories.Alerts.Alert.build(:alert, active_period: active_period, effect: :shuttle)
         ]
       end)

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -728,7 +728,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
 
       affected_line = Faker.Util.pick(@lines_without_branches)
 
-      {effect, _severity} = Faker.Util.pick(service_impacting_effects() -- [{:delay, 1}])
+      {effect, _severity} = Faker.Util.pick(service_impacting_effects() -- [{:delay, 2}])
 
       alerts =
         [
@@ -763,7 +763,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
       affected_line = Faker.Util.pick(@lines_without_branches)
 
       {effect1, _severity} = Faker.Util.pick(service_impacting_effects())
-      {effect2, _severity} = Faker.Util.pick(service_impacting_effects() -- [{:delay, 1}])
+      {effect2, _severity} = Faker.Util.pick(service_impacting_effects() -- [{:delay, 2}])
 
       alerts =
         [
@@ -836,7 +836,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
 
       affected_line = Faker.Util.pick(@lines_without_branches)
 
-      {effect2, _severity} = Faker.Util.pick(service_impacting_effects() -- [{:delay, 1}])
+      {effect2, _severity} = Faker.Util.pick(service_impacting_effects() -- [{:delay, 2}])
 
       alerts =
         [


### PR DESCRIPTION
In order to avoid hiding useful subway status when there are system-wide low-severity alerts, for instance for today's heat wave.

![Screenshot 2025-06-23 at 10 58 18 AM](https://github.com/user-attachments/assets/c732a5b6-cd55-441b-8d97-af7f62eb53f5)
