### PR TITLE
Trip Planner [Fix]: Out of system transfer logic

### DIFF
--- a/lib/dotcom/trip_plan/fares.ex
+++ b/lib/dotcom/trip_plan/fares.ex
@@ -32,6 +32,7 @@ defmodule Dotcom.TripPlan.Fares do
 
   defp add_fares({leg, 0}, 0, _), do: cents_for_leg(leg)
 
+  # credo:disable-for-next-line
   defp add_fares({leg, leg_index}, total, transit_legs) do
     # Look at this transit leg and previous transit leg(s)
     two_legs = transit_legs |> Enum.slice(leg_index - 1, 2)

--- a/lib/dotcom/trip_plan/fares.ex
+++ b/lib/dotcom/trip_plan/fares.ex
@@ -38,12 +38,18 @@ defmodule Dotcom.TripPlan.Fares do
     three_legs = transit_legs |> Enum.slice(leg_index - 2, 3)
     # If this is part of a free transfer, don't add fare
     cond do
+      Transfer.subway_transfer?(three_legs) ->
+        total
+
       Transfer.bus_to_subway_transfer?(three_legs) ->
         if total == cents_for_leg(List.first(three_legs)),
           do: total + 70,
           else: total
 
       Transfer.maybe_transfer?(three_legs) ->
+        total
+
+      Transfer.subway_transfer?(two_legs) ->
         total
 
       Transfer.subway_after_sl1_from_airport?(two_legs) ->

--- a/lib/dotcom/trip_plan/transfer.ex
+++ b/lib/dotcom/trip_plan/transfer.ex
@@ -64,16 +64,15 @@ defmodule Dotcom.TripPlan.Transfer do
   end
 
   def maybe_transfer?([from, to])
-      when agency_name?(from, "MBTA") and agency_name?(to, "MBTA") and
-             from.mode == :SUBWAY and to.mode == :SUBWAY do
-    same_station?(from.to, to.from)
+      when agency_name?(from, "MBTA") and agency_name?(to, "MBTA") do
+    subway?(from.route) && subway?(to.route) && same_station?(from.to, to.from)
   end
 
   def maybe_transfer?([from, middle, to])
       when agency_name?(from, "MBTA") and agency_name?(to, "MBTA") and
-             agency_name?(middle, "MBTA") and
-             from.mode == :SUBWAY and to.mode == :SUBWAY and middle.mode == :SUBWAY do
-    same_station?(from.to, middle.from) && same_station?(middle.to, to.from)
+             agency_name?(middle, "MBTA") do
+    (subway?(from.route) and subway?(to.route) and subway?(middle.route) and
+       same_station?(from.to, middle.from)) && same_station?(middle.to, to.from)
   end
 
   def maybe_transfer?([from, to]) when agency_name?(from, "MBTA") and agency_name?(to, "MBTA") do

--- a/lib/dotcom/trip_plan/transfer.ex
+++ b/lib/dotcom/trip_plan/transfer.ex
@@ -63,6 +63,19 @@ defmodule Dotcom.TripPlan.Transfer do
     |> Kernel.and(maybe_transfer?([middle_leg, last_leg]))
   end
 
+  def maybe_transfer?([from, to])
+      when agency_name?(from, "MBTA") and agency_name?(to, "MBTA") and
+             from.mode == :SUBWAY and to.mode == :SUBWAY do
+    same_station?(from.to, to.from)
+  end
+
+  def maybe_transfer?([from, middle, to])
+      when agency_name?(from, "MBTA") and agency_name?(to, "MBTA") and
+             agency_name?(middle, "MBTA") and
+             from.mode == :SUBWAY and to.mode == :SUBWAY and middle.mode == :SUBWAY do
+    same_station?(from.to, middle.from) && same_station?(middle.to, to.from)
+  end
+
   def maybe_transfer?([from, to]) when agency_name?(from, "MBTA") and agency_name?(to, "MBTA") do
     if from.route === to.route and
          Enum.all?([from.route, to.route], &bus?/1) do

--- a/lib/dotcom/trip_plan/transfer.ex
+++ b/lib/dotcom/trip_plan/transfer.ex
@@ -34,10 +34,18 @@ defmodule Dotcom.TripPlan.Transfer do
 
   @doc "Searches a list of legs for evidence of an in-station subway transfer."
   @spec subway_transfer?([Leg.t()]) :: boolean
