### PR TITLE
fix: Subway status handling for multiple skipped stop alerts

### DIFF
--- a/lib/dotcom/alerts/affected_stops.ex
+++ b/lib/dotcom/alerts/affected_stops.ex
@@ -20,25 +20,34 @@ defmodule Dotcom.Alerts.AffectedStops do
 
   @impl Behaviour
   def affected_stops(alerts, route_ids) do
-    stop_ids = alerts |> get_all_entities(:stop)
+    alerts
+    |> Stream.flat_map(fn alert -> affected_stops_for_alert(alert, route_ids) end)
+    |> Enum.group_by(& &1.stop.id)
+    |> Enum.map(fn {_stop_id, affected_stops} -> affected_stops |> combine_directions() end)
+  end
 
-    direction_ids = alerts |> get_all_direction_ids()
+  defp affected_stops_for_alert(alert, route_ids) do
+    affected_stop_ids = alert |> Alert.get_entity(:stop)
 
+    alert
+    |> Alert.get_entity(:direction_id)
+    |> Enum.flat_map(&convert_nil_to_all/1)
+    |> Enum.uniq()
+    |> outer_product(route_ids)
+    |> Enum.flat_map(fn {direction_id, route_id} ->
+      affected_stops_along_route(route_id, direction_id, affected_stop_ids)
+    end)
+  end
+
+  defp affected_stops_along_route(route_id, direction_id, affected_stop_ids) do
     direction_names =
-      route_ids
-      |> List.first()
+      route_id
       |> @routes_repo.get()
       |> Kernel.then(& &1.direction_names)
 
-    route_ids
-    |> outer_product(direction_ids)
-    |> Enum.flat_map(fn {route_id, direction_id} ->
-      @stops_repo.by_route(route_id, direction_id)
-      |> Enum.filter(&(stop_ids |> MapSet.member?(&1.id)))
-      |> Enum.map(&%{stop: &1, direction: {:direction, direction_names |> Map.get(direction_id)}})
-    end)
-    |> Enum.group_by(& &1.stop.id)
-    |> Enum.map(fn {_stop_id, affected_stops} -> affected_stops |> combine_directions() end)
+    @stops_repo.by_route(route_id, direction_id)
+    |> Enum.filter(&(affected_stop_ids |> MapSet.member?(&1.id)))
+    |> Enum.map(&%{stop: &1, direction: {:direction, direction_names |> Map.get(direction_id)}})
   end
 
   defp combine_directions(affected_stops) do
@@ -50,16 +59,8 @@ defmodule Dotcom.Alerts.AffectedStops do
     end
   end
 
-  @spec get_all_direction_ids([Alerts.Alert.t()]) :: [0 | 1]
-  defp get_all_direction_ids(alerts) do
-    alerts
-    |> get_all_entities(:direction_id)
-    |> Enum.reject(&Kernel.is_nil/1)
-    |> case do
-      [] -> [0, 1]
-      direction_ids -> direction_ids
-    end
-  end
+  defp convert_nil_to_all(nil), do: [0, 1]
+  defp convert_nil_to_all(direction_id), do: [direction_id]
 
   defp get_all_entities(alerts, type) do
     alerts

--- a/livebooks/reusable/alerts.livemd
+++ b/livebooks/reusable/alerts.livemd
@@ -250,6 +250,164 @@ now() |> Alerts.Repo.all()
 
 <!-- livebook:{"branch_parent_index":1} -->
 
