### PR TITLE
fix: Remove trip planner from `robots.txt` to allow search engines to crawl it

### DIFF
--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -2,8 +2,6 @@ User-agent: *
 Disallow: /?*
 Disallow: /transit-near-me?*
 Disallow: /transit_near_me?*
-Disallow: /trip_planner?*
-Disallow: /trip-planner?*
 Disallow: /search?*
 Disallow: /*?*preview*&vid=*
 Disallow: /schedules/*/line?*date*


### PR DESCRIPTION
Hopefully this will fix issues like this

**Google**

<img width="608" height="276" alt="Screenshot 2025-09-18 at 2 27 49 PM" src="https://github.com/user-attachments/assets/35ef841f-5db2-49bc-bcff-5403768127dd" />

**DuckDuckGo**

<img width="1078" height="382" alt="Screenshot 2025-09-18 at 2 27 42 PM" src="https://github.com/user-attachments/assets/617be856-1deb-42cf-937c-ac7b23713acb" />

#### Summary of changes


---
<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Update Trip Planner title link for search results](https://app.asana.com/1/15492006741476/project/555089885850811/task/1210734368249332?focus=true)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211412726392058