### PR TITLE
fix(timetable): use date param when getting timetable for franklin shuttles

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -137,7 +137,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     shuttle_schedules =
       timetable_schedules(%{
         assigns: %{
-          date: ~D[2026-06-13],
+          date: date,
           route: shuttle_route,
           direction_id: direction_id
         }
@@ -146,7 +146,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     route_schedules =
       timetable_schedules(%{
         assigns: %{
-          date: ~D[2026-06-13],
+          date: date,
           route: route,
           direction_id: direction_id
         }


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** ad-hoc

## Implementation

Problem: 
The Franklin line World Cup gameday function head was using a hard-coded date of 6/13 instead of using the passed in from parameters

Solution:
Use date passed in from HTTP request parameters when rendering timetable for the Franklin line on World Cup game days.