### PR TITLE
perf: Cache `predicted_schedule` construction

### DIFF
--- a/lib/dotcom/schedule_finder/upcoming_departures.ex
+++ b/lib/dotcom/schedule_finder/upcoming_departures.ex
@@ -13,7 +13,6 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
   import Dotcom.Utils.Time, only: [truncate: 2]
 
   alias Dotcom.ScheduleFinder.{TripDetails, Platforms}
-  alias Dotcom.Utils.ServiceDateTime
   alias Predictions.Prediction
   alias Routes.Route
   alias Schedules.Schedule
@@ -21,8 +20,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
   alias Stops.Stop
   alias Vehicles.Vehicle
 
-  @predictions_repo Application.compile_env!(:dotcom, :repo_modules)[:predictions]
-  @schedules_repo Application.compile_env!(:dotcom, :repo_modules)[:schedules]
+  @predicted_schedules_repo PredictedSchedule.Repo
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
 
   defmodule UpcomingDeparture do
@@ -128,23 +126,13 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
       }) do
     route_type = Route.type_atom(route)
 
-    predictions =
-      @predictions_repo.all(
+    predicted_schedules =
+      @predicted_schedules_repo.predicted_schedules_for_stop(%{
         direction_id: direction_id,
-        discard_past_subway_predictions: false,
-        include_terminals: true,
-        route: route.id,
-        stop: stop_id
-      )
-
-    schedules =
-      @schedules_repo.by_route_ids([route.id],
-        direction_id: direction_id,
-        date: ServiceDateTime.service_date(now),
-        stop_ids: [stop_id]
-      )
-
-    predicted_schedules = PredictedSchedule.group(predictions, schedules)
+        now: now,
+        route_id: route.id,
+        stop_id: stop_id
+      })
 
     predicted_schedules_at_stop =
       predicted_schedules
@@ -364,17 +352,8 @@ defmodule Dotcom.ScheduleFinder.UpcomingDepartures do
         stop_id: stop_id,
         stop_sequence: stop_sequence
       }) do
-    predictions =
-      @predictions_repo.all(
-        trip: trip_id,
-        include_terminals: true,
-        discard_past_subway_predictions: false
-      )
-
-    schedules = @schedules_repo.schedule_for_trip(trip_id)
-
     predicted_schedules =
-      PredictedSchedule.group(predictions, schedules)
+      @predicted_schedules_repo.predicted_schedules_for_trip(%{now: now, trip_id: trip_id})
       |> Enum.reject(&past_schedule?(&1, now))
 
     vehicle =

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -361,7 +361,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
   defp assign_last_trip_time(socket) do
     route_id = socket.assigns.route.id
     direction_id = socket.assigns.direction_id
-    date = DateTime.to_date(@date_time.now()) |> Date.to_string()
+    date = service_date() |> Date.to_string()
     stop = socket.assigns.stop
 
     assign_async(
@@ -1282,16 +1282,20 @@ defmodule DotcomWeb.ScheduleFinderLive do
 
     last_departure_time = last_departure.time
 
-    if(is_nil(last_departure_time)) do
-      true
-    else
-      if (not is_nil(last_trip_time) and DateTime.after?(last_departure_time, last_trip_time)) or
-           DateTime.before?(last_trip_time, @date_time.now()) or
-           has_last_trip? do
-        false
-      else
-        true
-      end
+    # Do we show "Service continues until <last scheduled time>"?
+    cond do
+      # we have a prediction specifically tagged "last trip"
+      has_last_trip? -> false
+      # we don't even have a last scheduled time
+      is_nil(last_trip_time) -> false
+      # we don't have any last prediction
+      is_nil(last_departure_time) -> true
+      # last predicted time happens to be after last scheduled time
+      DateTime.after?(last_departure_time, last_trip_time) -> false
+      # last scheduled time already passed
+      DateTime.before?(last_trip_time, @date_time.now()) -> false
+      # Just show it
+      true -> true
     end
   end
 

--- a/lib/predicted_schedule/repo.ex
+++ b/lib/predicted_schedule/repo.ex
@@ -1,0 +1,53 @@
+defmodule PredictedSchedule.Repo do
+  use Nebulex.Caching.Decorators
+
+  alias Dotcom.Utils.ServiceDateTime
+
+  @cache Application.compile_env!(:dotcom, :cache)
+  @predictions_repo Application.compile_env!(:dotcom, :repo_modules)[:predictions]
+  @schedules_repo Application.compile_env!(:dotcom, :repo_modules)[:schedules]
+
+  @ttl :timer.seconds(1)
+
+  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
+  def predicted_schedules_for_stop(%{
+        direction_id: direction_id,
+        now: now,
+        route_id: route_id,
+        stop_id: stop_id
+      }) do
+    predictions =
+      @predictions_repo.all(
+        direction_id: direction_id,
+        discard_past_subway_predictions: false,
+        include_terminals: true,
+        route: route_id
+      )
+      |> Enum.filter(&(&1.stop.id == stop_id))
+
+    schedules =
+      @schedules_repo.by_route_ids([route_id],
+        direction_id: direction_id,
+        date: ServiceDateTime.service_date(now),
+        stop_ids: [stop_id]
+      )
+
+    PredictedSchedule.group(predictions, schedules)
+  end
+
+  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
+  def predicted_schedules_for_trip(%{
+        trip_id: trip_id
+      }) do
+    predictions =
+      @predictions_repo.all(
+        trip: trip_id,
+        include_terminals: true,
+        discard_past_subway_predictions: false
+      )
+
+    schedules = @schedules_repo.schedule_for_trip(trip_id)
+
+    PredictedSchedule.group(predictions, schedules)
+  end
+end

--- a/test/dotcom/schedule_finder/upcoming_departures_test.exs
+++ b/test/dotcom/schedule_finder/upcoming_departures_test.exs
@@ -1,5 +1,5 @@
 defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import Dotcom.Utils.Time, only: [truncate: 2]
   import Mox
@@ -18,6 +18,9 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
     stub(Stops.Repo.Mock, :get, fn id ->
       Factories.Stops.Stop.build(:stop, id: id, parent_id: nil)
     end)
+
+    cache = Application.get_env(:dotcom, :cache)
+    cache.flush()
 
     :ok
   end
@@ -2375,7 +2378,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         })
 
       # Verify
-      assert [%{headsign: headsign}] = departures
+      assert %{headsign: headsign} = departures |> List.first()
       assert updated_schedules |> Enum.find(fn s -> s.stop_headsign == headsign end)
     end
 
@@ -2415,7 +2418,7 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
         })
 
       # Verify
-      assert [%{headsign: headsign}] = departures
+      assert %{headsign: headsign} = departures |> List.first()
       assert updated_schedules |> Enum.find(fn s -> s.trip.headsign == headsign end)
     end
   end
@@ -2504,8 +2507,8 @@ defmodule Dotcom.ScheduleFinder.UpcomingDeparturesTest do
           stop_ids: [stop_id_1, stop_id_multi, stop_id_2, stop_id_multi, stop_id_3]
         )
 
-      expect(Predictions.Repo.Mock, :all, 2, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :schedule_for_trip, 2, fn ^trip_id -> [] end)
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
       expect(Vehicles.Repo.Mock, :get, 2, fn _ -> vehicle end)
 
       # Exercise


### PR DESCRIPTION
Making a draft PR for this to test out in a deployed environment how much caching `predicted_schedules` helps with some of the other performance improvements implemented in https://github.com/mbta/dotcom/pull/3124