### PR TITLE
WC[feat]: Add World Cup Guide to the main menu

### DIFF
--- a/lib/dotcom_web/views/layout_view.ex
+++ b/lib/dotcom_web/views/layout_view.ex
@@ -97,6 +97,7 @@ defmodule DotcomWeb.LayoutView do
           %{
             sub_menu_section: ~t(Plan Your Journey),
             links: [
+              {~t(World Cup Guide), "/schedules/bostonstadium", :internal_link},
               {~t(Trip Planner), "/trip-planner", :internal_link},
               {~t(Service Alerts), "/alerts", :internal_link},
               {~t(Sign Up for Service Alerts), "https://alerts.mbta.com/", :external_link},
@@ -228,6 +229,23 @@ defmodule DotcomWeb.LayoutView do
         ]
       }
     ]
+
+  def render_nav_link({link_name, href = "/schedules/bostonstadium", _}) do
+    icon =
+      content_tag(:img, "",
+        src: "/icon-svg/football.svg",
+        class: "icon-small-inline -top-[0.125em]"
+      )
+
+    link_content = [content_tag(:div, [icon, content_tag(:span, link_name)])]
+    attrs = ["data-nav": "link", href: href, class: "m-menu__link"]
+
+    content_tag(
+      :a,
+      link_content,
+      attrs
+    )
+  end
 
   def render_nav_link({link_name, href, link_host}) do
     link_content =


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽️ Add World Cup Guide to the main menu](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214427583552348?focus=true)

## Implementation

- Added the world cup guide to the main menu.  
- Added a function override to render the little soccer ball icon!


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Desktop
<img width="747" height="335" alt="Screenshot 2026-05-18 at 12 23 44 PM" src="https://github.com/user-attachments/assets/5e99c2fc-8f30-4583-9fac-32cbdf93912b" />

### Mobile
<img width="315" height="445" alt="Screenshot 2026-05-18 at 12 24 04 PM" src="https://github.com/user-attachments/assets/4afafe4b-3b5a-46b9-ad20-4832799d97cc" />

### Mobile Thin
<img width="303" height="407" alt="Screenshot 2026-05-18 at 12 24 17 PM" src="https://github.com/user-attachments/assets/f1c24d3d-2e2b-4b66-8ba6-191dfb716d7f" />

### Large font
<img width="275" height="114" alt="Screenshot 2026-05-18 at 12 24 53 PM" src="https://github.com/user-attachments/assets/40c8a4e3-5c2b-4567-bc76-032f175ac07c" />

### Tiny font
<img width="104" height="37" alt="Screenshot 2026-05-18 at 12 25 07 PM" src="https://github.com/user-attachments/assets/1a2c1497-beed-49dd-b35b-bd1625ff0f2c" />





## How to test

http://localhost:4001/ or any other page on this branch
Check the main menu and ensure that the World Cup Guide link is in the right place, links to the right page, and looks good on all screens and configs.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
