### PR TITLE
refactor(UpcomingDepatures): try using streamed predictions

### DIFF
--- a/lib/dotcom/schedule_finder/upcoming_departures.ex
+++ b/lib/dotcom/schedule_finder/upcoming_departures.ex
@@ -102,26 +102,34 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
   @typep vehicle_at_stop_status_t() ::
            :after_stop | :before_stop | :different_trip | Vehicles.Vehicle.status()
 
-  @spec upcoming_departures(%{
-          direction_id: 0 | 1,
-          now: DateTime.t(),
-          route: Route.t(),
-          stop_id: Stop.id_t()
-        }) ::
+  @spec upcoming_departures(
+          %{
+            direction_id: 0 | 1,
+            now: DateTime.t(),
+            route: Route.t(),
+            stop_id: Stop.id_t()
+          },
+          [Prediction.t()] | nil
+        ) ::
           [__MODULE__.UpcomingDeparture.t()]
           | :no_realtime
           | :no_service
           | :service_ended
           | {:before_service, __MODULE__.UpcomingDeparture.t()}
           | {:no_realtime, [__MODULE__.UpcomingDeparture.t()]}
-  def upcoming_departures(%{
-        direction_id: direction_id,
-        now: now,
-        route: route,
-        stop_id: stop_id
-      }) do
+  def upcoming_departures(
+        %{
+          direction_id: direction_id,
+          now: now,
+          route: route,
+          stop_id: stop_id
+        },
+        predictions \\ nil
+      ) do
     route_type = Route.type_atom(route)
-    predicted_schedules = predicted_schedules(route.id, direction_id, now)
+
+    predicted_schedules =
+      predicted_schedules(predictions, route.id, route_type, direction_id, now)
 
     predicted_schedules_by_trip_id =
       predicted_schedules
@@ -185,20 +193,28 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
     end
   end
 
-  defp predicted_schedules(route_id, direction_id, now) do
+  defp predicted_schedules(predictions, route_id, route_type, direction_id, now) do
     all_predictions =
-      @predictions_repo.all(
-        route: route_id,
-        direction_id: direction_id,
-        include_terminals: true,
-        discard_past_subway_predictions: false
-      )
+      if is_nil(predictions) do
+        @predictions_repo.all(
+          route: route_id,
+          direction_id: direction_id,
+          include_terminals: true,
+          discard_past_subway_predictions: false
+        )
+      else
+        predictions
+      end
 
     all_schedules =
-      @schedules_repo.by_route_ids([route_id],
-        direction_id: direction_id,
-        date: ServiceDateTime.service_date(now)
-      )
+      if route_type !== :subway do
+        @schedules_repo.by_route_ids([route_id],
+          direction_id: direction_id,
+          date: ServiceDateTime.service_date(now)
+        )
+      else
+        []
+      end
 
     PredictedSchedule.group(all_predictions, all_schedules)
   end

--- a/lib/dotcom_web/channels/predictions_channel.ex
+++ b/lib/dotcom_web/channels/predictions_channel.ex
@@ -26,12 +26,12 @@ defmodule DotcomWeb.PredictionsChannel do
   @impl Channel
   @spec join(topic :: binary(), payload :: Channel.payload(), socket :: Socket.t()) ::
           {:ok, %{predictions: [Prediction.t()]}, Socket.t()} | {:error, map()}
-  def join("predictions:" <> topic, _message, socket) do
-    case @predictions_pub_sub.subscribe(topic) do
+  def join("predictions:stop:" <> stop_id, _message, socket) do
+    case @predictions_pub_sub.subscribe(%{stop_id: stop_id}) do
       {:error, _reason} ->
         {:error,
          %{
-           message: "Cannot subscribe to predictions for #{topic}."
+           message: "Cannot subscribe to predictions for stop_id #{stop_id}."
          }}
 
       predictions ->

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -26,6 +26,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
   alias Stops.Stop
 
   @date_time Application.compile_env!(:dotcom, :date_time_module)
