### PR TITLE
A11Y: Improve semantics of visual tab panels that are links (take 2, part 1)

### DIFF
--- a/lib/dotcom/components/tabs/tab_selector/component.html.eex
+++ b/lib/dotcom/components/tabs/tab_selector/component.html.eex
@@ -1,13 +1,14 @@
 <div class="tab-selector-container">
-  <nav class="<%= args.class %>" role="navigation">
+  <nav class="<%= args.class %>" role="navigation" aria-label="station mode tabs">
     <div class="tab-select-btn-group">
       <div class="stacked-tab-label"><strong><%= args.stacked_label %></strong></div>
       <%= for {tab_item_name, title, href} <- args.links do %>
         <%
-        selected_class = if selected?(tab_item_name, args.selected), do: "tab-select-btn-selected", else: ""
+        currently_selected? = if selected?(tab_item_name, args.selected), do: true, else: false
+        selected_class = if currently_selected?, do: "tab-select-btn-selected", else: ""
         slug = slug(title)
         %>
-        <%= PhoenixHTMLHelpers.Link.link to: "#{href}\##{slug}", data: [scroll: "false"], id: slug, class: "btn #{selected_class}" do %>
+        <%= PhoenixHTMLHelpers.Link.link to: "#{href}\##{slug}", data: [scroll: "false"], id: slug, aria_selected: currently_selected?, class: "btn #{selected_class}" do %>
           <%= if icon = args.icon_map[title] do %>
             <%= icon %>
           <% end %>

--- a/lib/dotcom_web/components/layouts/alerts_layout.html.heex
+++ b/lib/dotcom_web/components/layouts/alerts_layout.html.heex
@@ -10,7 +10,7 @@
       </div>
     </div>
     <div class="col-lg-8 col-lg-offset-1">
-      <nav aria-label="alert mode tabs" id="alertnsav" class="m-alerts__mode-buttons mb-lg">
+      <nav aria-label="alert mode tabs" class="m-alerts__mode-buttons mb-lg">
         <a
           :for={mode <- [:subway, :bus, :commuter_rail, :ferry, :access]}
           href={~p"/alerts/#{mode}"}

--- a/lib/dotcom_web/components/layouts/alerts_layout.html.heex
+++ b/lib/dotcom_web/components/layouts/alerts_layout.html.heex
@@ -10,11 +10,12 @@
       </div>
     </div>
     <div class="col-lg-8 col-lg-offset-1">
-      <div class="m-alerts__mode-buttons mb-lg">
+      <nav aria-label="alert mode tabs" id="alertnsav" class="m-alerts__mode-buttons mb-lg">
         <a
           :for={mode <- [:subway, :bus, :commuter_rail, :ferry, :access]}
           href={~p"/alerts/#{mode}"}
           class="m-alerts__mode-button-container"
+          aria-selected={@mode == mode}
         >
           <div class={[
             "m-alerts__mode-button",
@@ -24,7 +25,7 @@
             <div class="m-alerts__mode-name">{DotcomWeb.AlertView.type_name(mode)}</div>
           </div>
         </a>
-      </div>
+      </nav>
 
       {render_slot(@main_section)}
 

--- a/lib/dotcom_web/views/partial/header_tabs.ex
+++ b/lib/dotcom_web/views/partial/header_tabs.ex
@@ -9,7 +9,7 @@ defmodule DotcomWeb.PartialView.HeaderTabs do
     selected = Keyword.get(opts, :selected, "")
     tab_class = Keyword.get(opts, :tab_class, "")
 
-    content_tag :div, class: "header-tabs" do
+    content_tag :nav, aria_label: "schedule page tabs", class: "header-tabs" do
       Enum.map(tabs, &render_tab(&1, tab_class, &1.id == selected))
     end
   end
@@ -20,6 +20,7 @@ defmodule DotcomWeb.PartialView.HeaderTabs do
 
     Link.link to: href,
               id: id,
+              aria_selected: selected?,
               class: "header-tab #{selected_class(selected?)} #{class} #{id}" do
       [name, render_badge(badge)]
     end

--- a/test/dotcom_web/views/partial_view_test.exs
+++ b/test/dotcom_web/views/partial_view_test.exs
@@ -179,7 +179,7 @@ defmodule DotcomWeb.PartialViewTest do
         |> IO.iodata_to_binary()
 
       expected =
-        "<div class=\"header-tabs\"><a class=\"header-tab  some-tab-class a-tab\" href=\"/a\" id=\"a-tab\">A</a><a class=\"header-tab header-tab--selected some-tab-class b-tab\" href=\"/b\" id=\"b-tab\">B</a><a class=\"header-tab  some-tab-class c-tab\" href=\"/c\" id=\"c-tab\">C<span aria-label=\"5 things\" class=\"some-tab-badge\">5</span></a></div>"
+        "<nav aria-label=\"schedule page tabs\" class=\"header-tabs\"><a class=\"header-tab  some-tab-class a-tab\" href=\"/a\" id=\"a-tab\">A</a><a aria-selected class=\"header-tab header-tab--selected some-tab-class b-tab\" href=\"/b\" id=\"b-tab\">B</a><a class=\"header-tab  some-tab-class c-tab\" href=\"/c\" id=\"c-tab\">C<span aria-label=\"5 things\" class=\"some-tab-badge\">5</span></a></nav>"
 
       assert actual == expected
     end


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Improve semantics of visual tab panels that are links](https://app.asana.com/1/15492006741476/project/555089885850811/task/1212906222065889?focus=true)

## Implementation
Wrapped link tabs in a labeled nav element. 
 Added aria-selected attributes. 
Updated test to reflect new elements and attributes..
<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

No visual or behavioral changes, just new attributes and a &lt;nav&gt; wrapper.

## How to test

http://localhost:4001/alerts/subway
http://localhost:4001/stops/subway
http://localhost:4001/schedules/Red/line

Inspect tabs and ensure that they are wrapped in a labelled nav element, and that the currently selected tab has the aria-selected attribute.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
