### PR TITLE
fix(SF2.0): No `The` for ferry names

### DIFF
--- a/lib/dotcom/schedule_finder/trip_details.ex
+++ b/lib/dotcom/schedule_finder/trip_details.ex
@@ -279,7 +279,7 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
   end
 
   defp boat_name(name) do
-    ("The " <> name)
+    name
     |> String.split(" ")
     |> Enum.map_join(
       " ",

--- a/test/dotcom/schedule_finder/trip_details_test.exs
+++ b/test/dotcom/schedule_finder/trip_details_test.exs
@@ -975,7 +975,7 @@ defmodule Dotcom.ScheduleFinder.TripDetailsTest do
       })
 
     vehicle_info = trip_details.vehicle_info
-    assert vehicle_info.vehicle_name == "The " <> vehicle_id
+    assert vehicle_info.vehicle_name == vehicle_id
   end
 
   test "does not show vehicle names for busses and such" do


### PR DESCRIPTION
## Scope

No ticket - feedback from the Director of Ferry Ops when I showed him a screenshot.

## Screenshots

Ferry data isn't available in any environment right now, sadly.

## How to Test

The update unit test should hopefully provide at least some confidence that the change works as expected.

Or we can wait until ferry data is available again, and visit a [ferry departures page](http://localhost:4001/departures/?route_id=Boat-F1&direction_id=1&stop_id=Boat-Hingham) (or maybe [this one](https://dev-green.mbtace.com/departures/?route_id=Boat-F2H&direction_id=1&stop_id=Boat-Hingham)? I've gotten a bit lost with how the Hingham/Hull route splitting is working).