### PR TITLE
remove unnecessary fetching of route pdfs

### DIFF
--- a/lib/cms/repo.ex
+++ b/lib/cms/repo.ex
@@ -176,46 +176,6 @@ defmodule CMS.Repo do
     end
   end
 
-  @spec get_route_pdfs(Route.id_t()) :: [RoutePdf.t()]
-  def get_route_pdfs(route_id) do
-    case do_get_route_pdfs(route_id) do
-      {:ok, pdfs} ->
-        pdfs
-
-      error ->
-        _ =
-          Logger.warning(fn ->
-            "Error getting pdfs for route #{route_id}. Using default []. Error: #{inspect(error)}"
-          end)
-
-        []
-    end
-  end
-
-  @decorate cacheable(
-              cache: @cache,
-              key: "cms.repo|route-pdfs|#{String.downcase(route_id)}",
-              on_error: :nothing,
-              opts: [ttl: @ttl]
-            )
-  defp do_get_route_pdfs(route_id) do
-    case @cms_api.view("/cms/route-pdfs/#{route_id}", []) do
-      {:ok, []} ->
-        {:ok, []}
-
-      {:ok, [api_data | _]} ->
-        pdfs =
-          api_data
-          |> Map.get("field_pdfs")
-          |> Enum.map(&RoutePdf.from_api/1)
-
-        {:ok, pdfs}
-
-      error ->
-        error
-    end
-  end
-
   # BEGIN PAGE CACHING #
 
   @behaviour Nebulex.Caching.KeyGenerator

--- a/lib/dotcom/route_pdfs.ex
+++ b/lib/dotcom/route_pdfs.ex
@@ -8,8 +8,7 @@ defmodule Dotcom.RoutePdfs do
   @spec fetch_and_choose_pdfs(String.t(), Date.t()) :: [RoutePdf.t()]
   def fetch_and_choose_pdfs(route_id, date) do
     route_id
-    |> Repo.get_route_pdfs()
-    |> Enum.concat(Repo.get_schedule_pdfs(route_id))
+    |> Repo.get_schedule_pdfs()
     |> choose_pdfs(date)
   end
 

--- a/test/dotcom_web/controllers/schedule/pdf_test.exs
+++ b/test/dotcom_web/controllers/schedule/pdf_test.exs
@@ -4,16 +4,14 @@ defmodule DotcomWeb.ScheduleController.PdfTest do
   import Test.Support.EnvHelpers, only: [reassign_env: 3]
 
   describe "pdf/2" do
-    test "redirects to PDF for route when present", %{conn: conn} do
+    test "redirects to a PDF for route when present", %{conn: conn} do
       reassign_env(:dotcom, :is_prod_env?, true)
-
-      expected_path = "/sites/default/files/route_pdfs/route087.pdf"
 
       conn =
         conn
         |> get(route_pdf_path(conn, :pdf, "87"), date: Date.to_iso8601(~D[2018-01-01]))
 
-      assert redirected_to(conn, 302) == expected_path
+      assert redirected_to(conn, 302) =~ ".pdf"
     end
 
     test "renders 404 if we have no pdfs for the route", %{conn: conn} do


### PR DESCRIPTION
I just noticed while looking at cache values that all of these PDFs were outdated. Turns out, we don't even use them; we filter them all out. This removes the code that loads them.