### PR TITLE
feat: Add app store redirects for mticket

### DIFF
--- a/lib/dotcom_web/controllers/app_store_controller.ex
+++ b/lib/dotcom_web/controllers/app_store_controller.ex
@@ -5,28 +5,38 @@ defmodule DotcomWeb.AppStoreController do
   """
   use DotcomWeb, :controller
 
-  @android_store_base_url "https://play.google.com/store/apps/details?id=com.mbta.tid.mbta_app"
-  @ios_store_base_url "https://apps.apple.com/app/apple-store/id6472726821"
-  @default_project_page "/goapp"
+  @go_android_store_base_url "https://play.google.com/store/apps/details?id=com.mbta.tid.mbta_app"
+  @go_ios_store_base_url "https://apps.apple.com/app/apple-store/id6472726821"
+  @go_default_project_page "/goapp"
+
+  @mticket_android_store_base_url "https://play.google.com/store/apps/details?id=com.mbta.mobileapp"
+  @mticket_ios_store_base_url "https://apps.apple.com/us/app/apple-store/id560487958"
+  @mticket_default_project_page "/#TODO"
 
   def redirect_mbta_go(conn, params) do
     conn
-    |> redirect_to_app_store(params)
+    |> redirect_to_app_store(params, @go_ios_store_base_url, @go_android_store_base_url, @go_default_project_page)
     |> halt
   end
 
-  defp redirect_to_app_store(conn, params) do
+  def redirect_mticket(conn, params) do
+    conn
+    |> redirect_to_app_store(params, @mticket_ios_store_base_url, @mticket_android_store_base_url, @mticket_default_project_page)
+    |> halt
+  end
+
+  defp redirect_to_app_store(conn, params, ios_url, android_url, desktop_url) do
     cond do
       Browser.ios?(conn) ->
         redirect(conn,
-          external: campaign_url(@ios_store_base_url, ios_params(params))
+          external: campaign_url(ios_url, ios_params(params))
         )
 
       Browser.android?(conn) ->
-        redirect(conn, external: campaign_url(@android_store_base_url, params))
+        redirect(conn, external: campaign_url(android_url, params))
 
       true ->
-        redirect(conn, to: campaign_url(@default_project_page, params))
+        redirect(conn, to: campaign_url(desktop_url, params))
     end
   end
 

--- a/lib/dotcom_web/controllers/app_store_controller.ex
+++ b/lib/dotcom_web/controllers/app_store_controller.ex
@@ -11,7 +11,7 @@ defmodule DotcomWeb.AppStoreController do
 
   @mticket_android_store_base_url "https://play.google.com/store/apps/details?id=com.mbta.mobileapp"
   @mticket_ios_store_base_url "https://apps.apple.com/us/app/apple-store/id560487958"
-  @mticket_default_project_page "/#TODO"
+  @mticket_default_project_page "/mbta-endorsed-apps"
 
   def redirect_mbta_go(conn, params) do
     conn

--- a/lib/dotcom_web/controllers/app_store_controller.ex
+++ b/lib/dotcom_web/controllers/app_store_controller.ex
@@ -15,13 +15,23 @@ defmodule DotcomWeb.AppStoreController do
 
   def redirect_mbta_go(conn, params) do
     conn
-    |> redirect_to_app_store(params, @go_ios_store_base_url, @go_android_store_base_url, @go_default_project_page)
+    |> redirect_to_app_store(
+      params,
+      @go_ios_store_base_url,
+      @go_android_store_base_url,
+      @go_default_project_page
+    )
     |> halt
   end
 
   def redirect_mticket(conn, params) do
     conn
-    |> redirect_to_app_store(params, @mticket_ios_store_base_url, @mticket_android_store_base_url, @mticket_default_project_page)
+    |> redirect_to_app_store(
+      params,
+      @mticket_ios_store_base_url,
+      @mticket_android_store_base_url,
+      @mticket_default_project_page
+    )
     |> halt
   end
 

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -207,7 +207,7 @@ defmodule DotcomWeb.Router do
     get("/menu", PageController, :menu)
 
     get("/app-store", AppStoreController, :redirect_mbta_go)
-    get("/#TODO", AppStoreController, :redirect_mticket)
+    get("/mTicketapp", AppStoreController, :redirect_mticket)
     get("/events", EventController, :index)
     get("/events/icalendar/*path_params", EventController, :icalendar)
     get("/node/icalendar/*path_params", EventController, :icalendar)

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -207,6 +207,7 @@ defmodule DotcomWeb.Router do
     get("/menu", PageController, :menu)
 
     get("/app-store", AppStoreController, :redirect_mbta_go)
+    get("/#TODO", AppStoreController, :redirect_mticket)
     get("/events", EventController, :index)
     get("/events/icalendar/*path_params", EventController, :icalendar)
     get("/node/icalendar/*path_params", EventController, :icalendar)

--- a/test/dotcom_web/controllers/app_store_controller_test.exs
+++ b/test/dotcom_web/controllers/app_store_controller_test.exs
@@ -2,9 +2,7 @@ defmodule DotcomWeb.AppStoreControllerTest do
   use DotcomWeb.ConnCase, async: true
   import Test.Support.EnvHelpers
 
-  test "redirects to default project page by default, preserving params", %{conn: conn} do
-    reassign_env(:dotcom, :mbta_go_app, default_project_page: "/default_project_page")
-
+  test "redirects to default mbta go project page by default, preserving params", %{conn: conn} do
     conn =
       get(
         conn,
@@ -16,7 +14,7 @@ defmodule DotcomWeb.AppStoreControllerTest do
     assert redirected_to(conn, 302) =~ "/goapp?param_1=val_1"
   end
 
-  test "redirects to app store for ios browser", %{conn: conn} do
+  test "redirects to mbta go app store for ios browser", %{conn: conn} do
     conn =
       conn
       |> put_req_header(
@@ -37,7 +35,7 @@ defmodule DotcomWeb.AppStoreControllerTest do
     assert redirected_to =~ "?pt=fake%20pt&ct=fake%20ct&mt=fake-mt"
   end
 
-  test "redirects to app store for android browser", %{conn: conn} do
+  test "redirects to mbta go app store for android browser", %{conn: conn} do
     conn =
       conn
       |> put_req_header(
@@ -46,6 +44,61 @@ defmodule DotcomWeb.AppStoreControllerTest do
       )
       |> get(
         app_store_path(conn, :redirect_mbta_go, %{
+          "referrer" => "fake referrer",
+          "utm_source" => "fake utm source",
+          "utm_campaign" => "fake-utm-campaign"
+        })
+      )
+
+    redirected_to = redirected_to(conn, 302)
+    assert redirected_to =~ "https://play.google.com"
+
+    assert redirected_to =~
+             "&referrer=fake%20referrer&utm_campaign=fake-utm-campaign&utm_source=fake%20utm%20source"
+  end
+
+  test "redirects to default mticket project page by default, preserving params", %{conn: conn} do
+    conn =
+      get(
+        conn,
+        app_store_path(conn, :redirect_mticket, %{
+          "param_1" => "val_1"
+        })
+      )
+
+    assert redirected_to(conn, 302) =~ "/#TODO?param_1=val_1"
+  end
+
+  test "redirects to mticket app store for ios browser", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header(
+        "user-agent",
+        "Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/1A542a Safari/419.3"
+      )
+      |> get(
+        app_store_path(conn, :redirect_mticket, %{
+          "mt" => "fake-mt",
+          "ct" => "fake ct",
+          "pt" => "fake pt",
+          "extra" => "other param"
+        })
+      )
+
+    redirected_to = redirected_to(conn, 302)
+    assert redirected_to =~ "https://apps.apple.com"
+    assert redirected_to =~ "?pt=fake%20pt&ct=fake%20ct&mt=fake-mt"
+  end
+
+  test "redirects to mticket app store for android browser", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header(
+        "user-agent",
+        "Android SDK 1.5r3: Mozilla/5.0 (Linux; U; Android 1.5; de-; sdk Build/CUPCAKE) AppleWebkit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1"
+      )
+      |> get(
+        app_store_path(conn, :redirect_mticket, %{
           "referrer" => "fake referrer",
           "utm_source" => "fake utm source",
           "utm_campaign" => "fake-utm-campaign"

--- a/test/dotcom_web/controllers/app_store_controller_test.exs
+++ b/test/dotcom_web/controllers/app_store_controller_test.exs
@@ -66,7 +66,7 @@ defmodule DotcomWeb.AppStoreControllerTest do
         })
       )
 
-    assert redirected_to(conn, 302) =~ "/#TODO?param_1=val_1"
+    assert redirected_to(conn, 302) =~ "/mbta-endorsed-apps?param_1=val_1"
   end
 
   test "redirects to mticket app store for ios browser", %{conn: conn} do


### PR DESCRIPTION
## Scope

**Asana Ticket:** No ticket, [slack thread](https://mbta.slack.com/archives/C8THJ1NJY/p1777477613853979)

## Implementation

CEX is asking for an mticket redirect that works the same way as the existing MBTA Go one. This just takes that code and makes the app store and desktop URLs params.

## How to test

Open https://dev-green.mbtace.com/mTicketapp on iOS, Android and desktop, the URLs are properly redirected to either app store or https://dev-green.mbtace.com/mbta-endorsed-apps