### PR TITLE
fix(TripPlanner): open the CapeFLYER itinerary

### DIFF
--- a/lib/dotcom_web/components/trip_planner/route_icons.ex
+++ b/lib/dotcom_web/components/trip_planner/route_icons.ex
@@ -76,8 +76,15 @@ defmodule DotcomWeb.Components.TripPlanner.RouteIcons do
     """
   end
 
+  def otp_route_icon(%{route: route} = assigns)
+      when agency_name?(route, "Cape Cod Regional Transit Authority") do
+    mbta_icon(assigns)
+  end
+
   def otp_route_icon(%{route: route} = assigns) when agency_name?(route, "MBTA"),
     do: mbta_icon(assigns)
+
+  def otp_route_icon(assigns), do: fallback_icon(assigns)
 
   attr :class, :string, default: ""
 

--- a/test/dotcom/trip_plan/fares_test.exs
+++ b/test/dotcom/trip_plan/fares_test.exs
@@ -10,6 +10,15 @@ defmodule Dotcom.TripPlan.FaresTest do
       assert fare(itinerary) |> is_integer()
     end
 
+    test "returns nil if involving transit agency we don't know fares for" do
+      itinerary =
+        build(:itinerary,
+          legs: build_list(1, :transit_leg, agency: build(:agency, name: Faker.Lorem.word()))
+        )
+
+      assert fare(itinerary) |> is_nil()
+    end
+
     test "gives a free subway transfer after taking the SL1 from the airport" do
       airport_stop = Faker.Util.pick(~w(17091 27092 17093 17094 17095))
 


### PR DESCRIPTION
- fix(TripPlan.Fares): return nil for unknown fares
- fix(TripPlanner.RouteIcons): give CapeFLYER the MBTA icon treatment

and actually remember to define a fallback icon this time

<img width="1317" height="935" alt="image" src="https://github.com/user-attachments/assets/294226b0-dbc5-4a56-8cf4-eff417666789" />

<img width="1257" height="606" alt="image" src="https://github.com/user-attachments/assets/6d0faf9f-ed17-4a47-84f5-04fe5b0010c3" />
