### PR TITLE
Revert "fix: Allow timetables to scroll all the way to the left (#2646)"

### DIFF
--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -74,7 +74,7 @@
             >
               <div class="m-timetable__row-header">Stops</div>
             </th>
-            <td class="hidden-no-js m-timetable__cell">
+            <td class="hidden-no-js">
               <div class="m-timetable__row-header"></div>
             </td>
             <%= for {schedule, index} <- Enum.with_index(@header_schedules) do %>


### PR DESCRIPTION
This reverts commit 14d8714f5573c67438cd2bc19be7a01440a3af8c.

I tested it out on the [Quincy Timetable Page](https://dev.mbtace.com/schedules/Boat-F7/timetable) on dev before deploying, and it doesn't look quite right. 👇 screenshot is from a 1400px-wide Firefox window.

<img width="231" height="91" alt="Screenshot 2025-07-16 at 11 37 48 AM" src="https://github.com/user-attachments/assets/f04ff98d-9708-4a3f-b755-5ee3e39c96d0" />

Let's revert for now and figure out a more Right™ way of doing this.

