### PR TITLE
cleanup: Remove autogenerated auto-save file

### DIFF
--- a/lib/dotcom/timetables/timetable.ex~
+++ b/lib/dotcom/timetables/timetable.ex~
@@ -1,3 +1,0 @@
-defmodule Dotcom.Timetables.Timetable do
-  defstruct :rows
-end


### PR DESCRIPTION
## Scope

I forgot to clean up my editor's `*~` autosave files. Oops