### PR TITLE
fix(Dotcom.ServicePatterns): extra_service date handling

### DIFF
--- a/lib/dotcom/service_patterns.ex
+++ b/lib/dotcom/service_patterns.ex
@@ -61,10 +61,8 @@ defmodule Dotcom.ServicePatterns do
     |> to_service_pattern()
   end
 
-  defp unwrap_multiple_holidays(
-         %{typicality: :holiday_service, added_dates: added_dates} = service
-       )
-       when length(added_dates) > 1 do
+  defp unwrap_multiple_holidays(%{typicality: extra, added_dates: added_dates} = service)
+       when extra in [:extra_service, :holiday_service] and length(added_dates) > 1 do
     for added_date <- added_dates do
       %{
         service
@@ -76,25 +74,29 @@ defmodule Dotcom.ServicePatterns do
 
   defp unwrap_multiple_holidays(service), do: [service]
 
-  defp add_single_date_description(
-         %{
-           added_dates: [single_date],
-           added_dates_notes: added_dates_notes,
-           typicality: typicality
-         } = service
-       )
+  defp add_single_date_description(%{typicality: typicality} = service)
        when typicality in [:extra_service, :holiday_service] do
-    date_note = Map.get(added_dates_notes, single_date) || service.description
+    case Service.all_valid_dates_for_service(service) do
+      [single_date] ->
+        date_string = Date.to_string(single_date)
 
-    formatted_date =
-      single_date
-      |> Date.from_iso8601!()
-      |> format_tiny_date()
+        date_note =
+          Map.get(service.added_dates_notes, date_string) || service.description
 
-    %{
-      service
-      | description: "#{date_note}, #{formatted_date}"
-    }
+        formatted_date = format_tiny_date(single_date)
+
+        # In the case of :extra_service, a single valid date may not be present
+        # in added_dates, so we add it here to aid in preventing deduplication
+        %{
+          service
+          | description: "#{date_note}, #{formatted_date}",
+            added_dates: [date_string],
+            added_dates_notes: Map.new([{date_string, date_note}])
+        }
+
+      _ ->
+        service
+    end
   end
 
   defp add_single_date_description(service), do: service
@@ -168,6 +170,7 @@ defmodule Dotcom.ServicePatterns do
     end
   end
 
+  defp service_completely_overlapped?(%{typicality: :extra_service}, _), do: false
   defp service_completely_overlapped?(%{typicality: :holiday_service}, _), do: false
 
   defp service_completely_overlapped?(service, services) do

--- a/lib/dotcom/service_patterns.ex
+++ b/lib/dotcom/service_patterns.ex
@@ -61,8 +61,8 @@ defmodule Dotcom.ServicePatterns do
     |> to_service_pattern()
   end
 
-  defp unwrap_multiple_holidays(%{typicality: extra, added_dates: added_dates} = service)
-       when extra in [:extra_service, :holiday_service] and length(added_dates) > 1 do
+  defp unwrap_multiple_holidays(%{typicality: typicality, added_dates: added_dates} = service)
+       when typicality in [:extra_service, :holiday_service] and length(added_dates) > 1 do
     for added_date <- added_dates do
       %{
         service

--- a/test/dotcom/service_patterns_test.exs
+++ b/test/dotcom/service_patterns_test.exs
@@ -105,7 +105,9 @@ defmodule Dotcom.ServicePatternsTest do
     test "splits multi-holiday services" do
       route_id = FactoryHelpers.build(:id)
       holiday_count = Faker.random_between(2, 4)
-      service = build(:service, date: Faker.Date.forward(1), typicality: :holiday_service)
+
+      service =
+        build(:service, date: Faker.Date.forward(1), typicality: :holiday_service, valid_days: [])
 
       added_dates =
         Faker.Util.sample_uniq(holiday_count, fn ->
@@ -143,7 +145,8 @@ defmodule Dotcom.ServicePatternsTest do
             date: service_date(),
             typicality: :holiday_service,
             added_dates: [added_date],
-            added_dates_notes: added_date_notes
+            added_dates_notes: added_date_notes,
+            valid_days: []
           )
         ]
       end)
@@ -154,6 +157,28 @@ defmodule Dotcom.ServicePatternsTest do
 
       assert text =~
                added_date |> Date.from_iso8601!() |> Dotcom.Utils.Time.format!(:month_day_short)
+    end
+
+    test "adjusts description to add formatted date, for a extra service on one date" do
+      route_id = FactoryHelpers.build(:id)
+      random_date = Faker.random_between(2, 10) |> Faker.Date.forward()
+
+      expect(Services.Repo.Mock, :by_route_id, fn _ ->
+        [
+          build(:service,
+            start_date: random_date,
+            end_date: random_date,
+            typicality: :extra_service,
+            added_dates: [],
+            added_dates_notes: %{},
+            valid_days: [Date.day_of_week(random_date)]
+          )
+        ]
+      end)
+
+      assert [pattern] = patterns_for_route(route_id)
+      %{service_label: {:extra_service, ^random_date, text}} = pattern
+      assert text =~ Dotcom.Utils.Time.format!(random_date, :month_day_short)
     end
 
     test "adjusts description for planned work" do


### PR DESCRIPTION

## Scope

[Slack thread](https://mbta.slack.com/archives/C076FBBC21K/p1780325860708129) - came up while testing the upcoming rating and noticing Jun 13 not being clear

## Implementation

It turns out services using the `:extra_service` typicality  might not use `added_dates` to describe its single date of service, but we were relying on parsing that to show special dates.

## Screenshots

### Before - extended event service without date (or missing entirely)
<img width="632" height="244" alt="image" src="https://github.com/user-attachments/assets/97e8f9db-938f-47bb-9b21-258b73f74c22" />

<img width="426" height="88" alt="image" src="https://github.com/user-attachments/assets/bfd11c5b-f846-4e19-ad24-0beb94650658" />

### After - extended event service now annotated with Jun 13
<img width="1466" height="770" alt="image" src="https://github.com/user-attachments/assets/bf4cb1cc-b759-4ecb-bc6d-517cae3969ee" />
<img width="607" height="121" alt="image" src="https://github.com/user-attachments/assets/fd737242-b2e4-484b-9389-d8d74ee37a26" />



## How to test

Using dev-blue data, you can visit schedule finders for most routes using [this service](https://api-dev-blue.mbtace.com/services/RTL20262-hmb26sp6-Saturday-01) on June 13.