### PR TITLE
SF Perf Experiment: JS polling and tab visibility

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -36,6 +36,8 @@ import previousEventsButton from "./view-previous-events";
 
 import mobileAppBanner from "./mobile-app-banner.js";
 
+import scheduleFinder from './schedule-finder.js';
+
 // Establish Phoenix Socket and LiveView configuration.
 import { Socket } from "phoenix";
 import { LiveSocket } from "phoenix_live_view";
@@ -138,3 +140,8 @@ accordionInit();
 juxtapose();
 
 mobileAppBanner();
+
+scheduleFinder();
+
+
+

--- a/assets/js/schedule-finder.js
+++ b/assets/js/schedule-finder.js
@@ -2,15 +2,28 @@ export default () => {
     let sf_interval = 0;
 
     window.addEventListener("load", ()=>{
-       if(sfhack){
+        //Logic request new upcoming departures every 5s while the window is visible
+       if(typeof refresh_input !== 'undefined'){
             clearInterval(sf_interval);
             sf_interval = setInterval(()=>{
                 if(!document.hidden){
-                    sfhack.dispatchEvent(
+                    refresh_input.dispatchEvent(
                         new Event("change", {bubbles:true})
                     );
                 }
             }, 5000);
         }
+       
+        
     });
+    //Log to sent hidden/visible state to the server so it can do smart stuff
+    window.addEventListener("visibilitychange", ()=>{
+        if(typeof vis_state !== 'undefined'){
+            vis_state.value = document.hidden?"hidden":"visible"
+            vis_state.dispatchEvent(
+                new Event("change", {bubbles:true})
+            );
+        }
+    });
+    
 }

--- a/assets/js/schedule-finder.js
+++ b/assets/js/schedule-finder.js
@@ -1,0 +1,16 @@
+export default () => {
+    let sf_interval = 0;
+
+    window.addEventListener("load", ()=>{
+       if(sfhack){
+            clearInterval(sf_interval);
+            sf_interval = setInterval(()=>{
+                if(!document.hidden){
+                    sfhack.dispatchEvent(
+                        new Event("change", {bubbles:true})
+                    );
+                }
+            }, 5000);
+        }
+    });
+}

--- a/assets/js/schedule-finder.js
+++ b/assets/js/schedule-finder.js
@@ -3,13 +3,11 @@ export default () => {
 
     window.addEventListener("load", ()=>{
         //Logic request new upcoming departures every 5s while the window is visible
-       if(typeof refresh_input !== 'undefined'){
+       if( typeof liveSocket !== 'undefined'){
             clearInterval(sf_interval);
             sf_interval = setInterval(()=>{
                 if(!document.hidden){
-                    refresh_input.dispatchEvent(
-                        new Event("change", {bubbles:true})
-                    );
+                    liveSocket.js().push(document.body,"refresh_departures",{})
                 }
             }, 5000);
         }
@@ -18,11 +16,8 @@ export default () => {
     });
     //Log to sent hidden/visible state to the server so it can do smart stuff
     window.addEventListener("visibilitychange", ()=>{
-        if(typeof vis_state !== 'undefined'){
-            vis_state.value = document.hidden?"hidden":"visible"
-            vis_state.dispatchEvent(
-                new Event("change", {bubbles:true})
-            );
+        if(typeof liveSocket !== 'undefined'){
+            liveSocket.js().push(document.body,"visibility_change", {value:{vis_state: document.hidden?"hidden":"visible"}})
         }
     });
     

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -93,22 +93,6 @@ defmodule DotcomWeb.ScheduleFinderLive do
   @impl LiveView
   def render(assigns) do
     ~H"""
-    <form>
-      <input
-        type="hidden"
-        id="refresh_input"
-        value="0"
-        phx-change="refresh_departures"
-        name="refresh_input"
-      />
-      <input
-        type="hidden"
-        id="vis_state"
-        value="visible"
-        phx-change="visibility_change"
-        name="vis_state"
-      />
-    </form>
     <.route_banner route={@route} direction_id={@direction_id} />
     <.stop_banner stop={@stop} />
     <div class="container">

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -93,6 +93,9 @@ defmodule DotcomWeb.ScheduleFinderLive do
   @impl LiveView
   def render(assigns) do
     ~H"""
+    <form>
+      <input type="hidden" id="sfhack" value="0" phx-change="refresh_departures" />
+    </form>
     <.route_banner route={@route} direction_id={@direction_id} />
     <.stop_banner stop={@stop} />
     <div class="container">
@@ -200,6 +203,14 @@ defmodule DotcomWeb.ScheduleFinderLive do
      |> assign(:departures, AsyncResult.loading())}
   end
 
+  def handle_event("refresh_departures", _, socket) do
+    dbg("ref")
+
+    {:noreply,
+     socket
+     |> assign_upcoming_departures()}
+  end
+
   def handle_event(_, _, socket), do: {:noreply, socket}
 
   @impl Phoenix.LiveView
@@ -246,11 +257,6 @@ defmodule DotcomWeb.ScheduleFinderLive do
     end
   end
 
-  defp schedule_refresh_upcoming_departures(pid) do
-    # Refresh every second
-    Process.send_after(pid, :refresh_upcoming_departures, 5000)
-  end
-
   defp validate_params(%{
          "direction_id" => direction,
          "route_id" => route_id,
@@ -278,8 +284,6 @@ defmodule DotcomWeb.ScheduleFinderLive do
     direction_id = socket.assigns.direction_id
     stop_id = stop_id
 
-    parent_pid = self()
-
     socket
     |> assign_async(
       :upcoming_departures,
@@ -291,8 +295,6 @@ defmodule DotcomWeb.ScheduleFinderLive do
             route: route,
             stop_id: stop_id
           })
-
-        schedule_refresh_upcoming_departures(parent_pid)
 
         {:ok, %{upcoming_departures: departures}}
       end

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -94,7 +94,20 @@ defmodule DotcomWeb.ScheduleFinderLive do
   def render(assigns) do
     ~H"""
     <form>
-      <input type="hidden" id="sfhack" value="0" phx-change="refresh_departures" />
+      <input
+        type="hidden"
+        id="refresh_input"
+        value="0"
+        phx-change="refresh_departures"
+        name="refresh_input"
+      />
+      <input
+        type="hidden"
+        id="vis_state"
+        value="visible"
+        phx-change="visibility_change"
+        name="vis_state"
+      />
     </form>
     <.route_banner route={@route} direction_id={@direction_id} />
     <.stop_banner stop={@stop} />
@@ -209,6 +222,11 @@ defmodule DotcomWeb.ScheduleFinderLive do
     {:noreply,
      socket
      |> assign_upcoming_departures()}
+  end
+
+  def handle_event("visibility_change", %{"vis_state" => vis_state?}, socket) do
+    dbg(vis_state?)
+    {:noreply, socket}
   end
 
   def handle_event(_, _, socket), do: {:noreply, socket}


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

~~**Asana Ticket:** [TICKET_NAME](TICKET_LINK)~~
I just had an idea when testing with 40 tabs, 38 of them were hidden yet still loading up the CPU just as much as the visible ones.  We should fix that, so I tried.

I wasn't able to reliably get the setTimeout->new data->setTimeout pattern to work, but I was able to get a normal setInterval() to work.  I don't think we need to worry about >5s load times anymore anyway.  What this does do is check if the tab is even visible before requesting new upcoming_departures data.  I know that personally, I open a new MBTA tab (on my phone and/or desktop), then put it in the background instead of closing it.  If many others are like me, we could be wasting a lot of compute, energy, and money sending data for pages that will never be seen.  This change should alleviate that, but I can't think of any way to test it besides putting it in prod after SF2.0 is live.

## Implementation

- Removed Elixir based polling and replaced it with JS based polling
- Added logic on client to skip polling requests when the page isn't visible
- Added logic on client to send visibility state to the server when it changes
- Added a stub handler for that event on the server end.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

## How to test

I left in a dbg() call in the handle_event() for this event so that you can minimize/hide the tab and see if it's still firing in the dotcom console/logs.


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
