### PR TITLE
[DO NOT MERGE until ferry real-time] ferry: Add MBTA GO promo banner to ferry timetable page

### DIFF
--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -1,11 +1,16 @@
 <.promo_banner
-  :if={commuter_rail?(@route) && @conn |> user_agent() |> Browser.mobile?()}
+  :if={ferry_or_commuter_rail?(@route) && @conn |> user_agent() |> Browser.mobile?()}
   href="https://www.mbta.com/app-store?pt=117998862&ct=dotcom-cr-banner&mt=8&referrer=utm_source%3Ddotcom%26utm_campaign%3Dcr-banner"
   class="mb-5 p-3 leading-none flex gap-2 items-center bg-cobalt-90 border-xs border-cobalt-70 rounded-lg"
 >
   <.icon type="icon-svg" name="icon-mbta-go" class="size-11 shrink-0" />
   <div class="leading-tight">
-    Download <strong>MBTA Go</strong> to track your train &#8594;
+    {gettext("Download %{mbta_go} to track your %{vehicle_name}",
+      mbta_go: "<strong>MBTA Go</strong>",
+      vehicle_name: Route.vehicle_name(@route) |> String.downcase()
+      )
+      |> raw()}
+    <span aria-hidden="true">&#8594;</span>
   </div>
 </.promo_banner>
 

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -8,8 +8,8 @@
     {gettext("Download %{mbta_go} to track your %{vehicle_name}",
       mbta_go: "<strong>MBTA Go</strong>",
       vehicle_name: Route.vehicle_name(@route) |> String.downcase()
-      )
-      |> raw()}
+    )
+    |> raw()}
     <span aria-hidden="true">&#8594;</span>
   </div>
 </.promo_banner>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -1,6 +1,6 @@
 <.promo_banner
   :if={
-    commuter_rail?(@route) && @route.id != "CR-Franklin" && @route.id != "CR-Foxboro" &&
+    ferry_or_commuter_rail?(@route) && @route.id != "CR-Franklin" && @route.id != "CR-Foxboro" &&
       @conn |> user_agent() |> Browser.mobile?()
   }
   href="https://www.mbta.com/app-store?pt=117998862&ct=dotcom-cr-banner&mt=8&referrer=utm_source%3Ddotcom%26utm_campaign%3Dcr-banner"
@@ -8,7 +8,12 @@
 >
   <.icon type="icon-svg" name="icon-mbta-go" class="size-11 shrink-0" />
   <div class="leading-tight">
-    Download <strong>MBTA Go</strong> to track your train &#8594;
+    {gettext("Download %{mbta_go} to track your %{vehicle_name}",
+      mbta_go: "<strong>MBTA Go</strong>",
+      vehicle_name: Route.vehicle_name(@route) |> String.downcase()
+      )
+      |> raw()}
+    <span aria-hidden="true">&#8594;</span>
   </div>
 </.promo_banner>
 

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -11,8 +11,8 @@
     {gettext("Download %{mbta_go} to track your %{vehicle_name}",
       mbta_go: "<strong>MBTA Go</strong>",
       vehicle_name: Route.vehicle_name(@route) |> String.downcase()
-      )
-      |> raw()}
+    )
+    |> raw()}
     <span aria-hidden="true">&#8594;</span>
   </div>
 </.promo_banner>

--- a/lib/dotcom_web/views/schedule/timetable.ex
+++ b/lib/dotcom_web/views/schedule/timetable.ex
@@ -99,4 +99,7 @@ defmodule DotcomWeb.ScheduleView.Timetable do
 
   @spec commuter_rail?(Route.t()) :: boolean
   def commuter_rail?(route), do: Routes.Route.type_atom(route) == :commuter_rail
+
+  @spec ferry_or_commuter_rail?(Route.t()) :: boolean
+  def ferry_or_commuter_rail?(route), do: ferry?(route) || commuter_rail?(route)
 end


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [[Blocked by ferry realtime in prod ~4/27] ⛴️ Stand up MBTA Go promo on Ferry pages](https://app.asana.com/1/15492006741476/project/555089885850811/task/1213211957832379)

## Implementation
Adjusts the existing CR promo banner to show up on ferry 

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
CR (no change):
<img width="373" height="510" alt="image" src="https://github.com/user-attachments/assets/552e8369-2958-45ac-a039-7ff84f74b952" />

Ferry (before): 
<img width="377" height="346" alt="image" src="https://github.com/user-attachments/assets/bbe06856-dbfa-4655-9f2c-d55a548eb70a" />

Ferry (after): 
<img width="374" height="412" alt="image" src="https://github.com/user-attachments/assets/0c611b31-2203-45d7-8c5d-779d064f0466" />


## How to test
Verify banner appears on mobile browser (can imitate in dev tools) and does not appear when not on mobile browser. 

Local links:
- [CR - Fairmount](http://localhost:4001/schedules/CR-Fairmount/timetable)
- [Ferry - Charlestown](http://localhost:4001/schedules/Boat-F4/timetable?queryID=0c2d3d99ca4e8e98c6933d1570b17363)
<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
