### PR TITLE
chore: Replace commuter-rail alerts page with a LiveView

### DIFF
--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -5,6 +5,7 @@ defmodule Dotcom.Alerts do
 
   import Dotcom.Utils.DateTime, only: [in_range?: 2]
 
+  alias Dotcom.SystemStatus
   alias Alerts.Alert
   alias Alerts.InformedEntity
   alias Alerts.Match
@@ -128,6 +129,22 @@ defmodule Dotcom.Alerts do
     non_banner_alerts = excluding_banner(@alerts_repo_module.banner(), alerts)
 
     [0, 1]
+    |> @routes_repo_module.by_type()
+    |> with_alert_lists(non_banner_alerts)
+    |> drop_empty_groups()
+  end
+
+  @spec commuter_rail_alert_groups() :: [{Route.t(), [Alert.t()]}]
+  def commuter_rail_alert_groups() do
+    now = @date_time_module.now()
+
+    alerts =
+      @alerts_repo_module.all(now)
+      |> Enum.reject(&SystemStatus.status_alert?(&1, now))
+
+    non_banner_alerts = excluding_banner(@alerts_repo_module.banner(), alerts)
+
+    2
     |> @routes_repo_module.by_type()
     |> with_alert_lists(non_banner_alerts)
     |> drop_empty_groups()

--- a/lib/dotcom_web/live/commuter_rail_alerts.ex
+++ b/lib/dotcom_web/live/commuter_rail_alerts.ex
@@ -15,12 +15,14 @@ defmodule DotcomWeb.Live.CommuterRailAlerts do
 
   embed_templates "layouts/*"
 
+  @meta_description ~t"Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
+
   def mount(_params, _session, socket) do
     {:ok,
      socket
      |> assign(
        :meta_description,
-       ~t"Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
+       @meta_description
      )
      |> assign(:breadcrumbs, [Breadcrumb.build(~t"Alerts")])
      |> assign_result(&@date_time.now/0)

--- a/lib/dotcom_web/live/commuter_rail_alerts.ex
+++ b/lib/dotcom_web/live/commuter_rail_alerts.ex
@@ -1,0 +1,75 @@
+defmodule DotcomWeb.Live.CommuterRailAlerts do
+  @moduledoc """
+  The commuter rail alerts/status page, showing current subway status, planned work, and
+  other upcoming and relevant alerts.
+  """
+
+  use DotcomWeb, :live_view
+
+  import DotcomWeb.Components.SystemStatus.CommuterRailStatus,
+    only: [alerts_commuter_rail_status: 1]
+
+  @alerts_repo Application.compile_env!(:dotcom, :repo_modules)[:alerts]
+
+  @date_time Application.compile_env!(:dotcom, :date_time_module)
+
+  embed_templates "layouts/*"
+
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(
+       :meta_description,
+       ~t"Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."
+     )
+     |> assign(:breadcrumbs, [Breadcrumb.build(~t"Alerts")])
+     |> assign_result(&@date_time.now/0)
+     |> assign_banner_alert()
+     |> assign_result(&Dotcom.Alerts.commuter_rail_alert_groups/0)
+     |> assign_result(&Dotcom.SystemStatus.CommuterRail.commuter_rail_status/0)}
+  end
+
+  def handle_params(%{"alerts_timeframe" => _} = params, _uri, socket) do
+    new_path = socket |> live_path(__MODULE__, params |> Map.drop(["alerts_timeframe"]))
+    {:noreply, socket |> push_patch(to: new_path)}
+  end
+
+  def handle_params(_params, _uri, socket) do
+    {:noreply, socket}
+  end
+
+  defp assign_banner_alert(socket) do
+    case @alerts_repo.banner() do
+      nil -> socket
+      banner -> socket |> assign(:alert_banner, banner)
+    end
+  end
+
+  def render(assigns) do
+    assigns = assigns |> assign(:id, :commuter_rail)
+
+    ~H"""
+    <.alerts_layout mode={@id}>
+      <:sidebar_bottom>
+        {DotcomWeb.AlertView.render("_t-alerts.html")}
+      </:sidebar_bottom>
+      <:main_section>
+        <.alerts_commuter_rail_status commuter_rail_status={@commuter_rail_status} />
+        <.alerts_page_content_layout
+          {assigns |> Map.take([:alert_banner])}
+          alert_groups={@commuter_rail_alert_groups}
+          date_time={@now}
+          empty_message="There are no other commuter rail alerts at this time."
+        >
+          <:heading>
+            <h2 class="mt-8">Station & Service Alerts</h2>
+          </:heading>
+          <:alert_header_icon>
+            <MbtaMetro.Components.SystemIcons.mode_icon mode="commuter-rail" />
+          </:alert_header_icon>
+        </.alerts_page_content_layout>
+      </:main_section>
+    </.alerts_layout>
+    """
+  end
+end

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -100,6 +100,7 @@ defmodule DotcomWeb.Router do
 
     live_session :alerts, layout: {DotcomWeb.LayoutView, :live} do
       live("/alerts/subway", Live.SubwayAlerts)
