### PR TITLE
feat(RouteComponents): rail replacement bus icon

### DIFF
--- a/lib/dotcom/schedule_finder/upcoming_departures.ex
+++ b/lib/dotcom/schedule_finder/upcoming_departures.ex
@@ -7,6 +7,8 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
   info about an upcoming departure.
   """
 
+  use Dotcom.Gettext.Sigils
+
   import Dotcom.ScheduleFinder, only: [simplify_platform_name: 2]
   import Dotcom.Utils.Time, only: [truncate: 2]
 
@@ -286,6 +288,8 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
         vehicle: vehicle
       })
 
+    predicted_schedule_route = PredictedSchedule.route(predicted_schedule)
+
     %UpcomingDeparture{
       arrival_status:
         arrival_status(%{
@@ -303,13 +307,27 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
       headsign: trip.headsign,
       last_trip?: PredictedSchedule.last_trip?(predicted_schedule),
       platform_name: platform_name(predicted_schedule),
-      route: PredictedSchedule.route(predicted_schedule),
+      route: predicted_schedule_route,
       stop_sequence: stop_sequence,
       trip_details: trip_details,
       trip_id: trip.id,
-      trip_name: if(route_type == :commuter_rail, do: trip.name, else: nil)
+      trip_name:
+        if(route_type == :commuter_rail,
+          do: trip_name(predicted_schedule_route, trip.name),
+          else: nil
+        )
     }
   end
+
+  defp trip_name(%Route{description: :rail_replacement_bus}, name) when is_binary(name) do
+    gettext("Bus %{trip_name}", trip_name: name)
+  end
+
+  defp trip_name(%Route{type: 2}, name) when is_binary(name) do
+    gettext("Train %{trip_name}", trip_name: name)
+  end
+
+  defp trip_name(_, _), do: nil
 
   # Retrieves status if a vehicle is associated with the given stop/sequence
   @spec vehicle_at_stop_status(nil | Vehicles.Vehicle.t(), Trip.id_t(), integer()) ::

--- a/lib/dotcom_web/components/route_components.ex
+++ b/lib/dotcom_web/components/route_components.ex
@@ -26,6 +26,12 @@ defmodule DotcomWeb.RouteComponents do
     """
   end
 
+  def route_icon(%{route: %Route{description: :rail_replacement_bus}} = assigns) do
+    ~H"""
+    <SystemIcons.mode_icon mode="bus" size={@size} {@rest} />
+    """
+  end
+
   def route_icon(%{route: %Route{id: route_id}} = assigns) do
     case line_name(route_id) do
       nil ->

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -886,7 +886,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
       </:headsign>
 
       <:additional_info :if={@upcoming_departure.trip_name}>
-        {gettext("Train %{trip_name}", trip_name: @upcoming_departure.trip_name)}
+        {@upcoming_departure.trip_name}
         <span :if={!is_nil(@upcoming_departure.platform_name)} aria-hidden="true">
           &bull;
         </span>

--- a/test/dotcom/schedule_finder/upcoming_departures_test.exs
+++ b/test/dotcom/schedule_finder/upcoming_departures_test.exs
@@ -198,55 +198,42 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       # Verify
       assert [departure] = departures
 
-      assert departure.trip_name =~ trip.name
+      assert departure.trip_name == "Train #{trip.name}"
       assert departure.platform_name == platform_name
     end
 
-    test "adjusts trip name by predicted schedule route type" do
+    test "prepends 'Bus' to trip names for rail replacement buses" do
       # Setup
       %{
         predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
-        route: route,
         stops: [_, stop, _],
         trip: trip,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
-          route_factory_types: [:commuter_rail_route],
+          route_factory_types: [:rail_replacement_bus_route],
           stop_id_options: Platforms.stations_with_commuter_rail_platforms()
         )
+
+      original_route = Factories.Routes.Route.build(:commuter_rail_route)
 
       expect(Predictions.Repo.Mock, :all, 1, fn _ -> predictions end)
       expect(Schedules.Repo.Mock, :by_route_ids, 1, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, 1, fn _ -> vehicle end)
 
