### PR TITLE
fix(LocationService): actually handle long text

### DIFF
--- a/lib/location_service/location_service.ex
+++ b/lib/location_service/location_service.ex
@@ -28,7 +28,7 @@ defmodule LocationService do
   @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
   def autocomplete(text, limit, options \\ @bias_options)
 
-  def autocomplete(text, _, _) when length(text) > 200, do: {:error, :invalid_arguments}
+  def autocomplete(text, _, _) when byte_size(text) > 200, do: {:ok, []}
 
   def autocomplete(text, limit, options) do
     options

--- a/test/location_service/location_service_test.exs
+++ b/test/location_service/location_service_test.exs
@@ -92,10 +92,14 @@ defmodule LocationServiceTest do
       assert {:error, :internal_error} = autocomplete(text, 2)
     end
 
-    test "rejects long text" do
+    test "does nothing with excessively long text" do
       deny(AwsClient.Mock, :search_place_index_for_suggestions, 2)
-      long_text = Faker.Lorem.characters(201..1000)
-      assert {:error, :invalid_arguments} = autocomplete(long_text, 2)
+
+      long_text =
+        Faker.random_between(201, 1000)
+        |> Faker.String.base64()
+
+      assert {:ok, []} = autocomplete(long_text, 2)
     end
   end
 end


### PR DESCRIPTION
:( I failed at fixing https://app.asana.com/1/15492006741476/project/1204352509486278/task/1210649423464213?focus=true and this PR should actually fix it so it no longer errors when someone pastes way too much text (beyond the limit which AWS Location Service accepts) into the trip planner location inputs. I decided it to make it do "nothing" (return an empty list).