### PR TITLE
fix: Don't crash the planned disruptions page if an alert is recurring and "until further notice"

### DIFF
--- a/lib/dotcom/alerts/subway/disruptions.ex
+++ b/lib/dotcom/alerts/subway/disruptions.ex
@@ -75,6 +75,15 @@ defmodule Dotcom.Alerts.Subway.Disruptions do
   # after, so active periods of {Mon, Wed} and {Thu, Fri} would be
   # combined into {Mon, Fri}, as would {Mon, Wed} and {Wed, Fri}, but
   # {Mon, Tue} and {Thu, Fri} would be kept separate.
+  defp combine_contiguous_active_periods(active_periods)
+
+  # Short-circuit: If the end time of a given active period is "until
+  # further notice", then the entire active period is contiguous and
+  # "until further notice".
+  defp combine_contiguous_active_periods([{start, nil} | _]), do: [{start, nil}]
+
+  # Otherwise, check whether the first two dates are contiguous and
+  # combine or separate them as appropriate.
   defp combine_contiguous_active_periods([active_period1, active_period2 | rest]) do
     {start1, end1} = active_period1
     {start2, end2} = active_period2

--- a/test/dotcom/alerts/subway/disruptions_test.exs
+++ b/test/dotcom/alerts/subway/disruptions_test.exs
@@ -322,6 +322,31 @@ defmodule Dotcom.Alerts.Subway.DisruptionsTest do
              ]
     end
 
+    # This use case is a sign that someone entered something
+    # incorrectly into Alerts UI, since a recurring alert necessarily
+    # should have an end time, but since the UI allows it, we need to
+    # handle it
+    test "does the right thing for recurring `until further notice` alerts" do
+      # Setup
+      {start_1, _} = service_range_day()
+      {start_2, _} = service_range_next_week()
+
+      # A nil end-time indicates that the alert is `until futher notice`
+      alert_indefinite = disruption_alert([{start_1, nil}, {start_2, nil}])
+
+      expect(Alerts.Repo.Mock, :by_route_ids, fn _route_ids, _now ->
+        [alert_indefinite]
+      end)
+
+      # Exercise
+      disruptions = todays_disruptions()
+
+      # Verify
+      assert disruptions.today |> Enum.map(& &1.id) == [
+               alert_indefinite.id
+             ]
+    end
+
     test "sorts alerts by start time" do
       # Setup
       {start, stop} = service_range_day()


### PR DESCRIPTION
While testing https://github.com/mbta/dotcom/pull/2675, we discovered that the `/alerts/subway` page was crashing on both [dev-blue](https://dev-blue.mbtace.com/alerts/subway) and [dev-green](https://dev-green.mbtace.com/alerts/subway). That's because there's an alert in the test environment that is recurring and also has an effect period of `until further notice`.

<img width="618" height="190" alt="Screenshot 2025-10-06 at 11 25 35 AM" src="https://github.com/user-attachments/assets/7b452c3c-3f93-4cb7-be36-8da39db350a1" />

Our [logic to combine contiguous active periods](https://github.com/mbta/dotcom/blob/d5a4a370f08037acbda9f731d2cdfd572a58ecb3/lib/dotcom/alerts/subway/disruptions.ex#L83) croaks if the active period list looks like `[{date1, nil}, {date2, _}]`, because it tries to get the service date of `nil`, which isn't a sensible thing to do. This PR fixes that by just short-circuiting when it sees `nil` in that spot.

---

This is a scenario that shouldn't happen in the real world, because the units of recurring alerts almost definitionally should be bounded in time. But Alerts UI allows you to do this, so we need to handle it.

---

No ticket.