### PR TITLE
Keep focus after changing date in timetable

### DIFF
--- a/lib/build_calendar.ex
+++ b/lib/build_calendar.ex
@@ -72,7 +72,11 @@ defmodule BuildCalendar do
       formatted_date = Dotcom.Utils.Time.format!(date, :weekday_date_full)
 
       content_tag :td, class: class(day) do
-        link("#{date.day}", to: url, title: formatted_date, "aria-label": formatted_date)
+        link("#{date.day}",
+          to: url <> "#date-filter",
+          title: formatted_date,
+          "aria-label": formatted_date
+        )
       end
     end
 

--- a/test/build_calendar_test.exs
+++ b/test/build_calendar_test.exs
@@ -203,7 +203,7 @@ defmodule BuildCalendarTest do
         })
 
       assert safe_to_string(actual) =~ "23"
-      assert safe_to_string(actual) =~ ~s(href="url")
+      assert safe_to_string(actual) =~ ~s(href="url#date-filter")
     end
 
     test "if the day is selected, adds a class" do


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Keep focus after changing date in timetable](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211676340821162?focus=true)

## Implementation

Updated the date selector so that it includes "#date-filter" in the URL for choosing a date, this causes to focus to return to the date selector after the page reloads.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots


https://github.com/user-attachments/assets/e0c7b27f-94ca-4dd4-b9f5-e41e85e52811



## How to test

Visit any ferry or commuter rail timetable, and use keyboard navigation to change the date.  Confirm that the date selector is still focused after the page reloads and functions similarly to the change direction button.

http://localhost:4001/schedules/Boat-F1/timetable

http://localhost:4001/schedules/CR-NewBedford/timetable

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
