### PR TITLE
fix: Boston Stadium trains button should link to /schedules/bostonstadium

### DIFF
--- a/lib/dotcom_web/templates/mode/_grid_button.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_button.html.heex
@@ -7,6 +7,13 @@
     <% end %>
 
     <span class="c-grid-button__name notranslate">
+      <.icon
+        :if={!is_atom(@route) and @route.id == "Bostonstadium"}
+        type="icon-svg"
+        name="football"
+        class="size-4 relative top-[0.1em]"
+        aria-hidden="true"
+      />
       {grid_button_text(@route)}
     </span>
 

--- a/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
@@ -24,16 +24,20 @@
       name: "Boston Stadium Trains",
       sort_order: 20014,
       type: 2
-    } %>
-  {render("_grid_button.html",
-    conn: @conn,
-    route: wc_route,
-    show_icon?: @show_icons?,
-    link_path: ~p"/schedules/Bostonstadium",
-    has_alert?: has_alert?(wc_route, @alerts, @date_time),
-    id_prefix: assigns[:id_prefix],
-    index: Enum.count(@routes)
-  )}
+    }
+
+  test_route = @routes |> Enum.at(0) %>
+  {if !is_atom(test_route) and test_route.type == 2,
+    do:
+      render("_grid_button.html",
+        conn: @conn,
+        route: wc_route,
+        show_icon?: @show_icons?,
+        link_path: ~p"/schedules/bostonstadium",
+        has_alert?: has_alert?(wc_route, @alerts, @date_time),
+        id_prefix: assigns[:id_prefix],
+        index: Enum.count(@routes)
+      )}
   <%= if assigns[:sub_routes] do %>
     <div class="c-grid-button c-grid-buttons__condensed">
       <%= for {route, idx} <- Enum.with_index(Map.get(assigns, :sub_routes, [])) do %>

--- a/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
@@ -12,17 +12,8 @@
   <% end %>
   <% wc_route =
     %Routes.Route{
-      color: "80276C",
-      description: :regional_rail,
-      direction_destinations: %{0 => "Boston Stadium", 1 => "South Station"},
-      direction_names: %{0 => "Outbound", 1 => "Inbound"},
       id: "Bostonstadium",
-      fare_class: nil,
-      line_id: nil,
-      listed?: true,
-      long_name: "Boston Stadium Trains",
       name: "Boston Stadium Trains",
-      sort_order: 20014,
       type: 2
     }
 
@@ -34,7 +25,7 @@
         route: wc_route,
         show_icon?: @show_icons?,
         link_path: ~p"/schedules/bostonstadium",
-        has_alert?: has_alert?(wc_route, @alerts, @date_time),
+        has_alert?: false,
         id_prefix: assigns[:id_prefix],
         index: Enum.count(@routes)
       )}

--- a/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
+++ b/lib/dotcom_web/templates/mode/_grid_buttons.html.heex
@@ -1,5 +1,5 @@
 <div class="c-grid-buttons">
-  <%= for {route, idx} <- Enum.with_index(@routes) do %>
+  <%= for {route, idx} <- (Enum.filter(@routes, fn(route) -> is_atom(route) or route.id != "CR-Foxboro" end) |> Enum.with_index()) do %>
     {render("_grid_button.html",
       conn: @conn,
       route: route,
@@ -10,6 +10,30 @@
       index: idx
     )}
   <% end %>
+  <% wc_route =
+    %Routes.Route{
+      color: "80276C",
+      description: :regional_rail,
+      direction_destinations: %{0 => "Boston Stadium", 1 => "South Station"},
+      direction_names: %{0 => "Outbound", 1 => "Inbound"},
+      id: "Bostonstadium",
+      fare_class: nil,
+      line_id: nil,
+      listed?: true,
+      long_name: "Boston Stadium Trains",
+      name: "Boston Stadium Trains",
+      sort_order: 20014,
+      type: 2
+    } %>
+  {render("_grid_button.html",
+    conn: @conn,
+    route: wc_route,
+    show_icon?: @show_icons?,
+    link_path: ~p"/schedules/Bostonstadium",
+    has_alert?: has_alert?(wc_route, @alerts, @date_time),
+    id_prefix: assigns[:id_prefix],
+    index: Enum.count(@routes)
+  )}
   <%= if assigns[:sub_routes] do %>
     <div class="c-grid-button c-grid-buttons__condensed">
       <%= for {route, idx} <- Enum.with_index(Map.get(assigns, :sub_routes, [])) do %>


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [fix: Boston Stadium trains button should link to /schedules/bostonstadium](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214400724705466?focus=true)

## Implementation

Added code to filter out CR-Foxboro
Added a hand coded route for Boston Stadium Trains and logic to render buttons for it in the Commuter Rail context
This also fixes the issue of Boston Stadium Trains showing up in recently visited

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Schedules
<img width="729" height="567" alt="Screenshot 2026-04-29 at 3 17 33 PM" src="https://github.com/user-attachments/assets/ceecdfe1-78a4-4bbd-8a13-840d66d18e15" />

### Schedules/Commuter-Rail
<img width="748" height="496" alt="Screenshot 2026-04-29 at 3 17 47 PM" src="https://github.com/user-attachments/assets/197cb556-3e0b-46d6-a673-6204da2cd9f6" />


## How to test

http://localhost:4001/schedules

http://localhost:4001/schedules/commuter-rail

Confirm that the Foxboro Event Service link is gone and has been replaced with the Boston Stadium Trains link
Confirm that it goes to the World Cup / Boston Stadium page


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
