### PR TITLE
refactor: Simplify boundary between `<.alerts_commuter_rail_status />` and `SystemStatus.CommuterRail.commuter_rail_status/0`

### DIFF
--- a/lib/dotcom/system_status/commuter_rail.ex
+++ b/lib/dotcom/system_status/commuter_rail.ex
@@ -291,11 +291,14 @@ defmodule Dotcom.SystemStatus.CommuterRail do
              alert_counts: map(),
              name: String.t(),
              service_today?: boolean(),
-             sort_order: integer()
+             sort_order: integer(),
+             status: route_status_t()
            }}
   defp route_info(%Route{id: id, name: name, sort_order: sort_order}) do
+    status = commuter_rail_route_status(id)
+
     alert_counts =
-      case commuter_rail_route_status(id) do
+      case status do
         %{
           delays: delays,
           cancellations: cancellations,
@@ -318,7 +321,8 @@ defmodule Dotcom.SystemStatus.CommuterRail do
        alert_counts: alert_counts,
        name: name,
        service_today?: service_today?,
-       sort_order: sort_order
+       sort_order: sort_order,
+       status: status
      }}
   end
 end

--- a/livebooks/reusable/alerts.livemd
+++ b/livebooks/reusable/alerts.livemd
@@ -242,7 +242,7 @@ now() |> Alerts.Repo.all()
 
 <!-- livebook:{"branch_parent_index":1} -->
 
-## Commuter Rail Upcoming Shuttle
+## Commuter Rail Upcoming Shuttle and Delay
 
 ```elixir
 # Create an informed entity for a commuter rail route
@@ -250,31 +250,58 @@ route = Routes.Repo.by_type(2) |> Faker.Util.pick()
 
 schedules = Schedules.Repo.by_route_ids([route.id])
 
-informed_entities =
+trip_ids =
+  Faker.Util.sample_uniq(3, fn -> Faker.Util.pick(schedules) end)
+  |> Enum.map(& &1.trip.id)
+
+alerts =
   [
-    InformedEntity.build(:informed_entity,
-      activities: MapSet.new([:exit, :ride, :board]),
-      route: route.id,
-      route_type: 2
+    Alert.build(:alert,
+      active_period: [
+        {
+          now() |> Timex.shift(hours: -4),
+          now() |> Timex.shift(hours: 8)
+        }
+      ],
+      effect: :delay,
+      informed_entity:
+        Alerts.InformedEntitySet.new(
+          trip_ids
+          |> Enum.map(
+            &InformedEntity.build(:informed_entity,
+              activities: MapSet.new([:exit, :ride, :board]),
+              route: route.id,
+              route_type: 2,
+              trip: &1
+            )
+          )
+        ),
+      priority: :high,
+      severity: 3
+    ),
+    Alert.build(:alert,
+      active_period: [
+        {
+          now() |> Timex.shift(hours: 4),
+          now() |> Timex.shift(hours: 8)
+        }
+      ],
+      effect: :shuttle,
+      informed_entity:
+        Alerts.InformedEntitySet.new([
+          InformedEntity.build(:informed_entity,
+            activities: MapSet.new([:exit, :ride, :board]),
+            route: route.id,
+            route_type: 2
+          )
+        ]),
+      priority: :high,
+      severity: 3
     )
   ]
 
-alert =
-  Alert.build(:alert,
-    active_period: [
-      {
-        now() |> Timex.shift(hours: 4),
-        now() |> Timex.shift(hours: 8)
-      }
-    ],
-    effect: :shuttle,
-    informed_entity: Alerts.InformedEntitySet.new(informed_entities),
-    priority: :high,
-    severity: 3
-  )
-
 # Remove all other alerts and only use the one you created
-Alerts.Cache.Store.update([alert], nil)
+Alerts.Cache.Store.update(alerts, nil)
 
 now() |> Alerts.Repo.all()
 ```
@@ -327,6 +354,56 @@ alerts =
             trip: trip_id_2
           )
         ]),
