### PR TITLE
refactor(UpcomingDeparturesLive): subscribe to data updates from a GenServer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -58,6 +58,8 @@ config :dotcom, :req_module, Req
 
 config :dotcom, :search_service, Dotcom.SearchService
 
+config :dotcom, :upcoming_departures_module, Dotcom.UpcomingDepartures
+
 config :dotcom, :service_rollover_time, ~T[03:00:00]
 
 config :dotcom, :timezone, "America/New_York"

--- a/config/test.exs
+++ b/config/test.exs
@@ -52,6 +52,8 @@ config :dotcom, :otp_module, OpenTripPlannerClient.Mock
 config :dotcom, :req_module, Req.Mock
 config :dotcom, :search_service, Dotcom.SearchService.Mock
 
+config :dotcom, :upcoming_departures_module, Dotcom.UpcomingDepartures.Mock
+
 # Let test requests get routed through the :secure pipeline
 config :dotcom, :secure_pipeline,
   force_ssl: [

--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -53,6 +53,7 @@ defmodule Dotcom.Application do
           Alerts.CacheSupervisor,
           {DynamicSupervisor, name: Dotcom.UpcomingDepartures.Supervisor},
           {Phoenix.PubSub, name: Dotcom.PubSub},
+          DotcomWeb.Presence,
           DotcomWeb.Endpoint
         ] ++
         if Application.get_env(:dotcom, :env) != :test do

--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -51,7 +51,7 @@ defmodule Dotcom.Application do
           Predictions.Supervisor,
           Alerts.BusStopChangeSupervisor,
           Alerts.CacheSupervisor,
-          {DynamicSupervisor, name: UpcomingDeparturesSupervisor},
+          {DynamicSupervisor, name: Dotcom.UpcomingDepartures.Supervisor},
           {Phoenix.PubSub, name: Dotcom.PubSub},
           DotcomWeb.Endpoint
         ] ++

--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -51,6 +51,7 @@ defmodule Dotcom.Application do
           Predictions.Supervisor,
           Alerts.BusStopChangeSupervisor,
           Alerts.CacheSupervisor,
+          {DynamicSupervisor, name: UpcomingDeparturesSupervisor},
           {Phoenix.PubSub, name: Dotcom.PubSub},
           DotcomWeb.Endpoint
         ] ++

--- a/lib/dotcom/upcoming_departures.ex
+++ b/lib/dotcom/upcoming_departures.ex
@@ -12,7 +12,7 @@ defmodule Dotcom.UpcomingDepartures do
 
   @spec subscribe(map()) :: :ok
   def subscribe(params) do
-    {:ok, topic} = topic_name(params)
+    topic = topic_name(params)
     :ok = DotcomWeb.Endpoint.subscribe(topic)
 
     topic
@@ -22,7 +22,7 @@ defmodule Dotcom.UpcomingDepartures do
 
   @spec unsubscribe(map()) :: :ok
   def unsubscribe(params) do
-    {:ok, topic} = topic_name(params)
+    topic = topic_name(params)
     :ok = DotcomWeb.Endpoint.unsubscribe(topic)
 
     worker = get_worker(topic)
@@ -33,7 +33,7 @@ defmodule Dotcom.UpcomingDepartures do
   end
 
   defp topic_name(%{route_id: route_id, direction_id: direction_id, stop_id: stop_id}) do
-    {:ok, "departures:#{route_id}:#{direction_id}:#{stop_id}"}
+    "departures:#{route_id}:#{direction_id}:#{stop_id}"
   end
 
   defp get_or_start_worker(topic) do

--- a/lib/dotcom/upcoming_departures.ex
+++ b/lib/dotcom/upcoming_departures.ex
@@ -12,10 +12,9 @@ defmodule Dotcom.UpcomingDepartures do
 
   @spec subscribe(map()) :: :ok
   def subscribe(params) do
-    :ok =
-      params
-      |> topic_name()
-      |> DotcomWeb.Endpoint.subscribe()
+    topic = topic_name(params)
+    :ok = DotcomWeb.Endpoint.subscribe(topic)
+    _ = DotcomWeb.Presence.track(self(), topic, "upcoming_departures", %{})
 
     params
     |> get_or_start_worker()
@@ -28,12 +27,6 @@ defmodule Dotcom.UpcomingDepartures do
       params
       |> topic_name()
       |> DotcomWeb.Endpoint.unsubscribe()
-
-    worker = get_worker(params)
-
-    if worker do
-      GenServer.cast(worker, {:unsubscribe, self()})
-    end
   end
 
   def topic_name(%{route_id: route_id, direction_id: direction_id, stop_id: stop_id}) do

--- a/lib/dotcom/upcoming_departures.ex
+++ b/lib/dotcom/upcoming_departures.ex
@@ -12,40 +12,44 @@ defmodule Dotcom.UpcomingDepartures do
 
   @spec subscribe(map()) :: :ok
   def subscribe(params) do
-    topic = topic_name(params)
-    :ok = DotcomWeb.Endpoint.subscribe(topic)
+    :ok =
+      params
+      |> topic_name()
+      |> DotcomWeb.Endpoint.subscribe()
 
-    topic
+    params
     |> get_or_start_worker()
     |> GenServer.cast({:subscribe, self()})
   end
 
   @spec unsubscribe(map()) :: :ok
   def unsubscribe(params) do
-    topic = topic_name(params)
-    :ok = DotcomWeb.Endpoint.unsubscribe(topic)
+    :ok =
+      params
+      |> topic_name()
+      |> DotcomWeb.Endpoint.unsubscribe()
 
-    worker = get_worker(topic)
+    worker = get_worker(params)
 
     if worker do
       GenServer.cast(worker, {:unsubscribe, self()})
     end
   end
 
-  defp topic_name(%{route_id: route_id, direction_id: direction_id, stop_id: stop_id}) do
+  def topic_name(%{route_id: route_id, direction_id: direction_id, stop_id: stop_id}) do
     "departures:#{route_id}:#{direction_id}:#{stop_id}"
   end
 
-  defp get_or_start_worker(topic) do
-    get_worker(topic) || start_worker(topic)
+  defp get_or_start_worker(params) do
+    get_worker(params) || start_worker(params)
   end
 
-  defp get_worker(topic) do
-    GenServer.whereis({:global, topic})
+  defp get_worker(params) do
+    GenServer.whereis({:global, params})
   end
 
-  defp start_worker(topic) do
-    case DynamicSupervisor.start_child(Dotcom.UpcomingDepartures.Supervisor, {Server, topic}) do
+  defp start_worker(params) do
+    case DynamicSupervisor.start_child(Dotcom.UpcomingDepartures.Supervisor, {Server, params}) do
       {:ok, pid} -> pid
       {:error, {:already_started, pid}} -> pid
     end

--- a/lib/dotcom/upcoming_departures.ex
+++ b/lib/dotcom/upcoming_departures.ex
@@ -45,7 +45,7 @@ defmodule Dotcom.UpcomingDepartures do
   end
 
   defp start_worker(topic) do
-    case DynamicSupervisor.start_child(UpcomingDeparturesSupervisor, {Server, topic}) do
+    case DynamicSupervisor.start_child(Dotcom.UpcomingDepartures.Supervisor, {Server, topic}) do
       {:ok, pid} -> pid
       {:error, {:already_started, pid}} -> pid
     end

--- a/lib/dotcom/upcoming_departures.ex
+++ b/lib/dotcom/upcoming_departures.ex
@@ -10,6 +10,7 @@ defmodule Dotcom.UpcomingDepartures do
 
   defdelegate trip_details(args), to: Processor
 
+  @spec subscribe(map()) :: :ok
   def subscribe(params) do
     {:ok, topic} = topic_name(params)
     :ok = DotcomWeb.Endpoint.subscribe(topic)
@@ -19,6 +20,7 @@ defmodule Dotcom.UpcomingDepartures do
     |> GenServer.cast({:subscribe, self()})
   end
 
+  @spec unsubscribe(map()) :: :ok
   def unsubscribe(params) do
     {:ok, topic} = topic_name(params)
     :ok = DotcomWeb.Endpoint.unsubscribe(topic)
@@ -43,7 +45,7 @@ defmodule Dotcom.UpcomingDepartures do
   end
 
   defp start_worker(topic) do
-    case Server.start(topic) do
+    case DynamicSupervisor.start_child(UpcomingDeparturesSupervisor, {Server, topic}) do
       {:ok, pid} -> pid
       {:error, {:already_started, pid}} -> pid
     end

