### PR TITLE
fix(stops): Restore tooltips to stop page

### DIFF
--- a/lib/dotcom_web/views/stop_view.ex
+++ b/lib/dotcom_web/views/stop_view.ex
@@ -23,7 +23,8 @@ defmodule DotcomWeb.StopView do
     svg_icon_with_circle(%SvgIconWithCircle{
       icon: stop_feature_icon_atom(feature),
       size: size,
-      aria_hidden?: false
+      aria_hidden?: false,
+      show_tooltip?: true
     })
     |> add_aria_label(feature)
   end


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [Restore tooltips on Stations page](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214903096193366)

## Implementation
Turns `show_tooltip?` on for `stop_feature_icon`, which, based on a quick search of the codebase, seems to be only used on the [stops index page](https://www.mbta.com/stops/subway)
<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
Tooltips are back!
<img width="284" height="102" alt="image" src="https://github.com/user-attachments/assets/22289df8-cb7c-43d3-a7a9-73282652f278" />


## How to test
Go to [Stops/Stations page](http://localhost:4001/stops/subway) and verify that the tooltips are back
<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
