### PR TITLE
fix: Don't cache `Green` and `Hinham/Hull` stops under the same key

### DIFF
--- a/lib/stops/repo.ex
+++ b/lib/stops/repo.ex
@@ -80,23 +80,25 @@ defmodule Stops.Repo do
 
   @impl Behaviour
   @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
-  def by_route(route_id, direction_id, opts \\ [])
+  def by_route(route_id, direction_id, opts \\ []) do
+    do_by_route(route_id, direction_id, opts)
+  end
 
   # Combine Green Line branch stops into one list for the "Green" route
-  def by_route("Green", direction_id, opts) do
+  defp do_by_route("Green", direction_id, opts) do
     by_routes(GreenLine.branch_ids(), direction_id, opts)
   end
 
   # Combine stops from Boat-F1 onto the Boat-F2H route.
   # Unfortunately by_routes recurses infinitely if we use it,
   # since it would just call this function again
-  def by_route("Boat-F2H", direction_id, opts) do
+  defp do_by_route("Boat-F2H", direction_id, opts) do
     with stops1 when is_list(stops1) <- Api.by_route({"Boat-F2H", direction_id, opts}) do
       (stops1 ++ by_route("Boat-F1", direction_id, opts)) |> Enum.uniq()
     end
   end
 
-  def by_route(route_id, direction_id, opts) do
+  defp do_by_route(route_id, direction_id, opts) do
     with stops when is_list(stops) <- Api.by_route({route_id, direction_id, opts}) do
       for stop <- stops do
         key = KeyGenerator.generate(__MODULE__, :stop, stop.id)

--- a/test/stops/repo_test.exs
+++ b/test/stops/repo_test.exs
@@ -189,6 +189,34 @@ defmodule Stops.RepoTest do
       assert response |> Enum.map(& &1.id) |> MapSet.new() ==
                [f1_stop_id, f2h_stop_id, shared_stop_id] |> MapSet.new()
     end
+
+    test "correctly segregates 'Green' and 'Boat-F2H' responses in the cache" do
+      f2h_stop_id = "Boat-F2H-#{Test.Support.FactoryHelpers.build(:id)}"
+      f2h_stop_item = build(:stop_item, id: f2h_stop_id)
+
+      green_stop_id = "Green-#{Test.Support.FactoryHelpers.build(:id)}"
+      green_stop_item = build(:stop_item, id: green_stop_id)
+
+      stub(MBTA.Api.Mock, :get_json, fn "/stops/", args ->
+        case args[:route] do
+          "Boat-F2H" -> %JsonApi{data: [f2h_stop_item]}
+          "Green-B" -> %JsonApi{data: [green_stop_item]}
+          _ -> %JsonApi{data: []}
+        end
+      end)
+
+      direction_id = Faker.Util.pick([0, 1])
+
+      response = by_route("Green", direction_id)
+
+      assert response |> Enum.map(& &1.id) |> MapSet.new() ==
+               [green_stop_id] |> MapSet.new()
+
+      response = by_route("Boat-F2H", direction_id)
+
+      assert response |> Enum.map(& &1.id) |> MapSet.new() ==
+               [f2h_stop_id] |> MapSet.new()
+    end
   end
 
   describe "by_routes/3" do


### PR DESCRIPTION
## Scope

No ticket, but a pretty silly bug, where [the ferry tab on the stations page](https://www.mbta.com/stops/ferry#ferry-tab) claims that the Hingham/Hull ferry visits all of the Green Line stops.

<img width="2514" height="1546" alt="Screenshot 2026-05-08 at 6 10 41 PM" src="https://github.com/user-attachments/assets/ff661455-e477-40d6-9c41-7aca38eb73da" />

## How to test / Why did this happen?

On `main`, in an iEX shell, run
```elixir
iex> Dotcom.Cache.Multilevel.flush(); Stops.Repo.by_route("Green", 0)
```

In the broken version, this seeds the cache key `Stops.Repo | :by_route | [0, []]`, and then [this page](http://localhost:4001/stops/ferry#ferry-tab) looks like the screenshot above. On this branch, the page in question looks right no matter what you do.

Why? Because apparently, if the `@cacheable` annotation is attached to a function, one of whose clauses has a pattern match, then the matched part of the pattern isn't passed to the `KeyGenerator` as part of its `args`. That is, if you call `by_route("Red", 0, [])`, then `["Red", 0, []]` is packaged up as `args` and sent to `KeyGenerator`, but if you call `by_route("Green", 0, [])`, then because ["Green" has a special pattern-match](https://github.com/mbta/dotcom/blob/b249152c18fbc18fd1887e2518deb2e74edd2ec0/lib/stops/repo.ex#L85-L88), `args` only contains `[0, []]`.

Because there are special pattern-matches for both ["Green"](https://github.com/mbta/dotcom/blob/b249152c18fbc18fd1887e2518deb2e74edd2ec0/lib/stops/repo.ex#L86-L88) and ["Boat-F2H"](https://github.com/mbta/dotcom/blob/b249152c18fbc18fd1887e2518deb2e74edd2ec0/lib/stops/repo.ex#L93-L97), those were both getting stored under the same cache key, leading to this highly amusing bug.

---

Oh also, without the fix, the test added in this PR fails like so:
```elixir
1) test by_route/3 correctly segregates 'Green' and 'Boat-F2H' responses in the cache (Stops.RepoTest)
     test/stops/repo_test.exs:193
     Assertion with == failed
     code:  assert response |> Enum.map(& &1.id) |> MapSet.new() == [f2h_stop_id] |> MapSet.new()
     left:  MapSet.new(["Green-sit-et-magni-aperiam"])
     right: MapSet.new(["Boat-F2H-eum-tempore-veniam-iusto-id"])
     stacktrace:
       test/stops/repo_test.exs:217: (test)
```