### PR TITLE
fix: Don't pattern-match on the string `"Now"`

### DIFF
--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -91,6 +91,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
 
     ~H"""
     <.status_row_heading
+      future
       alerts={[@alert]}
       prefix={@time_range_str}
       route_ids={@route_ids}

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -102,6 +102,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
       status={@row.status_entry.status}
       prefix={@row.status_entry.prefix}
       plural={@row.status_entry.plural}
+      future={@row.status_entry.future}
       route_ids={[@row.route_info.route_id | @row.route_info.branch_ids]}
     />
     """
@@ -234,7 +235,8 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
         status_entry: %{
           status: :normal,
           plural: false,
-          prefix: nil
+          prefix: nil,
+          future: false
         },
         style: %{
           hide_route_pill: true
@@ -256,7 +258,8 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
             status_entry: %{
               status: alert.effect,
               plural: false,
-              prefix: prefix
+              prefix: prefix,
+              future: future?(status_entry)
             },
             style: %{
               hide_route_pill: true
@@ -275,7 +278,8 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
           status_entry: %{
             status: status,
             plural: multiple,
-            prefix: prefix
+            prefix: prefix,
+            future: future?(status_entry)
           },
           style: %{
             hide_route_pill: true
@@ -312,5 +316,5 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
   defp prefix(%{time: :current}), do: "Now"
   defp prefix(%{time: {:future, time}}), do: Util.narrow_time(time)
 
-  defp see_alerts_status(), do: %{status: :see_alerts, prefix: nil, plural: false}
+  defp see_alerts_status(), do: %{status: :see_alerts, prefix: nil, plural: false, future: false}
 end

--- a/livebooks/reusable/alerts.livemd
+++ b/livebooks/reusable/alerts.livemd
@@ -98,3 +98,60 @@ Alerts.Cache.Store.update(alerts, nil)
 
 now() |> Alerts.Repo.all()
 ```
+
+<!-- livebook:{"branch_parent_index":1} -->
+
+## Section
+
+```elixir
+informed_entities = [
+  InformedEntity.build(:informed_entity,
+    activities: MapSet.new([:exit, :ride, :board]),
+    route: "Red",
+    route_type: 1
+  )
+]
+
+# Create a currently active and an upcoming delay alert
+alerts =
+  [
+    Alert.build(:alert,
+      active_period: [
+        {
+          now() |> Timex.shift(hours: -4),
+          now() |> Timex.shift(hours: 8)
+        }
+      ],
+      effect: :delay,
+      severity: 3,
+      informed_entity: Alerts.InformedEntitySet.new(informed_entities)
+    ),
+    Alert.build(:alert,
+      active_period: [
+        {
+          now() |> Timex.shift(hours: 4),
+          now() |> Timex.shift(hours: 8)
+        }
+      ],
+      effect: :delay,
+      severity: 3,
+      informed_entity: Alerts.InformedEntitySet.new(informed_entities)
+    ),
+    Alert.build(:alert,
+      active_period: [
+        {
+          now() |> Timex.shift(days: 4),
+          now() |> Timex.shift(days: 8)
+        }
+      ],
+      effect: :delay,
+      severity: 3,
+      informed_entity: Alerts.InformedEntitySet.new(informed_entities)
+    )
+  ]
+
+# Remove all other alerts and only use the ones you created
+Alerts.Cache.Store.update(alerts, nil)
+
+now() |> Alerts.Repo.all()
+```


### PR DESCRIPTION
This is a follow-up to [this comment on an earlier PR](https://github.com/mbta/dotcom/pull/2716#discussion_r2326064661), which highlighted a prospective bug that was waiting to happen due to some old tech debt.

The bug would have been that in languages other than English, upcoming delays would use the translated version of `"Delays"` instead of `"Expect Delays"`. The root cause was that at the point where we decided between `"Delays"` (current) versus `"Expect Delays"` (future), we were using the prefix, which would be either `"Now"` or `nil` if the alert was current, and would be something else if the alert was in the future.

Except that in not-English, the prefix wouldn't be `"Now"` - it would be `"Ahora"` or whatever `~t"Now"` is in the rider's language.

The solution is to explicitly tell the `status_row_heading` whether the alert is in the future, rather than trying to reverse-engineer that info based on string data.

**Asana Ticket:** [Ensure that "Now: Delays" is translated correctly](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211272883431416?focus=true)
