### PR TITLE
feat(ScheduleFinderLive): show LiveView error

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -103,7 +103,8 @@ module.exports = {
       addVariant("phx-change-loading", [
         ".phx-change-loading&",
         ".phx-change-loading &"
-      ])
+      ]),
+      addVariant("phx-error", [".phx-error&", ".phx-error &"])
     ]),
     // Base styling for HTML elements
     plugin(({ addBase }) =>

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -104,25 +104,30 @@ defmodule DotcomWeb.ScheduleFinderLive do
         <section>
           <h2 class="mt-0 mb-md">{~t"Upcoming Departures"}</h2>
           <%= if @service_today? do %>
-            <.async_result :let={upcoming_departures} assign={@upcoming_departures}>
-              <:loading>
-                <div class="mt-lg mb-md flex justify-center">
-                  <.spinner aria_label={~t"Loading upcoming departures"} />
-                </div>
-              </:loading>
-              <:failed :let={_fail}>
-                <.callout>{~t(There was a problem loading upcoming departures)}</.callout>
-              </:failed>
-              <%= if upcoming_departures do %>
-                <.upcoming_departures_section
-                  stop={@stop}
-                  loaded_upcoming_trips={@loaded_upcoming_trips}
-                  upcoming_departures={upcoming_departures}
-                  route={@route}
-                  last_trip_time={@last_trip_time}
-                />
-              <% end %>
-            </.async_result>
+            <div class="hidden phx-error:block">
+              <.callout>{~t(There was a problem loading upcoming departures)}</.callout>
+            </div>
+            <div class="block phx-error:hidden">
+              <.async_result :let={upcoming_departures} assign={@upcoming_departures}>
+                <:loading>
+                  <div class="mt-lg mb-md flex justify-center">
+                    <.spinner aria_label={~t"Loading upcoming departures"} />
+                  </div>
+                </:loading>
+                <:failed :let={_fail}>
+                  <.callout>{~t(There was a problem loading upcoming departures)}</.callout>
+                </:failed>
+                <%= if upcoming_departures do %>
+                  <.upcoming_departures_section
+                    stop={@stop}
+                    loaded_upcoming_trips={@loaded_upcoming_trips}
+                    upcoming_departures={upcoming_departures}
+                    route={@route}
+                    last_trip_time={@last_trip_time}
+                  />
+                <% end %>
+              </.async_result>
+            </div>
           <% else %>
             <.callout>{~t(No service today)}</.callout>
           <% end %>


### PR DESCRIPTION
## Scope

The other day @joshlarson and I were discussing what happens to the UI when we use a separate process to populate Upcoming Departures and that process happens to stop sending updates to the LiveView. Turns out the current behavior is super underwhelming and even problematic -- the display essentially stops updating, and the data eventually becomes wildly outdated.

This PR is not technically about that. But I did notice that LiveView itself adds a CSS class to the parent container, `.phx-error`, when the connection to the server is lost or fails. This PR adjusts Upcoming Departures to display its `"There was a problem loading upcoming departures"` state when this happens.

## Implementation

- Added a [Tailwind variant](https://v3.tailwindcss.com/docs/plugins#adding-variants) that's active when the element has a parent element with the `.phx-error` class.
- Use it to, when there's a LiveView error, both hide the potentially outdated UI and show the `"There was a problem loading upcoming departures"` message.

## How to test

<img width="687" height="177" alt="image" src="https://github.com/user-attachments/assets/4bfa240f-8f64-4e59-a0bc-64f3390117f4" />

It's actually very easy to play with in the browser. Open up the JS console, and toggle the error view by typing `liveSocket.disconnect()` or `liveSocket.connect()`!
