### PR TITLE
fix: Don't include `Commuter Rail` in the description of ferry pages

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -43,7 +43,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     conn
     |> assign(
       :meta_description,
-      "MBTA #{route_name_for_description(conn.assigns.route)} stations and " <>
+      "MBTA #{route_name_for_description(conn.assigns.route)} #{station_type_name(conn.assigns.route)} and " <>
         "schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, " <>
         "and connections."
     )
@@ -57,6 +57,9 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
 
   defp route_name_for_description(%Route{type: 2} = route), do: "#{route.name} Commuter Rail"
   defp route_name_for_description(route), do: route.name
+
+  defp station_type_name(%Route{type: 4}), do: "docks"
+  defp station_type_name(_route), do: "stations"
 
   defp assign_cr_status(%{assigns: %{route: route}} = conn) do
     cr_status =

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -43,7 +43,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     conn
     |> assign(
       :meta_description,
-      "MBTA #{conn.assigns.route.name} Commuter Rail stations and " <>
+      "MBTA #{route_name_for_description(conn.assigns.route)} stations and " <>
         "schedules, including timetables, maps, fares, real-time updates, parking and accessibility information, " <>
         "and connections."
     )
@@ -54,6 +54,9 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     |> put_view(ScheduleView)
     |> render("show.html", [])
   end
+
+  defp route_name_for_description(%Route{type: 2} = route), do: "#{route.name} Commuter Rail"
+  defp route_name_for_description(route), do: route.name
 
   defp assign_cr_status(%{assigns: %{route: route}} = conn) do
     cr_status =


### PR DESCRIPTION
<img width="878" height="102" alt="Screenshot 2025-07-15 at 4 59 13 PM" src="https://github.com/user-attachments/assets/252f591f-648e-4085-80d4-badc19c5fd79" />

---

**Asana Ticket:** [QF | Update the description of ferry timetable pages in search results](https://app.asana.com/1/15492006741476/project/385363666817452/task/1210117915242712?focus=true)
