### PR TITLE
fix: Temporarily hide MBTA Go promo while WC intercept is present

### DIFF
--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -1,5 +1,8 @@
 <.promo_banner
-  :if={commuter_rail?(@route) && @conn |> user_agent() |> Browser.mobile?()}
+  :if={
+    commuter_rail?(@route) && @route.id != "CR-Franklin" && @route.id != "CR-Foxboro" &&
+      @conn |> user_agent() |> Browser.mobile?()
+  }
   href="https://www.mbta.com/app-store?pt=117998862&ct=dotcom-cr-banner&mt=8&referrer=utm_source%3Ddotcom%26utm_campaign%3Dcr-banner"
   class="mb-5 p-3 leading-none flex gap-2 items-center bg-cobalt-90 border-xs border-cobalt-70 rounded-lg"
 >


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope
Noticed that the MBTA Go banner was still appearing on mobile while the WC intercept was around and corrected it per the AC of the ticket linked
<!-- Why does this PR exist? -->

**Asana Ticket:**  [⚽️ [Not Release-Blocking] Add World Cup intercepts to various pages](https://app.asana.com/1/15492006741476/project/1213039586590742/task/1213834498258583?focus=true)

## Implementation
Check against route ID to hide MBTA Go promo on Franklin and Foxboro CR schedules.
<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
Before: 
<img width="375" height="420" alt="image" src="https://github.com/user-attachments/assets/d68ce71f-5981-4bd9-b422-650a36d3361e" />

After:
<img width="373" height="405" alt="image" src="https://github.com/user-attachments/assets/f36c88d3-bb94-4233-b47c-1b337365b274" />

## How to test
View these pages at a mobile breakpoint and verify that the MBTA Go banner does _not_ appear. 
- [Franklin/Foxboro](http://localhost:4001/schedules/CR-Franklin/timetable)
- [Foxboro Event Service](http://localhost:4001/schedules/CR-Foxboro/timetable)

View a different CR page and verify that the MBTA Go banner _does_ still appear.
- [Fairmount](http://localhost:4001/schedules/CR-Fairmount/timetable) for convenience
<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
