### PR TITLE
fix(timetable): add canton junction to franklin timetable for all FIFA match days

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -116,12 +116,20 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
           assigns: %{
             route: route,
             blocking_alert: nil,
-            date: ~D[2026-06-13],
+            date: date,
             direction_id: direction_id
           }
         } = conn
       )
-      when route.id == "CR-Franklin" do
+      when date in [
+             ~D[2026-06-13],
+             ~D[2026-06-14],
+             ~D[2026-06-19],
+             ~D[2026-06-23],
+             ~D[2026-06-29],
+             ~D[2026-07-09]
+           ] and
+             route.id == "CR-Franklin" do
     shuttle_route = @routes_repo.get("Shuttle-CantonJunctionForgePark")
 
     shuttle_schedules =


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** ad-hoc

## Implementation

Extends #3188 to apply for all FIFA match days (and 6/14) instead of just 6/13. Compare to the PDF schedule. 

## Screenshots

## How to test
Deploy to `dev-blue` (where the new rating is living) and ensure that all FIFA match days have Canton Junction as a stop on the Franklin timetable. 


https://dev-blue.mbtace.com/schedules/CR-Franklin/timetable?date=2026-06-16&schedule_direction[direction_id]=0#date-filter