### PR TITLE
fix: add host to check_origin

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -161,6 +161,7 @@ if config_env() == :prod do
   config :dotcom, alerts_bus_stop_change_bucket: System.get_env("S3_PREFIX_BUSCHANGE")
 
   config :dotcom, DotcomWeb.Endpoint,
+    check_origin: ["https://#{host}"],
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.


### PR DESCRIPTION
No ticket, just noticed a lot of `Could not check origin for Phoenix.Socket transport.` errors logged in prod.