### PR TITLE
Add redirect from CR-Foxboro to Boston Stadium Trains page 

### DIFF
--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -203,6 +203,9 @@ defmodule DotcomWeb.Router do
       to: "/schedules/CR-NewBedford"
     )
 
+    # Redirect Foxboro line to World Cup Timetable Page for the World Cup (revert this later)
+    get("/schedules/CR-Foxboro/*path_params", Redirector, to: "/schedules/bostonstadium")
+
     get("/", PageController, :index)
     get("/menu", PageController, :menu)
 


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽️⚠️ Add redirect from CR-Foxboro to Boston Stadium Trains page ](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214574388398221?focus=true)

## Implementation

Added a temporary redirect from /schedules/CR-Foxboro to /schedules/bostonstadium


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A?

## How to test

http://localhost:4001/schedules/CR-Foxboro

Confirm the above link redirects to http://localhost:4001/schedules/bostonstadium

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
