### PR TITLE
feat(WC): Add World Cup intercepts

### DIFF
--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -345,6 +345,32 @@ defmodule DotcomWeb.Components do
     """
   end
 
+  attr(:rest, :global, include: ~w(disabled))
+  attr(:class, :string, default: "")
+
+  @doc """
+  A banner tailor made for the world cup. Default styling color is yellow.
+  """
+  def world_cup_intercept(assigns) do
+    ~H"""
+    <.descriptive_link
+      href="/WorldCup"
+      class={@class}
+      {@rest}
+    >
+      <:title>
+        {~t(Going to a World Cup match at Boston Stadium?)}
+      </:title>
+      <p class="c-descriptive-link__world-cup">
+        {gettext("Read our %{world_cup_link}",
+          world_cup_link: "<span class='underline font-medium'>World Cup Guide</span>"
+        )
+        |> Phoenix.HTML.raw()}
+      </p>
+    </.descriptive_link>
+    """
+  end
+
   slot :inner_block, required: true
 
   @doc """

--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -307,6 +307,7 @@ defmodule DotcomWeb.Components do
   slot(:inner_block, required: true, doc: "Content displayed within the link")
   slot(:title, required: true)
   attr(:href, :string, doc: "Optional link to navigate to")
+  attr(:class, :string, default: "")
   attr(:rest, :global, include: ~w(disabled))
 
   @doc """
@@ -315,7 +316,7 @@ defmodule DotcomWeb.Components do
   """
   def descriptive_link(%{href: _} = assigns) do
     ~H"""
-    <a href={@href} class="c-descriptive-link">
+    <a href={@href} class={"c-descriptive-link #{@class}"} {@rest}>
       <.icon type="icon-svg" name="football" class="c-descriptive-link__football-icon" />
       <div class="c-descriptive-link__text">
         <div class="c-descriptive-link__title">{render_slot(@title)}</div>

--- a/lib/dotcom_web/live/trip_planner_live.ex
+++ b/lib/dotcom_web/live/trip_planner_live.ex
@@ -113,19 +113,10 @@ defmodule DotcomWeb.TripPlannerLive do
     ~H"""
     <div class="container">
       <h1>{~t(Trip Planner)}</h1>
-      <.descriptive_link
-        href="/WorldCup"
+      <.world_cup_intercept
         class="mb-5"
         style="background-color: var(--colors-cobalt-80)"
-      >
-        <:title>Going to a World Cup match at Boston Stadium?</:title>
-        <p class="c-descriptive-link__world-cup">
-          {gettext("Read our %{world_cup_link}",
-            world_cup_link: "<span class='underline font-medium'>World Cup Guide</span>"
-          )
-          |> raw()}
-        </p>
-      </.descriptive_link>
+      />
       <div>
         <.input_form class="mb-4" changeset={@input_form.changeset} />
         <div>

