### PR TITLE
WC: fix description list items flowing into each other

### DIFF
--- a/assets/css/_description-list.scss
+++ b/assets/css/_description-list.scss
@@ -6,9 +6,7 @@
 
 .dl--item {
   // added this because at larger breakpoints items float into different rows
-  @include media-breakpoint-up(md) {
-    clear: both;
-  }
+  clear: both;
 }
 
 .dt {


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽️ Fix tablet-sized layout on "What You Can Bring on Boston Stadium Trains" page](https://app.asana.com/1/15492006741476/project/385363666817452/task/1214777883134932?focus=true)

## Implementation
simply forces the sides of the `dl--item` to be clear. I don't think there are any cases where we wouldn't want this to happen, so I've simply removed the breakpoint for this style entirely.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
Before (Window width 624px) 
<img width="617" height="754" alt="image" src="https://github.com/user-attachments/assets/9a36754b-06bf-49f6-bbdc-8d72c2c23f97" />

After (same width)
<img width="618" height="798" alt="image" src="https://github.com/user-attachments/assets/3836a8c9-749e-4a43-a41f-6009b6f34afe" />

## How to test
Visit the [What You Can Bring on Boston Stadium Trains page](http://localhost:4001/security/what-you-can-bring-boston-stadium-trains) on this branch and check the appearance of the description list at different breakpoints. 

Would also be good to check other pages with description lists to make sure their behavior hasn't regressed; of the ones I'm aware of: 
- Fares: [local](http://localhost:4001/fares) | [prod](https://www.mbta.com/fares)
- Main menu, in the fares section on mobile and the right side at larger breakpoints, "Most Popular Fares" 
<img width="344" height="456" alt="image" src="https://github.com/user-attachments/assets/7d83f4e8-d693-4c9b-9604-05b885512f74" />
<img width="349" height="236" alt="image" src="https://github.com/user-attachments/assets/0228cca4-7d5b-45ff-b04e-6011295efdd4" />

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