-  def subway_transfer?([first_leg, next_leg | _])
+  def subway_transfer?([first_leg, next_leg])
       when agency_name?(first_leg, "MBTA") and agency_name?(next_leg, "MBTA") do
     same_station?(first_leg.to, next_leg.from) and subway?(first_leg.route) and
       subway?(next_leg.route)
+  end
+
+  def subway_transfer?([first_leg, next_leg, last_leg])
+      when agency_name?(first_leg, "MBTA") and agency_name?(next_leg, "MBTA") and
+             agency_name?(last_leg, "MBTA") do
+    same_station?(first_leg.to, next_leg.from) and subway?(first_leg.route) and
+      subway?(next_leg.route) and same_station?(next_leg.to, last_leg.from) and
+      subway?(last_leg.route)
   end
 
   def subway_transfer?([_ | legs]), do: subway_transfer?(legs)

--- a/lib/dotcom/trip_plan/transfer.ex
+++ b/lib/dotcom/trip_plan/transfer.ex
@@ -15,7 +15,7 @@ defmodule Dotcom.TripPlan.Transfer do
   # (can't be certain, as it depends on media used)!
   @single_ride_transfers %{
     :bus => [:subway, :bus],
-    :subway => [:subway, :bus],
+    :subway => [:bus],
     :express_bus => [:subway, :bus, :express_bus]
   }
 
@@ -61,18 +61,6 @@ defmodule Dotcom.TripPlan.Transfer do
     )
     |> Kernel.and(maybe_transfer?([first_leg, middle_leg]))
     |> Kernel.and(maybe_transfer?([middle_leg, last_leg]))
-  end
-
-  def maybe_transfer?([from, to])
-      when agency_name?(from, "MBTA") and agency_name?(to, "MBTA") do
-    subway?(from.route) && subway?(to.route) && same_station?(from.to, to.from)
-  end
-
-  def maybe_transfer?([from, middle, to])
-      when agency_name?(from, "MBTA") and agency_name?(to, "MBTA") and
-             agency_name?(middle, "MBTA") do
-    (subway?(from.route) and subway?(to.route) and subway?(middle.route) and
-       same_station?(from.to, middle.from)) && same_station?(middle.to, to.from)
   end
 
   def maybe_transfer?([from, to]) when agency_name?(from, "MBTA") and agency_name?(to, "MBTA") do

--- a/test/dotcom/trip_plan/fares_test.exs
+++ b/test/dotcom/trip_plan/fares_test.exs
@@ -101,6 +101,188 @@ defmodule Dotcom.TripPlan.FaresTest do
     end
   end
 
