### PR TITLE
fix: Don't double-wrap alerts-page LiveViews in `container` elements

### DIFF
--- a/lib/dotcom_web/components/layouts/alerts_layout.html.heex
+++ b/lib/dotcom_web/components/layouts/alerts_layout.html.heex
@@ -1,37 +1,35 @@
-<div class="container">
-  <div class="page-section">
-    <div class="page-header">
-      <h1>Alerts</h1>
-    </div>
-    <div class="row">
-      <div class="col-lg-3">
-        {if(assigns[:sidebar_top], do: render_slot(@sidebar_top))}
-        <div :if={@sidebar_bottom} class="hidden-md-down">
-          {render_slot(@sidebar_bottom)}
-        </div>
+<div class="page-section">
+  <div class="page-header">
+    <h1>Alerts</h1>
+  </div>
+  <div class="row">
+    <div class="col-lg-3">
+      {if(assigns[:sidebar_top], do: render_slot(@sidebar_top))}
+      <div :if={@sidebar_bottom} class="hidden-md-down">
+        {render_slot(@sidebar_bottom)}
       </div>
-      <div class="col-lg-8 col-lg-offset-1">
-        <div class="m-alerts__mode-buttons mb-lg">
-          <a
-            :for={mode <- [:subway, :bus, :commuter_rail, :ferry, :access]}
-            href={~p"/alerts/#{mode}"}
-            class="m-alerts__mode-button-container"
-          >
-            <div class={[
-              "m-alerts__mode-button",
-              if(@mode == mode, do: "m-alerts__mode-button--selected")
-            ]}>
-              <div class="m-alerts__mode-icon">{DotcomWeb.AlertView.type_icon(mode)}</div>
-              <div class="m-alerts__mode-name">{DotcomWeb.AlertView.type_name(mode)}</div>
-            </div>
-          </a>
-        </div>
+    </div>
+    <div class="col-lg-8 col-lg-offset-1">
+      <div class="m-alerts__mode-buttons mb-lg">
+        <a
+          :for={mode <- [:subway, :bus, :commuter_rail, :ferry, :access]}
+          href={~p"/alerts/#{mode}"}
+          class="m-alerts__mode-button-container"
+        >
+          <div class={[
+            "m-alerts__mode-button",
+            if(@mode == mode, do: "m-alerts__mode-button--selected")
+          ]}>
+            <div class="m-alerts__mode-icon">{DotcomWeb.AlertView.type_icon(mode)}</div>
+            <div class="m-alerts__mode-name">{DotcomWeb.AlertView.type_name(mode)}</div>
+          </div>
+        </a>
+      </div>
 
-        {render_slot(@main_section)}
+      {render_slot(@main_section)}
 
-        <div :if={@sidebar_bottom} class="hidden-lg-up">
-          {render_slot(@sidebar_bottom)}
-        </div>
+      <div :if={@sidebar_bottom} class="hidden-lg-up">
+        {render_slot(@sidebar_bottom)}
       </div>
     </div>
   </div>

