### PR TITLE
A11Y: Implement tab behavior for homepage tabs

### DIFF
--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -1,17 +1,57 @@
-const updateTabs = (tabType, navTabs, contentTabs) => e => {
+const updateTabs = (
+  tabType,
+  navTabs,
+  contentTabs,
+  updateContent = true
+) => e => {
   e.preventDefault();
+  e.stopPropagation();
 
   navTabs.forEach(tab => {
     const clickedTab = tab.dataset.tabType === tabType;
     tab.classList.toggle("active", clickedTab);
     tab.setAttribute("aria-selected", clickedTab);
+    tab.removeAttribute("aria-current");
+    if (clickedTab) {
+      if (updateContent) {
+        tab.setAttribute("aria-current", "page");
+      }
+      tab.focus();
+    }
   });
 
-  contentTabs.forEach(tab => {
-    const clickedTabContentType = tab.dataset.tabContentType === tabType;
-    tab.classList.toggle("active", clickedTabContentType);
-  });
+  if (updateContent) {
+    contentTabs.forEach(tab => {
+      const clickedTabContentType = tab.dataset.tabContentType === tabType;
+      tab.classList.toggle("active", clickedTabContentType);
+    });
+  }
 };
+
+function focusNextElement(contentElementId) {
+  // Select all visible, non-disabled focusable elements
+  const focusables = Array.from(document.getElementById(contentElementId).querySelectorAll(
+    'button, input, select, textarea, [tabindex]:not([tabindex="-1"]), a'
+  )).filter(el => !el.disabled && el.offsetWidth > 0);
+
+  const nextElement = focusables[0]; // Wrap to start if at end
+  if (nextElement) nextElement.focus();
+}
+
+function focusPreviousElement() {
+  // Select all visible, non-disabled focusable elements
+  const focusables = Array.from(document.querySelectorAll(
+    'button, input, select, textarea, [tabindex]:not([tabindex="-1"]), a'
+  )).filter(el => !el.disabled && el.offsetWidth > 0);
+
+  const currentIndex = focusables.indexOf(document.activeElement);
+  let nextIndex = currentIndex ? (currentIndex - 1) : focusables.length-1;
+  while(focusables[nextIndex].classList.contains("m-tabbed-nav__item")){
+    nextIndex = nextIndex ? (nextIndex - 1) : focusables.length-1;
+  } 
+  const nextElement = focusables[nextIndex]; // Wrap to start if at end
+  if (nextElement) nextElement.focus();
+}
 
 const tabbedNavSetup = () => {
   const navTabs = document.querySelectorAll(".m-tabbed-nav__item");
@@ -22,9 +62,45 @@ const tabbedNavSetup = () => {
     const callback = updateTabs(tabType, navTabs, contentTabs);
 
     item.addEventListener("click", callback);
-    item.addEventListener("keyup", e => {
+    item.addEventListener("keydown", e => {
       if (e.key === "Enter") {
         callback(e);
+      }
+      const selectedTab = Array.from(navTabs).findIndex(
+        tab => tab === document.activeElement
+      );
+      if (e.key === "ArrowLeft" && selectedTab > 0) {
+        updateTabs(
+          navTabs[selectedTab - 1].dataset.tabType,
+          navTabs,
+          contentTabs,
+          false
+        )(e);
+      }
+      if (e.key === "ArrowRight" && selectedTab < navTabs.length - 1) {
+        updateTabs(
+          navTabs[selectedTab + 1].dataset.tabType,
+          navTabs,
+          contentTabs,
+          false
+        )(e);
+      }
+      if (e.key === " ") {
+        updateTabs(
+          navTabs[selectedTab].dataset.tabType,
+          navTabs,
+          contentTabs,
+          true
+        )(e);
+      }
+      if (e.key === "Tab"){
+        if(e.shiftKey){
+          focusPreviousElement();
+        }else{
+          focusNextElement(navTabs[selectedTab].getAttribute("aria-controls"));
+        }
+        e.preventDefault();
+        e.stopPropagation();
       }
     });
   });

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -12,10 +12,13 @@ const updateTabs = (
     tab.classList.toggle("active", clickedTab);
     tab.setAttribute("aria-selected", clickedTab);
     tab.removeAttribute("aria-current");
+    tab.setAttribute("tabindex","-1")
+
     if (clickedTab) {
       if (updateContent) {
         tab.setAttribute("aria-current", "page");
       }
+      tab.setAttribute("tabindex","0")
       tab.focus();
     }
   });
@@ -28,31 +31,6 @@ const updateTabs = (
   }
 };
 
-function focusNextElement(contentElementId) {
-  // Select all visible, non-disabled focusable elements
-  const focusables = Array.from(document.getElementById(contentElementId).querySelectorAll(
-    'button, input, select, textarea, [tabindex]:not([tabindex="-1"]), a'
-  )).filter(el => !el.disabled && el.offsetWidth > 0);
-
-  const nextElement = focusables[0]; // Wrap to start if at end
-  if (nextElement) nextElement.focus();
-}
-
-function focusPreviousElement() {
-  // Select all visible, non-disabled focusable elements
-  const focusables = Array.from(document.querySelectorAll(
-    'button, input, select, textarea, [tabindex]:not([tabindex="-1"]), a'
-  )).filter(el => !el.disabled && el.offsetWidth > 0);
-
-  const currentIndex = focusables.indexOf(document.activeElement);
-  let nextIndex = currentIndex ? (currentIndex - 1) : focusables.length-1;
-  while(focusables[nextIndex].classList.contains("m-tabbed-nav__item")){
-    nextIndex = nextIndex ? (nextIndex - 1) : focusables.length-1;
-  } 
-  const nextElement = focusables[nextIndex]; // Wrap to start if at end
-  if (nextElement) nextElement.focus();
-}
-
 const tabbedNavSetup = () => {
   const navTabs = document.querySelectorAll(".m-tabbed-nav__item");
   const contentTabs = document.querySelectorAll(".m-tabbed-nav__content-item");
@@ -63,7 +41,7 @@ const tabbedNavSetup = () => {
 
     item.addEventListener("click", callback);
     item.addEventListener("keydown", e => {
-      if (e.key === "Enter") {
+      if (e.key === "Enter" || e.key === " ") {
         callback(e);
       }
       const selectedTab = Array.from(navTabs).findIndex(
@@ -85,15 +63,8 @@ const tabbedNavSetup = () => {
           false
         )(e);
       }
-      if (e.key === " ") {
-        updateTabs(
-          navTabs[selectedTab].dataset.tabType,
-          navTabs,
-          contentTabs,
-          true
-        )(e);
-      }
-      if (e.key === "Tab"){
+      
+      /*if (e.key === "Tab"){
         if(e.shiftKey){
           focusPreviousElement();
         }else{
@@ -101,7 +72,7 @@ const tabbedNavSetup = () => {
         }
         e.preventDefault();
         e.stopPropagation();
-      }
+      }*/
     });
   });
 };

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -1,9 +1,7 @@
 const updateTabs = (
   tabType,
   navTabs,
-  contentTabs,
-  updateContent = true
-) => e => {
+  contentTabs) => e => {
   e.preventDefault();
   e.stopPropagation();
 
@@ -15,20 +13,17 @@ const updateTabs = (
     tab.setAttribute("tabindex", "-1");
 
     if (clickedTab) {
-      if (updateContent) {
-        tab.setAttribute("aria-current", "page");
-      }
+      tab.setAttribute("aria-current", "page");
       tab.setAttribute("tabindex", "0");
       tab.focus();
     }
   });
 
-  if (updateContent) {
-    contentTabs.forEach(tab => {
-      const clickedTabContentType = tab.dataset.tabContentType === tabType;
-      tab.classList.toggle("active", clickedTabContentType);
-    });
-  }
+  contentTabs.forEach(tab => {
+    const clickedTabContentType = tab.dataset.tabContentType === tabType;
+    tab.classList.toggle("active", clickedTabContentType);
+  });
+  
 };
 
 const focusOtherTab = (navTabs, selectedTab, increment) => {

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -31,6 +31,19 @@ const updateTabs = (
   }
 };
 
+const focusOtherTab = (navTabs, selectedTab, increment) => {
+  let newIndex = selectedTab + increment;
+  if (newIndex < 0) {
+    newIndex = navTabs.length - 1;
+  }
+  if (newIndex > navTabs.length - 1) {
+    newIndex = 0;
+  }
+  navTabs[newIndex].setAttribute("tabindex", "0");
+  navTabs[newIndex].focus();
+  navTabs[selectedTab].setAttribute("tabindex", "-1");
+};
+
 const tabbedNavSetup = () => {
   const navTabs = document.querySelectorAll(".m-tabbed-nav__item");
   const contentTabs = document.querySelectorAll(".m-tabbed-nav__content-item");
@@ -48,31 +61,11 @@ const tabbedNavSetup = () => {
         tab => tab === document.activeElement
       );
       if (e.key === "ArrowLeft" && selectedTab > 0) {
-        updateTabs(
-          navTabs[selectedTab - 1].dataset.tabType,
-          navTabs,
-          contentTabs,
-          false
-        )(e);
+        focusOtherTab(navTabs, selectedTab, -1);
       }
       if (e.key === "ArrowRight" && selectedTab < navTabs.length - 1) {
-        updateTabs(
-          navTabs[selectedTab + 1].dataset.tabType,
-          navTabs,
-          contentTabs,
-          false
-        )(e);
+        focusOtherTab(navTabs, selectedTab, 1);
       }
-
-      /* if (e.key === "Tab"){
-        if(e.shiftKey){
-          focusPreviousElement();
-        }else{
-          focusNextElement(navTabs[selectedTab].getAttribute("aria-controls"));
-        }
-        e.preventDefault();
-        e.stopPropagation();
-      } */
     });
   });
 };

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -12,13 +12,13 @@ const updateTabs = (
     tab.classList.toggle("active", clickedTab);
     tab.setAttribute("aria-selected", clickedTab);
     tab.removeAttribute("aria-current");
-    tab.setAttribute("tabindex","-1")
+    tab.setAttribute("tabindex", "-1");
 
     if (clickedTab) {
       if (updateContent) {
         tab.setAttribute("aria-current", "page");
       }
-      tab.setAttribute("tabindex","0")
+      tab.setAttribute("tabindex", "0");
       tab.focus();
     }
   });