+  test "valid two leg subway transfers" do
+    start_leg =
+      build(:transit_leg,
+        from: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-start"})),
+        to: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midA"})),
+        route:
+          build(:route,
+            agency: build(:agency, name: "MBTA"),
+            type: 0
+          )
+      )
+
+    end_leg =
+      build(:transit_leg,
+        from: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midA"})),
+        to: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-end"})),
+        route:
+          build(:route,
+            agency: build(:agency, name: "MBTA"),
+            type: 0
+          )
+      )
+
+    one_subway_fare =
+      build(:itinerary,
+        legs:
+          build_list(1, :transit_leg,
+            route:
+              build(:route,
+                agency: build(:agency, name: "MBTA"),
+                type: 0
+              )
+          )
+      )
+      |> fare()
+
+    fare = build(:itinerary, legs: [start_leg, end_leg]) |> fare()
+    assert fare <= one_subway_fare
+  end
+
+  test "valid three leg subway transfers" do
+    start_leg =
+      build(:transit_leg,
+        from: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-start"})),
+        to: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midA"})),
+        route:
+          build(:route,
+            agency: build(:agency, name: "MBTA"),
+            type: 0
+          )
+      )
+
+    mid_leg =
+      build(:transit_leg,
+        from: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midA"})),
+        to: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midB"})),
+        route:
+          build(:route,
+            agency: build(:agency, name: "MBTA"),
+            type: 0
+          )
+      )
+
+    end_leg =
+      build(:transit_leg,
+        from: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midB"})),
+        to: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-end"})),
+        route:
+          build(:route,
+            agency: build(:agency, name: "MBTA"),
+            type: 0
+          )
+      )
+
+    one_subway_fare =
+      build(:itinerary,
+        legs:
+          build_list(1, :transit_leg,
+            route:
+              build(:route,
+                agency: build(:agency, name: "MBTA"),
+                type: 0
+              )
+          )
+      )
+      |> fare()
+
+    fare = build(:itinerary, legs: [start_leg, mid_leg, end_leg]) |> fare()
+    assert fare <= one_subway_fare
+  end
+
+  test "invalid two leg subway transfers (eg red <-> blue)" do
+    start_leg =
+      build(:transit_leg,
+        from: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-start"})),
+        to: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midA"})),
+        route:
+          build(:route,
+            agency: build(:agency, name: "MBTA"),
+            type: 0
+          )
+      )
+
+    end_leg =
+      build(:transit_leg,
+        from: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midB"})),
+        to: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-end"})),
+        route:
+          build(:route,
+            agency: build(:agency, name: "MBTA"),
+            type: 0
+          )
+      )
+
+    one_subway_fare =
+      build(:itinerary,
+        legs:
+          build_list(1, :transit_leg,
+            route:
+              build(:route,
+                agency: build(:agency, name: "MBTA"),
+                type: 0
+              )
+          )
+      )
+      |> fare()
+
+    fare = build(:itinerary, legs: [start_leg, end_leg]) |> fare()
+    assert fare > one_subway_fare
+  end
+
+  test "invalid three leg subway transfers (eg red <-> blue)" do
+    start_leg =
+      build(:transit_leg,
+        from: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-start"})),
+        to: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midA"})),
+        route:
+          build(:route,
+            agency: build(:agency, name: "MBTA"),
+            type: 0
+          )
+      )
+
+    mid_leg =
+      build(:transit_leg,
+        from: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midA"})),
+        to: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-midB"})),
+        route:
+          build(:route,
+            agency: build(:agency, name: "MBTA"),
+            type: 0
+          )
+      )
+
+    end_leg =
+      build(:transit_leg,
+        from: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-other"})),
+        to: build(:place, stop: build(:stop, parent_station: %{gtfs_id: "mock-end"})),
+        route:
+          build(:route,
+            agency: build(:agency, name: "MBTA"),
+            type: 0
+          )
+      )
+
+    one_subway_fare =
+      build(:itinerary,
+        legs:
+          build_list(1, :transit_leg,
+            route:
+              build(:route,
+                agency: build(:agency, name: "MBTA"),
+                type: 0
+              )
+          )
+      )
+      |> fare()
+
+    fare = build(:itinerary, legs: [start_leg, mid_leg, end_leg]) |> fare()
+    assert fare > one_subway_fare
+  end
+
   describe "cents_for_leg/1" do
     test "walking leg" do
       leg = build(:walking_leg)

--- a/test/dotcom/trip_plan/transfer_test.exs
+++ b/test/dotcom/trip_plan/transfer_test.exs
@@ -59,44 +59,6 @@ defmodule Dotcom.TripPlan.TransferTest do
       refute [nil, bus_leg()] |> maybe_transfer?
     end
 
-    test "subway -> subway when transferring at the same station" do
-      from_leg =
-        build(:transit_leg,
-          agency: build(:agency, name: "MBTA"),
-          route: build(:route, type: 1),
-          to:
-            build(:place, %{
-              stop: build(:stop, %{parent_station: "place-mock"})
-            })
-        )
-
-      to_leg =
-        build(:transit_leg,
-          agency: build(:agency, name: "MBTA"),
-          route: build(:route, type: 1),
-          from:
-            build(:place, %{
-              stop: build(:stop, %{parent_station: "place-mock"})
-            })
-        )
-
-      assert [from_leg, to_leg] |> subway_transfer?
-    end
-
-    test "subway -> subway when transferring at different station" do
-      from_leg =
-        build(:transit_leg,
-          agency: build(:agency, name: "MBTA"),
-          route: build(:route, type: 1),
-          to:
-            build(:place, %{
-              stop: build(:stop, %{parent_station: "place-mock"})
-            })
-        )
-
-      assert !([from_leg, subway_leg()] |> subway_transfer?)
-    end
-
     test "subway -> local bus" do
       assert [subway_leg(), bus_leg()] |> maybe_transfer?
     end

