### PR TITLE
Adds sigils for gettext

### DIFF
--- a/lib/dotcom/locale.ex
+++ b/lib/dotcom/locale.ex
@@ -1,0 +1,9 @@
+defmodule Dotcom.Locale do
+  @moduledoc """
+  A locale is a combination of an [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code
+  along with its [endonym](https://en.wikipedia.org/wiki/Endonym_and_exonym).
+  """
+  @enforce_keys [:code, :endonym]
+
+  defstruct [:code, :endonym]
+end

--- a/lib/dotcom/locales.ex
+++ b/lib/dotcom/locales.ex
@@ -43,7 +43,7 @@ defmodule Dotcom.Locales do
   Given a locale code, return the entire locale or nil.
   """
   def locale(code) do
-    Map.get(locales_map(), code)
+    Enum.find(@locales, fn locale -> locale.code === code end)
   end
 
   @doc """
@@ -51,9 +51,5 @@ defmodule Dotcom.Locales do
   """
   def locale?(code) do
     locale(code) != nil
-  end
-
-  defp locales_map do
-    Enum.reduce(@locales, %{}, fn locale, locales -> Map.put(locales, locale.code, locale) end)
   end
 end

--- a/lib/dotcom/locales.ex
+++ b/lib/dotcom/locales.ex
@@ -1,0 +1,59 @@
+defmodule Dotcom.Locales do
+  @moduledoc """
+  Definitions of and convenience functions for supported locales.
+  """
+
+  alias Dotcom.Locale
+
+  @default_locale %Locale{code: "en", endonym: "English"}
+  @development_locale %Locale{code: "xx", endonym: "Development"}
+  # @future_locales [
+  #   %Locale{code: "es", endonym: "Español"},
+  #   %Locale{code: "ht", endonym: "Kreyòl Ayisyen"},
+  #   %Locale{code: "pt", endonym: "Português"},
+  #   %Locale{code: "vi", endonym: "Tiếng Việt"},
+  #   %Locale{code: "zh", endonym: "中文"}
+  # ]
+  @locales [
+    @default_locale,
+    @development_locale
+  ]
+
+  @doc """
+  The default locale.
+  """
+  def default_locale, do: @default_locale
+
+  @doc """
+  The default locale code.
+  """
+  def default_locale_code, do: Map.get(@default_locale, :code)
+
+  @doc """
+  All of the locales.
+  """
+  def locales, do: @locales
+
+  @doc """
+  All of the locale codes.
+  """
+  def locale_codes, do: Enum.map(@locales, & &1.code)
+
+  @doc """
+  Given a locale code, return the entire locale or nil.
+  """
+  def locale(code) do
+    Map.get(locales_map(), code)
+  end
+
+  @doc """
+  Is the given code a supported locale?
+  """
+  def locale?(code) do
+    locale(code) != nil
+  end
+
+  defp locales_map do
+    Enum.reduce(@locales, %{}, fn locale, locales -> Map.put(locales, locale.code, locale) end)
+  end
+end

--- a/lib/dotcom_web.ex
+++ b/lib/dotcom_web.ex
@@ -20,7 +20,7 @@ defmodule DotcomWeb do
 
   def controller do
     quote do
-      use Gettext, backend: DotcomWeb.Gettext
+      use DotcomWeb.Gettext.Sigils
       use Phoenix.Controller, namespace: DotcomWeb
 
       import DotcomWeb.{CmsRouterHelpers, ControllerHelpers}

--- a/lib/dotcom_web/controllers/health_controller.ex
+++ b/lib/dotcom_web/controllers/health_controller.ex
@@ -2,10 +2,13 @@ defmodule DotcomWeb.HealthController do
   @moduledoc """
   Simple controller to return 200 OK when the website is healthy.
   """
+
   use DotcomWeb, :controller
 
   def index(conn, _params) do
+    status = ~i(1 error | %{count} errors | #{:random.uniform(99)})p
+
     conn
-    |> send_resp(200, "")
+    |> send_resp(200, status)
   end
 end

--- a/lib/dotcom_web/controllers/health_controller.ex
+++ b/lib/dotcom_web/controllers/health_controller.ex
@@ -6,7 +6,7 @@ defmodule DotcomWeb.HealthController do
   use DotcomWeb, :controller
 
   def index(conn, _params) do
-    status = ~i(1 error | %{count} errors | #{:random.uniform(99)})p
+    status = ~i(1 error | %{count} errors | #{:rand.uniform(99)})p
 
     conn
     |> send_resp(200, status)

--- a/lib/dotcom_web/gettext.ex
+++ b/lib/dotcom_web/gettext.ex
@@ -25,5 +25,8 @@ defmodule DotcomWeb.Gettext do
     {:nowarn_function, lngettext: 6}
   ]
 
-  use Gettext.Backend, otp_app: :dotcom
+  use Gettext.Backend,
+    otp_app: :dotcom,
+    default_locale: Dotcom.Locales.default_locale_code(),
+    locales: Dotcom.Locales.locale_codes()
 end

--- a/lib/dotcom_web/gettext/sigils.ex
+++ b/lib/dotcom_web/gettext/sigils.ex
@@ -14,19 +14,19 @@ defmodule DotcomWeb.Gettext.Sigils do
   @doc """
   Sigil for Gettext translations.
   """
-  defmacro sigil_i(string, []) do
+  defmacro sigil_i(string, []) when is_binary(string) do
     quote do
-      text = unquote(string) |> String.trim()
-
-      Gettext.gettext(DotcomWeb.Gettext, text)
+      gettext(unquote(string))
     end
   end
 
-  defmacro sigil_i(string, [?p]) do
-    quote do
-      [s, p, n] = unquote(string) |> String.split("|") |> Enum.map(&String.trim/1)
+  defmacro sigil_i({:<<>>, _, pieces} = string, [?p]) do
+    [s, p, _] = pieces |> List.first() |> String.split(" | ")
 
-      Gettext.ngettext(DotcomWeb.Gettext, s, p, String.to_integer(n))
+    quote do
+      n = unquote(string) |> String.split(" | ") |> List.last() |> String.to_integer()
+
+      ngettext(unquote(s), unquote(p), n)
     end
   end
 end

--- a/lib/dotcom_web/gettext/sigils.ex
+++ b/lib/dotcom_web/gettext/sigils.ex
@@ -1,6 +1,6 @@
 defmodule DotcomWeb.Gettext.Sigils do
   @moduledoc """
