### PR TITLE
QF | A11Y: Fix focus indicator contrast for "share"/"privacy policy"/etc on the footer

### DIFF
--- a/assets/css/_footer.scss
+++ b/assets/css/_footer.scss
@@ -436,6 +436,12 @@ address {
   @include media-breakpoint-down(xs) {
     padding-top: 20px;
   }
+  a {
+    &:focus {
+      outline: 2px solid $brand-secondary;
+      outline-offset: 0.25em;
+    }
+  }
 }
 
 .social-icons-container a:first-of-type {
@@ -513,5 +519,8 @@ address {
 
   a {
     color: $brand-primary-light-contrast;
+    &:focus {
+      outline: 2px solid $brand-secondary;
+    }
   }
 }


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ♿️ Fix focus indicator contrast for "share"/"privacy policy"/etc on the footer](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214363119160440?focus=true)

## Implementation

Updated focus CSS for links in the very bottom part of the dark blue section of the footer to be $brand-secondary (yellow).  Added a bit of offset to the share link outlines, since they were overlapping the icons without it.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots


https://github.com/user-attachments/assets/b1eb28cb-5bf5-4c73-8d81-adb1cd70cd83



## How to test
http://localhost:4001/

Visit any page, go to the footer, use keyboard navigation and confirm that the focus indicator on the social icons and policy links are now yellow and much easier to see.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
