### PR TITLE
WC[feat]: Update Foxboro Event Service from CR status summary

### DIFF
--- a/lib/dotcom_web/components/system_status/commuter_rail_status.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_status.ex
@@ -233,7 +233,7 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailStatus do
             if is_map(assigns.status.status) do
               assigns.status.rows
             else
-              [%{label: "Normal Service", icon_atom: :normal}]
+              [%{label: ~t"Normal Service", icon_atom: :normal}]
             end
           else
             [%{label: "No Scheduled Service", icon_atom: :no_scheduled_service}]

--- a/lib/dotcom_web/components/system_status/commuter_rail_status.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_status.ex
@@ -7,6 +7,7 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailStatus do
 
   import DotcomWeb.Components, only: [bordered_container: 1]
   import DotcomWeb.Components.SystemStatus.StatusIcon, only: [status_icon: 1]
+  import DotcomWeb.WorldCupTimetableLive, only: [match_day?: 0]
 
   alias Dotcom.SystemStatus.CommuterRail
 
@@ -212,7 +213,45 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailStatus do
 
   # For cases where we have alerts, we have to show the first alert along with route information
   # and then show subsequent rows without the route information.
+
+  defp rows_for_line(%{status: %{route_id: "CR-Foxboro"}} = assigns) do
+    match_status =
+      %{
+        name: "Boston Stadium Trains",
+        status:
+          if match_day?() do
+            if is_map(assigns.status.status) do
+              assigns.status.status
+            else
+              :normal
+            end
+          else
+            :no_scheduled_service
+          end,
+        rows:
+          if match_day?() do
+            if is_map(assigns.status.status) do
+              assigns.status.rows
+            else
+              [%{label: "Normal Service", icon_atom: :normal}]
+            end
+          else
+            [%{label: "No Scheduled Service", icon_atom: :no_scheduled_service}]
+          end,
+        url: "/schedules/bostonstadium",
+        route_id: "CR-Foxboro"
+      }
+
+    assigns = assigns |> assign(:status, match_status)
+
+    do_rows_for_line(assigns)
+  end
+
   defp rows_for_line(assigns) do