-
+  Sigils for Gettext translations.
   """
 
   defmacro __using__(_ \\ []) do
@@ -12,7 +12,7 @@ defmodule DotcomWeb.Gettext.Sigils do
   end
 
   @doc """
-
+  Sigil for Gettext translations.
   """
   defmacro sigil_i(string, []) do
     quote do
@@ -22,9 +22,6 @@ defmodule DotcomWeb.Gettext.Sigils do
     end
   end
 
-  @doc """
-
-  """
   defmacro sigil_i(string, [?p]) do
     quote do
       [s, p, n] = unquote(string) |> String.split("|") |> Enum.map(&String.trim/1)

--- a/lib/dotcom_web/gettext/sigils.ex
+++ b/lib/dotcom_web/gettext/sigils.ex
@@ -1,0 +1,29 @@
+defmodule DotcomWeb.Gettext.Sigils do
+  @moduledoc """
+
+  """
+
+  use Gettext, backend: DotcomWeb.Gettext
+
+  @doc """
+
+  """
+  defmacro sigil_i(string, []) do
+    quote do
+      text = unquote(string) |> String.trim()
+
+      Gettext.gettext(DotcomWeb.Gettext, text)
+    end
+  end
+
+  @doc """
+
+  """
+  defmacro sigil_i(string, [?p]) do
+    quote do
+      [s, p, n] = unquote(string) |> String.split("|") |> Enum.map(&String.trim/1)
+
+      Gettext.ngettext(DotcomWeb.Gettext, s, p, String.to_integer(n))
+    end
+  end
+end

--- a/lib/dotcom_web/gettext/sigils.ex
+++ b/lib/dotcom_web/gettext/sigils.ex
@@ -3,7 +3,13 @@ defmodule DotcomWeb.Gettext.Sigils do
 
   """
 
