### PR TITLE
fix: Don't crash the timetable page when the shuttle route isn't available

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -250,7 +250,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
         } = conn
       )
       when route.id == "CR-Providence" do
-    shuttle_route = @routes_repo.get("Shuttle-CantonJunctionStoughton")
+    shuttle_route = %Route{id: "Shuttle-CantonJunctionStoughton", type: 3}
 
     shuttle_schedules =
       timetable_schedules(%{

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -18,8 +18,6 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   @route_patterns_repo Application.compile_env!(:dotcom, :repo_modules)[:route_patterns]
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
 
-  @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
-
   plug(DotcomWeb.Plugs.Route)
   plug(DotcomWeb.Plugs.DateInRating)
   plug(:tab_name)
@@ -131,7 +129,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
              ~D[2026-07-09]
            ] and
              route.id == "CR-Franklin" do
-    shuttle_route = @routes_repo.get("Shuttle-CantonJunctionForgePark")
+    shuttle_route = %Route{id: "Shuttle-CantonJunctionForgePark", type: 3}
 
     shuttle_schedules =
       timetable_schedules(%{


### PR DESCRIPTION
## Scope

This should fix the fact that the [Providence timetable on dev](https://dev.mbtace.com/schedules/CR-Providence/timetable) is unable to load right now.

## Implementation

- Replace `@routes_repo.get(shuttle_route_id)` with a skeleton `%Route{id: shuttle_route_id, type: 3}`. We don't need any info about the shuttle route other than its route ID - the schedule query happens elsewhere (and gracefully handles a missing route).

## Screenshots

<img width="2850" height="1780" alt="Screenshot 2026-05-29 at 3 43 00 PM" src="https://github.com/user-attachments/assets/d4f122a5-1879-4867-a567-136e119a51df" />

## How to test

- Clear your cache (`Dotcom.Cache.Multilevel.flush` in an IEx shell), and then look at the [Providence timetable](http://localhost:4001/schedules/CR-Providence/timetable) using dev or prod data.
- On this branch, it will load exactly what you'd expect
- On `main`, it'll crash