-      [departure] =
+      departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
           now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
+          route: original_route,
           stop_id: stop.id
         })
 
-      IO.inspect(departure.trip_name)
-      # Exercise
-      # [[shuttle_departure], [train_departure]] =
-      #   [
-      #     %{route | type: 3, description: :rail_replacement_bus},
-      #     %{route | type: 2, description: :commuter_rail}
-      #   ]
-      #   |> Enum.map(
-      #     &UpcomingDepartures.upcoming_departures(%{
-      #       direction_id: Faker.Util.pick([0, 1]),
-      #       now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-      #       route: routr,
-      #       stop_id: stop.id
-      #     })
-      #   )
+      # Verify
+      assert [departure] = departures
 
-      # assert shuttle_departure.trip_name == "Bus #{trip.name}"
-      # assert train_departure.trip_name == "Train #{trip.name}"
+      assert departure.trip_name == "Bus #{trip.name}"
     end
 
     test "does hide platform names for bus or commuter rail stops outside allowlist" do

--- a/test/dotcom/schedule_finder/upcoming_departures_test.exs
+++ b/test/dotcom/schedule_finder/upcoming_departures_test.exs
@@ -198,8 +198,55 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       # Verify
       assert [departure] = departures
 
-      assert departure.trip_name == trip.name
+      assert departure.trip_name =~ trip.name
       assert departure.platform_name == platform_name
+    end
+
+    test "adjusts trip name by predicted schedule route type" do
+      # Setup
+      %{
+        predicted_arrival_times: [_, arrival_time, _],
+        predictions: predictions,
+        route: route,
+        stops: [_, stop, _],
+        trip: trip,
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(
+          route_factory_types: [:commuter_rail_route],
+          stop_id_options: Platforms.stations_with_commuter_rail_platforms()
+        )
+
+      expect(Predictions.Repo.Mock, :all, 1, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :by_route_ids, 1, fn _, _ -> [] end)
+      expect(Vehicles.Repo.Mock, :get, 1, fn _ -> vehicle end)
+
+      [departure] =
+        UpcomingDepartures.upcoming_departures(%{
+          direction_id: Faker.Util.pick([0, 1]),
+          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
+          route: route,
+          stop_id: stop.id
+        })
+
+      IO.inspect(departure.trip_name)
+      # Exercise
+      # [[shuttle_departure], [train_departure]] =
+      #   [
+      #     %{route | type: 3, description: :rail_replacement_bus},
+      #     %{route | type: 2, description: :commuter_rail}
+      #   ]
+      #   |> Enum.map(
+      #     &UpcomingDepartures.upcoming_departures(%{
+      #       direction_id: Faker.Util.pick([0, 1]),
+      #       now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
+      #       route: routr,
+      #       stop_id: stop.id
+      #     })
+      #   )
+
+      # assert shuttle_departure.trip_name == "Bus #{trip.name}"
+      # assert train_departure.trip_name == "Train #{trip.name}"
     end
 
     test "does hide platform names for bus or commuter rail stops outside allowlist" do

--- a/test/support/factories/routes/route.ex
+++ b/test/support/factories/routes/route.ex
@@ -55,6 +55,9 @@ defmodule Test.Support.Factories.Routes.Route do
     |> route_factory()
   end
 
+  def rail_replacement_bus_route_factory(attrs),
+    do: build(:route, attrs |> Map.put(:type, 3) |> Map.put(:description, :rail_replacement_bus))
+
   def route_factory(attrs) do
     type = attrs[:type] || Faker.Util.pick([0, 1, 2, 3, 4])
     fare_class = fare_class(attrs, type)


### PR DESCRIPTION
<img width="997" height="704" alt="image" src="https://github.com/user-attachments/assets/085a0810-407a-436a-b7b4-df35b0f6295c" />

Quick fix for how we render rail replacement buses. Thanks @joshlarson for finding ([Slack thread](https://mbta.slack.com/archives/GRB64NPHS/p1775760861450949)) and contributing!