### PR TITLE
Ferry [fix]: Add redirect from F1 to F2H pages

### DIFF
--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -206,6 +206,9 @@ defmodule DotcomWeb.Router do
     # Redirect Foxboro line to World Cup Timetable Page for the World Cup (revert this later)
     get("/schedules/CR-Foxboro/*path_params", Redirector, to: "/schedules/bostonstadium")
 
+    # Redirect Boat-F1 to Boat-F2H until Boat-F1 can be unlisted
+    get("/schedules/Boat-F1/*path_params", Redirector, to: "/schedules/Boat-F2H")
+
     get("/", PageController, :index)
     get("/menu", PageController, :menu)
 

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -207,7 +207,7 @@ defmodule DotcomWeb.Router do
     get("/schedules/CR-Foxboro/*path_params", Redirector, to: "/schedules/bostonstadium")
 
     # Redirect Boat-F1 to Boat-F2H until Boat-F1 can be unlisted
-    get("/schedules/Boat-F1/*path_params", Redirector, to: "/schedules/Boat-F2H")
+    get("/schedules/Boat-F1/*path_params", Plugs.PathParamsRedirector, to: "/schedules/Boat-F2H")
 
     get("/", PageController, :index)
     get("/menu", PageController, :menu)


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⛴️ Add redirect from F1 to F2H pages](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214976592187210?focus=true)

## Implementation

Added a redirect from Boat-F1 /schedule/ pages to Boat-F2H timetable

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A

## How to test

http://localhost:4001/schedules/Boat-F1/line
http://localhost:4001/schedules/Boat-F1/alerts
http://localhost:4001/schedules/Boat-F1/timetable
http://localhost:4001/schedules/Boat-F1/whatever

Confirm they all go to http://localhost:4001/schedules/Boat-F2H/timetable


<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