--- a/test/dotcom/trip_plan/transfer_test.exs
+++ b/test/dotcom/trip_plan/transfer_test.exs
@@ -59,8 +59,42 @@ defmodule Dotcom.TripPlan.TransferTest do
       refute [nil, bus_leg()] |> maybe_transfer?
     end
 
-    test "subway -> subway" do
-      assert [subway_leg(), subway_leg()] |> maybe_transfer?
+    test "subway -> subway when transferring at the same station" do
+      from_leg =
+        build(:transit_leg,
+          agency: build(:agency, name: "MBTA"),
+          route: build(:route, type: 1),
+          to:
+            build(:place, %{
+              stop: build(:stop, %{parent_station: "place-mock"})
+            })
+        )
+
+      to_leg =
+        build(:transit_leg,
+          agency: build(:agency, name: "MBTA"),
+          route: build(:route, type: 1),
+          from:
+            build(:place, %{
+              stop: build(:stop, %{parent_station: "place-mock"})
+            })
+        )
+
+      assert [from_leg, to_leg] |> subway_transfer?
+    end
+
+    test "subway -> subway when transferring at different station" do
+      from_leg =
+        build(:transit_leg,
+          agency: build(:agency, name: "MBTA"),
+          route: build(:route, type: 1),
+          to:
+            build(:place, %{
+              stop: build(:stop, %{parent_station: "place-mock"})
+            })
+        )
+
+      assert !([from_leg, subway_leg()] |> subway_transfer?)
     end
 
     test "subway -> local bus" do


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🐞 Trip Planner | Fix out of system transfer logic](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211924997183377?focus=true)

## Implementation

Removed subway -> subway transfers from the maybe_transfer?()/@single_ride_transfer logic, as this needs to know the stations involved to properly calculate transfers.  Re-added the formerly unused subway_transfer?() logic that did this already.  

This is to handle the cases where OTP suggests walking between stations, but the fare was incorrectly calculated as if that was an in-fare transfer.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Branch
<img width="339" height="725" alt="Screenshot 2026-05-22 at 1 20 34 PM" src="https://github.com/user-attachments/assets/5ea97771-5567-4de2-8b2a-e468bbec44d6" />


### Dev
<img width="338" height="712" alt="Screenshot 2026-05-22 at 1 20 18 PM" src="https://github.com/user-attachments/assets/f7a80dd2-67ef-461e-adb3-24b29c9ddb13" />


## How to test

http://localhost:4001/trip-planner?plan=hsQVX3VudXNlZF9kYXRldGltZV90eXBlxADEEl91bnVzZWRfd2hlZWxjaGFpcsQAxAhkYXRldGltZcQgMjAyNi0wNS0yMlQxMjo1MDo0Ny4xMzQ4NTItMDQ6MDDEBGZyb22ExAhsYXRpdHVkZctARS_O2RaHK8QJbG9uZ2l0dWRly8BRx5y2hIvrxARuYW1lxDlIYXJ2YXJkIFNxdWFyZSwgQnJhdHRsZSBTdHJlZXQsIENhbWJyaWRnZSwgTUEsIDAyMTM4LCBVU0HEB3N0b3BfaWTEAMQFbW9kZXOJxANCVVPEBHRydWXEBUZFUlJZxAR0cnVlxARSQUlMxAR0cnVlxAZTVUJXQVnEBHRydWXEDl9wZXJzaXN0ZW50X2lkxAEwxAtfdW51c2VkX0JVU8QAxA1fdW51c2VkX0ZFUlJZxADEDF91bnVzZWRfUkFJTMQAxA5fdW51c2VkX1NVQldBWcQAxAJ0b4TECGxhdGl0dWRly0BFMxYJVsDXxAlsb25naXR1ZGXLwFG_nYg7o0TEBG5hbWXES1dvbmRlcmxhbmQgR3JleWhvdW5kIFBhcmssIDE5MCBSZXZlcmUgQmVhY2ggUGFya3dheSwgUmV2ZXJlLCBNQSwgMDIxNTEsIFVTQcQHc3RvcF9pZMQA

Any other route that involves a red to blue transfer should work.  
Confirm that leaving one station and entering another on foot is included in the fare calculation. 
Confirm that transfers within the fare gates are still free.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