+## Tappan Street Closures (Time-based, now)
+
+```elixir
+alerts = [
+  Alert.build(:alert,
+    active_period: [
+      {
+        Timex.parse!("2026-05-18T03:00:00-04:00", "{ISO:Extended}"),
+        Timex.parse!("2026-06-13T02:59:59-04:00", "{ISO:Extended}")
+      }
+    ],
+    header:
+      "Tappan Street will be closed from Monday, May 18 through Friday, June 12 due to maintenance work on the C branch. Riders can board or exit trains one stop away, at either Washington Square or Dean Road.",
+    effect: :station_closure,
+    informed_entity:
+      Alerts.InformedEntitySet.new([
+        InformedEntity.build(:informed_entity,
+          activities: MapSet.new([:exit, :ride, :board]),
+          direction_id: nil,
+          route: "Green-C",
+          route_type: 0,
+          stop: "place-tapst",
+          trip: nil
+        )
+      ]),
+    severity: 7,
+    priority: :high,
+    lifecycle: :new,
+    banner: nil
+  ),
+  Alert.build(:alert,
+    active_period: [
+      {
+        Timex.parse!("2026-06-13T03:00:00-04:00", "{ISO:Extended}"),
+        Timex.parse!("2026-07-11T02:59:59-04:00", "{ISO:Extended}")
+      }
+    ],
+    header:
+      "Green Line C Branch: Due to infrastructure upgrades, outbound trains will bypass Tappan Street Monday, May 18 through Friday, July 10. Passengers can instead board or disembark one stop away at Washington Square or Dean Road.",
+    effect: :station_closure,
+    informed_entity:
+      Alerts.InformedEntitySet.new([
+        InformedEntity.build(:informed_entity,
+          activities: MapSet.new([:exit, :ride, :board]),
+          direction_id: 0,
+          route: "Green-C",
+          route_type: 0,
+          stop: "place-tapst",
+          trip: nil
+        )
+      ]),
+    severity: 7,
+    priority: :high,
+    lifecycle: :new,
+    banner: nil
+  ),
+  Alert.build(:alert,
+    active_period: [
+      {
+        Timex.parse!("2026-05-18T03:00:00-04:00", "{ISO:Extended}"),
+        Timex.parse!("2026-07-11T02:59:59-04:00", "{ISO:Extended}")
+      }
+    ],
+    header:
+      "Green Line C Branch: Due to maintenance work, outbound trains will bypass Englewood Avenue Monday, May 18 through Friday, July 10. Passengers can instead board or disembark one stop away at Cleveland Circle or Dean Road.",
+    effect: :station_closure,
+    informed_entity:
+      Alerts.InformedEntitySet.new([
+        InformedEntity.build(:informed_entity,
+          activities: MapSet.new([:exit, :ride, :board]),
+          direction_id: 0,
+          route: "Green-C",
+          route_type: 0,
+          stop: "place-engav",
+          trip: nil
+        )
+      ]),
+    severity: 7,
+    priority: :high,
+    lifecycle: :new,
+    banner: nil
+  )
+]
+
+# Remove all other alerts and only use the one's you created
+Alerts.Cache.Store.update(alerts, nil)
+
+now() |> Alerts.Repo.all()
+```
+
+<!-- livebook:{"branch_parent_index":1} -->
+
+## Tappan Street Closures (later, with Englewood completely closed)
+
+```elixir
+alerts = [
+  Alert.build(:alert,
+    active_period: [
+      {
+        Timex.parse!("2026-05-18T03:00:00-04:00", "{ISO:Extended}"),
+        Timex.parse!("2026-07-11T02:59:59-04:00", "{ISO:Extended}")
+      }
+    ],
+    header:
+      "Green Line C Branch: Due to infrastructure upgrades, outbound trains will bypass Tappan Street Monday, May 18 through Friday, July 10. Passengers can instead board or disembark one stop away at Washington Square or Dean Road.",
+    effect: :station_closure,
+    informed_entity:
+      Alerts.InformedEntitySet.new([
+        InformedEntity.build(:informed_entity,
+          activities: MapSet.new([:exit, :ride, :board]),
+          direction_id: 0,
+          route: "Green-C",
+          route_type: 0,
+          stop: "place-tapst",
+          trip: nil
+        )
+      ]),
+    severity: 7,
+    priority: :high,
+    lifecycle: :new,
+    banner: nil
+  ),
+  Alert.build(:alert,
+    active_period: [
+      {
+        Timex.parse!("2026-05-18T03:00:00-04:00", "{ISO:Extended}"),
+        Timex.parse!("2026-07-11T02:59:59-04:00", "{ISO:Extended}")
+      }
+    ],
+    header:
+      "Green Line C Branch: Due to maintenance work, all trains will bypass Englewood Avenue Monday, May 18 through Friday, July 10. Passengers can instead board or disembark one stop away at Cleveland Circle or Dean Road.",
+    effect: :station_closure,
+    informed_entity:
+      Alerts.InformedEntitySet.new([
+        InformedEntity.build(:informed_entity,
+          activities: MapSet.new([:exit, :ride, :board]),
+          direction_id: nil,
+          route: "Green-C",
+          route_type: 0,
+          stop: "place-engav",
+          trip: nil
+        )
+      ]),
+    severity: 7,
+    priority: :high,
+    lifecycle: :new,
+    banner: nil
+  )
+]
+
+# Remove all other alerts and only use the one's you created
+Alerts.Cache.Store.update(alerts, nil)
+
+now() |> Alerts.Repo.all()
+```
+
+<!-- livebook:{"branch_parent_index":1} -->
+
 ## Two Red Line Stations Skipped
 
 ```elixir

--- a/test/dotcom/alerts/affected_stops_test.exs
+++ b/test/dotcom/alerts/affected_stops_test.exs
@@ -83,12 +83,10 @@ defmodule Dotcom.Alerts.AffectedStopsTest do
         Route.build(:route, direction_names: %{direction_id => direction_name})
       end)
 
-      informed_entities = stops |> Enum.map(&%InformedEntity{stop: &1.id})
+      informed_entities =
+        stops |> Enum.map(&%InformedEntity{stop: &1.id, direction_id: direction_id})
 
-      alert =
-        Alert.new(
-          informed_entity: informed_entities ++ [%InformedEntity{direction_id: direction_id}]
-        )
+      alert = Alert.new(informed_entity: informed_entities)
 
       # Exercise
       queried_route_ids = build_random_size_id_list() ++ [route_id] ++ build_random_size_id_list()
@@ -181,6 +179,170 @@ defmodule Dotcom.Alerts.AffectedStopsTest do
       total_stops_count = (stops1 ++ stops2 ++ overlap_stops) |> Enum.count()
       assert affected_stops_count == total_stops_count
     end
+
+    test "reports a direction of `:all` when given multiple different direction ID's from the same alert" do
+      # Setup
+      route_id = FactoryHelpers.build(:id)
+
+      affected_stops = build_random_size_non_empty_stop_list()
+
+      Stops.Repo.Mock
+      |> stub(:by_route, fn
+        ^route_id, _direction_id ->
+          build_random_size_stop_list() ++ affected_stops ++ build_random_size_stop_list()
+
+        _, _direction_id ->
+          build_random_size_stop_list()
+      end)
+
+      informed_entities =
+        affected_stops
+        |> Enum.flat_map(
+          &[
+            %InformedEntity{stop: &1.id, direction_id: 0},
+            %InformedEntity{stop: &1.id, direction_id: 1}
+          ]
+        )
+
+      alert = Alert.new(informed_entity: informed_entities)
+
+      # Exercise
+      affected_stops = AffectedStops.affected_stops([alert], [route_id])
+
+      # Verify
+      assert affected_stops |> Enum.map(& &1.direction) ==
+               1..(affected_stops |> Enum.count()) |> Enum.map(fn _ -> :all end)
+    end
+
+    test "reports a direction of `:all` when given multiple different direction ID's from different alerts" do
+      # Setup
+      route_id = FactoryHelpers.build(:id)
+
+      affected_stops = build_random_size_non_empty_stop_list()
+
+      Stops.Repo.Mock
+      |> stub(:by_route, fn
+        ^route_id, _direction_id ->
+          build_random_size_stop_list() ++ affected_stops ++ build_random_size_stop_list()
+
+        _, _direction_id ->
+          build_random_size_stop_list()
+      end)
+
+      informed_entities0 =
+        affected_stops |> Enum.map(&%InformedEntity{stop: &1.id, direction_id: 0})
+
+      alert0 = Alert.new(informed_entity: informed_entities0)
+
+      informed_entities1 =
+        affected_stops |> Enum.map(&%InformedEntity{stop: &1.id, direction_id: 1})
+
+      alert1 = Alert.new(informed_entity: informed_entities1)
+
+      # Exercise
+      affected_stops = AffectedStops.affected_stops([alert0, alert1], [route_id])
+
+      # Verify
+      assert affected_stops |> Enum.map(& &1.direction) ==
+               1..(affected_stops |> Enum.count()) |> Enum.map(fn _ -> :all end)
+    end
+
+    test "reports a direction of `:all` when given a `nil` direction ID plus anything else" do
+      # Setup
+      direction_id = Faker.Util.pick([0, 1])
+      route_id = FactoryHelpers.build(:id)
+
+      affected_stops = build_random_size_non_empty_stop_list()
+
+      Stops.Repo.Mock
+      |> stub(:by_route, fn
+        ^route_id, _direction_id ->
+          build_random_size_stop_list() ++ affected_stops ++ build_random_size_stop_list()
+
+        _, _direction_id ->
+          build_random_size_stop_list()
+      end)
+
+      informed_entities1 =
+        affected_stops |> Enum.map(&%InformedEntity{stop: &1.id, direction_id: direction_id})
+
+      informed_entities2 =
+        affected_stops |> Enum.map(&%InformedEntity{stop: &1.id, direction_id: nil})
+
+      alert1 = Alert.new(informed_entity: informed_entities1)
+      alert2 = Alert.new(informed_entity: informed_entities2)
+
+      # Exercise
+      affected_stops = AffectedStops.affected_stops([alert1, alert2], [route_id])
+
+      # Verify
+      assert affected_stops |> Enum.map(& &1.direction) ==
+               1..(affected_stops |> Enum.count()) |> Enum.map(fn _ -> :all end)
+    end
+
+    test "reports different directions for different stops" do
+      # Setup
+      route_id = FactoryHelpers.build(:id)
+
+      [bypass_direction_id, other_direction_id] =
+        Faker.Util.sample_uniq(2, fn -> Faker.Util.pick([0, 1]) end)
+
+      [bypassed_stop, closed_stop] = Stop.build_list(2, :stop)
+
+      Stops.Repo.Mock
+      |> stub(:by_route, fn
+        ^route_id, _direction_id ->
+          build_random_size_stop_list() ++
+            [bypassed_stop] ++
+            build_random_size_stop_list() ++
+            [closed_stop] ++
+            build_random_size_stop_list()
+
+        _, _direction_id ->
+          build_random_size_stop_list()
+      end)
+
+      [bypass_direction_name, other_direction_name] =
+        Faker.Util.sample_uniq(2, fn -> Faker.Cat.breed() end)
+
+      Routes.Repo.Mock
+      |> stub(:get, fn
+        _ ->
+          Route.build(:route,
+            direction_names: %{
+              bypass_direction_id => bypass_direction_name,
+              other_direction_id => other_direction_name
+            }
+          )
+      end)
+
+      bypass_alert =
+        Alert.new(
+          informed_entity: [
+            %InformedEntity{stop: bypassed_stop.id, direction_id: bypass_direction_id}
+          ]
+        )
+
+      closure_alert =
+        Alert.new(
+          informed_entity: [
+            %InformedEntity{stop: closed_stop.id}
+          ]
+        )
+
+      # Exercise
+      queried_route_ids = build_random_size_id_list() ++ [route_id] ++ build_random_size_id_list()
+
+      affected_stops =
+        AffectedStops.affected_stops([bypass_alert, closure_alert], queried_route_ids)
+
+      # Verify
+      assert affected_stops |> Enum.map(& &1.direction) |> MapSet.new() ==
+               MapSet.new([
+                 {:direction, bypass_direction_name},
+                 :all
+               ])
+    end
   end
 
   describe "affected_stops/1" do
@@ -207,10 +369,10 @@ defmodule Dotcom.Alerts.AffectedStopsTest do
     end
   end
 
-  defp build_random_size_stop_list(), do: Stop.build_list(Faker.random_between(0, 10), :stop)
+  defp build_random_size_stop_list(), do: Stop.build_list(Faker.random_between(0, 3), :stop)
 
   defp build_random_size_id_list() do
-    count = Faker.random_between(0, 10)
+    count = Faker.random_between(0, 2)
     FactoryHelpers.build_list(count, :id)
   end
 


### PR DESCRIPTION
## Scope

**Asana Ticket:** [In status, handle when there's separate alerts for inbound/outbound stop closures at same time](https://app.asana.com/1/15492006741476/project/385363666817452/task/1214905054024584?focus=true)

This fixes two bugs:
- When a station closure and a unidirectional bypass are active at the same time, they should be combined on the homepage to show that the whole station is closed - e.g. `Stop Skipped: Tappan Street`, but they're instead being combined to show the unidirectional one - `Stop Skipped: Tappen Street (Westbound)`.
  - This only affects the Green line because [we add direction ID's to alerts differently for light rail versus heavy rail](https://github.com/mbta/dotcom/blob/dd08be281e7095548eb29863fcc6e9c380e21bec/lib/alerts/alert.ex#L157-L172).
- When there are bypasses and/or station closures affecting different stops on the same route, all affected directions are attached to all affected stops, rather than having each stop get its own affected direction.

<img width="2612" height="880" alt="Screenshot 2026-05-18 at 4 39 20 PM" src="https://github.com/user-attachments/assets/59200037-7979-433c-b51f-cdc74ee28cac" />

This (dev-blue [alerts page](https://dev-blue.mbtace.com/alerts/subway) on the left; [homepage](https://dev-blue.mbtace.com/) on the right) shows both bugs in action. For the two alerts on the Green Line, the bidirectional alert at Coolidge Corner gets combined with the unidirectional alert at Tappan Street into just the Westbound direction, which is what shows on homepage status (right). For the two Orange Line alerts, it's the same phenomenon, except that the bidirectional and unidirectional alerts combine into "Both Directions" for _both_ stations (which then gets hidden, because "Both Directions" only shows when there are also unidirectional alerts).

## Implementation

- In `affected_stops`, instead of pulling all direction ID's at the beginning, pull stop / direction ID combos per-alert, and then combine them at the very end.

## Screenshots

### dev-blue
<img width="3006" height="1070" alt="Screenshot 2026-05-18 at 9 49 42 PM" src="https://github.com/user-attachments/assets/16e9398c-6e9e-4686-a62d-5ea705fcc172" />
The above scenario on dev-blue (middle), and this branch (right), along with the expanded display on the [dev-blue subway alerts page](https://dev-blue.mbtace.com/alerts/subway), which shows how closely the summary matches the actual alerts.

### prod
<img width="3000" height="984" alt="Screenshot 2026-05-18 at 9 57 34 PM" src="https://github.com/user-attachments/assets/2c07cd86-9cfe-4d5d-aed7-563ba22dfaf5" />
Current real-world data.

## How to test
Look at this branch against the prod API, and observe that Englewood is shown as `Westbound`, while Tappan Street is shown as `Both Directions`... in prod, right now both are shown implicitly as `Both Directions`.

Look at this branch against the dev-blue API, and compare against the screenshots above.
