### PR TITLE
fix: Alert counts for multi-trip alerts in commuter rail status

### DIFF
--- a/lib/dotcom/system_status/commuter_rail.ex
+++ b/lib/dotcom/system_status/commuter_rail.ex
@@ -303,15 +303,9 @@ defmodule Dotcom.SystemStatus.CommuterRail do
         } ->
           service_impacts
           |> Enum.group_by(& &1.alert.effect)
-          |> Map.new(fn {effect, impact_list} ->
-            {effect, impact_summary(impact_list)}
-          end)
-          |> Enum.into(%{
-            cancellation: impact_summary(cancellations),
-            delay: impact_summary(delays)
-          })
-          |> Enum.reject(fn {_effect, impact} -> impact.count == 0 end)
-          |> Map.new()
+          |> Enum.into(%{cancellation: cancellations, delay: delays})
+          |> Enum.reject(fn {_effect, impact_list} -> Enum.empty?(impact_list) end)
+          |> Map.new(fn {effect, impact_list} -> {effect, impact_summary(impact_list)} end)
 
         _ ->
           %{}

--- a/livebooks/reusable/alerts.livemd
+++ b/livebooks/reusable/alerts.livemd
@@ -156,3 +156,125 @@ Alerts.Cache.Store.update(alerts, nil)
 
 now() |> Alerts.Repo.all()
 ```
+
+<!-- livebook:{"branch_parent_index":1} -->
+
+## Commuter Rail Multi-Trip Train Alert
+
+```elixir
+# Create an informed entity for a commuter rail route
+route = Routes.Repo.by_type(2) |> Faker.Util.pick()
+
+schedules = Schedules.Repo.by_route_ids([route.id])
+
+trip_ids =
+  Faker.Util.sample_uniq(3, fn -> Faker.Util.pick(schedules) end)
+  |> Enum.map(& &1.trip.id)
+
+informed_entities =
+  trip_ids
+  |> Enum.map(
+    &InformedEntity.build(:informed_entity,
+      activities: MapSet.new([:exit, :ride, :board]),
+      route: route.id,
+      route_type: 2,
+      trip: &1
+    )
+  )
+
+alert =
+  Alert.build(:alert,
+    active_period: [
+      {
+        now() |> Timex.shift(hours: -4),
+        now() |> Timex.shift(hours: 8)
+      }
+    ],
+    effect: Faker.Util.pick([:delay, :cancellation]),
+    informed_entity: Alerts.InformedEntitySet.new(informed_entities),
+    priority: :high,
+    severity: 3
+  )
+
+# Remove all other alerts and only use the one you created
+Alerts.Cache.Store.update([alert], nil)
+
+now() |> Alerts.Repo.all()
+```
+
+<!-- livebook:{"branch_parent_index":1} -->
+
+## Commuter Rail All Trains or Direction-Specific Alert
+
+```elixir
+# Create an informed entity for a commuter rail route
+route = Routes.Repo.by_type(2) |> Faker.Util.pick()
+
+informed_entities = [
+  InformedEntity.build(:informed_entity,
+    activities: MapSet.new([:exit, :ride, :board]),
+    direction_id: Faker.Util.pick([0, 1, nil]),
+    route: route.id,
+    route_type: 2,
+    trip: nil
+  )
+]
+
+alert =
+  Alert.build(:alert,
+    active_period: [
+      {
+        now() |> Timex.shift(hours: -4),
+        now() |> Timex.shift(hours: 8)
+      }
+    ],
+    effect: Faker.Util.pick([:delay, :cancellation]),
+    informed_entity: Alerts.InformedEntitySet.new(informed_entities),
+    priority: :high,
+    severity: 3
+  )
+
+# Remove all other alerts and only use the one you created
+Alerts.Cache.Store.update([alert], nil)
+
+now() |> Alerts.Repo.all()
+```
+
+<!-- livebook:{"branch_parent_index":1} -->
+
+## Commuter Rail Upcoming Shuttle
+
+```elixir
+# Create an informed entity for a commuter rail route
+route = Routes.Repo.by_type(2) |> Faker.Util.pick()
+
+schedules = Schedules.Repo.by_route_ids([route.id])
+
+informed_entities =
+  [
+    InformedEntity.build(:informed_entity,
+      activities: MapSet.new([:exit, :ride, :board]),
+      route: route.id,
+      route_type: 2
+    )
+  ]
+
+alert =
+  Alert.build(:alert,
+    active_period: [
+      {
+        now() |> Timex.shift(hours: 4),
+        now() |> Timex.shift(hours: 8)
+      }
+    ],
+    effect: :shuttle,
+    informed_entity: Alerts.InformedEntitySet.new(informed_entities),
+    priority: :high,
+    severity: 3
+  )
+
+# Remove all other alerts and only use the one you created
+Alerts.Cache.Store.update([alert], nil)
+
+now() |> Alerts.Repo.all()
+```

--- a/livebooks/reusable/alerts.livemd
+++ b/livebooks/reusable/alerts.livemd
@@ -278,3 +278,62 @@ Alerts.Cache.Store.update([alert], nil)
 
 now() |> Alerts.Repo.all()
 ```
