### PR TITLE
 "Required" text near "Privacy Policy" checkbox is ambiguous/misleading

### DIFF
--- a/assets/css/_customer-support.scss
+++ b/assets/css/_customer-support.scss
@@ -47,6 +47,11 @@
     color: $brand-danger
   }
 
+  #privacy-error-indicator {
+    margin-top: -0.5em;
+    margin-bottom: 0.5em;
+  }
+
   .error-container {
     margin: 0 0 .5em;
   }


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿️👁️‍🗨️ "Required" text near "Privacy Policy" checkbox is ambiguous/misleading](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214395239522160?focus=true)

## Implementation


Tweaked the margins of the privacy error indicator to make visually clearer what input it's associated with.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Prod
<img width="504" height="213" alt="Screenshot 2026-05-11 at 1 00 26 PM" src="https://github.com/user-attachments/assets/d33eda02-5bd1-4c9e-9058-ae02441cee08" />

### Local
<img width="500" height="209" alt="Screenshot 2026-05-11 at 1 00 08 PM" src="https://github.com/user-attachments/assets/6a04ebe6-c1bc-4bcb-9e70-e720cebfc287" />


## How to test

http://localhost:4001/customer-support#customer_support

Submit the form without checking the privacy policy acknowledgement and confirm that its error message is noticeably closer to the _privacy_ input than the _receive email_ input

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
