### PR TITLE
fix: Filter out empty params in QueryReducer

### DIFF
--- a/assets/ts/helpers/query.ts
+++ b/assets/ts/helpers/query.ts
@@ -31,6 +31,10 @@ const queryReducer = (decoder: EncoderDecoder): QueryReducer => (
   kvString: string
 ) => {
   const [key, val] = kvString.split("=");
+
+  if (key === "") {
+    return { ...params };
+  }
   return { ...params, [decoder(key)]: decoder(val.replace(/\+/g, " ")) };
 };
 

--- a/assets/ts/helpers/query.ts
+++ b/assets/ts/helpers/query.ts
@@ -33,7 +33,7 @@ const queryReducer = (decoder: EncoderDecoder): QueryReducer => (
   const [key, val] = kvString.split("=");
 
   if (key === "") {
-    return { ...params };
+    return params;
   }
 
   if (val === undefined) {

--- a/assets/ts/helpers/query.ts
+++ b/assets/ts/helpers/query.ts
@@ -35,6 +35,11 @@ const queryReducer = (decoder: EncoderDecoder): QueryReducer => (
   if (key === "") {
     return { ...params };
   }
+
+  if (val === undefined) {
+    return { ...params, [decoder(key)]: val };
+  }
+
   return { ...params, [decoder(key)]: decoder(val.replace(/\+/g, " ")) };
 };
 


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->
No asana ticket. @thecristen mentioned this in Slack.
> https://www.mbta.com/departures/?route_id=Red&&direction_id=0&stop_id=place-sstat prod seems to hang indefinitely when I fail at typing and insert an extra & heheh

See [slack thread](https://mbta.slack.com/archives/C06TP48CJ9W/p1776114081358089) for more details.

## Implementation
QueryReducer fails when the URI param has an undefined value (e.g. `mbta.com/?&&` and `mbta.com/?foo&`). This PR filters out cases where the key name is empty and adds basic handling for `undefined` values (simply passes it through as `undefined`) 
<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
Before - page hangs due to the JS param parsing erroring 
<img width="631" height="526" alt="image" src="https://github.com/user-attachments/assets/d533d5f9-84ca-4067-a81b-1ce6bfff62ec" />

After - normal display
<img width="603" height="799" alt="image" src="https://github.com/user-attachments/assets/d4a14963-61a6-4e8f-81e5-7abdd47351ab" />


## How to test
Visit a schedule finder 2.0 page with various unexpected params: 
- && (empty key, no val) [local link](http://localhost:4001/departures/?route_id=Red&&direction_id=0&stop_id=place-sstat)
- &foo& (present key, no val) [local link](http://localhost:4001/departures/?route_id=Red&foo&direction_id=0&stop_id=place-sstat)
- &foo=& (present key, empty val) [local link](http://localhost:4001/departures/?route_id=Red&foo=&direction_id=0&stop_id=place-sstat)
  - this should not hang even before this PR 
- &=bar& (empty key, present val) [local link](http://localhost:4001/departures/?route_id=Red&=bar&direction_id=0&stop_id=place-sstat)
  - this should not hang even before this PR, but the QueryReducer now strips this entry from the params
  - it may be good to go to other places where we use params to make sure they haven't been affected

verify that they no longer hang 

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
