### PR TITLE
A11Y: Add contrast-compliant background colors

### DIFF
--- a/assets/css/_colors.scss
+++ b/assets/css/_colors.scss
@@ -55,6 +55,20 @@ $brand-commuter-rail: map-get($mbta-line-colors, 'commuter-rail');
 $brand-ferry: map-get($mbta-line-colors, 'ferry');
 $brand-the-ride: map-get($mbta-line-colors, 'the-ride');
 
+//Modes and Lines backgrounds
+$brand-blue-line-background: map-get($mbta-line-colors, 'blue-line');
+$brand-green-line-background: map-get($mbta-line-colors, 'green-line');
+$brand-orange-line-background: #D67D00;
+$brand-red-line-background: map-get($mbta-line-colors, 'red-line');
+$brand-silver-line-background: map-get($mbta-line-colors, 'silver-line');
+$brand-subway-background: map-get($mbta-line-colors, 'subway');
+$brand-bus-background: map-get($mbta-line-colors, 'bus');
+$brand-logan-express-background: map-get($mbta-line-colors, 'logan-express');
+$brand-massport-shuttle-background: map-get($mbta-line-colors, 'massport-shuttle');
+$brand-commuter-rail-background: map-get($mbta-line-colors, 'commuter-rail');
+$brand-ferry-background: map-get($mbta-line-colors, 'ferry');
+$brand-the-ride-background: map-get($mbta-line-colors, 'the-ride');
+
 // Alerts
 $alert-color: $brand-secondary;
 $alert-color-lighter: #fffae9;

--- a/assets/css/_utilities.scss
+++ b/assets/css/_utilities.scss
@@ -16,7 +16,7 @@
 
 .u-bg--orange-line {
   @include bg-text($white);
-  background-color: $brand-orange-line;
+  background-color: $brand-orange-line-background;
 }
 
 .u-bg--green-line,
@@ -25,53 +25,53 @@
 .u-bg--green-line-d,
 .u-bg--green-line-e {
   @include bg-text($white);
-  background-color: $brand-green-line;
+  background-color: $brand-green-line-background;
 }
 
 .u-bg--red-line {
   @include bg-text($white);
-  background-color: $brand-red-line;
+  background-color: $brand-red-line-background;
 }
 
 .u-bg--blue-line {
   @include bg-text($white);
-  background-color: $brand-blue-line;
+  background-color: $brand-blue-line-background;
 }
 
 .u-bg--silver-line {
   @include bg-text($white);
-  background-color: $brand-silver-line;
+  background-color: $brand-silver-line-background;
 }
 
 .u-bg--mattapan-line,
 .u-bg--mattapan-trolley {
   @include bg-text($white);
-  background-color: $brand-red-line;
+  background-color: $brand-red-line-background;
 }
 
 .u-bg--commuter-rail {
   @include bg-text($white);
-  background-color: $brand-commuter-rail;
+  background-color: $brand-commuter-rail-background;
 }
 
 .u-bg--bus {
   @include bg-text($black);
-  background-color: $brand-bus;
+  background-color: $brand-bus-background;
 }
 
 .u-bg--ferry {
   @include bg-text($white);
-  background-color: $brand-ferry;
+  background-color: $brand-ferry-background;
 }
 
 .u-bg--subway {
   @include bg-text($white);
-  background-color: $brand-subway;
+  background-color: $brand-subway-background;
 }
 
 .u-bg--the-ride {
   @include bg-text($black);
-  background-color: $brand-the-ride;
+  background-color: $brand-the-ride-background;
 }
 
 .u-bg--unknown {

--- a/assets/css/_utilities.scss
+++ b/assets/css/_utilities.scss
@@ -17,6 +17,7 @@
 .u-bg--orange-line {
   @include bg-text($white);
   background-color: $brand-orange-line-background;
+  fill: $brand-orange-line-background;
 }
 
 .u-bg--green-line,

--- a/lib/css_helpers.ex
+++ b/lib/css_helpers.ex
@@ -51,6 +51,10 @@ defmodule CSSHelpers do
     end
   end
 
+  def route_to_background_class(route) do
+    route_to_class(route) |> String.replace("mbta-route", "u-bg-")
+  end
+
   @doc """
   Returns a Tailwind stroke color class for a route.
   This is used for SVG elements that need stroke colors.

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -413,7 +413,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
       })
 
     ~H"""
-    <div class={route_to_class(@route)}>
+    <div class={route_to_background_class(@route)}>
       <.link
         class="block text-current hover:text-current focus:text-current hover:no-underline active:no-underline focus:no-underline"
         patch={~p"/schedules/#{@route.id}?schedule_direction[direction_id]=#{@direction_id}"}

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -425,7 +425,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
                 aria-hidden
                 line={@line_name}
                 mode={@mode}
-                class="shrink-0 -ml-xs"
+                class={"shrink-0 -ml-xs #{route_to_background_class(@route)}"}
               />
               <span class="grow notranslate">{@route.name}</span>
               <.icon


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿️ Add contrast-compliant background colors](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214045032671566?focus=true)