--- a/lib/dotcom_web/templates/alert/show.html.heex
+++ b/lib/dotcom_web/templates/alert/show.html.heex
@@ -1,57 +1,59 @@
-<.alerts_layout mode={@id}>
-  <:sidebar_top :if={@id != :subway}>
-    {DotcomWeb.PartialView.alert_time_filters(@alerts_timeframe,
-      method: :alert_path,
-      item: @id
-    )}
-  </:sidebar_top>
-  <:sidebar_bottom>
-    {render("_t-alerts.html")}
-  </:sidebar_bottom>
-  <:main_section :if={@id == :commuter_rail}>
-    <.alerts_commuter_rail_status commuter_rail_status={@commuter_rail_status} />
-    <.alerts_page_content_layout
-      {assigns}
-      empty_message={~t(There are no other) <>  " #{format_alerts_timeframe(@alerts_timeframe)} #{mode_name(@id)} " <> ~t(alerts at this time) <> "."}
-    >
-      <:heading>
-        <h2 class="mt-8">{~t(Station & Service Alerts)}</h2>
-      </:heading>
-      <:alert_header_icon>
-        <MbtaMetro.Components.SystemIcons.mode_icon mode="commuter-rail" />
-      </:alert_header_icon>
-    </.alerts_page_content_layout>
-  </:main_section>
-  <:main_section :if={@id == :subway}>
-    <section class="mb-lg">
-      <.alerts_subway_status subway_status={@subway_status} />
-    </section>
-    <section id="planned" class="mb-lg">
-      <.disruptions disruptions={@disruption_groups} />
-    </section>
-    <.alerts_page_content_layout
-      {assigns}
-      empty_message={~t(There are no other) <> " #{format_alerts_timeframe(@alerts_timeframe)} #{mode_name(@id)} " <> ~t(alerts at this time) <> "."}
-    >
-      <:heading>
-        <h2 class="mt-0">{~t(Station & Service Alerts)}</h2>
-      </:heading>
-      <:alert_header_icon :let={route_or_stop}>
-        <.subway_route_pill route_ids={[route_or_stop.id]} />
-      </:alert_header_icon>
-    </.alerts_page_content_layout>
-  </:main_section>
-  <:main_section :if={@id != :commuter_rail && @id != :subway}>
-    <.alerts_page_content_layout
-      {assigns}
-      empty_message={~t(There are no) <> " #{format_alerts_timeframe(@alerts_timeframe)} #{mode_name(@id)} " <> ~t(alerts at this time) <> "."}
-    >
-      <:heading>
-        <h2 class="sr-only">{~t(All Alerts)}</h2>
-      </:heading>
-      <:alert_header_icon :let={route_or_stop}>
-        <.route_icon :if={show_mode_icon?(route_or_stop)} route={route_or_stop} />
-      </:alert_header_icon>
-    </.alerts_page_content_layout>
-  </:main_section>
-</.alerts_layout>
+<div class="container">
+  <.alerts_layout mode={@id}>
+    <:sidebar_top :if={@id != :subway}>
+      {DotcomWeb.PartialView.alert_time_filters(@alerts_timeframe,
+        method: :alert_path,
+        item: @id
+      )}
+    </:sidebar_top>
+    <:sidebar_bottom>
+      {render("_t-alerts.html")}
+    </:sidebar_bottom>
+    <:main_section :if={@id == :commuter_rail}>
+      <.alerts_commuter_rail_status commuter_rail_status={@commuter_rail_status} />
+      <.alerts_page_content_layout
+        {assigns}
+        empty_message={~t(There are no other) <>  " #{format_alerts_timeframe(@alerts_timeframe)} #{mode_name(@id)} " <> ~t(alerts at this time) <> "."}
+      >
+        <:heading>
+          <h2 class="mt-8">{~t(Station & Service Alerts)}</h2>
+        </:heading>
+        <:alert_header_icon>
+          <MbtaMetro.Components.SystemIcons.mode_icon mode="commuter-rail" />
+        </:alert_header_icon>
+      </.alerts_page_content_layout>
+    </:main_section>
+    <:main_section :if={@id == :subway}>
+      <section class="mb-lg">
+        <.alerts_subway_status subway_status={@subway_status} />
+      </section>
+      <section id="planned" class="mb-lg">
+        <.disruptions disruptions={@disruption_groups} />
+      </section>
+      <.alerts_page_content_layout
+        {assigns}
+        empty_message={~t(There are no other) <> " #{format_alerts_timeframe(@alerts_timeframe)} #{mode_name(@id)} " <> ~t(alerts at this time) <> "."}
+      >
+        <:heading>
+          <h2 class="mt-0">{~t(Station & Service Alerts)}</h2>
+        </:heading>
+        <:alert_header_icon :let={route_or_stop}>
+          <.subway_route_pill route_ids={[route_or_stop.id]} />
+        </:alert_header_icon>
+      </.alerts_page_content_layout>
+    </:main_section>
+    <:main_section :if={@id != :commuter_rail && @id != :subway}>
+      <.alerts_page_content_layout
+        {assigns}
+        empty_message={~t(There are no) <> " #{format_alerts_timeframe(@alerts_timeframe)} #{mode_name(@id)} " <> ~t(alerts at this time) <> "."}
+      >
+        <:heading>
+          <h2 class="sr-only">{~t(All Alerts)}</h2>
+        </:heading>
+        <:alert_header_icon :let={route_or_stop}>
+          <.route_icon :if={show_mode_icon?(route_or_stop)} route={route_or_stop} />
+        </:alert_header_icon>
+      </.alerts_page_content_layout>
+    </:main_section>
+  </.alerts_layout>
+</div>


### PR DESCRIPTION
Before on the left; After on the right

<img width="1790" height="1512" alt="Screenshot 2025-09-19 at 12 43 15 PM" src="https://github.com/user-attachments/assets/28f68d04-4c9a-4e86-bc8f-09661425ba0c" />

Notice that the margin is wider in the `before` picture, and doesn't match the margin for the other non-subway modes. This is because the subway alerts page is a LiveView, and is thus getting double-wrapped in `<div class="container">` elements: One in the [alerts layout](https://github.com/mbta/dotcom/blob/23d8b9eeb4ba36afb4c1079821af11534025bbc2/lib/dotcom_web/components/layouts/alerts_layout.html.heex#L1) and one in the [parent LiveView layout](https://github.com/mbta/dotcom/blob/23d8b9eeb4ba36afb4c1079821af11534025bbc2/lib/dotcom_web/templates/layout/live.html.heex). Each `<div class="container">` is adding a padding value, which means that when an `alerts_layout` is rendered inside a LiveView, it gets twice the padding.

This fixes that by removing the `<div class="container">` from the alerts layout, and moving it to the alerts `show` template (so that the padding is still applied to alerts pages that aren't LiveViews).

---

No ticket, but would probably be good to merge before https://github.com/mbta/dotcom/pull/2737, since https://github.com/mbta/dotcom/pull/2737 will replace the commuter rail page with a LiveView, and thus cause this problem to appear on the CR alerts page as well as the subway alerts page.