### PR TITLE
Fix: Trip planner input label layout

### DIFF
--- a/assets/ts/ui/autocomplete/index.ts
+++ b/assets/ts/ui/autocomplete/index.ts
@@ -46,7 +46,9 @@ function setupAlgoliaAutocomplete(
   const forms = container.querySelectorAll(".aa-Form");
   forms.forEach(form => {
     const prefix = form?.querySelector(".aa-InputWrapperPrefix");
-    const isTripPlanner = form?.parentElement?.parentElement?.getAttribute("data-config")==="trip-planner";
+    const isTripPlanner =
+      form?.parentElement?.parentElement?.getAttribute("data-config") ===
+      "trip-planner";
     if (prefix && !isTripPlanner) {
       form?.appendChild(prefix);
     }

--- a/assets/ts/ui/autocomplete/index.ts
+++ b/assets/ts/ui/autocomplete/index.ts
@@ -43,11 +43,14 @@ function setupAlgoliaAutocomplete(
   }
 
   // rearrange components of the input so the tab order aligns with the visuals
-  const form = container.querySelector(".aa-Form");
-  const prefix = form?.querySelector(".aa-InputWrapperPrefix");
-  if (prefix) {
-    form?.appendChild(prefix);
-  }
+  const forms = container.querySelectorAll(".aa-Form");
+  forms.forEach(form => {
+    const prefix = form?.querySelector(".aa-InputWrapperPrefix");
+    const isTripPlanner = form?.parentElement?.parentElement?.getAttribute("data-config")==="trip-planner";
+    if (prefix && !isTripPlanner) {
+      form?.appendChild(prefix);
+    }
+  });
 
   // close on homepage veil click
   document


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

~~**Asana Ticket:** [TICKET_NAME](TICKET_LINK)~~
https://mbta.slack.com/archives/C06TP48CJ9W/p1776173398774909

## Implementation
Added logic to handle multiple autocomplete forms in one page and to not rearrange the trip planner elements.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

https://github.com/user-attachments/assets/eaa55d14-d45f-4629-bf37-7b7d423f890a


## How to test

http://localhost:4001/trip-planner

Observe that the location inputs have their A and B back in the right spot and hat the tab order for all other autocompletes still makes sense.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
