### PR TITLE
fix(tooltips): tooltip hover triangle 

### DIFF
--- a/assets/css/_bootstrap.scss
+++ b/assets/css/_bootstrap.scss
@@ -68,3 +68,19 @@
     max-width: 70vw;
   }
 }
+
+// Persistent tooltips for line diagrams
+.m-schedule-diagram [data-toggle='tooltip'] {
+  &:has(.c-icon__bus-pill--small)::before,
+  &:has(.m-schedule-diagram__feature-icon)::before {
+    margin-left: calc($base-spacing / 4);
+  }
+
+  &::before {
+    content: " ";
+    position: absolute;
+    margin-top: 1rem;
+    height: $base-spacing;
+    width: $base-spacing;
+  }
+}

--- a/assets/css/_bootstrap.scss
+++ b/assets/css/_bootstrap.scss
@@ -70,8 +70,8 @@
 }
 
 .tooltip::before {
-  content: "";
-  position: absolute;
-  inset: -0.5rem 0 1.5rem 0;
   clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  content: '';
+  inset: -.5rem 0 1.5rem 0;
+  position: absolute;
 }

--- a/assets/css/_bootstrap.scss
+++ b/assets/css/_bootstrap.scss
@@ -73,6 +73,5 @@
   content: "";
   position: absolute;
   inset: -0.5rem 0 1.5rem 0;
-  background: #3498db;
   clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
 }

--- a/assets/css/_bootstrap.scss
+++ b/assets/css/_bootstrap.scss
@@ -69,18 +69,10 @@
   }
 }
 
