### PR TITLE
fix(CMSController): render diversions based on planned service-impacting alerts

### DIFF
--- a/lib/alerts/repo.ex
+++ b/lib/alerts/repo.ex
@@ -1,5 +1,5 @@
 defmodule Alerts.Repo do
-  import Dotcom.Alerts, only: [diversion_alert?: 1]
+  import Dotcom.Alerts, only: [planned_service_impacting_alert?: 1]
 
   alias Alerts.{Alert, Banner, Priority}
   alias Alerts.Cache.Store
@@ -34,16 +34,12 @@ defmodule Alerts.Repo do
     |> Store.alerts(now)
   end
 
-  @doc """
-  Get alerts that are diversions: detour, service change, shuttle, station closure, stop closure, or suspension.
-
-  Sort them so that earlier alerts are displaed first.
-  """
-  @spec diversions_by_route_ids([String.t()], DateTime.t()) :: [Alert.t()]
-  def diversions_by_route_ids(route_ids, now) do
+  @impl Behaviour
+  @spec planned_service_impacts_by_routes([String.t()], DateTime.t()) :: [Alert.t()]
+  def planned_service_impacts_by_routes(route_ids, now) do
     route_ids
     |> by_route_ids(now)
-    |> Enum.filter(&diversion_alert?/1)
+    |> Enum.filter(&planned_service_impacting_alert?/1)
     |> Enum.sort(fn a, b ->
       first = a.active_period |> List.first() |> elem(0)
       second = b.active_period |> List.first() |> elem(0)

--- a/lib/alerts/repo/behaviour.ex
+++ b/lib/alerts/repo/behaviour.ex
@@ -19,4 +19,11 @@ defmodule Alerts.Repo.Behaviour do
   Return all alerts for the given stop id.
   """
   @callback by_stop_id(String.t()) :: [Alert.t()]
+
+  @doc """
+  Get alerts which describe planned work that impacts service on the given routes at the given time.
+
+  Sort them so that earlier alerts are displayed first.
+  """
+  @callback planned_service_impacts_by_routes([String.t()], DateTime.t()) :: [Alert.t()]
 end

--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -25,16 +25,6 @@ defmodule Dotcom.Alerts do
           | :suspension
           | :station_closure
 
-  # A keyword list of effects and the severity level necessary to make an alert a 'diversion.'
-  @diversion_effects [
-    detour: 1,
-    service_change: 3,
-    shuttle: 1,
-    station_closure: 1,
-    stop_closure: 1,
-    suspension: 1
-  ]
-
   # A keyword list of effects and the severity level necessary to make an alert 'service impacting.'
   @service_impacting_effects [
     cancellation: 1,
@@ -62,27 +52,20 @@ defmodule Dotcom.Alerts do
   end
 
   @doc """
-  Does the alert have an effect/severity that is considered a diversion?
-  And, was it planned?
-  """
-  @spec diversion_alert?(Alert.t()) :: boolean()
-  def diversion_alert?(alert) do
-    effects_match?(@diversion_effects, alert) &&
-      planned_alert?(alert)
-  end
-
-  @doc """
-  Returns a keyword list of the alert effects that are considered service-impacting and their severity levels.
-  """
-  @spec diversion_effects() :: [{diversion_effect_t(), integer()}]
-  def diversion_effects(), do: @diversion_effects
-
-  @doc """
   Does the alert match a group of effects/severities?
   """
   @spec effects_match?(list(), Alert.t()) :: boolean()
   def effects_match?(effects, alert) do
     Enum.any?(effects, &effect_match?(&1, alert))
+  end
+
+  @doc """
+  Does the alert have an effect/severity that is considered service impacting?
+  And, was it planned?
+  """
+  @spec planned_service_impacting_alert?(Alert.t()) :: boolean()
+  def planned_service_impacting_alert?(alert) do
+    service_impacting_alert?(alert) && planned_alert?(alert)
   end
 
   @doc """

--- a/lib/dotcom_web/controllers/cms_controller.ex
+++ b/lib/dotcom_web/controllers/cms_controller.ex
@@ -17,6 +17,8 @@ defmodule DotcomWeb.CMSController do
     ProjectController
   }
 
+  @alerts_repo Application.compile_env!(:dotcom, :repo_modules)[:alerts]
+
   @generic [
     Page.Basic,
     Page.Diversions,
@@ -108,14 +110,14 @@ defmodule DotcomWeb.CMSController do
       Breadcrumb.build(project.title)
     ]
 
-    conn = assign(conn, :alerts, Alerts.Repo.all(conn.assigns.date_time))
+    conn = assign(conn, :alerts, @alerts_repo.all(conn.assigns.date_time))
 
     render_generic(conn, project, breadcrumbs)
   end
 
   defp render_page(conn, %Page.ProjectUpdate{} = update) do
     base = ProjectController.get_breadcrumb_base()
