### PR TITLE
Fix:  Franklin Shuttle Take 3

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -18,6 +18,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   @route_patterns_repo Application.compile_env!(:dotcom, :repo_modules)[:route_patterns]
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
   @loop_ferries ["Boat-F6", "Boat-F7"]
+  @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
 
   plug(DotcomWeb.Plugs.Route)
   plug(DotcomWeb.Plugs.DateInRating)
@@ -137,6 +138,84 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
         |> assign(:timetable_schedules, [])
         |> assign(:header_schedules, [])
     end
+  end
+
+  def assign_trip_schedules(
+        %{
+          assigns: %{
+            route: route,
+            blocking_alert: nil,
+            date: ~D[2026-06-13],
+            direction_id: direction_id
+          }
+        } = conn
+      )
+      when route.id == "CR-Franklin" do
+    shuttle_route = @routes_repo.get("Shuttle-CantonJunctionForgePark")
+
+    shuttle_schedules =
+      timetable_schedules(%{
+        assigns: %{
+          date: ~D[2026-06-13],
+          route: shuttle_route,
+          direction_id: direction_id
+        }
+      })
+
+    route_schedules =
+      timetable_schedules(%{
+        assigns: %{
+          date: ~D[2026-06-13],
+          route: route,
+          direction_id: direction_id
+        }
+      })
+
+    timetable_schedules =
+      route_schedules ++ shuttle_schedules
+
+    trip_ids = Enum.map(timetable_schedules, & &1.trip.id)
+
+    %{
+      trip_schedules: route_schedules,
+      trip_stops: route_stops
+    } = build_timetable(conn, route_schedules)
+
+    %{
+      trip_schedules: shuttle_schedules,
+      trip_stops: shuttle_stops
+    } =
+      build_timetable(
+        %{assigns: %{route: shuttle_route, direction_id: direction_id}},
+        shuttle_schedules
+      )
+
+    trip_schedules = Map.merge(route_schedules, shuttle_schedules)
+
+    trip_stops =
+      shuttle_stops |> Enum.reduce(route_stops, &merge_into_stop_list(&1, &2, direction_id == 1))
+
+    header_schedules =
+      trip_schedules
+      |> Map.values()
+      |> Kernel.then(&header_schedules(route, &1))
+
+    track_changes = track_changes(trip_schedules, Enum.map(trip_stops, & &1.id))
+
+    header_stops =
+      trip_stops
+      |> Enum.map(&@stops_repo.get_parent/1)
+      |> Enum.uniq()
+      |> Enum.with_index()
+
+    conn
+    |> assign(:timetable_schedules, timetable_schedules)
+    |> assign(:offset, find_offset(timetable_schedules, conn.assigns.date_time))
+    |> assign(:header_schedules, header_schedules)
+    |> assign(:header_stops, header_stops)
+    |> assign(:trip_schedules, trip_schedules)
+    |> assign(:track_changes, track_changes)
+    |> assign(:trip_messages, trip_messages(route, direction_id, trip_ids))
   end
 
   def assign_trip_schedules(
@@ -548,17 +627,21 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     "Boat-Long-North-5A" => {:after, "Rowes Wharf"},
     "Boat-Long-North-5B" => {:after, "Lewis Mall Wharf"},
     "Boat-Long-North-5C" => {:after, "Blossom Street Pier"},
-    # Franklin/Foxboro WC shuttle
-    "place-NEC-2139" => {:before, "Readville"},
-    "91637" => {:before, "Canton Juntion"},
-    "71689" => {:before, "Canton Juntion"},
-    "81668" => {:after, "Walpole"},
-    "81698" => {:after, "Walpole"},
-    "39213" => {:after, "Norfolk"},
-    "92133" => {:after, "Norfolk"},
-    "31331" => {:after, "Franklin"},
-    "31330" => {:after, "Franklin"},
-    "place-FB-0303" => {:after, "Forge Park/495"}
+    # ----Franklin/Foxboro WC shuttle----
+    # Franklin Station - Bus Shuttle
+    "31330" => {:after, "Forge Park/495"},
+    "31331" => {:after, "Forge Park/495"},
+    # Norfolk Station - Bus Shuttle
+    "92133" => {:after, "Franklin Station - Bus Shuttle"},
+    "39213" => {:after, "Franklin Station - Bus Shuttle"},
+    # Walpole Station - Bus Shuttle
+    "81668" => {:after, "Norfolk Station - Bus Shuttle"},
+    "81698" => {:after, "Norfolk Station - Bus Shuttle"},
+    # Washington Street
+    "91637" => {:before, "Canton Junction"},
+    "71689" => {:before, "Canton Junction"},
+    # Canton Junction
+    "place-NEC-2139" => {:before, "Readville"}
   }
   @shuttle_ids Map.keys(@shuttle_overrides)
 

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -219,6 +219,47 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   end
 
   def assign_trip_schedules(
+        %{
+          assigns: %{
+            route: route,
+            blocking_alert: nil,
+            direction_id: direction_id
+          }
+        } = conn
+      )
+      when route.id == "CR-Franklin" do
+    timetable_schedules = timetable_schedules(conn)
+    trip_ids = Enum.map(timetable_schedules, & &1.trip.id)
+
+    %{
+      trip_schedules: trip_schedules,
+      trip_stops: trip_stops
+    } = build_timetable(conn, timetable_schedules)
+
+    header_schedules =
+      trip_schedules
+      |> Map.values()
+      |> Kernel.then(&header_schedules(route, &1))
+
+    track_changes = track_changes(trip_schedules, Enum.map(trip_stops, & &1.id))
+    # Filter out Canton Junction on non shuttle days
+    header_stops =
+      trip_stops
+      |> Enum.map(&@stops_repo.get_parent/1)
+      |> Enum.filter(fn %Stops.Stop{id: id} -> id != "place-NEC-2139" end)
+      |> Enum.with_index()
+
+    conn
+    |> assign(:timetable_schedules, timetable_schedules)
+    |> assign(:offset, find_offset(timetable_schedules, conn.assigns.date_time))
+    |> assign(:header_schedules, header_schedules)
+    |> assign(:header_stops, header_stops)
+    |> assign(:trip_schedules, trip_schedules)
+    |> assign(:track_changes, track_changes)
+    |> assign(:trip_messages, trip_messages(route, direction_id, trip_ids))
+  end
+
+  def assign_trip_schedules(
         %{assigns: %{route: route, blocking_alert: nil, date_in_rating?: true}} = conn
       )
       when route.id in @loop_ferries do
