### PR TITLE
fix: use in-memory storage if session/localStorage is unavailable

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -49,6 +49,8 @@ let csrfToken = document
   .querySelector("meta[name='csrf-token']")
   .getAttribute("content");
 
+import storageOptions from "./storage.js";
+
 let liveSocket = new LiveSocket("/live", Socket, {
   params: { _csrf_token: csrfToken },
   hooks: { ...Hooks, ...DotcomHooks },
@@ -71,7 +73,8 @@ let liveSocket = new LiveSocket("/live", Socket, {
         }
       }
     }
-  }
+  },
+  ...storageOptions
 });
 
 // connect if there are any LiveViews on the page

--- a/assets/js/storage.js
+++ b/assets/js/storage.js
@@ -1,0 +1,35 @@
+let sessionStore, localStore;
+try {
+  sessionStore = window.sessionStorage;
+  localStore = window.localStorage;
+} catch (_e) {
+  /*
+	When cookies are blocked, sessionStorage and localStorage aren't available
+	in browsers. Provide a workable alternative here to avoid triggering errors
+	in Phoenix's LiveSocket.
+	*/
+  class InMemoryStorage {
+    constructor() {
+      this.storage = {};
+    }
+    getItem(keyName) {
+      return this.storage[keyName] || null;
+    }
+    removeItem(keyName) {
+      delete this.storage[keyName];
+    }
+    setItem(keyName, keyValue) {
+      this.storage[keyName] = keyValue;
+    }
+  }
+
+  sessionStore = new InMemoryStorage();
+  localStore = new InMemoryStorage();
+}
+
+const storageOptions = {
+  sessionStorage: sessionStore,
+  localStorage: localStore
+};
+
+export default storageOptions;

--- a/assets/ts/app/channels.ts
+++ b/assets/ts/app/channels.ts
@@ -1,4 +1,5 @@
-import { Channel, Socket } from "phoenix";
+import { Channel, Socket, SocketConnectOption } from "phoenix";
+import storageOptions from "../../js/storage.js";
 
 declare global {
   interface Window {
@@ -92,7 +93,8 @@ const leaveChannel = (id: string): void => {
 };
 
 const setupChannels = (): void => {
-  window.socket = new Socket("/socket", {});
+  const socketOptions = { ...storageOptions } as Partial<SocketConnectOption>;
+  window.socket = new Socket("/socket", socketOptions);
   window.socket.onClose(event => {
     if (event.type === "close" && !event.wasClean) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | SecurityError: The operation is insecure.](https://app.asana.com/1/15492006741476/project/555089885850811/task/1210755669845451?focus=true)

Reproducible if you make your browser block all cookies. This PR lets our JS instantiate a Phoenix `LiveSocket` and `Socket` without the uncaught error that hindered much of the rest of the website JS from loading.

The resulting website isn't _perfect_ mind you, but at least it restores basic functionality to the searchbar, homepage tabs, etc.