### PR TITLE
fix(cms): handle case where _format=json is not the last item

### DIFF
--- a/lib/cms/api.ex
+++ b/lib/cms/api.ex
@@ -116,10 +116,11 @@ defmodule CMS.Api do
     nil
   end
 
+  @format_re ~r/^_format=json&|&_format=json(&)?/
   defp update_query(query) when is_binary(query) do
-    # If the redirect path happens to include query params,
-    # Drupal will append the request query parameters to the redirect params.
-    String.replace_suffix(query, "&_format=json", "")
+    # If the redirect path happens to include query params, Drupal will add the
+    # request query parameters to the redirect params, in an unspecified order
+    Regex.replace(@format_re, query, "\\1", global: false)
   end
 
   @spec internal_uri(URI.t()) :: URI.t()

--- a/test/cms/api_test.exs
+++ b/test/cms/api_test.exs
@@ -12,6 +12,26 @@ defmodule CMS.ApiTest do
                Api.set_redirect_options(uri)
     end
 
+    test "strips _format=json when it's the first query" do
+      uri =
+        URI.parse(
+          "https://www.mbta.com/projects/lynnway-multimodal-corridor-project?_format=json&fbclid=IwY2xjawM"
+        )
+
+      assert [
+               external:
+                 "https://www.mbta.com/projects/lynnway-multimodal-corridor-project?fbclid=IwY2xjawM"
+             ] =
+               Api.set_redirect_options(uri)
+    end
+
+    test "strips _format=json when it's the a middle query" do
+      uri = URI.parse("https://www.example.com?query=first&_format=json&second=query")
+
+      assert [external: "https://www.example.com?query=first&second=query"] =
+               Api.set_redirect_options(uri)
+    end
+
     test "strips _format=json when it's the only query" do
       uri = URI.parse("https://example.com/url?_format=json")
       assert [external: "https://example.com/url"] = Api.set_redirect_options(uri)


### PR DESCRIPTION
The previous documentation indicated that `_format=json` would always be the final item in the query string. This is not always the case, so our replacement strategy needs to handle it appearing anywhere.

We do this with a regular expression which can get find the string in any location, and replace it with either an empty string (if it's at the beginning or end) or a single `&` if it's in the middle

Test cases are also updated to handle all three positions.

Slack thread: https://mbta.slack.com/archives/C0PPF1WNB/p1758635602707149

Follow up to #2728 