+      live("/alerts/commuter-rail-live", Live.CommuterRailAlerts)
     end
   end
 

--- a/livebooks/reusable/alerts.livemd
+++ b/livebooks/reusable/alerts.livemd
@@ -98,3 +98,61 @@ Alerts.Cache.Store.update(alerts, nil)
 
 now() |> Alerts.Repo.all()
 ```
+
+<!-- livebook:{"branch_parent_index":1} -->
+
+## Commuter Rail Current and Upcoming Service Change Alerts
+
+```elixir
+# Create an informed entity for a commuter rail route
+cr_route_ids = Routes.Repo.by_type(2) |> Enum.map(& &1.id)
+
+current_active_period = {
+  now() |> Timex.shift(hours: -4),
+  now() |> Timex.shift(hours: 8)
+}
+
+future_active_period = {
+  now() |> Timex.shift(hours: 40),
+  now() |> Timex.shift(hours: 98)
+}
+
+current_alert =
+  Alert.build(:alert,
+    active_period: [current_active_period],
+    effect: :service_change,
+    informed_entity:
+      Alerts.InformedEntitySet.new([
+        InformedEntity.build(:informed_entity,
+          activities: MapSet.new([:exit, :ride, :board]),
+          route: Faker.Util.pick(cr_route_ids),
+          route_type: 2
+        )
+      ]),
+    priority: :high,
+    severity: 3
+  )
+
+future_alert =
+  Alert.build(:alert,
+    active_period: [future_active_period],
+    effect: :service_change,
+    informed_entity:
+      Alerts.InformedEntitySet.new([
+        InformedEntity.build(:informed_entity,
+          activities: MapSet.new([:exit, :ride, :board]),
+          route: Faker.Util.pick(cr_route_ids),
+          route_type: 2
+        )
+      ]),
+    priority: :high,
+    severity: 3
+  )
+
+alerts = [current_alert, future_alert]
+
+# Remove all other alerts and only use the one's you created
+Alerts.Cache.Store.update(alerts, nil)
+
+now() |> Alerts.Repo.all()
+```

--- a/priv/gettext/dotcom.pot
+++ b/priv/gettext/dotcom.pot
@@ -414,6 +414,7 @@ msgstr ""
 msgid "Sustainability"
 msgstr ""
 
+#: lib/dotcom_web/live/commuter_rail_alerts.ex:25
 #: lib/dotcom_web/live/subway_alerts.ex:27
 #: lib/dotcom_web/templates/page/_tabbed_nav.html.heex:48
 #: lib/dotcom_web/templates/schedule/_alerts.html.heex:16
@@ -2080,6 +2081,7 @@ msgstr ""
 msgid "Zone %{zone}"
 msgstr ""
 
+#: lib/dotcom_web/live/commuter_rail_alerts.ex:23
 #: lib/dotcom_web/live/subway_alerts.ex:25
 #, elixir-autogen, elixir-format
 msgid "Live service alerts for all MBTA transportation modes, including subway, bus, Commuter Rail, and ferry. Updates on delays, construction, elevator outages, and more."

--- a/priv/gettext/es/LC_MESSAGES/dotcom.po
+++ b/priv/gettext/es/LC_MESSAGES/dotcom.po
@@ -508,7 +508,7 @@ msgid "Student CharlieCard"
 msgstr "Estudiante CharlieCard"
 
 msgid "To submit an ADA/Accessibility complaint or feedback, please call"
-msgstr "Para presentar una reclamación o retroalimentación de ADA/Accesibilidad, por favor llame"
+msgstr "Para presentar una queja o retroalimentación de ADA/Accesibilidad, por favor llame"
 
 msgid "Report a Railroad Crossing Gate Issue"
 msgstr "Informe un problema de la puerta de cruce de ferrocarril"
@@ -586,10 +586,10 @@ msgid "Service alert or delay"
 msgstr "Alerta o demora del servicio"
 
 msgid "Depart at"
-msgstr "Salida en"
+msgstr "Salida"
 
 msgid " minute walk"
-msgstr " minuto andando"
+msgstr " minuto caminando"
 
 msgid "%{time} on %{date}"
 msgstr "%{time} el %{date}"
@@ -613,7 +613,7 @@ msgid "Typically fewer than 33% of seats available and distancing is unlikely (~
 msgstr "Típicamente menos del 33% de los asientos disponibles y el distanciamiento es poco probable (~3+ personas por fila)"
 
 msgid "Main Hotline"
-msgstr "Línea caliente principal"
+msgstr "Hotline principal"
 
 msgid "Work with Us"
 msgstr "Trabaja con nosotros"
@@ -625,7 +625,7 @@ msgid "Page Not Found | MBTA - Massachusetts Bay Transportation Authority"
 msgstr "Page Not Found Silencio MBTA - Massachusetts Bay Transportation Authority"
 
 msgid "Due to Single Tracking"
-msgstr "Debido a un seguimiento único"
+msgstr "Due to Single Tracking"
 
 msgid "Recently Visited Schedules"
 msgstr "Horarios visitados recientemente"
@@ -709,7 +709,7 @@ msgid "Featured MBTA Updates and Projects"
 msgstr "Destacados MBTA Actualizaciones y proyectos"
 
 msgid "Tell us about your regular trips and receive text or email alerts that are relevant to you, at times when you want them."
-msgstr "Háblenos de sus viajes regulares y reciba alertas de texto o correo electrónico que sean relevantes para usted, a veces cuando los desee."
+msgstr "Cuéntanos sobre tus viajes regulares y recibe alertas de texto o correo electrónico que son relevantes para ti, a veces cuando los desees."
 
 msgid "Note"
 msgstr "Nota"
@@ -871,7 +871,7 @@ msgid "Sorry, Your App Appears to be Out of Date"
 msgstr "Lo siento, tu apariencia parece estar fuera de la fecha"
 
 msgid "Official website of the MBTA — Plan a trip on public transit in the Greater Boston region"
-msgstr "Página web oficial del MBTA — Planifique un viaje en tránsito público en la región de Gran Boston"
+msgstr "Sitio web oficial del MBTA — Planear un viaje en tránsito público en la región del Gran Boston"
 
 msgid "Showing all"
 msgstr "Mostrando todo"
@@ -958,7 +958,7 @@ msgid "View"
 msgstr "Ver"
 
 msgid "Arriving by %{time}"
-msgstr "Conducir por %{time}"
+msgstr "Conducción por %{time}"
 
 msgid "Origin or destination location is outside of our service area"
 msgstr "La ubicación de origen o destino está fuera de nuestra zona de servicio"
@@ -991,7 +991,7 @@ msgid "Please enter an address that is within 100 miles of an MBTA service area.
 msgstr "Introduce una dirección que está a menos de 100 millas de un área de servicio MBTA."
 
 msgid "Bad grouped fare card data"
-msgstr "Datos de tarjeta de tarifa mal agrupado"
+msgstr "Datos de tarjetas de tarifa agrupadas mal"
 
 msgid "See Something, Say Something"
 msgstr "Ver algo, decir algo"
@@ -1123,7 +1123,7 @@ msgid "Terms of Use"
 msgstr "Términos de uso"
 
 msgid "Create an Account"
-msgstr "Crear una cuenta"
+msgstr "Crear una Cuenta"
 
 msgid "Least Walking"
 msgstr "Al menos caminando"
@@ -1333,7 +1333,7 @@ msgid "Hard right"
 msgstr "Derecho duro"
 
 msgid "Find a Store Near You"
-msgstr "Encontrar una tienda cerca de usted"
+msgstr "Encuentra una tienda cerca de ti"
 
 msgid "Posted on"
 msgstr "Publicado en"
@@ -1357,7 +1357,7 @@ msgid "or complete the feedback form on this page."
 msgstr "o completar el formulario de comentarios en esta página."
 
 msgid "Lost & Found"
-msgstr "Lost &amp; Found"
+msgstr "Perdido &amp; encontrado"
 
 msgid "Seat Availability"
 msgstr "Seat Disponibilidad"
@@ -1459,7 +1459,7 @@ msgid "Accessible"
 msgstr "Accesible"
 
 msgid "711 for TTY callers;  VRS for ASL callers"
-msgstr "711 para llamadas TTY; VRS para llamadas ASL"
+msgstr "711 para las llamadas TTY; VRS para las llamadas ASL"
 
 msgid "Sign up for Auto-pay"
 msgstr "Regístrate para Auto-pago"
@@ -1705,7 +1705,7 @@ msgid "Show Details"
 msgstr "Mostrar detalles"
 
 msgid "Please select an origin location."
-msgstr "Seleccione una ubicación de origen."
+msgstr "Por favor seleccione una ubicación de origen."
 
 msgid " may leave ahead of schedule at these stops."
 msgstr " puede salir antes del horario en estas paradas."

--- a/test/support/factories/alerts/alert.ex
+++ b/test/support/factories/alerts/alert.ex
@@ -113,6 +113,12 @@ defmodule Test.Support.Factories.Alerts.Alert do
     %{alert | active_period: [{start_time, ServiceDateTime.end_of_service_day(start_time)}]}
   end
 
+  def active_upcoming(alert) do
+    start_time = time_after(Dotcom.Utils.DateTime.now() |> DateTime.shift(day: 7))
+    end_time = time_after(start_time)
+    %{alert | active_period: [{start_time, end_time}]}
+  end
+
   # Returns a random time during the day today before the time provided.
   defp time_before(time) do
     between(Timex.beginning_of_day(time), time)


### PR DESCRIPTION
Two rider-facing benefits:
1. This removes the not-terribly-helpful `All Alerts` / `Current Alerts` / `Planned Service Alerts` tab group from [the commuter rail alerts page](https://www.mbta.com/alerts/commuter-rail).
2. This lays the groundwork for live-updating commuter rail status when alerts change without requiring a page refresh.

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Replace CR alerts page with a LiveView](https://app.asana.com/1/15492006741476/project/1205718271156548/task/1210893459312443?focus=true)
