### PR TITLE
WC [feat]: Change heading of Foxboro Event Service section on CR alerts page

### DIFF
--- a/lib/dotcom_web/views/alert_view.ex
+++ b/lib/dotcom_web/views/alert_view.ex
@@ -206,6 +206,10 @@ defmodule DotcomWeb.AlertView do
     ]
   end
 
+  def group_header_name(%Route{id: "CR-Foxboro"}) do
+    ["Boston Stadium Trains"]
+  end
+
   def group_header_name(%Route{name: name}) do
     [name]
   end


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽️⚠️ Change heading of Foxboro Event Service section on CR alerts page](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214574388398222?focus=true)

## Implementation

Added override to rename CR-Foxboro (Foxboro Event Service) header in Alerts to "Boston Stadium Trains"


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

<img width="810" height="491" alt="Screenshot 2026-05-13 at 3 55 53 PM" src="https://github.com/user-attachments/assets/d50d386d-c2e4-4e5f-87a3-91b441d94575" />


## How to test

http://localhost:4001/alerts/commuter-rail

Confirm that alerts for CR-Foxboro are shown under Boston Stadium Trains

(There needs to be an alert on the line for it to show up, you may have to switch dev environments or make one)

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