+      priority: :high,
+      severity: 3
+    )
+  ]
+
+# Remove all other alerts and only use the one you created
+Alerts.Cache.Store.update(alerts, nil)
+
+now() |> Alerts.Repo.all()
+```
+
+<!-- livebook:{"branch_parent_index":1} -->
+
+## Commuter Rail Collapsed Service Impacts
+
+```elixir
+# Create an informed entity for a commuter rail route
+route = Routes.Repo.by_type(2) |> Faker.Util.pick()
+
+schedules = Schedules.Repo.by_route_ids([route.id])
+
+active_period = [
+  {
+    now() |> Timex.shift(hours: -4),
+    now() |> Timex.shift(hours: 8)
+  }
+]
+
+informed_entities =
+  Alerts.InformedEntitySet.new([
+    InformedEntity.build(:informed_entity,
+      activities: MapSet.new([:exit, :ride, :board]),
+      route: route.id,
+      route_type: 2
+    )
+  ])
+
+alerts =
+  [
+    Alert.build(:alert,
+      active_period: active_period,
+      effect: :shuttle,
+      informed_entity: informed_entities,
+      priority: :high,
+      severity: 3
+    ),
+    Alert.build(:alert,
+      active_period: active_period,
+      effect: :suspension,
+      informed_entity: informed_entities,
       priority: :high,
       severity: 3
     )

--- a/test/dotcom_web/components/system_status/commuter_rail_status_test.exs
+++ b/test/dotcom_web/components/system_status/commuter_rail_status_test.exs
@@ -1,22 +1,65 @@
 defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
   use ExUnit.Case
 
-  import DotcomWeb.Components.SystemStatus.CommuterRailStatus
+  import Dotcom.SystemStatus.CommuterRail, only: [commuter_rail_status: 0]
+
+  import DotcomWeb.Components.SystemStatus.CommuterRailStatus,
+    only: [alerts_commuter_rail_status: 1]
+
+  import Mox
   import Phoenix.LiveViewTest
+  import Test.Support.Generators.DateTime, only: [random_time_range_date_time: 1]
+
+  alias Dotcom.Utils.ServiceDateTime
+  alias Test.Support.Factories
+  alias Test.Support.FactoryHelpers
+
+  setup do
+    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+
+    stub(Alerts.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+
+    stub(Routes.Repo.Mock, :all, fn ->
+      [
+        Factories.Routes.Route.build(:route, type: 2)
+      ]
+    end)
+
+    stub(Schedules.RepoCondensed.Mock, :by_route_ids, fn _ ->
+      [
+        %Schedules.ScheduleCondensed{
+          time: Dotcom.Utils.DateTime.now()
+        }
+      ]
+    end)
+
+    stub(Schedules.Repo.Mock, :schedule_for_trip, fn _, "filter[stop_sequence]": "first,last" ->
+      Factories.Schedules.Schedule.build_list(2, :schedule)
+    end)
+
+    :ok
+  end
 
   describe "alerts_commuter_rail_status/1" do
     test "shows no service when a route isn't in service" do
       # SETUP
-      assigns = %{
-        commuter_rail_status: %{
-          Faker.Cat.breed() => %{
-            alert_counts: %{},
-            name: Faker.Cat.breed(),
-            service_today?: false,
-            sort_order: 0
+      commuter_rail_id = Faker.Color.fancy_name()
+
+      expect(Routes.Repo.Mock, :all, fn ->
+        [
+          Factories.Routes.Route.build(:route, id: commuter_rail_id, type: 2)
+        ]
+      end)
+
+      expect(Schedules.RepoCondensed.Mock, :by_route_ids, 2, fn _ ->
+        [
+          %Schedules.ScheduleCondensed{
+            time: Dotcom.Utils.DateTime.now() |> Timex.shift(days: 1)
           }
-        }
-      }
+        ]
+      end)
+
+      assigns = %{commuter_rail_status: commuter_rail_status()}
 
       # EXERCISE
       html = render_component(&alerts_commuter_rail_status/1, assigns)
@@ -27,16 +70,7 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
 
     test "shows normal service when a route has no alert counts" do
       # SETUP
-      assigns = %{
-        commuter_rail_status: %{
-          Faker.Cat.breed() => %{
-            alert_counts: %{},
-            name: Faker.Cat.breed(),
-            service_today?: true,
-            sort_order: 0
-          }
-        }
-      }
+      assigns = %{commuter_rail_status: commuter_rail_status()}
 
       # EXERCISE
       html = render_component(&alerts_commuter_rail_status/1, assigns)
@@ -46,19 +80,18 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
     end
 
     test "shows a single cancellation" do
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ ->
+        [
+          Factories.Alerts.Alert.build(:alert,
+            effect: :cancellation,
+            severity: 3
+          )
+          |> Factories.Alerts.Alert.active_now()
+        ]
+      end)
+
       # SETUP
-      assigns = %{
-        commuter_rail_status: %{
-          Faker.Cat.breed() => %{
-            alert_counts: %{
-              cancellation: %{count: 1}
-            },
-            name: Faker.Cat.breed(),
-            service_today?: true,
-            sort_order: 0
-          }
-        }
-      }
+      assigns = %{commuter_rail_status: commuter_rail_status()}
 
       # EXERCISE
       html = render_component(&alerts_commuter_rail_status/1, assigns)
@@ -70,18 +103,80 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
 
     test "shows multiple cancellations" do
       # SETUP
-      assigns = %{
-        commuter_rail_status: %{
-          Faker.Cat.breed() => %{
-            alert_counts: %{
-              cancellation: %{count: 2}
-            },
-            name: Faker.Cat.breed(),
-            service_today?: true,
-            sort_order: 0
-          }
-        }
-      }
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ ->
+        Factories.Alerts.Alert.build_list(2, :alert,
+          effect: :cancellation,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+      end)
+
+      assigns = %{commuter_rail_status: commuter_rail_status()}
+
+      # EXERCISE
+      html = render_component(&alerts_commuter_rail_status/1, assigns)
+
+      # VERIFY
+      assert html =~ "2 Cancellations"
+    end
+
+    test "shows a single delay" do
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ ->
+        [
+          Factories.Alerts.Alert.build(:alert,
+            effect: :delay,
+            severity: 3
+          )
+          |> Factories.Alerts.Alert.active_now()
+        ]
+      end)
+
+      # SETUP
+      assigns = %{commuter_rail_status: commuter_rail_status()}
+
+      # EXERCISE
+      html = render_component(&alerts_commuter_rail_status/1, assigns)
+
+      # VERIFY
+      assert html =~ "1 Delay"
+      refute html =~ "1 Delays"
+    end
+
+    test "shows multiple delays" do
+      # SETUP
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ ->
+        Factories.Alerts.Alert.build_list(2, :alert,
+          effect: :delay,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+      end)
+
+      assigns = %{commuter_rail_status: commuter_rail_status()}
+
+      # EXERCISE
+      html = render_component(&alerts_commuter_rail_status/1, assigns)
+
+      # VERIFY
+      assert html =~ "2 Delays"
+    end
+
+    test "shows multiple cancellations even if they originate from the same alert" do
+      # SETUP
+      [trip_id1, trip_id2] = Faker.Util.sample_uniq(2, fn -> FactoryHelpers.build(:id) end)
+
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ ->
+        [
+          Factories.Alerts.Alert.build(:alert_for_trips,
+            effect: :cancellation,
+            severity: 3,
+            trip_ids: [trip_id1, trip_id2]
+          )
+          |> Factories.Alerts.Alert.active_now()
+        ]
+      end)
+
+      assigns = %{commuter_rail_status: commuter_rail_status()}
 
       # EXERCISE
       html = render_component(&alerts_commuter_rail_status/1, assigns)
