### PR TITLE
perf(SF2.0): Dynamically load trip details on expand

### DIFF
--- a/lib/dotcom/schedule_finder/upcoming_departures.ex
+++ b/lib/dotcom/schedule_finder/upcoming_departures.ex
@@ -40,7 +40,8 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
       :stop_sequence,
       :trip_details,
       :trip_id,
-      :trip_name
+      :trip_name,
+      :vehicle_name
     ]
 
     @type realtime_arrival_status_t ::
@@ -76,7 +77,8 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
             stop_sequence: non_neg_integer(),
             trip_details: __MODULE__.UpcomingTripDetails.t(),
             trip_id: Trip.id_t(),
-            trip_name: String.t()
+            trip_name: String.t(),
+            vehicle_name: String.t() | nil
           }
 
     defmodule UpcomingTripDetails do
@@ -319,7 +321,8 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
         if(route_type == :commuter_rail,
           do: trip_name(predicted_schedule_route, trip.name),
           else: nil
-        )
+        ),
+      vehicle_name: vehicle_name(vehicle, route_type)
     }
   end
 
@@ -352,6 +355,19 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
       vehicle.stop_sequence > stop_sequence ->
         :after_stop
     end
+  end
+
+  defp vehicle_name(nil, _route_type), do: nil
+  defp vehicle_name(vehicle, :ferry), do: boat_name(vehicle.id)
+  defp vehicle_name(_vehicle, _route_type), do: nil
+
+  defp boat_name(name) do
+    name
+    |> String.split(" ")
+    |> Enum.map_join(
+      " ",
+      &String.capitalize/1
+    )
   end
 
   def trip_details(%{

--- a/lib/dotcom/schedule_finder/upcoming_departures.ex
+++ b/lib/dotcom/schedule_finder/upcoming_departures.ex
@@ -39,6 +39,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
       :platform_name,
       :route,
       :stop_sequence,
+      :time,
       :trip_details,
       :trip_id,
       :trip_name,
@@ -77,6 +78,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
             platform_name: String.t() | nil,
             route: Route.t(),
             stop_sequence: non_neg_integer(),
+            time: DateTime.t(),
             trip_details: __MODULE__.UpcomingTripDetails.t(),
             trip_id: Trip.id_t(),
             trip_name: String.t(),
@@ -318,6 +320,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
       platform_name: platform_name(predicted_schedule),
       route: predicted_schedule_route,
       stop_sequence: stop_sequence,
+      time: PredictedSchedule.display_time(predicted_schedule),
       trip_details: trip_details,
       trip_id: trip.id,
       trip_name:

--- a/lib/dotcom/schedule_finder/upcoming_departures.ex
+++ b/lib/dotcom/schedule_finder/upcoming_departures.ex
@@ -40,7 +40,6 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
       :route,
       :stop_sequence,
       :time,
-      :trip_details,
       :trip_id,
       :trip_name,
       :vehicle_name
@@ -79,7 +78,6 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
             route: Route.t(),
             stop_sequence: non_neg_integer(),
             time: DateTime.t(),
-            trip_details: __MODULE__.UpcomingTripDetails.t(),
             trip_id: Trip.id_t(),
             trip_name: String.t(),
             vehicle_name: String.t() | nil
@@ -131,11 +129,6 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
     route_type = Route.type_atom(route)
     predicted_schedules = predicted_schedules(route.id, direction_id, now)
 
-    predicted_schedules_by_trip_id =
-      predicted_schedules
-      |> Stream.reject(&past_schedule?(&1, now))
-      |> Enum.group_by(&PredictedSchedule.trip(&1).id)
-
     predicted_schedules_at_stop =
       predicted_schedules
       |> Stream.filter(&(PredictedSchedule.stop(&1).id == stop_id))
@@ -163,9 +156,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
            to_upcoming_departure(%{
              now: now,
              predicted_schedule: first_predicted_schedule,
-             predicted_schedules_by_trip_id: %{},
-             route_type: route_type,
-             stop_id: stop_id
+             route_type: route_type
            })
            |> Map.put(
              :arrival_status,
@@ -180,9 +171,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
           upcoming_predicted_schedules_at_stop
           |> to_upcoming_departures(%{
             now: now,
-            predicted_schedules_by_trip_id: predicted_schedules_by_trip_id,
-            route_type: route_type,
-            stop_id: stop_id
+            route_type: route_type
           })
 
         if no_predictions?(upcoming_predicted_schedules_at_stop) do
@@ -276,23 +265,12 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
   def to_upcoming_departure(%{
         now: now,
         predicted_schedule: predicted_schedule,
-        predicted_schedules_by_trip_id: predicted_schedules_by_trip_id,
-        route_type: route_type,
-        stop_id: stop_id
+        route_type: route_type
       }) do
     trip = predicted_schedule |> PredictedSchedule.trip()
     stop_sequence = PredictedSchedule.stop_sequence(predicted_schedule)
     vehicle = PredictedSchedule.vehicle(predicted_schedule)
     vehicle_at_stop_status = vehicle_at_stop_status(vehicle, trip.id, stop_sequence)
-
-    trip_details =
-      trip_details(%{
-        predicted_schedules_by_trip_id: predicted_schedules_by_trip_id,
-        trip_id: trip.id,
-        stop_id: stop_id,
-        stop_sequence: stop_sequence,
-        vehicle: vehicle
-      })
 
     predicted_schedule_route = PredictedSchedule.route(predicted_schedule)
 
@@ -321,7 +299,6 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
       route: predicted_schedule_route,
       stop_sequence: stop_sequence,
       time: PredictedSchedule.display_time(predicted_schedule),
-      trip_details: trip_details,
       trip_id: trip.id,
       trip_name:
         if(route_type == :commuter_rail,
@@ -381,35 +358,6 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
       " ",
       &String.capitalize/1
     )
-  end
-
-  def trip_details(%{
-        predicted_schedules_by_trip_id: predicted_schedules_by_trip_id,
-        trip_id: trip_id,
-        stop_id: stop_id,
-        stop_sequence: stop_sequence,
-        vehicle: vehicle
-      }) do
-    %TripDetails{stops: stops, vehicle_info: vehicle_info} =
-      TripDetails.trip_details(%{
-        predicted_schedules: predicted_schedules_by_trip_id |> Map.get(trip_id, []),
-        trip_vehicle: vehicle
-      })
-
-    {stops_before, stop, stops_after} =
-      stops
-      |> Enum.split_while(&(&1.stop_id != stop_id || &1.stop_sequence != stop_sequence))
-      |> case do
-        {all, []} -> {[], nil, all}
-        {bef, [st | aft]} -> {bef, st, aft}
-      end
-
-    %__MODULE__.UpcomingDeparture.UpcomingTripDetails{
-      stops_before: stops_before,
-      stop: stop,
-      stops_after: stops_after,
-      vehicle_info: vehicle_info
-    }
   end
 
   def trip_details(%{

--- a/lib/dotcom/schedule_finder/upcoming_departures.ex
+++ b/lib/dotcom/schedule_finder/upcoming_departures.ex
@@ -33,6 +33,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
     defstruct [
       :arrival_status,
       :arrival_substatus,
+      :crowding,
       :headsign,
       :last_trip?,
       :platform_name,
@@ -70,6 +71,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
     @type t :: %__MODULE__{
             arrival_status: arrival_status_t(),
             arrival_substatus: arrival_substatus_t(),
+            crowding: Vehicle.crowding(),
             headsign: Schedules.Trip.headsign(),
             last_trip?: boolean(),
             platform_name: String.t() | nil,
@@ -310,6 +312,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
           predicted_schedule: predicted_schedule,
           route_type: route_type
         }),
+      crowding: crowding(vehicle, trip.id),
       headsign: stop_headsign || trip.headsign,
       last_trip?: PredictedSchedule.last_trip?(predicted_schedule),
       platform_name: platform_name(predicted_schedule),
@@ -325,6 +328,13 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
       vehicle_name: vehicle_name(vehicle, route_type)
     }
   end
+
+  defp crowding(nil, _trip_id), do: nil
+
+  defp crowding(%Vehicle{trip_id: vehicle_trip_id}, trip_id)
+       when vehicle_trip_id != trip_id, do: nil
+
+  defp crowding(%Vehicle{crowding: crowding}, _trip_id), do: crowding
 
   defp trip_name(%Route{description: :rail_replacement_bus}, name) when is_binary(name) do
     gettext("Bus %{trip_name}", trip_name: name)

--- a/lib/dotcom/schedule_finder/upcoming_departures.ex
+++ b/lib/dotcom/schedule_finder/upcoming_departures.ex
@@ -384,6 +384,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
   end
 
   def trip_details(%{
+        now: now,
         trip_id: trip_id,
         stop_id: stop_id,
         stop_sequence: stop_sequence
@@ -397,7 +398,9 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
 
     schedules = @schedules_repo.schedule_for_trip(trip_id)
 
-    predicted_schedules = PredictedSchedule.group(predictions, schedules)
+    predicted_schedules =
+      PredictedSchedule.group(predictions, schedules)
+      |> Enum.reject(&past_schedule?(&1, now))
 
     vehicle =
       predicted_schedules

--- a/lib/dotcom/schedule_finder/upcoming_departures.ex
+++ b/lib/dotcom/schedule_finder/upcoming_departures.ex
@@ -354,16 +354,59 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
     end
   end
 
-  defp trip_details(%{
-         predicted_schedules_by_trip_id: predicted_schedules_by_trip_id,
-         trip_id: trip_id,
-         stop_id: stop_id,
-         stop_sequence: stop_sequence,
-         vehicle: vehicle
-       }) do
+  def trip_details(%{
+        predicted_schedules_by_trip_id: predicted_schedules_by_trip_id,
+        trip_id: trip_id,
+        stop_id: stop_id,
+        stop_sequence: stop_sequence,
+        vehicle: vehicle
+      }) do
     %TripDetails{stops: stops, vehicle_info: vehicle_info} =
       TripDetails.trip_details(%{
         predicted_schedules: predicted_schedules_by_trip_id |> Map.get(trip_id, []),
+        trip_vehicle: vehicle
+      })
+
+    {stops_before, stop, stops_after} =
+      stops
+      |> Enum.split_while(&(&1.stop_id != stop_id || &1.stop_sequence != stop_sequence))
+      |> case do
+        {all, []} -> {[], nil, all}
+        {bef, [st | aft]} -> {bef, st, aft}
+      end
+
+    %__MODULE__.UpcomingDeparture.UpcomingTripDetails{
+      stops_before: stops_before,
+      stop: stop,
+      stops_after: stops_after,
+      vehicle_info: vehicle_info
+    }
+  end
+
+  def trip_details(%{
+        trip_id: trip_id,
+        stop_id: stop_id,
+        stop_sequence: stop_sequence
+      }) do
+    predictions =
+      @predictions_repo.all(
+        trip: trip_id,
+        include_terminals: true,
+        discard_past_subway_predictions: false
+      )
+
+    schedules = @schedules_repo.schedule_for_trip(trip_id)
+
+    predicted_schedules = PredictedSchedule.group(predictions, schedules)
+
+    vehicle =
+      predicted_schedules
+      |> List.first()
+      |> PredictedSchedule.vehicle()
+
+    %TripDetails{stops: stops, vehicle_info: vehicle_info} =
+      TripDetails.trip_details(%{
+        predicted_schedules: predicted_schedules,
         trip_vehicle: vehicle
       })
 

--- a/lib/dotcom/schedule_finder/upcoming_departures.ex
+++ b/lib/dotcom/schedule_finder/upcoming_departures.ex
@@ -127,11 +127,27 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
         stop_id: stop_id
       }) do
     route_type = Route.type_atom(route)
-    predicted_schedules = predicted_schedules(route.id, direction_id, now)
+
+    predictions =
+      @predictions_repo.all(
+        route: route.id,
+        direction_id: direction_id,
+        include_terminals: true,
+        discard_past_subway_predictions: false
+      )
+      |> Enum.filter(&(&1.stop.id == stop_id))
+
+    schedules =
+      @schedules_repo.by_route_ids([route.id],
+        direction_id: direction_id,
+        date: ServiceDateTime.service_date(now),
+        stop_ids: [stop_id]
+      )
+
+    predicted_schedules = PredictedSchedule.group(predictions, schedules)
 
     predicted_schedules_at_stop =
       predicted_schedules
-      |> Stream.filter(&(PredictedSchedule.stop(&1).id == stop_id))
       |> Stream.reject(&end_of_trip?/1)
       |> reject_timeless_predictions()
       |> Enum.sort_by(&PredictedSchedule.display_time/1, DateTime)
@@ -180,24 +196,6 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
           upcoming_departures
         end
     end
-  end
-
-  defp predicted_schedules(route_id, direction_id, now) do
-    all_predictions =
-      @predictions_repo.all(
-        route: route_id,
-        direction_id: direction_id,
-        include_terminals: true,
-        discard_past_subway_predictions: false
-      )
-
-    all_schedules =
-      @schedules_repo.by_route_ids([route_id],
-        direction_id: direction_id,
-        date: ServiceDateTime.service_date(now)
-      )
-
-    PredictedSchedule.group(all_predictions, all_schedules)
   end
 
   defp no_predictions?(predicted_schedules),

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -807,7 +807,10 @@ defmodule DotcomWeb.ScheduleFinderLive do
           <.upcoming_departure_heading upcoming_departure={upcoming_departure} />
         </:heading>
         <:content>
-          <.trip_details upcoming_departure={upcoming_departure} />
+          <.trip_details
+            trip_details={upcoming_departure.trip_details}
+            route={upcoming_departure.route}
+          />
         </:content>
       </.unstyled_accordion>
     </div>
@@ -858,29 +861,29 @@ defmodule DotcomWeb.ScheduleFinderLive do
     ~H"""
     <.lined_list>
       <.lined_list_item
-        route={@upcoming_departure.route}
+        route={@route}
         variant="mode"
-        stop_pin?={@upcoming_departure.trip_details.stop == nil}
+        stop_pin?={@trip_details.stop == nil}
       >
         <div class="grow font-medium">
           <.vehicle_label
-            vehicle_info={@upcoming_departure.trip_details.vehicle_info}
-            route={@upcoming_departure.route}
+            vehicle_info={@trip_details.vehicle_info}
+            route={@route}
           />
         </div>
-        <div :if={@upcoming_departure.trip_details.vehicle_info.departure_time}>
-          <.formatted_time time={@upcoming_departure.trip_details.vehicle_info.departure_time} />
+        <div :if={@trip_details.vehicle_info.departure_time}>
+          <.formatted_time time={@trip_details.vehicle_info.departure_time} />
         </div>
       </.lined_list_item>
       <details
-        :if={Enum.count(@upcoming_departure.trip_details.stops_before) > 0}
+        :if={Enum.count(@trip_details.stops_before) > 0}
         class="group/details"
       >
         <summary class="cursor-pointer bg-charcoal-90">
           <.lined_list_item
             background="charcoal-90"
             class="group-open/details:hidden"
-            route={@upcoming_departure.route}
+            route={@route}
             variant="squiggle"
           >
             <div class="grow">
@@ -895,7 +898,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
           <.lined_list_item
             background="charcoal-90"
             class="hidden group-open/details:flex"
-            route={@upcoming_departure.route}
+            route={@route}
             variant="none"
           >
             <div class="grow">
@@ -909,24 +912,24 @@ defmodule DotcomWeb.ScheduleFinderLive do
           </.lined_list_item>
         </summary>
         <.other_stop
-          :for={other_stop <- @upcoming_departure.trip_details.stops_before}
+          :for={other_stop <- @trip_details.stops_before}
           background="charcoal-90"
           class="border-t-xs border-gray-lightest bg-charcoal-90"
           other_stop={other_stop}
-          route={@upcoming_departure.route}
+          route={@route}
         />
       </details>
 
       <.other_stop
-        :if={@upcoming_departure.trip_details.stop}
+        :if={@trip_details.stop}
         highlight
-        other_stop={@upcoming_departure.trip_details.stop}
-        route={@upcoming_departure.route}
+        other_stop={@trip_details.stop}
+        route={@route}
       />
       <.other_stop
-        :for={other_stop <- @upcoming_departure.trip_details.stops_after}
+        :for={other_stop <- @trip_details.stops_after}
         other_stop={other_stop}
-        route={@upcoming_departure.route}
+        route={@route}
       />
     </.lined_list>
     """

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -900,7 +900,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
         <div class="flex flex-col items-end">
           <div class="inline-flex gap-xs flex-nowrap items-center">
             <.prediction_time_display arrival_status={@upcoming_departure.arrival_status} />
-            <.vehicle_crowding crowding={crowding(@upcoming_departure.trip_details.vehicle_info)} />
+            <.vehicle_crowding crowding={@upcoming_departure.crowding} />
           </div>
           <.prediction_substatus_display arrival_substatus={@upcoming_departure.arrival_substatus} />
         </div>

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -890,10 +890,10 @@ defmodule DotcomWeb.ScheduleFinderLive do
       </:additional_info>
 
       <:additional_info :if={
-        @upcoming_departure.trip_details.vehicle_info.vehicle_name &&
+        @upcoming_departure.vehicle_name &&
           @upcoming_departure.route.type == 4
       }>
-        <i>{@upcoming_departure.trip_details.vehicle_info.vehicle_name}</i>
+        <i>{@upcoming_departure.vehicle_name}</i>
       </:additional_info>
 
       <:time>

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -204,20 +204,9 @@ defmodule DotcomWeb.ScheduleFinderLive do
         %{"stop-sequence" => stop_sequence, "trip-id" => trip_id},
         socket
       ) do
-    stop_id = socket.assigns.stop.id
-
     {:noreply,
      socket
-     |> update(:loaded_upcoming_trips, fn loaded_upcoming_trips ->
-       trip_details =
-         UpcomingDepartures.trip_details(%{
-           stop_id: stop_id,
-           stop_sequence: stop_sequence,
-           trip_id: trip_id
-         })
-
-       Map.put(loaded_upcoming_trips, {trip_id, stop_sequence}, AsyncResult.ok(trip_details))
-     end)}
+     |> assign_trip_details(trip_id, String.to_integer(stop_sequence))}
   end
 
   def handle_event("select_service", %{"selected_service" => selected_service_label}, socket) do
@@ -256,7 +245,8 @@ defmodule DotcomWeb.ScheduleFinderLive do
   def handle_info(:refresh_upcoming_departures, socket) do
     {:noreply,
      socket
-     |> assign_upcoming_departures()}
+     |> assign_upcoming_departures()
+     |> refresh_upcoming_trip_details()}
   end
 
   def handle_info(%{event: "alerts_updated"}, socket) do
@@ -337,6 +327,32 @@ defmodule DotcomWeb.ScheduleFinderLive do
 
   defp assign_upcoming_departures(socket) do
     socket |> assign(:upcoming_departures, [])
+  end
+
+  defp refresh_upcoming_trip_details(socket) do
+    trip_ids_and_stop_seqs = Map.keys(socket.assigns.loaded_upcoming_trips)
+
+    Enum.reduce(trip_ids_and_stop_seqs, socket, fn {trip_id, stop_sequence}, s ->
+      s |> assign_trip_details(trip_id, stop_sequence)
+    end)
+  end
+
+  defp assign_trip_details(socket, trip_id, stop_sequence) do
+    now = @date_time.now()
+    stop_id = socket.assigns.stop.id
+
+    trip_details =
+      UpcomingDepartures.trip_details(%{
+        now: now,
+        stop_id: stop_id,
+        stop_sequence: stop_sequence,
+        trip_id: trip_id
+      })
+
+    socket
+    |> update(:loaded_upcoming_trips, fn loaded_upcoming_trips ->
+      Map.put(loaded_upcoming_trips, {trip_id, stop_sequence}, AsyncResult.ok(trip_details))
+    end)
   end
 
   defp assign_alerts(%{assigns: %{stop: stop}} = socket) when not is_nil(stop) do
@@ -842,7 +858,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
             trip_details={
               Map.get(
                 @loaded_upcoming_trips,
-                {upcoming_departure.trip_id, Integer.to_string(upcoming_departure.stop_sequence)},
+                {upcoming_departure.trip_id, upcoming_departure.stop_sequence},
                 AsyncResult.loading()
               )
             }

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -807,79 +807,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
           <.upcoming_departure_heading upcoming_departure={upcoming_departure} />
         </:heading>
         <:content>
-          <.lined_list>
-            <.lined_list_item
-              route={upcoming_departure.route}
-              variant="mode"
-              stop_pin?={upcoming_departure.trip_details.stop == nil}
-            >
-              <div class="grow font-medium">
-                <.vehicle_label
-                  vehicle_info={upcoming_departure.trip_details.vehicle_info}
-                  route={upcoming_departure.route}
-                />
-              </div>
-              <div :if={upcoming_departure.trip_details.vehicle_info.departure_time}>
-                <.formatted_time time={upcoming_departure.trip_details.vehicle_info.departure_time} />
-              </div>
-            </.lined_list_item>
-            <details
-              :if={Enum.count(upcoming_departure.trip_details.stops_before) > 0}
-              class="group/details"
-            >
-              <summary class="cursor-pointer bg-charcoal-90">
-                <.lined_list_item
-                  background="charcoal-90"
-                  class="group-open/details:hidden"
-                  route={upcoming_departure.route}
-                  variant="squiggle"
-                >
-                  <div class="grow">
-                    <span class="text-[0.75rem] underline">
-                      {~t"Show more stops"}
-                    </span>
-                  </div>
-                  <div class="shrink-0">
-                    <.icon name="chevron-down" class="h-3 w-3" />
-                  </div>
-                </.lined_list_item>
-                <.lined_list_item
-                  background="charcoal-90"
-                  class="hidden group-open/details:flex"
-                  route={upcoming_departure.route}
-                  variant="none"
-                >
-                  <div class="grow">
-                    <span class="text-[0.75rem] underline">
-                      {~t"Show fewer stops"}
-                    </span>
-                  </div>
-                  <div class="shrink-0">
-                    <.icon name="chevron-down" class="h-3 w-3 rotate-180" />
-                  </div>
-                </.lined_list_item>
-              </summary>
-              <.other_stop
-                :for={other_stop <- upcoming_departure.trip_details.stops_before}
-                background="charcoal-90"
-                class="border-t-xs border-gray-lightest bg-charcoal-90"
-                other_stop={other_stop}
-                route={upcoming_departure.route}
-              />
-            </details>
-
-            <.other_stop
-              :if={upcoming_departure.trip_details.stop}
-              highlight
-              other_stop={upcoming_departure.trip_details.stop}
-              route={upcoming_departure.route}
-            />
-            <.other_stop
-              :for={other_stop <- upcoming_departure.trip_details.stops_after}
-              other_stop={other_stop}
-              route={upcoming_departure.route}
-            />
-          </.lined_list>
+          <.trip_details upcoming_departure={upcoming_departure} />
         </:content>
       </.unstyled_accordion>
     </div>
@@ -923,6 +851,84 @@ defmodule DotcomWeb.ScheduleFinderLive do
         </div>
       </:time>
     </.departure_heading>
+    """
+  end
+
+  defp trip_details(assigns) do
+    ~H"""
+    <.lined_list>
+      <.lined_list_item
+        route={@upcoming_departure.route}
+        variant="mode"
+        stop_pin?={@upcoming_departure.trip_details.stop == nil}
+      >
+        <div class="grow font-medium">
+          <.vehicle_label
+            vehicle_info={@upcoming_departure.trip_details.vehicle_info}
+            route={@upcoming_departure.route}
+          />
+        </div>
+        <div :if={@upcoming_departure.trip_details.vehicle_info.departure_time}>
+          <.formatted_time time={@upcoming_departure.trip_details.vehicle_info.departure_time} />
+        </div>
+      </.lined_list_item>
+      <details
+        :if={Enum.count(@upcoming_departure.trip_details.stops_before) > 0}
+        class="group/details"
+      >
+        <summary class="cursor-pointer bg-charcoal-90">
+          <.lined_list_item
+            background="charcoal-90"
+            class="group-open/details:hidden"
+            route={@upcoming_departure.route}
+            variant="squiggle"
+          >
+            <div class="grow">
+              <span class="text-[0.75rem] underline">
+                {~t"Show more stops"}
+              </span>
+            </div>
+            <div class="shrink-0">
+              <.icon name="chevron-down" class="h-3 w-3" />
+            </div>
+          </.lined_list_item>
+          <.lined_list_item
+            background="charcoal-90"
+            class="hidden group-open/details:flex"
+            route={@upcoming_departure.route}
+            variant="none"
+          >
+            <div class="grow">
+              <span class="text-[0.75rem] underline">
+                {~t"Show fewer stops"}
+              </span>
+            </div>
+            <div class="shrink-0">
+              <.icon name="chevron-down" class="h-3 w-3 rotate-180" />
+            </div>
+          </.lined_list_item>
+        </summary>
+        <.other_stop
+          :for={other_stop <- @upcoming_departure.trip_details.stops_before}
+          background="charcoal-90"
+          class="border-t-xs border-gray-lightest bg-charcoal-90"
+          other_stop={other_stop}
+          route={@upcoming_departure.route}
+        />
+      </details>
+
+      <.other_stop
+        :if={@upcoming_departure.trip_details.stop}
+        highlight
+        other_stop={@upcoming_departure.trip_details.stop}
+        route={@upcoming_departure.route}
+      />
+      <.other_stop
+        :for={other_stop <- @upcoming_departure.trip_details.stops_after}
+        other_stop={other_stop}
+        route={@upcoming_departure.route}
+      />
+    </.lined_list>
     """
   end
 

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -1280,18 +1280,6 @@ defmodule DotcomWeb.ScheduleFinderLive do
 
   defp substatus_icon(assigns), do: ~H""
 
-  def get_last_departure_time(last_departure) do
-    if(is_nil(last_departure.trip_details.stop)) do
-      nil
-    else
-      {_, last_departure_time} = last_departure.trip_details.stop.time
-
-      if(is_struct(last_departure_time, DateTime)) do
-        last_departure_time
-      end
-    end
-  end
-
   defp show_last_service?(%{
          remaining_departures: remaining_departures,
          last_trip_time: %{result: last_trip_time}
@@ -1305,7 +1293,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
         |> Enum.find(nil, fn departure -> departure |> Map.get(:last_trip?, nil) end)
       )
 
-    last_departure_time = get_last_departure_time(last_departure)
+    last_departure_time = last_departure.time
 
     if(is_nil(last_departure_time)) do
       true

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -67,6 +67,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
          |> assign_new(:direction_id, fn -> direction_id end)
          |> assign_new(:stop, fn -> stop end)
          |> assign_new(:upcoming_departures, fn -> AsyncResult.loading([]) end)
+         |> assign_new(:loaded_upcoming_trips, fn -> %{} end)
          |> assign_new(:last_trip_time, fn -> AsyncResult.loading() end)
          |> assign_new(:alerts, fn -> [] end)
          |> assign_new(:service_groups, fn -> service_groups end)
@@ -118,6 +119,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
               <%= if upcoming_departures do %>
                 <.upcoming_departures_section
                   stop={@stop}
+                  loaded_upcoming_trips={@loaded_upcoming_trips}
                   upcoming_departures={upcoming_departures}
                   route={@route}
                   last_trip_time={@last_trip_time}
@@ -195,6 +197,27 @@ defmodule DotcomWeb.ScheduleFinderLive do
       GenServer.cast(self(), {:get_next, {schedule_id, [trip_id, stop_sequence, date]}})
       {:noreply, socket}
     end
+  end
+
+  def handle_event(
+        "open_upcoming_trip",
+        %{"stop-sequence" => stop_sequence, "trip-id" => trip_id},
+        socket
+      ) do
+    stop_id = socket.assigns.stop.id
+
+    {:noreply,
+     socket
+     |> update(:loaded_upcoming_trips, fn loaded_upcoming_trips ->
+       trip_details =
+         UpcomingDepartures.trip_details(%{
+           stop_id: stop_id,
+           stop_sequence: stop_sequence,
+           trip_id: trip_id
+         })
+
+       Map.put(loaded_upcoming_trips, {trip_id, stop_sequence}, AsyncResult.ok(trip_details))
+     end)}
   end
 
   def handle_event("select_service", %{"selected_service" => selected_service_label}, socket) do
@@ -764,6 +787,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
     </.attached_callout>
     <.upcoming_departures_section
       stop={@stop}
+      loaded_upcoming_trips={@loaded_upcoming_trips}
       upcoming_departures={@upcoming_departures}
       route={@route}
       last_trip_time={@last_trip_time}
@@ -781,8 +805,10 @@ defmodule DotcomWeb.ScheduleFinderLive do
     <.upcoming_departures_table
       stop_id={@stop.id}
       upcoming_departures={@upcoming_departures |> Enum.take(5)}
+      loaded_upcoming_trips={@loaded_upcoming_trips}
     />
     <.remaining_service
+      loaded_upcoming_trips={@loaded_upcoming_trips}
       remaining_departures={@upcoming_departures |> Enum.drop(5)}
       route={@route}
       route_type={@route.type}
@@ -792,6 +818,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
     """
   end
 
+  attr :loaded_upcoming_trips, AsyncResult
   attr :stop_id, :string
   attr :upcoming_departures, :list
 
@@ -800,6 +827,9 @@ defmodule DotcomWeb.ScheduleFinderLive do
     <div class="divide-y-xs divide-gray-lightest border-xs border-gray-lightest">
       <.unstyled_accordion
         :for={upcoming_departure <- @upcoming_departures}
+        phx-click="open_upcoming_trip"
+        phx-value-trip-id={upcoming_departure.trip_id}
+        phx-value-stop-sequence={upcoming_departure.stop_sequence}
         id={"upcoming-departure-#{upcoming_departure.trip_id}-#{upcoming_departure.stop_sequence}"}
         summary_class="flex items-center border-gray-lightest py-3 px-2 gap-2 group-open:bg-gray-lightest hover:bg-brand-primary-lightest group-open:hover:bg-brand-primary-lightest"
       >
@@ -807,9 +837,15 @@ defmodule DotcomWeb.ScheduleFinderLive do
           <.upcoming_departure_heading upcoming_departure={upcoming_departure} />
         </:heading>
         <:content>
-          <.trip_details
-            trip_details={upcoming_departure.trip_details}
+          <.trip_details_wrapper
             route={upcoming_departure.route}
+            trip_details={
+              Map.get(
+                @loaded_upcoming_trips,
+                {upcoming_departure.trip_id, Integer.to_string(upcoming_departure.stop_sequence)},
+                AsyncResult.loading()
+              )
+            }
           />
         </:content>
       </.unstyled_accordion>
@@ -854,6 +890,23 @@ defmodule DotcomWeb.ScheduleFinderLive do
         </div>
       </:time>
     </.departure_heading>
+    """
+  end
+
+  defp trip_details_wrapper(assigns) do
+    ~H"""
+    <.async_result :let={trip_details} assign={@trip_details}>
+      <:loading>
+        <div class="mt-lg mb-md flex justify-center">
+          <.spinner aria_label={~t"Loading trip details"} />
+        </div>
+      </:loading>
+      <:failed>
+        <.callout>{~t(There was a problem loading trip details)}</.callout>
+      </:failed>
+
+      <.trip_details trip_details={trip_details} route={@route} />
+    </.async_result>
     """
   end
 
@@ -1297,6 +1350,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
         </.attached_callout>
       </summary>
       <.upcoming_departures_table
+        loaded_upcoming_trips={@loaded_upcoming_trips}
         stop_id={@stop_id}
         upcoming_departures={@remaining_departures}
       />

--- a/test/dotcom/schedule_finder/upcoming_departures_test.exs
+++ b/test/dotcom/schedule_finder/upcoming_departures_test.exs
@@ -2424,31 +2424,29 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       # Setup
       %{
         predictions: predictions,
-        route: route,
         predicted_arrival_times: [_, time, time_after],
         predicted_departure_times: [time_before, _, _],
         stops: [stop_before, stop, stop_after],
         stop_sequences: [seq_before, seq, seq_after],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(vehicle_stop_index: 0)
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(time),
-          route: route,
+          trip_id: trip_id,
+          stop_sequence: seq,
           stop_id: stop.id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
-
       assert trip_details.stops_before
              |> Enum.map(
                &(&1
@@ -2488,16 +2486,16 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
              ]
     end
 
-    test "shows correct trip details if a trip visits a stop multiple times" do
+    test "splits stops_before and stops_after based on stop_sequence if a trip visits a stop multiple times" do
+      # Setup
       [stop_id_multi, stop_id_1, stop_id_2, stop_id_3] =
         Faker.Util.sample_uniq(4, fn -> FactoryHelpers.build(:id) end)
 
-      # Setup
       %{
         predictions: predictions,
-        route: route,
         predicted_arrival_times: [_, arrival_time | _],
         stop_sequences: [seq_1, seq_2, seq_3, seq_4, seq_5],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
@@ -2505,22 +2503,30 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
           stop_ids: [stop_id_1, stop_id_multi, stop_id_2, stop_id_multi, stop_id_3]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Predictions.Repo.Mock, :all, 2, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, 2, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, 2, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop_id_multi
+      now = Generators.ServiceDateTime.earlier_on_day(arrival_time)
+
+      trip_details_1 =
+        UpcomingDepartures.trip_details(%{
+          now: now,
+          trip_id: trip_id,
+          stop_id: stop_id_multi,
+          stop_sequence: seq_2
+        })
+
+      trip_details_2 =
+        UpcomingDepartures.trip_details(%{
+          now: now,
+          trip_id: trip_id,
+          stop_id: stop_id_multi,
+          stop_sequence: seq_4
         })
 
       # Verify
-      assert [%{trip_details: trip_details_1}, %{trip_details: trip_details_2}] = departures
-
       assert trip_details_1.stops_before |> Enum.map(&{&1.stop_id, &1.stop_sequence}) == [
                {stop_id_1, seq_1}
              ]
@@ -2547,27 +2553,27 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       %{
         predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
-        route: route,
         stops: [_, stop, _],
+        stop_sequences: [_, stop_seq, _],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(vehicle_stop_index: 0)
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
+          trip_id: trip_id,
+          stop_id: stop.id,
+          stop_sequence: stop_seq
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
       assert trip_details.vehicle_info.status == vehicle.status
     end
 
@@ -2576,8 +2582,9 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       %{
         predicted_arrival_times: [_, arrival_time | _],
         predictions: predictions,
-        route: route,
+        stop_sequences: [_, stop_seq, _],
         stops: [_, stop, _],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
@@ -2586,20 +2593,19 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
       assert trip_details.stop == nil
     end
 
@@ -2608,8 +2614,9 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       %{
         predicted_arrival_times: [_, arrival_time | _],
         predictions: predictions,
-        route: route,
+        stop_sequences: [_, stop_seq, _],
         stops: [_, stop, _],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
@@ -2618,20 +2625,19 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
       assert trip_details.stop.stop_id == stop.id
     end
 
@@ -2640,8 +2646,9 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       %{
         predicted_arrival_times: [_, arrival_time | _],
         predictions: predictions,
-        route: route,
+        stop_sequences: [_, _, _, stop_seq_3, _],
         stops: [_stop_0, _stop_1, stop_2, stop_3, _],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
@@ -2651,20 +2658,19 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop_3.id
+          stop_id: stop_3.id,
+          stop_sequence: stop_seq_3,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
       assert trip_details.stops_before |> Enum.map(& &1.stop_id) == [stop_2.id]
     end
 
@@ -2673,8 +2679,9 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       %{
         predicted_arrival_times: [_, arrival_time | _],
         predictions: predictions,
-        route: route,
+        stop_sequences: [_, _, _, stop_seq_3, _],
         stops: [_stop_0, stop_1, stop_2, stop_3, _],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
@@ -2684,20 +2691,19 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop_3.id
+          stop_id: stop_3.id,
+          stop_sequence: stop_seq_3,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
       assert trip_details.stops_before |> Enum.map(& &1.stop_id) == [stop_1.id, stop_2.id]
     end
 
@@ -2705,28 +2711,28 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       # Setup
       %{
         scheduled_departure_times: [departure_time | _],
-        route: route,
         schedules: schedules,
-        stops: [_, stop, _]
+        stop_sequences: [_, stop_seq, _],
+        stops: [_, stop, _],
+        trip_id: trip_id
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
           route_factory_types: [:bus_route, :commuter_rail_route, :ferry_route]
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> schedules end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(departure_time),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert {:no_realtime, [%{trip_details: trip_details}]} = departures
       assert trip_details.vehicle_info.status == :scheduled_to_depart
     end
 
@@ -2734,29 +2740,29 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       # Setup
       %{
         scheduled_departure_times: [departure_time_1, departure_time_2 | _],
-        route: route,
         schedules: schedules,
-        stops: [_, stop, _]
+        stop_sequences: [_, stop_seq, _],
+        stops: [_, stop, _],
+        trip_id: trip_id
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
           route_factory_types: [:bus_route, :commuter_rail_route, :ferry_route]
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> schedules end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now:
             Generators.DateTime.random_time_range_date_time({departure_time_1, departure_time_2}),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert {:no_realtime, [%{trip_details: trip_details}]} = departures
       assert trip_details.vehicle_info.status == :location_unavailable
     end
 
@@ -2764,26 +2770,26 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       # Setup
       %{
         predictions: predictions,
-        route: route,
         predicted_departure_times: [time | _],
-        stops: [_, stop, _]
+        stop_sequences: [_, stop_seq, _],
+        stops: [_, stop, _],
+        trip_id: trip_id
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(missing_vehicle?: true)
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(time),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
       assert trip_details.vehicle_info.status == :location_unavailable
     end
 
@@ -2791,28 +2797,28 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       # Setup
       %{
         predictions: predictions,
-        route: route,
         predicted_departure_times: [time | _],
+        stop_sequences: [_, stop_seq, _],
         stops: [_, stop, _],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data()
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> %{vehicle | stop_id: nil} end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(time),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
       assert trip_details.vehicle_info.status == :location_unavailable
     end
 
@@ -2820,28 +2826,28 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       # Setup
       %{
         predictions: predictions,
-        route: route,
         predicted_departure_times: [time | _],
+        stop_sequences: [_, stop_seq, _],
         stops: [_, stop, _],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(vehicle_on_different_trip?: true)
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(time),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
       assert trip_details.vehicle_info.status == :finishing_another_trip
     end
 
@@ -2849,9 +2855,10 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       # Setup
       %{
         predictions: predictions,
-        route: route,
         predicted_departure_times: [time | _],
+        stop_sequences: [_, stop_seq, _],
         stops: [_, stop, _],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
@@ -2860,30 +2867,30 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(time),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
       assert trip_details.vehicle_info.status == :waiting_to_depart
     end
 
     test "pulls trip details from schedules for scheduled trips" do
       # Setup
       %{
-        route: route,
         schedules: schedules,
         scheduled_arrival_times: [_, time_1, time_2],
-        stops: [_stop_0, stop_1, stop_2]
+        stop_sequences: [_, stop_seq, _],
+        stops: [_stop_0, stop_1, stop_2],
+        trip_id: trip_id
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
           route_factory_types: [:bus_route, :commuter_rail_route, :ferry_route],
@@ -2891,20 +2898,18 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> schedules end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(time_1),
-          route: route,
-          stop_id: stop_1.id
+          stop_id: stop_1.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert {:no_realtime, [%{trip_details: trip_details}]} = departures
-
       assert trip_details.stop |> then(&{&1.stop_id, &1.time}) ==
                {stop_1.id, {:time, time_1 |> truncate(:minute)}}
 
@@ -2918,29 +2923,28 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       %{
         predicted_departure_times: [predicted_time_0 | _],
         predictions: [prediction | _],
-        route: route,
         scheduled_arrival_times: [_, scheduled_time_1, scheduled_time_2],
         schedules: schedules,
-        stops: [stop_0, stop_1, stop_2]
+        stop_sequences: [stop_seq, _, _],
+        stops: [stop_0, stop_1, stop_2],
+        trip_id: trip_id
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(vehicle_stop_index: 0)
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [prediction] end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> schedules end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> Factories.Vehicles.Vehicle.build(:vehicle) end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(predicted_time_0),
-          route: route,
-          stop_id: stop_0.id
+          stop_id: stop_0.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
-
       assert trip_details.stops_after |> Enum.map(&{&1.stop_id, &1.time}) == [
                {stop_1.id, {:time, scheduled_time_1 |> truncate(:minute)}},
                {stop_2.id, {:time, scheduled_time_2 |> truncate(:minute)}}
@@ -2950,11 +2954,12 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
     test "does not include past scheduled stops in trip details" do
       # Setup
       %{
-        route: route,
         scheduled_departure_times: [_, departure_time_1, departure_time_2, _, _],
         scheduled_arrival_times: [_, _, arrival_time_2, _, _],
         schedules: schedules,
-        stops: [_, _stop_1, stop_2, stop, _]
+        stop_sequences: [_, _, _, stop_seq, _],
+        stops: [_, _stop_1, stop_2, stop, _],
+        trip_id: trip_id
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
           route_factory_types: [:bus_route, :commuter_rail_route, :ferry_route],
@@ -2962,21 +2967,19 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> schedules end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now:
             Generators.DateTime.random_time_range_date_time({departure_time_1, departure_time_2}),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert {:no_realtime, [%{trip_details: trip_details}]} = departures
-
       assert trip_details.stops_before |> Enum.map(&{&1.stop_id, &1.time}) == [
                {stop_2.id, {:time, arrival_time_2 |> truncate(:minute)}}
              ]
@@ -2985,31 +2988,30 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
     test "uses `departure_time` as other_stop.time if `arrival_time` isn't available" do
       # Setup
       %{
-        route: route,
         predicted_departure_times: [predicted_time | _],
         predicted_arrival_times: [nil | _],
         predictions: predictions,
+        stop_sequences: [_, stop_seq, _],
         stops: [_, stop, _],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(vehicle_stop_index: 0)
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(predicted_time),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
-
       assert trip_details.stops_before |> Enum.map(& &1.time) == [
                {:time, predicted_time |> truncate(:minute)}
              ]
@@ -3018,12 +3020,13 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
     test "shows a trip_stop as cancelled if the stop is skipped (nil times on predictions, non-nil on schedules)" do
       # Setup
       %{
-        route: route,
         predicted_departure_times: [predicted_time | _],
         predicted_arrival_times: [nil | _],
         predictions: predictions,
         schedules: schedules,
+        stop_sequences: [_, _, stop_seq, _],
         stops: [_, _, stop, _],
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
@@ -3033,21 +3036,19 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> schedules end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
+      trip_details =
+        UpcomingDepartures.trip_details(%{
           now: Generators.ServiceDateTime.earlier_on_day(predicted_time),
-          route: route,
-          stop_id: stop.id
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
         })
 
       # Verify
-      assert [%{trip_details: trip_details}] = departures
-
       assert [trip_stop_0, trip_stop_1] = trip_details.stops_before
       refute trip_stop_0.cancelled?
       assert trip_stop_1.cancelled?

--- a/test/dotcom/schedule_finder/upcoming_departures_test.exs
+++ b/test/dotcom/schedule_finder/upcoming_departures_test.exs
@@ -2238,6 +2238,188 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       assert departure.arrival_substatus == {:delayed_from, scheduled_departure_time}
     end
 
+    test "marks the last upcoming departure with last_trip? = true for non-subway routes" do
+      # Setup
+      now = Dotcom.Utils.DateTime.now()
+
+      route =
+        Factories.Routes.Route.build(
+          Faker.Util.pick([:bus_route, :commuter_rail_route, :ferry_route])
+        )
+
+      stop_id = FactoryHelpers.build(:id)
+      direction_id = Faker.Util.pick([0, 1])
+
+      arrival_times =
+        Faker.Util.sample_uniq(4, fn ->
+          Generators.DateTime.random_time_range_date_time(
+            {now, ServiceDateTime.end_of_service_day(now)}
+          )
+        end)
+        |> Enum.sort(DateTime)
+
+      predictions =
+        Enum.map(arrival_times, fn arrival_time ->
+          Factories.Predictions.Prediction.build(:prediction,
+            arrival_time: arrival_time,
+            stop: Factories.Stops.Stop.build(:stop, id: stop_id),
+            trip: Factories.Schedules.Trip.build(:trip)
+          )
+        end)
+
+      stub(Vehicles.Repo.Mock, :get, fn _ -> Factories.Vehicles.Vehicle.build(:vehicle) end)
+      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+
+      # Exercise
+      departures =
+        UpcomingDepartures.upcoming_departures(%{
+          direction_id: direction_id,
+          now: now,
+          route: route,
+          stop_id: stop_id
+        })
+
+      # Verify
+      assert is_list(departures)
+      assert length(departures) == 4
+
+      # All departures except the last should have last_trip? = false
+      for departure <- Enum.take(departures, 3) do
+        refute departure.last_trip?
+      end
+
+      # The last departure should have last_trip? = true
+      last_departure = List.last(departures)
+      assert last_departure.last_trip?
+    end
+
+    test "does not mark last_trip? = true for subway routes" do
+      # Setup
+      now = Dotcom.Utils.DateTime.now()
+      route = Factories.Routes.Route.build(:subway_route)
+      stop_id = FactoryHelpers.build(:id)
+      direction_id = Faker.Util.pick([0, 1])
+
+      arrival_times =
+        Faker.Util.sample_uniq(4, fn ->
+          Generators.DateTime.random_time_range_date_time(
+            {now, ServiceDateTime.end_of_service_day(now)}
+          )
+        end)
+        |> Enum.sort(DateTime)
+
+      predictions =
+        Enum.map(arrival_times, fn arrival_time ->
+          Factories.Predictions.Prediction.build(:prediction,
+            arrival_time: arrival_time,
+            stop: Factories.Stops.Stop.build(:stop, id: stop_id),
+            trip: Factories.Schedules.Trip.build(:trip)
+          )
+        end)
+
+      stub(Vehicles.Repo.Mock, :get, fn _ -> Factories.Vehicles.Vehicle.build(:vehicle) end)
+      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+
+      # Exercise
+      departures =
+        UpcomingDepartures.upcoming_departures(%{
+          direction_id: direction_id,
+          now: now,
+          route: route,
+          stop_id: stop_id
+        })
+
+      # Verify
+      assert is_list(departures)
+      assert length(departures) == 4
+
+      # All departures including the last should have last_trip? = false for subway
+      for departure <- departures do
+        refute departure.last_trip?
+      end
+    end
+
+    test "shows schedule's stop_headsign if available" do
+      # Setup
+      %{
+        route: route,
+        predicted_departure_times: [predicted_time | _],
+        predicted_arrival_times: [nil | _],
+        predictions: predictions,
+        schedules: schedules,
+        stops: [_, stop, _],
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(vehicle_stop_index: 0)
+
+      updated_schedules =
+        schedules
+        |> Enum.map(fn schedule ->
+          schedule |> Map.put(:stop_headsign, Faker.Pokemon.location())
+        end)
+
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> updated_schedules end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
+      # Exercise
+      departures =
+        UpcomingDepartures.upcoming_departures(%{
+          direction_id: Faker.Util.pick([0, 1]),
+          now: Generators.ServiceDateTime.earlier_on_day(predicted_time),
+          route: route,
+          stop_id: stop.id
+        })
+
+      # Verify
+      assert [%{headsign: headsign}] = departures
+      assert updated_schedules |> Enum.find(fn s -> s.stop_headsign == headsign end)
+    end
+
+    test "shows trip's headsign if available schedule's stop_headsign is not available" do
+      # Setup
+      %{
+        route: route,
+        predicted_departure_times: [predicted_time | _],
+        predicted_arrival_times: [nil | _],
+        predictions: predictions,
+        schedules: schedules,
+        stops: [_, _, stop, _],
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(
+          vehicle_stop_index: 0,
+          stop_count: 4
+        )
+
+      updated_schedules =
+        schedules
+        |> Enum.map(fn schedule ->
+          schedule |> Map.put(:stop_headsign, nil)
+        end)
+
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> updated_schedules end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
+      # Exercise
+      departures =
+        UpcomingDepartures.upcoming_departures(%{
+          direction_id: Faker.Util.pick([0, 1]),
+          now: Generators.ServiceDateTime.earlier_on_day(predicted_time),
+          route: route,
+          stop_id: stop.id
+        })
+
+      # Verify
+      assert [%{headsign: headsign}] = departures
+      assert updated_schedules |> Enum.find(fn s -> s.trip.headsign == headsign end)
+    end
+  end
+
+  describe "trip_details/1" do
     test "shows trip details with other stops" do
       # Setup
       %{
@@ -2869,186 +3051,6 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       assert [trip_stop_0, trip_stop_1] = trip_details.stops_before
       refute trip_stop_0.cancelled?
       assert trip_stop_1.cancelled?
-    end
-
-    test "marks the last upcoming departure with last_trip? = true for non-subway routes" do
-      # Setup
-      now = Dotcom.Utils.DateTime.now()
-
-      route =
-        Factories.Routes.Route.build(
-          Faker.Util.pick([:bus_route, :commuter_rail_route, :ferry_route])
-        )
-
-      stop_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
-
-      arrival_times =
-        Faker.Util.sample_uniq(4, fn ->
-          Generators.DateTime.random_time_range_date_time(
-            {now, ServiceDateTime.end_of_service_day(now)}
-          )
-        end)
-        |> Enum.sort(DateTime)
-
-      predictions =
-        Enum.map(arrival_times, fn arrival_time ->
-          Factories.Predictions.Prediction.build(:prediction,
-            arrival_time: arrival_time,
-            stop: Factories.Stops.Stop.build(:stop, id: stop_id),
-            trip: Factories.Schedules.Trip.build(:trip)
-          )
-        end)
-
-      stub(Vehicles.Repo.Mock, :get, fn _ -> Factories.Vehicles.Vehicle.build(:vehicle) end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-
-      # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          now: now,
-          route: route,
-          stop_id: stop_id
-        })
-
-      # Verify
-      assert is_list(departures)
-      assert length(departures) == 4
-
-      # All departures except the last should have last_trip? = false
-      for departure <- Enum.take(departures, 3) do
-        refute departure.last_trip?
-      end
-
-      # The last departure should have last_trip? = true
-      last_departure = List.last(departures)
-      assert last_departure.last_trip?
-    end
-
-    test "does not mark last_trip? = true for subway routes" do
-      # Setup
-      now = Dotcom.Utils.DateTime.now()
-      route = Factories.Routes.Route.build(:subway_route)
-      stop_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
-
-      arrival_times =
-        Faker.Util.sample_uniq(4, fn ->
-          Generators.DateTime.random_time_range_date_time(
-            {now, ServiceDateTime.end_of_service_day(now)}
-          )
-        end)
-        |> Enum.sort(DateTime)
-
-      predictions =
-        Enum.map(arrival_times, fn arrival_time ->
-          Factories.Predictions.Prediction.build(:prediction,
-            arrival_time: arrival_time,
-            stop: Factories.Stops.Stop.build(:stop, id: stop_id),
-            trip: Factories.Schedules.Trip.build(:trip)
-          )
-        end)
-
-      stub(Vehicles.Repo.Mock, :get, fn _ -> Factories.Vehicles.Vehicle.build(:vehicle) end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-
-      # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          now: now,
-          route: route,
-          stop_id: stop_id
-        })
-
-      # Verify
-      assert is_list(departures)
-      assert length(departures) == 4
-
-      # All departures including the last should have last_trip? = false for subway
-      for departure <- departures do
-        refute departure.last_trip?
-      end
-    end
-
-    test "shows schedule's stop_headsign if available" do
-      # Setup
-      %{
-        route: route,
-        predicted_departure_times: [predicted_time | _],
-        predicted_arrival_times: [nil | _],
-        predictions: predictions,
-        schedules: schedules,
-        stops: [_, stop, _],
-        vehicle: vehicle
-      } =
-        PredictedScheduleHelper.predicted_schedule_trip_data(vehicle_stop_index: 0)
-
-      updated_schedules =
-        schedules
-        |> Enum.map(fn schedule ->
-          schedule |> Map.put(:stop_headsign, Faker.Pokemon.location())
-        end)
-
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> updated_schedules end)
-      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
-
-      # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(predicted_time),
-          route: route,
-          stop_id: stop.id
-        })
-
-      # Verify
-      assert [%{headsign: headsign}] = departures
-      assert updated_schedules |> Enum.find(fn s -> s.stop_headsign == headsign end)
-    end
-
-    test "shows trip's headsign if available schedule's stop_headsign is not available" do
-      # Setup
-      %{
-        route: route,
-        predicted_departure_times: [predicted_time | _],
-        predicted_arrival_times: [nil | _],
-        predictions: predictions,
-        schedules: schedules,
-        stops: [_, _, stop, _],
-        vehicle: vehicle
-      } =
-        PredictedScheduleHelper.predicted_schedule_trip_data(
-          vehicle_stop_index: 0,
-          stop_count: 4
-        )
-
-      updated_schedules =
-        schedules
-        |> Enum.map(fn schedule ->
-          schedule |> Map.put(:stop_headsign, nil)
-        end)
-
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> updated_schedules end)
-      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
-
-      # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(predicted_time),
-          route: route,
-          stop_id: stop.id
-        })
-
-      # Verify
-      assert [%{headsign: headsign}] = departures
-      assert updated_schedules |> Enum.find(fn s -> s.trip.headsign == headsign end)
     end
   end
 end

--- a/test/dotcom/schedule_finder/upcoming_departures_test.exs
+++ b/test/dotcom/schedule_finder/upcoming_departures_test.exs
@@ -13,6 +13,8 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
   setup do
     stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
 
+    stub(Routes.Repo.Mock, :get, fn _ -> Factories.Routes.Route.build(:route) end)
+
     stub(Stops.Repo.Mock, :get, fn id ->
       Factories.Stops.Stop.build(:stop, id: id, parent_id: nil)
     end)
@@ -391,6 +393,90 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       # Verify
       assert [departure] = departures
       assert departure.trip_name == nil
+    end
+
+    test "includes vehicle name for ferry" do
+      # Setup
+      vehicle_name = Faker.Pokemon.name() <> " " <> Faker.Pokemon.name()
+      vehicle_id = String.upcase(vehicle_name)
+
+      %{
+        predicted_arrival_times: [_, arrival_time, _],
+        predictions: predictions,
+        route: route,
+        platform_stop_ids: [_, platform_id, _],
+        stops: [_, stop, _],
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(route_factory_types: [:ferry_route])
+
+      route_id = route.id
+
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle |> Map.put(:id, vehicle_id) end)
+      stub(Routes.Repo.Mock, :get, fn ^route_id -> route end)
+
+      stub(Stops.Repo.Mock, :get, fn
+        ^platform_id -> Factories.Stops.Stop.build(:stop, platform_name: "Commuter Rail")
+        _ -> Factories.Stops.Stop.build(:stop)
+      end)
+
+      # Exercise
+      departures =
+        UpcomingDepartures.upcoming_departures(%{
+          direction_id: Faker.Util.pick([0, 1]),
+          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
+          route: route,
+          stop_id: stop.id
+        })
+
+      # Verify
+      assert [departure] = departures
+      assert departure.vehicle_name == vehicle_name
+    end
+
+    test "does not include vehicle name for non-ferry" do
+      # Setup
+      vehicle_name = Faker.Pokemon.name() <> " " <> Faker.Pokemon.name()
+      vehicle_id = String.upcase(vehicle_name)
+
+      %{
+        predicted_arrival_times: [_, arrival_time, _],
+        predictions: predictions,
+        route: route,
+        platform_stop_ids: [_, platform_id, _],
+        stops: [_, stop, _],
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(
+          route_factory_types: [:subway_route, :bus_route, :commuter_rail_route]
+        )
+
+      route_id = route.id
+
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle |> Map.put(:id, vehicle_id) end)
+      stub(Routes.Repo.Mock, :get, fn ^route_id -> route end)
+
+      stub(Stops.Repo.Mock, :get, fn
+        ^platform_id -> Factories.Stops.Stop.build(:stop, platform_name: "Commuter Rail")
+        _ -> Factories.Stops.Stop.build(:stop)
+      end)
+
+      # Exercise
+      departures =
+        UpcomingDepartures.upcoming_departures(%{
+          direction_id: Faker.Util.pick([0, 1]),
+          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
+          route: route,
+          stop_id: stop.id
+        })
+
+      # Verify
+      assert [departure] = departures
+      assert departure.vehicle_name == nil
     end
 
     test "includes scheduled trips and upcoming departures interleaved for bus and commuter rail and ferry" do

--- a/test/dotcom/schedule_finder/upcoming_departures_test.exs
+++ b/test/dotcom/schedule_finder/upcoming_departures_test.exs
@@ -595,7 +595,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       end)
 
       expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: date ->
+        [^route_id], direction_id: ^direction_id, date: date, stop_ids: [^stop_id] ->
           assert date == ServiceDateTime.service_date(now)
 
           [
@@ -644,7 +644,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       end)
 
       expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: date ->
+        [^route_id], direction_id: ^direction_id, date: date, stop_ids: [^stop_id] ->
           assert date == ServiceDateTime.service_date(now)
 
           [
@@ -695,7 +695,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       end)
 
       expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: date ->
+        [^route_id], direction_id: ^direction_id, date: date, stop_ids: [^stop_id] ->
           assert date == ServiceDateTime.service_date(now)
 
           [
@@ -751,7 +751,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       end)
 
       expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: date ->
+        [^route_id], direction_id: ^direction_id, date: date, stop_ids: [^stop_id] ->
           assert date == ServiceDateTime.service_date(now)
 
           [
@@ -807,7 +807,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       end)
 
       expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: date ->
+        [^route_id], direction_id: ^direction_id, date: date, stop_ids: [^stop_id] ->
           assert date == ServiceDateTime.service_date(now)
 
           [
@@ -851,7 +851,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
 
       # Exercise
       departures =
@@ -886,7 +886,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -946,7 +946,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       end)
 
       expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: _date ->
+        [^route_id], direction_id: ^direction_id, date: _date, stop_ids: [^stop_id] ->
           [
             Factories.Schedules.Schedule.build(:schedule,
               arrival_time: arrival_time_2,
@@ -984,7 +984,8 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         PredictedScheduleHelper.predicted_schedule_trip_data(route_factory_types: [:bus_route])
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
@@ -1045,7 +1046,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1077,7 +1078,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1111,7 +1112,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1141,7 +1142,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
 
       # Exercise
       departures =
@@ -1171,7 +1172,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1205,7 +1206,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1235,7 +1236,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
 
       # Exercise
       departures =
@@ -1265,7 +1266,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1297,7 +1298,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1915,7 +1916,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1982,7 +1983,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -2017,7 +2018,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -2051,7 +2052,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -2081,7 +2082,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
 
       # Exercise
       departures =
@@ -2109,7 +2110,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         PredictedScheduleHelper.predicted_schedule_trip_data(route_factory_types: [:bus_route])
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
 
       # Exercise
       departures =
@@ -2182,7 +2183,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -2219,7 +2220,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> schedules end)
+      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -2361,7 +2362,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         end)
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> updated_schedules end)
+      expect_schedule_call_filtered_by_stop(updated_schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -2401,7 +2402,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         end)
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> updated_schedules end)
+      expect_schedule_call_filtered_by_stop(updated_schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -3053,5 +3054,14 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       refute trip_stop_0.cancelled?
       assert trip_stop_1.cancelled?
     end
+  end
+
+  defp expect_schedule_call_filtered_by_stop(schedules, route_id: route_id) do
+    expect(Schedules.Repo.Mock, :by_route_ids, fn [^route_id],
+                                                  direction_id: _,
+                                                  date: _,
+                                                  stop_ids: [stop_id] ->
+      schedules |> Enum.filter(&(&1.stop.id == stop_id))
+    end)
   end
 end

--- a/test/dotcom/schedule_finder/upcoming_departures_test.exs
+++ b/test/dotcom/schedule_finder/upcoming_departures_test.exs
@@ -479,6 +479,80 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
       assert departure.vehicle_name == nil
     end
 
+    test "includes crowding data when available" do
+      # Setup
+      %{
+        predicted_arrival_times: [_, arrival_time, _],
+        predictions: predictions,
+        route: route,
+        platform_stop_ids: [_, platform_id, _],
+        stops: [_, stop, _],
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data()
+
+      crowding = Faker.Util.pick([:not_crowded, :some_crowding, :crowded])
+
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle |> Map.put(:crowding, crowding) end)
+
+      stub(Stops.Repo.Mock, :get, fn
+        ^platform_id -> Factories.Stops.Stop.build(:stop, platform_name: "Commuter Rail")
+        _ -> Factories.Stops.Stop.build(:stop)
+      end)
+
+      # Exercise
+      departures =
+        UpcomingDepartures.upcoming_departures(%{
+          direction_id: Faker.Util.pick([0, 1]),
+          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
+          route: route,
+          stop_id: stop.id
+        })
+
+      # Verify
+      assert [departure] = departures
+      assert departure.crowding == crowding
+    end
+
+    test "does not include crowding data if the predictions' assigned vehicle has a different trip ID" do
+      # Setup
+      %{
+        predicted_arrival_times: [_, arrival_time, _],
+        predictions: predictions,
+        route: route,
+        platform_stop_ids: [_, platform_id, _],
+        stops: [_, stop, _],
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(vehicle_on_different_trip?: true)
+
+      crowding = Faker.Util.pick([:not_crowded, :some_crowding, :crowded])
+
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle |> Map.put(:crowding, crowding) end)
+
+      stub(Stops.Repo.Mock, :get, fn
+        ^platform_id -> Factories.Stops.Stop.build(:stop, platform_name: "Commuter Rail")
+        _ -> Factories.Stops.Stop.build(:stop)
+      end)
+
+      # Exercise
+      departures =
+        UpcomingDepartures.upcoming_departures(%{
+          direction_id: Faker.Util.pick([0, 1]),
+          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
+          route: route,
+          stop_id: stop.id
+        })
+
+      # Verify
+      assert [departure] = departures
+      assert departure.crowding == nil
+    end
+
     test "includes scheduled trips and upcoming departures interleaved for bus and commuter rail and ferry" do
       # Setup
       now = Dotcom.Utils.DateTime.now()

--- a/test/dotcom/schedule_finder/upcoming_departures_test.exs
+++ b/test/dotcom/schedule_finder/upcoming_departures_test.exs
@@ -23,7 +23,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
   end
 
   describe "upcoming_departures/1" do
-    test "includes the stop_sequence and trip_id in upcoming departures" do
+    test "includes the stop_sequence, trip_id, and time in upcoming departures" do
       # Setup
       %{
         predicted_arrival_times: [_, arrival_time, _],
@@ -55,6 +55,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
 
       assert departure.stop_sequence == stop_sequence
       assert departure.trip_id == trip_id
+      assert departure.time == arrival_time
     end
 
     test "shows the number of minutes until arrival for bus and subway departures" do

--- a/test/support/predicted_scheduler_helper.ex
+++ b/test/support/predicted_scheduler_helper.ex
@@ -87,6 +87,7 @@ defmodule Test.Support.PredictedScheduleHelper do
 
     vehicle =
       Factories.Vehicles.Vehicle.build(:vehicle,
+        route_id: route.id,
         status: Faker.Util.pick(vehicle_statuses),
         stop_id: stop.id,
         stop_sequence: stop_sequence,


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [📅🔎🎭 Improve SF2.0 performance](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214093591659854?focus=true)

## Implementation

- Add a handler to the LiveView that loads trip details into the socket when their associated row is expanded.
- Lift all upcoming-departures related fields (that is, fields that are visible when upcoming departures rows are collapsed) to the `UpcomingDepartures` struct.
- Remove `trip_details` from `UpcomingDepartures`, in favor of calculating that out of band (on expand).
- Reduce the scope of `Schedules.Repo` queries to avoid iterating over as many `%Schedule{}` structs.

## Screenshots

<img width="632" height="450" alt="Screenshot 2026-04-17 at 3 08 02 PM" src="https://github.com/user-attachments/assets/d0d53b6a-4074-42dc-a367-8e406a6dcb5f" />

This is a mostly invisible change (except that hopefully things will load faster!) This state is kind of the exception - it's not possible to see a loading spinner in that spot on `main` right now.

## How to test

The real test is to deploy this to dev-{green,blue}, and [compare CPU utilization](https://mbta.splunkcloud.com/en-US/app/search/dotcom_dev_cpu_comparison?form.global_time_tok.earliest=-1h&form.global_time_tok.latest=now) between dev-{green,blue} and dev-{blue,green} while having like 20 SF2.0 tabs open.