### PR TITLE
fix(ScheduleController): 404 /route/*path fallback

### DIFF
--- a/lib/dotcom_web/controllers/schedule_controller.ex
+++ b/lib/dotcom_web/controllers/schedule_controller.ex
@@ -112,6 +112,10 @@ defmodule DotcomWeb.ScheduleController do
     conn |> redirect(to: schedule_path) |> halt
   end
 
+  def route_redirect(conn, _) do
+    render_404(conn)
+  end
+
   def cape_flyer(conn, _params) do
     redirect(conn, external: "https://capeflyer.com")
   end


### PR DESCRIPTION
Going to `/route/66/schedules/66` or such now 404s instead of erroring.

#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | Sentry Error | Phoenix.ActionClauseError: no function clause matching in DotcomWeb.ScheduleController.route_redirect/2](https://app.asana.com/1/15492006741476/project/385363666817452/task/1210645218695509?focus=true)
https://mbtace.sentry.io/issues/6660236623/