### PR TITLE
fix(Dotcom.ServicePatterns): better date handling

### DIFF
--- a/lib/dotcom/service_patterns.ex
+++ b/lib/dotcom/service_patterns.ex
@@ -36,8 +36,8 @@ defmodule Dotcom.ServicePatterns do
     |> Stream.reject(&(&1.typicality == :canonical))
     |> Stream.flat_map(&unwrap_multiple_holidays/1)
     |> Stream.map(&add_single_date_description/1)
+    |> Stream.map(&{Service.all_valid_dates_for_service(&1), &1})
     |> Stream.map(&adjust_planned_description/1)
-    |> Enum.reject(&Date.before?(&1.end_date, ServiceDateTime.service_date()))
     |> dedup_identical_services()
     |> dedup_similar_services()
   end
@@ -101,28 +101,34 @@ defmodule Dotcom.ServicePatterns do
 
   defp format_tiny_date(date), do: Dotcom.Utils.Time.format!(date, :month_day_short)
 
-  defp adjust_planned_description(%{typicality: :planned_disruption} = service) do
-    dates =
-      if service.start_date == service.end_date do
-        " (#{format_tiny_date(service.start_date)})"
+  defp adjust_planned_description({dates, %{typicality: :planned_disruption} = service}) do
+    start_date = List.first(dates)
+    end_date = List.last(dates)
+
+    formatted_dates =
+      if start_date == end_date do
+        " (#{format_tiny_date(start_date)})"
       else
-        " (#{format_tiny_date(service.start_date)} - #{format_tiny_date(service.end_date)})"
+        " (#{format_tiny_date(start_date)} - #{format_tiny_date(end_date)})"
       end
 
-    Map.update!(service, :description, &(&1 <> dates))
+    {dates, Map.update!(service, :description, &(&1 <> formatted_dates))}
   end
 
-  defp adjust_planned_description(service), do: service
+  defp adjust_planned_description(other), do: other
 
-  defp dedup_identical_services(services) do
-    services
-    |> Enum.group_by(fn service ->
-      {service.start_date, service.end_date, service.valid_days, service.removed_dates,
-       service.added_dates}
-    end)
-    |> Enum.map(fn {_key, [service | _rest]} ->
-      service
-    end)
+  defp dedup_identical_services(dated_services) do
+    {_unique_dates, unique_services} =
+      dated_services
+      |> Enum.reject(fn {dates, _} ->
+        dates
+        |> List.last()
+        |> Date.before?(ServiceDateTime.service_date())
+      end)
+      |> Enum.uniq_by(fn {dates, _} -> dates end)
+      |> Enum.unzip()
+
+    unique_services
   end
 
   # If we have two services A and B with the same type and typicality,


### PR DESCRIPTION
## Scope

[Slack thread](https://mbta.slack.com/archives/C076FBBC21K/p1779117109219299)

The schedule picker was showing `Sunday (modified service)` as concluding on May 31 instead of on June 7.

## Implementation

The service in question: https://api-dev-blue.mbtace.com/services/PRIV20262-hpa26sp7-Sunday-01

<details><summary>While the service's <kbd>end_date</kbd> was May 31, it <i>also</i> had an <kbd>added_date</kbd> of June 7.</summary>
<p>

```
{
  "added_dates": ["2026-06-07"],
  "added_dates_notes": [null],
  "description": "Sunday schedule (modified service)",
  "end_date": "2026-05-31",
  "rating_description": "Spring",
  "rating_end_date": "2026-06-13",
  "rating_start_date": "2026-04-05",
  "removed_dates": [],
  "removed_dates_notes": [],
  "schedule_name": "Sunday (modified service)",
  "schedule_type": "Sunday",
  "schedule_typicality": 4,
  "start_date": "2026-05-24",
  "valid_days": [1, 7]
}
```

</p>
</details> 


Instead of using service start/end dates, this PR more consistently uses **all** dates (as `added_dates` may and will fall outside of the supposed start/end range). This impacts 
- the displayed text for planned disruptions
- how we determine which services are identical (having the same dates)
- how we identify whether a service is entirely in the past

## Screenshots

| Before | After |
|--------|--------|
| <img width="778" height="806" alt="image" src="https://github.com/user-attachments/assets/92560ef6-4a77-4035-b7ed-9bf9178584fb" /> | <img width="822" height="842" alt="image" src="https://github.com/user-attachments/assets/1d31f0e7-c43d-4b8d-8db0-4ef40abcda06" /> |
| <img width="758" height="750" alt="image" src="https://github.com/user-attachments/assets/4b0e2326-3f9e-485c-8eb5-723113a25ace" /> | <img width="781" height="755" alt="image" src="https://github.com/user-attachments/assets/49492b56-8d29-46f1-ac3e-7ed8025e0f97" /> | 

## How to test

Visit the 716 route (and probably others, but this one was clear) and view departures from any stop **with data from api-dev-blue**.
- [Schedule Finder 2.0](http://localhost:4001/departures/?route_id=716&direction_id=0&stop_id=place-matt)
- [Schedule Finder 1.0](http://localhost:4001/schedules/716/line?schedule_direction%5Bdirection_id%5D=0&schedule_finder%5Bdirection_id%5D=0&schedule_finder%5Borigin%5D=place-matt)

Sunday service should not be labelled as ending May 31.
