### PR TITLE
Improve screenreader interaction with headers with links

### DIFF
--- a/assets/css/_homepage.scss
+++ b/assets/css/_homepage.scss
@@ -210,6 +210,69 @@
     }
   }
 
+  .heading-link {
+    h2,
+    h3,
+    h4 {
+      color: $gray-dark;
+      display: inline-flex;
+      font-size: inherit;
+      line-height: inherit;
+
+      &:hover {
+        text-decoration: inherit;
+      }
+
+      > .header-text {
+        margin-left: .5em;
+        text-decoration: underline;
+
+        @include media-breakpoint-down(xs) {
+          font-size: $font-size-base;
+          margin-bottom: $base-spacing;
+        }
+      }
+    }
+
+    h2 {
+      @include media-breakpoint-down(sm) {
+        font-size: 1.125rem;
+        line-height: 1.5rem;
+      }
+
+      @include media-breakpoint-only(md) {
+        font-size: 1.31rem;
+        line-height: 1.68rem;
+      }
+
+      @include media-breakpoint-up(lg) {
+        font-size: 2rem;
+        line-height: 2.5rem;
+      }
+    }
+
+    h3 {
+      @include media-breakpoint-down(sm) {
+        font-size: .875rem;
+        line-height: 1rem;
+      }
+
+      @include media-breakpoint-only(md) {
+        font-size: 1rem;
+        line-height: 1.5rem;
+      }
+
+      @include media-breakpoint-up(lg) {
+        font-size: 1.5rem;
+        line-height: 1.875rem;
+      }
+    }
+
+    svg * {
+      fill: currentColor;
+    }
+  }
+
   h2 {
     @include media-breakpoint-down(sm) {
       font-size: 1.125rem;

--- a/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -121,7 +121,10 @@ const StopCard = ({
           className="m-schedule-diagram__stop-heading"
           ref={el => refs.set(stopId, el)}
         >
-          <h4 className="m-schedule-diagram__stop-link notranslate">
+          <h4
+            className="m-schedule-diagram__stop-link notranslate"
+            aria-label={`${routeStop.name}`}
+          >
             <a href={`/stops/${stopId}`}>
               {hasHighPriorityAlert(stopId, alerts) && <Alert />}
               <MatchHighlight text={routeStop.name} matchQuery={searchQuery} />

--- a/assets/ts/schedule/components/line-diagram/StopCard.tsx
+++ b/assets/ts/schedule/components/line-diagram/StopCard.tsx
@@ -121,15 +121,12 @@ const StopCard = ({
           className="m-schedule-diagram__stop-heading"
           ref={el => refs.set(stopId, el)}
         >
-          <h4
-            className="m-schedule-diagram__stop-link notranslate"
-            aria-label={`${routeStop.name}`}
-          >
-            <a href={`/stops/${stopId}`}>
+          <a href={`/stops/${stopId}`}>
+            <h4 className="m-schedule-diagram__stop-link notranslate">
               {hasHighPriorityAlert(stopId, alerts) && <Alert />}
               <MatchHighlight text={routeStop.name} matchQuery={searchQuery} />
-            </a>
-          </h4>
+            </h4>
+          </a>
           {StopFeatures(routeStop)}
         </header>
 

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -102,7 +102,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">
-                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                     <a href=\\"/stops/b1\\">
                       <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                         <span />
@@ -135,7 +135,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
               <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                 <section className=\\"m-schedule-diagram__content\\">
                   <header className=\\"m-schedule-diagram__stop-heading\\">
-                    <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                    <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                       <a href=\\"/stops/b2\\">
                         <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                           <span />
@@ -168,7 +168,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                 <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                   <section className=\\"m-schedule-diagram__content\\">
                     <header className=\\"m-schedule-diagram__stop-heading\\">
-                      <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                      <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                         <a href=\\"/stops/b3\\">
                           <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                             <span />
@@ -201,7 +201,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                   <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                     <section className=\\"m-schedule-diagram__content\\">
                       <header className=\\"m-schedule-diagram__stop-heading\\">
-                        <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                        <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                           <a href=\\"/stops/a1\\">
                             <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                               <span />
@@ -267,7 +267,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                     <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                       <section className=\\"m-schedule-diagram__content\\">
                         <header className=\\"m-schedule-diagram__stop-heading\\">
-                          <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                          <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                             <a href=\\"/stops/m1\\">
                               <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                 <span />
@@ -300,7 +300,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                       <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                         <section className=\\"m-schedule-diagram__content\\">
                           <header className=\\"m-schedule-diagram__stop-heading\\">
-                            <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                            <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                               <a href=\\"/stops/c1\\">
                                 <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                   <span />
@@ -366,7 +366,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                           <section className=\\"m-schedule-diagram__content\\">
                             <header className=\\"m-schedule-diagram__stop-heading\\">
-                              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                                 <a href=\\"/stops/m2\\">
                                   <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                     <span />
@@ -399,7 +399,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                           <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                             <section className=\\"m-schedule-diagram__content\\">
                               <header className=\\"m-schedule-diagram__stop-heading\\">
-                                <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                                <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                                   <a href=\\"/stops/m3\\">
                                     <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                       <span />
@@ -432,7 +432,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                               <section className=\\"m-schedule-diagram__content\\">
                                 <header className=\\"m-schedule-diagram__stop-heading\\">
-                                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                                     <a href=\\"/stops/y1\\">
                                       <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                         <span />
@@ -465,7 +465,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                               <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                                 <section className=\\"m-schedule-diagram__content\\">
                                   <header className=\\"m-schedule-diagram__stop-heading\\">
-                                    <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                                    <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                                       <a href=\\"/stops/x1\\">
                                         <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                           <span />
@@ -498,7 +498,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                 <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                                   <section className=\\"m-schedule-diagram__content\\">
                                     <header className=\\"m-schedule-diagram__stop-heading\\">
-                                      <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+                                      <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
                                         <a href=\\"/stops/x2\\">
                                           <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                             <span />

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -102,13 +102,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
               <section className=\\"m-schedule-diagram__content\\">
                 <header className=\\"m-schedule-diagram__stop-heading\\">
-                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                    <a href=\\"/stops/b1\\">
+                  <a href=\\"/stops/b1\\">
+                    <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                       <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                         <span />
                       </MatchHighlight>
-                    </a>
-                  </h4>
+                    </h4>
+                  </a>
                   <div className=\\"m-schedule-diagram__features\\">
                     <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                       <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
@@ -135,13 +135,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
               <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                 <section className=\\"m-schedule-diagram__content\\">
                   <header className=\\"m-schedule-diagram__stop-heading\\">
-                    <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                      <a href=\\"/stops/b2\\">
+                    <a href=\\"/stops/b2\\">
+                      <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                         <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                           <span />
                         </MatchHighlight>
-                      </a>
-                    </h4>
+                      </h4>
+                    </a>
                     <div className=\\"m-schedule-diagram__features\\">
                       <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                         <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
@@ -168,13 +168,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                 <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                   <section className=\\"m-schedule-diagram__content\\">
                     <header className=\\"m-schedule-diagram__stop-heading\\">
-                      <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                        <a href=\\"/stops/b3\\">
+                      <a href=\\"/stops/b3\\">
+                        <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                           <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                             <span />
                           </MatchHighlight>
-                        </a>
-                      </h4>
+                        </h4>
+                      </a>
                       <div className=\\"m-schedule-diagram__features\\">
                         <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                           <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
@@ -201,13 +201,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                   <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                     <section className=\\"m-schedule-diagram__content\\">
                       <header className=\\"m-schedule-diagram__stop-heading\\">
-                        <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                          <a href=\\"/stops/a1\\">
+                        <a href=\\"/stops/a1\\">
+                          <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                             <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                               <span />
                             </MatchHighlight>
-                          </a>
-                        </h4>
+                          </h4>
+                        </a>
                         <div className=\\"m-schedule-diagram__features\\">
                           <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                             <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
@@ -267,13 +267,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                     <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                       <section className=\\"m-schedule-diagram__content\\">
                         <header className=\\"m-schedule-diagram__stop-heading\\">
-                          <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                            <a href=\\"/stops/m1\\">
+                          <a href=\\"/stops/m1\\">
+                            <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                               <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                 <span />
                               </MatchHighlight>
-                            </a>
-                          </h4>
+                            </h4>
+                          </a>
                           <div className=\\"m-schedule-diagram__features\\">
                             <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
@@ -300,13 +300,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                       <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                         <section className=\\"m-schedule-diagram__content\\">
                           <header className=\\"m-schedule-diagram__stop-heading\\">
-                            <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                              <a href=\\"/stops/c1\\">
+                            <a href=\\"/stops/c1\\">
+                              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                                 <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                   <span />
                                 </MatchHighlight>
-                              </a>
-                            </h4>
+                              </h4>
+                            </a>
                             <div className=\\"m-schedule-diagram__features\\">
                               <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                                 <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
@@ -366,13 +366,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                         <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                           <section className=\\"m-schedule-diagram__content\\">
                             <header className=\\"m-schedule-diagram__stop-heading\\">
-                              <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                                <a href=\\"/stops/m2\\">
+                              <a href=\\"/stops/m2\\">
+                                <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                                   <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                     <span />
                                   </MatchHighlight>
-                                </a>
-                              </h4>
+                                </h4>
+                              </a>
                               <div className=\\"m-schedule-diagram__features\\">
                                 <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                                   <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
@@ -399,13 +399,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                           <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                             <section className=\\"m-schedule-diagram__content\\">
                               <header className=\\"m-schedule-diagram__stop-heading\\">
-                                <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                                  <a href=\\"/stops/m3\\">
+                                <a href=\\"/stops/m3\\">
+                                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                                     <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                       <span />
                                     </MatchHighlight>
-                                  </a>
-                                </h4>
+                                  </h4>
+                                </a>
                                 <div className=\\"m-schedule-diagram__features\\">
                                   <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                                     <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
@@ -432,13 +432,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                             <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                               <section className=\\"m-schedule-diagram__content\\">
                                 <header className=\\"m-schedule-diagram__stop-heading\\">
-                                  <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                                    <a href=\\"/stops/y1\\">
+                                  <a href=\\"/stops/y1\\">
+                                    <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                                       <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                         <span />
                                       </MatchHighlight>
-                                    </a>
-                                  </h4>
+                                    </h4>
+                                  </a>
                                   <div className=\\"m-schedule-diagram__features\\">
                                     <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                                       <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
@@ -465,13 +465,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                               <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                                 <section className=\\"m-schedule-diagram__content\\">
                                   <header className=\\"m-schedule-diagram__stop-heading\\">
-                                    <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                                      <a href=\\"/stops/x1\\">
+                                    <a href=\\"/stops/x1\\">
+                                      <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                                         <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                           <span />
                                         </MatchHighlight>
-                                      </a>
-                                    </h4>
+                                      </h4>
+                                    </a>
                                     <div className=\\"m-schedule-diagram__features\\">
                                       <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                                         <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
@@ -498,13 +498,13 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                 <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
                                   <section className=\\"m-schedule-diagram__content\\">
                                     <header className=\\"m-schedule-diagram__stop-heading\\">
-                                      <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-                                        <a href=\\"/stops/x2\\">
+                                      <a href=\\"/stops/x2\\">
+                                        <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
                                           <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                                             <span />
                                           </MatchHighlight>
-                                        </a>
-                                      </h4>
+                                        </h4>
+                                      </a>
                                       <div className=\\"m-schedule-diagram__features\\">
                                         <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
                                           <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
@@ -6,8 +6,8 @@ exports[`StopCard renders and matches snapshot 1`] = `
     <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
       <section className=\\"m-schedule-diagram__content\\">
         <header className=\\"m-schedule-diagram__stop-heading\\">
-          <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
-            <a href=\\"/stops/a\\">
+          <a href=\\"/stops/a\\">
+            <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
               <Alert>
                 <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />
                 <span className=\\"sr-only\\">
@@ -18,8 +18,8 @@ exports[`StopCard renders and matches snapshot 1`] = `
               <MatchHighlight text={[undefined]} matchQuery={[undefined]}>
                 <span />
               </MatchHighlight>
-            </a>
-          </h4>
+            </h4>
+          </a>
           <div className=\\"m-schedule-diagram__features\\">
             <TooltipWrapper tooltipText=\\"Parking\\" tooltipOptions={{...}}>
               <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\">

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
@@ -6,7 +6,7 @@ exports[`StopCard renders and matches snapshot 1`] = `
     <li className=\\"m-schedule-diagram__stop\\" style={{...}}>
       <section className=\\"m-schedule-diagram__content\\">
         <header className=\\"m-schedule-diagram__stop-heading\\">
-          <h4 className=\\"m-schedule-diagram__stop-link notranslate\\">
+          <h4 className=\\"m-schedule-diagram__stop-link notranslate\\" aria-label=\\"undefined\\">
             <a href=\\"/stops/a\\">
               <Alert>
                 <span className=\\"notranslate c-svg__icon-alerts-triangle\\" aria-hidden=\\"false\\" dangerouslySetInnerHTML={{...}} />

--- a/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+++ b/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
@@ -74,13 +74,13 @@ card_title = [content_tag(:span, name, class: "c-fare-card__mode"), duration] %>
     {mode_icon(mode, :default)}
   </div>
 
-  <h3 class="c-fare-card__name" aria-label={name}>
-    <%= if @fare_card.link do %>
-      {link(card_title, to: @fare_card.link.url, class: "u-linked-card__primary-link")}
-    <% else %>
-      {card_title}
+  <%= if @fare_card.link do %>
+    <%= link to: @fare_card.link.url, class: "u-linked-card__primary-link c-fare-card__name" do %>
+      <h3>{card_title}</h3>
     <% end %>
-  </h3>
+  <% else %>
+    <h3 class="c-fare-card__name">{card_title}</h3>
+  <% end %>
 
   <div class="c-fare-card__fare h2">
     {price}

--- a/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+++ b/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
@@ -74,7 +74,7 @@ card_title = [content_tag(:span, name, class: "c-fare-card__mode"), duration] %>
     {mode_icon(mode, :default)}
   </div>
 
-  <h3 class="c-fare-card__name">
+  <h3 class="c-fare-card__name" aria-label={name}>
     <%= if @fare_card.link do %>
       {link(card_title, to: @fare_card.link.url, class: "u-linked-card__primary-link")}
     <% else %>

--- a/lib/dotcom_web/templates/mode/index.html.heex
+++ b/lib/dotcom_web/templates/mode/index.html.heex
@@ -6,7 +6,7 @@
         <% route_types =
           Enum.map(@grouped_routes, fn {mode, _routes} -> {mode, mode_path(@conn, mode)} end) %>
         <% the_ride = [the_ride: cms_static_page_path(@conn, "/accessibility/the-ride")] %>
-        {content_tag(h_level_section, ~t"Schedules and Maps", aria_label: ~t"Schedules and Maps")}
+        {content_tag(h_level_section, ~t"Schedules and Maps")}
         <div class="m-mode__recently-visited">
           {render(DotcomWeb.PartialView, "_recently_visited.html",
             conn: @conn,

--- a/lib/dotcom_web/templates/mode/index.html.heex
+++ b/lib/dotcom_web/templates/mode/index.html.heex
@@ -6,7 +6,7 @@
         <% route_types =
           Enum.map(@grouped_routes, fn {mode, _routes} -> {mode, mode_path(@conn, mode)} end) %>
         <% the_ride = [the_ride: cms_static_page_path(@conn, "/accessibility/the-ride")] %>
-        {content_tag(h_level_section, ~t"Schedules and Maps")}
+        {content_tag(h_level_section, ~t"Schedules and Maps", aria_label: ~t"Schedules and Maps")}
         <div class="m-mode__recently-visited">
           {render(DotcomWeb.PartialView, "_recently_visited.html",
             conn: @conn,

--- a/lib/dotcom_web/templates/page/_alerts.html.heex
+++ b/lib/dotcom_web/templates/page/_alerts.html.heex
@@ -6,12 +6,12 @@
         <%= for {mode, routes} <- @routes_with_high_priority_alerts_by_mode do %>
           <% mode_name = Routes.Route.type_name(mode) %>
           <div class="m-homepage__alerts-mode">
-            <h3>
-              <a href={"#{ alerts_mode_url(mode) }"}>
+            <a class="heading-link" href={"#{ alerts_mode_url(mode) }"}>
+              <h3>
                 {svg(alerts_mode_icon_name(mode))}
                 <span class="header-text">{mode_name}</span>
-              </a>
-            </h3>
+              </h3>
+            </a>
             <%= if Enum.empty?(routes) do %>
               <p>
                 {~t(There are no high priority)} {String.downcase(mode_name)} {~t(alerts at this time)}
@@ -32,12 +32,12 @@
       </div>
     </div>
     <div class="m-homepage__alerts-accessibility">
-      <h2>
-        <a href={"#{ alerts_access_url() }"}>
+      <a class="heading-link" href={"#{ alerts_access_url() }"}>
+        <h2>
           {svg("icon-accessibility.svg")}
           <span class="header-text">{~t(Station Accessibility)}</span>
-        </a>
-      </h2>
+        </h2>
+      </a>
       <div class="m-homepage__alerts-accessibility-by-type">
         <%= for {type, stops} <- @stops_with_accessibility_alerts_by_issue do %>
           <% title = Alerts.Accessibility.effect_type_to_group_title(type) %>

--- a/lib/dotcom_web/templates/page/_banner_content.html.heex
+++ b/lib/dotcom_web/templates/page/_banner_content.html.heex
@@ -3,15 +3,13 @@
     <div class="c-banner__category u-small-caps">
       {link_category(@banner.category)}
     </div>
-    <h2
-      aria-label={"#{@banner.title}"}
-      class={"c-banner__title c-banner__title--#{ @banner.banner_type }"}
-    >
-      {link(@banner.title,
-        to: cms_static_page_path(@conn, @banner.utm_url),
-        class: "u-linked-card__primary-link"
-      )}
-    </h2>
+    <%= link to: cms_static_page_path(@conn, @banner.utm_url),
+             class: "u-linked-card__primary-link c-banner__title-link",
+             aria_label: @banner.title do %>
+      <h2 class={"c-banner__title c-banner__title--#{@banner.banner_type}"}>
+        {@banner.title}
+      </h2>
+    <% end %>
     <%= if @banner.banner_type == :important do %>
       <p>{@banner.blurb}</p>
     <% end %>

--- a/lib/dotcom_web/templates/page/_banner_content.html.heex
+++ b/lib/dotcom_web/templates/page/_banner_content.html.heex
@@ -4,9 +4,9 @@
       {link_category(@banner.category)}
     </div>
     <%= link to: cms_static_page_path(@conn, @banner.utm_url),
-             class: "u-linked-card__primary-link c-banner__title-link",
+             class: "u-linked-card__primary-link c-banner__title--#{@banner.banner_type}",
              aria_label: @banner.title do %>
-      <h2 class={"c-banner__title c-banner__title--#{@banner.banner_type}"}>
+      <h2>
         {@banner.title}
       </h2>
     <% end %>

--- a/lib/dotcom_web/templates/page/_banner_content.html.heex
+++ b/lib/dotcom_web/templates/page/_banner_content.html.heex
@@ -3,7 +3,10 @@
     <div class="c-banner__category u-small-caps">
       {link_category(@banner.category)}
     </div>
-    <h2 class={"c-banner__title c-banner__title--#{ @banner.banner_type }"}>
+    <h2
+      aria-label={"#{@banner.title}"}
+      class={"c-banner__title c-banner__title--#{ @banner.banner_type }"}
+    >
       {link(@banner.title,
         to: cms_static_page_path(@conn, @banner.utm_url),
         class: "u-linked-card__primary-link"

--- a/lib/dotcom_web/views/mode_view.ex
+++ b/lib/dotcom_web/views/mode_view.ex
@@ -59,23 +59,22 @@ defmodule DotcomWeb.ModeView do
   defp mode_group_header_tag(true), do: :h3
   defp mode_group_header_tag(false), do: :h2
 
-  @spec mode_group_header_content(atom, Phoenix.HTML.Safe.t(), String.t()) :: [
+  @spec mode_group_header_content(atom, Phoenix.HTML.Safe.t(), String.t()) ::
           Phoenix.HTML.Safe.t()
-        ]
+
   defp mode_group_header_content(mode, header_content, href) do
-    [
-      content_tag(
-        :div,
-        [
-          link(
-            header_content,
-            to: href
-          ),
-          view_all_link(mode, href)
-        ],
-        class: "m-mode__header"
-      )
-    ]
+    content_tag(
+      :div,
+      [
+        link(
+          header_content,
+          to: href,
+          id: "mode-header-link"
+        ),
+        view_all_link(mode, href)
+      ],
+      class: "m-mode__header"
+    )
   end
 
   @spec view_all_link(atom, String.t()) :: [Phoenix.HTML.Safe.t()]

--- a/lib/dotcom_web/views/mode_view.ex
+++ b/lib/dotcom_web/views/mode_view.ex
@@ -37,12 +37,21 @@ defmodule DotcomWeb.ModeView do
   """
   @spec mode_group_header(atom, String.t(), boolean) :: Phoenix.HTML.Safe.t()
   def mode_group_header(mode, href, is_homepage?) do
-    is_homepage?
-    |> mode_group_header_tag()
-    |> content_tag(mode_group_header_content(mode, href),
-      class: "m-mode__header",
-      aria_label: Route.type_name(mode)
-    )
+    header_tag =
+      mode_group_header_tag(is_homepage?)
+
+    header_content =
+      content_tag(
+        header_tag,
+        [
+          svg_icon_with_circle(%SvgIconWithCircle{icon: mode, aria_hidden?: true}),
+          " ",
+          Route.type_name(mode)
+        ],
+        class: "m-mode__name"
+      )
+
+    mode_group_header_content(mode, header_content, href)
   end
 
   @spec mode_group_header_tag(boolean) :: :h2 | :h3
@@ -50,19 +59,22 @@ defmodule DotcomWeb.ModeView do
   defp mode_group_header_tag(true), do: :h3
   defp mode_group_header_tag(false), do: :h2
 
-  @spec mode_group_header_content(atom, String.t()) :: [Phoenix.HTML.Safe.t()]
-  defp mode_group_header_content(mode, href) do
+  @spec mode_group_header_content(atom, Phoenix.HTML.Safe.t(), String.t()) :: [
+          Phoenix.HTML.Safe.t()
+        ]
+  defp mode_group_header_content(mode, header_content, href) do
     [
-      link(
+      content_tag(
+        :div,
         [
-          svg_icon_with_circle(%SvgIconWithCircle{icon: mode, aria_hidden?: true}),
-          " ",
-          Route.type_name(mode)
+          link(
+            header_content,
+            to: href
+          ),
+          view_all_link(mode, href)
         ],
-        to: href,
-        class: "m-mode__name"
-      ),
-      view_all_link(mode, href)
+        class: "m-mode__header"
+      )
     ]
   end
 

--- a/lib/dotcom_web/views/mode_view.ex
+++ b/lib/dotcom_web/views/mode_view.ex
@@ -39,7 +39,10 @@ defmodule DotcomWeb.ModeView do
   def mode_group_header(mode, href, is_homepage?) do
     is_homepage?
     |> mode_group_header_tag()
-    |> content_tag(mode_group_header_content(mode, href), class: "m-mode__header")
+    |> content_tag(mode_group_header_content(mode, href),
+      class: "m-mode__header",
+      aria_label: Route.type_name(mode)
+    )
   end
 
   @spec mode_group_header_tag(boolean) :: :h2 | :h3

--- a/test/dotcom_web/views/mode_view_test.exs
+++ b/test/dotcom_web/views/mode_view_test.exs
@@ -15,8 +15,8 @@ defmodule DotcomWeb.ModeViewTest do
                :commuter_rail
                |> ModeView.mode_group_header("/schedules/commuter-rail", false)
                |> safe_to_string()
-               |> Floki.parse_fragment()
-               |> elem(1)
+               |> Floki.parse_fragment!()
+               |> Floki.find(".m-mode__name")
 
       assert tag == "h2"
     end
@@ -26,8 +26,8 @@ defmodule DotcomWeb.ModeViewTest do
                :commuter_rail
                |> ModeView.mode_group_header("/schedules/commuter-rail", true)
                |> safe_to_string()
-               |> Floki.parse_fragment()
-               |> elem(1)
+               |> Floki.parse_fragment!()
+               |> Floki.find(".m-mode__name")
 
       assert tag == "h3"
     end
@@ -49,13 +49,15 @@ defmodule DotcomWeb.ModeViewTest do
           |> Floki.parse_document!()
 
         assert document
+               |> Floki.find(".m-mode__header")
                |> Floki.find(".m-mode__name")
                |> Floki.text(deep: false)
                |> String.trim() == text
 
         assert document
-               |> Floki.find(".m-mode__name")
-               |> Floki.attribute("href") == [href]
+               |> Floki.find(".m-mode__header #mode-header-link")
+               |> Floki.attribute("href") ==
+                 [href]
 
         view_all = Floki.find(document, ".m-mode__view-all")
 


### PR DESCRIPTION
## Scope

There is a screen reader issue on the homepage causing some headings to be read as multiple levels of headings, i.e., VoiceOver will say "heading level 2, level 1" (noisy!) instead of just "heading level 2."

Acceptance Criteria
* Update headings on the homepage so that each one is only identified as a single level of heading, not multiple ones (ex. both level 3 and level 2)

Steps to reproduce:
* Open [mbta.com](https://mbta.com/) and turn on a screen reader (ex. Voice Over)
* Navigate by heading (in Voice Over: ctrl + option + cmd + h)
* Observe that some headers are identified as both level 2 and level 3, including:
"Bus", "Subway", etc. in the Alerts tab

**Asana Ticket:** https://app.asana.com/1/15492006741476/project/555089885850811/task/1211600360082773?focus=true

## Implementation
The issue with some of these headings is that they have nested links within them, whereas the screenreader needs links to wrap the headers, not the other way around.

Note that I'm new to Elixir, so if there's a cleaner way to handle this, let me know. Right now, I've gone through and made one-off changes to sections/pages that were flagged in the Asana ticket. I also did a quick check for other headings with nested elements in the dotcom app, but a more thorough audit _could_ be necessary.

## Screenshots

## How to test
* Open [mbta.com](https://mbta.com/) and turn on a screen reader (ex. Voice Over)
* Navigate by heading (in Voice Over: ctrl + option + cmd + h)
* Headers should be identified as just having one level, including:
"Bus", "Subway", etc. in the Alerts tab