-    conn = assign(conn, :alerts, Alerts.Repo.all(conn.assigns.date_time))
+    conn = assign(conn, :alerts, @alerts_repo.all(conn.assigns.date_time))
 
     case Repo.get_page(update.project_url) do
       %Page.Project{} = project ->
@@ -143,7 +145,7 @@ defmodule DotcomWeb.CMSController do
     conn
     |> assign(
       :alerts,
-      Alerts.Repo.diversions_by_route_ids(page.related_transit, conn.assigns.date_time)
+      @alerts_repo.planned_service_impacts_by_routes(page.related_transit, conn.assigns.date_time)
     )
     |> assign(:breadcrumbs, page.breadcrumbs)
     |> assign(:page, page)

--- a/test/alerts/repo_test.exs
+++ b/test/alerts/repo_test.exs
@@ -63,11 +63,11 @@ defmodule Alerts.RepoTest do
     end
   end
 
-  describe "diversions_by_route_id/2" do
-    test "returns only diversions for the given route_ids" do
+  describe "planned_service_impacts_by_routes/2" do
+    test "returns only planned service impacts for the given route_ids" do
       # Setup
       diversion = Factories.Alerts.Alert.build(:alert, effect: :service_change, severity: 3)
-      non_diversion = Factories.Alerts.Alert.build(:alert, effect: :delay, severity: 1)
+      non_diversion = Factories.Alerts.Alert.build(:alert, effect: :amber_alert, severity: 1)
 
       Store.update([diversion, non_diversion], nil)
 
@@ -79,7 +79,10 @@ defmodule Alerts.RepoTest do
 
       # Exercise
       diversions =
-        Repo.diversions_by_route_ids([diversion_route, non_diversion_route], Timex.now())
+        Repo.planned_service_impacts_by_routes(
+          [diversion_route, non_diversion_route],
+          Timex.now()
+        )
 
       # Verify
       assert [^diversion] = diversions

--- a/test/dotcom/alerts_test.exs
+++ b/test/dotcom/alerts_test.exs
@@ -23,69 +23,6 @@ defmodule Dotcom.AlertsTest do
     :ok
   end
 
-  describe "diversion_alert?/1" do
-    test "returns true if the alert has an effect that is considered a diversion" do
-      # Setup
-      {effect, severity} = diversion_effects() |> Faker.Util.pick()
-      alert = Factories.Alerts.Alert.build(:alert, effect: effect, severity: severity)
-
-      # Exercise/Verify
-      assert diversion_alert?(alert)
-    end
-
-    test "returns false if the alert does not have an effect that is considered a diversion" do
-      # Setup
-      alert = Factories.Alerts.Alert.build(:alert, effect: :not_a_diversion)
-
-      # Exercise/Verify
-      refute diversion_alert?(alert)
-    end
-
-    test "returns true when created at is before active period" do
-      # Setup
-      created_at = Timex.now()
-      active_period = [{Timex.shift(created_at, days: 1), Timex.shift(created_at, days: 2)}]
-
-      {effect, severity} = diversion_effects() |> Faker.Util.pick()
-
-      alert =
-        Factories.Alerts.Alert.build(:alert,
-          active_period: active_period,
-          created_at: created_at,
-          effect: effect,
-          severity: severity
-        )
-
-      # Exercise/Verify
-      assert diversion_alert?(alert)
-    end
-
-    test "returns false when created at is after active period" do
-      created_at = Timex.now()
-      active_period = [{Timex.shift(created_at, days: -2), Timex.shift(created_at, days: -1)}]
-
-      {effect, severity} = diversion_effects() |> Faker.Util.pick()
-
-      alert =
-        Factories.Alerts.Alert.build(:alert,
-          active_period: active_period,
-          created_at: created_at,
-          effect: effect,
-          severity: severity
-        )
-
-      # Exercise/Verify
-      refute diversion_alert?(alert)
-    end
-  end
-
-  describe "diversion_effects/0" do
-    test "returns a list of the alert effects as keywords" do
-      # Exercise/Verify
-      assert Keyword.keyword?(diversion_effects())
-    end
-  end
-
   describe "affected_stations/1" do
     test "returns a list of stations that are affected by the alert" do
       # Setup

--- a/test/dotcom_web/controllers/cms_controller_test.exs
+++ b/test/dotcom_web/controllers/cms_controller_test.exs
@@ -1,7 +1,18 @@
 defmodule DotcomWeb.CMSControllerTest do
   use DotcomWeb.ConnCase, async: false
+  import Mox
 
   alias Plug.Conn
+
+  setup :verify_on_exit!
+
+  setup do
+    stub(Alerts.Repo.Mock, :all, fn _ ->
+      []
+    end)
+
+    :ok
+  end
 
   describe "GET - page" do
     test "renders a basic page when the CMS returns a CMS.Page.Basic", %{conn: conn} do


### PR DESCRIPTION

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Everywhere we use   @diversion_effects replace with using  @service_impacting_effects  instead](https://app.asana.com/1/15492006741476/project/555089885850811/task/1210824489259944?focus=true)
