### PR TITLE
fix: 500 error on /cache page due to bad base64 decoding

### DIFF
--- a/lib/dotcom_web/controllers/cache_controller.ex
+++ b/lib/dotcom_web/controllers/cache_controller.ex
@@ -69,7 +69,6 @@ defmodule DotcomWeb.CacheController do
       _ ->
         %{type: :unstructured_keys}
     end
-    |> dbg()
   end
 
   defp parse_structured(_), do: %{type: :unstructured_keys}

--- a/lib/dotcom_web/controllers/cache_controller.ex
+++ b/lib/dotcom_web/controllers/cache_controller.ex
@@ -54,13 +54,23 @@ defmodule DotcomWeb.CacheController do
     |> Map.update!(:structured_keys, &nest_by_mod_and_fun/1)
   end
 
-  defp parse_structured([mod, fun, base_64_args]),
-    do: %{
-      type: :structured_keys,
-      mod: mod,
-      fun: fun,
-      args: base_64_args |> Base.decode64!()
-    }
+  defp parse_structured([mod, fun, base_64_args]) do
+    base_64_args
+    |> Base.decode64()
+    |> case do
+      {:ok, decoded} ->
+        %{
+          type: :structured_keys,
+          mod: mod,
+          fun: fun,
+          args: decoded
+        }
+
+      _ ->
+        %{type: :unstructured_keys}
+    end
+    |> dbg()
+  end
 
   defp parse_structured(_), do: %{type: :unstructured_keys}
 


### PR DESCRIPTION
## Scope

**Asana Ticket:** [QF | ArgumentError: non-alphabet character found: "-" (byte 45)](https://app.asana.com/1/15492006741476/project/555089885850811/task/1213836742803033?focus=true)

## Implementation

The cache page assumes that any cache key that's formatted a particular way has a certain section that is base-64 encoded, but that assumption isn't true for CMS cache keys. This fix treats a base-64 decoding error as a signal that the key is actually unstructured, thus allowing the cache page to be reached without 500 errors.

## How to test

Visiting certain schedule pages (e.g. [the Hingham/Hull Ferry one](http://localhost:4001/schedules/Boat-F2H/line)) seeds the cache with keys like `cms.repo|schedules|boat-f2h`. If you visit that page, and then visit [the cache page](http://localhost:4001/cache), then on `main`, the page will 500, and on this branch, it will load successfully.