-// Persistent tooltips for line diagrams
-.m-schedule-diagram [data-toggle='tooltip'] {
-  &:has(.c-icon__bus-pill--small)::before,
-  &:has(.m-schedule-diagram__feature-icon)::before {
-    margin-left: calc($base-spacing / 4);
-  }
-
-  &::before {
-    content: " ";
-    position: absolute;
-    margin-top: 1rem;
-    height: $base-spacing;
-    width: $base-spacing;
-  }
+.tooltip::before {
+  content: "";
+  position: absolute;
+  inset: -0.5rem 0 1.5rem 0;
+  background: #3498db;
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
 }

--- a/assets/js/sticky-tooltip.js
+++ b/assets/js/sticky-tooltip.js
@@ -55,7 +55,7 @@ export default function($) {
       // which messes with tooltip persistence, so we prevent the call if a tooltip
       // for the trigger already exists, which we can find if the "aria-describedby"
       // field is not empty
-      if ($this.attr('aria-describedby')){
+      if ($this.attr("aria-describedby")) {
         return;
       }
       $this.tooltip("show");
@@ -66,18 +66,24 @@ export default function($) {
         return;
       }
       // Prevent tooltip from closing when mousing over the tooltip itself
-      if (typeof e?.relatedTarget?.className === "string" && e.relatedTarget.className.includes("tooltip")) {
+      if (
+        typeof e?.relatedTarget?.className === "string" &&
+        e.relatedTarget.className.includes("tooltip")
+      ) {
         const $tooltip = $(`#${$this.attr("aria-describedby")}`);
         // The tooltip trigger's listener doesn't cover the tooltip, so we need a new listener
         // to close the tooltip when the mouse leaves the tooltip
-        if (!$tooltip.data('listener')) {
-          $tooltip.on("mouseleave", function(event) {
-            if ($(event.relatedTarget).data('original-title') == $this.data('original-title')) {
+        if (!$tooltip.data("listener")) {
+          $tooltip.on("mouseleave", event => {
+            if (
+              $(event.relatedTarget).data("original-title") ===
+              $this.data("original-title")
+            ) {
               return;
             }
-          hideTooltip($this);
+            hideTooltip($this);
           });
-          $tooltip.data('listener', true);
+          $tooltip.data("listener", true);
         }
         return;
       }

--- a/assets/js/sticky-tooltip.js
+++ b/assets/js/sticky-tooltip.js
@@ -51,6 +51,12 @@ export default function($) {
       if (wasTouchedRecently($this)) {
         return;
       }
+      // Calling "show" again changes the tooltip ID and the aria-describedby field,
+      // which messes with tooltip persistence, so we prevent the call if a tooltip
+      // for the trigger already exists, as pointed to by aria-describedby
+      if ($this.attr('aria-describedby')){
+        return;
+      }
       $this.tooltip("show");
     });
     $(document).on("mouseleave", selector, function(e) {
@@ -58,7 +64,22 @@ export default function($) {
       if (wasTouchedRecently($this)) {
         return;
       }
-
+      // Prevent tooltip from closing when mousing over the tooltip itself
+      if (typeof e.relatedTarget.className === "string" && e.relatedTarget.className.includes("tooltip")) {
+        const $tooltip = $(`#${$this.attr("aria-describedby")}`);
+        // The tooltip trigger's listener doesn't cover the tooltip, so we need a new listener
+        // to close the tooltip when the mouse leaves the tooltip
+        if (!$tooltip.data('listener')) {
+          $tooltip.on("mouseleave", function(event) {
+            if ($(event.relatedTarget).data('original-title') == $this.data('original-title')) {
+              return;
+            }
+          hideTooltip($this);
+          });
+          $tooltip.data('listener', true);
+        }
+        return;
+      }
       hideTooltip($this);
     });
     $(document).on("focus", selector, function(e) {

--- a/assets/js/sticky-tooltip.js
+++ b/assets/js/sticky-tooltip.js
@@ -53,7 +53,8 @@ export default function($) {
       }
       // Calling "show" again changes the tooltip ID and the aria-describedby field,
       // which messes with tooltip persistence, so we prevent the call if a tooltip
-      // for the trigger already exists, as pointed to by aria-describedby
+      // for the trigger already exists, which we can find if the "aria-describedby"
+      // field is not empty
       if ($this.attr('aria-describedby')){
         return;
       }
@@ -65,7 +66,7 @@ export default function($) {
         return;
       }
       // Prevent tooltip from closing when mousing over the tooltip itself
-      if (typeof e.relatedTarget.className === "string" && e.relatedTarget.className.includes("tooltip")) {
+      if (typeof e?.relatedTarget?.className === "string" && e.relatedTarget.className.includes("tooltip")) {
         const $tooltip = $(`#${$this.attr("aria-describedby")}`);
         // The tooltip trigger's listener doesn't cover the tooltip, so we need a new listener
         // to close the tooltip when the mouse leaves the tooltip

--- a/assets/ts/helpers/icon.tsx
+++ b/assets/ts/helpers/icon.tsx
@@ -185,7 +185,10 @@ const defaultTooltipOptions: TooltipOptions = {
   animation: true,
   html: false,
   placement: "top",
-  trigger: "hover focus"
+  // We define some custom trigger behavior in tooltip-hover.js in order to support
+  // keeping the tooltip open when hovering over the tooltip element.
+  // Behaves like "hover focus" otherwise.
+  trigger: "manual"
 };
 
 export const TooltipWrapper: React.FC<{

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LineDiagramWithStopsTest.tsx.snap
@@ -111,7 +111,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                   </a>
                   <div className=\\"m-schedule-diagram__features\\">
                     <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                         <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                       </span>
                     </TooltipWrapper>
@@ -144,7 +144,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                     </a>
                     <div className=\\"m-schedule-diagram__features\\">
                       <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                        <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                        <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                           <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                         </span>
                       </TooltipWrapper>
@@ -177,7 +177,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                       </a>
                       <div className=\\"m-schedule-diagram__features\\">
                         <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                          <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                          <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                             <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                           </span>
                         </TooltipWrapper>
@@ -210,7 +210,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                         </a>
                         <div className=\\"m-schedule-diagram__features\\">
                           <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                            <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                            <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                               <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                             </span>
                           </TooltipWrapper>
@@ -276,7 +276,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                           </a>
                           <div className=\\"m-schedule-diagram__features\\">
                             <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                                 <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                               </span>
                             </TooltipWrapper>
@@ -309,7 +309,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                             </a>
                             <div className=\\"m-schedule-diagram__features\\">
                               <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                                <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                                   <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                                 </span>
                               </TooltipWrapper>
@@ -375,7 +375,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                               </a>
                               <div className=\\"m-schedule-diagram__features\\">
                                 <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                                  <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                                  <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                                     <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                                   </span>
                                 </TooltipWrapper>
@@ -408,7 +408,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                 </a>
                                 <div className=\\"m-schedule-diagram__features\\">
                                   <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                                    <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                                       <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                                     </span>
                                   </TooltipWrapper>
@@ -441,7 +441,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                   </a>
                                   <div className=\\"m-schedule-diagram__features\\">
                                     <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                                      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                                         <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                                       </span>
                                     </TooltipWrapper>
@@ -474,7 +474,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                     </a>
                                     <div className=\\"m-schedule-diagram__features\\">
                                       <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                                        <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                                        <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                                           <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                                         </span>
                                       </TooltipWrapper>
@@ -507,7 +507,7 @@ exports[`LineDiagramWithStops renders and matches snapshot 1`] = `
                                       </a>
                                       <div className=\\"m-schedule-diagram__features\\">
                                         <TooltipWrapper tooltipText=\\"Accessible\\" tooltipOptions={{...}}>
-                                          <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
+                                          <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Accessible\\">
                                             <span className=\\"notranslate c-svg__icon-acessible-default m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Accessible\\" dangerouslySetInnerHTML={{...}} />
                                           </span>
                                         </TooltipWrapper>

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LiveCrowdingIconTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/LiveCrowdingIconTest.tsx.snap
@@ -4,7 +4,7 @@ exports[`LiveCrowdingIcon with crowded renders and matches snapshot 1`] = `
 "<LiveCrowdingIcon crowding=\\"crowded\\">
   <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <TooltipWrapper tooltipText=\\"Currently <strong>crowded</strong>\\" tooltipOptions={{...}}>
-      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>crowded</strong>\\">
+      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>crowded</strong>\\">
         <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--crowded\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
       </span>
     </TooltipWrapper>
@@ -16,7 +16,7 @@ exports[`LiveCrowdingIcon with not_crowded renders and matches snapshot 1`] = `
 "<LiveCrowdingIcon crowding=\\"not_crowded\\">
   <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <TooltipWrapper tooltipText=\\"Currently <strong>not crowded</strong>\\" tooltipOptions={{...}}>
-      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>not crowded</strong>\\">
+      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>not crowded</strong>\\">
         <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--not_crowded\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
       </span>
     </TooltipWrapper>
@@ -28,7 +28,7 @@ exports[`LiveCrowdingIcon with some_crowding renders and matches snapshot 1`] = 
 "<LiveCrowdingIcon crowding=\\"some_crowding\\">
   <div className=\\"m-schedule-diagram__prediction-crowding\\">
     <TooltipWrapper tooltipText=\\"Currently <strong>some crowding</strong>\\" tooltipOptions={{...}}>
-      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>some crowding</strong>\\">
+      <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"left\\" data-animation={false} data-html={true} data-selector=\\"true\\" data-original-title=\\"Currently <strong>some crowding</strong>\\">
         <span className=\\"notranslate c-svg__icon c-icon__crowding c-icon__crowding--some_crowding\\" aria-hidden=\\"true\\" dangerouslySetInnerHTML={{...}} />
       </span>
     </TooltipWrapper>

--- a/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
+++ b/assets/ts/schedule/components/line-diagram/__tests__/__snapshots__/StopCardTest.tsx.snap
@@ -22,7 +22,7 @@ exports[`StopCard renders and matches snapshot 1`] = `
           </a>
           <div className=\\"m-schedule-diagram__features\\">
             <TooltipWrapper tooltipText=\\"Parking\\" tooltipOptions={{...}}>
-              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\">
+              <span href={[undefined]} data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={true} data-html={false} data-selector=\\"true\\" data-original-title=\\"Parking\\">
                 <i className=\\"fa fa-square-parking notranslate u-color-gray-light m-schedule-diagram__feature-icon\\" aria-hidden=\\"false\\" aria-label=\\"Parking\\" />
               </span>
             </TooltipWrapper>
@@ -32,7 +32,7 @@ exports[`StopCard renders and matches snapshot 1`] = `
           <StopConnections connections={{...}}>
             <div className=\\"m-schedule-diagram__connections\\">
               <TooltipWrapper href=\\"/schedules/Orange/line\\" tooltipText=\\"Orange Line\\" tooltipOptions={{...}}>
-                <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"hover focus\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Orange Line\\">
+                <a href=\\"/schedules/Orange/line\\" data-toggle=\\"tooltip\\" data-trigger=\\"manual\\" data-placement=\\"bottom\\" data-animation={false} data-html={false} data-selector=\\"true\\" data-original-title=\\"Orange Line\\">
                   <span className=\\"m-schedule-diagram__connection\\">
                     <span className=\\"notranslate c-svg__icon\\" aria-hidden=\\"false\\" aria-label=\\"Orange Line\\" dangerouslySetInnerHTML={{...}} />
                   </span>


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Update tooltips to remain open if cursor is moved onto tooltip display](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211709578469472)

## Implementation
Updates bootstrap tooltips to be able to be hovered over (currently disappears when you try), and have an invisible triangle to allow you to move your mouse more naturally into the tooltip. 

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
Green triangle for illustration purposes only; this PR does not actually color the area
<img width="197" height="94" alt="image" src="https://github.com/user-attachments/assets/7bb7fdd4-080b-4f3e-8049-6af09c053af7" />

the tooltip for the parking icon is slightly off center but it was off-center before this PR as well
<img width="123" height="80" alt="image" src="https://github.com/user-attachments/assets/cccf64f6-3166-4923-aa11-18021c62abfe" />

there should be no visual change to the tooltips
<img width="183" height="108" alt="image" src="https://github.com/user-attachments/assets/60665970-ecdd-4fc3-b525-ff0017fb6f55" />

## How to test
Go to a line diagram page with connections, hover over the icons and observe that the tooltip appears and does not disappear when  you try to hover over the tooltip itself. 

[Orange line on local](http://localhost:4001/schedules/Orange/line) for convenience
<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
