### PR TITLE
WC[feat]: Pixel request for World Cup page

### DIFF
--- a/lib/dotcom_web/templates/layout/root.html.heex
+++ b/lib/dotcom_web/templates/layout/root.html.heex
@@ -1,6 +1,17 @@
 <!DOCTYPE html>
 <html lang={Map.get(assigns, :locale, "en")}>
   <head>
+    <%= if (@conn.request_path |> String.contains?("world-cup-guide")) do %>
+      <!-- Google Tag Manager -->
+      <script>
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-594M28WJ');
+      </script>
+      <!-- End Google Tag Manager -->
+    <% end %>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -64,6 +75,19 @@
     <% end %>
   </head>
   <%= content_tag(:body, class: Dotcom.BodyTag.class_name(@conn)) do %>
+    <%= if (@conn.request_path |> String.contains?("world-cup-guide")) do %>
+      <!-- Google Tag Manager (noscript) -->
+      <noscript>
+        <iframe
+          src="https://www.googletagmanager.com/ns.html?id=GTM-594M28WJ"
+          height="0"
+          width="0"
+          style="display:none;visibility:hidden"
+        >
+        </iframe>
+      </noscript>
+      <!-- End Google Tag Manager (noscript) -->
+    <% end %>
     <div class="body-wrapper" id="body-wrapper">
       <%= if !Application.get_env(:dotcom, :is_prod_env?) do %>
         <% language =


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽️ Pixel request for World Cup page](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215132590558179?focus=true)

## Implementation

Added google tracking code for the world cup guide to the root layout template.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Script tag
<img width="507" height="196" alt="Screenshot 2026-06-02 at 11 54 37 AM" src="https://github.com/user-attachments/assets/254044f9-7f4c-4849-bc6a-eb3135fd251d" />

### Noscript iframe
<img width="516" height="159" alt="Screenshot 2026-06-02 at 11 54 49 AM" src="https://github.com/user-attachments/assets/ebe18a53-9916-40d2-aaf7-586a341b9dc2" />


## How to test

http://localhost:4001/guides/world-cup-guide

Confirm that the extra google script tag is in the head, and that the noscript version is just below the body tag.  
Confirm that those elements do not show up on any other page.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
