### PR TITLE
feat: add metrics to our LiveDashboard

### DIFF
--- a/lib/dotcom/telemetry.ex
+++ b/lib/dotcom/telemetry.ex
@@ -37,12 +37,15 @@ defmodule Dotcom.Telemetry do
     Supervisor.init(children, strategy: :one_for_one)
   end
 
-  defp metrics do
+  def metrics do
     [
-      Metrics.last_value("vm.memory.total", unit: :byte),
-      Metrics.last_value("vm.total_run_queue_lengths.total"),
-      Metrics.last_value("vm.total_run_queue_lengths.cpu"),
-      Metrics.last_value("vm.system_counts.process_count")
+      Metrics.last_value("vm.memory.total",
+        description: "Total Allocated Memory KB",
+        unit: {:byte, :megabyte}
+      ),
+      Metrics.last_value("vm.total_run_queue_lengths.total", description: "Run Queue (Total)"),
+      Metrics.last_value("vm.total_run_queue_lengths.cpu", description: "Run Queue (CPU)"),
+      Metrics.last_value("vm.system_counts.process_count", description: "Process Count")
     ]
   end
 end

--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -25,7 +25,7 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
         www.googletagmanager.com
       ],
     default_src: ~w['self'],
-    font_src: ~w['self' cdn.mbta.com],
+    font_src: ~w['self' cdn.mbta.com data:],
     frame_src: ~w[
         'self'
         *.arcgis.com

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -301,7 +301,7 @@ defmodule DotcomWeb.Router do
     import Phoenix.LiveDashboard.Router
 
     pipe_through([:browser, :browser_live, :basic_auth_readonly])
-    live_dashboard("/dashboard")
+    live_dashboard("/dashboard", csp_nonce_assign_key: :csp_nonce)
   end
 
   if Mix.env() == :dev do

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -301,7 +301,7 @@ defmodule DotcomWeb.Router do
     import Phoenix.LiveDashboard.Router
 
     pipe_through([:browser, :browser_live, :basic_auth_readonly])
-    live_dashboard("/dashboard", csp_nonce_assign_key: :csp_nonce)
+    live_dashboard("/dashboard", metrics: Dotcom.Telemetry, csp_nonce_assign_key: :csp_nonce)
   end
 
   if Mix.env() == :dev do


### PR DESCRIPTION
## Scope

We have an instance of `Phoenix.LiveDashboard` which can show metrics. While tackling understanding our CPU usage, I figured we should use this...

## Implementation

Enables metrics in our LiveDashboard by adding `metrics: Dotcom.Telemetry`

~~During this I realized we have many different telemetry modules. Here we try combining them into a single module, to make it easier to show every metric at once!~~ Combining them didn't seem to work particularly well, so left this separate for now.

## How to test

Go to `/dashboard` and visit the "Metrics" tab, which was previously disabled. It should have some charts. It seems that when running locally, they take some time to populate while the page is open. On a staging server it should look a little more interesting.