### PR TITLE
feat(ScheduleFinderLive): use visibilitychange (closes #3125)

### DIFF
--- a/assets/ts/phoenix-hooks/index.ts
+++ b/assets/ts/phoenix-hooks/index.ts
@@ -1,5 +1,6 @@
 import AlgoliaAutocomplete from "./algolia-autocomplete";
 import MBTAGoCTABanner from "./mbta-go-cta-banner";
+import PageVisibility from "./page-visibility";
 import ScrollIntoView from "./scroll-into-view";
 import TripPlannerForm from "./trip-planner-form";
 import TripPlannerMap from "./trip-planner-map";
@@ -15,6 +16,7 @@ import TripPlannerMap from "./trip-planner-map";
 const Hooks = {
   AlgoliaAutocomplete,
   MBTAGoCTABanner,
+  PageVisibility,
   ScrollIntoView,
   TripPlannerForm,
   TripPlannerMap

--- a/assets/ts/phoenix-hooks/page-visibility.ts
+++ b/assets/ts/phoenix-hooks/page-visibility.ts
@@ -1,0 +1,35 @@
+import { ViewHook } from "phoenix_live_view";
+
+interface PageVisibilityHook extends ViewHook {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+/**
+ * Send `visibilitychange` events to the parent LiveView
+ *
+ * 1. add `phx-hook="PageVisibility"` somewhere in the LiveView
+ * 2. use `handle_event("visibility_change", %{"state" => state}, socket)` to add code to handle the change. `state` will either be "visible" or "hidden".
+ */
+const PageVisibility: Partial<PageVisibilityHook> = {
+  mounted() {
+    this.handlePageVisibility = () => {
+      if (this.pushEvent) {
+        this.pushEvent("visibility_change", {
+          state: document.visibilityState
+        });
+      }
+    };
+
+    document.addEventListener("visibilitychange", this.handlePageVisibility);
+    this.handlePageVisibility(); // send current state
+  },
+  reconnected() {
+    this.handlePageVisibility(); // send current state
+  },
+  destroyed() {
+    document.removeEventListener("visibilitychange", this.handlePageVisibility);
+  }
+};
+
+export default PageVisibility;

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -73,6 +73,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
          |> assign_new(:loaded_trips, fn -> %{} end)
          |> assign_new(:selected_service_name, fn -> Map.get(selected_service, :label, "") end)
          |> assign_new(:daily_schedule_date, fn -> service_date() end)
+         |> assign_new(:should_refresh?, fn -> true end)
          |> assign_alerts()
          |> assign_departures()
          |> assign_upcoming_departures()
@@ -95,7 +96,11 @@ defmodule DotcomWeb.ScheduleFinderLive do
     ~H"""
     <.route_banner route={@route} direction_id={@direction_id} />
     <.stop_banner stop={@stop} />
-    <div class="container">
+    <div
+      class="container"
+      id={"#{@route.id}-#{@direction_id}-#{@stop.id}-schedule-finder"}
+      phx-hook="PageVisibility"
+    >
       <div class="flex flex-col gap-y-xl max-w-xl mx-auto mt-xl">
         <.alert_banner alerts={@alerts} />
         <section>
@@ -200,6 +205,13 @@ defmodule DotcomWeb.ScheduleFinderLive do
      |> assign(:departures, AsyncResult.loading())}
   end
 
+  def handle_event("visibility_change", %{"state" => state}, socket) do
+    {:noreply,
+     socket
+     |> assign(:should_refresh?, state == "visible")
+     |> assign_upcoming_departures()}
+  end
+
   def handle_event(_, _, socket), do: {:noreply, socket}
 
   @impl Phoenix.LiveView
@@ -279,6 +291,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
     stop_id = stop_id
 
     parent_pid = self()
+    should_refresh? = socket.assigns.should_refresh?
 
     socket
     |> assign_async(
@@ -292,7 +305,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
             stop_id: stop_id
           })
 
-        schedule_refresh_upcoming_departures(parent_pid)
+        _ = if should_refresh?, do: schedule_refresh_upcoming_departures(parent_pid)
 
         {:ok, %{upcoming_departures: departures}}
       end


### PR DESCRIPTION
## Scope

Builds off prior art:
- #3125 

## Implementation

- Basically rewrites the JS logic into a [Phoenix client hook](https://hexdocs.pm/phoenix_live_view/js-interop.html#client-hooks-via-phx-hook). 
  - On component mount, assigns the `visibilitychange` event listener. It pushes the document `visibilityState` to the server, which can be handled in the parent LiveView via `handle_event`.
  - On mount also immediately sends the current `visibilityState`
  - Reconnections also trigger immediately sending the current `visibilityState`
  - On component `destroyed()` we remove the event listener.

Then I edited the Schedule Finder to respond to the changed value:
- Toggles a new assign, `:should_refresh?`, which if `true` will schedule (ahem) the next upcoming departure update.

## How to test

I put an `IO.inspect()` in `assign_upcoming_departures/1` to see how frequently it's being called after changing the tab visibility state! I'll note it's not a perfect/immediate transition - for example, if the next upcoming departure update is already queued when the tab changes to a hidden state, that next update will still happen.
