### PR TITLE
WC[feat]: Add alerts to Boston Stadium Trains timetable

### DIFF
--- a/assets/css/_alerts.scss
+++ b/assets/css/_alerts.scss
@@ -359,8 +359,3 @@
     top: calc(#{$base-spacing} / 1.75);
   }
 }
-
-//World Cup alerts style tweak for wider pages.
-.wc-alerts {
-  width: 100%
-}

--- a/assets/css/_alerts.scss
+++ b/assets/css/_alerts.scss
@@ -360,3 +360,7 @@
   }
 }
 
+//World Cup alerts style tweak for wider pages.
+.wc-alerts {
+  width: 100%
+}

--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -154,12 +154,6 @@ defmodule Dotcom.Alerts do
     |> drop_empty_groups()
   end
 
-  def route_alerts(route_id) do
-    now = @date_time_module.now()
-
-    @alerts_repo_module.all(now) |> Enum.filter(fn alert -> route_alert?(alert, route_id) end)
-  end
-
   defp with_alert_lists(routes, alerts) do
     routes
     |> Enum.map(fn route ->

--- a/lib/dotcom/alerts.ex
+++ b/lib/dotcom/alerts.ex
@@ -154,6 +154,12 @@ defmodule Dotcom.Alerts do
     |> drop_empty_groups()
   end
 
+  def route_alerts(route_id) do
+    now = @date_time_module.now()
+
+    @alerts_repo_module.all(now) |> Enum.filter(fn alert -> route_alert?(alert, route_id) end)
+  end
+
   defp with_alert_lists(routes, alerts) do
     routes
     |> Enum.map(fn route ->

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -9,7 +9,10 @@ defmodule DotcomWeb.WorldCupTimetableLive do
   import DotcomWeb.WorldCupTimetable.MatchLink, only: [match_link: 1, selected_match_banner: 1]
 
   on_mount {DotcomWeb.Hooks.Breadcrumbs, :world_cup_timetable}
+  @alerts_repo Application.compile_env!(:dotcom, :repo_modules)[:alerts]
 
+  @date_time Application.compile_env!(:dotcom, :date_time_module)
+  @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
   @match_list [
     {~D[2026-06-13], ~T[21:00:00], ~t"Match 5", [:haiti, :scotland],
      [
@@ -71,10 +74,17 @@ defmodule DotcomWeb.WorldCupTimetableLive do
 
   @impl true
   def mount(_params, _session, socket) do
+    route = @routes_repo.get("CR-Foxboro")
+    alerts = Dotcom.Alerts.route_alerts(route.id)
+    dbg(alerts)
+
     {:ok,
      assign(socket, %{
        match_list: @match_list,
-       selected_match: nil
+       selected_match: nil,
+       date_time: @date_time.now(),
+       route: route,
+       alerts: alerts
      })}
   end
 

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -76,7 +76,6 @@ defmodule DotcomWeb.WorldCupTimetableLive do
   def mount(_params, _session, socket) do
     route = @routes_repo.get("CR-Foxboro")
     alerts = Dotcom.Alerts.route_alerts(route.id)
-    dbg(alerts)
 
     {:ok,
      assign(socket, %{

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -9,10 +9,11 @@ defmodule DotcomWeb.WorldCupTimetableLive do
   import DotcomWeb.WorldCupTimetable.MatchLink, only: [match_link: 1, selected_match_banner: 1]
 
   on_mount {DotcomWeb.Hooks.Breadcrumbs, :world_cup_timetable}
-  @alerts_repo Application.compile_env!(:dotcom, :repo_modules)[:alerts]
 
-  @date_time Application.compile_env!(:dotcom, :date_time_module)
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
+  @alerts_repo Application.compile_env!(:dotcom, :repo_modules)[:alerts]
+  @date_time Application.compile_env!(:dotcom, :date_time_module)
+
   @match_list [
     {~D[2026-06-13], ~T[21:00:00], ~t"Match 5", [:haiti, :scotland],
      [
@@ -74,8 +75,9 @@ defmodule DotcomWeb.WorldCupTimetableLive do
 
   @impl true
   def mount(_params, _session, socket) do
+    now = @date_time.now()
     route = @routes_repo.get("CR-Foxboro")
-    alerts = Dotcom.Alerts.route_alerts(route.id)
+    alerts = @alerts_repo.by_route_ids([route.id], now)
 
     {:ok,
      assign(socket, %{

--- a/lib/dotcom_web/live/world_cup_timetable_live.html.heex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.html.heex
@@ -20,6 +20,13 @@
     )
     |> raw()}
   </.callout_link>
+  <div class="wc-alerts">
+    {DotcomWeb.AlertView.group(
+      alerts: @alerts,
+      route: @route,
+      date_time: @date_time
+    )}
+  </div>
   <nav
     aria-label={~t"World Cup Matches"}
     class="w-full flex flex-col gap-4"

--- a/lib/dotcom_web/live/world_cup_timetable_live.html.heex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.html.heex
@@ -20,7 +20,7 @@
     )
     |> raw()}
   </.callout_link>
-  <div class="wc-alerts">
+  <div class="w-full">
     {DotcomWeb.AlertView.group(
       alerts: @alerts,
       route: @route,

--- a/lib/dotcom_web/live/world_cup_timetable_live.html.heex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.html.heex
@@ -20,7 +20,7 @@
     )
     |> raw()}
   </.callout_link>
-  <div class="w-full">
+  <div :if={Enum.any?(@alerts)} class="w-full">
     {DotcomWeb.AlertView.group(
       alerts: @alerts,
       route: @route,

--- a/test/dotcom_web/live/world_cup_timetable_live_test.exs
+++ b/test/dotcom_web/live/world_cup_timetable_live_test.exs
@@ -2,6 +2,7 @@ defmodule DotcomWeb.WorldCupTimetableLiveTest do
   use DotcomWeb.ConnCase, async: true
 
   import DotcomWeb.Router.Helpers, only: [live_path: 2, live_path: 3]
+  import Mox
 
   import Phoenix.LiveViewTest
 
@@ -9,6 +10,20 @@ defmodule DotcomWeb.WorldCupTimetableLiveTest do
 
   describe "WorldCupTimetableLive" do
     setup %{conn: conn} do
+      stub(Routes.Repo.Mock, :get, fn _ ->
+        Test.Support.Factories.Routes.Route.commuter_rail_route_factory(%{id: "CR-Foxboro"})
+      end)
+
+      datetime = Faker.DateTime.between(~D[2026-01-01], ~D[2026-12-30])
+
+      stub(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        datetime
+      end)
+
+      stub(Alerts.Repo.Mock, :all, fn _ ->
+        []
+      end)
+
       %{conn: logged_in_basic_auth(conn)}
     end
 

--- a/test/dotcom_web/live/world_cup_timetable_live_test.exs
+++ b/test/dotcom_web/live/world_cup_timetable_live_test.exs
@@ -20,7 +20,7 @@ defmodule DotcomWeb.WorldCupTimetableLiveTest do
         datetime
       end)
 
-      stub(Alerts.Repo.Mock, :all, fn _ ->
+      stub(Alerts.Repo.Mock, :by_route_ids, fn _, _ ->
         []
       end)
 


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽️⚠️ Add alerts to Boston Stadium Trains timetable](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214574388398220?focus=true)

## Implementation

Added function to get alerts for a route (now that I think about it, this may be wrong)
Added alerts for CR-Foxboro to the World Cup Timetable Page
Added some CSS so the alerts fit better on the World Cup Timetable Page
Updated test to mock out repos used by this new feature

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Wide
<img width="1108" height="317" alt="Screenshot 2026-05-14 at 1 45 22 PM" src="https://github.com/user-attachments/assets/5bca6560-6ffe-47d6-83fd-04ceb47363b8" />

### Narrow
<img width="495" height="354" alt="Screenshot 2026-05-14 at 1 47 53 PM" src="https://github.com/user-attachments/assets/3851fd73-8fe7-4871-bf38-6dd287a21370" />




## How to test

http://localhost:4001/schedules/bostonstadium

Confirm that the test alert shows as expected.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
