### PR TITLE
A11Y: Improve semantics of visual tab panels that are links

### DIFF
--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -1,16 +1,25 @@
-const updateTabs = (tabType, navTabs, contentTabs) => e => {
+const updateTabs = (tabType, navTabs, contentTabs, updateContent=true) => e => {
+
   e.preventDefault();
+  e.stopPropagation();
 
   navTabs.forEach(tab => {
     const clickedTab = tab.dataset.tabType === tabType;
     tab.classList.toggle("active", clickedTab);
     tab.setAttribute("aria-selected", clickedTab);
+    tab.removeAttribute("aria-current")
+    if(clickedTab){
+      if(updateContent){tab.setAttribute("aria-current","page");}
+      tab.focus();
+    }
   });
 
-  contentTabs.forEach(tab => {
-    const clickedTabContentType = tab.dataset.tabContentType === tabType;
-    tab.classList.toggle("active", clickedTabContentType);
-  });
+  if(updateContent){
+    contentTabs.forEach(tab => {
+      const clickedTabContentType = tab.dataset.tabContentType === tabType;
+      tab.classList.toggle("active", clickedTabContentType);
+    });
+  }
 };
 
 const tabbedNavSetup = () => {
@@ -22,9 +31,19 @@ const tabbedNavSetup = () => {
     const callback = updateTabs(tabType, navTabs, contentTabs);
 
     item.addEventListener("click", callback);
-    item.addEventListener("keyup", e => {
+    item.addEventListener("keydown", e => {
       if (e.key === "Enter") {
         callback(e);
+      }
+      const selectedTab = Array.from(navTabs).findIndex(tab=>{tab.getAttribute("aria-selected")=="true"});
+      if(e.key === "ArrowLeft" && selectedTab > 0){
+        updateTabs(navTabs[selectedTab-1].dataset.tabType, navTabs, contentTabs, false)(e);
+      }
+      if(e.key === "ArrowRight" && selectedTab < navTabs.length - 1){
+        updateTabs(navTabs[selectedTab+1].dataset.tabType, navTabs, contentTabs, false)(e);
+      }
+      if(e.key === " "){
+        updateTabs(navTabs[selectedTab].dataset.tabType, navTabs, contentTabs, true)(e);
       }
     });
   });

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -1,5 +1,9 @@
-const updateTabs = (tabType, navTabs, contentTabs, updateContent=true) => e => {
-
+const updateTabs = (
+  tabType,
+  navTabs,
+  contentTabs,
+  updateContent = true
+) => e => {
   e.preventDefault();
   e.stopPropagation();
 
@@ -7,14 +11,16 @@ const updateTabs = (tabType, navTabs, contentTabs, updateContent=true) => e => {
     const clickedTab = tab.dataset.tabType === tabType;
     tab.classList.toggle("active", clickedTab);
     tab.setAttribute("aria-selected", clickedTab);
-    tab.removeAttribute("aria-current")
-    if(clickedTab){
-      if(updateContent){tab.setAttribute("aria-current","page");}
+    tab.removeAttribute("aria-current");
+    if (clickedTab) {
+      if (updateContent) {
+        tab.setAttribute("aria-current", "page");
+      }
       tab.focus();
     }
   });
 
-  if(updateContent){
+  if (updateContent) {
     contentTabs.forEach(tab => {
       const clickedTabContentType = tab.dataset.tabContentType === tabType;
       tab.classList.toggle("active", clickedTabContentType);
@@ -35,17 +41,74 @@ const tabbedNavSetup = () => {
       if (e.key === "Enter") {
         callback(e);
       }
-      const selectedTab = Array.from(navTabs).findIndex(tab=>tab.getAttribute("aria-selected")=="true");
-      if(e.key === "ArrowLeft" && selectedTab > 0){
-        updateTabs(navTabs[selectedTab-1].dataset.tabType, navTabs, contentTabs, false)(e);
+      const selectedTab = Array.from(navTabs).findIndex(
+        tab => tab.getAttribute("aria-selected") === "true"
+      );
+      if (e.key === "ArrowLeft" && selectedTab > 0) {
+        updateTabs(
+          navTabs[selectedTab - 1].dataset.tabType,
+          navTabs,
+          contentTabs,
+          false
+        )(e);
       }
-      if(e.key === "ArrowRight" && selectedTab < navTabs.length - 1){
-        updateTabs(navTabs[selectedTab+1].dataset.tabType, navTabs, contentTabs, false)(e);
+      if (e.key === "ArrowRight" && selectedTab < navTabs.length - 1) {
+        updateTabs(
+          navTabs[selectedTab + 1].dataset.tabType,
+          navTabs,
+          contentTabs,
+          false
+        )(e);
       }
-      if(e.key === " "){
-        updateTabs(navTabs[selectedTab].dataset.tabType, navTabs, contentTabs, true)(e);
+      if (e.key === " ") {
+        updateTabs(
+          navTabs[selectedTab].dataset.tabType,
+          navTabs,
+          contentTabs,
+          true
+        )(e);
       }
     });
+  });
+};
+
+// The following code is for handling keyboard navigation and aria attributes for tabs that are links to other pages
+
+const handleTabsKeys = event => {
+  const { key, currentTarget } = event;
+  const { parentNode } = currentTarget;
+  const selectedTabIndex = Array.from(parentNode.children).findIndex(
+    tab => tab === document.activeElement
+  );
+  let newIndex = selectedTabIndex;
+
+  if (
+    key === "ArrowRight" &&
+    selectedTabIndex < parentNode.children.length - 1
+  ) {
+    newIndex += 1;
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  if (key === "ArrowLeft" && selectedTabIndex > 0) {
+    newIndex -= 1;
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  if (key === " ") {
+    currentTarget.click();
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  currentTarget.setAttribute("aria-selected", false);
+  parentNode.children[newIndex].focus();
+  parentNode.children[newIndex].setAttribute("aria-selected", true);
+};
+
+const genericTabsSetup = () => {
+  Array.from(document.querySelectorAll(".tabnav")).forEach(elem => {
+    elem.addEventListener("keydown", handleTabsKeys);
   });
 };
 
@@ -54,38 +117,4 @@ export default function init() {
     tabbedNavSetup();
     genericTabsSetup();
   });
-}
-
-const genericTabsSetup = ()=>{
-  Array.from(document.querySelectorAll(".tabnav")).forEach(elem => {
-    elem.addEventListener("keydown", handleTabsKeys)
-  });
-}
-
-const handleTabsKeys = (event) => {
- 
-  const {key, currentTarget} = event;
-  const {id, parentNode} = currentTarget;
-  const selectedTabIndex = Array.from(parentNode.children).findIndex(tab=>tab==document.activeElement);
-  let newIndex = selectedTabIndex;
-
-  if(key === "ArrowRight" && selectedTabIndex < parentNode.children.length-1){
-    newIndex+=1;
-    event.preventDefault();
-    event.stopPropagation();
-  }
-  if(key === "ArrowLeft" && selectedTabIndex > 0){
-    newIndex-=1;
-    event.preventDefault();
-    event.stopPropagation();
-  }
-  if(key === " "){
-    currentTarget.click();
-    event.preventDefault();
-    event.stopPropagation();
-  }
-  
-  currentTarget.setAttribute("aria-selected",false);
-  parentNode.children[newIndex].focus();
-  parentNode.children[newIndex].setAttribute("aria-selected",true);
 }

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -42,7 +42,7 @@ const tabbedNavSetup = () => {
         callback(e);
       }
       const selectedTab = Array.from(navTabs).findIndex(
-        tab => tab.getAttribute("aria-selected") === "true"
+        tab => tab===document.activeElement
       );
       if (e.key === "ArrowLeft" && selectedTab > 0) {
         updateTabs(

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -28,6 +28,36 @@ const updateTabs = (
   }
 };
 
+function focusNextElement() {
+  // Select all visible, non-disabled focusable elements
+  const focusables = Array.from(document.querySelectorAll(
+    'button, input, select, textarea, [tabindex]:not([tabindex="-1"]), a'
+  )).filter(el => !el.disabled && el.offsetWidth > 0);
+
+  const currentIndex = focusables.indexOf(document.activeElement);
+  let nextIndex = (currentIndex + 1) % focusables.length;
+  while(focusables[nextIndex].classList.contains("m-tabbed-nav__item")){
+    nextIndex = (nextIndex + 1) % focusables.length
+  } 
+  const nextElement = focusables[nextIndex]; // Wrap to start if at end
+  if (nextElement) nextElement.focus();
+}
+
+function focusPreviousElement() {
+  // Select all visible, non-disabled focusable elements
+  const focusables = Array.from(document.querySelectorAll(
+    'button, input, select, textarea, [tabindex]:not([tabindex="-1"]), a'
+  )).filter(el => !el.disabled && el.offsetWidth > 0);
+
+  const currentIndex = focusables.indexOf(document.activeElement);
+  let nextIndex = currentIndex ? (currentIndex - 1) : focusables.length-1;
+  while(focusables[nextIndex].classList.contains("m-tabbed-nav__item")){
+    nextIndex = nextIndex ? (nextIndex - 1) : focusables.length-1;
+  } 
+  const nextElement = focusables[nextIndex]; // Wrap to start if at end
+  if (nextElement) nextElement.focus();
+}
+
 const tabbedNavSetup = () => {
   const navTabs = document.querySelectorAll(".m-tabbed-nav__item");
   const contentTabs = document.querySelectorAll(".m-tabbed-nav__content-item");
@@ -67,6 +97,15 @@ const tabbedNavSetup = () => {
           contentTabs,
           true
         )(e);
+      }
+      if (e.key === "Tab"){
+        if(e.shiftKey){
+          focusPreviousElement();
+        }else{
+          focusNextElement();
+        }
+        e.preventDefault();
+        e.stopPropagation();
       }
     });
   });

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -35,7 +35,7 @@ const tabbedNavSetup = () => {
       if (e.key === "Enter") {
         callback(e);
       }
-      const selectedTab = Array.from(navTabs).findIndex(tab=>{tab.getAttribute("aria-selected")=="true"});
+      const selectedTab = Array.from(navTabs).findIndex(tab=>tab.getAttribute("aria-selected")=="true");
       if(e.key === "ArrowLeft" && selectedTab > 0){
         updateTabs(navTabs[selectedTab-1].dataset.tabType, navTabs, contentTabs, false)(e);
       }
@@ -52,5 +52,40 @@ const tabbedNavSetup = () => {
 export default function init() {
   window.addEventListener("load", () => {
     tabbedNavSetup();
+    genericTabsSetup();
   });
+}
+
+const genericTabsSetup = ()=>{
+  Array.from(document.querySelectorAll(".tabnav")).forEach(elem => {
+    elem.addEventListener("keydown", handleTabsKeys)
+  });
+}
+
+const handleTabsKeys = (event) => {
+ 
+  const {key, currentTarget} = event;
+  const {id, parentNode} = currentTarget;
+  const selectedTabIndex = Array.from(parentNode.children).findIndex(tab=>tab==document.activeElement);
+  let newIndex = selectedTabIndex;
+
+  if(key === "ArrowRight" && selectedTabIndex < parentNode.children.length-1){
+    newIndex+=1;
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  if(key === "ArrowLeft" && selectedTabIndex > 0){
+    newIndex-=1;
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  if(key === " "){
+    currentTarget.click();
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  
+  currentTarget.setAttribute("aria-selected",false);
+  parentNode.children[newIndex].focus();
+  parentNode.children[newIndex].setAttribute("aria-selected",true);
 }

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -42,7 +42,7 @@ const tabbedNavSetup = () => {
         callback(e);
       }
       const selectedTab = Array.from(navTabs).findIndex(
-        tab => tab===document.activeElement
+        tab => tab === document.activeElement
       );
       if (e.key === "ArrowLeft" && selectedTab > 0) {
         updateTabs(

--- a/lib/dotcom/components/tabs/tab_selector/component.html.eex
+++ b/lib/dotcom/components/tabs/tab_selector/component.html.eex
@@ -1,5 +1,5 @@
 <div class="tab-selector-container">
-  <nav class="<%= args.class %>" role="navigation">
+  <nav class="<%= args.class %>" role="navigation" aria-label="stations mode tabs">
     <div class="tab-select-btn-group">
       <div class="stacked-tab-label"><strong><%= args.stacked_label %></strong></div>
       <%= for {tab_item_name, title, href} <- args.links do %>
@@ -7,7 +7,7 @@
         selected_class = if selected?(tab_item_name, args.selected), do: "tab-select-btn-selected", else: ""
         slug = slug(title)
         %>
-        <%= PhoenixHTMLHelpers.Link.link to: "#{href}\##{slug}", data: [scroll: "false"], id: slug, class: "btn #{selected_class}" do %>
+        <%= PhoenixHTMLHelpers.Link.link to: "#{href}\##{slug}", data: [scroll: "false"], id: slug, aria_selected: args.selected, aria_current: (if args.selected, do: "page"), class: "btn #{selected_class} tabnav" do %>
           <%= if icon = args.icon_map[title] do %>
             <%= icon %>
           <% end %>

--- a/lib/dotcom_web/components/layouts/alerts_layout.html.heex
+++ b/lib/dotcom_web/components/layouts/alerts_layout.html.heex
@@ -10,11 +10,14 @@
       </div>
     </div>
     <div class="col-lg-8 col-lg-offset-1">
-      <div class="m-alerts__mode-buttons mb-lg">
+      <nav aria-label="alert mode tabs" id="alertnsav" class="m-alerts__mode-buttons mb-lg">
         <a
           :for={mode <- [:subway, :bus, :commuter_rail, :ferry, :access]}
           href={~p"/alerts/#{mode}"}
-          class="m-alerts__mode-button-container"
+          class="m-alerts__mode-button-container tabnav"
+          aria-selected={@mode == mode}
+          aria-current={if @mode == mode, do: "page"}
+          id={"nav_tab_#{mode}"}
         >
           <div class={[
             "m-alerts__mode-button",
@@ -24,7 +27,7 @@
             <div class="m-alerts__mode-name">{DotcomWeb.AlertView.type_name(mode)}</div>
           </div>
         </a>
-      </div>
+      </nav>
 
       {render_slot(@main_section)}
 

--- a/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+++ b/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
@@ -1,54 +1,56 @@
 <div class="m-tabbed-nav" role="navigation">
-  <div class="nav m-tabbed-nav__items" role="tablist">
-    <div class="m-tabbed-nav__item-container">
-      <a
-        tabindex="0"
-        class="nav-link m-tabbed-nav__item active"
-        role="tab"
-        data-toggle="tab"
-        data-tab-type="schedules"
-        aria-controls="schedules-content"
-        aria-selected="true"
-      >
-        <span aria-hidden="true">
-          {svg("icon-map-default.svg")}
-        </span>
-        <span href="/schedules" class="m-tabbed-nav__icon-text">{~t(Routes)}</span>
-      </a>
+  <nav aria-label="home navigation" id="homenav">
+    <div class="nav m-tabbed-nav__items" role="tablist">
+      <div class="m-tabbed-nav__item-container">
+        <a
+          tabindex="0"
+          class="nav-link m-tabbed-nav__item active"
+          role="tab"
+          data-toggle="tab"
+          data-tab-type="schedules"
+          aria-controls="schedules-content"
+          aria-selected="true"
+        >
+          <span aria-hidden="true">
+            {svg("icon-map-default.svg")}
+          </span>
+          <span href="/schedules" class="m-tabbed-nav__icon-text">{~t(Routes)}</span>
+        </a>
+      </div>
+      <div class="m-tabbed-nav__item-container">
+        <a
+          tabindex="0"
+          class="nav-link m-tabbed-nav__item"
+          role="tab"
+          data-toggle="tab"
+          data-tab-type="trip-planner"
+          aria-controls="trip-planner-content"
+          aria-selected="false"
+        >
+          <span aria-hidden="true">
+            {svg("icon-trip-planner-default.svg")}
+          </span>
+          <span href="/trip-planner" class="m-tabbed-nav__icon-text">{~t(Trip Planner)}</span>
+        </a>
+      </div>
+      <div class="m-tabbed-nav__item-container">
+        <a
+          tabindex="0"
+          class="nav-link m-tabbed-nav__item"
+          role="tab"
+          data-toggle="tab"
+          data-tab-type="alerts"
+          aria-controls="alerts-content"
+          aria-selected="false"
+        >
+          <span aria-hidden="true">
+            {svg("icon-alerts-default.svg")}
+          </span>
+          <span href="/alerts" class="m-tabbed-nav__icon-text">{~t(Alerts)}</span>
+        </a>
+      </div>
     </div>
-    <div class="m-tabbed-nav__item-container">
-      <a
-        tabindex="0"
-        class="nav-link m-tabbed-nav__item"
-        role="tab"
-        data-toggle="tab"
-        data-tab-type="trip-planner"
-        aria-controls="trip-planner-content"
-        aria-selected="false"
-      >
-        <span aria-hidden="true">
-          {svg("icon-trip-planner-default.svg")}
-        </span>
-        <span href="/trip-planner" class="m-tabbed-nav__icon-text">{~t(Trip Planner)}</span>
-      </a>
-    </div>
-    <div class="m-tabbed-nav__item-container">
-      <a
-        tabindex="0"
-        class="nav-link m-tabbed-nav__item"
-        role="tab"
-        data-toggle="tab"
-        data-tab-type="alerts"
-        aria-controls="alerts-content"
-        aria-selected="false"
-      >
-        <span aria-hidden="true">
-          {svg("icon-alerts-default.svg")}
-        </span>
-        <span href="/alerts" class="m-tabbed-nav__icon-text">{~t(Alerts)}</span>
-      </a>
-    </div>
-  </div>
+  </nav>
   <div class="m-tabbed-nav__content">
     <div
       role="tabpanel"

--- a/lib/dotcom_web/views/partial/header_tabs.ex
+++ b/lib/dotcom_web/views/partial/header_tabs.ex
@@ -9,7 +9,7 @@ defmodule DotcomWeb.PartialView.HeaderTabs do
     selected = Keyword.get(opts, :selected, "")
     tab_class = Keyword.get(opts, :tab_class, "")
 
-    content_tag :div, class: "header-tabs" do
+    content_tag :nav, class: "header-tabs" do
       Enum.map(tabs, &render_tab(&1, tab_class, &1.id == selected))
     end
   end
@@ -20,7 +20,9 @@ defmodule DotcomWeb.PartialView.HeaderTabs do
 
     Link.link to: href,
               id: id,
-              class: "header-tab #{selected_class(selected?)} #{class} #{id}" do
+              aria_current: if(selected?, do: "page"),
+              aria_selected: selected?,
+              class: "header-tab #{selected_class(selected?)} #{class} #{id} tabnav" do
       [name, render_badge(badge)]
     end
   end

--- a/test/dotcom_web/views/partial_view_test.exs
+++ b/test/dotcom_web/views/partial_view_test.exs
@@ -179,7 +179,7 @@ defmodule DotcomWeb.PartialViewTest do
         |> IO.iodata_to_binary()
 
       expected =
-        "<div class=\"header-tabs\"><a class=\"header-tab  some-tab-class a-tab\" href=\"/a\" id=\"a-tab\">A</a><a class=\"header-tab header-tab--selected some-tab-class b-tab\" href=\"/b\" id=\"b-tab\">B</a><a class=\"header-tab  some-tab-class c-tab\" href=\"/c\" id=\"c-tab\">C<span aria-label=\"5 things\" class=\"some-tab-badge\">5</span></a></div>"
+        "<nav class=\"header-tabs\"><a class=\"header-tab  some-tab-class a-tab tabnav\" href=\"/a\" id=\"a-tab\">A</a><a aria-current=\"page\" aria-selected class=\"header-tab header-tab--selected some-tab-class b-tab tabnav\" href=\"/b\" id=\"b-tab\">B</a><a class=\"header-tab  some-tab-class c-tab tabnav\" href=\"/c\" id=\"c-tab\">C<span aria-label=\"5 things\" class=\"some-tab-badge\">5</span></a></nav>"
 
       assert actual == expected
     end


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Improve semantics of visual tab panels that are links](https://app.asana.com/1/15492006741476/project/555089885850811/task/1212906222065889?focus=true)

## Implementation

Two different implementations for two different behaviors:

For the tabs on the main page (Routes, Trip Planner, Alerts) I updated the existing javascript that currently hides the appropriate content and sets the css classes to also set the aria attributes and respect keyboard navigation.

For the tabs on the other pages that are links to new pages I created a generic keyboard event hander to enabled keyboard navigation and to update the aria-selected attribute accordingly.

Users should be able to use the arrow keys to switch which tab is focused, and then either Space or Enter to activate that tab.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### MBTA.com index page tabs
https://github.com/user-attachments/assets/1848db50-9a9b-4a30-afc7-f050733cfa0d

### Alerts page mode tabs
https://github.com/user-attachments/assets/fbca6029-c018-4787-bcd8-9dbad5734441

### Schedule/Line page tabs
https://github.com/user-attachments/assets/e97fe47b-e166-48a6-ad9f-8c321716a41d

### Stops page tabs
https://github.com/user-attachments/assets/6fe3c33c-51d6-40dd-86e0-70a6de1a1190



## How to test

http://localhost:4001/
http://localhost:4001/alerts
http://localhost:4001/schedules/Orange/line
http://localhost:4001/stops/subway

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211525768292437