### PR TITLE
add initial tests for ScheduleFinderLive

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -48,6 +48,8 @@ config :dotcom, :repo_modules,
   stops: Stops.Repo,
   vehicles: Vehicles.Repo
 
+config :dotcom, :schedule_finder_module, Dotcom.ScheduleFinder
+
 config :dotcom, :system_status_cache_modules,
   commuter_rail: Dotcom.SystemStatus.CommuterRailCache,
   subway: Dotcom.SystemStatus.SubwayCache

--- a/config/test.exs
+++ b/config/test.exs
@@ -42,6 +42,8 @@ config :dotcom, :redis, Dotcom.Redis.Mock
 config :dotcom, :redix, Dotcom.Redix.Mock
 config :dotcom, :redix_pub_sub, Dotcom.Redix.PubSub.Mock
 
+config :dotcom, :schedule_finder_module, Dotcom.ScheduleFinder.Mock
+
 config :dotcom, :system_status_cache_modules,
   commuter_rail: Dotcom.SystemStatus.CommuterRailCache.Mock,
   subway: Dotcom.SystemStatus.SubwayCache.Mock

--- a/lib/dotcom/schedule_finder.ex
+++ b/lib/dotcom/schedule_finder.ex
@@ -14,6 +14,8 @@ defmodule Dotcom.ScheduleFinder do
   alias Schedules.{Schedule, Trip}
   alias Stops.Stop
 
+  @behaviour Dotcom.ScheduleFinder.Behaviour
+
   @alerts_repo_module Application.compile_env!(:dotcom, :repo_modules)[:alerts]
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
   @route_patterns_repo Application.compile_env!(:dotcom, :repo_modules)[:route_patterns]
@@ -59,11 +61,7 @@ defmodule Dotcom.ScheduleFinder do
           }
   end
 
-  @doc """
-  Service-impacting currently active alerts for a route, including track changes
-  at the indicated stop. Excludes commuter rail trip cancellations and delays.
-  """
-  @spec current_alerts(Stop.t(), Route.t()) :: [Alert.t()]
+  @impl Dotcom.ScheduleFinder.Behaviour
   def current_alerts(stop, route) do
     route.id
     |> @alerts_repo_module.by_route_id_and_type(route.type, @date_time_module.now())
@@ -94,11 +92,7 @@ defmodule Dotcom.ScheduleFinder do
 
   defp cr_trip_cancellation_or_delay?(_), do: false
 
