### PR TITLE
hotfix: Don't select `Weekday` in schedule-finder menu on Fridays

### DIFF
--- a/assets/ts/schedule/components/schedule-finder/daily-schedule/DailyScheduleSubway.tsx
+++ b/assets/ts/schedule/components/schedule-finder/daily-schedule/DailyScheduleSubway.tsx
@@ -5,7 +5,6 @@ import {
   isSameDay,
   isSaturday,
   isSunday,
-  isWeekend,
   parse
 } from "date-fns";
 import { find } from "lodash";
@@ -109,7 +108,11 @@ const DailyScheduleSubway = ({
   const isTodayFriday = isFriday(todayDate) && !isTodaySpecialService;
   const isTodaySaturday = isSaturday(todayDate) && !isTodaySpecialService;
   const isTodaySunday = isSunday(todayDate) && !isTodaySpecialService;
-  const isTodayAWeekday = !isWeekend(todayDate) && !isTodaySpecialService;
+  const isTodayAWeekday =
+    !isTodaySpecialService &&
+    !isTodayFriday &&
+    !isTodaySaturday &&
+    !isTodaySunday;
 
   const hideScheduleFrequency = route.id === "Orange";
 


### PR DESCRIPTION
<img width="1676" height="714" alt="Screenshot 2025-08-29 at 10 25 03 AM" src="https://github.com/user-attachments/assets/0a82b717-30a2-4946-aafe-d97f19245922" />

---

No Ticket.