### PR TITLE
fix(TripPlanner): match Mattapan shuttle routes

### DIFF
--- a/lib/dotcom/trip_plan/helpers.ex
+++ b/lib/dotcom/trip_plan/helpers.ex
@@ -99,6 +99,7 @@ defmodule Dotcom.TripPlan.Helpers do
       "Green" <> _ -> "00843D"
       "Orange" <> _ -> "#ED8B00"
       "Red" <> _ -> "#DA291C"
+      "Mattapan" <> _ -> "#DA291C"
       _ -> "#80276c"
     end
   end

--- a/lib/dotcom_web/components/trip_planner/route_icons.ex
+++ b/lib/dotcom_web/components/trip_planner/route_icons.ex
@@ -61,6 +61,7 @@ defmodule DotcomWeb.Components.TripPlanner.RouteIcons do
         "Green" <> _ -> "green"
         "Orange" <> _ -> "orange"
         "Red" <> _ -> "red"
+        "Mattapan" <> _ -> "red"
         _ -> "cr"
       end
 


### PR DESCRIPTION
## Scope

**Asana Ticket:** [Trip Planner | Mattapan shuttle should be red](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214589897986832?focus=true)

## Implementation

Raised by Transit Data in [this Slack thread](https://mbta.slack.com/archives/C076FBBC21K/p1778095234809179). 

Complete resolution relies on a change they'll make to update the [shuttle route](https://api-dev-green.mbtace.com/routes/Shuttle-MattapanAshmont)'s `short_name` to `"Mattapan"` (it was initially `"Shuttle"`).

The change in `Dotcom.TripPlan.Helpers` should fix the map and the change in `DotcomWeb.Components.TripPlanner.RouteIcons` should fix the shuttle icon... and I _think_ the line will start appearing once the short name fix happens.

## How to test

After the GTFS fix is out, can deploy this branch to dev-green to check using the itinerary referenced in the Asana ticket. Alternately we can run the trip planner locally after building it against dev-green GTFS data. 
- https://github.com/mbta/gtfs_creator/pull/3311
