### PR TITLE
cleanup: Remove unused import in `AppStoreControllerTest`

### DIFF
--- a/test/dotcom_web/controllers/app_store_controller_test.exs
+++ b/test/dotcom_web/controllers/app_store_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule DotcomWeb.AppStoreControllerTest do
   use DotcomWeb.ConnCase, async: true
-  import Test.Support.EnvHelpers
 
   test "redirects to default mbta go project page by default, preserving params", %{conn: conn} do
     conn =


### PR DESCRIPTION
## Scope

This cleans up 👇 warning:
```elixir
    warning: unused import Test.Support.EnvHelpers
    │
  3 │   import Test.Support.EnvHelpers
    │   ~
    │
    └─ test/dotcom_web/controllers/app_store_controller_test.exs:3:3
```

No ticket.