### PR TITLE
cleanup: Remove special March 26 Foxboro schedule, since that's in the past now

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -112,35 +112,6 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   end
 
   def assign_trip_schedules(
-        %{assigns: %{route: route, blocking_alert: nil, date: ~D[2026-03-26]}} = conn
-      )
-      when route.id == "CR-Foxboro" do
-    case TimetableLoader.from_csv(route.id, conn.assigns.direction_id, conn.assigns.date) do
-      {:ok, timetable_schedules} ->
-        header_schedules = List.first(timetable_schedules, [])
-
-        header_stops =
-          timetable_schedules
-          |> Enum.map(&List.first/1)
-          |> Enum.with_index(fn trip, index ->
-            {@stops_repo.get(trip.stop_id), index}
-          end)
-
-        conn
-        |> assign(:use_pdf_schedules?, true)
-        |> assign(:timetable_schedules, timetable_schedules)
-        |> assign(:header_schedules, header_schedules)
-        |> assign(:header_stops, header_stops)
-
-      {:error, _} ->
-        conn
-        |> assign(:suppress_timetable?, false)
-        |> assign(:timetable_schedules, [])
-        |> assign(:header_schedules, [])
-    end
-  end
-
-  def assign_trip_schedules(
         %{
           assigns: %{
             route: route,

--- a/lib/timetable_loader.ex
+++ b/lib/timetable_loader.ex
@@ -24,9 +24,6 @@ defmodule Dotcom.TimetableLoader do
     },
     "Boat-F8" => %{
       effective_dates: {~D[2026-05-23], ~D[2026-06-13]}
-    },
-    "CR-Foxboro" => %{
-      effective_dates: {~D[2026-03-26], ~D[2026-03-26]}
     }
   }
   @available_route_ids Map.keys(@metadata)

--- a/priv/timetables/CR-Foxboro-0.csv
+++ b/priv/timetables/CR-Foxboro-0.csv
@@ -1,3 +1,0 @@
-Stop,A1,A2,B1,B2
-place-sstat,12:45 PM,1 PM,1:15 PM,1:30 PM
-place-FS-0049,1:45 PM,2 PM,2:15 PM,2:30 PM

--- a/test/timetable_loader_test.exs
+++ b/test/timetable_loader_test.exs
@@ -9,7 +9,6 @@ defmodule Dotcom.TimetableLoaderTest do
   setup :verify_on_exit!
 
   describe "from_csv/1" do
-    defp valid_date("CR-Foxboro"), do: ~D[2026-03-26]
     defp valid_date(_), do: Faker.Date.between(@ferry_date_range.first, @ferry_date_range.last)
 
     test "error for invalid route" do


### PR DESCRIPTION
## Scope

No ticket - I just happened to notice dates that are in the past in the code, and figured that we don't need special handling for those anymore!

## Implementation

<img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2Zsd3dwM3JnZXV4eHRlaDNlN3M4bW40YnVtdGJjenlnbmJ0NndqcCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/26xBIUj4Y6K2LcIz6/giphy.gif" />
