### PR TITLE
Fixes docker compose

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
     nginx:
         image: nginx:stable-alpine3.17-slim
@@ -38,7 +37,7 @@ services:
             - PORT=4002
             - REDIS_HOST=10.0.0.11
             - REDIS_PORT=6379
-            - SNAME=dotcom1
+            - NAME=dotcom@10.0.0.2
             - WEBPACK_PORT=8092
         expose:
             - 4002
@@ -75,7 +74,7 @@ services:
             - PORT=4003
             - REDIS_HOST=10.0.0.11
             - REDIS_PORT=6379
-            - SNAME=dotcom2
+            - NAME=dotcom@10.0.0.3
             - WEBPACK_PORT=8093
         expose:
             - 4003
@@ -96,6 +95,32 @@ services:
         networks:
             dotcom_network:
                 ipv4_address: 10.0.0.3
+    libretranslate:
+        image: libretranslate/libretranslate
+        environment:
+            - LOAD_ONLY="en,es"
+        ports:
+            - 9999:5000
+        healthcheck:
+            test: curl --fail http://localhost:5000/languages || exit 1
+            interval: 10s
+            retries: 5
+            start_period: 15s
+            timeout: 10s
+        networks:
+            dotcom_network:
+                ipv4_address: 10.0.0.4
+    livebook:
+        image: ghcr.io/livebook-dev/livebook:nightly
+        environment:
+            - LIVEBOOK_DEFAULT_RUNTIME=attached:dotcom@10.0.0.2:foobarbaz
+            - LIVEBOOK_PASSWORD=foobarbazfoobarbaz
+        ports:
+            - 8080:8080
+            - 8081:8081
+        networks:
+            dotcom_network:
+                ipv4_address: 10.0.0.5
     monitor:
         build:
             context: ../
@@ -109,7 +134,7 @@ services:
         command: node /home/runner/integration/monitor/all-health-checks.js
         networks:
             dotcom_network:
-                ipv4_address: 10.0.0.4
+                ipv4_address: 10.0.0.6
     redis-cluster-init:
         image: redis:7.2.4
         command: redis-cli --cluster create 10.0.0.11:6379 10.0.0.12:6379 10.0.0.13:6379 10.0.0.14:6379 10.0.0.15:6379 10.0.0.16:6379 --cluster-replicas 1 --cluster-yes

--- a/deploy/dotcom/dev/Dockerfile
+++ b/deploy/dotcom/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.18.3-erlang-27.3.3-debian-buster-20240612-slim
+FROM hexpm/elixir:1.18.4-erlang-27.3.4.2-debian-bullseye-20250811
 
 RUN apt-get update && apt-get install -y curl git make build-essential inotify-tools
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
@@ -12,6 +12,8 @@ COPY package.json .
 COPY assets/package.json ./assets/package.json
 COPY assets/package-lock.json ./assets/package-lock.json
 
+RUN touch /tmp/.functions
+
 RUN mix local.hex --force
 RUN mix local.rebar --force
 
@@ -19,4 +21,4 @@ RUN mix deps.get
 RUN mix deps.compile
 RUN npm install --prefix assets --omit=optional --audit false --fund false --loglevel verbose --ignore-scripts
 
-CMD mix deps.get && elixir --sname $SNAME --cookie foobarbaz -S mix phx.server
+CMD mix mbta_metro.update_assets && elixir --name $NAME --cookie foobarbaz -S mix phx.server


### PR DESCRIPTION
Buster was no longer supported so I upgraded the dev environment. I also added livebook and libretranslate into the docker compose. Livebook automatically connects to the first dotcom node.