--- a/lib/dotcom/upcoming_departures.ex
+++ b/lib/dotcom/upcoming_departures.ex
@@ -4,11 +4,48 @@ defmodule Dotcom.UpcomingDepartures do
   get information about realtime upcoming departures.
   """
 
-  def upcoming_departures(args) do
-    __MODULE__.Processor.upcoming_departures(args)
+  alias Dotcom.UpcomingDepartures.{Processor, Server}
+
+  defdelegate upcoming_departures(args), to: Processor
+
+  defdelegate trip_details(args), to: Processor
+
+  def subscribe(params) do
+    {:ok, topic} = topic_name(params)
+    :ok = DotcomWeb.Endpoint.subscribe(topic)
+
+    topic
+    |> get_or_start_worker()
+    |> GenServer.cast({:subscribe, self()})
   end
 
-  def trip_details(args) do
-    __MODULE__.Processor.trip_details(args)
+  def unsubscribe(params) do
+    {:ok, topic} = topic_name(params)
+    :ok = DotcomWeb.Endpoint.unsubscribe(topic)
+
+    worker = get_worker(topic)
+
+    if worker do
+      GenServer.cast(worker, {:unsubscribe, self()})
+    end
+  end
+
+  defp topic_name(%{route_id: route_id, direction_id: direction_id, stop_id: stop_id}) do
+    {:ok, "departures:#{route_id}:#{direction_id}:#{stop_id}"}
+  end
+
+  defp get_or_start_worker(topic) do
+    get_worker(topic) || start_worker(topic)
+  end
+
+  defp get_worker(topic) do
+    GenServer.whereis({:global, topic})
+  end
+
+  defp start_worker(topic) do
+    case Server.start(topic) do
+      {:ok, pid} -> pid
+      {:error, {:already_started, pid}} -> pid
+    end
   end
 end

--- a/lib/dotcom/upcoming_departures/behaviour.ex
+++ b/lib/dotcom/upcoming_departures/behaviour.ex
@@ -1,0 +1,17 @@
+defmodule Dotcom.UpcomingDepartures.Behaviour do
+  @moduledoc """
+  Behaviour for the upcoming departures module.
+  """
+
+  alias Dotcom.UpcomingDepartures.{UpcomingDeparture, UpcomingTripDetails}
+
+  @callback upcoming_departures(map()) ::
+              [UpcomingDeparture.t()]
+              | :no_realtime
+              | :no_service
+              | :service_ended
+              | {:before_service, UpcomingDeparture.t()}
+              | {:no_realtime, [UpcomingDeparture.t()]}
+
+  @callback trip_details(map()) :: UpcomingTripDetails.t()
+end

--- a/lib/dotcom/upcoming_departures/processor.ex
+++ b/lib/dotcom/upcoming_departures/processor.ex
@@ -22,7 +22,7 @@ defmodule Dotcom.UpcomingDepartures.Processor do
   alias Vehicles.Vehicle
 
   @behaviour Dotcom.UpcomingDepartures.Behaviour
-
+  @date_time Application.compile_env!(:dotcom, :date_time_module)
   @predictions_repo Application.compile_env!(:dotcom, :repo_modules)[:predictions]
   @schedules_repo Application.compile_env!(:dotcom, :repo_modules)[:schedules]
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
@@ -33,10 +33,10 @@ defmodule Dotcom.UpcomingDepartures.Processor do
   @impl Dotcom.UpcomingDepartures.Behaviour
   def upcoming_departures(%{
         direction_id: direction_id,
-        now: now,
         route: route,
         stop_id: stop_id
       }) do
+    now = @date_time.now()
     route_type = Route.type_atom(route)
 
     predictions =

--- a/lib/dotcom/upcoming_departures/processor.ex
+++ b/lib/dotcom/upcoming_departures/processor.ex
@@ -19,8 +19,9 @@ defmodule Dotcom.UpcomingDepartures.Processor do
   alias Routes.Route
   alias Schedules.Schedule
   alias Schedules.Trip
-  alias Stops.Stop
   alias Vehicles.Vehicle
+
+  @behaviour Dotcom.UpcomingDepartures.Behaviour
 
   @predictions_repo Application.compile_env!(:dotcom, :repo_modules)[:predictions]
   @schedules_repo Application.compile_env!(:dotcom, :repo_modules)[:schedules]
@@ -29,18 +30,7 @@ defmodule Dotcom.UpcomingDepartures.Processor do
   @typep vehicle_at_stop_status_t() ::
            :after_stop | :before_stop | :different_trip | Vehicles.Vehicle.status()
 
-  @spec upcoming_departures(%{
-          direction_id: 0 | 1,
-          now: DateTime.t(),
-          route: Route.t(),
-          stop_id: Stop.id_t()
-        }) ::
-          [UpcomingDeparture.t()]
-          | :no_realtime
-          | :no_service
-          | :service_ended
-          | {:before_service, UpcomingDeparture.t()}
-          | {:no_realtime, [UpcomingDeparture.t()]}
+  @impl Dotcom.UpcomingDepartures.Behaviour
   def upcoming_departures(%{
         direction_id: direction_id,
         now: now,
@@ -279,6 +269,7 @@ defmodule Dotcom.UpcomingDepartures.Processor do
     )
   end
 
+  @impl Dotcom.UpcomingDepartures.Behaviour
   def trip_details(%{
         now: now,
         trip_id: trip_id,

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -11,8 +11,8 @@ defmodule Dotcom.UpcomingDepartures.Server do
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
   @upcoming_departures_module Application.compile_env!(:dotcom, :upcoming_departures_module)
 
-  def start(topic) do
-    GenServer.start(__MODULE__, topic, name: {:global, topic})
+  def start_link(topic) do
+    GenServer.start_link(__MODULE__, topic, name: {:global, topic})
   end
 
   @impl GenServer

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -47,7 +47,7 @@ defmodule Dotcom.UpcomingDepartures.Server do
   def handle_cast({:subscribe, caller_pid}, state) do
     Logger.notice("subscribing #{inspect(caller_pid)} to #{state.topic}")
     new_state = add_subscriber(caller_pid, state)
-    send(caller_pid, {:subscribed, state.departures_fn.()})
+    send(caller_pid, {:upcoming_departures, state.departures_fn.()})
     {:noreply, new_state}
   end
 

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -1,0 +1,86 @@
+defmodule Dotcom.UpcomingDepartures.Server do
+  @moduledoc """
+  Worker process that manages fetching upcoming departures and broadcasting them via PubSub for a given route/direction/stop.
+  """
+
+  require Logger
+
+  use GenServer, restart: :transient
+
+  @date_time Application.compile_env!(:dotcom, :date_time_module)
+  @refresh_interval_ms 5000
+  @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
+  @upcoming_departures_module Application.compile_env!(:dotcom, :upcoming_departures_module)
+
+  def start(topic) do
+    GenServer.start(__MODULE__, topic, name: {:global, topic})
+  end
+
+  @impl GenServer
+  def init(topic) do
+    [_departures, route_id, direction_id, stop_id] = String.split(topic, ":")
+    route = @routes_repo.get(route_id)
+    direction_id = String.to_integer(direction_id)
+
+    departures_fn = fn ->
+      now = @date_time.now()
+
+      @upcoming_departures_module.upcoming_departures(%{
+        direction_id: direction_id,
+        now: now,
+        route: route,
+        stop_id: stop_id
+      })
+    end
+
+    send(self(), :refresh)
+
+    {:ok, %{departures_fn: departures_fn, topic: topic, subscribers: MapSet.new([])}}
+  end
+
+  @impl GenServer
+  def handle_info(:refresh, state) do
+    :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", state.departures_fn.())
+    _ = Process.send_after(self(), :refresh, @refresh_interval_ms)
+    {:noreply, state}
+  end
+
+  def handle_info(_, state), do: {:noreply, state}
+
+  @impl GenServer
+  def handle_cast({:subscribe, caller_pid}, state) do
+    Logger.notice("subscribing #{inspect(caller_pid)} to #{state.topic}")
+    new_state = add_subscriber(caller_pid, state)
+    send(caller_pid, {:subscribed, state.departures_fn.()})
+    {:noreply, new_state}
+  end
+
+  def handle_cast({:unsubscribe, caller_pid}, state) do
+    Logger.notice("removing #{inspect(caller_pid)} from #{state.topic}")
+    new_state = remove_subscriber(caller_pid, state)
+
+    # if there are no more subscribers, stop the worker
+    if subscriber_count(new_state) == 0 do
+      {:stop, :normal, new_state}
+    else
+      {:noreply, new_state}
+    end
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", :terminated)
+  end
+
+  defp add_subscriber(caller_pid, state) do
+    Map.update(state, :subscribers, MapSet.new(), &MapSet.put(&1, caller_pid))
+  end
+
+  defp remove_subscriber(caller_pid, state) do
+    Map.update(state, :subscribers, MapSet.new(), &MapSet.delete(&1, caller_pid))
+  end
+
+  defp subscriber_count(state) do
+    Map.get(state, :subscribers, MapSet.new()) |> MapSet.size()
+  end
+end

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -11,15 +11,14 @@ defmodule Dotcom.UpcomingDepartures.Server do
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
   @upcoming_departures_module Application.compile_env!(:dotcom, :upcoming_departures_module)
 
-  def start_link(topic) do
-    GenServer.start_link(__MODULE__, topic, name: {:global, topic})
+  def start_link(params) do
+    GenServer.start_link(__MODULE__, params, name: {:global, params})
   end
 
   @impl GenServer
-  def init(topic) do
-    [_departures, route_id, direction_id, stop_id] = String.split(topic, ":")
+  def init(params) do
+    %{route_id: route_id, direction_id: direction_id, stop_id: stop_id} = params
     route = @routes_repo.get(route_id)
-    direction_id = String.to_integer(direction_id)
 
     departures_fn = fn ->
       @upcoming_departures_module.upcoming_departures(%{
@@ -30,6 +29,8 @@ defmodule Dotcom.UpcomingDepartures.Server do
     end
 
     send(self(), :refresh)
+
+    topic = Dotcom.UpcomingDepartures.topic_name(params)
 
     {:ok, %{departures_fn: departures_fn, topic: topic, subscribers: MapSet.new([])}}
   end

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -7,7 +7,6 @@ defmodule Dotcom.UpcomingDepartures.Server do
 
   use GenServer, restart: :transient
 
-  @date_time Application.compile_env!(:dotcom, :date_time_module)
   @refresh_interval_ms 5000
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
   @upcoming_departures_module Application.compile_env!(:dotcom, :upcoming_departures_module)
@@ -23,11 +22,8 @@ defmodule Dotcom.UpcomingDepartures.Server do
     direction_id = String.to_integer(direction_id)
 
     departures_fn = fn ->
-      now = @date_time.now()
-
       @upcoming_departures_module.upcoming_departures(%{
         direction_id: direction_id,
-        now: now,
         route: route,
         stop_id: stop_id
       })

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -31,15 +31,25 @@ defmodule Dotcom.UpcomingDepartures.Server do
     send(self(), :refresh)
 
     topic = Dotcom.UpcomingDepartures.topic_name(params)
+    Logger.notice("Starting server for #{topic}.")
 
-    {:ok, %{departures_fn: departures_fn, topic: topic, subscribers: MapSet.new([])}}
+    {:ok, %{departures_fn: departures_fn, topic: topic}}
   end
 
   @impl GenServer
-  def handle_info(:refresh, state) do
-    :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", state.departures_fn.())
-    _ = Process.send_after(self(), :refresh, @refresh_interval_ms)
-    {:noreply, state}
+  def handle_info(:refresh, %{topic: topic} = state) do
+    case topic_subscriber_count(topic) do
+      0 ->
+        Logger.notice("No more subscribers for #{topic}, closing server.")
+        {:stop, :normal, state}
+
+      count ->
+        Logger.notice("Sending departures for #{topic} to #{count} subscribers")
+        :ok = DotcomWeb.Endpoint.broadcast(topic, "upcoming_departures", state.departures_fn.())
+        _ = Process.send_after(self(), :refresh, @refresh_interval_ms)
+
+        {:noreply, state}
+    end
   end
 
   def handle_info(_, state), do: {:noreply, state}
@@ -47,21 +57,8 @@ defmodule Dotcom.UpcomingDepartures.Server do
   @impl GenServer
   def handle_cast({:subscribe, caller_pid}, state) do
     Logger.notice("subscribing #{inspect(caller_pid)} to #{state.topic}")
-    new_state = add_subscriber(caller_pid, state)
     send(caller_pid, {:upcoming_departures, state.departures_fn.()})
-    {:noreply, new_state}
-  end
-
-  def handle_cast({:unsubscribe, caller_pid}, state) do
-    Logger.notice("removing #{inspect(caller_pid)} from #{state.topic}")
-    new_state = remove_subscriber(caller_pid, state)
-
-    # if there are no more subscribers, stop the worker
-    if subscriber_count(new_state) == 0 do
-      {:stop, :normal, new_state}
-    else
-      {:noreply, new_state}
-    end
+    {:noreply, state}
   end
 
   @impl GenServer
@@ -69,15 +66,10 @@ defmodule Dotcom.UpcomingDepartures.Server do
     :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", :terminated)
   end
 
-  defp add_subscriber(caller_pid, state) do
-    Map.update(state, :subscribers, MapSet.new(), &MapSet.put(&1, caller_pid))
-  end
-
-  defp remove_subscriber(caller_pid, state) do
-    Map.update(state, :subscribers, MapSet.new(), &MapSet.delete(&1, caller_pid))
-  end
-
-  defp subscriber_count(state) do
-    Map.get(state, :subscribers, MapSet.new()) |> MapSet.size()
+  defp topic_subscriber_count(topic) do
+    case DotcomWeb.Presence.list(topic) do
+      %{"upcoming_departures" => %{metas: list}} -> Enum.count(list)
+      _other -> 0
+    end
   end
 end

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -5,8 +5,6 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
 
   use DotcomWeb, :live_view
 
-  require Logger
-
   import Dotcom.Utils.Diff, only: [minutes_to_localized_minutes: 1]
   import Dotcom.Utils.ServiceDateTime, only: [service_date: 0]
   import Dotcom.Utils.Time, only: [format!: 2]
@@ -32,6 +30,8 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     {:ok,
      socket
      |> assign(:direction_id, direction_id)
+     |> assign(:route_id, route_id)
+     |> assign(:stop_id, stop_id)
      |> assign_new(:route, fn -> @routes_repo.get(route_id) end)
      |> assign_new(:stop, fn -> @stops_repo.get(stop_id) end)
      |> assign_new(:should_refresh?, fn -> true end)
@@ -48,7 +48,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
        end
      end)
      |> assign(:departures, AsyncResult.loading())
-     |> assign_upcoming_departures()}
+     |> subscribe_to_upcoming_departures()}
   end
 
   @impl LiveView
@@ -59,17 +59,21 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
       phx-hook="PageVisibility"
     >
       <div class="hidden phx-error:block">
-        <.callout>{~t(There was a problem loading upcoming departures)}</.callout>
+        <.callout data-test="u_d:error">
+          {~t(There was a problem loading upcoming departures)}
+        </.callout>
       </div>
       <div class="block phx-error:hidden">
         <.async_result :let={departures} assign={@departures}>
           <:loading>
-            <div class="mt-lg mb-md flex justify-center">
+            <div data-test="u_d:async_loading" class="mt-lg mb-md flex justify-center">
               <.spinner aria_label={~t"Loading upcoming departures"} />
             </div>
           </:loading>
           <:failed :let={_fail}>
-            <.callout>{~t(There was a problem loading upcoming departures)}</.callout>
+            <.callout data-test="u_d:async_failed">
+              {~t(There was a problem loading upcoming departures)}
+            </.callout>
           </:failed>
           <%= if departures do %>
             <.upcoming_departures_section
@@ -87,14 +91,10 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
   end
 
   @impl LiveView
-  def handle_async(:get_upcoming_departures, {:ok, {:ok, departures}}, socket) do
-    {:noreply, assign(socket, :departures, AsyncResult.ok(departures))}
-  end
-
-  def handle_async(:get_upcoming_departures, other, socket) do
-    _ = Logger.error("module=#{__MODULE__} error=#{inspect(other)}")
-    departures = socket.assigns.departures
-    {:noreply, assign(socket, :departures, AsyncResult.failed(departures, :other))}
+  def terminate(_reason, socket) do
+    socket.assigns
+    |> Map.take([:route_id, :direction_id, :stop_id])
+    |> Dotcom.UpcomingDepartures.unsubscribe()
   end
 
   @impl LiveView
@@ -113,7 +113,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
       :noreply,
       socket
       |> assign(:should_refresh?, state == "visible")
-      |> assign_upcoming_departures()
+      |> subscribe_to_upcoming_departures()
     }
   end
 
@@ -121,10 +121,30 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
 
   @impl LiveView
   def handle_info(:refresh_upcoming_departures, socket) do
+    {:noreply, refresh_upcoming_trip_details(socket)}
+  end
+
+  def handle_info({:subscribed, upcoming_departures}, socket) do
     {:noreply,
      socket
-     |> assign_upcoming_departures()
+     |> update(:departures, &AsyncResult.ok(&1, upcoming_departures))
      |> refresh_upcoming_trip_details()}
+  end
+
+  def handle_info(
+        %Phoenix.Socket.Broadcast{event: "upcoming_departures", payload: upcoming_departures},
+        socket
+      ) do
+    case upcoming_departures do
+      :terminated ->
+        {:noreply, assign(socket, :departures, AsyncResult.failed(%AsyncResult{}, :terminated))}
+
+      upcoming_departures ->
+        {:noreply,
+         socket
+         |> update(:departures, &AsyncResult.ok(&1, upcoming_departures))
+         |> refresh_upcoming_trip_details()}
+    end
   end
 
   defp assign_trip_details(socket, trip_id, stop_sequence) do
@@ -145,25 +165,20 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     end)
   end
 
-  defp assign_upcoming_departures(socket) do
-    direction_id = socket.assigns.direction_id
-    route = socket.assigns.route
-    stop_id = socket.assigns.stop.id
+  defp subscribe_to_upcoming_departures(socket) do
+    if connected?(socket) do
+      params =
+        socket.assigns
+        |> Map.take([:route_id, :direction_id, :stop_id])
 
-    parent_pid = self()
-    should_refresh? = socket.assigns.should_refresh?
+      if socket.assigns.should_refresh? do
+        Dotcom.UpcomingDepartures.subscribe(params)
+      else
+        Dotcom.UpcomingDepartures.unsubscribe(params)
+      end
+    end
 
     socket
-    |> start_async(:get_upcoming_departures, fn ->
-      _ = if should_refresh?, do: schedule_refresh_upcoming_departures(parent_pid)
-
-      {:ok,
-       @upcoming_departures_module.upcoming_departures(%{
-         direction_id: direction_id,
-         route: route,
-         stop_id: stop_id
-       })}
-    end)
   end
 
   defp schedule_refresh_upcoming_departures(pid) do
@@ -172,6 +187,8 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
   end
 
   defp refresh_upcoming_trip_details(socket) do
+    _ = if socket.assigns.should_refresh?, do: schedule_refresh_upcoming_departures(self())
+
     trip_ids_and_stop_seqs = Map.keys(socket.assigns.loaded_upcoming_trips)
 
     Enum.reduce(trip_ids_and_stop_seqs, socket, fn {trip_id, stop_sequence}, s ->

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -124,7 +124,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     {:noreply, refresh_upcoming_trip_details(socket)}
   end
 
-  def handle_info({:subscribed, upcoming_departures}, socket) do
+  def handle_info({:upcoming_departures, upcoming_departures}, socket) do
     {:noreply,
      socket
      |> update(:departures, &AsyncResult.ok(&1, upcoming_departures))

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -155,14 +155,11 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
 
     socket
     |> start_async(:get_upcoming_departures, fn ->
-      now = @date_time.now()
-
       _ = if should_refresh?, do: schedule_refresh_upcoming_departures(parent_pid)
 
       {:ok,
        @upcoming_departures_module.upcoming_departures(%{
          direction_id: direction_id,
-         now: now,
          route: route,
          stop_id: stop_id
        })}

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -147,6 +147,8 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     end
   end
 
+  def handle_info(_, socket), do: {:noreply, socket}
+
   defp assign_trip_details(socket, trip_id, stop_sequence) do
     now = @date_time.now()
     stop_id = socket.assigns.stop.id

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -19,6 +19,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
   @schedules_repo Application.compile_env!(:dotcom, :repo_modules)[:schedules]
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
+  @upcoming_departures_module Application.compile_env!(:dotcom, :upcoming_departures_module)
 
   @impl LiveView
   def mount(_not_mounted_at_router, session, socket) do
@@ -131,7 +132,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     stop_id = socket.assigns.stop.id
 
     trip_details =
-      Dotcom.UpcomingDepartures.trip_details(%{
+      @upcoming_departures_module.trip_details(%{
         now: now,
         stop_id: stop_id,
         stop_sequence: stop_sequence,
@@ -159,7 +160,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
       _ = if should_refresh?, do: schedule_refresh_upcoming_departures(parent_pid)
 
       {:ok,
-       Dotcom.UpcomingDepartures.upcoming_departures(%{
+       @upcoming_departures_module.upcoming_departures(%{
          direction_id: direction_id,
          now: now,
          route: route,

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -75,7 +75,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
               {~t(There was a problem loading upcoming departures)}
             </.callout>
           </:failed>
-          <%= if departures do %>
+          <section data-test="u_d:async_success">
             <.upcoming_departures_section
               stop={@stop}
               loaded_upcoming_trips={@loaded_upcoming_trips}
@@ -83,7 +83,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
               route={@route}
               last_trip_time={@last_trip_time}
             />
-          <% end %>
+          </section>
         </.async_result>
       </div>
     </section>

--- a/lib/dotcom_web/presence.ex
+++ b/lib/dotcom_web/presence.ex
@@ -1,0 +1,8 @@
+defmodule DotcomWeb.Presence do
+  @moduledoc """
+  Adds presence tracking to processes and channels with `Dotcom.PubSub`.
+  """
+  use Phoenix.Presence,
+    otp_app: :my_app,
+    pubsub_server: Dotcom.PubSub
+end

--- a/test/dotcom/upcoming_departures/server_test.exs
+++ b/test/dotcom/upcoming_departures/server_test.exs
@@ -1,0 +1,194 @@
+defmodule Dotcom.UpcomingDepartures.ServerTest do
+  use ExUnit.Case
+
+  import Mox
+
+  alias Dotcom.UpcomingDepartures.Server
+  alias Test.Support.Factories
+
+  setup [:verify_on_exit!, :set_mox_global]
+
+  setup do
+    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+    stub(Routes.Repo.Mock, :get, fn id -> Factories.Routes.Route.build(:route, id: id) end)
+    stub(Stops.Repo.Mock, :get, fn id -> Factories.Stops.Stop.build(:stop, id: id) end)
+    stub(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ -> :service_ended end)
+
+    n = System.unique_integer([:positive])
+    topic = "departures:route-#{n}:0:stop-#{n}"
+
+    %{topic: topic}
+  end
+
+  describe "start/1" do
+    test "starts the server process successfully", %{topic: topic} do
+      {:ok, pid} = Server.start(topic)
+      assert Process.alive?(pid)
+    end
+
+    test "registers the server globally under the topic name", %{topic: topic} do
+      {:ok, pid} = Server.start(topic)
+      assert GenServer.whereis({:global, topic}) == pid
+    end
+
+    test "returns {:error, {:already_started, pid}} when started twice with the same topic",
+         %{topic: topic} do
+      {:ok, pid} = Server.start(topic)
+      assert {:error, {:already_started, ^pid}} = Server.start(topic)
+    end
+  end
+
+  describe "init/1" do
+    test "returns :ok tuple", %{topic: topic} do
+      assert {:ok, _state} = Server.init(topic)
+    end
+
+    test "stores the topic in state", %{topic: topic} do
+      {:ok, state} = Server.init(topic)
+      assert state.topic == topic
+    end
+
+    test "stores a zero-arity departures_fn in state", %{topic: topic} do
+      {:ok, state} = Server.init(topic)
+      assert is_function(state.departures_fn, 0)
+    end
+
+    test "queues a :refresh message to trigger the initial broadcast", %{topic: topic} do
+      _ = Server.init(topic)
+      assert_receive :refresh
+    end
+  end
+
+  describe "handle_info/2 - :refresh" do
+    test "broadcasts upcoming departures to the PubSub topic", %{topic: topic} do
+      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      fake_departures = [:departure_a, :departure_b]
+      state = %{departures_fn: fn -> fake_departures end, topic: topic}
+
+      Server.handle_info(:refresh, state)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "upcoming_departures",
+        payload: ^fake_departures,
+        topic: ^topic
+      }
+    end
+
+    test "returns {:noreply, state} keeping state unchanged", %{topic: topic} do
+      state = %{departures_fn: fn -> :no_service end, topic: topic}
+      assert {:noreply, ^state} = Server.handle_info(:refresh, state)
+    end
+
+    test "broadcasts again each time :refresh is sent to the live process", %{topic: topic} do
+      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      {:ok, pid} = Server.start(topic)
+      # Drain the automatic initial :refresh broadcast from init/1.
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "upcoming_departures",
+        payload: _,
+        topic: ^topic
+      }
+
+      send(pid, :refresh)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "upcoming_departures",
+        payload: _,
+        topic: ^topic
+      }
+    end
+  end
+
+  describe "handle_cast/2 - :subscribe" do
+    test "sends upcoming departures directly to the specified pid", %{topic: topic} do
+      fake_result = :service_ended
+      state = %{departures_fn: fn -> fake_result end, topic: topic}
+
+      Server.handle_cast({:subscribe, self()}, state)
+
+      assert_receive {:subscribed, ^fake_result}
+    end
+
+    test "returns {:noreply, state} with new subscriber pid in state", %{topic: topic} do
+      state = %{departures_fn: fn -> :no_service end, topic: topic, subscribers: MapSet.new([])}
+      {:noreply, new_state} = Server.handle_cast({:subscribe, self()}, state)
+      assert MapSet.member?(new_state.subscribers, self())
+    end
+
+    test "does not publish to PubSub – only sends to the target pid", %{topic: topic} do
+      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      other_pid = spawn(fn -> Process.sleep(:infinity) end)
+      state = %{departures_fn: fn -> [:trip] end, topic: topic}
+
+      Server.handle_cast({:subscribe, other_pid}, state)
+
+      # Test process is subscribed but should NOT receive this particular broadcast.
+      refute_receive {:upcoming_departures, _}
+    end
+
+    test "does not crash a live server process", %{topic: topic} do
+      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      {:ok, pid} = Server.start(topic)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "upcoming_departures",
+        payload: _,
+        topic: ^topic
+      }
+
+      GenServer.cast(pid, {:subscribe, self()})
+      assert_receive {:subscribed, _}
+
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "terminate/2" do
+    test "broadcasts :terminated to the PubSub topic", %{topic: topic} do
+      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      state = %{departures_fn: fn -> :no_service end, topic: topic}
+
+      Server.terminate(:normal, state)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "upcoming_departures",
+        payload: :terminated,
+        topic: ^topic
+      }
+    end
+
+    test "broadcasts :terminated when the server process is stopped normally", %{topic: topic} do
+      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      {:ok, pid} = Server.start(topic)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "upcoming_departures",
+        payload: payload,
+        topic: ^topic
+      }
+
+      assert payload != :terminated
+
+      GenServer.stop(pid, :normal)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "upcoming_departures",
+        payload: :terminated,
+        topic: ^topic
+      }
+    end
+
+    test "broadcasts :terminated regardless of the stop reason", %{topic: topic} do
+      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      state = %{departures_fn: fn -> :no_service end, topic: topic}
+
+      Server.terminate(:shutdown, state)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "upcoming_departures",
+        payload: :terminated,
+        topic: ^topic
+      }
+    end
+  end
+end

--- a/test/dotcom/upcoming_departures/server_test.exs
+++ b/test/dotcom/upcoming_departures/server_test.exs
@@ -106,7 +106,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
 
       Server.handle_cast({:subscribe, self()}, state)
 
-      assert_receive {:subscribed, ^fake_result}
+      assert_receive {:upcoming_departures, ^fake_result}
     end
 
     test "returns {:noreply, state} with new subscriber pid in state", %{topic: topic} do
@@ -137,7 +137,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       }
 
       GenServer.cast(pid, {:subscribe, self()})
-      assert_receive {:subscribed, _}
+      assert_receive {:upcoming_departures, _}
 
       assert Process.alive?(pid)
     end

--- a/test/dotcom/upcoming_departures/server_test.exs
+++ b/test/dotcom/upcoming_departures/server_test.exs
@@ -199,10 +199,11 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
     assert ^pid = GenServer.whereis({:global, topic})
     Process.exit(pid, :kill)
     # need some time for it to restart
-    Process.sleep(100)
-    new_pid = GenServer.whereis({:global, topic})
-    assert new_pid
-    assert new_pid !== pid
+    Dotcom.Assertions.wait_until(fn ->
+      new_pid = GenServer.whereis({:global, topic})
+      assert new_pid
+      assert new_pid !== pid
+    end)
 
     refute_receive %Phoenix.Socket.Broadcast{
       event: "upcoming_departures",

--- a/test/dotcom/upcoming_departures/server_test.exs
+++ b/test/dotcom/upcoming_departures/server_test.exs
@@ -65,13 +65,26 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
     end
   end
 
+  defp subscribe_and_track(topic) do
+    DotcomWeb.Endpoint.subscribe(topic)
+    DotcomWeb.Presence.track(self(), topic, "upcoming_departures", %{})
+
+    on_exit(fn ->
+      for pid <- DotcomWeb.Presence.fetchers_pids() do
+        ref = Process.monitor(pid)
+        assert_receive {:DOWN, ^ref, _, _, _}, 1000
+      end
+    end)
+  end
+
   describe "handle_info/2 - :refresh" do
     test "broadcasts upcoming departures to the PubSub topic", %{topic: topic} do
-      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      subscribe_and_track(topic)
+
       fake_departures = [:departure_a, :departure_b]
       state = %{departures_fn: fn -> fake_departures end, topic: topic}
 
-      Server.handle_info(:refresh, state)
+      assert {:noreply, ^state} = Server.handle_info(:refresh, state)
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "upcoming_departures",
@@ -80,16 +93,11 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       }
     end
 
-    test "returns {:noreply, state} keeping state unchanged", %{topic: topic} do
-      state = %{departures_fn: fn -> :no_service end, topic: topic}
-      assert {:noreply, ^state} = Server.handle_info(:refresh, state)
-    end
-
     test "broadcasts again each time :refresh is sent to the live process", %{
       params: params,
       topic: topic
     } do
-      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      subscribe_and_track(topic)
       {:ok, pid} = Server.start_link(params)
       # Drain the automatic initial :refresh broadcast from init/1.
       assert_receive %Phoenix.Socket.Broadcast{
@@ -118,14 +126,8 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       assert_receive {:upcoming_departures, ^fake_result}
     end
 
-    test "returns {:noreply, state} with new subscriber pid in state", %{topic: topic} do
-      state = %{departures_fn: fn -> :no_service end, topic: topic, subscribers: MapSet.new([])}
-      {:noreply, new_state} = Server.handle_cast({:subscribe, self()}, state)
-      assert MapSet.member?(new_state.subscribers, self())
-    end
-
     test "does not publish to PubSub – only sends to the target pid", %{topic: topic} do
-      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      subscribe_and_track(topic)
       other_pid = spawn(fn -> Process.sleep(:infinity) end)
       state = %{departures_fn: fn -> [:trip] end, topic: topic}
 
@@ -136,7 +138,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
     end
 
     test "does not crash a live server process", %{params: params, topic: topic} do
-      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      subscribe_and_track(topic)
       {:ok, pid} = Server.start_link(params)
 
       assert_receive %Phoenix.Socket.Broadcast{
@@ -154,7 +156,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
 
   describe "terminate/2" do
     test "broadcasts :terminated to the PubSub topic", %{topic: topic} do
-      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      subscribe_and_track(topic)
       state = %{departures_fn: fn -> :no_service end, topic: topic}
 
       Server.terminate(:normal, state)
@@ -170,7 +172,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       params: params,
       topic: topic
     } do
-      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      subscribe_and_track(topic)
       {:ok, pid} = Server.start_link(params)
 
       assert_receive %Phoenix.Socket.Broadcast{
@@ -191,7 +193,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
     end
 
     test "broadcasts :terminated regardless of the stop reason", %{topic: topic} do
-      Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+      subscribe_and_track(topic)
       state = %{departures_fn: fn -> :no_service end, topic: topic}
 
       Server.terminate(:shutdown, state)
@@ -205,7 +207,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
   end
 
   test "gets restarted if it crashes", %{params: params, topic: topic} do
-    Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+    subscribe_and_track(topic)
 
     {:ok, pid} = start_supervised({Server, params})
     assert ^pid = GenServer.whereis({:global, params})

--- a/test/dotcom/upcoming_departures/server_test.exs
+++ b/test/dotcom/upcoming_departures/server_test.exs
@@ -20,21 +20,21 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
     %{topic: topic}
   end
 
-  describe "start/1" do
+  describe "start_link/1" do
     test "starts the server process successfully", %{topic: topic} do
-      {:ok, pid} = Server.start(topic)
+      {:ok, pid} = Server.start_link(topic)
       assert Process.alive?(pid)
     end
 
     test "registers the server globally under the topic name", %{topic: topic} do
-      {:ok, pid} = Server.start(topic)
+      {:ok, pid} = Server.start_link(topic)
       assert GenServer.whereis({:global, topic}) == pid
     end
 
     test "returns {:error, {:already_started, pid}} when started twice with the same topic",
          %{topic: topic} do
-      {:ok, pid} = Server.start(topic)
-      assert {:error, {:already_started, ^pid}} = Server.start(topic)
+      {:ok, pid} = Server.start_link(topic)
+      assert {:error, {:already_started, ^pid}} = Server.start_link(topic)
     end
   end
 
@@ -81,7 +81,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
 
     test "broadcasts again each time :refresh is sent to the live process", %{topic: topic} do
       Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
-      {:ok, pid} = Server.start(topic)
+      {:ok, pid} = Server.start_link(topic)
       # Drain the automatic initial :refresh broadcast from init/1.
       assert_receive %Phoenix.Socket.Broadcast{
         event: "upcoming_departures",
@@ -128,7 +128,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
 
     test "does not crash a live server process", %{topic: topic} do
       Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
-      {:ok, pid} = Server.start(topic)
+      {:ok, pid} = Server.start_link(topic)
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "upcoming_departures",
@@ -159,7 +159,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
 
     test "broadcasts :terminated when the server process is stopped normally", %{topic: topic} do
       Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
-      {:ok, pid} = Server.start(topic)
+      {:ok, pid} = Server.start_link(topic)
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "upcoming_departures",
@@ -190,5 +190,24 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
         topic: ^topic
       }
     end
+  end
+
+  test "gets restarted if it crashes", %{topic: topic} do
+    Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
+
+    {:ok, pid} = start_supervised({Server, topic})
+    assert ^pid = GenServer.whereis({:global, topic})
+    Process.exit(pid, :kill)
+    # need some time for it to restart
+    Process.sleep(100)
+    new_pid = GenServer.whereis({:global, topic})
+    assert new_pid
+    assert new_pid !== pid
+
+    refute_receive %Phoenix.Socket.Broadcast{
+      event: "upcoming_departures",
+      payload: :terminated,
+      topic: ^topic
+    }
   end
 end

--- a/test/dotcom/upcoming_departures/server_test.exs
+++ b/test/dotcom/upcoming_departures/server_test.exs
@@ -17,44 +17,50 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
     n = System.unique_integer([:positive])
     topic = "departures:route-#{n}:0:stop-#{n}"
 
-    %{topic: topic}
+    params = %{
+      route_id: "route-#{n}",
+      direction_id: "0",
+      stop_id: "stop-#{n}"
+    }
+
+    %{params: params, topic: topic}
   end
 
   describe "start_link/1" do
-    test "starts the server process successfully", %{topic: topic} do
-      {:ok, pid} = Server.start_link(topic)
+    test "starts the server process successfully", %{params: params} do
+      {:ok, pid} = Server.start_link(params)
       assert Process.alive?(pid)
     end
 
-    test "registers the server globally under the topic name", %{topic: topic} do
-      {:ok, pid} = Server.start_link(topic)
-      assert GenServer.whereis({:global, topic}) == pid
+    test "registers the server globally under the topic name", %{params: params} do
+      {:ok, pid} = Server.start_link(params)
+      assert GenServer.whereis({:global, params}) == pid
     end
 
     test "returns {:error, {:already_started, pid}} when started twice with the same topic",
-         %{topic: topic} do
-      {:ok, pid} = Server.start_link(topic)
-      assert {:error, {:already_started, ^pid}} = Server.start_link(topic)
+         %{params: params} do
+      {:ok, pid} = Server.start_link(params)
+      assert {:error, {:already_started, ^pid}} = Server.start_link(params)
     end
   end
 
   describe "init/1" do
-    test "returns :ok tuple", %{topic: topic} do
-      assert {:ok, _state} = Server.init(topic)
+    test "returns :ok tuple", %{params: params} do
+      assert {:ok, _state} = Server.init(params)
     end
 
-    test "stores the topic in state", %{topic: topic} do
-      {:ok, state} = Server.init(topic)
-      assert state.topic == topic
+    test "stores the topic in state", %{params: params} do
+      {:ok, state} = Server.init(params)
+      assert state.topic == Dotcom.UpcomingDepartures.topic_name(params)
     end
 
-    test "stores a zero-arity departures_fn in state", %{topic: topic} do
-      {:ok, state} = Server.init(topic)
+    test "stores a zero-arity departures_fn in state", %{params: params} do
+      {:ok, state} = Server.init(params)
       assert is_function(state.departures_fn, 0)
     end
 
-    test "queues a :refresh message to trigger the initial broadcast", %{topic: topic} do
-      _ = Server.init(topic)
+    test "queues a :refresh message to trigger the initial broadcast", %{params: params} do
+      _ = Server.init(params)
       assert_receive :refresh
     end
   end
@@ -79,9 +85,12 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       assert {:noreply, ^state} = Server.handle_info(:refresh, state)
     end
 
-    test "broadcasts again each time :refresh is sent to the live process", %{topic: topic} do
+    test "broadcasts again each time :refresh is sent to the live process", %{
+      params: params,
+      topic: topic
+    } do
       Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
-      {:ok, pid} = Server.start_link(topic)
+      {:ok, pid} = Server.start_link(params)
       # Drain the automatic initial :refresh broadcast from init/1.
       assert_receive %Phoenix.Socket.Broadcast{
         event: "upcoming_departures",
@@ -126,9 +135,9 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       refute_receive {:upcoming_departures, _}
     end
 
-    test "does not crash a live server process", %{topic: topic} do
+    test "does not crash a live server process", %{params: params, topic: topic} do
       Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
-      {:ok, pid} = Server.start_link(topic)
+      {:ok, pid} = Server.start_link(params)
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "upcoming_departures",
@@ -157,9 +166,12 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       }
     end
 
-    test "broadcasts :terminated when the server process is stopped normally", %{topic: topic} do
+    test "broadcasts :terminated when the server process is stopped normally", %{
+      params: params,
+      topic: topic
+    } do
       Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
-      {:ok, pid} = Server.start_link(topic)
+      {:ok, pid} = Server.start_link(params)
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "upcoming_departures",
@@ -192,15 +204,15 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
     end
   end
 
-  test "gets restarted if it crashes", %{topic: topic} do
+  test "gets restarted if it crashes", %{params: params, topic: topic} do
     Phoenix.PubSub.subscribe(Dotcom.PubSub, topic)
 
-    {:ok, pid} = start_supervised({Server, topic})
-    assert ^pid = GenServer.whereis({:global, topic})
+    {:ok, pid} = start_supervised({Server, params})
+    assert ^pid = GenServer.whereis({:global, params})
     Process.exit(pid, :kill)
     # need some time for it to restart
     Dotcom.Assertions.wait_until(fn ->
-      new_pid = GenServer.whereis({:global, topic})
+      new_pid = GenServer.whereis({:global, params})
       assert new_pid
       assert new_pid !== pid
     end)

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -853,6 +853,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(departure_time)
       end)
@@ -989,6 +990,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.later_on_day(scheduled_time)
       end)
@@ -1054,6 +1056,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.later_on_day(scheduled_time)
       end)
@@ -1088,6 +1091,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(scheduled_time)
       end)
@@ -1124,6 +1128,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(scheduled_time)
       end)
@@ -1155,6 +1160,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.later_on_day(scheduled_time)
       end)
@@ -1188,6 +1194,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(scheduled_time)
       end)
@@ -1224,6 +1231,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(scheduled_time)
       end)
@@ -1255,6 +1263,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.later_on_day(scheduled_time)
       end)
@@ -1288,6 +1297,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(scheduled_time)
       end)
@@ -1322,6 +1332,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(scheduled_time)
       end)
@@ -1368,6 +1379,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       stub(Vehicles.Repo.Mock, :get, fn _ ->
         Factories.Vehicles.Vehicle.build(:vehicle, stop_sequence: stop_sequence)
       end)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
@@ -1420,6 +1432,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       stub(Vehicles.Repo.Mock, :get, fn _ ->
         Factories.Vehicles.Vehicle.build(:vehicle, stop_sequence: stop_sequence)
       end)
+
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -81,11 +81,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
       seconds_before_arrival = minutes_before_arrival * 60 + Faker.random_between(-30, 29)
 
       now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -853,12 +853,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(departure_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -895,11 +897,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
       seconds_before_arrival = minutes_before_arrival * 60 + Faker.random_between(-30, 29)
 
       now = predicted_time |> DateTime.shift(second: -seconds_before_arrival)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -959,11 +961,12 @@ defmodule Dotcom.UpcomingDeparturesTest do
           ]
       end)
 
+      stub(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: direction_id,
-          now: now,
           route: route,
           stop_id: stop_id
         })
@@ -986,12 +989,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.later_on_day(scheduled_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.later_on_day(scheduled_time),
           route: route,
           stop_id: stop.id
         })
@@ -1015,12 +1020,12 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
       expect(Schedules.Repo.Mock, :by_route_ids, fn [^route_id], _opts -> [] end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: direction_id,
-          now: now,
           route: route,
           stop_id: stop_id
         })
@@ -1049,12 +1054,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.later_on_day(scheduled_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.later_on_day(scheduled_time),
           route: route,
           stop_id: stop.id
         })
@@ -1081,12 +1088,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(scheduled_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(scheduled_time),
           route: route,
           stop_id: stop.id
         })
@@ -1115,12 +1124,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(scheduled_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(scheduled_time),
           route: route,
           stop_id: stop.id
         })
@@ -1144,12 +1155,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.later_on_day(scheduled_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.later_on_day(scheduled_time),
           route: route,
           stop_id: stop.id
         })
@@ -1175,12 +1188,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(scheduled_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(scheduled_time),
           route: route,
           stop_id: stop.id
         })
@@ -1209,12 +1224,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(scheduled_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(scheduled_time),
           route: route,
           stop_id: stop.id
         })
@@ -1238,12 +1255,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.later_on_day(scheduled_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.later_on_day(scheduled_time),
           route: route,
           stop_id: stop.id
         })
@@ -1269,12 +1288,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(scheduled_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(scheduled_time),
           route: route,
           stop_id: stop.id
         })
@@ -1301,12 +1322,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(scheduled_time)
+      end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(scheduled_time),
           route: route,
           stop_id: stop.id
         })
@@ -1345,12 +1368,12 @@ defmodule Dotcom.UpcomingDeparturesTest do
       stub(Vehicles.Repo.Mock, :get, fn _ ->
         Factories.Vehicles.Vehicle.build(:vehicle, stop_sequence: stop_sequence)
       end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: direction_id,
-          now: now,
           route: route,
           stop_id: stop_id
         })
@@ -1397,12 +1420,12 @@ defmodule Dotcom.UpcomingDeparturesTest do
       stub(Vehicles.Repo.Mock, :get, fn _ ->
         Factories.Vehicles.Vehicle.build(:vehicle, stop_sequence: stop_sequence)
       end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: direction_id,
-          now: now,
           route: route,
           stop_id: stop_id
         })
@@ -1436,11 +1459,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
       seconds_before_departure = minutes_before_departure * 60 + Faker.random_between(-30, 29)
 
       now = departure_time |> DateTime.shift(second: -seconds_before_departure)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -1515,11 +1538,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
       seconds_before_arrival = minutes_before_arrival * 60 + Faker.random_between(-30, 29)
 
       now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -1547,11 +1570,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
       seconds_before_arrival = Faker.random_between(0, 29)
 
       now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -1582,11 +1605,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
       seconds_before_arrival = Faker.random_between(0, 29)
 
       now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -1616,11 +1639,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       # Exercise
       now = Generators.DateTime.random_time_range_date_time({arrival_time, departure_time})
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -1652,11 +1675,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
       seconds_before_departure = Faker.random_between(0, 90)
 
       now = departure_time |> DateTime.shift(second: -seconds_before_departure)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -1688,11 +1711,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       # Exercise
       now = Generators.DateTime.random_time_range_date_time({arrival_time, departure_time})
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -1724,11 +1747,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
       seconds_before_departure = Faker.random_between(91, 300)
 
       now = departure_time |> DateTime.shift(second: -seconds_before_departure)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -1755,12 +1778,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
-      # Exercise
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.later_on_day(departure_time)
+      end)
 
+      # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.later_on_day(departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -1787,12 +1812,15 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(departure_time)
+      end)
+
       # Exercise
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -1819,12 +1847,15 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(departure_time)
+      end)
+
       # Exercise
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -1846,16 +1877,15 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+      seconds_before_arrival = Faker.random_between(0, 29)
+      now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
-      seconds_before_arrival = Faker.random_between(0, 29)
-
-      now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -1887,11 +1917,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
       seconds_before_departure = Faker.random_between(0, 90)
 
       now = departure_time |> DateTime.shift(second: -seconds_before_departure)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: now,
           route: route,
           stop_id: stop.id
         })
@@ -1920,11 +1950,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(departure_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -1952,11 +1985,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(departure_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -1987,11 +2023,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(predicted_departure_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(predicted_departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -2022,11 +2061,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(predicted_departure_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(predicted_departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -2056,11 +2098,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(predicted_departure_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(predicted_departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -2085,11 +2130,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(scheduled_departure_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(scheduled_departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -2113,11 +2161,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(scheduled_arrival_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(scheduled_arrival_time),
           route: route,
           stop_id: stop.id
         })
@@ -2151,11 +2202,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(predicted_departure_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(predicted_departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -2187,11 +2241,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(predicted_departure_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(predicted_departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -2224,11 +2281,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(predicted_departure_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(predicted_departure_time),
           route: route,
           stop_id: stop.id
         })
@@ -2272,12 +2332,12 @@ defmodule Dotcom.UpcomingDeparturesTest do
       stub(Vehicles.Repo.Mock, :get, fn _ -> Factories.Vehicles.Vehicle.build(:vehicle) end)
       expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: direction_id,
-          now: now,
           route: route,
           stop_id: stop_id
         })
@@ -2323,12 +2383,12 @@ defmodule Dotcom.UpcomingDeparturesTest do
       stub(Vehicles.Repo.Mock, :get, fn _ -> Factories.Vehicles.Vehicle.build(:vehicle) end)
       expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: direction_id,
-          now: now,
           route: route,
           stop_id: stop_id
         })
@@ -2366,11 +2426,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect_schedule_call_filtered_by_stop(updated_schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(predicted_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(predicted_time),
           route: route,
           stop_id: stop.id
         })
@@ -2406,11 +2469,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect_schedule_call_filtered_by_stop(updated_schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
+      expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
+        Generators.ServiceDateTime.earlier_on_day(predicted_time)
+      end)
+
       # Exercise
       departures =
         UpcomingDepartures.upcoming_departures(%{
           direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(predicted_time),
           route: route,
           stop_id: stop.id
         })

--- a/test/dotcom_web/live/schedule_finder_live_test.exs
+++ b/test/dotcom_web/live/schedule_finder_live_test.exs
@@ -21,6 +21,18 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
     :ok
   end
 
+  defp allow_mocks(route_id, stop_id, direction_id) do
+    upcoming_departure_params = %{
+      route_id: route_id,
+      direction_id: direction_id,
+      stop_id: stop_id
+    }
+
+    allow(Routes.Repo.Mock, self(), fn ->
+      GenServer.whereis({:global, upcoming_departure_params})
+    end)
+  end
+
   test "loads, fetching route info", %{conn: conn} do
     route_id = FactoryHelpers.build(:id)
     stop_id = FactoryHelpers.build(:id)
@@ -38,7 +50,7 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
     end)
 
     expect(Services.Repo.Mock, :by_route_id, 2, fn ^route_id ->
-      Factories.Services.Service.build_list(5, :service)
+      []
     end)
 
     expect(Stops.Repo.Mock, :get, 2, fn ^stop_id ->
@@ -68,6 +80,8 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
     stop_id = FactoryHelpers.build(:id)
     direction_id = FactoryHelpers.build(:direction_id)
 
+    allow_mocks(route_id, stop_id, direction_id)
+
     path =
       live_path(conn, ScheduleFinderLive,
         route_id: route_id,
@@ -88,6 +102,8 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
     route_id = FactoryHelpers.build(:id)
     stop_id = FactoryHelpers.build(:id)
     direction_id = FactoryHelpers.build(:direction_id)
+
+    allow_mocks(route_id, stop_id, direction_id)
 
     path =
       live_path(conn, ScheduleFinderLive,
@@ -393,13 +409,16 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
       []
     end)
 
-    # Dotcom.ScheduleFinder.UpcomingDepartures.Mock
-    # |> stub(:upcoming_departures, fn _ -> [] end)
+    Dotcom.UpcomingDepartures.Mock
+    |> stub(:upcoming_departures, fn _ -> :no_service end)
+
     stub(Predictions.Repo.Mock, :all, fn _ -> [] end)
     stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
 
     stub(Dotcom.Alerts.AffectedStops.Mock, :affected_stops, fn _, _ -> [] end)
     stub(Dotcom.Alerts.EndpointStops.Mock, :endpoint_stops, fn _, _ -> [] end)
+
+    allow_mocks(route_id, stop_id, direction_id)
 
     path =
       live_path(conn, ScheduleFinderLive,

--- a/test/dotcom_web/live/upcoming_departures_live_test.exs
+++ b/test/dotcom_web/live/upcoming_departures_live_test.exs
@@ -1,5 +1,5 @@
 defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
-  use DotcomWeb.ConnCase, async: true
+  use DotcomWeb.ConnCase
 
   import Mox
   import Phoenix.LiveViewTest
@@ -11,7 +11,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
 
   @moduletag capture_log: false
 
-  setup :verify_on_exit!
+  setup [:verify_on_exit!, :set_mox_global]
 
   setup _ do
     stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
@@ -26,15 +26,19 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
 
     stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
 
+    stub(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+      :no_service
+    end)
+
     :ok
   end
 
-  test "loads, fetching route, stop info", %{conn: conn} do
+  test "loads, fetching route, stop info & subscribing to upcoming departures", %{conn: conn} do
     route_id_param = FactoryHelpers.build(:id)
     stop_id_param = FactoryHelpers.build(:id)
     direction_id = FactoryHelpers.build(:direction_id)
 
-    expect(Routes.Repo.Mock, :get, 2, fn route_id ->
+    expect(Routes.Repo.Mock, :get, 3, fn route_id ->
       assert route_id == route_id_param
       Factories.Routes.Route.build(:route)
     end)
@@ -44,9 +48,21 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
       Factories.Stops.Stop.build(:stop, %{id: stop_id})
     end)
 
-    {:ok, _, html} = start_live_view(conn, route_id_param, direction_id, stop_id_param)
+    parent = self()
+    ref = make_ref()
 
-    assert html =~ "Loading upcoming departures"
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+      send(parent, {ref, :done})
+      :no_service
+    end)
+
+    {:ok, view, _} = start_live_view(conn, route_id_param, direction_id, stop_id_param)
+    assert_receive {^ref, :done}
+    assert_receive {^ref, :done}
+
+    assert view
+           |> element("[data-test=\"u_d:async_success\"]")
+           |> has_element?()
   end
 
   test "fetches schedules info on load for subway", %{conn: conn} do
@@ -55,7 +71,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     stop_id = FactoryHelpers.build(:id)
     direction_id = FactoryHelpers.build(:direction_id)
 
-    expect(Routes.Repo.Mock, :get, 2, fn ^route_id -> route end)
+    expect(Routes.Repo.Mock, :get, 3, fn ^route_id -> route end)
 
     expect(Schedules.Repo.Mock, :by_route_ids, 2, fn routes, opts ->
       assert routes == [route_id]
@@ -66,34 +82,24 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
       []
     end)
 
-    {:ok, _, html} = start_live_view(conn, route_id, direction_id, stop_id)
+    parent = self()
+    ref = make_ref()
 
-    assert html =~ "Loading upcoming departures"
-  end
-
-  test "requests upcoming departures", %{conn: conn} do
-    stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
-
-    route_id = FactoryHelpers.build(:id)
-    stop_id = FactoryHelpers.build(:id)
-    direction_id = FactoryHelpers.build(:direction_id)
-
-    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn arg ->
-      assert arg[:stop_id] == stop_id
-      assert arg[:route].id == route_id
-      assert arg[:direction_id] == direction_id
-      assert arg[:now]
-
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+      send(parent, {ref, :done})
       :no_service
     end)
 
     {:ok, view, _} = start_live_view(conn, route_id, direction_id, stop_id)
+    assert_receive {^ref, :done}
+    assert_receive {^ref, :done}
 
-    assert render_async(view)
+    assert view
+           |> element("[data-test=\"u_d:async_success\"]")
+           |> has_element?()
   end
 
   test "shows last scheduled trip for subway", %{conn: conn} do
-    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
     route = Factories.Routes.Route.build(:subway_route)
     stop = Factories.Stops.Stop.build(:stop)
     route_id = route.id
@@ -115,85 +121,111 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
       schedules ++ [last_schedule]
     end)
 
+    parent = self()
+    ref = make_ref()
+
     # Available upcoming departures are earlier than the last scheduled time
-    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+      send(parent, {ref, :done})
+
       Factories.UpcomingDepartures.build_list(15, :upcoming_departure,
         time: @date_time_module.now() |> DateTime.shift(minute: 20)
       )
     end)
 
     {:ok, view, _} = start_live_view(conn, route_id, direction_id, stop_id)
+    assert_receive {^ref, :done}
+    assert_receive {^ref, :done}
 
     {:ok, rendered_time} = Dotcom.Utils.Time.format(last_schedule.time, :hour_12_minutes)
 
-    assert render_async(view) =~ "Scheduled service continues until #{rendered_time}"
+    assert view
+           |> element("[data-test=\"u_d:async_success\"]")
+           |> has_element?()
+
+    assert render(view) =~ "Scheduled service continues until #{rendered_time}"
   end
 
-  test "shows service ended message", %{conn: conn} do
+  test "receives and shows service ended message", %{conn: conn} do
     # Setup
-    stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+    parent = self()
+    ref = make_ref()
 
-    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+      send(parent, {ref, :done})
       :service_ended
     end)
 
-    {:ok, view, _} =
-      live_isolated(conn, UpcomingDeparturesLive,
-        session: %{
-          "route_id" => FactoryHelpers.build(:id),
-          "direction_id" => FactoryHelpers.build(:direction_id),
-          "stop_id" => FactoryHelpers.build(:id)
-        }
-      )
+    {:ok, view, _} = start_live_view(conn)
+    assert_receive {^ref, :done}
+    assert_receive {^ref, :done}
 
-    assert render_async(view) =~ "Service ended"
+    assert view
+           |> element("[data-test=\"u_d:async_success\"]")
+           |> has_element?()
+
+    assert render(view) =~ "Service ended"
   end
 
-  describe "for non-subway routes" do
-    test "shows no realtime message", %{conn: conn} do
-      stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
-      route_id = FactoryHelpers.build(:id)
+  describe "shows no realtime message" do
+    setup do
+      stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ ->
+        Factories.Schedules.Schedule.build_list(1, :schedule,
+          time: @date_time_module.now() |> DateTime.shift(minute: 40)
+        )
+      end)
 
-      route =
-        Factories.Routes.Route.build(:route, %{id: route_id, type: Faker.Util.pick([2, 3, 4])})
+      :ok
+    end
 
-      stub(Routes.Repo.Mock, :get, fn _ -> route end)
-
-      stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
-
+    test "with scheduled departures", %{conn: conn} do
       upcoming_departures =
         Factories.UpcomingDepartures.build_list(15, :upcoming_departure,
           time: @date_time_module.now() |> DateTime.shift(minute: 20)
         )
 
-      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+      parent = self()
+      ref = make_ref()
+
+      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+        send(parent, {ref, :done})
         {:no_realtime, upcoming_departures}
       end)
 
-      {:ok, view, _} = start_live_view(conn, route_id)
+      {:ok, view, _} = start_live_view(conn)
+      assert_receive {^ref, :done}
+      assert_receive {^ref, :done}
 
-      assert render_async(view) =~
+      assert view
+             |> element("[data-test=\"u_d:async_success\"]")
+             |> has_element?()
+
+      assert render(view) =~
                "There are currently no realtime departures available. Scheduled departures are shown below."
     end
-  end
 
-  describe "for subway routes" do
-    test "shows no realtime message", %{conn: conn} do
-      route = Factories.Routes.Route.build(:subway_route)
-      stub(Routes.Repo.Mock, :get, fn _ -> route end)
-      stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+    test "without scheduled departures", %{conn: conn} do
+      parent = self()
+      ref = make_ref()
 
-      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+        send(parent, {ref, :done})
         :no_realtime
       end)
 
-      {:ok, view, _} = start_live_view(conn, route.id)
+      {:ok, view, _} = start_live_view(conn)
+      assert_receive {^ref, :done}
+      assert_receive {^ref, :done}
 
-      render_async(view) =~ "There are currently no realtime departures available."
+      assert view
+             |> element("[data-test=\"u_d:async_success\"]")
+             |> has_element?()
+
+      assert render(view) =~ "There are currently no realtime departures available."
     end
   end
 
-  defp start_live_view(conn, route_id, direction_id \\ nil, stop_id \\ nil) do
+  defp start_live_view(conn, route_id \\ nil, direction_id \\ nil, stop_id \\ nil) do
     live_isolated(conn, UpcomingDeparturesLive,
       session: %{
         "route_id" => route_id || FactoryHelpers.build(:id),

--- a/test/dotcom_web/live/upcoming_departures_live_test.exs
+++ b/test/dotcom_web/live/upcoming_departures_live_test.exs
@@ -5,14 +5,17 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
   import Phoenix.LiveViewTest
 
   alias DotcomWeb.Live.UpcomingDeparturesLive
-  alias Test.Support.{Factories, FactoryHelpers, PredictedScheduleHelper}
+  alias Test.Support.{Factories, FactoryHelpers}
 
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
+
   @moduletag capture_log: false
 
   setup :verify_on_exit!
 
   setup _ do
+    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+
     stub(Routes.Repo.Mock, :get, fn id ->
       Factories.Routes.Route.build(:route, %{id: id})
     end)
@@ -21,41 +24,32 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
       Factories.Stops.Stop.build(:stop, %{id: id})
     end)
 
-    stub(Vehicles.Repo.Mock, :get, fn _ -> nil end)
+    stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
 
     :ok
   end
 
   test "loads, fetching route, stop info", %{conn: conn} do
-    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
-    route_id = FactoryHelpers.build(:id)
-
-    route =
-      Factories.Routes.Route.build(:route, %{id: route_id, type: Faker.Util.pick([2, 3, 4])})
-
-    stop_id = FactoryHelpers.build(:id)
+    route_id_param = FactoryHelpers.build(:id)
+    stop_id_param = FactoryHelpers.build(:id)
     direction_id = FactoryHelpers.build(:direction_id)
 
-    expect(Routes.Repo.Mock, :get, 2, fn ^route_id -> route end)
+    expect(Routes.Repo.Mock, :get, 2, fn route_id ->
+      assert route_id == route_id_param
+      Factories.Routes.Route.build(:route)
+    end)
 
-    expect(Stops.Repo.Mock, :get, 2, fn ^stop_id ->
+    expect(Stops.Repo.Mock, :get, 2, fn stop_id ->
+      assert stop_id == stop_id_param
       Factories.Stops.Stop.build(:stop, %{id: stop_id})
     end)
 
-    {:ok, _, html} =
-      live_isolated(conn, UpcomingDeparturesLive,
-        session: %{
-          "route_id" => route_id,
-          "direction_id" => direction_id,
-          "stop_id" => stop_id
-        }
-      )
+    {:ok, _, html} = start_live_view(conn, route_id_param, direction_id, stop_id_param)
 
     assert html =~ "Loading upcoming departures"
   end
 
   test "fetches schedules info on load for subway", %{conn: conn} do
-    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
     route_id = FactoryHelpers.build(:id)
     route = Factories.Routes.Route.build(:route, %{id: route_id, type: Faker.Util.pick([0, 1])})
     stop_id = FactoryHelpers.build(:id)
@@ -72,32 +66,28 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
       []
     end)
 
-    {:ok, _, html} =
-      live_isolated(conn, UpcomingDeparturesLive,
-        session: %{
-          "route_id" => route_id,
-          "direction_id" => direction_id,
-          "stop_id" => stop_id
-        }
-      )
+    {:ok, _, html} = start_live_view(conn, route_id, direction_id, stop_id)
 
     assert html =~ "Loading upcoming departures"
   end
 
-  test "requests predictions info", %{conn: conn} do
-    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+  test "requests upcoming departures", %{conn: conn} do
     stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
 
-    expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
+    route_id = FactoryHelpers.build(:id)
+    stop_id = FactoryHelpers.build(:id)
+    direction_id = FactoryHelpers.build(:direction_id)
 
-    {:ok, view, _} =
-      live_isolated(conn, UpcomingDeparturesLive,
-        session: %{
-          "route_id" => FactoryHelpers.build(:id),
-          "direction_id" => FactoryHelpers.build(:direction_id),
-          "stop_id" => FactoryHelpers.build(:id)
-        }
-      )
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn arg ->
+      assert arg[:stop_id] == stop_id
+      assert arg[:route].id == route_id
+      assert arg[:direction_id] == direction_id
+      assert arg[:now]
+
+      :no_service
+    end)
+
+    {:ok, view, _} = start_live_view(conn, route_id, direction_id, stop_id)
 
     assert render_async(view)
   end
@@ -115,67 +105,44 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
 
     schedules = Factories.Schedules.Schedule.build_list(3, :schedule)
 
+    # Last scheduled time is in the future
     last_schedule =
       Factories.Schedules.Schedule.build(:schedule,
         time: @date_time_module.now() |> DateTime.shift(minute: 40)
       )
 
-    expect(Schedules.Repo.Mock, :by_route_ids, 3, fn _, _ ->
+    expect(Schedules.Repo.Mock, :by_route_ids, 2, fn _, _ ->
       schedules ++ [last_schedule]
     end)
 
-    expect(Predictions.Repo.Mock, :all, fn _ ->
-      Factories.Predictions.Prediction.build_list(15, :prediction,
-        route: route,
-        stop: stop,
+    # Available upcoming departures are earlier than the last scheduled time
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+      Factories.UpcomingDepartures.build_list(15, :upcoming_departure,
         time: @date_time_module.now() |> DateTime.shift(minute: 20)
       )
     end)
 
-    {:ok, view, _} =
-      live_isolated(conn, UpcomingDeparturesLive,
-        session: %{
-          "route_id" => route_id,
-          "direction_id" => direction_id,
-          "stop_id" => stop_id
-        },
-        on_error: :warn
-      )
+    {:ok, view, _} = start_live_view(conn, route_id, direction_id, stop_id)
 
     {:ok, rendered_time} = Dotcom.Utils.Time.format(last_schedule.time, :hour_12_minutes)
+
     assert render_async(view) =~ "Scheduled service continues until #{rendered_time}"
   end
 
   test "shows service ended message", %{conn: conn} do
     # Setup
-    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+    stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
 
-    %{
-      route: route,
-      scheduled_departure_times: [_, scheduled_time, _],
-      schedules: schedules,
-      stops: [_, stop, _]
-    } =
-      PredictedScheduleHelper.predicted_schedule_trip_data(route_factory_types: [:bus_route])
-
-    route_id = route.id
-    stop_id = stop.id
-    expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-
-    stub(Dotcom.Utils.DateTime.Mock, :now, fn ->
-      Dotcom.Utils.ServiceDateTime.end_of_service_day(scheduled_time)
-    end)
-
-    stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ ->
-      schedules |> Enum.filter(&(&1.stop.id == stop_id))
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+      :service_ended
     end)
 
     {:ok, view, _} =
       live_isolated(conn, UpcomingDeparturesLive,
         session: %{
-          "route_id" => route_id,
+          "route_id" => FactoryHelpers.build(:id),
           "direction_id" => FactoryHelpers.build(:direction_id),
-          "stop_id" => stop_id
+          "stop_id" => FactoryHelpers.build(:id)
         }
       )
 
@@ -192,22 +159,18 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
 
       stub(Routes.Repo.Mock, :get, fn _ -> route end)
 
-      stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ ->
-        Factories.Schedules.Schedule.build_list(10, :schedule,
-          time: @date_time_module.now() |> DateTime.shift(minute: 40)
+      stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+
+      upcoming_departures =
+        Factories.UpcomingDepartures.build_list(15, :upcoming_departure,
+          time: @date_time_module.now() |> DateTime.shift(minute: 20)
         )
+
+      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+        {:no_realtime, upcoming_departures}
       end)
 
-      stub(Predictions.Repo.Mock, :all, fn _ -> [] end)
-
-      {:ok, view, _} =
-        live_isolated(conn, UpcomingDeparturesLive,
-          session: %{
-            "route_id" => route_id,
-            "direction_id" => FactoryHelpers.build(:direction_id),
-            "stop_id" => FactoryHelpers.build(:id)
-          }
-        )
+      {:ok, view, _} = start_live_view(conn, route_id)
 
       assert render_async(view) =~
                "There are currently no realtime departures available. Scheduled departures are shown below."
@@ -216,29 +179,28 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
 
   describe "for subway routes" do
     test "shows no realtime message", %{conn: conn} do
-      stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
-      route_id = FactoryHelpers.build(:id)
-      route = Factories.Routes.Route.build(:subway_route, %{id: route_id})
+      route = Factories.Routes.Route.build(:subway_route)
       stub(Routes.Repo.Mock, :get, fn _ -> route end)
+      stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
 
-      stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ ->
-        Factories.Schedules.Schedule.build_list(10, :schedule,
-          time: @date_time_module.now() |> DateTime.shift(minute: 40)
-        )
+      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+        :no_realtime
       end)
 
-      stub(Predictions.Repo.Mock, :all, fn _ -> [] end)
-
-      {:ok, view, _} =
-        live_isolated(conn, UpcomingDeparturesLive,
-          session: %{
-            "route_id" => route_id,
-            "direction_id" => FactoryHelpers.build(:direction_id),
-            "stop_id" => FactoryHelpers.build(:id)
-          }
-        )
+      {:ok, view, _} = start_live_view(conn, route.id)
 
       render_async(view) =~ "There are currently no realtime departures available."
     end
+  end
+
+  defp start_live_view(conn, route_id, direction_id \\ nil, stop_id \\ nil) do
+    live_isolated(conn, UpcomingDeparturesLive,
+      session: %{
+        "route_id" => route_id || FactoryHelpers.build(:id),
+        "direction_id" => direction_id || FactoryHelpers.build(:direction_id),
+        "stop_id" => stop_id || FactoryHelpers.build(:id)
+      },
+      on_error: :warn
+    )
   end
 end

--- a/test/dotcom_web/live/upcoming_departures_live_test.exs
+++ b/test/dotcom_web/live/upcoming_departures_live_test.exs
@@ -225,6 +225,51 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     end
   end
 
+  test "shows error when server error occurs", %{conn: conn} do
+    parent = self()
+    ref = make_ref()
+
+    stub(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+      send(parent, {ref, :done})
+      :no_realtime
+    end)
+
+    route_id = FactoryHelpers.build(:id)
+    direction_id = FactoryHelpers.build(:direction_id)
+    stop_id = FactoryHelpers.build(:id)
+    topic = "departures:#{route_id}:#{direction_id}:#{stop_id}"
+
+    {:ok, view, _} = start_live_view(conn, route_id, direction_id, stop_id)
+
+    assert_receive {^ref, :done}
+    assert_receive {^ref, :done}
+
+    pid = view.pid
+    :erlang.trace(pid, true, [:receive])
+
+    assert view
+           |> element("[data-test=\"u_d:async_success\"]")
+           |> has_element?()
+
+    # trigger the correct server's terminate/2
+    :ok =
+      GenServer.whereis({:global, topic})
+      |> GenServer.stop(:normal)
+
+    assert_receive {:trace, ^pid, :receive,
+                    %Phoenix.Socket.Broadcast{event: "upcoming_departures", payload: :terminated}}
+
+    refute view
+           |> element("[data-test=\"u_d:async_success\"]")
+           |> has_element?()
+
+    assert view
+           |> element("[data-test=\"u_d:async_failed\"]")
+           |> has_element?()
+
+    assert render(view) =~ "There was a problem loading upcoming departures"
+  end
+
   defp start_live_view(conn, route_id \\ nil, direction_id \\ nil, stop_id \\ nil) do
     live_isolated(conn, UpcomingDeparturesLive,
       session: %{

--- a/test/dotcom_web/live/upcoming_departures_live_test.exs
+++ b/test/dotcom_web/live/upcoming_departures_live_test.exs
@@ -237,7 +237,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     route_id = FactoryHelpers.build(:id)
     direction_id = FactoryHelpers.build(:direction_id)
     stop_id = FactoryHelpers.build(:id)
-    topic = "departures:#{route_id}:#{direction_id}:#{stop_id}"
+    params = %{route_id: route_id, direction_id: direction_id, stop_id: stop_id}
 
     {:ok, view, _} = start_live_view(conn, route_id, direction_id, stop_id)
 
@@ -253,7 +253,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
 
     # trigger the correct server's terminate/2
     :ok =
-      GenServer.whereis({:global, topic})
+      GenServer.whereis({:global, params})
       |> GenServer.stop(:normal)
 
     assert_receive {:trace, ^pid, :receive,

--- a/test/support/assertions.ex
+++ b/test/support/assertions.ex
@@ -12,4 +12,21 @@ defmodule Dotcom.Assertions do
       assert Enum.sort(unquote(list1)) == Enum.sort(unquote(list2))
     end
   end
+
+  @doc """
+  Retries a function until it succeeds without an assertion error, or the timeout is reached
+  """
+  def wait_until(fun), do: wait_until(1_000, fun)
+
+  def wait_until(0, fun), do: fun.()
+
+  def wait_until(timeout, fun) do
+    try do
+      fun.()
+    rescue
+      ExUnit.AssertionError ->
+        :timer.sleep(10)
+        wait_until(max(0, timeout - 10), fun)
+    end
+  end
 end

--- a/test/support/factories/upcoming_departures.ex
+++ b/test/support/factories/upcoming_departures.ex
@@ -1,0 +1,13 @@
+defmodule Test.Support.Factories.UpcomingDepartures do
+  use ExMachina
+
+  alias Test.Support.Factories
+
+  def upcoming_departure_factory do
+    %Dotcom.UpcomingDepartures.UpcomingDeparture{
+      arrival_status: {:arrival_minutes, Faker.Util.pick(1..60)},
+      route: Factories.Routes.Route.build(:route),
+      time: sequence(:time, &DateTime.from_unix!/1)
+    }
+  end
+end

--- a/test/support/factories/upcoming_departures.ex
+++ b/test/support/factories/upcoming_departures.ex
@@ -1,13 +1,19 @@
 defmodule Test.Support.Factories.UpcomingDepartures do
   use ExMachina
 
-  alias Test.Support.Factories
+  alias Test.Support.{Factories, FactoryHelpers}
 
   def upcoming_departure_factory do
     %Dotcom.UpcomingDepartures.UpcomingDeparture{
       arrival_status: {:arrival_minutes, Faker.Util.pick(1..60)},
+      crowding: Faker.Util.pick([:not_crowded, :some_crowding, :crowded]),
+      headsign: Faker.Address.city(),
+      last_trip?: false,
       route: Factories.Routes.Route.build(:route),
-      time: sequence(:time, &DateTime.from_unix!/1)
+      stop_sequence: Faker.Util.pick(0..200),
+      time: sequence(:time, &DateTime.from_unix!/1),
+      trip_id: FactoryHelpers.build(:id),
+      trip_name: Faker.Cat.name()
     }
   end
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -20,6 +20,7 @@ Mox.defmock(OpenTripPlannerClient.Mock, for: OpenTripPlannerClient.Behaviour)
 Mox.defmock(Predictions.Phoenix.PubSub.Mock, for: Phoenix.Channel)
 Mox.defmock(Predictions.PubSub.Mock, for: [GenServer, Predictions.PubSub.Behaviour])
 Mox.defmock(Predictions.Store.Mock, for: Predictions.Store.Behaviour)
+Mox.defmock(Dotcom.UpcomingDepartures.Mock, for: Dotcom.UpcomingDepartures.Behaviour)
 
 # Repos
 Mox.defmock(Alerts.Repo.Mock, for: Alerts.Repo.Behaviour)


### PR DESCRIPTION
## Scope

**Asana Ticket:** [📅🔎🎭 Extract upcoming departures calculation from LiveView into a separate module](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214587664555338?focus=true) (**update**: and [📅🔎🎭 De-duplicate Upcoming Departures GenServers](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214587664555339?focus=true) with commit f46c55a839402db49063f8e9d3074e5e2529dba1)

The linked ticket describes the background and prior art nicely!

## Implementation

> [!WARNING]
> There are a few other changes bundled into here, so I'll describe it commit-by-commit.
> 
> These changes felt needed after I ran into many surprises testing this PR. Because this PR makes `UpcomingDeparturesLive` receive data from another process, and tests run in their own process, and LiveView renders in a separate process, _and_ test mocks (via Mox's `expect/4` or `stub/3` calls) individually run in other processes.... I quickly found myself in a brittle mess of race conditions. The first two commits helped me get through that mess.

### 4722e989b1683c731d9cced1df401751f4f59a01 refactor(UpcomingDeparturesLive): use behaviour

> [!TIP]
>  This makes `upcoming_departures/1` able to be mocked in tests.

[This section of the Mox documentation](https://mox.hexdocs.pm/Mox.html#module-blocking-on-expectations) describes a technique to prevent the test from finishing executing before it has a chance to call the mock and meet the expectations. It basically entails sending a message from the `expect/4` function to the test, and asserting on receiving said message in the test.

The `upcoming_departures/1` function internally makes several different calls to the MBTA V3 API, which we can dutifully mock in the tests. But it proved hard to use this test technique with so many different mocks!

I went back and forth on whether to make `upcoming_departures/1` itself mockable or not. For tests which call code which calls `upcoming_departures/1`:
- If we don't mock it, those tests can use the same predictions/schedules/`now()` mocks to produce the same output even if we change the `upcoming_departures/1` internals
- If we do mock it, our tests can help enforce changes to the shape of the `upcoming_departures/1` output (because of the addition of the Behaviour), and we are free to change the internals without adjusting other mocks. It doesn't capture how particular predictions/schedules/`now()` states create certain outputs (though that's covered directly in the function's own tests)

I'm getting rambly. I decided to mock it, so that I'd only have one thing to mock for the associated LiveView's tests, and one place to fix Mox's treatment.

### 81826c6df8a4687d32c96e2fc27894e6c39f22a1 refactor(UpcomingDepartures.Processor) inline date

> [!TIP]
>  This means we don't have to mock `Dotcom.Utils.DateTime.now()` _every_ single time we deal with calling `upcoming_departures/1` in tests.

We were always calling `now/0` right before calling `upcoming_departures/1` anyways, so I figure it doesn't make any particular performance impact to make that call from inside of `upcoming_departures/1`  🤷🏼‍♀️ 

### 27c46de206613a0b38c9b971ce426ea3183400fd & 6da3ee7c10220a87323b776c5d4dc35d89f5e6b1 feat(UpcomingDepartures.Server): add worker process + fix(UpcomingDeparturesLive): unbreak all the tests

> [!TIP]
>  **This is the main part!** Instead of calling `upcoming_departures/1` in a LiveView, move that to a separate process.

#### About `Dotcom.UpcomingDepartures.Server`

It's a `GenServer` that's configured to be a long-lived process handling sending upcoming departures to other processes! 

- The actual subscribing/unsubscribing/broadcasting-to-subscribers pieces are actually handled ultimately by `Phoenix.PubSub` (via the `DotcomWeb.Endpoint` `subscribe/1`, `unsubscribe/1`, and `broadcast/3` functions) . 
- Each route/direction/stop is associated with a topic. e.g. the Orange line inbound from Back Bay is associated with the topic name `"departures:Orange:1:place-bbsta"`. (`Phoenix.PubSub` requires the topic to be a string)
- A single `Dotcom.UpcomingDepartures.Server` process is started for each unique topic.
  - On process startup, it stores the function we'll call to get upcoming departures, the topic name, and a list of unique subscribers (initialized to empty).
  - It handles periodically calling the stored function and broadcasting its output to the topic's subscribers
  - When someone new subscribes, it replies immediately with the current upcoming departures
  - While it does internally keep an updated list of current subscribers to a topic, it's only used for checking when we have no subscribers left. When that happens, we stop the process.

My theory was that because subscribing/unsubscribing to a topic is decoupled from the `Dotcom.UpcomingDepartures.Server` process, if `Dotcom.UpcomingDepartures.Server` happens to crash/ and get restarted, it could quickly resume broadcasting to subscribers since `Phoenix.Pubsub` will still know who's subscribed to which topic. 

However that'd mess up our subscriber count tracking! 

So I also added some logic to the `Dotcom.UpcomingDepartures.Server` `terminate/2` callback, to send _another_ broadcast to the topic indicating it's been terminated. In `UpcomingDeparturesLive` we can detect that event and clear the results from the screen before the data gets stale (here it should switch to "There was a problem loading upcoming departures").
 
## Screenshots

There should be no visual changes from this! Compare side-to-side with a prod or staging environment of your choice.

## How to test

I added some logging so we could see what's going on. We could remove this before going live if we'd like, as it'd get quite noisy :)
<img width="804" height="134" alt="image" src="https://github.com/user-attachments/assets/5ee8fe32-53f2-4774-ad65-48cb85dc93b1" />

I hadn't quite gotten so far in my own testing, but I'd love to verify that terminating the server produces the expected output, I might probably come back and add that tomorrow.