### PR TITLE
chore: Remove train numbers from `via Fairmount Line` list

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -250,13 +250,6 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
           "1785",
           "793",
           "5715",
-          "5721",
-          "5731",
-          "5739",
-          "5747",
-          "5755",
-          "5767",
-          "5777",
           "5785",
           "5793"
         ]
@@ -280,12 +273,6 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
           "776",
           "784",
           "5706",
-          "5724",
-          "5730",
-          "5738",
-          "5746",
-          "5754",
-          "5768",
           "5778",
           "5784"
         ]


### PR DESCRIPTION
Make select Franklin Line train numbers no longer show `via Fairmount Line`.

(Before on the left; After on the right)
![Screenshot 2025-06-30 at 1 47 35 PM](https://github.com/user-attachments/assets/452623aa-213b-48a9-bca2-e2961865a2dd)

---

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | Update via Fairmount line numbers](https://app.asana.com/1/15492006741476/project/555089885850811/task/1210678262944572?focus=true)

