### PR TITLE
fix: Only use new timetable code for Quincy, Winthrop, and Harbor Loop ferries

### DIFF
--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -326,8 +326,10 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
         } = conn
       )
       when route.id in [
-	   "Boat-F6", "Boat-F7", "Boat-F10"
-	   ] do
+             "Boat-F6",
+             "Boat-F7",
+             "Boat-F10"
+           ] do
     timetable_schedules =
       conn
       |> timetable_schedules()

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -325,7 +325,9 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
           }
         } = conn
       )
-      when route.type == 4 do
+      when route.id in [
+	   "Boat-F6", "Boat-F7", "Boat-F10"
+	   ] do
     timetable_schedules =
       conn
       |> timetable_schedules()


### PR DESCRIPTION
## Scope

No ticket, but I just noticed that the [Hingham/Hull Ferry timetable](https://www.mbta.com/schedules/Boat-F2H/timetable?schedule_direction[direction_id]=0#direction-filter) looked kind of silly. I suspect it's because using `Enum.reduce` [here](https://github.com/mbta/dotcom/blob/3c59ef4fd86e7bc9ebe3779d30c14082c0b3a3b8/lib/dotcom/timetables.ex#L319) treats combining more than two stop lists together as a greedy algorithm. 

## Implementation

- For now, only use the fancy new timetable logic for the three loopy ferry routes where we know it works. We can come up with more robust fixes later.

## Screenshots

<img width="1268" height="697" alt="Screenshot 2026-06-03 at 12 13 48 PM" src="https://github.com/user-attachments/assets/5fcd3229-d660-4c50-8ba0-c64a47dfd139" />

## How to test

Look at the [Hingham Hull Ferry timetable](http://localhost:4001/schedules/Boat-F2H). Compare it with prod.