### PR TITLE
QF | Remove pedal & park photo on station pages

### DIFF
--- a/lib/dotcom_web/components/stops/bike_amenity.html.heex
+++ b/lib/dotcom_web/components/stops/bike_amenity.html.heex
@@ -35,11 +35,6 @@
       date_time: @date_time
     )}
     <h2 class="text-xl mb-4">{~t"Facility Information"}</h2>
-    <.amenity_image
-      :if={:bike_storage_cage in @stop.bike_storage}
-      src="https://cdn.mbta.com/sites/default/files/styles/max_2600x2600/public/media/2020-07/bike-parking-back-bay.jpg"
-      alt={~t"MBTA Pedal and Park bike storage"}
-    />
     <ul>
       <li :if={:bike_storage_cage in @stop.bike_storage}>
         {~t"Free Pedal and Park secured parking"} ({~t"requires"}


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | Remove pedal & park photo on station pages](https://app.asana.com/1/15492006741476/project/555089885850811/task/1213794574581778?focus=true)

## Implementation

Removed the amenity image from the stop page pedal and park modal.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Prod
<img width="661" height="715" alt="Screenshot 2026-05-11 at 11 59 00 AM" src="https://github.com/user-attachments/assets/e34daec7-0ea0-42f0-bb61-533b46bfb7ac" />

### Local
<img width="667" height="382" alt="Screenshot 2026-05-11 at 11 58 35 AM" src="https://github.com/user-attachments/assets/11240e6a-a27d-42ec-9111-f58b4a85fbb1" />



## How to test

Go to any stop page with a pedal and park (http://localhost:4001/stops/place-sstat)  Confirm that the image of the pedal and park that doesn't exist anymore is gone.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
