### PR TITLE
feat: Show severity (e.g. `up to 20 min`) for delay statuses

### DIFF
--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -267,6 +267,20 @@ defmodule Alerts.Alert do
 
   def human_label(_), do: ""
 
+  def human_severity(%__MODULE__{effect: :delay, severity: severity}),
+    do: do_human_delay_severity(severity)
+
+  def human_severity(%__MODULE__{}), do: nil
+
+  defp do_human_delay_severity(3), do: "up to 10 min"
+  defp do_human_delay_severity(4), do: "up to 15 min"
+  defp do_human_delay_severity(5), do: "up to 20 min"
+  defp do_human_delay_severity(6), do: "up to 25 min"
+  defp do_human_delay_severity(7), do: "up to 30 min"
+  defp do_human_delay_severity(8), do: "of more than 30 min"
+  defp do_human_delay_severity(9), do: "of more than an hour"
+  defp do_human_delay_severity(_), do: nil
+
   @spec icon(t) :: icon_type
   def icon(%{priority: :low}), do: :none
   def icon(%{priority: :high, effect: :suspension}), do: :cancel

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -49,6 +49,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
         plural={@plural}
         prefix={@prefix}
         route_ids={@route_ids}
+        severity={severity(@alerts)}
         status={@status}
         subheading_text={@subheading_text}
         subheading_aria_label={@subheading_aria_label}
@@ -81,7 +82,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
     </div>
 
     <.status_label
-      description={"#{@rendered_prefix}#{description(@status, @prefix, @plural)}"}
+      description={"#{@rendered_prefix}#{description(@status, @prefix, @plural)}#{severity_suffix(@status, @severity)}"}
       status={@status}
       subheading_aria_label={@subheading_aria_label}
       subheading_text={@subheading_text}
@@ -123,8 +124,9 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
   # "Expect Delay" (or Expect Delays) rather than simply "Delay". A
   # prefix of "Now" should still display as "Delay", rather than
   # "Expect Delay".
-  defp description(:delay, "Now"), do: "Delay"
-  defp description(:delay, prefix) when is_binary(prefix), do: "Expect Delay"
+  defp description(:delay, "Now"), do: "Delays"
+  defp description(:delay, prefix) when is_binary(prefix), do: "Expect Delays"
+  defp description(:delay, _), do: "Delays"
   defp description(:shuttle, _), do: "Shuttles"
   defp description(status, _), do: Alert.human_effect(%Alert{effect: status})
 
@@ -161,6 +163,20 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
     do: "#{stop_name1}, #{stop_name2} & #{stop_name3}"
 
   defp humanize_stop_names(stop_names), do: "#{Enum.count(stop_names)} Stops"
+
+  defp severity([]), do: nil
+  defp severity(alerts), do: alerts |> Enum.map(& &1.severity) |> Enum.max()
+
+  defp severity_suffix(effect, severity),
+    do:
+      %Alert{effect: effect, severity: severity}
+      |> Alert.human_severity()
+      |> format_human_severity()
+
+  defp format_human_severity(nil), do: ""
+
+  defp format_human_severity(human_severity) when is_binary(human_severity),
+    do: " " <> human_severity
 
   defp top_padding(assigns) do
     ~H"""


### PR DESCRIPTION
![Screenshot 2025-07-03 at 5 22 07 PM](https://github.com/user-attachments/assets/37207ce9-7234-45bd-a3fc-4ff0d7b6abdd)

![Screenshot 2025-07-03 at 5 22 19 PM](https://github.com/user-attachments/assets/2f4e0ab9-0b23-4d8b-8c92-3a51ca9f02f2)

(Note that when delays of different severities exist and get collapsed together for the homepage, only the most severe severity is shown.)

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [SS/PW/Alerts | Delays "up to N minutes"](https://app.asana.com/1/15492006741476/project/1205718271156548/task/1210699069005382?focus=true)

---

<details>
<summary>Livebook code that I used to populate the data for ☝️ screenshots</summary>

I put 👇 code into this [LiveBook](https://github.com/mbta/dotcom/blob/main/livebooks/reusable/alerts.livemd)

```elixir
import Dotcom.Utils.DateTime, only: [now: 0]

alias Test.Support.Factories.Alerts.{Alert, InformedEntity}

# Create a currently active suspension alert
alerts =
  [
    Alert.build(:alert,
      active_period: [
        {
          now() |> Timex.shift(hours: -4),
          now() |> Timex.shift(hours: 8)
        }
      ],
      effect: :delay,
      severity: 3,
      informed_entity:
        Alerts.InformedEntitySet.new([
          InformedEntity.build(:informed_entity,
            activities: MapSet.new([:exit, :ride, :board]),
            route: "Red",
            route_type: 1,
            stop: nil
          )
        ])
    ),
    Alert.build(:alert,
      active_period: [
        {
          now() |> Timex.shift(hours: -4),
          now() |> Timex.shift(hours: 8)
        }
      ],
      effect: :delay,
      severity: 8,
      informed_entity:
        Alerts.InformedEntitySet.new([
          InformedEntity.build(:informed_entity,
            activities: MapSet.new([:exit, :ride, :board]),
            route: "Blue",
            route_type: 1,
            stop: nil
          )
        ])
    ),
    Alert.build(:alert,
      active_period: [
        {
          now() |> Timex.shift(hours: -4),
          now() |> Timex.shift(hours: 8)
        }
      ],
      effect: :delay,
      severity: 4,
      informed_entity:
        Alerts.InformedEntitySet.new([
          InformedEntity.build(:informed_entity,
            activities: MapSet.new([:exit, :ride, :board]),
            route: "Blue",
            route_type: 1,
            stop: nil
          )
        ])
    )
  ]

# Stop the fetcher so it doesn't update alerts
Supervisor.which_children(Dotcom.Supervisor)
|> Enum.find(fn {_, _, _, list} -> list == [Alerts.CacheSupervisor] end)
|> elem(1)
|> Supervisor.terminate_child(Alerts.Cache.Fetcher)

# Remove all other alerts and only use the one's you created
Alerts.Cache.Store.update(alerts, nil)

now() |> Alerts.Repo.all()
```
</details>
