### PR TITLE
fix(Map): reduce spurious console messages

### DIFF
--- a/assets/ts/app/__tests__/channels-test.ts
+++ b/assets/ts/app/__tests__/channels-test.ts
@@ -1,14 +1,14 @@
-import { Channel, Socket } from "phoenix";
 import { waitFor } from "@testing-library/react";
-import setupChannels, {
-  isVehicleChannel,
-  joinChannel,
-  leaveChannel
-} from "../channels";
+import { Channel, Socket } from "phoenix";
 import {
-  makeMockSocket,
-  makeMockChannel
+    makeMockChannel,
+    makeMockSocket
 } from "../../helpers/socketTestHelpers";
+import setupChannels, {
+    isVehicleChannel,
+    joinChannel,
+    leaveChannel
+} from "../channels";
 
 const mockOnLoadEventListener = () => {
   const ev = new CustomEvent("load");
@@ -127,18 +127,12 @@ describe("setupChannels", () => {
     // This should test the onError callback of the channel
     setupChannels();
     mockOnLoadEventListener();
-    const mockEventListener = jest.fn();
-    document.addEventListener("vehicles:Red:0", mockEventListener);
+
     const channel = window.channels["vehicles:Red:0"];
-    const consoleMock = jest
-      .spyOn(global.console, "error")
-      .mockImplementation(() => {});
+    const consoleMock = jest.spyOn(global.console, "error");
     // @ts-ignore... phoenix.js isn't properly typed. and technically this is a private property. how else to trigger a channel event!
-    channel.trigger("phx_error", { reason: "bad data" });
-    const event = new CustomEvent("vehicles:Red:0", {
-      detail: { error: "bad data" }
-    });
-    expect(mockEventListener).toHaveBeenCalledWith(event);
+    channel.trigger("phx_error", "bad data");
+    expect(consoleMock).toHaveBeenCalledWith("error on channel vehicles:Red:0 : bad data");
 
     consoleMock.mockRestore();
   });

--- a/assets/ts/app/channels.ts
+++ b/assets/ts/app/channels.ts
@@ -1,4 +1,4 @@
-import { Socket, Channel } from "phoenix";
+import { Channel, Socket } from "phoenix";
 
 declare global {
   interface Window {
@@ -67,12 +67,9 @@ const joinChannel = <T>(
   });
 
   channel.onError((reason: string) => {
-    console.error(`error on channel ${channelId} : ${reason}`);
-    /* eslint-enable no-console */
-    const errorEvent = new CustomEvent<{ error: string }>(channelId, {
-      detail: { error: reason }
-    });
-    document.dispatchEvent(errorEvent);
+    if (reason) {
+      console.error(`error on channel ${channelId} : ${reason}`);
+    }
   });
 
   if (isVehicleChannel(channelId)) {

--- a/assets/ts/schedule/components/Map.tsx
+++ b/assets/ts/schedule/components/Map.tsx
@@ -135,7 +135,7 @@ export const reducer: DataReducerType = (state, action) => {
     default:
       /* istanbul ignore next */
       // eslint-disable-next-line no-console
-      console.error("unexpected event", action);
+      console.warn("unexpected event", action);
       return state;
   }
 };

--- a/assets/ts/schedule/components/__tests__/MapTest.tsx
+++ b/assets/ts/schedule/components/__tests__/MapTest.tsx
@@ -1,11 +1,11 @@
-import React from "react";
 import { mount } from "enzyme";
-import Map, { iconOpts, reducer } from "../Map";
-import {
-  MapData,
-  MapMarker as Marker
-} from "../../../leaflet/components/__mapdata";
+import React from "react";
 import { TileLayer } from "react-leaflet";
+import {
+    MapData,
+    MapMarker as Marker
+} from "../../../leaflet/components/__mapdata";
+import Map, { iconOpts, reducer } from "../Map";
 
 /* eslint-disable camelcase */
 const data: MapData = {
@@ -156,23 +156,6 @@ describe("reducer", () => {
     expect(result.markers.map(m => m.id)).toEqual(data.markers.map(m => m.id));
     expect(data.markers[0].latitude).toEqual(42.39786911010742);
     expect(result.markers[0].latitude).toEqual(43.0);
-  });
-
-  it("doesn't handle unknown events empty data actions", () => {
-    const spy = jest
-      .spyOn(global.console, "error")
-      .mockImplementation(() => {});
-    const state = reducer(
-      { markers: data.markers },
-      {
-        // @ts-ignore
-        action: { event: "unsupported", data: [] }
-      }
-    );
-    expect(state).toEqual({ markers: data.markers });
-    expect(spy).toHaveBeenCalledWith("unexpected event", {
-      action: { data: [], event: "unsupported" }
-    });
   });
 
   it("handles empty data actions", () => {


### PR DESCRIPTION
We were emitting lots of `console.error` messages that don't translate into anything meaningful. This PR aims to reduce the noisy errors we get.

- removes the `channel.onError` that as far as I can tell has never registered an actual meaningful error, just creates new errors on page change 🙄 
- downgrades the `console.error` to `console.warn` when the Map's reducer type isn't one of the expected ones
- adjusts the `handleJoin` call to pass in something more meaningful than the usual `{}`