--- a/lib/dotcom_web/live/trip_planner_live.ex
+++ b/lib/dotcom_web/live/trip_planner_live.ex
@@ -113,6 +113,19 @@ defmodule DotcomWeb.TripPlannerLive do
     ~H"""
     <div class="container">
       <h1>{~t(Trip Planner)}</h1>
+      <.descriptive_link
+        href="/WorldCup"
+        class="mb-5"
+        style="background-color: var(--colors-cobalt-80)"
+      >
+        <:title>Going to a World Cup match at Boston Stadium?</:title>
+        <p class="c-descriptive-link__world-cup">
+          {gettext("Read our %{world_cup_link}",
+            world_cup_link: "<span class='underline font-medium'>World Cup Guide</span>"
+          )
+          |> raw()}
+        </p>
+      </.descriptive_link>
       <div>
         <.input_form class="mb-4" changeset={@input_form.changeset} />
         <div>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -9,19 +9,10 @@
   </div>
 </.promo_banner>
 
-<.descriptive_link
+<.world_cup_intercept
   :if={@route.id == "CR-Franklin" || @route.id == "CR-Foxboro"}
-  href="/WorldCup"
   class="mb-5"
->
-  <:title>Going to a World Cup match at Boston Stadium?</:title>
-  <p class="c-descriptive-link__world-cup">
-    {gettext("Read our %{world_cup_link}",
-      world_cup_link: "<span class='underline font-medium'>World Cup Guide</span>"
-    )
-    |> raw()}
-  </p>
-</.descriptive_link>
+/>
 
 {DotcomWeb.AlertView.group(
   alerts: @banner_alerts,

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -9,6 +9,20 @@
   </div>
 </.promo_banner>
 
+<.descriptive_link
+  :if={@route.id == "CR-Franklin" || @route.id == "CR-Foxboro"}
+  href="/WorldCup"
+  class="mb-5"
+>
+  <:title>Going to a World Cup match at Boston Stadium?</:title>
+  <p class="c-descriptive-link__world-cup">
+    {gettext("Read our %{world_cup_link}",
+      world_cup_link: "<span class='underline font-medium'>World Cup Guide</span>"
+    )
+    |> raw()}
+  </p>
+</.descriptive_link>
+
 {DotcomWeb.AlertView.group(
   alerts: @banner_alerts,
   route: @route,

--- a/lib/dotcom_web/templates/stop/show.html.heex
+++ b/lib/dotcom_web/templates/stop/show.html.heex
@@ -21,6 +21,19 @@
 </div>
 
 <div>
+  <.descriptive_link
+    :if={@stop.name == "Foxboro"}
+    href="/WorldCup"
+    class="mb-3 ml-3 mr-3"
+  >
+    <:title>Going to a World Cup match at Boston Stadium?</:title>
+    <p class="c-descriptive-link__world-cup">
+      {gettext("Read our %{world_cup_link}",
+        world_cup_link: "<span class='underline font-medium'>World Cup Guide</span>"
+      )
+      |> raw()}
+    </p>
+  </.descriptive_link>
   <div
     id="react-stop-root"
     data-mbta-stop-id={"#{@stop.id}"}

--- a/lib/dotcom_web/templates/stop/show.html.heex
+++ b/lib/dotcom_web/templates/stop/show.html.heex
@@ -12,19 +12,10 @@
 
 <div class="container">
   <div class="page-section">
-    <.descriptive_link
+    <.world_cup_intercept
       :if={@stop.name == "Foxboro"}
-      href="/WorldCup"
       class="mb-3"
-    >
-      <:title>Going to a World Cup match at Boston Stadium?</:title>
-      <p class="c-descriptive-link__world-cup">
-        {gettext("Read our %{world_cup_link}",
-          world_cup_link: "<span class='underline font-medium'>World Cup Guide</span>"
-        )
-        |> raw()}
-      </p>
-    </.descriptive_link>
+    />
     {DotcomWeb.AlertView.render(
       "group.html",
       alerts: @banner_alerts,

--- a/lib/dotcom_web/templates/stop/show.html.heex
+++ b/lib/dotcom_web/templates/stop/show.html.heex
@@ -12,6 +12,19 @@
 
 <div class="container">
   <div class="page-section">
+    <.descriptive_link
+      :if={@stop.name == "Foxboro"}
+      href="/WorldCup"
+      class="mb-3"
+    >
+      <:title>Going to a World Cup match at Boston Stadium?</:title>
+      <p class="c-descriptive-link__world-cup">
+        {gettext("Read our %{world_cup_link}",
+          world_cup_link: "<span class='underline font-medium'>World Cup Guide</span>"
+        )
+        |> raw()}
+      </p>
+    </.descriptive_link>
     {DotcomWeb.AlertView.render(
       "group.html",
       alerts: @banner_alerts,
@@ -21,19 +34,6 @@
 </div>
 
 <div>
-  <.descriptive_link
-    :if={@stop.name == "Foxboro"}
-    href="/WorldCup"
-    class="mb-3 ml-3 mr-3"
-  >
-    <:title>Going to a World Cup match at Boston Stadium?</:title>
-    <p class="c-descriptive-link__world-cup">
-      {gettext("Read our %{world_cup_link}",
-        world_cup_link: "<span class='underline font-medium'>World Cup Guide</span>"
-      )
-      |> raw()}
-    </p>
-  </.descriptive_link>
   <div
     id="react-stop-root"
     data-mbta-stop-id={"#{@stop.id}"}


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽️ [Not Release-Blocking] Add World Cup intercepts to various pages](https://app.asana.com/1/15492006741476/project/1213039586590742/task/1213834498258583)

## Implementation
Utilized the hacky world cup `description_link` component we have to add intercepts to various Foxboro pages.

There's one inline style to override the default yellow background color.
<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
Foxboro station page with alert
<img width="866" height="393" alt="image" src="https://github.com/user-attachments/assets/b0633ae2-0454-4657-bdee-63caa3c86554" />


without alert
<img width="869" height="289" alt="image" src="https://github.com/user-attachments/assets/ee8746dd-f720-44e9-9121-47f6caf628ef" />



Commuter rail schedule page
<img width="498" height="385" alt="image" src="https://github.com/user-attachments/assets/6df855c2-33b2-469c-99d1-eee75d8fe236" />

Trip planner 
<img width="883" height="363" alt="image" src="https://github.com/user-attachments/assets/630c94c9-ec4f-4aba-831e-c9e8ec7a41fc" />



## How to test
Local links: 
- [Foxboro station](http://localhost:4001/stops/place-FS-0049)
- [CR-Franklin](http://localhost:4001/schedules/CR-Franklin/timetable) and [CR-Foxboro](http://localhost:4001/schedules/CR-Foxboro/timetable) schedules
- [trip planner](http://localhost:4001/trip-planner)

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
