### PR TITLE
Fix small translation issues

### DIFF
--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -67,19 +67,11 @@
   <%= content_tag(:body, class: Dotcom.BodyTag.class_name(@conn)) do %>
     <div class="body-wrapper" id="body-wrapper">
       <%= if !Application.get_env(:dotcom, :is_prod_env?) && Gettext.get_locale(Dotcom.Gettext) != "en" do %>
-        <% completion_percent = Mix.Tasks.Gettext.Translate.completion_percent() %>
-        <% completion_ratio = Mix.Tasks.Gettext.Translate.completion_ratio() %>
         <% language =
           Dotcom.Gettext |> Gettext.get_locale() |> Dotcom.Locales.locale() |> Map.get(:endonym) %>
         <div class="w-full bg-cobalt-80 py-2 text-center text-cobalt-50">
           <i class="fa fa-globe"></i>
-          You are viewing <em>{Map.get(@conn, :host)}</em>
-          in <strong>{language}</strong>.
-          We have translated {Kernel.elem(completion_ratio, 0)} out of {Kernel.elem(
-            completion_ratio,
-            1
-          )} templates.
-          We are {completion_percent}% finished.
+          You are viewing <em>{Map.get(@conn, :host)}</em> in <strong>{language}</strong>.
         </div>
       <% end %>
       <a href="#main" class="sr-only sr-only-focusable">{~t(Skip to main content)}</a>

--- a/lib/mix/tasks/gettext/merge.ex
+++ b/lib/mix/tasks/gettext/merge.ex
@@ -1,0 +1,17 @@
+defmodule Mix.Tasks.Gettext.Merge do
+  @moduledoc """
+  We don't want to run the Gettext merge task.
+  Use `mix gettext.translate` instead.
+  """
+
+  @shortdoc "Do not run this task. Use `mix gettext.translate` instead"
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_) do
+    IO.puts("Do not use this task. Use `mix gettext.translate` instead")
+
+    :ok
+  end
+end

