### PR TITLE
hotfix: fix broken schedule links

### DIFF
--- a/lib/dotcom_web/templates/mode/_grid_button.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_button.html.heex
@@ -7,14 +7,6 @@
     <% end %>
 
     <span class="c-grid-button__name notranslate">
-      <.icon
-        :if={!is_atom(@route) and @route.id == "CR-Foxboro"}
-        type="icon-svg"
-        name="football"
-        class="size-4 relative top-[0.1em]"
-        aria-hidden="true"
-      />
-
       {grid_button_text(@route)}
     </span>
 

--- a/lib/dotcom_web/views/mode_view.ex
+++ b/lib/dotcom_web/views/mode_view.ex
@@ -132,10 +132,6 @@ defmodule DotcomWeb.ModeView do
     ~t"MBTA Paratransit Program"
   end
 
-  def grid_button_text(%Route{id: "CR-Foxboro"}) do
-    " Boston Stadium"
-  end
-
   def grid_button_text(%Route{name: name}) do
     break_text_at_slash(name)
   end

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -412,7 +412,7 @@ defmodule DotcomWeb.ScheduleView do
           gettext(" Additional service to Hingham and Hull is available via the %{link}", %{
             link:
               link(~t"Hingham/Hull ferry",
-                to: ~p"/schedule/Boat-F2H/timetable"
+                to: ~p"/schedules/Boat-F2H/timetable"
               )
               |> safe_to_string()
           })


### PR DESCRIPTION
## Scope

**Asana Ticket:** [fix: Ferry added note goes to wrong URL](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214400724705463?focus=true) and part of [fix: Boston Stadium trains button should link to /schedules/bostonstadium](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214400724705466?focus=true)

## Implementation

Reverted the Boston Stadium link addition, we can re-add this ASAP.
