### PR TITLE
feat: Use the pointer cursor over itinerary details, because they are clickable

### DIFF
--- a/lib/dotcom_web/components/trip_planner/results.ex
+++ b/lib/dotcom_web/components/trip_planner/results.ex
@@ -145,7 +145,7 @@ defmodule DotcomWeb.Components.TripPlanner.Results do
     <div class="flex flex-col gap-4">
       <div
         :for={{group, index} <- @summarized_groups}
-        class="border border-solid border-gray-lighter p-4"
+        class="border border-solid border-gray-lighter p-4 cursor-pointer"
         phx-click="select_itinerary_group"
         phx-value-index={index}
         data-test={"results:itinerary_group:#{index}"}


### PR DESCRIPTION
**Asana Ticket:** [QF | TP | Make itinerary cards show pointer cursor on hover](https://app.asana.com/1/15492006741476/project/385363666817452/task/1210744258068580?focus=true)

---

This is tough to screenshot because screenshots don't include the cursor, but imagine 👇 image with a 👆 cursor over it

<img width="846" height="436" alt="Screenshot 2025-07-15 at 3 51 49 PM" src="https://github.com/user-attachments/assets/7be6b1ab-2cfc-4f0a-975b-5b695e405c3b" />
