### PR TITLE
Resolve two search regions

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -35,6 +35,7 @@ import translateAnalytics from "./translate-analytics.js";
 import previousEventsButton from "./view-previous-events";
 
 import mobileAppBanner from "./mobile-app-banner.js";
+import mobileSearchA11y from "./mobile-search-a11y.js";
 
 // Establish Phoenix Socket and LiveView configuration.
 import { Socket } from "phoenix";
@@ -138,3 +139,5 @@ accordionInit();
 juxtapose();
 
 mobileAppBanner();
+
+mobileSearchA11y();

--- a/assets/js/mobile-search-a11y.js
+++ b/assets/js/mobile-search-a11y.js
@@ -1,0 +1,12 @@
+export default () => {
+  const doResize = ()=>{
+    const mobileSearch = document.getElementsByClassName("m-menu__search")[0];
+    const desktopSearch = document.getElementsByClassName("search-wrapper")[0];
+
+    mobileSearch.ariaHidden = (window.innerWidth > 543);
+    desktopSearch.ariaHidden = (window.innerWidth < 544);
+  }
+  window.addEventListener("resize", ()=>doResize());
+  window.addEventListener("load", ()=>doResize());
+  
+}

--- a/assets/js/mobile-search-a11y.js
+++ b/assets/js/mobile-search-a11y.js
@@ -1,12 +1,11 @@
 export default () => {
-  const doResize = ()=>{
+  const doResize = () => {
     const mobileSearch = document.getElementsByClassName("m-menu__search")[0];
     const desktopSearch = document.getElementsByClassName("search-wrapper")[0];
 
-    mobileSearch.ariaHidden = (window.innerWidth > 543);
-    desktopSearch.ariaHidden = (window.innerWidth < 544);
-  }
-  window.addEventListener("resize", ()=>doResize());
-  window.addEventListener("load", ()=>doResize());
-  
-}
+    mobileSearch.ariaHidden = window.innerWidth > 543;
+    desktopSearch.ariaHidden = window.innerWidth < 544;
+  };
+  window.addEventListener("resize", () => doResize());
+  window.addEventListener("load", () => doResize());
+};


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Resolve two search regions](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211600360082756?focus=true)

## Implementation

Added some javascript code to add "aria-hidden" attributes to the main nav search containers and update them accordingly as the page resizes and mobile or desktop view switches out.

These components already had a width of 0 and display:none, however that doesn't seem to be enough to hide them.  This code sets the ariaHidden property of the two search containers so that only one of them is visible at a time (depending on window width [aka mobile/desktop])

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### DOM for desktop mode 
<img width="797" height="381" alt="DOMDesktop" src="https://github.com/user-attachments/assets/57c65f75-506c-404f-954c-eb147608aae8" />

### A11y view for desktop mode
<img width="600" height="545" alt="Screenshot 2026-04-23 at 1 14 15 PM" src="https://github.com/user-attachments/assets/5f8c1feb-8361-4df9-97fd-3671ef81a1ca" />


### DOM for mobile mode
<img width="864" height="357" alt="DOMMobile" src="https://github.com/user-attachments/assets/9349828b-579e-488d-9af5-49faccc4962e" />

### A11y view for mobile mode
<img width="490" height="321" alt="Screenshot 2026-04-23 at 1 14 37 PM" src="https://github.com/user-attachments/assets/cedda884-66c0-44ab-bdb9-d508a7cbfe24" />



## How to test

Visit any url with the main navigation in mobile and desktop mode.  Observe that in each mode only one search region is visible.

http://localhost:4001/

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
