### PR TITLE
fix(timetable): add 6/16 to list of FIFA match days for showing canton junction franklin line timetable

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -124,6 +124,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
       when date in [
              ~D[2026-06-13],
              ~D[2026-06-14],
+             ~D[2026-06-16],
              ~D[2026-06-19],
              ~D[2026-06-23],
              ~D[2026-06-29],


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** n/a

## Implementation
Adds 6/16 to list of hard-coded match days for the Franklin line timetable.
