### PR TITLE
Trip Planner [fix]: Trip Planner fares bug with bus/subway/CR transfers

### DIFF
--- a/lib/dotcom/trip_plan/transfer.ex
+++ b/lib/dotcom/trip_plan/transfer.ex
@@ -101,7 +101,8 @@ defmodule Dotcom.TripPlan.Transfer do
   def bus_to_subway_transfer?([first, middle, last])
       when agency_name?(first, "MBTA") and agency_name?(middle, "MBTA") and
              agency_name?(last, "MBTA") do
-    bus_to_subway_transfer?([first, middle]) || bus_to_subway_transfer?([middle, last])
+    (bus_to_subway_transfer?([first, middle]) ||
+       bus_to_subway_transfer?([middle, last])) && !commuter_rail?([first, middle, last])
   end
 
   def bus_to_subway_transfer?([from, to])
@@ -110,6 +111,18 @@ defmodule Dotcom.TripPlan.Transfer do
   end
 
   def bus_to_subway_transfer?(_), do: false
+
+  def commuter_rail?([_, _, _] = legs) do
+    legs |> Enum.any?(fn leg -> commuter_rail?(leg) end)
+  end
+
+  def commuter_rail?(%{mode: :RAIL}) do
+    true
+  end
+
+  def commuter_rail?(_) do
+    false
+  end
 
   defp same_station?(%Place{stop: %Stop{} = from_stop}, %Place{stop: %Stop{} = to_stop}) do
     cond do


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🐞 Investigate Trip Planner fares bug with bus/subway/CR transfers](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214587941061910?focus=true)

## Implementation

Fixed bug where three leged trips didn't consider if the commuter rail was present when computing if transfers are allowed.  Added a function to check if any leg of a tripod-trip happens on :RAIL and therefore disqualify it as potential free transfer between the other two legs.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Dev
<img width="431" height="392" alt="Screenshot 2026-05-21 at 12 08 14 PM" src="https://github.com/user-attachments/assets/12ae80c1-60d2-46cc-a3f8-c537841b732f" />

### Branch
<img width="426" height="395" alt="Screenshot 2026-05-21 at 12 08 04 PM" src="https://github.com/user-attachments/assets/ca5ea15d-3d59-48bf-b929-c6ed2317684f" />


## How to test


### Original test case
http://localhost:4001/trip-planner?plan=hsQVX3VudXNlZF9kYXRldGltZV90eXBlxADEEl91bnVzZWRfd2hlZWxjaGFpcsQAxAhkYXRldGltZcQgMjAyNi0wNS0yMVQxMTo0MDo1Ny4wMzc5MzgtMDQ6MDDEBGZyb22ExARuYW1lxBVGZWxsc3dheSBXIEAgUGFyaXMgU3TECGxhdGl0dWRly0BFNmxD9fkWxAlsb25naXR1ZGXLwFHGOVxCIDbEB3N0b3BfaWTEBDgzMDXEBW1vZGVzicQDQlVTxAR0cnVlxAVGRVJSWcQEdHJ1ZcQEUkFJTMQEdHJ1ZcQGU1VCV0FZxAR0cnVlxA5fcGVyc2lzdGVudF9pZMQBMMQLX3VudXNlZF9CVVPEAMQNX3VudXNlZF9GRVJSWcQAxAxfdW51c2VkX1JBSUzEAMQOX3VudXNlZF9TVUJXQVnEAMQCdG-ExARuYW1lxAhFbmRpY290dMQIbGF0aXR1ZGXLQEUd2xptaZDECWxvbmdpdHVkZcvAUconRb8m8sQHc3RvcF9pZMQNcGxhY2UtRkItMDEwOQ==

### New case that coincidentally applies as well
http://localhost:4001/trip-planner?plan=hsQVX3VudXNlZF9kYXRldGltZV90eXBlxADEEl91bnVzZWRfd2hlZWxjaGFpcsQAxAhkYXRldGltZcQgMjAyNi0wNS0yMVQxMjoxNTowNC42ODI3NzEtMDQ6MDDEBGZyb22DxARuYW1lxC5XZ2JoLCAxIEd1ZXN0IFN0cmVldCwgQnJpZ2h0b24sIE1BLCAwMjEzNSwgVVNBxAhsYXRpdHVkZctARS2bPQfIS8QJbG9uZ2l0dWRly8BRyYPPLPldxAVtb2Rlc4nEA0JVU8QEdHJ1ZcQFRkVSUlnEBHRydWXEBFJBSUzEBHRydWXEBlNVQldBWcQEdHJ1ZcQOX3BlcnNpc3RlbnRfaWTEATDEC191bnVzZWRfQlVTxADEDV91bnVzZWRfRkVSUlnEAMQMX3VudXNlZF9SQUlMxADEDl91bnVzZWRfU1VCV0FZxADEAnRvg8QEbmFtZcQwTW9udGVsbG8sIDE1MCBTcGFyayBTdCwgQnJvY2t0b24sIE1BLCAwMjMwMSwgVVNBxAhsYXRpdHVkZctARQ2chC-lCcQJbG9uZ2l0dWRly8BRwWV_tpmF

Confirm that the fare is adding the commuter rail leg correctly, unlike on dev.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