+  @predictions_pub_sub Application.compile_env!(:dotcom, :predictions_pub_sub)
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
 
@@ -60,7 +61,6 @@ defmodule DotcomWeb.ScheduleFinderLive do
 
         {:ok,
          socket
-         |> subscribe_to_alerts()
          |> assign_new(:route, fn -> route end)
          |> assign_page_title(route)
          |> assign_new(:vehicle_name, fn -> Route.vehicle_name(route) end)
@@ -75,8 +75,9 @@ defmodule DotcomWeb.ScheduleFinderLive do
          |> assign_new(:daily_schedule_date, fn -> service_date() end)
          |> assign_alerts()
          |> assign_departures()
-         |> assign_upcoming_departures()
-         |> assign_last_trip_time()}
+         |> assign_last_trip_time()
+         |> subscribe_to_alerts()
+         |> subscribe_to_predictions()}
 
       _ ->
         # Raising this error will render the 404 page
@@ -86,8 +87,9 @@ defmodule DotcomWeb.ScheduleFinderLive do
 
   @impl LiveView
   def terminate(_, _) do
-    # stop listening for new alerts
+    # stop listening for new alerts or predictions
     _ = Alerts.Cache.Store.unsubscribe()
+    _ = @predictions_pub_sub.unsubscribe()
   end
 
   @impl LiveView
@@ -218,12 +220,6 @@ defmodule DotcomWeb.ScheduleFinderLive do
   end
 
   @impl LiveView
-  def handle_info(:refresh_upcoming_departures, socket) do
-    {:noreply,
-     socket
-     |> assign_upcoming_departures()}
-  end
-
   def handle_info(%{event: "alerts_updated"}, socket) do
     {:noreply, assign_alerts(socket)}
   end
@@ -233,6 +229,10 @@ defmodule DotcomWeb.ScheduleFinderLive do
      socket
      |> assign_service(selected_service_label)
      |> assign_departures()}
+  end
+
+  def handle_info({:new_predictions, predictions}, socket) do
+    {:noreply, assign_upcoming_departures(socket, predictions)}
   end
 
   def handle_info(_, socket), do: {:noreply, socket}
@@ -246,9 +246,29 @@ defmodule DotcomWeb.ScheduleFinderLive do
     end
   end
 
