### PR TITLE
Fix world cup guide link

### DIFF
--- a/lib/dotcom_web/views/layout_view.ex
+++ b/lib/dotcom_web/views/layout_view.ex
@@ -97,7 +97,7 @@ defmodule DotcomWeb.LayoutView do
           %{
             sub_menu_section: ~t(Plan Your Journey),
             links: [
-              {~t(World Cup Guide), "/schedules/bostonstadium", :internal_link},
+              {~t(World Cup Guide), "/WorldCup", :internal_link},
               {~t(Trip Planner), "/trip-planner", :internal_link},
               {~t(Service Alerts), "/alerts", :internal_link},
               {~t(Sign Up for Service Alerts), "https://alerts.mbta.com/", :external_link},
@@ -230,7 +230,7 @@ defmodule DotcomWeb.LayoutView do
       }
     ]
 
-  def render_nav_link({link_name, href = "/schedules/bostonstadium", _}) do
+  def render_nav_link({link_name, href = "/WorldCup", _}) do
     icon =
       content_tag(:img, "",
         src: "/icon-svg/football.svg",


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

~~**Asana Ticket:** [TICKET_NAME](TICKET_LINK)~~

## Implementation

Updated the world cup guide link to actually point to the world cup guide instead of the world cup timetable.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

## How to test

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
