### PR TITLE
Ferry[fix]: Add George's Island to the list of F2H stops

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -429,6 +429,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     "Boat-F2H" => [
       "Boat-Hingham",
       "Boat-Hull",
+      "Boat-George",
       "Boat-Logan",
       "Boat-Rowes",
       "Boat-Long"


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

~~**Asana Ticket:** [TICKET_NAME](TICKET_LINK)~~
https://mbta.slack.com/archives/C076FBBC21K/p1779129911512189

## Implementation

Service is back to Geroge's Island!  Put Boat-George back in the list of Boat-F2H stops on the timetable controller.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
<img width="1103" height="359" alt="Screenshot 2026-05-18 at 2 58 17 PM" src="https://github.com/user-attachments/assets/d4465873-e3ac-4588-a959-03ca7bb477ef" />



## How to test

**Set environment to point at dev-green**

http://localhost:4001/schedules/Boat-F2H/timetable?date=2026-05-24&schedule_direction%5Bdirection_id%5D=0#direction-filter

Confirm that George's Island is in the timetable in the right location during the weekend, but does not show on days when there is no service.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
