### PR TITLE
fix: Consider July 4 a weekend for ferry timetables

### DIFF
--- a/lib/timetable_loader.ex
+++ b/lib/timetable_loader.ex
@@ -64,6 +64,7 @@ defmodule Dotcom.TimetableLoader do
     end
   end
 
+  defp date_in_weekend?(~D[2025-07-04]), do: true
   defp date_in_weekend?(date), do: Date.day_of_week(date) in [6, 7]
 
   @doc """


### PR DESCRIPTION
Show the weekend timetable for the Quincy and Winthrop Ferries on Friday, July 4.

---

No ticket.