### PR TITLE
icons: Default to not showing tooltips

### DIFF
--- a/lib/dotcom_web/views/partial/svg_icon_with_circle.ex
+++ b/lib/dotcom_web/views/partial/svg_icon_with_circle.ex
@@ -6,8 +6,8 @@ defmodule DotcomWeb.PartialView.SvgIconWithCircle do
 
   defstruct icon: nil,
             size: :default,
-            show_tooltip?: true,
-            aria_hidden?: false
+            show_tooltip?: false,
+            aria_hidden?: true
 
   @type t :: %__MODULE__{
           icon: SvgIcon.icon_arg(),

--- a/test/dotcom/content_rewriter_test.exs
+++ b/test/dotcom/content_rewriter_test.exs
@@ -141,7 +141,7 @@ defmodule Dotcom.ContentRewriterTest do
       {:safe, output} = input |> raw() |> rewrite(conn)
 
       assert output =~
-               ~r/^<p>Before <a href=\"#\"><span data-toggle=\"tooltip\" title=\"Green Line\">/
+               ~r/^<p>Before <a href=\"#\"><span aria-hidden>/
 
       assert output =~ ~r/<span class=\"notranslate c-svg__icon-green-line-small\"><svg/
       assert output =~ ~r/<\/svg><\/span><\/span> link<\/a> after<\/p>$/

--- a/test/dotcom_web/views/paragraph_view_test.exs
+++ b/test/dotcom_web/views/paragraph_view_test.exs
@@ -629,7 +629,7 @@ defmodule DotcomWeb.CMS.ParagraphViewTest do
          ], _}
       ] = Floki.find(document, ".c-accordion-ui__trigger")
 
-      assert {"span", [{"data-toggle", "tooltip"}, {"title", "Red Line"}],
+      assert {"span", [{"aria-hidden", "aria-hidden"}],
               [{"span", [{"class", "notranslate c-svg__icon-red-line-default"}], _}]} = icon_1
 
       assert title_1 =~ ~r/\s*Section 1\s*/

--- a/test/dotcom_web/views/partial_view_test.exs
+++ b/test/dotcom_web/views/partial_view_test.exs
@@ -45,7 +45,6 @@ defmodule DotcomWeb.PartialViewTest do
 
       assert rendered =~ "</svg>"
       assert rendered =~ "c-svg__icon-mode-subway"
-      assert rendered =~ "title=\"Subway\""
     end
 
     test "uses small icon if size is set to small" do
@@ -69,7 +68,7 @@ defmodule DotcomWeb.PartialViewTest do
       assert title(%Routes.Route{type: 4}) == "Ferry"
     end
 
-    test "Title tooltip is shown if show_tooltip? is not specified" do
+    test "Title tooltip is not shown if show_tooltip? is not specified" do
       document =
         %SvgIconWithCircle{icon: :subway}
         |> svg_icon_with_circle()
@@ -77,18 +76,18 @@ defmodule DotcomWeb.PartialViewTest do
         |> IO.iodata_to_binary()
         |> Floki.parse_document!()
 
-      assert Floki.attribute(document, "data-toggle") == ["tooltip"]
+      assert document |> Floki.find("svg") |> List.first() |> Floki.attribute("data-toggle") == []
     end
 
-    test "Tooltip is not shown if show_tooltip? is false" do
+    test "Tooltip is shown if show_tooltip? is true" do
       document =
-        %SvgIconWithCircle{icon: :subway, show_tooltip?: false}
+        %SvgIconWithCircle{icon: :subway, show_tooltip?: true}
         |> svg_icon_with_circle()
         |> Phoenix.HTML.Safe.to_iodata()
         |> IO.iodata_to_binary()
         |> Floki.parse_document!()
 
-      assert document |> Floki.find("svg") |> List.first() |> Floki.attribute("data-toggle") == []
+      assert Floki.attribute(document, "data-toggle") == ["tooltip"]
     end
   end
 


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Remove unnecessary mode, route icon tooltips](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211709578469471)

## Implementation
straightforward change to SVGIconWithCircle to default to off/hidden tooltips. As far as I can tell from hours of scouring our pages, the remaining React pages which have icons and tooltips are just the line diagrams, which should continue to have tooltips, so I've not made any changes there

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
subway fares before: 
<img width="574" height="209" alt="image" src="https://github.com/user-attachments/assets/518af543-aa7f-406d-a61e-b24ab1c8ca17" />

subway fares after: 
<img width="637" height="195" alt="image" src="https://github.com/user-attachments/assets/8395ca07-c4d6-42a8-be6f-5d9ee4895fc2" />

(cursor wasn't captured but in both those cases I'm hovering over the subway icon)

## How to test

Places we should not see tooltips from route/mode icons:
- all content pages (probably only need to check one since they all use the same rendering code, but to be safe, I've listed the ones folks are most likely to come across) 
  - about - overview: [local](https://localhost:4001/about/how-to-ride-the-mbta-the-basics) / [prod](https://www.mbta.com/about/how-to-ride-the-mbta-the-basics)
  - lost and found: [local](http://localhost:4001/customer-support/lost-and-found) / [prod](http://www.mbta.com/customer-support/lost-and-found) 
  - fares:
    - subway: [local](http://localhost:4001/fares/subway-fares) / [prod](https://www.mbta.com/fares/subway-fares) 
    - bus: [local](http://localhost:4001/fares/bus-fares) / [prod](http://lwww.mbta.com/fares/bus-fares)
    - commuter rail: [local](https://localhost:4001/fares/commuter-rail-fares) / [prod](https://www.mbta.com/fares/commuter-rail-fares)
    - ferry: [local](https://localhost:4001/fares/ferry-fares) / [prod](https://www.mbta.com/fares/ferry-fares)
  -  world cup guide: [local](https://localhost:4001/guides/world-cup-guide) / [prod](https://www.mbta.com/guides/world-cup-guide)
- of our Elixir pages:
  - schedules: [local](https://localhost:4001/schedules) / [prod](https://www.mbta.com/schedules)
  

places we still expect tooltips: 
- non-mode/line icons
  - individual timetables' Parking, Accessible, Alerts icons
    - example: Fairmount [local](https://localhost:4001/schedules/CR-Fairmount/timetable) / [prod](https://www.mbta.com/schedules/CR-Fairmount/timetable) 
 - mode/line icons in line diagrams
   - example: Fairmount line tab [local](http://localhost:4001/schedules/CR-Fairmount/line) / [prod](http://www.mbta.com/schedules/CR-Fairmount/line)

~~tangential - we currently don't have tooltips on the alerts tab on the main page (prior to these changes too), but since there isn't any text for the subway and bus icons here, would it be useful to have the tooltips here?~~ per short [discussion](https://mbta.slack.com/archives/GRB64NPHS/p1778159850834509?thread_ts=1778158812.158739&cid=GRB64NPHS) in Slack, these will remain tooltipless. As neither use the SVGIconWithCircle partial to generate their icons (stop pages instead using RouteSymbol and the alerts tab using just a plain SVG component), the changes made in this file don't affect them 
<img width="725" height="600" alt="image" src="https://github.com/user-attachments/assets/60426421-c24e-4c75-a379-93212f3366a3" />

similar situation for stop page headers: 
<img width="487" height="161" alt="image" src="https://github.com/user-attachments/assets/500a0fe3-effd-4ba1-8234-b0a1d7daecf6" />


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
