### PR TITLE
fix: include host in static URL

### DIFF
--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -23,7 +23,7 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
         www.googletagmanager.com
       ],
     default_src: ~w['self'],
-    font_src: ~w['self'],
+    font_src: ~w['self' cdn.mbta.com],
     frame_src: ~w[
         'self'
         *.arcgis.com
@@ -59,6 +59,7 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
         'unsafe-eval'
         *.arcgis.com
         *.tableau.com
+        cdn.mbta.com
         connect.facebook.net
         data.mbta.com
         edge.fullstory.com
@@ -73,6 +74,7 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
     style_src: ~w[
         'self'
         'unsafe-inline'
+        cdn.mbta.com
         www.gstatic.com
       ],
     worker_src: ~w[blob: ;]

--- a/lib/dotcom_web/views/helpers.ex
+++ b/lib/dotcom_web/views/helpers.ex
@@ -581,12 +581,13 @@ defmodule DotcomWeb.ViewHelpers do
   @spec static_attributes(String.t()) :: map()
   def static_attributes(path) do
     {static_path, static_integrity} = DotcomWeb.Endpoint.static_lookup(path)
+    static_url = DotcomWeb.Endpoint.static_url() <> static_path
     href_or_src = if(String.starts_with?(path, "/css"), do: :href, else: :src)
 
     %{
       integrity: static_integrity,
       crossorigin: "anonymous"
     }
-    |> Map.put(href_or_src, static_path)
+    |> Map.put(href_or_src, static_url)
   end
 end


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Investigate requests we can offload to the CDN](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211036325896900?focus=true)

Can compare the network tab in dev-blue and in prod to see that assets at the `/js/` and `/css/` paths are now being retreived from `cdn.mbta.com` instead of from the application.