-  use Gettext, backend: DotcomWeb.Gettext
+  defmacro __using__(_ \\ []) do
+    quote do
+      use Gettext, backend: DotcomWeb.Gettext
+
+      import unquote(__MODULE__)
+    end
+  end
 
   @doc """
 

--- a/lib/dotcom_web/plugs/set_locale.ex
+++ b/lib/dotcom_web/plugs/set_locale.ex
@@ -43,9 +43,4 @@ defmodule DotcomWeb.Plugs.SetLocale do
   end
 
   defp get_locale_from_params(_), do: nil
-
-  # Get the locale from the session, if present.
-  defp get_locale_from_session(conn) do
-    get_session(conn, :locale)
-  end
 end

--- a/lib/dotcom_web/plugs/set_locale.ex
+++ b/lib/dotcom_web/plugs/set_locale.ex
@@ -1,0 +1,38 @@
+defmodule DotcomWeb.Plugs.SetLocale do
+  @moduledoc """
+  """
+
+  import Plug.Conn
+
+  import Dotcom.Locales, only: [default_locale_code: 0, locale?: 1]
+
+  def init(default), do: default
+
+  def call(conn, _opts) do
+    locale = get_locale(conn)
+
+    Gettext.put_locale(DotcomWeb.Gettext, locale)
+    Logger.metadata(locale: locale)
+
+    conn
+    |> put_resp_cookie("locale", locale, max_age: 365 * 24 * 60 * 60)
+  end
+
+  defp get_locale(conn) do
+    locale = get_locale_from_params(conn) || get_locale_from_cookie(conn) |> IO.inspect(label: "LOCALE")
+
+    if locale?(locale), do: locale, else: default_locale_code()
+  end
+
+  defp get_locale_from_params(%{params: %{"locale" => locale}}) do
+    locale
+  end
+
+  defp get_locale_from_params(_), do: nil
+
+  defp get_locale_from_cookie(%{cookies: %{"locale" => locale}}) do
+    locale
+  end
+
+  defp get_locale_from_cookie(_), do: nil
+end

--- a/lib/dotcom_web/plugs/set_locale.ex
+++ b/lib/dotcom_web/plugs/set_locale.ex
@@ -21,15 +21,11 @@ defmodule DotcomWeb.Plugs.SetLocale do
 
     conn
     |> put_resp_cookie("locale", locale, max_age: 365 * 24 * 60 * 60)
-    |> put_session(:locale, locale)
   end
 
-  # Check params, then session, then cookie, and use the default if none are present or supported.
+  # Check params, then cookie, and use the default if none are present or supported.
   defp get_locale(conn) do
-    locale =
-      get_locale_from_params(conn) ||
-        get_locale_from_session(conn) ||
-        get_locale_from_cookie(conn)
+    locale = get_locale_from_params(conn) || get_locale_from_cookie(conn)
 
     if locale?(locale), do: locale, else: default_locale_code()
   end

--- a/lib/dotcom_web/plugs/set_locale.ex
+++ b/lib/dotcom_web/plugs/set_locale.ex
@@ -24,12 +24,22 @@ defmodule DotcomWeb.Plugs.SetLocale do
     |> put_session(:locale, locale)
   end
 
-  # Check params, then cookie, and use the default if neither are present or supported.
+  # Check params, then session, then cookie, and use the default if none are present or supported.
   defp get_locale(conn) do
-    locale = get_locale_from_params(conn) || get_locale_from_cookie(conn)
+    locale =
+      get_locale_from_params(conn) ||
+        get_locale_from_session(conn) ||
+        get_locale_from_cookie(conn)
 
     if locale?(locale), do: locale, else: default_locale_code()
   end
+
+  # Destructure the cookies for the locale.
+  defp get_locale_from_cookie(%{cookies: %{"locale" => locale}}) do
+    locale
+  end
+
+  defp get_locale_from_cookie(_), do: nil
 
   # Destructure the params for the locale.
   defp get_locale_from_params(%{params: %{"locale" => locale}}) do
@@ -38,10 +48,8 @@ defmodule DotcomWeb.Plugs.SetLocale do
 
   defp get_locale_from_params(_), do: nil
 
-  # Destructure the cookies for the locale.
-  defp get_locale_from_cookie(%{cookies: %{"locale" => locale}}) do
-    locale
+  # Get the locale from the session, if present.
+  defp get_locale_from_session(conn) do
+    get_session(conn, :locale)
   end
-
-  defp get_locale_from_cookie(_), do: nil
 end

--- a/lib/dotcom_web/plugs/set_locale.ex
+++ b/lib/dotcom_web/plugs/set_locale.ex
@@ -21,6 +21,7 @@ defmodule DotcomWeb.Plugs.SetLocale do
 
     conn
     |> put_resp_cookie("locale", locale, max_age: 365 * 24 * 60 * 60)
+    |> put_session(:locale, locale)
   end
 
   # Check params, then cookie, and use the default if neither are present or supported.

--- a/lib/dotcom_web/plugs/set_locale.ex
+++ b/lib/dotcom_web/plugs/set_locale.ex
@@ -25,8 +25,7 @@ defmodule DotcomWeb.Plugs.SetLocale do
 
   # Check params, then cookie, and use the default if neither are present or supported.
   defp get_locale(conn) do
-    locale =
-      get_locale_from_params(conn) || get_locale_from_cookie(conn)
+    locale = get_locale_from_params(conn) || get_locale_from_cookie(conn)
 
     if locale?(locale), do: locale, else: default_locale_code()
   end

--- a/lib/dotcom_web/plugs/set_locale.ex
+++ b/lib/dotcom_web/plugs/set_locale.ex
@@ -1,5 +1,6 @@
 defmodule DotcomWeb.Plugs.SetLocale do
   @moduledoc """