-  @doc """
-  Get scheduled departures for a given route/direction/stop/date.
-  """
-  @spec daily_departures(Route.id_t(), 0 | 1, Stop.id_t(), String.t()) ::
-          {:ok, [DailyDeparture.t()]} | {:error, term()}
+  @impl Dotcom.ScheduleFinder.Behaviour
   def daily_departures(route_id, direction_id, stop_id, date) do
     # Maybe add filter[stop_sequence] to help looped routes
     case @schedules_repo.by_route_ids(routes(route_id),
@@ -152,11 +146,7 @@ defmodule Dotcom.ScheduleFinder do
 
   defp time_desc(_), do: nil
 
-  @doc """
-  Get scheduled arrivals for one trip on a date, starting at a given stop_sequence.
-  """
-  @spec next_arrivals(Trip.id_t(), non_neg_integer(), String.t()) ::
-          {:ok, [FutureArrival.t()]} | {:error, term()}
+  @impl Dotcom.ScheduleFinder.Behaviour
   def next_arrivals(trip_id, min_stop_sequence, date) do
     # Maybe add filter[stop_sequence] to help looped routes
     case @schedules_repo.schedule_for_trip(trip_id, date: date) do
@@ -255,14 +245,7 @@ defmodule Dotcom.ScheduleFinder do
 
   def simplify_platform_name(name, _), do: name
 
-  @doc """
-  Clearly group a list of departures by route and destination. Intended to be used with subway departures.
-
-  In the case of the Red and Green lines, scheduled departures might include multiple destinations, e.g. trains to Ashmont _and_ trains to Braintree, and/or multiple routes, as in the case of the distinct Green Line "branches".
-  """
-  @spec subway_groups([DailyDeparture.t()], 0 | 1, Stop.id_t()) :: [
-          {Route.t(), String.t(), [DateTime.t()]}
-        ]
+  @impl Dotcom.ScheduleFinder.Behaviour
   def subway_groups(departures, direction_id, stop_id) do
     departures
     |> Enum.group_by(& &1.route)

--- a/lib/dotcom/schedule_finder/behaviour.ex
+++ b/lib/dotcom/schedule_finder/behaviour.ex
@@ -1,0 +1,38 @@
+defmodule Dotcom.ScheduleFinder.Behaviour do
+  @moduledoc """
+  A behaviour to capture the interface of `Dotcom.ScheduleFinder`.
+  """
+
+  alias Alerts.Alert
+  alias Dotcom.ScheduleFinder.{DailyDeparture, FutureArrival}
+  alias Routes.Route
+  alias Schedules.Trip
+  alias Stops.Stop
+
+  @doc """
+  Service-impacting currently active alerts for a route, including track changes
+  at the indicated stop. Excludes commuter rail trip cancellations and delays.
+  """
+  @callback current_alerts(Stop.t(), Route.t()) :: [Alert.t()]
+
+  @doc """
+  Get scheduled departures for a given route/direction/stop/date.
+  """
+  @callback daily_departures(Route.id_t(), 0 | 1, Stop.id_t(), String.t()) ::
+              {:ok, [DailyDeparture.t()]} | {:error, term()}
+
+  @doc """
+  Get scheduled arrivals for one trip on a date, starting at a given stop_sequence.
+  """
+  @callback next_arrivals(Trip.id_t(), non_neg_integer(), String.t()) ::
+              {:ok, [FutureArrival.t()]} | {:error, term()}
+
+  @doc """
+  Clearly group a list of departures by route and destination. Intended to be used with subway departures.
+
+  In the case of the Red and Green lines, scheduled departures might include multiple destinations, e.g. trains to Ashmont _and_ trains to Braintree, and/or multiple routes, as in the case of the distinct Green Line "branches".
+  """
+  @callback subway_groups([DailyDeparture.t()], 0 | 1, Stop.id_t()) :: [
+              {Route.t(), String.t(), [DateTime.t()]}
+            ]
+end

--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -113,6 +113,10 @@ defmodule DotcomWeb.Components do
     """
   end
 
+  attr(:rest, :global)
+  attr(:title, :string)
+  slot(:inner_block, required: true)
+
   def error_container(assigns) do
     assigns =
       assigns
@@ -122,7 +126,7 @@ defmodule DotcomWeb.Components do
       end)
 
     ~H"""
-    <div class={"error-container rounded #{@padding_class}"}>
+    <div class={"error-container rounded #{@padding_class}"} {@rest}>
       <p :if={@title} class="font-bold mb-2">{@title}</p>
       {render_slot(@inner_block)}
     </div>
@@ -371,6 +375,7 @@ defmodule DotcomWeb.Components do
     """
   end
 
+  attr(:rest, :global)
   slot :inner_block, required: true
 
   @doc """
@@ -378,7 +383,7 @@ defmodule DotcomWeb.Components do
   """
   def callout(assigns) do
     ~H"""
-    <div class="callout font-bold text-center">
+    <div class="callout font-bold text-center" {@rest}>
       {render_slot(@inner_block)}
     </div>
     """

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -8,7 +8,6 @@ defmodule DotcomWeb.ScheduleFinderLive do
 
   import CSSHelpers
   import DotcomWeb.Components.Alerts
-  import Dotcom.ScheduleFinder
   import Dotcom.Utils.Diff, only: [minutes_to_localized_minutes: 1]
   import Dotcom.Utils.ServiceDateTime, only: [service_date: 0]
   import Dotcom.Utils.Time, only: [format!: 2]
@@ -27,6 +26,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
 
   @date_time Application.compile_env!(:dotcom, :date_time_module)
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
+  @schedule_finder Application.compile_env!(:dotcom, :schedule_finder_module)
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
 
   @impl LiveView
@@ -152,7 +152,8 @@ defmodule DotcomWeb.ScheduleFinderLive do
               <%= if @route.type in [0, 1] do %>
                 <div
                   :for={
-                    {route, destination, times} <- subway_groups(departures, @direction_id, @stop.id)
+                    {route, destination, times} <-
+                      get_subway_groups(departures, @direction_id, @stop.id)
                   }
                   class="mt-lg mb-md"
                 >
@@ -232,7 +233,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
      socket
      |> update(:loaded_trips, fn loaded_trips ->
        result =
-         case Kernel.apply(Dotcom.ScheduleFinder, :next_arrivals, args) do
+         case Kernel.apply(@schedule_finder, :next_arrivals, args) do
            {:ok, arrivals} -> AsyncResult.ok(arrivals)
            error -> AsyncResult.failed(error, :reason)
          end
@@ -431,10 +432,14 @@ defmodule DotcomWeb.ScheduleFinderLive do
   end
 
   defp get_departures(route_id, direction_id, stop_id, date) do
-    case daily_departures(route_id, direction_id, stop_id, date) do
+    case @schedule_finder.daily_departures(route_id, direction_id, stop_id, date) do
       {:ok, departures} -> {:ok, %{departures: departures}}
       error -> error
     end
+  end
+
+  defp get_subway_groups(departures, direction_id, stop_id) do
+    @schedule_finder.subway_groups(departures, direction_id, stop_id)
   end
 
   # Schedule Finder components =================================================

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -17,7 +17,6 @@ defmodule DotcomWeb.ScheduleFinderLive do
   alias Dotcom.ScheduleFinder.ServiceGroup
   alias Dotcom.ScheduleFinder.TripDetails
   alias Dotcom.ScheduleFinder.UpcomingDepartures
-  alias Dotcom.ServicePatterns
   alias DotcomWeb.RouteComponents
   alias MbtaMetro.Components.SystemIcons
   alias Phoenix.{LiveView, LiveView.AsyncResult}
@@ -45,18 +44,8 @@ defmodule DotcomWeb.ScheduleFinderLive do
     case validate_params(params) do
       {:ok, %{route: route, stop: stop, direction_id: direction_id}} ->
         service_groups = ServiceGroup.for_route(route.id, service_date())
-
-        selected_service =
-          service_groups
-          |> Enum.flat_map(& &1.services)
-          |> Enum.find(%{}, &(&1.now_date || &1.next_date))
-
-        socket =
-          if Map.get(selected_service, :next_date) do
-            assign(socket, :daily_schedule_date, selected_service.next_date)
-          else
-            socket
-          end
+        all_services = Enum.flat_map(service_groups, & &1.services)
+        selected_service = Enum.find(all_services, %{}, &(&1.now_date || &1.next_date))
 
         {:ok,
          socket
@@ -73,7 +62,15 @@ defmodule DotcomWeb.ScheduleFinderLive do
          |> assign_new(:service_groups, fn -> service_groups end)
          |> assign_new(:loaded_trips, fn -> %{} end)
          |> assign_new(:selected_service_name, fn -> Map.get(selected_service, :label, "") end)
-         |> assign_new(:daily_schedule_date, fn -> service_date() end)
+         |> assign_new(:service_today?, fn -> Enum.any?(all_services, &(!is_nil(&1.now_date))) end)
+         |> assign_new(:daily_schedule_date, fn assigns ->
+           # Current date if there's service today, next available service date otherwise... or current date if there's no service at all!
+           if assigns.service_today? do
+             service_date()
+           else
+             Map.get(selected_service, :next_date, service_date())
+           end
+         end)
          |> assign_new(:should_refresh?, fn -> true end)
          |> assign_alerts()
          |> assign_departures()
@@ -106,7 +103,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
         <.alert_banner alerts={@alerts} />
         <section>
           <h2 class="mt-0 mb-md">{~t"Upcoming Departures"}</h2>
-          <%= if ServicePatterns.has_service?(route: @route.id) do %>
+          <%= if @service_today? do %>
             <.async_result :let={upcoming_departures} assign={@upcoming_departures}>
               <:loading>
                 <div class="mt-lg mb-md flex justify-center">

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -136,12 +136,12 @@ defmodule DotcomWeb.ScheduleFinderLive do
           />
           <.async_result :let={departures} assign={@departures}>
             <:loading>
-              <div class="mt-lg mb-md flex justify-center">
+              <div class="mt-lg mb-md flex justify-center" data-test="departures_loading">
                 <.spinner aria_label={~t"Loading schedules for selected service"} />
               </div>
             </:loading>
             <:failed :let={_fail}>
-              <.error_container>
+              <.error_container data-test="departures_error">
                 {~t"There was a problem loading schedules"}
               </.error_container>
             </:failed>
@@ -153,6 +153,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
                       get_subway_groups(departures, @direction_id, @stop.id)
                   }
                   class="mt-lg mb-md"
+                  data-test="subway_group"
                 >
                   <.subway_destination route={route} destination={destination} />
                   <.first_last times={times} vehicle_name={@vehicle_name} />
@@ -165,7 +166,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
                 <.departures_table departures={departures} loaded_trips={@loaded_trips} />
               <% end %>
             <% else %>
-              <.callout>
+              <.callout data-test="no_service">
                 {no_service_message(@service_groups, @route, @stop)}
               </.callout>
             <% end %>
@@ -379,16 +380,19 @@ defmodule DotcomWeb.ScheduleFinderLive do
       socket,
       :last_trip_time,
       fn ->
-        {_, departures} =
-          get_departures(route_id, direction_id, stop.id, date)
+        case get_departures(route_id, direction_id, stop.id, date) do
+          {_, %{departures: departures}} ->
+            last_trip_time =
+              departures
+              |> Enum.sort_by(fn departure -> DateTime.to_unix(departure.time) end)
+              |> Enum.at(-1, %{})
+              |> Map.get(:time)
 
-        last_trip_time =
-          departures.departures
-          |> Enum.sort_by(fn departure -> DateTime.to_unix(departure.time) end)
-          |> Enum.at(-1, %{})
-          |> Map.get(:time)
+            {:ok, %{last_trip_time: last_trip_time}}
 
-        {:ok, %{last_trip_time: last_trip_time}}
+          _ ->
+            {:ok, %{last_trip_time: nil}}
+        end
       end,
       reset: true
     )
@@ -467,7 +471,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
       })
 
     ~H"""
-    <div class={route_to_background_class(@route)}>
+    <div data-test={"route_banner:#{@route.id}"} class={route_to_background_class(@route)}>
       <.link
         class="block text-current hover:text-current focus:text-current hover:no-underline active:no-underline focus:no-underline"
         patch={~p"/schedules/#{@route.id}?schedule_direction[direction_id]=#{@direction_id}"}
@@ -549,7 +553,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
 
   def stop_banner(assigns) do
     ~H"""
-    <div :if={@stop} class="bg-gray-lightest">
+    <div :if={@stop} data-test={"stop_banner:#{@stop.id}"} class="bg-gray-lightest">
       <.link
         class="block text-black hover:text-black focus:text-black hover:no-underline active:no-underline focus:no-underline"
         patch={~p"/stops/#{@stop}"}
@@ -559,6 +563,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
             <.icon
               type="icon-svg"
               aria-hidden
+              data-test={["stop_banner_icon:", if(@stop.station?, do: "station", else: "stop")]}
               name={if(@stop.station?, do: "mbta-logo", else: "icon-stop-default")}
               class="size-5 fill-current"
             />
@@ -657,7 +662,10 @@ defmodule DotcomWeb.ScheduleFinderLive do
 
   defp departures_table(assigns) do
     ~H"""
-    <div class="grid grid-cols-1 divide-y-xs divide-gray-lightest border-xs border-gray-lightest">
+    <div
+      class="grid grid-cols-1 divide-y-xs divide-gray-lightest border-xs border-gray-lightest"
+      data-test="departures_table"
+    >
       <.unstyled_accordion
         :for={departure <- @departures}
         summary_class="flex items-center gap-sm hover:bg-brand-primary-lightest px-sm py-3"

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -362,7 +362,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
     direction = socket.assigns.direction_id
 
     alerts =
-      current_alerts(stop, route)
+      @schedule_finder.current_alerts(stop, route)
       |> Enum.filter(fn %{informed_entity: %{direction_id: direction_id}} ->
         Enum.any?([nil, direction], &(&1 in direction_id))
       end)
@@ -459,7 +459,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
   attr :route, Route, required: true
   attr :direction_id, :string, required: true
 
-  defp route_banner(assigns) do
+  def route_banner(assigns) do
     mode = assigns.route |> Route.type_atom() |> atom_to_class()
     line_name = assigns.route |> Route.icon_atom() |> atom_to_class()
 
@@ -550,7 +550,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
 
   attr :stop, Stop
 
-  defp stop_banner(assigns) do
+  def stop_banner(assigns) do
     ~H"""
     <div :if={@stop} class="bg-gray-lightest">
       <.link

--- a/test/dotcom/service_patterns_test.exs
+++ b/test/dotcom/service_patterns_test.exs
@@ -5,6 +5,7 @@ defmodule Dotcom.ServicePatternsTest do
   import Dotcom.Utils.ServiceDateTime, only: [service_date: 0]
   import Mox
   import Test.Support.Factories.Services.Service
+  import Test.Support.Generators.Date, only: [random_date: 0]
 
   alias Test.Support.FactoryHelpers
 
@@ -28,11 +29,13 @@ defmodule Dotcom.ServicePatternsTest do
     end
 
     test "returns true if there are services for that date" do
+      date = random_date()
+
       expect(Services.Repo.Mock, :by_route_id, fn _ ->
-        build_list(5, :service, %{date: service_date()})
+        build_list(5, :service, %{date: date})
       end)
 
-      assert has_service?(route: FactoryHelpers.build(:id))
+      assert has_service?(route: FactoryHelpers.build(:id), date: date)
     end
 
     test "returns false if no service" do
@@ -44,13 +47,13 @@ defmodule Dotcom.ServicePatternsTest do
     end
 
     test "returns false if services only serve other dates" do
+      date = random_date()
+
       expect(Services.Repo.Mock, :by_route_id, fn _ ->
-        build_list(5, :service, %{date: service_date()})
+        build_list(5, :service, %{date: date})
       end)
 
-      other_date =
-        service_date()
-        |> Date.shift(year: 5)
+      other_date = Date.shift(date, year: 5)
 
       refute has_service?(route: FactoryHelpers.build(:id), date: other_date)
     end

--- a/test/dotcom_web/live/schedule_finder_live_test.exs
+++ b/test/dotcom_web/live/schedule_finder_live_test.exs
@@ -1,0 +1,344 @@
+defmodule DotcomWeb.ScheduleFinderLiveTest do
+  use DotcomWeb.ConnCase, async: true
+
+  import DotcomWeb.Router.Helpers, only: [live_path: 2, live_path: 3]
+  import Mox
+  import Phoenix.LiveViewTest
+  import Test.Support.Generators.DateTime, only: [random_date_time: 0]
+
+  alias DotcomWeb.ScheduleFinderLive
+  alias Test.Support.Factories
+  alias Test.Support.FactoryHelpers
+
+  setup :verify_on_exit!
+
+  setup _ do
+    cache = Application.get_env(:dotcom, :cache)
+    cache.flush()
+
+    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+
+    :ok
+  end
+
+  test "loads, fetching route info", %{conn: conn} do
+    route_id = FactoryHelpers.build(:id)
+    stop_id = FactoryHelpers.build(:id)
+    direction_id = FactoryHelpers.build(:direction_id)
+
+    # The LiveView lifecycle calls mount/3 twice, hence these are run twice
+    expect(Dotcom.ScheduleFinder.Mock, :current_alerts, 2, fn stop, route ->
+      assert stop.id == stop_id
+      assert route.id == route_id
+      []
+    end)
+
+    expect(Routes.Repo.Mock, :get, 2, fn ^route_id ->
+      Factories.Routes.Route.build(:route, %{id: route_id})
+    end)
+
+    expect(Services.Repo.Mock, :by_route_id, 2, fn ^route_id ->
+      Factories.Services.Service.build_list(5, :service)
+    end)
+
+    expect(Stops.Repo.Mock, :get, 2, fn ^stop_id ->
+      Factories.Stops.Stop.build(:stop, %{id: stop_id})
+    end)
+
+    path =
+      live_path(conn, ScheduleFinderLive,
+        route_id: route_id,
+        direction_id: direction_id,
+        stop_id: stop_id
+      )
+
+    assert {:ok, view, _html} = live(conn, path, on_error: :warn)
+    assert has_element?(view, "h2", "Upcoming Departures")
+    assert has_element?(view, "h2", "Daily Schedules")
+  end
+
+  test "redirects without params", %{conn: conn} do
+    path = live_path(conn, ScheduleFinderLive)
+    assert {:error, {:live_redirect, %{to: "/schedules", flash: %{}}}} = live(conn, path)
+  end
+
+  @tag :capture_log
+  test "shows 404 for invalid route param", %{conn: conn} do
+    route_id = FactoryHelpers.build(:id)
+    stop_id = FactoryHelpers.build(:id)
+    direction_id = FactoryHelpers.build(:direction_id)
+
+    path =
+      live_path(conn, ScheduleFinderLive,
+        route_id: route_id,
+        direction_id: direction_id,
+        stop_id: stop_id
+      )
+
+    expect(Routes.Repo.Mock, :get, 1, fn ^route_id -> nil end)
+    deny(Stops.Repo.Mock, :get, 1)
+
+    assert_raise DotcomWeb.NotFoundError, fn ->
+      live(conn, path)
+    end
+  end
+
+  @tag :capture_log
+  test "shows 404 for invalid stop param", %{conn: conn} do
+    route_id = FactoryHelpers.build(:id)
+    stop_id = FactoryHelpers.build(:id)
+    direction_id = FactoryHelpers.build(:direction_id)
+
+    path =
+      live_path(conn, ScheduleFinderLive,
+        route_id: route_id,
+        direction_id: direction_id,
+        stop_id: stop_id
+      )
+
+    expect(Routes.Repo.Mock, :get, 1, fn ^route_id ->
+      Factories.Routes.Route.build(:route, id: route_id)
+    end)
+
+    expect(Stops.Repo.Mock, :get, 1, fn ^stop_id -> nil end)
+
+    assert_raise DotcomWeb.NotFoundError, fn ->
+      live(conn, path)
+    end
+  end
+
+  describe "displays current route with link" do
+    setup do
+      %{direction_id: FactoryHelpers.build(:direction_id)}
+    end
+
+    test "default case", %{direction_id: direction_id} do
+      route = Factories.Routes.Route.build(:route)
+
+      html =
+        render_component(&ScheduleFinderLive.route_banner/1,
+          direction_id: direction_id,
+          route: route
+        )
+
+      assert html =~
+               ~s(<a href=\"/schedules/#{route.id}?schedule_direction[direction_id]=#{direction_id}\")
+
+      assert html =~ route.name
+      assert html =~ route.direction_names[direction_id]
+      assert html =~ "towards"
+      assert html =~ route.direction_destinations[direction_id]
+    end
+
+    test "omits destination for Green Line", %{direction_id: direction_id} do
+      green_line = Factories.Routes.Route.build(:route, %{id: "Green"})
+
+      html =
+        render_component(&ScheduleFinderLive.route_banner/1,
+          direction_id: direction_id,
+          route: green_line
+        )
+
+      assert html =~
+               ~s(<a href=\"/schedules/#{green_line.id}?schedule_direction[direction_id]=#{direction_id}\")
+
+      assert html =~ green_line.name
+      assert html =~ green_line.direction_names[direction_id]
+      refute html =~ "towards"
+      refute html =~ green_line.direction_destinations[direction_id]
+    end
+  end
+
+  test "displays current stop with link" do
+    stop = Factories.Stops.Stop.build(:stop, %{station?: Faker.Util.pick([true, false])})
+    html = render_component(&ScheduleFinderLive.stop_banner/1, stop: stop)
+    assert html =~ stop.name
+    assert html =~ ~s(<a href=\"/stops/#{stop.id}\")
+
+    if stop.station? do
+      assert html =~ ~s(id=\"mbta-logo\")
+    else
+      assert html =~ ~s(<title>\n        stop\n    </title>)
+    end
+  end
+
+  test "shows alerts", %{conn: conn} do
+    expect(Dotcom.ScheduleFinder.Mock, :current_alerts, 2, fn _, _ ->
+      Factories.Alerts.Alert.build_list(1, :alert_for_informed_entity,
+        informed_entity: %{direction_id: nil}
+      )
+    end)
+
+    {:ok, view, _html} = visit_with_valid_params(conn)
+    assert has_element?(view, "section.c-alert-group")
+  end
+
+  test "receives alert updates", %{conn: conn} do
+    # No alerts
+    expect(Dotcom.ScheduleFinder.Mock, :current_alerts, 2, fn _, _ -> [] end)
+    {:ok, view, _html} = visit_with_valid_params(conn)
+    refute has_element?(view, "section.c-alert-group")
+
+    # It will get called again!
+    expect(Dotcom.ScheduleFinder.Mock, :current_alerts, 1, fn _, _ ->
+      Factories.Alerts.Alert.build_list(1, :alert_for_informed_entity,
+        informed_entity: %{direction_id: nil}
+      )
+    end)
+
+    # Send out alert update
+    DotcomWeb.Endpoint.broadcast("alerts", "alerts_updated", [])
+
+    _ = render(view)
+    assert has_element?(view, "section.c-alert-group")
+  end
+
+  describe "Daily Departures" do
+    test "indicates no service", %{conn: conn} do
+      expect(Services.Repo.Mock, :by_route_id, 3, fn _ -> [] end)
+
+      expect(Dotcom.ScheduleFinder.Mock, :daily_departures, fn _, _, _, _ ->
+        {:ok, []}
+      end)
+
+      assert {:ok, view, _html} = visit_with_valid_params(conn)
+      rendered = render_async(view)
+      refute has_element?(view, "#service-picker-form")
+      assert rendered =~ ~r/There is currently no scheduled (\w+)./
+    end
+
+    test "indicates no service for selected schedule", %{conn: conn} do
+      active_services = Factories.Services.Service.build_list(15, :service)
+      expect(Services.Repo.Mock, :by_route_id, 2, fn _ -> active_services end)
+
+      expect(Dotcom.ScheduleFinder.Mock, :daily_departures, 2, fn _, _, _, _ ->
+        {:ok, []}
+      end)
+
+      assert {:ok, view, _html} = visit_with_valid_params(conn)
+      rendered = render_async(view)
+      assert has_element?(view, "#service-picker-form")
+      assert rendered =~ ~r/There is no scheduled (\N+) service at (\N+) for this time period./
+    end
+
+    test "handles loading errors & shows custom message", %{conn: conn} do
+      actual_error = "nonsense only a computer will understand"
+
+      expect(Dotcom.ScheduleFinder.Mock, :daily_departures, fn _, _, _, _ ->
+        {:error, actual_error}
+      end)
+
+      assert {:ok, view, _html} = visit_with_valid_params(conn)
+      rendered = render_async(view)
+      refute has_element?(view, "details")
+      assert rendered =~ "There was a problem loading schedules"
+      refute rendered =~ actual_error
+    end
+  end
+
+  describe "Daily Departures (non-subway)" do
+    test "loads & shows individual departures", %{conn: conn} do
+      departures =
+        2
+        |> Faker.random_between(20)
+        |> Factories.ScheduleFinder.build_list(:daily_departure)
+
+      expect(Dotcom.ScheduleFinder.Mock, :daily_departures, 2, fn _, _, _, _ ->
+        {:ok, departures}
+      end)
+
+      assert {:ok, view, html} = visit_with_valid_params(conn, [2, 3, 4])
+      assert html =~ "Loading schedules for selected service"
+      rendered = render_async(view)
+      refute rendered =~ "Loading schedules for selected service"
+      assert has_element?(view, ~s(details[phx-click="open_trip"]))
+
+      for %{time: t} <- departures do
+        assert rendered =~ "<time datetime=\"#{DateTime.to_iso8601(t)}\""
+      end
+    end
+  end
+
+  describe "Daily Departures (subway)" do
+    test "shows first/last trains for destinations instead of listing individual departures", %{
+      conn: conn
+    } do
+      departures =
+        2
+        |> Faker.random_between(20)
+        |> Factories.ScheduleFinder.build_list(:daily_departure)
+
+      subway_groups =
+        1
+        |> Faker.random_between(6)
+        |> Faker.Util.sample_uniq(fn ->
+          route = Factories.Routes.Route.build(:route)
+          destination = Faker.Lorem.word()
+          first_time = random_date_time()
+          last_time = random_date_time()
+          {route, destination, [first_time, last_time]}
+        end)
+
+      Dotcom.ScheduleFinder.Mock
+      |> expect(:daily_departures, 2, fn _, _, _, _ -> {:ok, departures} end)
+      |> expect(:subway_groups, 1, fn ^departures, _, _ -> subway_groups end)
+
+      assert {:ok, view, html} = visit_with_valid_params(conn, [0, 1])
+      assert html =~ "Loading schedules for selected service"
+      rendered = render_async(view)
+      refute rendered =~ "Loading schedules for selected service"
+      refute has_element?(view, ~s(details[phx-click="open_trip"]))
+
+      for %{time: t} <- departures do
+        refute rendered =~ "<time datetime=\"#{DateTime.to_iso8601(t)}\""
+      end
+
+      for {_route, destination, [first_time, last_time]} <- subway_groups do
+        assert rendered =~ "to #{destination}"
+        assert rendered =~ "First train:"
+        assert rendered =~ "<time datetime=\"#{DateTime.to_iso8601(first_time)}\""
+        assert rendered =~ "Last train:"
+        assert rendered =~ "<time datetime=\"#{DateTime.to_iso8601(last_time)}\""
+      end
+    end
+  end
+
+  defp visit_with_valid_params(conn, route_types \\ [0, 1, 2, 3, 4]) do
+    route_id = FactoryHelpers.build(:id)
+    direction_id = FactoryHelpers.build(:direction_id)
+    stop_id = FactoryHelpers.build(:id)
+
+    stub(Routes.Repo.Mock, :get, fn _ ->
+      Factories.Routes.Route.build(:route, %{id: route_id, type: Faker.Util.pick(route_types)})
+    end)
+
+    stub(Services.Repo.Mock, :by_route_id, fn _ ->
+      Factories.Services.Service.build_list(15, :service)
+    end)
+
+    stub(Stops.Repo.Mock, :get, fn _ ->
+      Factories.Stops.Stop.build(:stop, %{id: stop_id})
+    end)
+
+    Dotcom.ScheduleFinder.Mock
+    |> stub(:current_alerts, fn _, _ -> [] end)
+    |> stub(:daily_departures, fn _, _, _, _ -> {:ok, []} end)
+
+    # Dotcom.ScheduleFinder.UpcomingDepartures.Mock
+    # |> stub(:upcoming_departures, fn _ -> [] end)
+    stub(Predictions.Repo.Mock, :all, fn _ -> [] end)
+    stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+
+    stub(Dotcom.Alerts.AffectedStops.Mock, :affected_stops, fn _, _ -> [] end)
+    stub(Dotcom.Alerts.EndpointStops.Mock, :endpoint_stops, fn _, _ -> [] end)
+
+    path =
+      live_path(conn, ScheduleFinderLive,
+        route_id: route_id,
+        direction_id: direction_id,
+        stop_id: stop_id
+      )
+
+    live(conn, path, on_error: :warn)
+  end
+end

--- a/test/dotcom_web/live/schedule_finder_live_test.exs
+++ b/test/dotcom_web/live/schedule_finder_live_test.exs
@@ -112,53 +112,67 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
       %{direction_id: FactoryHelpers.build(:direction_id)}
     end
 
-    test "default case", %{direction_id: direction_id} do
+    test "default link", %{direction_id: direction_id} do
       route = Factories.Routes.Route.build(:route)
 
-      html =
+      link =
         render_component(&ScheduleFinderLive.route_banner/1,
           direction_id: direction_id,
           route: route
         )
+        |> Floki.parse_fragment!()
+        |> Floki.find("[data-test=\"route_banner:#{route.id}\"] a")
 
-      assert html =~
-               ~s(<a href=\"/schedules/#{route.id}?schedule_direction[direction_id]=#{direction_id}\")
+      assert Floki.attribute(link, "href") == [
+               "/schedules/#{route.id}?schedule_direction[direction_id]=#{direction_id}"
+             ]
 
-      assert html =~ route.name
-      assert html =~ route.direction_names[direction_id]
-      assert html =~ "towards"
-      assert html =~ route.direction_destinations[direction_id]
+      link_text = Floki.text(link)
+      assert link_text =~ route.name
+      assert link_text =~ route.direction_names[direction_id]
+      assert link_text =~ "towards"
+      assert link_text =~ route.direction_destinations[direction_id]
     end
 
     test "omits destination for Green Line", %{direction_id: direction_id} do
       green_line = Factories.Routes.Route.build(:route, %{id: "Green"})
 
-      html =
+      link =
         render_component(&ScheduleFinderLive.route_banner/1,
           direction_id: direction_id,
           route: green_line
         )
+        |> Floki.parse_fragment!()
+        |> Floki.find("[data-test=\"route_banner:Green\"] a")
 
-      assert html =~
-               ~s(<a href=\"/schedules/#{green_line.id}?schedule_direction[direction_id]=#{direction_id}\")
+      assert Floki.attribute(link, "href") == [
+               "/schedules/Green?schedule_direction[direction_id]=#{direction_id}"
+             ]
 
-      assert html =~ green_line.name
-      assert html =~ green_line.direction_names[direction_id]
-      refute html =~ "towards"
-      refute html =~ green_line.direction_destinations[direction_id]
+      link_text = Floki.text(link)
+
+      assert link_text =~ green_line.name
+      assert link_text =~ green_line.direction_names[direction_id]
+      refute link_text =~ "towards"
+      refute link_text =~ green_line.direction_destinations[direction_id]
     end
   end
 
   test "displays current stop with link" do
     stop = Factories.Stops.Stop.build(:stop, %{station?: Faker.Util.pick([true, false])})
-    html = render_component(&ScheduleFinderLive.stop_banner/1, stop: stop)
-    assert html =~ stop.name
-    assert html =~ ~s(<a href=\"/stops/#{stop.id}\")
+
+    link =
+      render_component(&ScheduleFinderLive.stop_banner/1, stop: stop)
+      |> Floki.parse_fragment!()
+      |> Floki.find("[data-test=\"stop_banner:#{stop.id}\"] a")
+
+    assert Floki.text(link) =~ stop.name
+    assert Floki.attribute(link, "href") == ["/stops/#{stop.id}"]
 
     if stop.station? do
-      assert html =~ ~s(id=\"mbta-logo\")
+      assert Floki.find(link, "[data-test=\"stop_banner_icon:station\"]") != []
     else
-      assert html =~ ~s(<title>\n        stop\n    </title>)
+      assert Floki.find(link, "[data-test=\"stop_banner_icon:stop\"]") != []
     end
   end
 
@@ -195,44 +209,58 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
 
   describe "Daily Departures" do
     test "indicates no service", %{conn: conn} do
-      expect(Services.Repo.Mock, :by_route_id, 3, fn _ -> [] end)
-
-      expect(Dotcom.ScheduleFinder.Mock, :daily_departures, fn _, _, _, _ ->
-        {:ok, []}
-      end)
-
+      expect(Services.Repo.Mock, :by_route_id, 2, fn _ -> [] end)
+      expect(Dotcom.ScheduleFinder.Mock, :daily_departures, 2, fn _, _, _, _ -> {:ok, []} end)
       assert {:ok, view, _html} = visit_with_valid_params(conn)
-      rendered = render_async(view)
+
+      no_service =
+        view
+        |> render_async()
+        |> Floki.parse_fragment!()
+        |> Floki.find("[data-test=\"no_service\"]")
+        |> Floki.text()
+
       refute has_element?(view, "#service-picker-form")
-      assert rendered =~ ~r/There is currently no scheduled (\w+)./
+      assert no_service =~ ~r/There is currently no scheduled (\w+)./
     end
 
     test "indicates no service for selected schedule", %{conn: conn} do
       active_services = Factories.Services.Service.build_list(15, :service)
       expect(Services.Repo.Mock, :by_route_id, 2, fn _ -> active_services end)
 
-      expect(Dotcom.ScheduleFinder.Mock, :daily_departures, 2, fn _, _, _, _ ->
-        {:ok, []}
-      end)
+      expect(Dotcom.ScheduleFinder.Mock, :daily_departures, 2, fn _, _, _, _ -> {:ok, []} end)
 
       assert {:ok, view, _html} = visit_with_valid_params(conn)
-      rendered = render_async(view)
+
+      no_service =
+        view
+        |> render_async()
+        |> Floki.parse_fragment!()
+        |> Floki.find("[data-test=\"no_service\"]")
+        |> Floki.text()
+
       assert has_element?(view, "#service-picker-form")
-      assert rendered =~ ~r/There is no scheduled (\N+) service at (\N+) for this time period./
+      assert no_service =~ ~r/There is no scheduled (\N+) service at (\N+) for this time period./
     end
 
     test "handles loading errors & shows custom message", %{conn: conn} do
       actual_error = "nonsense only a computer will understand"
 
-      expect(Dotcom.ScheduleFinder.Mock, :daily_departures, fn _, _, _, _ ->
+      expect(Dotcom.ScheduleFinder.Mock, :daily_departures, 2, fn _, _, _, _ ->
         {:error, actual_error}
       end)
 
       assert {:ok, view, _html} = visit_with_valid_params(conn)
-      rendered = render_async(view)
-      refute has_element?(view, "details")
-      assert rendered =~ "There was a problem loading schedules"
-      refute rendered =~ actual_error
+
+      departures_error =
+        view
+        |> render_async()
+        |> Floki.parse_fragment!()
+        |> Floki.find("[data-test=\"departures_error\"]")
+        |> Floki.text()
+
+      assert departures_error =~ "There was a problem loading schedules"
+      refute departures_error =~ actual_error
     end
   end
 
@@ -248,13 +276,29 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
       end)
 
       assert {:ok, view, html} = visit_with_valid_params(conn, [2, 3, 4])
-      assert html =~ "Loading schedules for selected service"
-      rendered = render_async(view)
-      refute rendered =~ "Loading schedules for selected service"
-      assert has_element?(view, ~s(details[phx-click="open_trip"]))
 
-      for %{time: t} <- departures do
-        assert rendered =~ "<time datetime=\"#{DateTime.to_iso8601(t)}\""
+      departures_loading =
+        html
+        |> Floki.parse_fragment!()
+        |> Floki.find("[data-test=\"departures_loading\"]")
+        |> Floki.text()
+
+      assert departures_loading =~ "Loading schedules for selected service"
+
+      # finish loading here
+      rendered =
+        view
+        |> render_async()
+        |> Floki.parse_fragment!()
+
+      assert Floki.find(rendered, "[data-test=\"departures_loading\"]") == []
+      assert has_element?(view, "[data-test=\"departures_table\"]")
+
+      departures_table = Floki.find(rendered, "[data-test=\"departures_table\"]")
+
+      for %{time: t, trip_id: trip_id} <- departures do
+        row = Floki.find(departures_table, "[phx-value-trip=\"#{trip_id}\"]")
+        assert Floki.find(row, "time[datetime=\"#{DateTime.to_iso8601(t)}\"]") != []
       end
     end
   end
@@ -284,21 +328,34 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
       |> expect(:subway_groups, 1, fn ^departures, _, _ -> subway_groups end)
 
       assert {:ok, view, html} = visit_with_valid_params(conn, [0, 1])
-      assert html =~ "Loading schedules for selected service"
-      rendered = render_async(view)
-      refute rendered =~ "Loading schedules for selected service"
-      refute has_element?(view, ~s(details[phx-click="open_trip"]))
 
-      for %{time: t} <- departures do
-        refute rendered =~ "<time datetime=\"#{DateTime.to_iso8601(t)}\""
-      end
+      departures_loading =
+        html
+        |> Floki.parse_fragment!()
+        |> Floki.find("[data-test=\"departures_loading\"]")
+        |> Floki.text()
 
-      for {_route, destination, [first_time, last_time]} <- subway_groups do
-        assert rendered =~ "to #{destination}"
-        assert rendered =~ "First train:"
-        assert rendered =~ "<time datetime=\"#{DateTime.to_iso8601(first_time)}\""
-        assert rendered =~ "Last train:"
-        assert rendered =~ "<time datetime=\"#{DateTime.to_iso8601(last_time)}\""
+      assert departures_loading =~ "Loading schedules for selected service"
+
+      # finish loading here
+      rendered =
+        view
+        |> render_async()
+        |> Floki.parse_fragment!()
+
+      assert Floki.find(rendered, "[data-test=\"departures_loading\"]") == []
+      refute has_element?(view, "[data-test=\"departures_table\"]")
+
+      subway_groups_html = Floki.find(rendered, "[data-test=\"subway_group\"]")
+
+      for {group, index} <- Enum.with_index(subway_groups_html) do
+        text = Floki.text(group)
+        {_, destination, [first_time, last_time]} = Enum.at(subway_groups, index)
+        assert text =~ "to #{destination}"
+        assert text =~ "First train:"
+        assert Floki.find(group, "time[datetime=\"#{DateTime.to_iso8601(first_time)}]")
+        assert text =~ "Last train:"
+        assert Floki.find(group, "time[datetime=\"#{DateTime.to_iso8601(last_time)}]")
       end
     end
   end
@@ -321,8 +378,20 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
     end)
 
     Dotcom.ScheduleFinder.Mock
-    |> stub(:current_alerts, fn _, _ -> [] end)
-    |> stub(:daily_departures, fn _, _, _, _ -> {:ok, []} end)
+    |> stub(:current_alerts, fn _, _ ->
+      Factories.Alerts.Alert.build_list(1, :alert_for_informed_entity,
+        informed_entity: %{direction_id: nil}
+      )
+    end)
+    |> stub(:daily_departures, fn _, _, _, _ ->
+      2
+      |> Faker.random_between(20)
+      |> Factories.ScheduleFinder.build_list(:daily_departure)
+      |> then(&{:ok, &1})
+    end)
+    |> stub(:subway_groups, fn _, _, _ ->
+      []
+    end)
 
     # Dotcom.ScheduleFinder.UpcomingDepartures.Mock
     # |> stub(:upcoming_departures, fn _ -> [] end)

--- a/test/support/factories/routes/route.ex
+++ b/test/support/factories/routes/route.ex
@@ -69,8 +69,8 @@ defmodule Test.Support.Factories.Routes.Route do
       long_name: Faker.Company.catch_phrase(),
       color: Faker.Color.rgb_hex(),
       direction_destinations: %{
-        0 => Faker.Address.street_address(),
-        1 => Faker.Address.street_address()
+        0 => Faker.Address.state(),
+        1 => Faker.Address.state()
       },
       description:
         [

--- a/test/support/factories/schedule_finder.ex
+++ b/test/support/factories/schedule_finder.ex
@@ -1,0 +1,24 @@
+defmodule Test.Support.Factories.ScheduleFinder do
+  @moduledoc """
+  Module for generating outputs to the functions in Dotcom.ScheduleFinder
+  """
+  use ExMachina
+
+  import Test.Support.Generators.DateTime, only: [random_date_time: 0]
+
+  alias Dotcom.ScheduleFinder.DailyDeparture
+  alias Test.Support.FactoryHelpers
+
+  def daily_departure_factory do
+    %DailyDeparture{
+      headsign: Faker.Address.city() |> FactoryHelpers.nullable_item(),
+      route: Test.Support.Factories.Routes.Route.build(:route),
+      schedule_id: FactoryHelpers.build(:id),
+      stop_sequence: Faker.random_between(0, 1000),
+      time: random_date_time(),
+      time_desc: Faker.Company.catch_phrase() |> FactoryHelpers.nullable_item(),
+      trip_id: FactoryHelpers.build(:id),
+      trip_name: Faker.App.name() |> FactoryHelpers.nullable_item()
+    }
+  end
+end

--- a/test/support/factories/services/service.ex
+++ b/test/support/factories/services/service.ex
@@ -36,7 +36,7 @@ defmodule Test.Support.Factories.Services.Service do
       removed_dates: [],
       removed_dates_notes: %{},
       start_date: service_start,
-      type: Faker.Util.pick([:saturday, :sunday, :weekday, :weekend, :other]),
+      type: Faker.Util.pick([:saturday, :sunday, :friday, :weekday, :weekend, :other]),
       typicality:
         Faker.Util.pick([
           :unknown,
@@ -49,7 +49,7 @@ defmodule Test.Support.Factories.Services.Service do
       valid_days: [1, 2, 3, 4, 5, 6, 7],
       rating_start_date: rating_start,
       rating_end_date: rating_end,
-      rating_description: Faker.Lorem.sentence()
+      rating_description: Faker.Lorem.word()
     }
     |> Map.merge(attrs)
   end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -40,3 +40,6 @@ Mox.defmock(Dotcom.SystemStatus.SubwayCache.Mock, for: Dotcom.SystemStatus.Subwa
 Mox.defmock(Dotcom.SystemStatus.CommuterRailCache.Mock,
   for: Dotcom.SystemStatus.CommuterRailCache.Behaviour
 )
+
+# Schedule Finder
+Mox.defmock(Dotcom.ScheduleFinder.Mock, for: Dotcom.ScheduleFinder.Behaviour)


### PR DESCRIPTION
We punted on writing unit tests for this particular file earlier, because we have lots of other unit tests covering the more critical functions being called in `ScheduleFinderLive`.

This is just an initial crack at it -- it only covers the file somewhere between 30-40% so there'll be more tests to come!

- There's a little refactoring on how services are handled, because it was too hard to test otherwise (the underlying functions weren't being called a consistent number of times). The service picker _should_ work the same way as before, though
- There're other unrelated test changes I just noticed while running tests over and over

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212779092699529