## Implementation

Added variables for mode and route background-colors, all but the Orange line are the same as the official line color.

Updated _utilities.scss to use these new variables for background colors instead of using the line colors  (this updates the schedule/line page header.) 

Created function to get a route's background color in CSShelpers and used that function to set the line header background color in SF2.0.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### New Orange<sup>(*brown😝)</sup> line header color with original colors everywhere else

<img width="603" height="140" alt="Screenshot 2026-04-27 at 2 33 55 PM" src="https://github.com/user-attachments/assets/ebdcecad-2814-415f-9ee8-55ee64d0e889" />

### Original Orange on Dev
<img width="608" height="142" alt="Screenshot 2026-04-27 at 2 35 19 PM" src="https://github.com/user-attachments/assets/ddcc25fc-a499-4975-b27c-f9fdec9c4c85" />

### New Orange Schedule/line page
<img width="705" height="363" alt="Screenshot 2026-04-27 at 2 36 07 PM" src="https://github.com/user-attachments/assets/5883f50d-ca92-4c8e-92bf-7fd7f33b0ea9" />

### Original Orange Schedule/line page
<img width="715" height="364" alt="Screenshot 2026-04-27 at 2 36 24 PM" src="https://github.com/user-attachments/assets/fbec8d14-c2ba-4cfe-9fa2-7e886b6be285" />

### Other
<img width="606" height="153" alt="Screenshot 2026-04-27 at 2 37 33 PM" src="https://github.com/user-attachments/assets/b0de2fcb-4129-4d6e-be1f-0035bd87ec3a" />

### Colors
<img width="594" height="146" alt="Screenshot 2026-04-27 at 2 37 44 PM" src="https://github.com/user-attachments/assets/334a0874-658f-42fa-875c-32a6b65265ae" />

### Remain
<img width="595" height="142" alt="Screenshot 2026-04-27 at 2 38 00 PM" src="https://github.com/user-attachments/assets/66ffb23c-1610-4e49-96cb-9a8f416886a8" />

### The
<img width="592" height="144" alt="Screenshot 2026-04-27 at 2 38 11 PM" src="https://github.com/user-attachments/assets/8c6dd2b2-cd2f-408a-ae54-69a8b91e57df" />

### Same
<img width="592" height="146" alt="Screenshot 2026-04-27 at 2 38 22 PM" src="https://github.com/user-attachments/assets/ec64e885-41bb-4111-81ed-e30481fce729" />

### As
<img width="597" height="144" alt="Screenshot 2026-04-27 at 2 38 35 PM" src="https://github.com/user-attachments/assets/d57a2116-d7ae-4445-9384-ed871fbbeec5" />

### Before
<img width="588" height="143" alt="Screenshot 2026-04-27 at 2 39 56 PM" src="https://github.com/user-attachments/assets/3e472c85-6b21-484f-97f8-85503b667688" />


## How to test

http://localhost:4001/departures/?route_id=Orange&direction_id=1&stop_id=place-welln

Check out an orange line stop on SF2.0 and observe the new background color

http://localhost:4001/schedules/Orange/line

Confirm the new Orange Line background color is used on the header here.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
