### PR TITLE
feat: Add custom direction names and timetable notes for Boat-F10

### DIFF
--- a/lib/dotcom_web/controllers/schedule/defaults.ex
+++ b/lib/dotcom_web/controllers/schedule/defaults.ex
@@ -42,8 +42,8 @@ defmodule DotcomWeb.Schedule.Defaults do
   def default_direction_id(%Conn{assigns: %{route: %Route{id: route_id}}} = conn) do
     direction_id = default_direction_id_for_hour(conn.assigns.date_time.hour)
 
-    # SL1 and SL2 are outbound in the morning, inbound otherwise
-    if route_id in ["741", "742"] do
+    # SL1, SL2, and Harbor Loop Ferry are outbound in the morning, inbound otherwise
+    if route_id in ["741", "742", "Boat-F10"] do
       invert_direction_id(direction_id)
     else
       direction_id

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -425,6 +425,50 @@ defmodule DotcomWeb.ScheduleView do
     end
   end
 
+  def timetable_note(%{route: %Route{id: "Boat-F10"}, direction_id: 0}) do
+    content_tag :div, class: "m-timetable__note" do
+      [
+        content_tag(:p, [
+          content_tag(:strong, ~t"Note:"),
+          gettext(
+            " Service continues later in the day in the opposite direction. %{link}",
+            %{
+              link:
+                link(~t"View evening timetable",
+                  to:
+                    ~p"/schedules/Boat-F10/timetable?schedule_direction[direction_id]=1#direction-filter"
+                )
+                |> safe_to_string()
+            }
+          )
+          |> raw()
+        ])
+      ]
+    end
+  end
+
+  def timetable_note(%{route: %Route{id: "Boat-F10"}, direction_id: 1}) do
+    content_tag :div, class: "m-timetable__note" do
+      [
+        content_tag(:p, [
+          content_tag(:strong, ~t"Note:"),
+          gettext(
+            " Service is available earlier in the day in the opposite direction. %{link}",
+            %{
+              link:
+                link(~t"View morning timetable",
+                  to:
+                    ~p"/schedules/Boat-F10/timetable?schedule_direction[direction_id]=0#direction-filter"
+                )
+                |> safe_to_string()
+            }
+          )
+          |> raw()
+        ])
+      ]
+    end
+  end
+
   def timetable_note(_), do: nil
 
   def json_safe_route(route) do

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -425,7 +425,7 @@ defmodule DotcomWeb.ScheduleView do
     end
   end
 
-  def timetable_note(%{route: %Route{id: "Boat-F10"}, direction_id: 0}) do
+  def timetable_note(%{route: %Route{id: "Boat-F10"}, direction_id: 0, date: date}) do
     content_tag :div, class: "m-timetable__note" do
       [
         content_tag(:p, [
@@ -436,7 +436,7 @@ defmodule DotcomWeb.ScheduleView do
               link:
                 link(~t"View evening timetable",
                   to:
-                    ~p"/schedules/Boat-F10/timetable?schedule_direction[direction_id]=1#direction-filter"
+                    "/schedules/Boat-F10/timetable?schedule_direction[direction_id]=1&date=#{date}#direction-filter"
                 )
                 |> safe_to_string()
             }
@@ -447,7 +447,7 @@ defmodule DotcomWeb.ScheduleView do
     end
   end
 
-  def timetable_note(%{route: %Route{id: "Boat-F10"}, direction_id: 1}) do
+  def timetable_note(%{route: %Route{id: "Boat-F10"}, direction_id: 1, date: date}) do
     content_tag :div, class: "m-timetable__note" do
       [
         content_tag(:p, [
@@ -458,7 +458,7 @@ defmodule DotcomWeb.ScheduleView do
               link:
                 link(~t"View morning timetable",
                   to:
-                    ~p"/schedules/Boat-F10/timetable?schedule_direction[direction_id]=0#direction-filter"
+                    "/schedules/Boat-F10/timetable?schedule_direction[direction_id]=0&date=#{date}#direction-filter"
                 )
                 |> safe_to_string()
             }

--- a/lib/routes/repo.ex
+++ b/lib/routes/repo.ex
@@ -52,6 +52,7 @@ defmodule Routes.Repo do
       {:error, _} -> nil
     end
     |> update_direction_destinations()
+    |> update_direction_names()
   end
 
   # Ferries F1 and F2H are functionally the same route for riders, but are treated separately
@@ -69,6 +70,18 @@ defmodule Routes.Repo do
   end
 
   defp update_direction_destinations(route), do: route
+
+  defp update_direction_names(%Route{id: "Boat-F10"} = route) do
+    %Route{
+      route
+      | direction_names:
+          route.direction_names
+          |> Map.put(0, "Counterclockwise (Morning)")
+          |> Map.put(1, "Clockwise (Evening)")
+    }
+  end
+
+  defp update_direction_names(route), do: route
 
   @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: @ttl])
 

--- a/test/routes/repo_test.exs
+++ b/test/routes/repo_test.exs
@@ -184,6 +184,16 @@ defmodule Routes.RepoTest do
       route = get("Boat-F2H")
       assert route.direction_destinations[1] == "Long Wharf or Rowes Wharf"
     end
+
+    test "updates the direction names for 'Boat-F10'" do
+      expect(MBTA.Api.Mock, :get_json, fn "/routes/Boat-F10", _ ->
+        %JsonApi{data: [build(:route_item, id: "Boat-F10")]}
+      end)
+
+      route = get("Boat-F10")
+      assert route.direction_names[0] == "Counterclockwise (Morning)"
+      assert route.direction_names[1] == "Clockwise (Evening)"
+    end
   end
 
   test "frequent bus routes are tagged" do


### PR DESCRIPTION
## Scope

**Asana Ticket:** [⛴️ Render F10 schedule in current timetable layout](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215284488469001?focus=true)

## Implementation

- A few tiny changes - direction name overrides and timetable notes for `Boat-F10`.

## Screenshots

<img width="2830" height="1430" alt="Screenshot 2026-06-01 at 10 36 09 AM" src="https://github.com/user-attachments/assets/740f9a2a-c44d-4864-83ba-cf785925dbfe" />

## How to test

Look at [the Harbor Loop Ferry timetable](http://localhost:4001/schedules/Boat-F10/timetable?date=2026-07-01&schedule_direction[direction_id]=1#direction-filter) and note that the directions in the direction picker make sense for this route.