+  A plug to set the locale for a request.
   """
 
   import Plug.Conn
@@ -8,6 +9,10 @@ defmodule DotcomWeb.Plugs.SetLocale do
 
   def init(default), do: default
 
+  @doc """
+  Gets a locale from a query param or cookie value and sets Gettext.
+  If no locale is present, the default locale "en" is used.
+  """
   def call(conn, _opts) do
     locale = get_locale(conn)
 
@@ -18,18 +23,22 @@ defmodule DotcomWeb.Plugs.SetLocale do
     |> put_resp_cookie("locale", locale, max_age: 365 * 24 * 60 * 60)
   end
 
+  # Check params, then cookie, and use the default if neither are present or supported.
   defp get_locale(conn) do
-    locale = get_locale_from_params(conn) || get_locale_from_cookie(conn) |> IO.inspect(label: "LOCALE")
+    locale =
+      get_locale_from_params(conn) || get_locale_from_cookie(conn)
 
     if locale?(locale), do: locale, else: default_locale_code()
   end
 
+  # Destructure the params for the locale.
   defp get_locale_from_params(%{params: %{"locale" => locale}}) do
     locale
   end
 
   defp get_locale_from_params(_), do: nil
 
+  # Destructure the cookies for the locale.
   defp get_locale_from_cookie(%{cookies: %{"locale" => locale}}) do
     locale
   end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -41,6 +41,7 @@ defmodule DotcomWeb.Router do
     plug(DotcomWeb.Plugs.DateTime)
     plug(DotcomWeb.Plugs.RewriteUrls)
     plug(DotcomWeb.Plugs.SecureHeaders)
+    plug(DotcomWeb.Plugs.SetLocale)
     plug(:optional_disable_indexing)
   end
 

--- a/test/dotcom_web/plugs/set_locale_test.exs
+++ b/test/dotcom_web/plugs/set_locale_test.exs
@@ -27,14 +27,6 @@ defmodule DotcomWeb.Plugs.SetLocaleTest do
     assert Gettext.get_locale(DotcomWeb.Gettext) == locale
   end
 
-  test "a conn with a session locale sets the locale", %{conn: conn} do
-    locale = Locales.locale_codes() |> Enum.random()
-
-    conn |> put_session(:locale, locale) |> call(%{})
-
-    assert Gettext.get_locale(DotcomWeb.Gettext) == locale
-  end
-
   test "a conn with a cookie locale sets the locale", %{conn: conn} do
     locale = Locales.locale_codes() |> Enum.random()
 

--- a/test/dotcom_web/plugs/set_locale_test.exs
+++ b/test/dotcom_web/plugs/set_locale_test.exs
@@ -1,0 +1,51 @@
+defmodule DotcomWeb.Plugs.SetLocaleTest do
+  use DotcomWeb.ConnCase, async: true
+
+  import DotcomWeb.Plugs.SetLocale
+
+  alias Dotcom.Locales
+
+  setup %{conn: conn} do
+    {:ok, conn: Plug.Test.init_test_session(conn, %{})}
+  end
+
+  describe "supported locales" do
+    test "sets the locale for each supported locale", %{conn: conn} do
+      Enum.each(Locales.locale_codes(), fn locale ->
+        conn
+        |> Map.put(:params, %{"locale" => locale})
+        |> call(%{})
+
+        assert Gettext.get_locale(DotcomWeb.Gettext) == locale
+      end)
+    end
+  end
+
+  test "a conn with a param locale set the locale", %{conn: conn} do
+    locale = Locales.locale_codes() |> Enum.random()
+
+    conn |> Map.put(:params, %{"locale" => locale}) |> call(%{})
+
+    assert Gettext.get_locale(DotcomWeb.Gettext) == locale
+  end
+
+  test "a conn with a cookie locale set the locale", %{conn: conn} do
+    locale = Locales.locale_codes() |> Enum.random()
+
+    conn |> Map.put(:cookies, %{"locale" => locale}) |> call(%{})
+
+    assert Gettext.get_locale(DotcomWeb.Gettext) == locale
+  end
+
+  test "a conn with an unsupported locale uses the default locale", %{conn: conn} do
+    conn |> Map.put(:cookies, %{"locale" => "zz"}) |> call(%{})
+
+    assert Gettext.get_locale(DotcomWeb.Gettext) == Locales.default_locale_code()
+  end
+
+  test "a conn with no locale information uses the default locale", %{conn: conn} do
+    conn |> call(%{})
+
+    assert Gettext.get_locale(DotcomWeb.Gettext) == Locales.default_locale_code()
+  end
+end

--- a/test/dotcom_web/plugs/set_locale_test.exs
+++ b/test/dotcom_web/plugs/set_locale_test.exs
@@ -9,19 +9,17 @@ defmodule DotcomWeb.Plugs.SetLocaleTest do
     {:ok, conn: Plug.Test.init_test_session(conn, %{})}
   end
 
-  describe "supported locales" do
-    test "sets the locale for each supported locale", %{conn: conn} do
-      Enum.each(Locales.locale_codes(), fn locale ->
-        conn
-        |> Map.put(:params, %{"locale" => locale})
-        |> call(%{})
+  test "sets the locale for each supported locale", %{conn: conn} do
+    Enum.each(Locales.locale_codes(), fn locale ->
+      conn
+      |> Map.put(:params, %{"locale" => locale})
+      |> call(%{})
 
-        assert Gettext.get_locale(DotcomWeb.Gettext) == locale
-      end)
-    end
+      assert Gettext.get_locale(DotcomWeb.Gettext) == locale
+    end)
   end
 
-  test "a conn with a param locale set the locale", %{conn: conn} do
+  test "a conn with a param locale sets the locale", %{conn: conn} do
     locale = Locales.locale_codes() |> Enum.random()
 
     conn |> Map.put(:params, %{"locale" => locale}) |> call(%{})
@@ -29,7 +27,15 @@ defmodule DotcomWeb.Plugs.SetLocaleTest do
     assert Gettext.get_locale(DotcomWeb.Gettext) == locale
   end
 
-  test "a conn with a cookie locale set the locale", %{conn: conn} do
+  test "a conn with a session locale sets the locale", %{conn: conn} do
+    locale = Locales.locale_codes() |> Enum.random()
+
+    conn |> put_session(:locale, locale) |> call(%{})
+
+    assert Gettext.get_locale(DotcomWeb.Gettext) == locale
+  end
+
+  test "a conn with a cookie locale sets the locale", %{conn: conn} do
     locale = Locales.locale_codes() |> Enum.random()
 
     conn |> Map.put(:cookies, %{"locale" => locale}) |> call(%{})


### PR DESCRIPTION
This is definitely open for review and interpretation. My idea is that we are going to be using gettext *all* over the place, so it will be nice to simplify its use somewhat. The basic sigil cuts a lot of typing out and also makes translations stand out in a template or module. The plural one is a little more iffy as it uses pipes to separate values. We can also add domains in if we want.

```
basic = ~i(foo bar baz)

num = :rand.uniform(99)
plural = ~i(one blind mouse | %{count} blind mice | #{num})
```