### PR TITLE
A11Y[fix]:  Add visible focus indicator when selecting images in photo galleries

### DIFF
--- a/assets/css/_photo-gallery.scss
+++ b/assets/css/_photo-gallery.scss
@@ -55,6 +55,7 @@
     padding-bottom: 20%;
     position: relative;
     width: 19.5%;
+    outline-offset: 0.25em;
   }
 }
 


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Add visible focus indicator when selecting images in photo galleries](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211676340821155?focus=true)

## Implementation

Added a bit of css to bring the focus outline out from behind the image so focus indication is visible


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Arts
<img width="662" height="183" alt="Screenshot 2026-05-19 at 2 11 09 PM" src="https://github.com/user-attachments/assets/c4c56973-213d-44f6-9723-d197e00fd657" />

### Commuter Rail Safety
<img width="634" height="312" alt="Screenshot 2026-05-19 at 2 11 41 PM" src="https://github.com/user-attachments/assets/db35b753-975f-40a5-b436-1be06bcd382f" />


## How to test
http://localhost:4001/arts
http://localhost:4001/projects/commuter-rail-safety-and-resiliency-program

Confirm that when using keyboard navigation, the images in carousels have a visible focus indicator.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
