### PR TITLE
fix(ScheduleFinderLive): check nil last_trip_time

### DIFF
--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -67,7 +67,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
          |> assign_new(:direction_id, fn -> direction_id end)
          |> assign_new(:stop, fn -> stop end)
          |> assign_new(:upcoming_departures, fn -> AsyncResult.loading([]) end)
-         |> assign_new(:last_trip_time, fn -> AsyncResult.loading([]) end)
+         |> assign_new(:last_trip_time, fn -> AsyncResult.loading() end)
          |> assign_new(:alerts, fn -> [] end)
          |> assign_new(:service_groups, fn -> service_groups end)
          |> assign_new(:loaded_trips, fn -> %{} end)
@@ -325,27 +325,23 @@ defmodule DotcomWeb.ScheduleFinderLive do
     date = DateTime.to_date(@date_time.now()) |> Date.to_string()
     stop = socket.assigns.stop
 
-    if stop do
-      assign_async(
-        socket,
-        :last_trip_time,
-        fn ->
-          {_, departures} =
-            get_departures(route_id, direction_id, stop.id, date)
+    assign_async(
+      socket,
+      :last_trip_time,
+      fn ->
+        {_, departures} =
+          get_departures(route_id, direction_id, stop.id, date)
 
-          last_trip_time =
-            departures.departures
-            |> Enum.sort_by(fn departure -> DateTime.to_unix(departure.time) end)
-            |> Enum.at(-1, %{})
-            |> Map.get(:time)
+        last_trip_time =
+          departures.departures
+          |> Enum.sort_by(fn departure -> DateTime.to_unix(departure.time) end)
+          |> Enum.at(-1, %{})
+          |> Map.get(:time)
 
-          {:ok, %{last_trip_time: last_trip_time}}
-        end,
-        reset: true
-      )
-    else
-      assign(socket, :last_trip_time, AsyncResult.ok(nil))
-    end
+        {:ok, %{last_trip_time: last_trip_time}}
+      end,
+      reset: true
+    )
   end
 
   defp assign_departures(socket) do

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -1223,7 +1223,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
     if(is_nil(last_departure_time)) do
       true
     else
-      if DateTime.after?(last_departure_time, last_trip_time) or
+      if (not is_nil(last_trip_time) and DateTime.after?(last_departure_time, last_trip_time)) or
            DateTime.before?(last_trip_time, @date_time.now()) or
            has_last_trip? do
         false


### PR DESCRIPTION
## Scope

Caught on Splunk:

```
fdb28a729ebe ** (exit) an exception was raised:
fdb28a729ebe ** (FunctionClauseError) no function clause matching in DateTime.compare/2
fdb28a729ebe (elixir 1.19.5) lib/calendar/datetime.ex:1475: DateTime.compare(#DateTime<2026-04-09 12:06:00-04:00 -04 Etc/UTC-4>, nil)
fdb28a729ebe (elixir 1.19.5) lib/calendar/datetime.ex:1535: DateTime.after?/2
fdb28a729ebe (dotcom 0.0.1) lib/dotcom_web/live/schedule_finder_live.ex:1226: DotcomWeb.ScheduleFinderLive.show_last_service?/1
fdb28a729ebe (dotcom 0.0.1) lib/dotcom_web/live/schedule_finder_live.ex:1241: DotcomWeb.ScheduleFinderLive.remaining_service/1
fdb28a729ebe (phoenix_live_view 1.1.26) lib/phoenix_live_view/tag_engine.ex:137: Phoenix.LiveView.TagEngine.component/3
fdb28a729ebe (dotcom 0.0.1) lib/dotcom_web/live/schedule_finder_live.ex:776: anonymous fn/2 in DotcomWeb.ScheduleFinderLive.upcoming_departures_section/1
fdb28a729ebe (dotcom 0.0.1) /home/lib/dotcom_web/live/schedule_finder_live.ex:114: DotcomWeb.ScheduleFinderLive.render/1
```

## Implementation

Technically just the first commit will do the job.

## How to test

No idea what causes `remaining_departures != []` _and_ a `nil` value for `last_trip_time`, curious for ideas there. But it only came up a few times, soon after deploying... so I wonder if there's some race condition going on here.
