### PR TITLE
fix(timetable): add 6/26 to franklin line override days so that canton junction shows up

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -126,6 +126,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
              ~D[2026-06-14],
              ~D[2026-06-19],
              ~D[2026-06-23],
+             ~D[2026-06-26],
              ~D[2026-06-29],
              ~D[2026-07-09]
            ] and


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** ad-hoc

## Implementation

I'm sorry... I forgot about 6/26