### PR TITLE
feat(Plugs.SetLocale): put locale in the session

### DIFF
--- a/lib/dotcom/locales.ex
+++ b/lib/dotcom/locales.ex
@@ -51,4 +51,18 @@ defmodule Dotcom.Locales do
   def locale?(code) do
     locale(code) != nil
   end
+
+  @doc """
+  Set the locale in the backend. Does nothing if given an unsupported locale.
+  """
+  @spec set_locale(String.t()) :: :ok
+  def set_locale(locale) do
+    if locale in locale_codes() do
+      _ = Gettext.put_locale(Dotcom.Gettext, locale)
+      _ = Cldr.put_locale(Dotcom.Cldr, locale)
+      Logger.metadata(locale: locale)
+    else
+      :ok
+    end
+  end
 end

--- a/lib/dotcom_web.ex
+++ b/lib/dotcom_web.ex
@@ -84,10 +84,21 @@ defmodule DotcomWeb do
   end
 
   def live_view do
-    quote do
-      use Phoenix.LiveView
+    # Since we're only testing translations right now, don't
+    # enable them in the live prod website yet.
+    if Application.get_env(:dotcom, :is_prod_env?) do
+      quote do
+        use Phoenix.LiveView
 
-      unquote(view_helpers())
+        unquote(view_helpers())
+      end
+    else
+      quote do
+        use Phoenix.LiveView
+        on_mount DotcomWeb.Hooks.RestoreLocale
+
+        unquote(view_helpers())
+      end
     end
   end
 

--- a/lib/dotcom_web/hooks/restore_locale.ex
+++ b/lib/dotcom_web/hooks/restore_locale.ex
@@ -1,0 +1,28 @@
+defmodule DotcomWeb.Hooks.RestoreLocale do
+  @moduledoc """
+  If the locale is specified in the params or already set in the session,
+  ensures that this locale is set in the LiveView process. Also assigns
+  `:locale` in the socket for convenience.
+  """
+
+  import Dotcom.Locales, only: [set_locale: 1]
+  import Phoenix.Component, only: [assign: 3]
+
+  # Using URL params
+  def on_mount(:default, %{"locale" => locale}, _session, socket) do
+    set_and_assign_locale(socket, locale)
+  end
+
+  # From session
+  def on_mount(:default, _params, %{"locale" => locale}, socket) do
+    set_and_assign_locale(socket, locale)
+  end
+
+  # catch-all case
+  def on_mount(:default, _params, _session, socket), do: {:cont, socket}
+
+  defp set_and_assign_locale(socket, locale) do
+    _ = set_locale(locale)
+    {:cont, assign(socket, :locale, locale)}
+  end
+end

--- a/lib/dotcom_web/plugs/set_locale.ex
+++ b/lib/dotcom_web/plugs/set_locale.ex
@@ -14,13 +14,19 @@ defmodule DotcomWeb.Plugs.SetLocale do
   If no locale is present, the default locale "en" is used.
   """
   def call(conn, _opts) do
-    conn = fetch_session(conn)
-    locale = get_locale(conn)
-    _ = set_locale(locale)
+    # Since we're only testing this out right now, don't
+    # enable this in the live prod website yet.
+    if Application.get_env(:dotcom, :is_prod_env?) do
+      conn
+    else
+      conn = fetch_session(conn)
+      locale = get_locale(conn)
+      _ = set_locale(locale)
 
-    conn
-    |> put_session("locale", locale)
-    |> put_resp_cookie("locale", locale, max_age: 365 * 24 * 60 * 60)
+      conn
+      |> put_session("locale", locale)
+      |> put_resp_cookie("locale", locale, max_age: 365 * 24 * 60 * 60)
+    end
   end
 
   # Check params, then session, then cookie, and use the default if none are present or supported.

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -41,6 +41,7 @@ defmodule DotcomWeb.Router do
     plug(DotcomWeb.Plugs.DateTime)
     plug(DotcomWeb.Plugs.RewriteUrls)
     plug(DotcomWeb.Plugs.SecureHeaders)
+    plug(DotcomWeb.Plugs.SetLocale)
     plug(:optional_disable_indexing)
   end
 
@@ -59,19 +60,6 @@ defmodule DotcomWeb.Router do
 
   pipeline :cached_daily do
     plug(DotcomWeb.Plugs.CacheControl, max_age: 86_400)
-  end
-
-  # This controller allows us to test out new features locally.
-  if Mix.env() === :dev do
-    pipeline :test do
-      plug(DotcomWeb.Plugs.SetLocale)
-    end
-
-    scope "/", DotcomWeb do
-      pipe_through([:test])
-
-      get("/_test", TestController, :index)
-    end
   end
 
   scope "/", DotcomWeb do

--- a/test/dotcom_web/hooks/restore_locale_test.exs
+++ b/test/dotcom_web/hooks/restore_locale_test.exs
@@ -1,0 +1,28 @@
+defmodule DotcomWeb.Hooks.RestoreLocaleTest do
+  use ExUnit.Case, async: true
+
+  alias Dotcom.Locales
+  alias DotcomWeb.Hooks.RestoreLocale
+
+  describe "on_mount" do
+    test "sets locale from session" do
+      locale = Locales.locale_codes() |> Enum.random()
+
+      {:cont, new_socket} =
+        RestoreLocale.on_mount(:default, nil, %{"locale" => locale}, %Phoenix.LiveView.Socket{})
+
+      assert new_socket.assigns.locale == locale
+      assert Gettext.get_locale(Dotcom.Gettext) == locale
+    end
+
+    test "sets locale from params" do
+      locale = Locales.locale_codes() |> Enum.random()
+
+      {:cont, new_socket} =
+        RestoreLocale.on_mount(:default, %{"locale" => locale}, %{}, %Phoenix.LiveView.Socket{})
+
+      assert new_socket.assigns.locale == locale
+      assert Gettext.get_locale(Dotcom.Gettext) == locale
+    end
+  end
+end

--- a/test/dotcom_web/plugs/set_locale_test.exs
+++ b/test/dotcom_web/plugs/set_locale_test.exs
@@ -35,6 +35,17 @@ defmodule DotcomWeb.Plugs.SetLocaleTest do
     assert Gettext.get_locale(Dotcom.Gettext) == locale
   end
 
+  test "a conn with a session locale sets the locale", %{conn: conn} do
+    locale = Locales.locale_codes() |> Enum.random()
+    conn = fetch_session(conn)
+
+    conn
+    |> put_session("locale", locale)
+    |> call(%{})
+
+    assert Gettext.get_locale(Dotcom.Gettext) == locale
+  end
+
   test "a conn with an unsupported locale uses the default locale", %{conn: conn} do
     conn |> Map.put(:cookies, %{"locale" => "zz"}) |> call(%{})
 


### PR DESCRIPTION
This enables easy retrieval of the locale for LiveViews. If there were a more straightforward way of reading the longer-lasting cookie into the LiveView I probably wouldn't bother with the session, but it works ✨ .

- Extracted the function for setting a locale into `Dotcom.Locales`
- Used `on_mount` to read the locale in all live views, and set it
- Restructured such that setting/using the locale should be disabled on the live prod website, and enabled everywhere else (including the staging environments).