### PR TITLE
fix: Allow timetables to scroll all the way to the left

### DIFF
--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -74,7 +74,7 @@
             >
               <div class="m-timetable__row-header">Stops</div>
             </th>
-            <td class="hidden-no-js">
+            <td class="hidden-no-js m-timetable__cell">
               <div class="m-timetable__row-header"></div>
             </td>
             <%= for {schedule, index} <- Enum.with_index(@header_schedules) do %>


### PR DESCRIPTION
Before to the left; After to the right

<img width="726" height="480" alt="Screenshot 2025-07-15 at 4 16 11 PM" src="https://github.com/user-attachments/assets/c9602fb0-8373-4cd6-8d82-0af8bcdfef24" />

---

**Asana Ticket:** [QF | Timetables scrolled all the way to the left cut off part of icons](https://app.asana.com/1/15492006741476/project/385363666817452/task/1209776227843947?focus=true)

