### PR TITLE
Adjust end of service boundary in Planned Work

### DIFF
--- a/lib/alerts/parser.ex
+++ b/lib/alerts/parser.ex
@@ -70,6 +70,10 @@ defmodule Alerts.Parser do
     defp do_activity(_), do: :unknown
 
     defp active_period(%{"start" => start, "end" => stop}) do
+      if !is_nil(stop) and String.match?(stop, ~r/.+T03:00:00.+/) do
+        stop = String.replace(stop, ~r/T03:00:00/, "T02:59:00")
+      end
+
       {parse_time(start), parse_time(stop)}
     end
 

--- a/lib/alerts/parser.ex
+++ b/lib/alerts/parser.ex
@@ -71,10 +71,10 @@ defmodule Alerts.Parser do
 
     defp active_period(%{"start" => start, "end" => stop}) do
       if !is_nil(stop) and String.match?(stop, ~r/.+T03:00:00.+/) do
-        stop = String.replace(stop, ~r/T03:00:00/, "T02:59:00")
+        {parse_time(start), parse_time(String.replace(stop, ~r/T03:00:00/, "T02:59:00"))}
+      else
+        {parse_time(start), parse_time(stop)}
       end
-
-      {parse_time(start), parse_time(stop)}
     end
 
     defp parse_time(nil) do


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [Adjust end of service boundary in Planned Work](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214077104643537?focus=true)

## Implementation

Added code to rewrite alerts with 3AM end times to have 2:59AM end times

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Images of alerts with the correct end day displayed

<img width="766" height="138" alt="Screenshot 2026-04-16 at 2 15 40 PM" src="https://github.com/user-attachments/assets/3f99cbdc-6bb0-450b-b5b2-9434e7388d4f" />

<img width="797" height="409" alt="Screenshot 2026-04-16 at 2 15 24 PM" src="https://github.com/user-attachments/assets/56ebb2f5-2cc5-432b-a60b-fe6c02be96b4" />

### Same alerts on dev

<img width="779" height="133" alt="Screenshot 2026-04-16 at 2 18 39 PM" src="https://github.com/user-attachments/assets/f1325f2d-a89a-4985-a3d1-81ef25bbadb4" />
<img width="779" height="366" alt="Screenshot 2026-04-16 at 2 18 51 PM" src="https://github.com/user-attachments/assets/241bfeb9-6cba-4124-addc-d12f6d86ce29" />


## How to test

http://localhost:4001/alerts/subway

Ensure that the end dates in the summary match the dates in the details.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
