### PR TITLE
fix(Components.Alerts): format the more info link

### DIFF
--- a/lib/dotcom_web/components/alerts.ex
+++ b/lib/dotcom_web/components/alerts.ex
@@ -45,7 +45,7 @@ defmodule DotcomWeb.Components.Alerts do
           <%= if @url do %>
             <hr class="my-4 border-t-[1px] border-gray-lightest" />
             <p class="my-0">
-              For more information: <a href={@url}>{@url}</a>
+              For more information: {Alerts.URLParsingHelpers.replace_urls_with_links(@url)}
             </p>
           <% end %>
           <div class="c-alert-item__updated">


### PR DESCRIPTION
#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Fix issue with links in alerts on subway status on /alerts/subway](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211343331348385?focus=true)

These links needed some extra help being valid links. Can look at next week's Station Closure alert under planned work to verify.