### PR TITLE
Update customer support form to make "Upload Button" keyboard navigable

### DIFF
--- a/assets/css/_customer-support.scss
+++ b/assets/css/_customer-support.scss
@@ -130,6 +130,7 @@
   text-align: center;
   width: 21rem;
   color: $link-color;
+  background-color: transparent;
 
   &:hover {
     color: $brand-primary;

--- a/assets/css/_customer-support.scss
+++ b/assets/css/_customer-support.scss
@@ -129,6 +129,7 @@
   line-height: 2.8rem;
   text-align: center;
   width: 21rem;
+  color: $link-color;
 
   &:hover {
     color: $brand-primary;

--- a/lib/dotcom_web/templates/customer_support/_form.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_form.html.eex
@@ -84,7 +84,7 @@
       <span id="upload-photo-error"></span>
       <div class="photo-preview-container <%= unless Map.has_key?(f.params, "photo"), do: "hidden-xs-up" %>" tabindex="-1">
       </div>
-      <a id="upload-photo-link" class="upload-photo-link" tabindex="-1"><%= fa "camera" %>Upload photo</a>
+      <button id="upload-photo-link" class="upload-photo-link" tabindex="0"><%= fa "camera" %>Upload photo</button>
       <%= file_input f, :photo, accept: "image/*", id: "photo", multiple: true %>
     </div>
   </section>


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Update customer support form to make "Upload Button" keyboard navigable](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211774216358320?focus=true)

## Implementation

Changed the Upload Image `<a>` tag to a `<button>` to restore tab navigation.  Interestingly this tag originally had `tabIndex="-1"`.  

Updated the CSS so it still looks like a link.  

Unfortunately it seems that once a user uploads a photo with keyboard navigation, they are unable to focus on or activate the tiny little 🅧 icons to remove an uploaded photo.  This will be addressed in a separate ticket/PR.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Demo of keyboard navigation
https://github.com/user-attachments/assets/b2a314a9-31a8-409d-89c6-932f3e2cf80e

### Appearance comparison between main/branch

Main:  <img width="347" height="62" alt="Screenshot 2026-04-27 at 12 30 59 PM" src="https://github.com/user-attachments/assets/f7b3feb7-753a-42f0-b161-e30d555fd662" />


Branch:  <img width="350" height="63" alt="Screenshot 2026-04-27 at 12 32 43 PM" src="https://github.com/user-attachments/assets/270b8bf2-0458-4e47-8f20-6e31c8a8aa86" />




## How to test

http://localhost:4001/customer-support

Confirm that you can use keyboard navigation to focus and activate the "Upload photo" button.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
