### PR TITLE
cleanup: Don't mock pure `DateTime` functions

### DIFF
--- a/lib/dotcom/utils/date_time.ex
+++ b/lib/dotcom/utils/date_time.ex
@@ -68,7 +68,10 @@ defmodule Dotcom.Utils.DateTime do
   @doc """
   Given a date_time_range and a date_time, returns true if the date_time is within the date_time_range.
   """
-  @impl Behaviour
+  @spec in_range?(
+          Dotcom.Utils.DateTime.date_time_range(),
+          DateTime.t()
+        ) :: boolean
   def in_range?({nil, nil}, _), do: false
 
   def in_range?({nil, %DateTime{} = stop}, %DateTime{} = date_time) do

--- a/lib/dotcom/utils/date_time.ex
+++ b/lib/dotcom/utils/date_time.ex
@@ -48,8 +48,12 @@ defmodule Dotcom.Utils.DateTime do
 
   If we are given something tha tis not a DateTime, AmbiguousDateTime, or an error tuple, we log the input and return `now`.
   """
-  @impl Behaviour
-  def coerce_ambiguous_date_time(%DateTime{} = date_time), do: date_time
+  @spec coerce_ambiguous_date_time(
+          DateTime.t()
+          | Timex.AmbiguousDateTime.t()
+          | {:error, term()}
+        ) :: DateTime.t()
+  def(coerce_ambiguous_date_time(%DateTime{} = date_time), do: date_time)
   def coerce_ambiguous_date_time(%Timex.AmbiguousDateTime{after: later}), do: later
 
   def coerce_ambiguous_date_time({:error, {_, @timezone, seconds_from_zeroyear, _}}) do

--- a/lib/dotcom/utils/date_time/behaviour.ex
+++ b/lib/dotcom/utils/date_time/behaviour.ex
@@ -6,9 +6,4 @@ defmodule Dotcom.Utils.DateTime.Behaviour do
   @callback now() :: DateTime.t()
 
   @callback today() :: Date.t()
-
-  @callback in_range?(
-              Dotcom.Utils.DateTime.date_time_range(),
-              DateTime.t()
-            ) :: boolean
 end

--- a/lib/dotcom/utils/date_time/behaviour.ex
+++ b/lib/dotcom/utils/date_time/behaviour.ex
@@ -7,13 +7,6 @@ defmodule Dotcom.Utils.DateTime.Behaviour do
 
   @callback today() :: Date.t()
 
-  @callback coerce_ambiguous_date_time(
-              DateTime.t()
-              | Timex.AmbiguousDateTime.t()
-              | {:error, term()}
-            ) ::
-              DateTime.t()
-
   @callback in_range?(
               Dotcom.Utils.DateTime.date_time_range(),
               DateTime.t()

--- a/lib/dotcom/utils/service_date_time.ex
+++ b/lib/dotcom/utils/service_date_time.ex
@@ -19,7 +19,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
 
   alias Dotcom.Utils
 
-  import Dotcom.Utils.DateTime, only: [coerce_ambiguous_date_time: 1]
+  import Dotcom.Utils.DateTime, only: [coerce_ambiguous_date_time: 1, in_range?: 2]
 
   @type named_service_range() ::
           :before_today | :today | :this_week | :next_week | :after_next_week
@@ -199,7 +199,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
   """
   @spec service_today?(DateTime.t()) :: boolean
   def service_today?(date_time) do
-    service_range_day() |> @date_time_module.in_range?(date_time)
+    service_range_day() |> in_range?(date_time)
   end
 
   @doc """
@@ -207,7 +207,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
   """
   @spec service_this_week?(DateTime.t()) :: boolean
   def service_this_week?(date_time) do
-    service_range_this_week() |> @date_time_module.in_range?(date_time)
+    service_range_this_week() |> in_range?(date_time)
   end
 
   @doc """
@@ -215,7 +215,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
   """
   @spec service_next_week?(DateTime.t()) :: boolean
   def service_next_week?(date_time) do
-    service_range_next_week() |> @date_time_module.in_range?(date_time)
+    service_range_next_week() |> in_range?(date_time)
   end
 
   @doc """
@@ -223,7 +223,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
   """
   @spec service_after_next_week?(DateTime.t()) :: boolean
   def service_after_next_week?(date_time) do
-    service_range_after_next_week() |> @date_time_module.in_range?(date_time)
+    service_range_after_next_week() |> in_range?((date_time))
   end
 
   @doc """

--- a/lib/dotcom/utils/service_date_time.ex
+++ b/lib/dotcom/utils/service_date_time.ex
@@ -19,6 +19,8 @@ defmodule Dotcom.Utils.ServiceDateTime do
 
   alias Dotcom.Utils
 
+  import Dotcom.Utils.DateTime, only: [coerce_ambiguous_date_time: 1]
+
   @type named_service_range() ::
           :before_today | :today | :this_week | :next_week | :after_next_week
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
@@ -45,7 +47,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
   def service_date(date_time \\ @date_time_module.now()) do
     if date_time.hour < @service_rollover_time.hour do
       Timex.shift(date_time, hours: -@service_rollover_time.hour)
-      |> @date_time_module.coerce_ambiguous_date_time()
+      |> coerce_ambiguous_date_time()
       |> Timex.to_date()
     else
       Timex.to_date(date_time)
@@ -95,7 +97,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
     datetime
     |> end_of_service_day()
     |> Timex.shift(microseconds: 1)
-    |> @date_time_module.coerce_ambiguous_date_time()
+    |> coerce_ambiguous_date_time()
   end
 
   @doc """