@@ -92,19 +187,23 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
 
     test "combines cancellations and delays into a single row" do
       # SETUP
-      assigns = %{
-        commuter_rail_status: %{
-          Faker.Cat.breed() => %{
-            alert_counts: %{
-              cancellation: %{count: 1},
-              delay: %{count: 2}
-            },
-            name: Faker.Cat.breed(),
-            service_today?: true,
-            sort_order: 0
-          }
-        }
-      }
+      cancellations =
+        Factories.Alerts.Alert.build_list(1, :alert,
+          effect: :cancellation,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+
+      delays =
+        Factories.Alerts.Alert.build_list(2, :alert,
+          effect: :delay,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ -> cancellations ++ delays end)
+
+      assigns = %{commuter_rail_status: commuter_rail_status()}
 
       # EXERCISE
       html = render_component(&alerts_commuter_rail_status/1, assigns)
@@ -115,20 +214,30 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
 
     test "shows service alerts and cancellations/delays in separate rows" do
       # SETUP
-      assigns = %{
-        commuter_rail_status: %{
-          Faker.Cat.breed() => %{
-            alert_counts: %{
-              cancellation: %{count: 1},
-              delay: %{count: 2},
-              shuttle: %{count: 1}
-            },
-            name: Faker.Cat.breed(),
-            service_today?: true,
-            sort_order: 0
-          }
-        }
-      }
+      cancellations =
+        Factories.Alerts.Alert.build_list(1, :alert,
+          effect: :cancellation,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+
+      delays =
+        Factories.Alerts.Alert.build_list(2, :alert,
+          effect: :delay,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+
+      shuttles =
+        Factories.Alerts.Alert.build_list(1, :alert,
+          effect: :shuttle,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ -> cancellations ++ delays ++ shuttles end)
+
+      assigns = %{commuter_rail_status: commuter_rail_status()}
 
       # EXERCISE
       html = render_component(&alerts_commuter_rail_status/1, assigns)
@@ -136,22 +245,40 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
       # VERIFY
       assert html =~ "3 Cancellations / Delays"
       assert html =~ "1 Shuttle"
+      refute html =~ "1 Shuttles"
+    end
+
+    test "does not show a row for 0 cancellations or delays" do
+      # SETUP
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ ->
+        Factories.Alerts.Alert.build_list(1, :alert,
+          effect: :shuttle,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+      end)
+
+      assigns = %{commuter_rail_status: commuter_rail_status()}
+
+      # EXERCISE
+      html = render_component(&alerts_commuter_rail_status/1, assigns)
+
+      # VERIFY
+      refute html =~ "Cancellation"
+      refute html =~ "Delay"
     end
 
     test "does not combine service alerts when there is only one type" do
       # SETUP
-      assigns = %{
-        commuter_rail_status: %{
-          Faker.Cat.breed() => %{
-            alert_counts: %{
-              shuttle: %{count: 2}
-            },
-            name: Faker.Cat.breed(),
-            service_today?: true,
-            sort_order: 0
-          }
-        }
-      }
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ ->
+        Factories.Alerts.Alert.build_list(2, :alert,
+          effect: :shuttle,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+      end)
+
+      assigns = %{commuter_rail_status: commuter_rail_status()}
 
       # EXERCISE
       html = render_component(&alerts_commuter_rail_status/1, assigns)
@@ -160,21 +287,48 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
       assert html =~ "2 Shuttles"
     end
 
+    test "shows the active-period start time for a single service impact starting in the future" do
+      # SETUP
+      {_, service_day_end} = ServiceDateTime.service_range_day()
+
+      start_time = random_time_range_date_time({Dotcom.Utils.DateTime.now(), service_day_end})
+
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ ->
+        Factories.Alerts.Alert.build_list(1, :alert,
+          effect: :shuttle,
+          severity: 3
+        )
+        |> Enum.map(&(&1 |> Factories.Alerts.Alert.active_starting_at(start_time)))
+      end)
+
+      assigns = %{commuter_rail_status: commuter_rail_status()}
+
+      # EXERCISE
+      html = render_component(&alerts_commuter_rail_status/1, assigns)
+
+      # VERIFY
+      assert html =~ "#{Util.narrow_time(start_time)}: Shuttle"
+    end
+
     test "combines service alerts into a single row when there multiple types" do
       # SETUP
-      assigns = %{
-        commuter_rail_status: %{
-          Faker.Cat.breed() => %{
-            alert_counts: %{
-              shuttle: %{count: 1},
-              station_closure: %{count: 2}
-            },
-            name: Faker.Cat.breed(),
-            service_today?: true,
-            sort_order: 0
-          }
-        }
-      }
+      shuttles =
+        Factories.Alerts.Alert.build_list(1, :alert,
+          effect: :shuttle,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+
+      station_closures =
+        Factories.Alerts.Alert.build_list(2, :alert,
+          effect: :station_closure,
+          severity: 3
+        )
+        |> Enum.map(&Factories.Alerts.Alert.active_now/1)
+
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _, _ -> shuttles ++ station_closures end)
+
+      assigns = %{commuter_rail_status: commuter_rail_status()}
 
       # EXERCISE
       html = render_component(&alerts_commuter_rail_status/1, assigns)


### PR DESCRIPTION
The current boundary between the backend and the frontend for Commuter Rail system status is a bit convoluted. The [CR system status backend function](https://github.com/mbta/dotcom/blob/d5a4a370f08037acbda9f731d2cdfd572a58ecb3/lib/dotcom/system_status/commuter_rail.ex#L297-L312) uses the [single-route status function](https://github.com/mbta/dotcom/blob/d5a4a370f08037acbda9f731d2cdfd572a58ecb3/lib/dotcom/system_status/commuter_rail.ex#L71-L87) to get alerts grouped into train impacts (delays and cancellations) versus service impacts (everything else), and then unpacks the delays and cancellations into a more flat `alert_counts` structure for the `<.alerts_commuter_rail_status />` component to render on the screen. `<.alerts_commuter_rail_status />` then [teases apart train impacts and service impacts](https://github.com/mbta/dotcom/blob/d5a4a370f08037acbda9f731d2cdfd572a58ecb3/lib/dotcom_web/components/system_status/commuter_rail_status.ex#L51-L131) and renders them separately.

The diagram below might make it clearer what I mean:

```mermaid
sequenceDiagram
    Participant route_status as commuter_rail_route_status/1
    Participant full_status as commuter_rail_status/0
    Participant component as <.alerts_cr_status />
    Participant html as Rendered HTML

    route_status ->> full_status: train_impacts: [...]<br />service_impacts: [...]<br />(separated)
    full_status ->> component: all_impacts<br />(flattened)
    component ->> html: <>train impacts row</><br /><>service impacts row</><br />(separated)
```

(Please forgive this abomination of a sequence diagram!)

In other words, the backend `commuter_rail_route_status/1` does a whole bunch of work to group train impacts apart from service impacts, and then `commuter_rail_status/0` forgets it, thus forcing `<.alerts_commuter_rail_status />` to have to redo the exact same work.

---

This PR simplifies the boundary between the backend and frontend by having `commuter_rail_status/0` return the same data structure that `commuter_rail_route_status/1` does with minimal processing (just adding a bit of additional info, like route ID and route name, which aren't needed for timetable status).

```mermaid
sequenceDiagram
    Participant route_status as commuter_rail_route_status/1
    Participant full_status as commuter_rail_status/0
    Participant component as <.alerts_cr_status />
    Participant html as Rendered HTML

    route_status ->> full_status: train_impacts: [...]<br />service_impacts: [...]<br />(separated)
    full_status ->> component: train_impacts: [...]<br />service_impacts: [...]<br />(separated)
    component ->> html: <>train impacts row</><br /><>service impacts row</><br />(separated)
```

That way `commuter_rail_status/0` can focus on aggregating without having to also transform the shape of the data, and `<.alerts_commuter_rail_status />` can focus on drawing things on the screen, and doing only full-status-page-specific grouping (such as collapsing multiple service impacts with different effects into a single `2 Alerts` row, and collapsing delays and cancellations into `N Delays / Cancellations`).

---

Historical note: There are good reasons why this exists the way it currently does. We [introduced CR-wide system status](https://github.com/mbta/dotcom/pull/2540) before route-specific status, and [when we added route-specific status](https://github.com/mbta/dotcom/pull/2587), we weren't really able to use the full-CR status logic, since the full CR-wide status only dealt with counts, not affected trains or alert details, which meant that `commuter_rail_status/0` and `commuter_rail_route_status/1` went through totally separate code paths. This was fine, if inelegant, until we noticed an inconsistency (how counts are calculated when a single alert affects multiple trips), which [we fixed by just having the counts be based more directly on the results](https://github.com/mbta/dotcom/pull/2744) from `commuter_rail_route_status/1`, but we decided to keep everything outside of `Dotcom.SystemStatus.CommuterRail` unchanged as part of that fix. Thus, here we are!