### PR TITLE
Ferry: Add a note on F1 pointing to F2H

### DIFF
--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -404,6 +404,24 @@ defmodule DotcomWeb.ScheduleView do
     end
   end
 
+  def timetable_note(%{route: %Route{id: "Boat-F1"}, direction_id: _}) do
+    content_tag :div, class: "m-timetable__note" do
+      [
+        content_tag(:p, [
+          content_tag(:strong, ~t"Note:"),
+          gettext(" Additional service to Hingham and Hull is available via the %{link}", %{
+            link:
+              link(~t"Hingham/Hull ferry",
+                to: ~p"/schedule/Boat-F2H/timetable"
+              )
+              |> safe_to_string()
+          })
+          |> raw()
+        ])
+      ]
+    end
+  end
+
   def timetable_note(_), do: nil
 
   def json_safe_route(route) do


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [[Blocked by route split in prod] ⛴️ Add a note on F1 pointing to F2H](https://app.asana.com/1/15492006741476/project/555089885850811/task/1213812972553377?focus=true)

## Implementation

Added a timetable note for Boat-F1

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Timetable note with link to Boat-F2H

<img width="852" height="424" alt="Screenshot 2026-04-28 at 1 47 49 PM" src="https://github.com/user-attachments/assets/8e3b6eb3-f6ae-45c6-bafd-367f24403945" />

## How to test

http://localhost:4001/schedules/Boat-F1/timetable

Visit the timetable for Boat-F1 and confirm that the timetable note is present and links to Boat-F2H

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
