### PR TITLE
tests(integration): fix schedule stop selector

### DIFF
--- a/integration/scenarios/view-subway-schedule.js
+++ b/integration/scenarios/view-subway-schedule.js
@@ -12,20 +12,18 @@ export async function scenario({ page, baseURL }) {
     "Orange Line",
   );
 
-  await page.waitForSelector("h4.m-schedule-diagram__stop-link a span");
+  await page.waitForSelector(".m-schedule-diagram__stop-link span");
   await expect
-    .poll(async () =>
-      page.locator("h4.m-schedule-diagram__stop-link a span").count(),
-    )
+    .poll(async () => page.locator(".m-schedule-diagram__stop-link").count())
     .toBeGreaterThan(1);
 
   // Get the first and last stop names
   const first = await page
-    .locator("h4.m-schedule-diagram__stop-link a span:last-child")
+    .locator(".m-schedule-diagram__stop-link span:last-child")
     .first()
     .textContent();
   const last = await page
-    .locator("h4.m-schedule-diagram__stop-link a span:last-child")
+    .locator(".m-schedule-diagram__stop-link span:last-child")
     .last()
     .textContent();
 
@@ -33,9 +31,9 @@ export async function scenario({ page, baseURL }) {
 
   // Expect them to be reversed after clicking the direction filter
   await expect(
-    page.locator("h4.m-schedule-diagram__stop-link a span:last-child").first(),
+    page.locator(".m-schedule-diagram__stop-link span:last-child").first(),
   ).toHaveText(last);
   await expect(
-    page.locator("h4.m-schedule-diagram__stop-link a span:last-child").last(),
+    page.locator(".m-schedule-diagram__stop-link span:last-child").last(),
   ).toHaveText(first);
 }


### PR DESCRIPTION
This should fix the failing "Critical User Journeys" set of tests which run post-deploy.

<img width="895" height="393" alt="image" src="https://github.com/user-attachments/assets/d90c9fe7-f1c9-4922-ac04-e4513888283d" />

I updated the selector to match the changes made in this PR!
- #3132 

## How to test
Can run this test locally with the following, with a `HOST` value of your choosing (if omitted it'll test against `localhost`):

```shell
HOST=dev.mbtace.com npx playwright test all-scenarios --grep @view_subway_schedule
```