-  defp schedule_refresh_upcoming_departures(pid) do
-    # Refresh every second
-    Process.send_after(pid, :refresh_upcoming_departures, 5000)
+  defp subscribe_to_predictions(socket) do
+    if connected?(socket) do
+      route_id = socket.assigns.route.id
+      direction_id = socket.assigns.direction_id
+      stop_id = socket.assigns.stop.id
+
+      case @predictions_pub_sub.subscribe(%{
+             route_id: route_id,
+             direction_id: direction_id,
+             stop_id: stop_id
+           }) do
+        {:error, reason} ->
+          update(socket, :upcoming_departures, &AsyncResult.failed(&1, reason))
+
+        [] ->
+          assign_upcoming_departures(socket)
+
+        predictions ->
+          assign_upcoming_departures(socket, predictions)
+      end
+    else
+      socket
+    end
   end
 
   defp validate_params(%{
@@ -272,35 +292,30 @@ defmodule DotcomWeb.ScheduleFinderLive do
     assigns |> assign(:page_title, long_name <> " | " <> ~t(Departures) <> " | " <> ~t(MBTA))
   end
 
-  defp assign_upcoming_departures(%{assigns: %{stop: %Stop{id: stop_id}}} = socket) do
+  defp assign_upcoming_departures(socket, predictions \\ nil) do
     now = @date_time.now()
     route = socket.assigns.route
     direction_id = socket.assigns.direction_id
-    stop_id = stop_id
-
-    parent_pid = self()
+    stop_id = socket.assigns.stop.id
 
     socket
     |> assign_async(
       :upcoming_departures,
       fn ->
         departures =
-          UpcomingDepartures.upcoming_departures(%{
-            direction_id: direction_id,
-            now: now,
-            route: route,
-            stop_id: stop_id
-          })
-
-        schedule_refresh_upcoming_departures(parent_pid)
+          UpcomingDepartures.upcoming_departures(
+            %{
+              direction_id: direction_id,
+              now: now,
+              route: route,
+              stop_id: stop_id
+            },
+            predictions
+          )
 
         {:ok, %{upcoming_departures: departures}}
       end
     )
-  end
-
-  defp assign_upcoming_departures(socket) do
-    socket |> assign(:upcoming_departures, [])
   end
 
   defp assign_alerts(%{assigns: %{stop: stop}} = socket) when not is_nil(stop) do

--- a/lib/predictions/pub_sub.ex
+++ b/lib/predictions/pub_sub.ex
@@ -30,10 +30,10 @@ defmodule Predictions.PubSub do
   end
 
   @impl Behaviour
-  def subscribe(topic) do
+  def subscribe(opts) do
     caller_pid = self()
 
-    case StreamTopic.new(topic) do
+    case StreamTopic.new(opts) do
       %StreamTopic{fetch_keys: fetch_keys} = stream_topic ->
         :ok = StreamTopic.start_streams(stream_topic)
         new_callers = Enum.map(stream_topic.streams, &{caller_pid, elem(&1, 1)})

--- a/lib/predictions/stream_parser.ex
+++ b/lib/predictions/stream_parser.ex
@@ -15,6 +15,7 @@ defmodule Predictions.StreamParser do
 
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
+  @timezone Application.compile_env!(:dotcom, :timezone)
 
   @spec parse(Item.t()) :: Prediction.t()
   def parse(%Item{} = item) do
@@ -66,7 +67,8 @@ defmodule Predictions.StreamParser do
   @spec parse_time(String.t()) :: DateTime.t()
   defp parse_time(time) do
     {:ok, dt, _} = DateTime.from_iso8601(time)
-    dt
+    {:ok, t} = DateTime.shift_zone(dt, @timezone)
+    t
   end
 
   @spec vehicle_id(Item.t()) :: Vehicles.Vehicle.id_t() | nil

--- a/lib/predictions/stream_topic.ex
+++ b/lib/predictions/stream_topic.ex
@@ -24,55 +24,72 @@ defmodule Predictions.StreamTopic do
   @type filter_params :: String.t()
   @type clear_keys :: Store.fetch_keys()
   @type t :: %__MODULE__{
-          topic: String.t(),
+          topic: map(),
           fetch_keys: Store.fetch_keys(),
           streams: [{clear_keys, filter_params}]
         }
 
-  @spec new(String.t()) :: t() | {:error, term()}
-  def new(topic)
+  @spec new(map()) :: t() | {:error, term()}
+  def new(%{route_id: route_id, direction_id: direction_id} = opts)
+      when is_binary(route_id) and is_integer(direction_id) do
+    fetch_keys =
+      case opts[:stop_id] do
+        nil ->
+          [route: route_id, direction: direction_id]
 
-  def new("stop:" <> stop_id = topic) do
-    [stop: stop_id]
-    |> do_new(topic)
+        stop_id ->
+          [route: route_id, direction: direction_id, stop: stop_id]
+      end
+
+    streams = [{fetch_keys, to_filter_name(%{route_id: route_id, direction_id: direction_id})}]
+
+    %__MODULE__{
+      topic: opts,
+      fetch_keys: fetch_keys,
+      streams: streams
+    }
+  end
+
+  def new(%{stop_id: stop_id} = opts) when is_binary(stop_id) do
+    fetch_keys = [stop: stop_id]
+
+    streams =
+      @route_patterns_repo.by_stop_id(stop_id)
+      |> Enum.map(&{fetch_keys, to_filter_name(&1)})
+      |> Enum.uniq()
+
+    if streams == [] do
+      {:error, :no_streams_found}
+    else
+      %__MODULE__{
+        topic: opts,
+        fetch_keys: fetch_keys,
+        streams: streams
+      }
+    end
   end
 
   def new(_) do
     {:error, :unsupported_topic}
   end
 
-  @spec do_new(Store.fetch_keys(), String.t()) :: t() | {:error, term()}
-  defp do_new(fetch_keys, topic) do
-    case streams_from_fetch_keys(fetch_keys) do
-      [] ->
-        {:error, :no_streams_found}
-
-      streams ->
-        %__MODULE__{
-          topic: topic,
-          fetch_keys: fetch_keys,
-          streams: Enum.uniq(streams)
-        }
-    end
-  end
-
-  @spec streams_from_fetch_keys(Store.fetch_keys()) :: [{clear_keys, filter_params}]
-  defp streams_from_fetch_keys(stop: stop_id) do
-    @route_patterns_repo.by_stop_id(stop_id)
-    |> Enum.map(&{to_keys(&1), to_filter_name(&1)})
-  end
-
-  defp to_keys(%RoutePatterns.RoutePattern{route_id: route_id, direction_id: direction_id}) do
-    [route: route_id, direction: direction_id]
-  end
-
-  defp to_filter_name(%RoutePatterns.RoutePattern{route_id: route_id, direction_id: direction_id}) do
+  defp to_filter_name(%{route_id: route_id, direction_id: direction_id}) do
     %{
       route: route_id,
       direction_id: direction_id
     }
     |> Enum.map_join("&", fn {filter, value} -> "filter[#{filter}]=#{value}" end)
   end
+
+  # defp to_filter_names(%{stop_id: stop_id}) do
+  #   @route_patterns_repo.by_stop_id(stop_id)
+  #   |> Enum.map(&{to_keys(&1), to_filter_name(&1)})
+  #   |> Enum.uniq()
+  # end
+
+  # defp to_keys(%{route_id: route_id, direction_id: direction_id}) do
+  #   [route: route_id, direction: direction_id]
+  # end
 
   @spec registration_keys(t()) :: [{Store.fetch_keys(), filter_params}]
   def registration_keys(%__MODULE__{fetch_keys: fetch_keys, streams: streams}) do

--- a/test/predictions/pub_sub_test.exs
+++ b/test/predictions/pub_sub_test.exs
@@ -24,18 +24,17 @@ defmodule Predictions.PubSubTest do
   setup :verify_on_exit!
 
   setup do
-    stop = Faker.Lorem.word()
-    channel = "stop:#{stop}"
+    stop_id = Faker.Lorem.word()
 
-    stub(@route_patterns_repo, :by_stop_id, fn ^stop ->
+    stub(@route_patterns_repo, :by_stop_id, fn ^stop_id ->
       [RoutePattern.build(:route_pattern)]
     end)
 
-    stub(@predictions_store, :fetch, fn [stop: ^stop] ->
+    stub(@predictions_store, :fetch, fn [stop: ^stop_id] ->
       {:reply, [], :foo}
     end)
 
-    {:ok, %{channel: channel, stop: stop}}
+    {:ok, %{stop_id: stop_id}}
   end
 
   describe "subscribe/2" do
@@ -43,20 +42,20 @@ defmodule Predictions.PubSubTest do
       # Setup
       setup_predictions = Prediction.build_list(3, :prediction)
 
-      expect(@route_patterns_repo, :by_stop_id, fn stop ->
-        assert stop == context.stop
+      expect(@route_patterns_repo, :by_stop_id, fn stop_id ->
+        assert stop_id == context.stop_id
 
         [RoutePattern.build(:route_pattern)]
       end)
 
-      expect(@predictions_store, :fetch, fn [stop: stop] ->
-        assert stop == context.stop
+      expect(@predictions_store, :fetch, fn [stop: stop_id] ->
+        assert stop_id == context.stop_id
 
         {:reply, setup_predictions, :foo}
       end)
 
       # Exercise
-      {:reply, verify_predictions, :foo} = PubSub.subscribe(context.channel)
+      {:reply, verify_predictions, :foo} = PubSub.subscribe(%{stop_id: context.stop_id})
 
       # Verify
       assert verify_predictions == setup_predictions
@@ -66,7 +65,7 @@ defmodule Predictions.PubSubTest do
       # Exercise
       assert Registry.count(:prediction_subscriptions_registry) == 0
 
-      PubSub.subscribe(context.channel)
+      PubSub.subscribe(%{stop_id: context.stop_id})
 
       # Verify
       assert Registry.count(:prediction_subscriptions_registry) == 1
@@ -78,7 +77,7 @@ defmodule Predictions.PubSubTest do
       :erlang.trace(pid, true, [:receive])
 
       # Exercise
-      PubSub.subscribe(context.channel)
+      PubSub.subscribe(%{stop_id: context.stop_id})
 
       # Verify
       assert_received {:trace, ^pid, :receive, {_, {_, _}, {:start_child, _}}}
@@ -91,8 +90,8 @@ defmodule Predictions.PubSubTest do
       pid = self()
 
       # Exercise
-      %{topic: topic_name} = StreamTopic.new(context.channel)
-      _ = PubSub.subscribe(topic_name)
+      %{topic: topic} = StreamTopic.new(%{stop_id: context.stop_id})
+      _ = PubSub.subscribe(topic)
 
       assert :ets.lookup(:callers_by_pid, pid) != []
       assert Registry.count(:prediction_subscriptions_registry) == 1
@@ -111,8 +110,8 @@ defmodule Predictions.PubSubTest do
       pid = self()
 
       # Exercise
-      %{topic: topic_name} = StreamTopic.new(context.channel)
-      _ = PubSub.subscribe(topic_name)
+      %{topic: topic} = StreamTopic.new(%{stop_id: context.stop_id})
+      _ = PubSub.subscribe(topic)
       :erlang.trace(pid, true, [:receive])
 
       # Exercise

--- a/test/predictions/stream_topic_test.exs
+++ b/test/predictions/stream_topic_test.exs
@@ -19,17 +19,17 @@ defmodule Predictions.StreamTopicTest do
         build_list(1, :route_pattern, route_id: "Route1", direction_id: 0)
       end)
 
-      topic = "stop:stopId"
+      topic = %{stop_id: "stopId"}
 
       assert %StreamTopic{
                topic: ^topic,
                fetch_keys: [stop: "stopId"],
                streams: streams
-             } = new("stop:stopId")
+             } = new(topic)
 
       [{list, string} | _] = streams
 
-      Dotcom.Assertions.assert_equal_lists(list, route: "Route1", direction: 0)
+      Dotcom.Assertions.assert_equal_lists(list, stop: "stopId")
 
       assert string =~ "filter[direction_id]=0"
       assert string =~ "filter[route]=Route1"
@@ -40,7 +40,7 @@ defmodule Predictions.StreamTopicTest do
         []
       end)
 
-      assert {:error, :no_streams_found} = new("stop:unserved_stop")
+      assert {:error, :no_streams_found} = new(%{stop_id: "unserved_stop"})
     end
 
     test "doesn't work for other topics" do


### PR DESCRIPTION
A small adjustment to SF2.0 which leverages the stop page's existing backend setup. _That_ setup connects to the V3 API streaming endpoint for predictions route-by-route, parses events from the stream to update an in-memory cache (`Predictions.Store`), and periodically dispatches the latest predictions info to subscribers. This LiveView is adjusted to subscribe to this system's updates!
A small adjustment is made to how upcoming departures are computed, in that you can now pass in a list of predictions.
This isn't useable as-is, because the trip details are not quite correct anymore. We likely will change how trip details work. This PR will remain in draft as a reference.