### PR TITLE
Change press release to media relations

### DIFF
--- a/lib/dotcom_web/templates/layout/_footer.html.heex
+++ b/lib/dotcom_web/templates/layout/_footer.html.heex
@@ -57,8 +57,8 @@
               data: [scroll: true],
               class: "m-footer__link"
             )}
-            {link(~t(Press Releases),
-              to: cms_static_page_path(@conn, "/news"),
+            {link(~t(Media Relations),
+              to: cms_static_page_path(@conn, "/about/media-relations"),
               data: [scroll: true],
               class: "m-footer__link"
             )}

--- a/lib/dotcom_web/views/layout_view.ex
+++ b/lib/dotcom_web/views/layout_view.ex
@@ -151,7 +151,7 @@ defmodule DotcomWeb.LayoutView do
               {"History", "/history", :internal_link},
               {"Financials", "/financials", :internal_link},
               {"Public Meetings", "/events", :internal_link},
-              {"Press Releases", "/news", :internal_link},
+              {"Media Relations", "/about/media-relations", :internal_link},
               {"MBTA Gift Shop", "https://www.mbtagifts.com", :external_link},
               {"Policies & Civil Rights", "/policies", :internal_link},
               {"Safety", "/safety", :internal_link},

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -192,7 +192,6 @@ msgstr ""
 msgid "Policies & Civil Rights"
 msgstr ""
 
-#: lib/dotcom_web/templates/layout/_footer.html.heex:60
 #: lib/dotcom_web/templates/page/_news_and_updates.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Press Releases"
@@ -2062,4 +2061,9 @@ msgstr ""
 #: lib/util/and_or.ex:19
 #, elixir-autogen, elixir-format
 msgid "or"
+msgstr ""
+
+#: lib/dotcom_web/templates/layout/_footer.html.heex:60
+#, elixir-autogen, elixir-format
+msgid "Media Relations"
 msgstr ""


### PR DESCRIPTION
Changes links from Press Releases to Media Relations in the header and footer.