### PR TITLE
QF | Remove Innovation Proposals from header/footer/menu

### DIFF
--- a/lib/dotcom_web/templates/layout/_footer.html.heex
+++ b/lib/dotcom_web/templates/layout/_footer.html.heex
@@ -84,10 +84,6 @@
               to: cms_static_page_path(@conn, "/business"),
               class: "m-footer__link"
             )}
-            {link(~t(Innovation Proposals),
-              to: cms_static_page_path(@conn, "/innovation"),
-              class: "m-footer__link"
-            )}
             {link(~t(Engineering Design Standards),
               to: cms_static_page_path(@conn, "/engineering/design-standards-and-guidelines"),
               class: "m-footer__link"

--- a/lib/dotcom_web/views/layout_view.ex
+++ b/lib/dotcom_web/views/layout_view.ex
@@ -209,7 +209,6 @@ defmodule DotcomWeb.LayoutView do
               {~t(Careers), "/careers", :internal_link},
               {~t(Institutional Sales), "/pass-program", :internal_link},
               {~t(Business Opportunities), "/business", :internal_link},
-              {~t(Innovation Proposals), "/innovation", :internal_link},
               {~t(Engineering Design Standards), "/engineering/design-standards-and-guidelines",
                :internal_link}
             ]


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | Remove Innovation Proposals from header/footer/menu](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214402812247660?focus=true)

## Implementation

Removed the innovation proposals link from the footer and menu

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Footer
<img width="282" height="352" alt="Screenshot 2026-05-07 at 10 42 49 AM" src="https://github.com/user-attachments/assets/7d710b71-2424-4aa5-9b95-2da402f58c08" />

### Menu
<img width="274" height="201" alt="Screenshot 2026-05-07 at 10 42 42 AM" src="https://github.com/user-attachments/assets/7d6a66c5-926d-491f-b349-d40197d606e4" />



## How to test

http://localhost:4001/  - Confirm that the _Innovation Proposals_ link no longer appears in the _Work with Us_ section of the _About_ menu, and also doesn't appear in the _Work With Us_ section of the footer.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