+    do_rows_for_line(assigns)
+  end
+
+  defp do_rows_for_line(assigns) do
     ~H"""
     <.row
       :for={

--- a/lib/dotcom_web/components/system_status/commuter_rail_status.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_status.ex
@@ -236,7 +236,7 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailStatus do
               [%{label: ~t"Normal Service", icon_atom: :normal}]
             end
           else
-            [%{label: "No Scheduled Service", icon_atom: :no_scheduled_service}]
+            [%{label: ~t"No Scheduled Service", icon_atom: :no_scheduled_service}]
           end,
         url: "/schedules/bostonstadium",
         route_id: "CR-Foxboro"

--- a/lib/dotcom_web/components/system_status/commuter_rail_status.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_status.ex
@@ -214,7 +214,7 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailStatus do
   # For cases where we have alerts, we have to show the first alert along with route information
   # and then show subsequent rows without the route information.
 
-  defp rows_for_line(%{status: %{route_id: "CR-Foxboro"}} = assigns) do
+  def rows_for_line(%{status: %{route_id: "CR-Foxboro"}} = assigns) do
     match_status =
       %{
         name: "Boston Stadium Trains",
@@ -247,7 +247,7 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailStatus do
     do_rows_for_line(assigns)
   end
 
-  defp rows_for_line(assigns) do
+  def rows_for_line(assigns) do
     do_rows_for_line(assigns)
   end
 

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -9,6 +9,7 @@ defmodule DotcomWeb.WorldCupTimetableLive do
   import DotcomWeb.WorldCupTimetable.MatchLink, only: [match_link: 1, selected_match_banner: 1]
 
   on_mount {DotcomWeb.Hooks.Breadcrumbs, :world_cup_timetable}
+  @date_time_module Application.compile_env!(:dotcom, :date_time_module)
 
   @match_list [
     {~D[2026-06-13], ~T[21:00:00], ~t"Match 5", [:haiti, :scotland],
@@ -70,7 +71,7 @@ defmodule DotcomWeb.WorldCupTimetableLive do
   ]
 
   def match_day?() do
-    date = Util.now()
+    date = @date_time_module.now()
     @match_list |> Enum.any?(fn {match_date, _, _, _, _} -> match_date == date end)
   end
 

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -69,6 +69,11 @@ defmodule DotcomWeb.WorldCupTimetableLive do
      ]}
   ]
 
+  def match_day?() do
+    date = Util.now()
+    @match_list |> Enum.any?(fn {match_date, _, _, _, _} -> match_date == date end)
+  end
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok,

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -71,7 +71,7 @@ defmodule DotcomWeb.WorldCupTimetableLive do
   ]
 
   def match_day?() do
-    date = @date_time_module.now()
+    date = Dotcom.Utils.ServiceDateTime.service_date(@date_time_module.now())
     @match_list |> Enum.any?(fn {match_date, _, _, _, _} -> match_date == date end)
   end
 

--- a/test/dotcom_web/components/system_status/commuter_rail_status_test.exs
+++ b/test/dotcom_web/components/system_status/commuter_rail_status_test.exs
@@ -4,7 +4,7 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
   import Dotcom.SystemStatus.CommuterRail, only: [commuter_rail_status: 0]
 
   import DotcomWeb.Components.SystemStatus.CommuterRailStatus,
-    only: [alerts_commuter_rail_status: 1]
+    only: [alerts_commuter_rail_status: 1, rows_for_line: 1]
 
   import Mox
   import Phoenix.LiveViewTest
@@ -612,6 +612,78 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
       # VERIFY
       assert html =~ "3 Service Alerts"
     end
+  end
+
+  test "Shows no service for CR-Foxboro on non-match days" do
+    expect(Dotcom.Utils.DateTime.Mock, :now, 2, fn ->
+      ~D[2027-01-01]
+    end)
+
+    assigns = %{
+      status: %{
+        route_id: "CR-Foxboro",
+        status: :no_scheduled_service,
+        rows: [%{label: "No Scheduled Service", icon_atom: :no_scheduled_service}]
+      }
+    }
+
+    html = render_component(&rows_for_line/1, assigns)
+
+    assert html =~ "No Scheduled Service"
+  end
+
+  test "Shows normal service for CR-Foxboro on match days" do
+    expect(Dotcom.Utils.DateTime.Mock, :now, 2, fn ->
+      ~D[2026-06-13]
+    end)
+
+    assigns = %{
+      status: %{
+        route_id: "CR-Foxboro",
+        status: :normal,
+        rows: [%{label: "Normal Service", icon_atom: :normal}]
+      }
+    }
+
+    html = render_component(&rows_for_line/1, assigns)
+
+    assert html =~ "Normal Service"
+  end
+
+  test "Shows alerts for CR-Foxboro on match days" do
+    expect(Dotcom.Utils.DateTime.Mock, :now, 2, fn ->
+      ~D[2026-06-13]
+    end)
+
+    assigns = %{
+      status: %{
+        route_id: "CR-Foxboro",
+        status: %{delays: []},
+        rows: [%{label: "Delayed Service", icon_atom: :normal}]
+      }
+    }
+
+    html = render_component(&rows_for_line/1, assigns)
+
+    assert html =~ "Delayed Service"
+  end
+
+  test "Shows no service for CR-Foxboro on non-match days with alerts (which shouldn't happen but...)" do
+    expect(Dotcom.Utils.DateTime.Mock, :now, 2, fn ->
+      ~D[2025-01-01]
+    end)
+
+    assigns = %{
+      status: %{
+        route_id: "CR-Foxboro",
+        status: %{delays: []},
+        rows: [%{label: "Delayed Service", icon_atom: :normal}]
+      }
+    }
+
+    html = render_component(&rows_for_line/1, assigns)
+
+    assert html =~ "No Scheduled Service"
   end
 
   defp direction_name(0), do: "Outbound"

--- a/test/dotcom_web/components/system_status/commuter_rail_status_test.exs
+++ b/test/dotcom_web/components/system_status/commuter_rail_status_test.exs
@@ -616,7 +616,7 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
 
   test "Shows no service for CR-Foxboro on non-match days" do
     expect(Dotcom.Utils.DateTime.Mock, :now, 2, fn ->
-      ~D[2027-01-01]
+      ~U[2027-01-01 12:00:00Z]
     end)
 
     assigns = %{
@@ -634,7 +634,7 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
 
   test "Shows normal service for CR-Foxboro on match days" do
     expect(Dotcom.Utils.DateTime.Mock, :now, 2, fn ->
-      ~D[2026-06-13]
+      ~U[2026-06-13 12:00:00Z]
     end)
 
     assigns = %{
@@ -652,7 +652,7 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
 
   test "Shows alerts for CR-Foxboro on match days" do
     expect(Dotcom.Utils.DateTime.Mock, :now, 2, fn ->
-      ~D[2026-06-13]
+      ~U[2026-06-13 12:00:00Z]
     end)
 
     assigns = %{
@@ -670,7 +670,7 @@ defmodule DotcomWeb.SystemStatus.CommuterRailStatusTest do
 
   test "Shows no service for CR-Foxboro on non-match days with alerts (which shouldn't happen but...)" do
     expect(Dotcom.Utils.DateTime.Mock, :now, 2, fn ->
-      ~D[2025-01-01]
+      ~U[2025-01-01 12:00:00Z]
     end)
 
     assigns = %{


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽️⚠️ Remove Foxboro Event Service from CR status summary](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214574388398226?focus=true)

## Implementation

Added a function that returns if its a match day or not.  Used that function as part of the logic for CR-Foxboro status summary overhaul for Boston Stadium Trains

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
<img width="825" height="89" alt="Screenshot 2026-05-11 at 3 18 16 PM" src="https://github.com/user-attachments/assets/a8936f43-adf6-4359-b1d2-d16598372be8" />



## How to test

Unit tests!


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
