### PR TITLE
A11Y [fix]: Ensure customer support form errors notify screen readers

### DIFF
--- a/assets/js/support-form.js
+++ b/assets/js/support-form.js
@@ -482,6 +482,12 @@ export function handleSubmitClick($, toUpload) {
         li.appendChild(text);
         return li;
       });
+      const recaptchaError = document.querySelectorAll(".has-danger > #g-recaptcha-response").length > 0
+      if(recaptchaError){
+        const li = document.createElement("li");
+        li.appendChild(document.createTextNode("Recaptcha"));
+        errors.push(li)
+      }
       if (errors.length) {
         errors.forEach(err => {
           errorList.appendChild(err);
@@ -495,6 +501,11 @@ export function handleSubmitClick($, toUpload) {
       errorIndicatorsToShow.forEach(elem => {
         elem.classList.remove("hidden");
       });
+
+      if(recaptchaError){
+        document.getElementById("recaptcha-error-indicator").classList.remove("hidden");
+      }
+      
       if (!document.getElementById("privacy").checked) {
         document
           .getElementById("privacy-error-indicator")

--- a/assets/js/test/support-form_test.js
+++ b/assets/js/test/support-form_test.js
@@ -254,6 +254,7 @@ describe("support form", () => {
             <div class="support-form-expanded" style="display: none"></div>
             <div class="error-container support-g-recaptcha-response-error-container" tabindex="-1"><div class="support-g-recaptcha-response-error"></div></div>
             <textarea id="g-recaptcha-response" name="g-recaptcha-response"></textarea>
+            <div class="error-indicator hidden" id="recaptcha-error-indicator"> Required</div>
             <button id="support-submit"></button>
             <span class="waiting" hidden>waiting...</span>
             <div class="error-container form-control-feedback hidden" id="support-form-errors">

--- a/lib/dotcom_web/templates/customer_support/_form.html.eex
+++ b/lib/dotcom_web/templates/customer_support/_form.html.eex
@@ -158,7 +158,7 @@
     <div class="form-group <%= class_for_error("recaptcha", @errors, "has-danger", "has-success") %>">
       <%= support_error_tag @errors, "recaptcha" %>
       <%= raw Recaptcha.Template.display(noscript: true) %>
-      <div class="error-indicator hidden">
+      <div class="error-indicator hidden" id="recaptcha-error-indicator">
         <span aria-hidden="true" class="fa fa-exclamation-circle error-icon"></span> Required
       </div>
       <button class="btn btn-primary submit-button" type="submit" id="support-submit">


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿ Ensure customer support form errors notify screen readers](https://app.asana.com/1/15492006741476/project/1212991513484373/task/1211545530335844?focus=true)

## Implementation

Added error indicators for the recaptcha input.  It needed a bit of extra logic since we don't control the HTML inside of it.

I also noticed that our JS scripts do not attach themselves until the document is fully loaded.  On local the recaptcha takes a few seconds to load, and if the form is submitted during that time it will fail to properly validate with javascript.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Prod
<img width="811" height="388" alt="Screenshot 2026-06-03 at 2 45 52 PM" src="https://github.com/user-attachments/assets/ef8235bf-84b3-4913-aa68-fbe119b944c3" />


### Local
<img width="509" height="408" alt="Screenshot 2026-06-03 at 2 38 19 PM" src="https://github.com/user-attachments/assets/b856fc5d-29a7-489d-a24f-1116126e7efe" />


## How to test

http://localhost:4001/customer-support

Leave the Recaptcha blank and try to submit the form

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