+
+## Commuter Rail Delays and Cancellations
+
+```elixir
+# Create an informed entity for a commuter rail route
+route = Routes.Repo.by_type(2) |> Faker.Util.pick()
+
+schedules = Schedules.Repo.by_route_ids([route.id])
+
+[trip_id_1, trip_id_2] =
+  Faker.Util.sample_uniq(2, fn -> Faker.Util.pick(schedules) end)
+  |> Enum.map(& &1.trip.id)
+
+active_period = [
+  {
+    now() |> Timex.shift(hours: -4),
+    now() |> Timex.shift(hours: 8)
+  }
+]
+
+alerts =
+  [
+    Alert.build(:alert,
+      active_period: active_period,
+      effect: :cancellation,
+      informed_entity:
+        Alerts.InformedEntitySet.new([
+          InformedEntity.build(:informed_entity,
+            activities: MapSet.new([:exit, :ride, :board]),
+            route: route.id,
+            route_type: 2,
+            trip: trip_id_1
+          )
+        ]),
+      priority: :high,
+      severity: 3
+    ),
+    Alert.build(:alert,
+      active_period: active_period,
+      effect: :delay,
+      informed_entity:
+        Alerts.InformedEntitySet.new([
+          InformedEntity.build(:informed_entity,
+            activities: MapSet.new([:exit, :ride, :board]),
+            route: route.id,
+            route_type: 2,
+            trip: trip_id_2
+          )
+        ]),
+      priority: :high,
+      severity: 3
+    )
+  ]
+
+# Remove all other alerts and only use the one you created
+Alerts.Cache.Store.update(alerts, nil)
+
+now() |> Alerts.Repo.all()
+```


### PR DESCRIPTION
## Before

<img width="587" height="408" alt="Screenshot 2025-09-26 at 1 37 45 PM" src="https://github.com/user-attachments/assets/d339d902-9882-4dc2-abc0-ab1f0cb042a1" />

## After

<img width="584" height="405" alt="Screenshot 2025-09-26 at 1 36 33 PM" src="https://github.com/user-attachments/assets/7f1ffa71-bb65-498a-ba84-cf36d6afca0d" />


The fix is deceptively simple, and also a bit inelegant. We already have `Dotcom.SystemStatus.CommuterRail.commuter_rail_route_status/1`, which figures out the correct delay/cancellation count, so we can just use the data from that to populate `commuter_rail_status/0` as well.

The inelegance comes from the fact that the `<.alerts_commuter_rail_status />` frontend component relies on the data structure returned from `commuter_rail_status/0` being structured a particular way, which is different from how `commuter_rail_route_status/1` does it. So I added a bit of "adapter" logic to `route_info/1` to convert the data structure `commuter_rail_route_status/1` presents to the data structure `<.alerts_commuter_rail_status /> expects.

(This is especially inelegant because `commuter_rail_route_status/1` already makes a distinction between train impacts (delays and cancellations) and service impacts (everything else), and `<.alerts_commuter_rail_status />` does care about that distinction, but has to re-figure it out on its own, because `commuter_rail_status/0` treats them all the same.)

Medium/longer-term, I think the thing to do is to update `<.alerts_commuter_rail_status />` to accept `commuter_rail_route_status/1`-shaped data. I'm actively working on that now, and can add that to this PR. But this fixes a rider-facing bug, so I figured I'd share this commit as a standalone fix. We can decide whether we want to merge as-is and treat a more elegant approach as a follow-up, versus combining it all together and holding this PR until the refactor is done.

<!-- Link to relevant Asana task; remove if not applicable -->
**Asana Ticket:** [Fix how we count cancellations/delays on CR system status](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211265393748828?focus=true)
