### PR TITLE
fix: Images in embedded alerts with no descriptions

### DIFF
--- a/lib/dotcom_web/components/alerts.ex
+++ b/lib/dotcom_web/components/alerts.ex
@@ -32,27 +32,25 @@ defmodule DotcomWeb.Components.Alerts do
       data-test={"alert_id:#{@alert.id}"}
     >
       {AlertView.format_alert_description(@header)}
-      <%= if @description do %>
-        <div class="mt-sm">
-          <a :if={@alert.image} href={@alert.image} target="_blank">
-            <img
-              class="w-full mb-4"
-              src={@alert.image}
-              alt={if @alert.image_alternative_text, do: @alert.image_alternative_text, else: ""}
-            />
-          </a>
-          {AlertView.format_alert_description(@description)}
-          <%= if @url do %>
-            <hr class="my-4 border-t-[1px] border-gray-lightest" />
-            <p class="my-0">
-              For more information: {Alerts.URLParsingHelpers.replace_urls_with_links(@url)}
-            </p>
-          <% end %>
-          <div class="c-alert-item__updated">
-            {AlertView.alert_updated(@alert, @now)}
-          </div>
+      <div class="mt-sm">
+        <a :if={@alert.image} href={@alert.image} target="_blank">
+          <img
+            class="w-full mb-4"
+            src={@alert.image}
+            alt={if @alert.image_alternative_text, do: @alert.image_alternative_text, else: ""}
+          />
+        </a>
+        {AlertView.format_alert_description(@description)}
+        <%= if @url do %>
+          <hr class="my-4 border-t-[1px] border-gray-lightest" />
+          <p class="my-0">
+            For more information: {Alerts.URLParsingHelpers.replace_urls_with_links(@url)}
+          </p>
+        <% end %>
+        <div class="c-alert-item__updated">
+          {AlertView.alert_updated(@alert, @now)}
         </div>
-      <% end %>
+      </div>
     </div>
     """
   end


### PR DESCRIPTION
Fixes a bug where images (and `For more information` URL's and `Updated` times) don't load when the description is missing.

## Before
<img width="1332" height="782" alt="Screenshot 2025-09-18 at 6 08 44 PM" src="https://github.com/user-attachments/assets/5da9a74b-b40b-4674-9809-cde96ab7cb90" />

## After
<img width="1326" height="1082" alt="Screenshot 2025-09-18 at 6 06 12 PM" src="https://github.com/user-attachments/assets/b5b7702c-a49a-45b2-96df-8aebe8a5c613" />


#### Summary of changes

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [QF | Alert images should show up on /alerts/subway status even  if they have no additional information](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211374431638884?focus=true)

