### PR TITLE
Crowding[A11Y]: Swap crowding icons for improved contrast

### DIFF
--- a/assets/css/_colors.scss
+++ b/assets/css/_colors.scss
@@ -130,9 +130,9 @@ $btn-primary-focus-color: $gray-dark;
 $btn-primary-focus-bg: $brand-primary-lightest;
 
 // Crowding
-$crowding-not-crowded: #14cc00;
-$crowding-not-crowded-bg: #d0f5cc;
-$crowding-some-crowding: #f90;
-$crowding-some-crowding-bg: #ffce85;
-$crowding-crowded: #e90d0d;
-$crowding-crowded-bg: #ffbfbf;
+$crowding-not-crowded: #1E8709;
+$crowding-not-crowded-bg: #E8EAEE;
+$crowding-some-crowding: #D67D00;
+$crowding-some-crowding-bg: #E8EAEE;
+$crowding-crowded: #C71A28;
+$crowding-crowded-bg: #E8EAEE;


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Swap crowding icons for improved contrast](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214394566780243?focus=true)

## Implementation

Turns out our crowding icons are actually just one icon and color is controlled by CSS, which made this much simpler to implement.  

- I adjusted the CSS values to the ones specified in the ticket, and it just worked.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Crowding icons on this branch
<img width="617" height="325" alt="Screenshot 2026-05-08 at 3 12 00 PM" src="https://github.com/user-attachments/assets/08776599-06e1-4f1c-99b6-d6323516cbe6" />


### Same bus on dev
<img width="638" height="380" alt="Screenshot 2026-05-08 at 3 12 11 PM" src="https://github.com/user-attachments/assets/cc069391-9c7c-42f7-a36f-31f156f13b46" />


## How to test

Find a busy bus and make sure the colors are darker and more contrasting compared to dev/prod.  One of these should work near rush-hour.

http://localhost:4001/departures/?route_id=28&direction_id=1&stop_id=place-nubn
http://localhost:4001/departures/?route_id=66&direction_id=1&stop_id=1319
http://localhost:4001/departures/?route_id=1&direction_id=0&stop_id=97

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
