### PR TITLE
WC[feat]: Update CSP to whitelist Norbella world cup pixel

### DIFF
--- a/lib/dotcom_web/plugs/content_security_policy.ex
+++ b/lib/dotcom_web/plugs/content_security_policy.ex
@@ -12,16 +12,20 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
         'self'
         #{@tile_server_url}
         *.arcgis.com
+        ad.doubleclick.net
         analytics.google.com
         analytics.tiktok.com
         analytics-ipv6.tiktokw.us
+        bded8a3c6ae-1-1053047382554.us-central1.run.app
         cdn.mbta.com
+        md-eecad2978f7a43f5b7838c919258e6de.ecs.us-east-2.on.aws
         px.ads.linkedin.com
         stats.g.doubleclick.net
         translate.googleapis.com
         translate-pa.googleapis.com
         www.google.com
         www.google-analytics.com
+        www.googleadservices.com
         www.googletagmanager.com
       ],
     default_src: ~w['self'],
@@ -31,6 +35,7 @@ defmodule DotcomWeb.Plugs.ContentSecurityPolicy do
         *.arcgis.com
         *.soundcloud.com
         *.vimeo.com
+        14897135.fls.doubleclick.net
         cdn.knightlab.com
         data.mbta.com
         livestream.com


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Tickets:** [⚽️ Update CSP to whitelist Norbella world cup pixel](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215164421878494?focus=true)
[Whitelist Norbella pixels in CSP](https://app.asana.com/1/15492006741476/project/555089885850811/task/1213902361011629?focus=true)

## Implementation

Added domains to our allow-list for various marketing tracking pixels.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A

## How to test

On prod 🫤

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