@@ -63,8 +63,8 @@ const tabbedNavSetup = () => {
           false
         )(e);
       }
-      
-      /*if (e.key === "Tab"){
+
+      /* if (e.key === "Tab"){
         if(e.shiftKey){
           focusPreviousElement();
         }else{
@@ -72,7 +72,7 @@ const tabbedNavSetup = () => {
         }
         e.preventDefault();
         e.stopPropagation();
-      }*/
+      } */
     });
   });
 };

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -26,7 +26,10 @@ const updateTabs = (
   
 };
 
-const focusOtherTab = (navTabs, selectedTab, increment) => {
+const focusOtherTab = (navTabs, increment) => {
+  const selectedTab = Array.from(navTabs).findIndex(
+    tab => tab === document.activeElement
+  );
   let newIndex = selectedTab + increment;
   if (newIndex < 0) {
     newIndex = navTabs.length - 1;
@@ -52,14 +55,12 @@ const tabbedNavSetup = () => {
       if (e.key === "Enter" || e.key === " ") {
         callback(e);
       }
-      const selectedTab = Array.from(navTabs).findIndex(
-        tab => tab === document.activeElement
-      );
-      if (e.key === "ArrowLeft" && selectedTab > 0) {
-        focusOtherTab(navTabs, selectedTab, -1);
+      
+      if (e.key === "ArrowLeft") {
+        focusOtherTab(navTabs, -1);
       }
-      if (e.key === "ArrowRight" && selectedTab < navTabs.length - 1) {
-        focusOtherTab(navTabs, selectedTab, 1);
+      if (e.key === "ArrowRight") {
+        focusOtherTab(navTabs, 1);
       }
     });
   });

--- a/assets/js/tabbed-nav.js
+++ b/assets/js/tabbed-nav.js
@@ -1,7 +1,4 @@
-const updateTabs = (
-  tabType,
-  navTabs,
-  contentTabs) => e => {
+const updateTabs = (tabType, navTabs, contentTabs) => e => {
   e.preventDefault();
   e.stopPropagation();
 
@@ -23,7 +20,6 @@ const updateTabs = (
     const clickedTabContentType = tab.dataset.tabContentType === tabType;
     tab.classList.toggle("active", clickedTabContentType);
   });
-  
 };
 
 const focusOtherTab = (navTabs, increment) => {
@@ -55,7 +51,7 @@ const tabbedNavSetup = () => {
       if (e.key === "Enter" || e.key === " ") {
         callback(e);
       }
-      
+
       if (e.key === "ArrowLeft") {
         focusOtherTab(navTabs, -1);
       }

--- a/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+++ b/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
@@ -1,4 +1,4 @@
-<div class="m-tabbed-nav" role="navigation">
+<nav class="m-tabbed-nav" role="navigation" aria-label="main page tabs">
   <div class="nav m-tabbed-nav__items" role="tablist">
     <div class="m-tabbed-nav__item-container">
       <a
@@ -92,4 +92,4 @@
       {alerts(@conn.assigns.alerts)}
     </div>
   </div>
-</div>
+</nav>

--- a/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
+++ b/lib/dotcom_web/templates/page/_tabbed_nav.html.heex
@@ -9,6 +9,7 @@
         data-tab-type="schedules"
         aria-controls="schedules-content"
         aria-selected="true"
+        aria-current="page"
       >
         <span aria-hidden="true">
           {svg("icon-map-default.svg")}
@@ -18,7 +19,7 @@
     </div>
     <div class="m-tabbed-nav__item-container">
       <a
-        tabindex="0"
+        tabindex="-1"
         class="nav-link m-tabbed-nav__item"
         role="tab"
         data-toggle="tab"
@@ -34,7 +35,7 @@
     </div>
     <div class="m-tabbed-nav__item-container">
       <a
-        tabindex="0"
+        tabindex="-1"
         class="nav-link m-tabbed-nav__item"
         role="tab"
         data-toggle="tab"


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Implement tab behavior for homepage tabs](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211525768292437?focus=true)

## Implementation

Changed the JS for the main page tabs to adhere to a11y guidelines:

- Only the active tab is focusable with the [tab] key, the arrow keys are used to focus other tabs, [space] or [enter] is used to active the focused tab
- Hitting [tab] from a tab group focuses the next focusable item in the tab's related content, not the next tab
- `aria-selected` attribute is set to true for the currently focused tab
- `aria-current` attribute is set to "page" for the currently active tab

Updated the template to wrap things in a <nav> instead of a <div> and setup the initial aria attributes and tabindexes (tabindices?)

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots


https://github.com/user-attachments/assets/256ddc5c-4c5d-4253-83c0-c456c78bf25f



## How to test

http://localhost:4001/

Use keyboard navigation and inspect the main page tabs to ensure the aria attributes are being set correctly, and the keyboard behavior works as expected.


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
