### PR TITLE
fix(nav): Hide unseen mobile nav from screen readers

### DIFF
--- a/assets/css/_header.scss
+++ b/assets/css/_header.scss
@@ -143,6 +143,11 @@ nav.m-menu {
 }
 
 nav.m-menu--mobile {
+  [data-nav-open] &,
+  [data-search-open] & {
+    display: block;
+  }
+
   display: none;
   position: absolute;
   z-index: $z-index-modal;
@@ -301,10 +306,6 @@ nav.m-menu--mobile {
 
 // show mobile menu, hide search button, hide search bar in tablet size
 .header--new[data-nav-open] {
-  nav.m-menu--mobile {
-    display: block;
-  }
-
   .m-menu__content {
     display: block;
     overflow-y: scroll;
@@ -353,10 +354,6 @@ nav.m-menu--mobile {
 
 // show search bar, hide menu button
 .header--new[data-search-open] {
-  nav.m-menu--mobile {
-    display: block;
-  }
-
   .m-menu__search {
     display: block;
     height: 3.75rem;

--- a/assets/css/_header.scss
+++ b/assets/css/_header.scss
@@ -353,6 +353,10 @@ nav.m-menu--mobile {
 
 // show search bar, hide menu button
 .header--new[data-search-open] {
+  nav.m-menu--mobile {
+    display: block;
+  }
+
   .m-menu__search {
     display: block;
     height: 3.75rem;

--- a/assets/css/_header.scss
+++ b/assets/css/_header.scss
@@ -143,6 +143,7 @@ nav.m-menu {
 }
 
 nav.m-menu--mobile {
+  display: none;
   position: absolute;
   z-index: $z-index-modal;
 }
@@ -300,6 +301,10 @@ nav.m-menu--mobile {
 
 // show mobile menu, hide search button, hide search bar in tablet size
 .header--new[data-nav-open] {
+  nav.m-menu--mobile {
+    display: block;
+  }
+
   .m-menu__content {
     display: block;
     overflow-y: scroll;


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Hide the navigation region from screen readers on mobile](https://app.asana.com/1/15492006741476/project/1213039586590742/task/1211600360082757)

## Implementation
Sets `display: none` on the mobile navigation menu when not in sight and thereby from most screen readers.
<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
No visual change

## How to test
links for convenience: 
- [localhost](http://localhost:4001/)
- [prod](https://www.mbta.com/)

For the mobile site, first verify that all nav menu buttons cause their menus to appear (so mobile menu appears, search menu appears)

For non-mobile site, you can test that screen reader behavior like so:
1. Start Voice Over (default shortcut for this is cmd+F5)
2. Click on the search box and 
3. Use ctrl+opt+rightarrow key until you reach the end of search
4. Use ctrl+opt+right one more time
  4a. Old behavior: it will announce "Navigation Menu, empty navigation" 
  4b. This branch: it will announce "end of banner" instead (i.e. will not announce the empty navigation)

For mobile site (by shrinking the window): 
1. Start Voice Over
2. Click on magnifying glass (e.g. open search)
3. Click on x to close search 
4. Use ctrl+opt+rightarrow
  4a. old behavior: "Navigation Menu, empty navigation"
  4b. this branch: "end of banner"



<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
