### PR TITLE
Identify which templates are used when loading a route

### DIFF
--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -41,6 +41,13 @@ defmodule Dotcom.Application do
         else
           []
         end ++
+        if Application.get_env(:dotcom, :env) === :dev do
+          [
+            {DotcomWeb.Translations, %{}}
+          ]
+        else
+          []
+        end ++
         if Application.get_env(:dotcom, :start_data_processes) do
           [
             Vehicles.Supervisor,

--- a/lib/dotcom_web.ex
+++ b/lib/dotcom_web.ex
@@ -79,8 +79,9 @@ defmodule DotcomWeb do
       # Include shared imports and aliases for views
       unquote(view_helpers())
 
-      def track_template(%{path_info: path_info}) do
+      def track_template() do
         if Mix.env() === :dev do
+          path_info = Process.get(:path_info, [])
           {_, trace} = Process.info(self(), :current_stacktrace)
 
           route =

--- a/lib/dotcom_web.ex
+++ b/lib/dotcom_web.ex
@@ -80,7 +80,7 @@ defmodule DotcomWeb do
       unquote(view_helpers())
 
       def track_template() do
-        if Mix.env() === :dev do
+        if Application.get_env(:dotcom, :env) === :dev do
           path_info = Process.get(:path_info, [])
           {_, trace} = Process.info(self(), :current_stacktrace)
 

--- a/lib/dotcom_web/plugs/set_process_path.ex
+++ b/lib/dotcom_web/plugs/set_process_path.ex
@@ -1,9 +1,7 @@
 defmodule DotcomWeb.Plugs.SetProcessPath do
-  @moduledoc"""
+  @moduledoc """
   Sets the request path as a process value so we can access it from templates.
   """
-
-  import Plug.Conn
 
   def init(default), do: default
 

--- a/lib/dotcom_web/plugs/set_process_path.ex
+++ b/lib/dotcom_web/plugs/set_process_path.ex
@@ -1,0 +1,15 @@
+defmodule DotcomWeb.Plugs.SetProcessPath do
+  @moduledoc"""
+  Sets the request path as a process value so we can access it from templates.
+  """
+
+  import Plug.Conn
+
+  def init(default), do: default
+
+  def call(%{path_info: path_info} = conn, _opts) do
+    Process.put(:path_info, path_info)
+
+    conn
+  end
+end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -41,6 +41,9 @@ defmodule DotcomWeb.Router do
     plug(DotcomWeb.Plugs.DateTime)
     plug(DotcomWeb.Plugs.RewriteUrls)
     plug(DotcomWeb.Plugs.SecureHeaders)
+    if Mix.env() === :dev do
+      plug(DotcomWeb.Plugs.SetProcessPath)
+    end
     plug(:optional_disable_indexing)
   end
 

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -41,9 +41,11 @@ defmodule DotcomWeb.Router do
     plug(DotcomWeb.Plugs.DateTime)
     plug(DotcomWeb.Plugs.RewriteUrls)
     plug(DotcomWeb.Plugs.SecureHeaders)
+
     if Mix.env() === :dev do
       plug(DotcomWeb.Plugs.SetProcessPath)
     end
+
     plug(:optional_disable_indexing)
   end
 

--- a/lib/dotcom_web/templates/alert/_banner.html.eex
+++ b/lib/dotcom_web/templates/alert/_banner.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% label = BannerAlert.human_label(@alert) %>
 <div tabindex="0" class="c-alert-item c-alert-item--system">
   <div class="c-alert-item__icon">

--- a/lib/dotcom_web/templates/alert/_item.html.eex
+++ b/lib/dotcom_web/templates/alert/_item.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% label = Alerts.Alert.human_label(@alert) %>
 <% alert_icon_type = Alerts.Alert.icon(@alert) %>
 <li tabindex="0"

--- a/lib/dotcom_web/templates/alert/_t-alerts.html.eex
+++ b/lib/dotcom_web/templates/alert/_t-alerts.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="m-alerts-ad">
   <h3>Get T-Alerts</h3>
   <div class="m-alerts-ad__content">

--- a/lib/dotcom_web/templates/alert/group.html.eex
+++ b/lib/dotcom_web/templates/alert/group.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <ul class="c-alert-group">
   <%= for alert <- @alerts do %>
     <%= render "_item.html", alert: alert, date_time: @date_time, hide_url: assigns[:hide_urls] %>

--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <.alerts_layout mode={@id}>
   <:sidebar_top :if={@id != :subway}>
     {DotcomWeb.PartialView.alert_time_filters(@alerts_timeframe,

--- a/lib/dotcom_web/templates/bus_stop_change/index.html.eex
+++ b/lib/dotcom_web/templates/bus_stop_change/index.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   all_alerts = if assigns[:past_alerts] do
     Enum.concat(@past_alerts, @alerts)

--- a/lib/dotcom_web/templates/cms/_sidebar_left.html.eex
+++ b/lib/dotcom_web/templates/cms/_sidebar_left.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="c-cms__sidebar">
   <h2 class="c-cms__sidebar-title">
     <span class="c-cms__title-prefix">More from </span><%= @page.sidebar_menu.title %>

--- a/lib/dotcom_web/templates/cms/_sidebar_right.html.eex
+++ b/lib/dotcom_web/templates/cms/_sidebar_right.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   right_rail_paragraphs =
     @page.paragraphs

--- a/lib/dotcom_web/templates/cms/diversions.html.eex
+++ b/lib/dotcom_web/templates/cms/diversions.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <%= DotcomWeb.CMS.PageView.render_page(@page, @conn) %>
 </div>

--- a/lib/dotcom_web/templates/cms/empty.html.eex
+++ b/lib/dotcom_web/templates/cms/empty.html.eex
@@ -1,1 +1,2 @@
+<% track_template() %>
 <% # No content in container; all in pre-container %>

--- a/lib/dotcom_web/templates/cms/landing_page.html.eex
+++ b/lib/dotcom_web/templates/cms/landing_page.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <style>
   @media
   (min-width: 800px) {

--- a/lib/dotcom_web/templates/cms/page.html.eex
+++ b/lib/dotcom_web/templates/cms/page.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <%= render_page(@page, @conn) %>
 </div>

--- a/lib/dotcom_web/templates/cms/page/_alerts.html.eex
+++ b/lib/dotcom_web/templates/cms/page/_alerts.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="alerts-section">
   <% alerts = alerts_for_project(@page, @alerts) %>
   <%= if !Enum.empty?(alerts) do %>

--- a/lib/dotcom_web/templates/cms/page/_diversions.html.eex
+++ b/lib/dotcom_web/templates/cms/page/_diversions.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="c-cms <%= @sidebar_class %>">
 
   <div class="c-cms__header">

--- a/lib/dotcom_web/templates/cms/page/_generic.html.eex
+++ b/lib/dotcom_web/templates/cms/page/_generic.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="page-section">
   <%= Dotcom.ContentRewriter.rewrite(@page.body, @conn) %>
 

--- a/lib/dotcom_web/templates/cms/page/_page.html.eex
+++ b/lib/dotcom_web/templates/cms/page/_page.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="c-cms <%= @sidebar_class %>">
 
   <div class="c-cms__header">

--- a/lib/dotcom_web/templates/cms/page/_project.html.eex
+++ b/lib/dotcom_web/templates/cms/page/_project.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @page.featured_image do %>
   <div class="page-section project-hero-image">
     <figure class="c-media c-media--image c-media--wide">

--- a/lib/dotcom_web/templates/cms/page/_project_update.html.eex
+++ b/lib/dotcom_web/templates/cms/page/_project_update.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="page-section">
   <h2 class="c-cms__meta">Updated on <%= format_full_date(@page.posted_on) %></h2>
 </div>

--- a/lib/dotcom_web/templates/cms/paragraph/_accordion.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_accordion.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @content.header do %>
   <%= ContentRewriter.rewrite(@content.header.text, @conn) %>
 <% end %>

--- a/lib/dotcom_web/templates/cms/paragraph/_accordion_content.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_accordion_content.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%=
   for content <- @content do
     render_paragraph_content(content, @conn)

--- a/lib/dotcom_web/templates/cms/paragraph/_agenda_topic.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_agenda_topic.html.eex
@@ -1,2 +1,3 @@
+<% track_template() %>
 <h3><%= ContentRewriter.rewrite(@content.title, @conn) %></h3>
 <div><%= ContentRewriter.rewrite(@content.description, @conn) %></div>

--- a/lib/dotcom_web/templates/cms/paragraph/_callout.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_callout.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= extend_width :callout do %>
   <div class="c-callout__row row">
     <div class="c-callout__column c-callout__column--text col-sm-6">

--- a/lib/dotcom_web/templates/cms/paragraph/_code_embed.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_code_embed.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @content.header do %>
   <%= ContentRewriter.rewrite(@content.header.text, @conn) %>
 <% end %>

--- a/lib/dotcom_web/templates/cms/paragraph/_column_multi.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_column_multi.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   has_cards? = ColumnMulti.includes?(@content, :fares) ||
                ColumnMulti.includes?(@content, :links)

--- a/lib/dotcom_web/templates/cms/paragraph/_content_list.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_content_list.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @content.header do %>
   <%= ContentRewriter.rewrite(@content.header.text, @conn) %>
 <% end %>

--- a/lib/dotcom_web/templates/cms/paragraph/_custom_html.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_custom_html.html.eex
@@ -1,1 +1,2 @@
+<% track_template() %>
 <%= ContentRewriter.rewrite(@content.body, @conn) %>

--- a/lib/dotcom_web/templates/cms/paragraph/_description_list.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_description_list.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @content.header do %>
   <%= ContentRewriter.rewrite(@content.header.text, @conn) %>
 <% end %>

--- a/lib/dotcom_web/templates/cms/paragraph/_descriptive_link.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_descriptive_link.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   content = [
     content_tag(:div, class: "c-descriptive-link__text") do [

--- a/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   fare = fare_from_token(@fare_card.fare_token)
 

--- a/lib/dotcom_web/templates/cms/paragraph/_files_grid.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_files_grid.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @content.title do %>
   <h3 class="file-grid-section-title"><%= @content.title %></h3>
 <% end %>

--- a/lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @fare_cards && length(@fare_cards) == 2 do %>
 
 <%

--- a/lib/dotcom_web/templates/cms/paragraph/_paragraph.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_paragraph.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   multi? = match?(%ColumnMulti{}, @paragraph)
   grouped? = ColumnMulti.grouped?(@paragraph)

--- a/lib/dotcom_web/templates/cms/paragraph/_people_grid.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_people_grid.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="people-grid-paragraph" role="people-grid-paragraph">
   <div class="row">
     <%= if length(@content.people) <= 2 do %>

--- a/lib/dotcom_web/templates/cms/paragraph/_person.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_person.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="people-grid-photo">
   <%= img_tag(@person.profile_image.url, alt: @person.profile_image.alt) %>
 </div>

--- a/lib/dotcom_web/templates/cms/paragraph/_photo_gallery.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_photo_gallery.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @content.header do %>
   <%= ContentRewriter.rewrite(@content.header.text, @conn) %>
 <% end %>

--- a/lib/dotcom_web/templates/cms/paragraph/_title_card_set.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_title_card_set.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="l-title-cards">
   <%= for descriptive_link <- @content.descriptive_links do %>
     <%= if descriptive_link.link do %>

--- a/lib/dotcom_web/templates/cms/paragraph/_trip_plan_widget.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_trip_plan_widget.html.eex
@@ -1,2 +1,3 @@
+<% track_template() %>
 <%= DotcomWeb.PartialView.render("_trip_planner_widget.html",
   Map.merge(assigns, Map.from_struct(assigns.content))) %>

--- a/lib/dotcom_web/templates/cms/paragraph/_unknown.html.eex
+++ b/lib/dotcom_web/templates/cms/paragraph/_unknown.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <p>
   The paragraph type <strong><%= @content.type %></strong> is an unsupported
   paragraph. Please contact the dev team to inquire when this paragraph type will

--- a/lib/dotcom_web/templates/cms/person.html.eex
+++ b/lib/dotcom_web/templates/cms/person.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <div class="page-section">
     <%= img_tag @person.profile_image.url, alt: @person.profile_image.alt, class: "hidden-xs-down content-person-sidebar-img" %>

--- a/lib/dotcom_web/templates/cms/teaser/_diversion.html.eex
+++ b/lib/dotcom_web/templates/cms/teaser/_diversion.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @teaser.title do %>
   <h3 class="c-content-teaser__title">
     <%= @teaser.title %>

--- a/lib/dotcom_web/templates/cms/teaser/_event.html.eex
+++ b/lib/dotcom_web/templates/cms/teaser/_event.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @teaser.date do %>
   <div class="c-content-teaser__date u-small-caps">
     <%= display_date(@teaser) %>

--- a/lib/dotcom_web/templates/cms/teaser/_generic.html.eex
+++ b/lib/dotcom_web/templates/cms/teaser/_generic.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @teaser.image && :image in @fields do %>
   <img class="c-content-teaser__image" src="<%= @teaser.image.url %>" alt="<%= @teaser.image.alt %>" />
 <% end %>

--- a/lib/dotcom_web/templates/cms/teaser/_news_entry.html.eex
+++ b/lib/dotcom_web/templates/cms/teaser/_news_entry.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @teaser.date do %>
   <div class="c-content-teaser__date u-small-caps">
     <%= display_date(@teaser) %>

--- a/lib/dotcom_web/templates/cms/teaser/_page.html.eex
+++ b/lib/dotcom_web/templates/cms/teaser/_page.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @teaser.image && :image in @fields do %>
   <img class="c-content-teaser__image" src="<%= @teaser.image.url %>" alt="<%= @teaser.image.alt %>" />
 <% end %>

--- a/lib/dotcom_web/templates/cms/teaser/_project.html.eex
+++ b/lib/dotcom_web/templates/cms/teaser/_project.html.eex
@@ -1,1 +1,2 @@
+<% track_template() %>
 <%= render("_project_or_update.html", teaser: @teaser, fields: @fields) %>

--- a/lib/dotcom_web/templates/cms/teaser/_project_or_update.html.eex
+++ b/lib/dotcom_web/templates/cms/teaser/_project_or_update.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @teaser.image do %>
   <img class="c-content-teaser__image" src="<%= @teaser.image.url %>" alt="<%= @teaser.image.alt %>" />
 <% end %>

--- a/lib/dotcom_web/templates/cms/teaser/_project_update.html.eex
+++ b/lib/dotcom_web/templates/cms/teaser/_project_update.html.eex
@@ -1,1 +1,2 @@
+<% track_template() %>
 <%= render("_project_or_update.html", teaser: @teaser, fields: @fields) %>

--- a/lib/dotcom_web/templates/cms/teaser/_teaser.html.eex
+++ b/lib/dotcom_web/templates/cms/teaser/_teaser.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   css_type = CSSHelpers.atom_to_class(@teaser.type)
   tag = transit_tag(@teaser)

--- a/lib/dotcom_web/templates/cms/teaser/_teaser_list.html.eex
+++ b/lib/dotcom_web/templates/cms/teaser/_teaser_list.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="c-teaser-list <%= @list_class %>">
   <%= for teaser <- @teasers do %>
     <%= render("_teaser.html", teaser: teaser, fields: @fields, conn: @conn) %>

--- a/lib/dotcom_web/templates/customer_support/_accessibility.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_accessibility.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <p>
   To submit an ADA/Accessibility complaint or feedback, please call <%= tel_link "617-222-3200" %> or complete the feedback form on this page. The Customer Engagement Coordinator in System-Wide Accessibility & Customer Liaison for The RIDE are responsible for coordinating the resolutions of ADA/Accessibility complaints once they are received.
 </p>

--- a/lib/dotcom_web/templates/customer_support/_call_us.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_call_us.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <p>
   Monday - Friday: 6:30 AM - 8 PM
 </p>

--- a/lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_discrimination_complaint.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <p>
   If your civil rights have been violated, you can file a complaint with the MBTA Office of Diversity and Civil Rights.
 </p>

--- a/lib/dotcom_web/templates/customer_support/_form.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_form.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <script id="js-routes-by-mode" type="text/plain">
   <%= raw Poison.encode!(@all_options_per_mode) %>
 </script>

--- a/lib/dotcom_web/templates/customer_support/_lost_and_found.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_lost_and_found.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <p>
   Follow the link below to find the number associated with the mode or route where you lost your item.
 </p>

--- a/lib/dotcom_web/templates/customer_support/_rail_road.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_rail_road.html.eex
@@ -1,1 +1,2 @@
+<% track_template() %>
 <p>To report a problem or emergency with a railroad crossing, call <%= tel_link "1-800-522-8236" %></p>

--- a/lib/dotcom_web/templates/customer_support/_report.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_report.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= content_tag(:p, "The Internal Special Audit Unit within the Office of the Inspector General monitors the quality, efficiency, and integrity of MassDOT programs.") %>
 
 <%= content_tag(:p, [

--- a/lib/dotcom_web/templates/customer_support/_request_public_records.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_request_public_records.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <p>Members of the public have the right to request copies of MBTA documents, with certain exceptions. Fees apply and may vary depending on the request.</p>
 <p>
   <%= link to: "https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&COID=64D93B66", target: "_blank", class: "c-call-to-action" do %>

--- a/lib/dotcom_web/templates/customer_support/_service_updates.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_service_updates.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <p>Receive notifications of MBTA service alerts by email or text.</p>
 <p><a class="c-call-to-action" href="https://alerts.mbta.com" target="_blank">Sign up for T-Alerts</a></p>
 <p><a class="c-call-to-action" href="https://twitter.com/MBTA" target="_blank">Follow @MBTA on Twitter</a></p>

--- a/lib/dotcom_web/templates/customer_support/_transit_police.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_transit_police.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <p>
   <strong>Emergency:</strong> <%= tel_link "617-222-1212" %><br>
   <strong>TTY:</strong> <%= tel_link "711" %>

--- a/lib/dotcom_web/templates/customer_support/_write_to_us.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_write_to_us.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <p>
   MBTA<br />
   10 Park Plaza<br />

--- a/lib/dotcom_web/templates/customer_support/index.html.eex
+++ b/lib/dotcom_web/templates/customer_support/index.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <div class="page-section">
     <h1>Customer Support</h1>

--- a/lib/dotcom_web/templates/error/error_layout.html.heex
+++ b/lib/dotcom_web/templates/error/error_layout.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container error-page">
   <div class="font-small error-pre-title">
     {@error_code <> " Error \u2022 " <> @error_type}

--- a/lib/dotcom_web/templates/event/_add_button.html.eex
+++ b/lib/dotcom_web/templates/event/_add_button.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="m-event__status-message <%= @class %>">
   <%= if not @event_started do %>
     <%= link to: event_icalendar_path(@conn, @path), class: "btn btn-secondary btn-lg m-event__add-button", title: "Add event to calendar" do %>

--- a/lib/dotcom_web/templates/event/_address.html.eex
+++ b/lib/dotcom_web/templates/event/_address.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div>
   <span class="event-info-label">Location:</span>
   <%= if @event.location do %>

--- a/lib/dotcom_web/templates/event/_calendar.html.eex
+++ b/lib/dotcom_web/templates/event/_calendar.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% events_by_day = grouped_by_day(@events, @month) %>
 
 <h2 class="m-event-list__month-header"><%= render_event_month(@month, @year) %></h2>

--- a/lib/dotcom_web/templates/event/_event_agenda.html.eex
+++ b/lib/dotcom_web/templates/event/_event_agenda.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if Enum.any?(@agenda.topics) do %>
   <ol type="A" class="agenda-topics">
     <%= for %CMS.Partial.Paragraph.AgendaTopic{description: description, title: title, video_bookmark: bookmark, sub_topics: sub_topics, files: files, links: _links} <- @agenda.topics do %>

--- a/lib/dotcom_web/templates/event/_event_list.html.eex
+++ b/lib/dotcom_web/templates/event/_event_list.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="m-event-listing">
   <nav class="m-event-list__nav--mobile-controls">
     <%= render "_month_select.html",

--- a/lib/dotcom_web/templates/event/_event_teaser.html.eex
+++ b/lib/dotcom_web/templates/event/_event_teaser.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   event_start = @event_teaser.date
   event_stop = @event_teaser.date_end

--- a/lib/dotcom_web/templates/event/_expandable_month.html.eex
+++ b/lib/dotcom_web/templates/event/_expandable_month.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <section id="<%= @month_number %>-<%= @year %>" class="m-event-list__month <%= if @month_number == @month, do: "m-event-list__month--active" %>">
   <% header_id = "header-#{@month_number}" %>
   <% panel_id = "panel-#{@month_number}" %>

--- a/lib/dotcom_web/templates/event/_meeting_info.html.eex
+++ b/lib/dotcom_web/templates/event/_meeting_info.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="c-paragraph <%= if @style do @style end %>">
   <h2>Meeting Info</h2>
   <div class="u-small-caps font-bold u-mb-05 u-mt-1">Date and Time</div>

--- a/lib/dotcom_web/templates/event/_month.html.eex
+++ b/lib/dotcom_web/templates/event/_month.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <ul class="list-group list-group-flush">
 
   <%= if @conn.assigns.date.year == @year and @conn.assigns.date.month == @month_number do %>

--- a/lib/dotcom_web/templates/event/_month_select.html.eex
+++ b/lib/dotcom_web/templates/event/_month_select.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <select class="c-select m-event-list__select">
   <option disabled selected value="">Jump to</option>
   <%= for month <- 1..12 do %>

--- a/lib/dotcom_web/templates/event/_popup.html.eex
+++ b/lib/dotcom_web/templates/event/_popup.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%!--
   Uses the 3rd-party a11y-dialog library as a base to create
   accessible dialog windows for various use cases.

--- a/lib/dotcom_web/templates/event/_year_select.html.eex
+++ b/lib/dotcom_web/templates/event/_year_select.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <select class="c-select m-event-list__select">
   <option disabled selected value="">Jump to</option>
   <%= for year <- years_for_selection(@conn) do %>

--- a/lib/dotcom_web/templates/event/index.html.eex
+++ b/lib/dotcom_web/templates/event/index.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container m-events-hub m-events-hub--list-view">
   <header class="m-events-header">
     <h1>Events</h1>

--- a/lib/dotcom_web/templates/event/show.html.eex
+++ b/lib/dotcom_web/templates/event/show.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% has_related_files = @event.agenda_file || @event.minutes_file || Enum.empty?(@event.files) == false %>
 <% sidebar_class = if has_related_files, do: "c-cms--with-sidebar c-cms--sidebar-right", else: "c-cms--no-sidebar" %>
 

--- a/lib/dotcom_web/templates/fare/_nearby_locations.html.eex
+++ b/lib/dotcom_web/templates/fare/_nearby_locations.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="c-sales-locations__cards">
   <%= for {location, distance} <- @locations do %>
     <%

--- a/lib/dotcom_web/templates/fare/_summary.html.eex
+++ b/lib/dotcom_web/templates/fare/_summary.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="fare-summary-container <%= @class || "fare-summary-container-table-multi-col" %>">
   <%= for chunk <- Enum.chunk_every(@summaries, 2, 2, []) do %>
     <div class="fare-summary-row">

--- a/lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
+++ b/lib/dotcom_web/templates/fare/proposed_sales_locations.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% psl_types = ["All Location Types", "Charlie Retailer", "Fare Vending Machine"] %>
 
 <div class="container m-sales-locations">

--- a/lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
+++ b/lib/dotcom_web/templates/fare/retail_sales_locations.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container m-sales-locations">
   <div class="col-md-8">
     <div class="limited-width">

--- a/lib/dotcom_web/templates/fare/show.html.eex
+++ b/lib/dotcom_web/templates/fare/show.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <div class="page-section">
     <%= render @fare_template, forward_assigns(@conn) %>

--- a/lib/dotcom_web/templates/layout/_alert_announcement.html.eex
+++ b/lib/dotcom_web/templates/layout/_alert_announcement.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="alert-announcement__header" onclick="location.href='<%= @alert_banner.url || alert_path(@conn, :index) %>';">
   <%= DotcomWeb.AlertView.render "_banner.html", alert: @alert_banner %>
 </div>

--- a/lib/dotcom_web/templates/layout/_footer.html.eex
+++ b/lib/dotcom_web/templates/layout/_footer.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="m-footer__outer-background">
   <div class="outer-container">
     <div class="all-container">

--- a/lib/dotcom_web/templates/layout/_google_translate_plugin.html.heex
+++ b/lib/dotcom_web/templates/layout/_google_translate_plugin.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% tag_id =
   case google_tag_manager_id() do
     nil -> "null"

--- a/lib/dotcom_web/templates/layout/_new_header.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_header.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <aside class="c-modal__cover m-menu--cover" aria-hidden="true" data-nav="veil"></aside>
 <header class="header--new">
   <div class="container new">

--- a/lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.eex
+++ b/lib/dotcom_web/templates/layout/_new_nav_contact_numbers.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="m-menu__feature top-section">
   <h3 class="m-menu__section-heading">Information & Support</h3>
   <small>Monday thru Friday: 6:30 AM - 8 PM</small>

--- a/lib/dotcom_web/templates/layout/_new_nav_desktop.html.eex
+++ b/lib/dotcom_web/templates/layout/_new_nav_desktop.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <nav id="navmenu-desktop" class="m-menu--desktop" aria-label="Main navigation">
   <%= for %{menu_section: name, link: href, sub_menus: sub_menus} <- DotcomWeb.LayoutView.nav_link_content() do %>
     <a class="m-menu--desktop__toggle"

--- a/lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
+++ b/lib/dotcom_web/templates/layout/_new_nav_mobile.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <nav class="m-menu--mobile" id="navmenu" aria-label="Navigation Menu">
   <div class="m-menu__content" data-nav="mobile-content">
     <h1 class="m-menu__title h2">Main Menu</h1>

--- a/lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.eex
+++ b/lib/dotcom_web/templates/layout/_new_nav_popular_fares.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="m-menu__feature">
   <h3 class="m-menu__section-heading">Most popular fares</h3>
   <dl title="Most popular fares">

--- a/lib/dotcom_web/templates/layout/_searchbar.html.eex
+++ b/lib/dotcom_web/templates/layout/_searchbar.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <noscript>
   <div class="search-results-header hidden-js">
     <div class="container">

--- a/lib/dotcom_web/templates/layout/admin.html.heex
+++ b/lib/dotcom_web/templates/layout/admin.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <marquee
   behavior="alternate"
   scrolldelay="60"

--- a/lib/dotcom_web/templates/layout/app.html.eex
+++ b/lib/dotcom_web/templates/layout/app.html.eex
@@ -1,1 +1,2 @@
+<% track_template() %>
 <%= @inner_content %>

--- a/lib/dotcom_web/templates/layout/live.html.heex
+++ b/lib/dotcom_web/templates/layout/live.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   {@inner_content}
 </div>

--- a/lib/dotcom_web/templates/layout/preview.html.heex
+++ b/lib/dotcom_web/templates/layout/preview.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div style="margin: 0; padding: .5rem; text-align: center; background-color: #00ffce; background-image: linear-gradient(45deg, #00ffce 25%, #FFFAE9 25%, #FFFAE9 50%, #00ffce 50%, #00ffce 75%, #fff 75%, #FFFAE9 100%); background-size: 56.57px 56.57px; font-weight: bold;">
   Preview Version
 </div>

--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -1,5 +1,4 @@
-<% track_template() %>
-<!DOCTYPE html>
+<% track_template() %> <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/lib/dotcom_web/templates/layout/style_guide.html.eex
+++ b/lib/dotcom_web/templates/layout/style_guide.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/lib/dotcom_web/templates/mode/_grid_button.html.eex
+++ b/lib/dotcom_web/templates/mode/_grid_button.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= link [to: @link_path, class: "c-grid-button c-grid-button--#{grid_button_class_modifier(@route)}", id: grid_button_id(assigns)] do %>
   <div class="c-grid-button__content">
     <%= if show_icon?(@route, @show_icon?) do %>

--- a/lib/dotcom_web/templates/mode/_grid_button_condensed.html.eex
+++ b/lib/dotcom_web/templates/mode/_grid_button_condensed.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= link [to: @link_path, class: "c-grid-button__condensed", id: grid_button_id(assigns)] do %>
   <div class="c-grid-button__content">
       <span class="c-grid-button__icon c-grid-button__icon--condensed" aria-hidden="true">

--- a/lib/dotcom_web/templates/mode/_grid_buttons.html.eex
+++ b/lib/dotcom_web/templates/mode/_grid_buttons.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="c-grid-buttons">
   <%= for {route, idx} <- Enum.with_index(@routes) do %>
     <%= render "_grid_button.html",

--- a/lib/dotcom_web/templates/mode/_grid_buttons_bus.html.eex
+++ b/lib/dotcom_web/templates/mode/_grid_buttons_bus.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div>
   <h3 class="m-mode__schedule-section--word">Silver Line</h3>
   <%= render "_grid_buttons.html", Map.put(assigns, :routes, Enum.filter(@routes, bus_filter_atom(:sl))) %>

--- a/lib/dotcom_web/templates/mode/hub.html.eex
+++ b/lib/dotcom_web/templates/mode/hub.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% mode = mode_atom(@mode_name) %>
 <% grid_template = if mode == :bus, do: "_grid_buttons_bus.html", else: "_grid_buttons.html" %>
 <div class="container">

--- a/lib/dotcom_web/templates/mode/index.html.eex
+++ b/lib/dotcom_web/templates/mode/index.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <div class="page-section <%= assigns[:card_class] %>" id="schedules">
     <div class="row">

--- a/lib/dotcom_web/templates/mticket/notice.html.eex
+++ b/lib/dotcom_web/templates/mticket/notice.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/lib/dotcom_web/templates/news_entry/_recent_news.html.eex
+++ b/lib/dotcom_web/templates/news_entry/_recent_news.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="recent-news">
   <h2>Recent News on the T</h2>
   <div class="l-title-cards">

--- a/lib/dotcom_web/templates/news_entry/index.html.eex
+++ b/lib/dotcom_web/templates/news_entry/index.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <div class="c-cms c-cms--with-sidebar c-cms--sidebar-right">
 

--- a/lib/dotcom_web/templates/news_entry/news_entry.html.eex
+++ b/lib/dotcom_web/templates/news_entry/news_entry.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="news-entry-hr-row news-entry-hr-col news-entry-item">
   <p><%= format_date(@news_entry.date) %></p>
   <p>

--- a/lib/dotcom_web/templates/news_entry/show.html.eex
+++ b/lib/dotcom_web/templates/news_entry/show.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <div class="c-cms c-cms--no-sidebar">
 

--- a/lib/dotcom_web/templates/page/_alerts.html.eex
+++ b/lib/dotcom_web/templates/page/_alerts.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="m-homepage__alerts">
   <div class="m-homepage__alerts-main">
     <div class="m-homepage__alerts-high-priority">

--- a/lib/dotcom_web/templates/page/_banner.html.eex
+++ b/lib/dotcom_web/templates/page/_banner.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="c-banner c-banner--responsive c-banner--<%= @banner.banner_type %> u-linked-card">
   <div class="c-banner__image c-banner__image--responsive c-banner__image--<%= @banner.banner_type %>" style="background-image: url(<%= @banner.thumb.url %>)">
     <div class="sr-only">

--- a/lib/dotcom_web/templates/page/_banner_content.html.eex
+++ b/lib/dotcom_web/templates/page/_banner_content.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="<%= banner_content_class(@banner) %>">
   <div class="c-banner__top">
     <div class="c-banner__category u-small-caps">

--- a/lib/dotcom_web/templates/page/_contact_us.html.eex
+++ b/lib/dotcom_web/templates/page/_contact_us.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="c-home-grid-section">
   <div class="c-home-grid-section-header">
     <h2>

--- a/lib/dotcom_web/templates/page/_fares_passes.html.eex
+++ b/lib/dotcom_web/templates/page/_fares_passes.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="page-section">
   <div class="container">
     <div class="m-homepage--10-col-sm-only">

--- a/lib/dotcom_web/templates/page/_find_a_location.html.eex
+++ b/lib/dotcom_web/templates/page/_find_a_location.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="c-home-grid-section grid-first-section">
   <div class="c-home-grid-section-header">
     <h2>

--- a/lib/dotcom_web/templates/page/_homepage-events.html.eex
+++ b/lib/dotcom_web/templates/page/_homepage-events.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= unless Enum.empty?(@event_teasers) do %>
 <div class="container page-section m-homepage__events">
   <div class="m-homepage--10-col-sm-only">

--- a/lib/dotcom_web/templates/page/_important_links.html.eex
+++ b/lib/dotcom_web/templates/page/_important_links.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container page-section" id="important-links">
   <div class="m-homepage--10-col-sm-only">
     <h2>Important Links</h2>

--- a/lib/dotcom_web/templates/page/_news_and_updates.html.eex
+++ b/lib/dotcom_web/templates/page/_news_and_updates.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if !Enum.empty?(@news) do %>
   <div class="container page-section m-homepage__news" id="news-and-updates">
     <div class="m-homepage--10-col-sm-only">

--- a/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+++ b/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="m-tabbed-nav" role="navigation">
   <div class="nav m-tabbed-nav__items" role="tablist">
     <div class="m-tabbed-nav__item-container">

--- a/lib/dotcom_web/templates/page/_user_guides.html.eex
+++ b/lib/dotcom_web/templates/page/_user_guides.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <section class="homepage-user-guides page-section">
   <div class="container">
     <header class="section-header">

--- a/lib/dotcom_web/templates/page/_whats_happening.html.eex
+++ b/lib/dotcom_web/templates/page/_whats_happening.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @whats_happening_items do %>
   <% tag = if @promoted do "promoted" else "secondary" end %>
   <div class="m-whats-happening__section m-whats-happening__section--<%= tag %>" id="<%= tag %>">

--- a/lib/dotcom_web/templates/page/index.html.eex
+++ b/lib/dotcom_web/templates/page/index.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="index">
   <h1 class="sr-only">MBTA Homepage</h1>
   <%= render "_tabbed_nav.html", assigns %>

--- a/lib/dotcom_web/templates/page/menu.html.heex
+++ b/lib/dotcom_web/templates/page/menu.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <h1>MBTA.com Menu</h1>
   <hr class="m-0" />

--- a/lib/dotcom_web/templates/pagination_helpers/_responsive_pagination.html.eex
+++ b/lib/dotcom_web/templates/pagination_helpers/_responsive_pagination.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% link = build_link(@link_context) %>
 <%= if @pagination.range != [] do %>
   <div class="pagination-box clearfix">

--- a/lib/dotcom_web/templates/partial/_accordion_ui.html.eex
+++ b/lib/dotcom_web/templates/partial/_accordion_ui.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% id = if Map.get(assigns, :id), do: "#{Map.get(assigns, :id)}-accordion", else: "accordion" %>
 
 <div class="c-accordion-ui" id="<%= id %>" role="presentation" <%= if @multiselectable do %> aria-multiselectable="true"<% end %>>

--- a/lib/dotcom_web/templates/partial/_accordion_ui_no_bootstrap.html.eex
+++ b/lib/dotcom_web/templates/partial/_accordion_ui_no_bootstrap.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% id = if Map.get(assigns, :id), do: "#{Map.get(assigns, :id)}-accordion", else: "accordion" %>
 
 <div class="c-accordion-ui c-accordion-ui--no-bootstrap" id="<%= id %>" data-accordion role="presentation" <%= if @multiselectable do %> aria-multiselectable="true"<% end %>>

--- a/lib/dotcom_web/templates/partial/_checkbox.html.eex
+++ b/lib/dotcom_web/templates/partial/_checkbox.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%!-- For simple checkboxes in forms.
     For more complex forms, use the Phoenix inputs_for pattern and add the classes:
     "c-checkbox" to the container div

--- a/lib/dotcom_web/templates/partial/_expandable_block.html.eex
+++ b/lib/dotcom_web/templates/partial/_expandable_block.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 
 <% header_id = "header-#{@id}" %>
 <% panel_id = "panel-#{@id}" %>

--- a/lib/dotcom_web/templates/partial/_file_columns.html.eex
+++ b/lib/dotcom_web/templates/partial/_file_columns.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="l-content-files">
   <%= for file <- @files do %>
     <div class="c-content-file">

--- a/lib/dotcom_web/templates/partial/_hidden_icons.html.eex
+++ b/lib/dotcom_web/templates/partial/_hidden_icons.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="hidden-js hidden-no-js" style="display: none" aria-hidden="true">
   <%=
     for light_rail <- ["Green", "Green-B", "Green-C", "Green-D", "Green-E", "Mattapan"] do

--- a/lib/dotcom_web/templates/partial/_photo_gallery.html.eex
+++ b/lib/dotcom_web/templates/partial/_photo_gallery.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <figure class="c-media c-media--widget c-media--wide">
   <div class="c-media__content">
     <div class="c-photo-gallery clearfix" data-component="photo-gallery">

--- a/lib/dotcom_web/templates/partial/_recently_visited.html.eex
+++ b/lib/dotcom_web/templates/partial/_recently_visited.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= unless Enum.empty?(@routes) do %>
   <div class="c-recently-visited">
     <%= content_tag(:h2, "Recently Visited Schedules", class: Map.get(assigns, :header_class, "")) %>

--- a/lib/dotcom_web/templates/partial/_search_input.html.eex
+++ b/lib/dotcom_web/templates/partial/_search_input.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   autocomplete? = Map.get(assigns, :autocomplete?, true)
   aria_attrs = if autocomplete? do

--- a/lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
+++ b/lib/dotcom_web/templates/partial/_trip_planner_widget.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% form = to_form(%{}, as: :plan, id: "plan") %>
 <div class="@container/trip-planner-widget c-trip-plan-widget">
   <%= if !assigns[:hide_text] do %>

--- a/lib/dotcom_web/templates/project/_all_projects.html.eex
+++ b/lib/dotcom_web/templates/project/_all_projects.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <script data-for="projects" id="js-projects-data" type="text/plain">
   <%= raw Poison.encode!(%{banner: @banner, featuredProjects: @featured_projects, projects: @projects, projectUpdates: @project_updates, placeholderImageUrl: @placeholder_image_url}) %>
 </script>

--- a/lib/dotcom_web/templates/project/_featured_project.html.eex
+++ b/lib/dotcom_web/templates/project/_featured_project.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="row">
   <div class="col-sm-4">
     <%= if @project.image do %>

--- a/lib/dotcom_web/templates/project/_photos.html.eex
+++ b/lib/dotcom_web/templates/project/_photos.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="page-section project-photos">
   <h2>Featured Photos</h2>
   <%= DotcomWeb.PartialView.render("_photo_gallery.html", photos: @photos, class: "project-photo") %>

--- a/lib/dotcom_web/templates/project/index.html.heex
+++ b/lib/dotcom_web/templates/project/index.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if Application.get_env(:dotcom, :dev_server?) do %>
   <script defer src={"#{Application.get_env(:dotcom, :webpack_path)}/projects.js"}>
   </script>

--- a/lib/dotcom_web/templates/project/update.html.eex
+++ b/lib/dotcom_web/templates/project/update.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <div class="c-cms c-cms--no-sidebar">
 

--- a/lib/dotcom_web/templates/project/updates.html.eex
+++ b/lib/dotcom_web/templates/project/updates.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <div class="c-cms c-cms--no-sidebar">
     <div class="c-cms__header">

--- a/lib/dotcom_web/templates/redirect/show.html.eex
+++ b/lib/dotcom_web/templates/redirect/show.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="error-card">
   <h1 class="error-card-header">Hold On&hellip;</h1>
   <p class="error-card-content">While we're working on the new site, we haven't moved everything over yet.</p>

--- a/lib/dotcom_web/templates/schedule/_alerts.html.heex
+++ b/lib/dotcom_web/templates/schedule/_alerts.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="page-section m-schedule-line">
   <% group_alerts? = Enum.member?([:commuter_rail, :subway], @mode) %>
   <div class="row">

--- a/lib/dotcom_web/templates/schedule/_cms_teasers.html.eex
+++ b/lib/dotcom_web/templates/schedule/_cms_teasers.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= DotcomWeb.PartialView.render_teasers(@featured_content, @conn) %>
 
 <%= unless Enum.empty?(@news) do %>

--- a/lib/dotcom_web/templates/schedule/_date_picker.html.eex
+++ b/lib/dotcom_web/templates/schedule/_date_picker.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="col-sm-3 hidden-xs-down">
   <h4>Upcoming Holidays</h4>
   <ul class="holiday-list">

--- a/lib/dotcom_web/templates/schedule/_direction_select.html.heex
+++ b/lib/dotcom_web/templates/schedule/_direction_select.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if Routes.Route.direction_destination(@route, @direction_id) do %>
   <% has_opposite_direction? =
     Routes.Route.direction_destination(@route, 1 - @direction_id) != nil %>

--- a/lib/dotcom_web/templates/schedule/_empty.html.eex
+++ b/lib/dotcom_web/templates/schedule/_empty.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="callout schedule-empty">
   <%= no_trips_message(@error, @direction, @date) %>
   <%= if @date && @date != Util.service_date() && @direction do %>

--- a/lib/dotcom_web/templates/schedule/_hours_of_op.html.eex
+++ b/lib/dotcom_web/templates/schedule/_hours_of_op.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if (Map.get(assigns, :route).description != :rapid_transit) do %>
   <% # Rapid transit data is rendered in front-end so render nothing here %>
   <%= for {period, {direction_0, direction_1}} <- Map.get(assigns, :hours_of_operation, []) do %>

--- a/lib/dotcom_web/templates/schedule/_line.html.heex
+++ b/lib/dotcom_web/templates/schedule/_line.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% branchesEmpty? = Enum.empty?(@branches) %>
 <script
   data-for="schedule-page"

--- a/lib/dotcom_web/templates/schedule/_line_header.html.eex
+++ b/lib/dotcom_web/templates/schedule/_line_header.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="schedule__header <%= header_class(@route) %>">
   <div class="schedule__header-container">
     <h1 class="schedule__route-name notranslate"><%= route_header_text(@route) %></h1>

--- a/lib/dotcom_web/templates/schedule/_pdf_schedules.html.eex
+++ b/lib/dotcom_web/templates/schedule/_pdf_schedules.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   pdfs = case Map.get(assigns, :route_pdfs, []) do
     {:error, _} -> []

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 {DotcomWeb.AlertView.group(
   alerts: @banner_alerts,
   route: @route,

--- a/lib/dotcom_web/templates/schedule/_timetable_blocked.html.eex
+++ b/lib/dotcom_web/templates/schedule/_timetable_blocked.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="callout schedule-empty">
   The interactive timetable for <%= @formatted_date %> is temporarily unavailable due to a service change.
   <div>

--- a/lib/dotcom_web/templates/schedule/_timetable_icon_key.html.eex
+++ b/lib/dotcom_web/templates/schedule/_timetable_icon_key.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%
   mode_name = Routes.Route.vehicle_name(@route) |> String.downcase()
 

--- a/lib/dotcom_web/templates/schedule/_timetable_schedule.html.eex
+++ b/lib/dotcom_web/templates/schedule/_timetable_schedule.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if @trip_schedule do %>
   <span class="m-timetable__schedule">
     <span class="m-timetable__left-icons">

--- a/lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable_suppressed.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="callout schedule-empty">
   <div>
     <.link href="#pdf-schedules">

--- a/lib/dotcom_web/templates/schedule/_trip_view_filters.html.eex
+++ b/lib/dotcom_web/templates/schedule/_trip_view_filters.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="row page-section trip-filters">
   <div class="date-filter col-xs-12 col-sm-6 col-md-4">
     <%= link to: update_schedule_url(@conn, shift: nil, date_select: !@show_date_select? || nil) <> "#date-filter",

--- a/lib/dotcom_web/templates/schedule/show.html.eex
+++ b/lib/dotcom_web/templates/schedule/show.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= render "_line_header.html", assigns %>
 <div class="container">
   <div class="page-section schedule__<%= @tab %>-tab">

--- a/lib/dotcom_web/templates/search/empty_query.html.eex
+++ b/lib/dotcom_web/templates/search/empty_query.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="page-section empty-search-page">
   <div class="col-md-12"></div>
 </div>

--- a/lib/dotcom_web/templates/search/error.html.eex
+++ b/lib/dotcom_web/templates/search/error.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="page-section search-page">
   <div class="col-md-12">
     <strong>Whoops! An error occurred.</strong>

--- a/lib/dotcom_web/templates/search/index-nojs.html.eex
+++ b/lib/dotcom_web/templates/search/index-nojs.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="page-section search-page">
   <div class="search-results-facets col-md-3">
     <%= form_for @conn, search_path(@conn, :index), [as: :search, method: :get, data: [form: "search-filter"]],

--- a/lib/dotcom_web/templates/search/index.html.eex
+++ b/lib/dotcom_web/templates/search/index.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container">
   <div class="hidden-no-js">
     <div class="c-search__results-header">

--- a/lib/dotcom_web/templates/search/no_results.html.eex
+++ b/lib/dotcom_web/templates/search/no_results.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="page-section search-page">
   <div class="col-md-12">
     <strong>Sorry about that. There are no results matching &ldquo;<%= @query %>&rdquo;.</strong>

--- a/lib/dotcom_web/templates/stop/_detailed_stop.html.eex
+++ b/lib/dotcom_web/templates/stop/_detailed_stop.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <a class="btn button stop-btn m-detailed-stop" href="<%= stop_path(@conn, :show, @detailed_stop.stop.id) %>" data-name="<%= @detailed_stop.stop.name %>">
   <div class="m-detailed-stop__name js-stop__name notranslate"><%= @detailed_stop.stop.name %></div>
   <div class="stop-features-list m-detailed-stop__features">

--- a/lib/dotcom_web/templates/stop/_detailed_stop_list.html.eex
+++ b/lib/dotcom_web/templates/stop/_detailed_stop_list.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="button-group">
   <div class="m-detailed-stops">
     <%= for detailed_stop <- @detailed_stops do %>

--- a/lib/dotcom_web/templates/stop/_hub_stops.html.eex
+++ b/lib/dotcom_web/templates/stop/_hub_stops.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <%= if !Enum.empty?(@hubs) do %>
   <div class="hub-stop-list">
     <div class="row hub-stop-container">

--- a/lib/dotcom_web/templates/stop/_search_bar.html.heex
+++ b/lib/dotcom_web/templates/stop/_search_bar.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <.algolia_autocomplete
   id="stops-search"
   class="md:max-w-2xl mb-md"

--- a/lib/dotcom_web/templates/stop/index.html.eex
+++ b/lib/dotcom_web/templates/stop/index.html.eex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <% subway? = @mode == :subway%>
 <% h_level_route = if @mode == :commuter_rail, do: :h3, else: :h2 %>
 <div class="container">

--- a/lib/dotcom_web/templates/stop/show.html.heex
+++ b/lib/dotcom_web/templates/stop/show.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <link rel="stylesheet" {static_attributes("/css/map.css")} />
 
 <div class="u-bg--gray-bordered-background">

--- a/lib/dotcom_web/templates/vote/show.html.heex
+++ b/lib/dotcom_web/templates/vote/show.html.heex
@@ -1,3 +1,4 @@
+<% track_template() %>
 <div class="container m-sales-locations">
   <div class="col-md-8">
     <div class="limited-width">

--- a/lib/dotcom_web/translations.ex
+++ b/lib/dotcom_web/translations.ex
@@ -33,12 +33,8 @@ defmodule DotcomWeb.Translations do
     end)
   end
 
-  def state() do
-    Agent.get(__MODULE__, & &1)
-  end
-
   @doc """
-  Returns all templates rendered for the route.
+  Outputs all templates rendered for the route.
 
   Then, it resets the template list for that route.
   """

--- a/lib/dotcom_web/translations.ex
+++ b/lib/dotcom_web/translations.ex
@@ -46,6 +46,7 @@ defmodule DotcomWeb.Translations do
     Agent.get(__MODULE__, & &1)
     |> Map.get(route)
     |> Map.keys()
+    |> Enum.uniq()
     |> Enum.sort()
     |> Enum.each(&IO.puts(&1))
 

--- a/lib/dotcom_web/translations.ex
+++ b/lib/dotcom_web/translations.ex
@@ -23,8 +23,8 @@ defmodule DotcomWeb.Translations do
   Handles telemetry events and aggregates them by route.
   """
   def handle_event(_name, _measurements, metadata, _config) do
-    route = metadata.route |> IO.inspect(label: "route")
-    template = metadata.template |> IO.inspect(label: "template")
+    route = metadata.route
+    template = metadata.template
 
     Agent.update(__MODULE__, fn state ->
       Map.update(state, route, %{}, fn template_list ->

--- a/lib/dotcom_web/translations.ex
+++ b/lib/dotcom_web/translations.ex
@@ -9,12 +9,13 @@ defmodule DotcomWeb.Translations do
   Starts the Agent and attaches to `[:template, :translation]` telemetry events.
   """
   def start_link(initial_value \\ %{}) do
-    :telemetry.attach(
-      "template-translation",
-      [:template, :translation],
-      &__MODULE__.handle_event/4,
-      nil
-    )
+    _ =
+      :telemetry.attach(
+        "template-translation",
+        [:template, :translation],
+        &__MODULE__.handle_event/4,
+        nil
+      )
 
     Agent.start_link(fn -> initial_value end, name: __MODULE__)
   end

--- a/lib/dotcom_web/translations.ex
+++ b/lib/dotcom_web/translations.ex
@@ -1,0 +1,61 @@
+defmodule DotcomWeb.Translations do
+  @moduledoc """
+  This Agent tracks template usage per route.
+  """
+
+  use Agent
+
+  @doc """
+  Starts the Agent and attaches to `[:template, :translation]` telemetry events.
+  """
+  def start_link(initial_value \\ %{}) do
+    :telemetry.attach(
+      "template-translation",
+      [:template, :translation],
+      &__MODULE__.handle_event/4,
+      nil
+    )
+
+    Agent.start_link(fn -> initial_value end, name: __MODULE__)
+  end
+
+  @doc """
+  Handles telemetry events and aggregates them by route.
+  """
+  def handle_event(_name, _measurements, metadata, _config) do
+    route = metadata.route |> IO.inspect(label: "route")
+    template = metadata.template |> IO.inspect(label: "template")
+
+    Agent.update(__MODULE__, fn state ->
+      Map.update(state, route, %{}, fn template_list ->
+        Map.put(template_list, template, nil)
+      end)
+    end)
+  end
+
+  def state() do
+    Agent.get(__MODULE__, & &1)
+  end
+
+  @doc """
+  Returns all templates rendered for the route.
+
+  Then, it resets the template list for that route.
+  """
+  def templates(route) do
+    Agent.get(__MODULE__, & &1)
+    |> Map.get(route)
+    |> Map.keys()
+    |> Enum.sort()
+    |> Enum.each(&IO.puts(&1))
+
+    reset_route(route)
+  end
+
+  # Empty out the template list for a route.
+  defp reset_route(route) do
+    Agent.update(__MODULE__, fn state ->
+      Map.put(state, route, %{})
+    end)
+  end
+end

--- a/test/dotcom_web/views/helpers/pagination_helpers_test.exs
+++ b/test/dotcom_web/views/helpers/pagination_helpers_test.exs
@@ -47,8 +47,7 @@ defmodule DotcomWeb.PaginationHelpersTest do
         |> render(pagination: %Dotcom.ResponsivePagination{}, link_context: @link_context)
         |> Phoenix.HTML.safe_to_string()
 
-      expects = "\n"
-      assert actual == expects
+      assert actual =~ "\n"
     end
   end
 end


### PR DESCRIPTION
```
%> iex -S mix phx.server
```
```
%> curl http://localhost:4001
```
```
iex> DotcomWeb.Translations.templates("/")
```

This will only run in `dev`, so it should be fine to merge and deploy without affecting anything.

For posterity, this is the code that writes the tracker into each template file.

```elixir
defmodule TranslationTracker do
  @base_directory "lib/dotcom_web/templates"

  def write_all_trackers() do
    Enum.each(get_all_templates(), &write_tracker/1)
  end

  defp get_all_templates(reference \\ @base_directory) do
    if File.dir?(reference) do
      File.ls!(reference)
      |> Enum.map(&(reference <> "/" <> &1))
      |> Enum.map(&get_all_templates/1)
      |> List.flatten()
    else
      reference
    end
  end

  defp write_tracker(reference) do
    current_content = File.read!(reference)
    tracked_content = "<% track_template() %>\n"

    new_content = tracked_content <> current_content

    File.write!(reference, new_content)
  end
end
```