### PR TITLE
feat[WC]: Add world cup timetable onto CR schedule selection pages

### DIFF
--- a/lib/dotcom_web/templates/mode/_grid_button.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_button.html.heex
@@ -7,6 +7,14 @@
     <% end %>
 
     <span class="c-grid-button__name notranslate">
+      <.icon
+        :if={!is_atom(@route) and @route.id == "CR-Foxboro"}
+        type="icon-svg"
+        name="football"
+        class="size-4 relative top-[0.1em]"
+        aria-hidden="true"
+      />
+
       {grid_button_text(@route)}
     </span>
 

--- a/lib/dotcom_web/views/mode_view.ex
+++ b/lib/dotcom_web/views/mode_view.ex
@@ -118,6 +118,10 @@ defmodule DotcomWeb.ModeView do
     ~t"MBTA Paratransit Program"
   end
 
+  def grid_button_text(%Route{id: "CR-Foxboro"}) do
+    " Boston Stadium"
+  end
+
   def grid_button_text(%Route{name: name}) do
     break_text_at_slash(name)
   end


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽ [Not Release-Blocking] Add world cup timetable onto CR schedule selection pages](https://app.asana.com/1/15492006741476/project/555089885850811/task/1213822112236923?focus=true)

## Implementation

Added code to render CR-Foxboro CR buttons as "⚽️ Boston Stadium" (but with our actual icon, not the emoji):

- Added `grid_button_text` handler for `route.id==CR-Foxboro` to mode_controller
- Added soccer ball icon (`if route.id==CR-Foxboro`) to `_grid_button.html `
- `@route` can also be an atom (`:the_ride`) so there's a check to make sure we don't try to get a property of an atom and crash things


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Wide
<img width="726" height="126" alt="Screenshot 2026-04-24 at 12 18 51 PM" src="https://github.com/user-attachments/assets/16a13537-8f86-4c4c-bfde-c1f917382710" />

### Medium
<img width="797" height="138" alt="Screenshot 2026-04-24 at 12 18 39 PM" src="https://github.com/user-attachments/assets/fb7dfdc9-4e4a-401e-888d-f8d5eed81c1d" />

### Mobile
<img width="515" height="126" alt="Screenshot 2026-04-24 at 12 19 01 PM" src="https://github.com/user-attachments/assets/f736f7e8-593a-456c-9801-9576329be2fe" />

### Very Large Font
<img width="364" height="87" alt="Screenshot 2026-04-24 at 12 23 12 PM" src="https://github.com/user-attachments/assets/01fe7164-40b9-44b1-b819-d9f4b5ea1623" />

### Very small font
<img width="358" height="37" alt="Screenshot 2026-04-24 at 12 23 30 PM" src="https://github.com/user-attachments/assets/42c3d434-7ad0-4458-87a0-8ac5b97a6229" />




## How to test
http://localhost:4001/schedules  &  http://localhost:4001/schedules/commuter-rail

Confirm that the button that usually reads "Foxboro Event Service" now says "Boston Stadium" and has a little soccer ball.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