--- a/lib/mix/tasks/gettext/translate.ex
+++ b/lib/mix/tasks/gettext/translate.ex
@@ -1,40 +1,3 @@
-defmodule Mix.Tasks.GetText.Translate.Progress do
-  @moduledoc """
-  A support module for tracking progress of our translation efforts.
-  """
-
-  import Dotcom.Utils.File, only: [list_all_files: 1]
-
-  @directory "lib/dotcom_web/templates"
-
-  def completion_ratio() do
-    all_templates = list_all_templates()
-    all_templates_count = Kernel.length(all_templates)
-
-    translated_templates =
-      all_templates
-      |> Enum.filter(&translated?/1)
-
-    translated_templates_count = Kernel.length(translated_templates)
-
-    {translated_templates_count, all_templates_count}
-  end
-
-  defp list_all_templates() do
-    @directory
-    |> list_all_files()
-    |> Enum.filter(fn ref -> String.match?(ref, ~r/eex$/) end)
-  end
-
-  defp translated?(reference) do
-    try do
-      not (File.read!(reference) =~ "<% track_template() %>")
-    rescue
-      _ -> false
-    end
-  end
-end
-
 defmodule Mix.Tasks.GetText.Translate.CustomTerminologies do
   @moduledoc """
   A support module for the task that lets us combine custom terminologies.
@@ -92,9 +55,6 @@ defmodule Mix.Tasks.Gettext.Translate do
   import Dotcom.Locales, only: [default_locale_code: 0, locale_codes: 0]
   import Mix.Tasks.GetText.Translate.CustomTerminologies, only: [get_terminologies: 0]
 
-  alias Mix.Tasks.GetText.Translate.Progress
-
-  @completion_ratio Progress.completion_ratio()
   @custom_terminologies get_terminologies()
   @directory "priv/gettext"
   @url "http://localhost:9999/translate"
@@ -103,7 +63,7 @@ defmodule Mix.Tasks.Gettext.Translate do
   # Translate the `.pot` file(s) into the given locales.
   # E.g., `mix gettext.translate --locales es,fr`
   def run(["--locales", locales]) do
-    :ok = Mix.Tasks.Gettext.Extract.run([])
+    Mix.Shell.cmd("mix gettext.extract", fn _ -> nil end)
 
     _ = Finch.start_link(name: TranslateFinch)
 
@@ -117,31 +77,12 @@ defmodule Mix.Tasks.Gettext.Translate do
 
   # Translate all non-default locales.
   def run([]) do
-    :ok = Mix.Tasks.Gettext.Extract.run([])
+    Mix.Shell.cmd("mix gettext.extract", fn _ -> nil end)
 
     _ = Finch.start_link(name: TranslateFinch)
 
     (locale_codes() -- [default_locale_code()]) |> translate()
   end
-
-  @doc """
-  The completion ratio expressed as a percent of completion.
-  """
-  def completion_percent() do
-    translated = Kernel.elem(@completion_ratio, 0)
-    total = Kernel.elem(@completion_ratio, 1)
-
-    if total < 1 do
-      0.0
-    else
-      (translated / total * 100) |> Float.round(1)
-    end
-  end
-
-  @doc """
-  The ratio of translated templates to all templates.
-  """
-  def completion_ratio(), do: @completion_ratio
 
   # Translate the given locales.
   defp translate(locales) when is_list(locales) do
@@ -150,9 +91,6 @@ defmodule Mix.Tasks.Gettext.Translate do
 
   # Translate a single locale.
   defp translate(locale) when is_binary(locale) do
-    IO.puts("Translating #{Kernel.elem(@completion_ratio, 0)} template files.")
-    IO.puts("We are #{completion_percent()}% done.")
-
     Enum.each(domains(), fn domain ->
       write_domain_translations(domain, locale)
     end)
@@ -169,8 +107,11 @@ defmodule Mix.Tasks.Gettext.Translate do
   end
 
   # Gets the content of msgid of a `.pot` file.
+  # Replaces " with ' so that the output doesn't break.
   defp domain_line(line) do
-    Regex.scan(~r/(?<=\")(.*?)(?=\")/, line)
+    text = String.replace(line, ~r/\\\"/, "'")
+
+    Regex.scan(~r/(?<=\")(.*?)(?=\")/, text)
     |> List.flatten()
     |> List.first()
   end

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -224,7 +224,7 @@ msgstr ""
 msgid "Send Us Feedback"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/root.html.heex:85
+#: lib/dotcom_web/templates/layout/root.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Skip to main content"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -16,7 +16,7 @@ msgid "Toll Free"
 msgstr "Toll Gratis"
 
 msgid "MBTA riders can purchase CharlieTickets and reload and purchase CharlieCards for the bus, subway, Commuter Rail, and ferry in retailers throughout the Greater Boston and Providence areas."
-msgstr "Los pilotos de MBTA pueden comprar CharlieTickets y recargar y comprar CharlieCards para el autobús, metro, Commuter Rail y ferry en minoristas por toda la zona de Greater Boston y Providence."
+msgstr "MBTA ciclistas pueden comprar CharlieTickets y recargar y comprar CharlieCards para el autobús, metro, Commuter Rail y ferry en minoristas por todas las zonas de Greater Boston y Providence."
 
 msgid "Friday"
 msgstr "Viernes"
@@ -175,7 +175,7 @@ msgid "More Guides"
 msgstr "Más Guías"
 
 msgid "Monthly Pass on mTicket App"
-msgstr "Paso mensual en mTicket App"
+msgstr "Pase mensual mTicket App"
 
 msgid "Stations and Parking"
 msgstr "Estaciones y estacionamiento"
@@ -673,7 +673,7 @@ msgid "Engineering Design Standards"
 msgstr "Normas de diseño de ingeniería"
 
 msgid "Senior CharlieCard or TAP ID"
-msgstr "Senior CharlieCard o TAP ID"
+msgstr "Senior CharlieCard or TAP ID"
 
 msgid "News"
 msgstr "Noticias"
@@ -832,7 +832,7 @@ msgid "Emergency Contacts"
 msgstr "Contactos de emergencia"
 
 msgid "We're expanding our network of places where riders can get or load a CharlieCard and purchase passes."
-msgstr "Estamos ampliando nuestra red de lugares donde los jinetes pueden conseguir o cargar un CharlieCard y pases de compra."
+msgstr "Estamos ampliando nuestra red de lugares donde los jinetes pueden obtener o cargar un CharlieCard y pases de compra."
 
 msgid "View PDF Timetable"
 msgstr "Ver PDF Calendario"


### PR DESCRIPTION
Fixes three issues. One, html tags were creating breaking translations. I fixed that by doing a first pass to change all double quotes to single quotes. Two, we were still reporting completion ratio of template translation based on the tracking tag. We are done translating templates and the tag has been repurposed. So, I just removed all of that code. Three, we don't want to run the gettext merge command. So, I wrote a module with the same name that tells you to use the translate task.