### PR TITLE
fix: Hide Harbor Loop Ferry timetable note when the timetable is empty

### DIFF
--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -425,6 +425,8 @@ defmodule DotcomWeb.ScheduleView do
     end
   end
 
+  def timetable_note(%{route: %Route{id: "Boat-F10"}, timetable_schedules: []}), do: nil
+
   def timetable_note(%{route: %Route{id: "Boat-F10"}, direction_id: 0, date: date}) do
     content_tag :div, class: "m-timetable__note" do
       [


### PR DESCRIPTION
## Scope

[Slack message](https://mbta.slack.com/archives/C076FBBC21K/p1780340402626499?thread_ts=1779805948.603259&cid=C076FBBC21K)

## Screenshots

### No message when no service
<img width="2738" height="1418" alt="Screenshot 2026-06-01 at 3 24 57 PM" src="https://github.com/user-attachments/assets/95a3d7aa-4138-4dc1-a651-19551eb09545" />

### Yes message when yes service
<img width="2738" height="1604" alt="Screenshot 2026-06-01 at 3 27 35 PM" src="https://github.com/user-attachments/assets/6fbe6c2e-902c-40ac-8ced-9fb24efa31ab" />

## How to test

Look at the Harbor Loop Ferry timetable for a [day when it has no service](http://localhost:4001/schedules/Boat-F10/timetable?date=2026-07-01#date-filter). Notice that the timetable note is gone.

Look at the Harbor Loop Ferry timetable for a [day when it does have service](http://localhost:4001/schedules/Boat-F10/timetable?date=2026-07-01#date-filter). Notice that the timetable note is still there.