### PR TITLE
QF | A11Y: Update custom footer focus indicator to be dark blue when background is light blue

### DIFF
--- a/assets/css/_footer.scss
+++ b/assets/css/_footer.scss
@@ -330,6 +330,9 @@ address {
     a {
       color: $brand-primary;
       display: inline;
+      &:focus {
+        outline: $brand-primary 2px solid;
+      }
     }
     @include media-breakpoint-down(xs) {
       a {


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ♿ Update custom footer focus indicator to be dark blue when background is light blue](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211707011832174?focus=true)

## Implementation
Adjusted focus outline for links (phone numbers) in the top, light blue, section of the footer.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Desktop

https://github.com/user-attachments/assets/2f8e3671-e8fa-4f87-b46f-841997d832b3

### Mobile

https://github.com/user-attachments/assets/62c6689b-e3c1-4365-a18d-9c68f76ce755





## How to test

http://localhost:4001/

Tab around until you focus on the links in the top section of the footer.  Confirm that the focus color is $brand-primary and not yellow.

Confirm that (most*) links in the dark blue section still have the yellow highlight.

*It seems that the "share" widget component, Privacy Policy, andTerms of Use links have CSS that doesn't do the yellow focus outline.  This is present on PROD, do we want to fix that and is there a ticket for that or should I expand the scope of this one?

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