@@ -107,7 +109,7 @@ defmodule Dotcom.Utils.ServiceDateTime do
     date_time
     |> service_date()
     |> Timex.to_datetime(@timezone)
-    |> @date_time_module.coerce_ambiguous_date_time()
+    |> coerce_ambiguous_date_time()
     |> Map.put(:hour, @service_rollover_time.hour)
   end
 
@@ -120,9 +122,9 @@ defmodule Dotcom.Utils.ServiceDateTime do
     date_time
     |> service_date()
     |> Timex.to_datetime(@timezone)
-    |> @date_time_module.coerce_ambiguous_date_time()
+    |> coerce_ambiguous_date_time()
     |> Timex.shift(days: 1, hours: @service_rollover_time.hour, microseconds: -1)
-    |> @date_time_module.coerce_ambiguous_date_time()
+    |> coerce_ambiguous_date_time()
     |> Map.put(:hour, @service_rollover_time.hour - 1)
   end
 

--- a/test/dotcom/alerts/group_test.exs
+++ b/test/dotcom/alerts/group_test.exs
@@ -13,10 +13,6 @@ defmodule Dotcom.Alerts.GroupTest do
   setup :verify_on_exit!
 
   setup do
-    stub(Dotcom.Utils.DateTime.Mock, :coerce_ambiguous_date_time, fn date_time ->
-      Dotcom.Utils.DateTime.coerce_ambiguous_date_time(date_time)
-    end)
-
     stub(Dotcom.Utils.DateTime.Mock, :now, fn ->
       Dotcom.Utils.DateTime.now()
     end)

--- a/test/dotcom/alerts_test.exs
+++ b/test/dotcom/alerts_test.exs
@@ -12,10 +12,6 @@ defmodule Dotcom.AlertsTest do
   setup :verify_on_exit!
 
   setup do
-    stub(Dotcom.Utils.DateTime.Mock, :coerce_ambiguous_date_time, fn date_time ->
-      Dotcom.Utils.DateTime.coerce_ambiguous_date_time(date_time)
-    end)
-
     stub(Dotcom.Utils.DateTime.Mock, :now, fn ->
       Dotcom.Utils.DateTime.now()
     end)

--- a/test/dotcom_web/live/trip_planner_test.exs
+++ b/test/dotcom_web/live/trip_planner_test.exs
@@ -15,10 +15,6 @@ defmodule DotcomWeb.Live.TripPlannerTest do
       Dotcom.Utils.ServiceDateTime.service_date() |> Timex.shift(days: 30)
     end)
 
-    stub(Dotcom.Utils.DateTime.Mock, :coerce_ambiguous_date_time, fn date_time ->
-      Dotcom.Utils.DateTime.coerce_ambiguous_date_time(date_time)
-    end)
-
     stub(Dotcom.Utils.DateTime.Mock, :now, fn ->
       Dotcom.Utils.DateTime.now()
     end)

--- a/test/support/generators/date_time.ex
+++ b/test/support/generators/date_time.ex
@@ -3,6 +3,8 @@ defmodule Test.Support.Generators.DateTime do
   Factories to help generate/evaluate date_times for testing.
   """
 
+  import Dotcom.Utils.DateTime, only: [coerce_ambiguous_date_time: 1]
+
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
   @timezone Application.compile_env!(:dotcom, :timezone)
 
@@ -11,9 +13,10 @@ defmodule Test.Support.Generators.DateTime do
     now = @date_time_module.now()
 
     beginning_of_time =
-      Timex.shift(now, years: -10) |> @date_time_module.coerce_ambiguous_date_time()
+      Timex.shift(now, years: -10) |> coerce_ambiguous_date_time()
 
-    end_of_time = Timex.shift(now, years: 10) |> @date_time_module.coerce_ambiguous_date_time()
+    end_of_time =
+      Timex.shift(now, years: 10) |> coerce_ambiguous_date_time()
 
     time_range_date_time_generator({beginning_of_time, end_of_time})
   end
@@ -40,12 +43,12 @@ defmodule Test.Support.Generators.DateTime do
 
   @doc "Generate a random date_time between the beginning and end of the time range."
   def time_range_date_time_generator({start, nil}) do
-    stop = Timex.shift(start, years: 10) |> @date_time_module.coerce_ambiguous_date_time()
+    stop = Timex.shift(start, years: 10) |> coerce_ambiguous_date_time()
     time_range_date_time_generator({start, stop})
   end
 
   def time_range_date_time_generator({nil, stop}) do
-    start = Timex.shift(stop, years: -10) |> @date_time_module.coerce_ambiguous_date_time()
+    start = Timex.shift(stop, years: -10) |> coerce_ambiguous_date_time()
     time_range_date_time_generator({start, stop})
   end
 
@@ -53,7 +56,7 @@ defmodule Test.Support.Generators.DateTime do
     StreamData.repeatedly(fn ->
       Faker.DateTime.between(start, stop)
       |> Timex.to_datetime(@timezone)
-      |> @date_time_module.coerce_ambiguous_date_time()
+      |> coerce_ambiguous_date_time()
     end)
   end
 end


### PR DESCRIPTION
I noticed that every time `coerce_ambiguous_date_time` appears in the call path, that requires a stub like
```elixir
stub(Dotcom.Utils.DateTime.Mock, :coerce_ambiguous_date_time, fn date_time ->
  Dotcom.Utils.DateTime.coerce_ambiguous_date_time(date_time)
end)
```

...which is just noise - `coerce_ambiguous_date_time` is a pure function, and there's no need to stub it to its own implementation.

This removes them from the behavior and just sets them up as pure functions, so that we don't need to stub them in seemingly random tests.