### PR TITLE
SF2.0[Fix]: Handle predictions with nil times and nil schedule

### DIFF
--- a/lib/dotcom/schedule_finder/trip_details.ex
+++ b/lib/dotcom/schedule_finder/trip_details.ex
@@ -145,7 +145,7 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
     if route_type in [0, 1] && status do
       {:status, status}
     else
-      if(display_time) do
+      if display_time do
         {:time, display_time |> truncate(:minute)}
       end
     end

--- a/lib/dotcom/schedule_finder/trip_details.ex
+++ b/lib/dotcom/schedule_finder/trip_details.ex
@@ -140,11 +140,14 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
   defp trip_stop_time(predicted_schedule) do
     %Route{type: route_type} = PredictedSchedule.route(predicted_schedule)
     status = PredictedSchedule.status(predicted_schedule)
+    display_time = predicted_schedule |> PredictedSchedule.display_time()
 
     if route_type in [0, 1] && status do
       {:status, status}
     else
-      {:time, predicted_schedule |> PredictedSchedule.display_time() |> truncate(:minute)}
+      if(display_time) do
+        {:time, display_time |> truncate(:minute)}
+      end
     end
   end
 

--- a/lib/predicted_schedule.ex
+++ b/lib/predicted_schedule.ex
@@ -262,6 +262,12 @@ defmodule PredictedSchedule do
 
   def display_time(%PredictedSchedule{
         prediction: %Prediction{arrival_time: nil, departure_time: nil},
+        schedule: nil
+      }),
+      do: nil
+
+  def display_time(%PredictedSchedule{
+        prediction: %Prediction{arrival_time: nil, departure_time: nil},
         schedule: schedule
       }),
       do: display_time(schedule)
@@ -348,6 +354,11 @@ defmodule PredictedSchedule do
     prediction_time = PredictedSchedule.display_time(prediction)
 
     schedule_time != nil && prediction_time == nil
+  end
+
+  def cancelled?(%PredictedSchedule{schedule: nil, prediction: prediction})
+      when prediction != nil do
+    is_nil(prediction.arrival_time) and is_nil(prediction.departure_time)
   end
 
   def cancelled?(_), do: false

--- a/test/dotcom/schedule_finder/trip_details_test.exs
+++ b/test/dotcom/schedule_finder/trip_details_test.exs
@@ -1063,6 +1063,7 @@ defmodule Dotcom.ScheduleFinder.TripDetailsTest do
 
     vehicle =
       Factories.Vehicles.Vehicle.build(:vehicle,
+        status: Faker.Util.pick([:in_transit, :incoming]),
         stop_id: stop_id,
         trip_id: trip.id,
         id: vehicle_id

--- a/test/dotcom/schedule_finder/trip_details_test.exs
+++ b/test/dotcom/schedule_finder/trip_details_test.exs
@@ -1027,4 +1027,56 @@ defmodule Dotcom.ScheduleFinder.TripDetailsTest do
     vehicle_info = trip_details.vehicle_info
     assert vehicle_info.vehicle_name == nil
   end
+
+  test "handles added trips with cancelled/skipped stops" do
+    platform_name = Faker.Pizza.sauce()
+    stop = Factories.Stops.Stop.build(:stop, parent_id: nil, platform_name: platform_name)
+    stop_id = stop.id
+    trip = Factories.Schedules.Trip.build(:trip)
+
+    stub(Routes.Repo.Mock, :get, fn id ->
+      Factories.Routes.Route.build(
+        Faker.Util.pick([:subway_route, :bus_route, :commuter_rail_route]),
+        id: id
+      )
+    end)
+
+    stub(Stops.Repo.Mock, :get, fn
+      ^stop_id -> stop
+      _ -> Factories.Stops.Stop.build(:stop)
+    end)
+
+    first_predicted_schedule = %PredictedSchedule{
+      prediction:
+        Factories.Predictions.Prediction.build(:prediction,
+          trip: trip,
+          platform_stop_id: stop_id,
+          arrival_time: nil,
+          departure_time: nil
+        ),
+      schedule: nil
+    }
+
+    predicted_schedules = [first_predicted_schedule]
+    route_id = Faker.Util.pick(["1", "2", "Red", "Green-B"])
+    vehicle_id = Faker.Pokemon.name()
+
+    vehicle =
+      Factories.Vehicles.Vehicle.build(:vehicle,
+        stop_id: stop_id,
+        trip_id: trip.id,
+        id: vehicle_id
+      )
+      |> Map.put(:route_id, route_id)
+
+    trip_details =
+      TripDetails.trip_details(%{
+        predicted_schedules: predicted_schedules,
+        trip_vehicle: vehicle
+      })
+
+    [trip_stop] = trip_details.stops
+    assert trip_stop.time == nil
+    assert trip_stop.cancelled? == true
+  end
 end


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

~~**Asana Ticket:** [TICKET_NAME](TICKET_LINK)~~
https://mbta.slack.com/archives/GRB64NPHS/p1775669968697359

## Implementation
Updated cancelled?() logic to return true if there are no prediction times nor schedule for a prediction
Added logic to handle display time for predictions without a schedule nor any predicted arrival or departure times and to treat them as cancelled/skipped.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### This branch
<img width="613" height="618" alt="Screenshot 2026-04-08 at 3 06 02 PM" src="https://github.com/user-attachments/assets/f44238e2-2651-4d21-ae59-1d38502e8090" />

### Dev Green
<img width="635" height="131" alt="Screenshot 2026-04-08 at 3 06 22 PM" src="https://github.com/user-attachments/assets/516a9b6d-5bd0-43f6-8378-afbb6b37f0cd" />

## How to test

Visit SF2.0 when stops are being skipped and trips are added(?)  THere's one now on dev-green
http://localhost:4001/departures/?route_id=Red&direction_id=0&stop_id=place-sstat

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