@@ -638,8 +679,8 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     "81668" => {:after, "Norfolk Station - Bus Shuttle"},
     "81698" => {:after, "Norfolk Station - Bus Shuttle"},
     # Washington Street
-    "91637" => {:before, "Canton Junction"},
-    "71689" => {:before, "Canton Junction"},
+    "91637" => {:after, "Walpole Station - Bus Shuttle"},
+    "71689" => {:after, "Walpole Station - Bus Shuttle"},
     # Canton Junction
     "place-NEC-2139" => {:before, "Readville"}
   }


### PR DESCRIPTION
Schedule changes on dev-blue broke how we were injecting the shuttle stops, I re-added the manual schedule merge code I wrote earlier in this work.

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

~~**Asana Ticket:** [TICKET_NAME](TICKET_LINK)~~

https://mbta.slack.com/archives/C076FBBC21K/p1778593783010819

## Implementation

Unreverted code that manually merged in the franklin shuttle stops, adjusted the shuttle ordering LUT to accomidate the removed stops.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

<img width="1095" height="600" alt="Screenshot 2026-05-15 at 1 42 48 PM" src="https://github.com/user-attachments/assets/0809df02-cc86-4043-9010-f1961c46906b" />
<img width="1102" height="600" alt="Screenshot 2026-05-15 at 1 42 35 PM" src="https://github.com/user-attachments/assets/4b1e7327-8cb7-4778-936a-8858ecd710a4" />


## How to test

http://localhost:4001/schedules/CR-Franklin/timetable?date=2026-06-13&schedule_direction[direction_id]=0#direction-filter

With dev-blue data

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
