### PR TITLE
fix(LocationService): limit autocomplete text to 200 chars

### DIFF
--- a/lib/dotcom_web/controllers/places_controller.ex
+++ b/lib/dotcom_web/controllers/places_controller.ex
@@ -105,7 +105,10 @@ defmodule DotcomWeb.PlacesController do
       {:ok, suggestions} ->
         json(conn, %{result: with_coordinates(suggestions)})
 
-      {:error, _} ->
+      {:error, :invalid_arguments} ->
+        ControllerHelpers.return_invalid_arguments_error(conn)
+
+      _ ->
         ControllerHelpers.return_internal_error(conn)
     end
   end

--- a/lib/location_service/location_service.ex
+++ b/lib/location_service/location_service.ex
@@ -26,7 +26,11 @@ defmodule LocationService do
 
   @impl LocationService.Behaviour
   @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  def autocomplete(text, limit, options \\ @bias_options) do
+  def autocomplete(text, limit, options \\ @bias_options)
+
+  def autocomplete(text, _, _) when length(text) > 200, do: {:error, :invalid_arguments}
+
+  def autocomplete(text, limit, options) do
     options
     |> Map.merge(%{"Text" => text, "MaxResults" => limit})
     |> then(&@aws_client.search_place_index_for_suggestions(index(), &1))

--- a/test/location_service/location_service_test.exs
+++ b/test/location_service/location_service_test.exs
@@ -91,5 +91,11 @@ defmodule LocationServiceTest do
       text = Faker.Company.name()
       assert {:error, :internal_error} = autocomplete(text, 2)
     end
+
+    test "rejects long text" do
+      deny(AwsClient.Mock, :search_place_index_for_suggestions, 2)
+      long_text = Faker.Lorem.characters(201..1000)
+      assert {:error, :invalid_arguments} = autocomplete(long_text, 2)
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** https://app.asana.com/1/15492006741476/project/555089885850811/task/1210649423464213?focus=true

AWS will return an error when asked to search for a text string longer than 200 characters. Let's handle this directly! 
