### PR TITLE
SF2.0[fix]: Skipped Stops disappear when the schedule drifts into the past, even if the vehicle is still upstream

### DIFF
--- a/lib/dotcom/upcoming_departures/processor.ex
+++ b/lib/dotcom/upcoming_departures/processor.ex
@@ -296,7 +296,6 @@ defmodule Dotcom.UpcomingDepartures.Processor do
 
     predicted_schedules =
       PredictedSchedule.group(predictions, schedules)
-      |> Enum.reject(&past_schedule?(&1, now))
 
     vehicle =
       predicted_schedules

--- a/lib/dotcom/upcoming_departures/processor.ex
+++ b/lib/dotcom/upcoming_departures/processor.ex
@@ -143,6 +143,16 @@ defmodule Dotcom.UpcomingDepartures.Processor do
     !prediction_departure_time && !schedule_departure_time
   end
 
+  defp past_schedule_keep_skipped?(
+         %PredictedSchedule{schedule: %Schedule{departure_time: time}, prediction: prediction},
+         now
+       )
+       when time != nil do
+    is_nil(prediction) and DateTime.before?(time, now)
+  end
+
+  defp past_schedule_keep_skipped?(_, _), do: false
+
   defp past_schedule?(
          %PredictedSchedule{schedule: %Schedule{departure_time: time}, prediction: prediction},
          now
@@ -296,6 +306,7 @@ defmodule Dotcom.UpcomingDepartures.Processor do
 
     predicted_schedules =
       PredictedSchedule.group(predictions, schedules)
+      |> Enum.reject(&past_schedule_keep_skipped?(&1, now))
 
     vehicle =
       predicted_schedules

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -2953,7 +2953,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
              ]
     end
 
-    @tag :skip
     test "does not include past scheduled stops in trip details" do
       # Setup
       %{

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -3029,13 +3029,13 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       # Verify
       after_count =
-        trip_details.stops_after |> Enum.filter(fn s -> !s.cancelled? end) |> Enum.count()
+        trip_details.stops_after |> Enum.count(fn s -> !s.cancelled? end)
 
       assert after_count == 2,
              "Unexpected number of stops_after, expected 2 got #{after_count}"
 
       before_count =
-        trip_details.stops_before |> Enum.filter(fn s -> !s.cancelled? end) |> Enum.count()
+        trip_details.stops_before |> Enum.count(fn s -> !s.cancelled? end)
 
       assert before_count == 0,
              "Unexpected number of stops_before, expected 0 got #{after_count}"

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -2987,6 +2987,59 @@ defmodule Dotcom.UpcomingDeparturesTest do
              ]
     end
 
+    test "includes skipped stops in trip details" do
+      # Setup
+      %{
+        scheduled_departure_times: [departure_time_1, departure_time_2, _, _, _],
+        scheduled_arrival_times: [_, _, arrival_time_2, _, _],
+        schedules: schedules,
+        stop_sequences: [_, _, _, stop_seq, _],
+        stops: [_, this_stop, stop_0, stop_1, stop_2] = stops,
+        trip_id: trip_id,
+        trip: trip,
+        route: route
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(
+          route_factory_types: [:bus_route, :commuter_rail_route, :ferry_route],
+          stop_count: 5,
+          skipped_stops: [2, 3, 4]
+        )
+
+      expect(Predictions.Repo.Mock, :all, fn _ ->
+        stops
+        |> Enum.map(fn stop ->
+          %Predictions.Prediction{
+            schedule_relationship:
+              if stop == this_stop do
+                nil
+              else
+                :skipped
+              end,
+            route: route,
+            trip: trip,
+            stop: stop
+          }
+        end)
+      end)
+
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> schedules end)
+
+      # Exercise
+      trip_details =
+        UpcomingDepartures.trip_details(%{
+          now:
+            Generators.DateTime.random_time_range_date_time({departure_time_1, departure_time_2}),
+          stop_id: this_stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
+        })
+
+      dbg(trip_details.stops_after, limit: :infinity)
+      # Verify
+      assert trip_details.stops_after |> Enum.count() == 3,
+             "Unexpected number of stops_after, expected 4 got #{trip_details.stops_before |> Enum.count()}"
+    end
+
     test "uses `departure_time` as other_stop.time if `arrival_time` isn't available" do
       # Setup
       %{

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -2987,14 +2987,13 @@ defmodule Dotcom.UpcomingDeparturesTest do
              ]
     end
 
-    test "includes skipped stops in trip details" do
+    test "includes only downstream skipped stops in trip details" do
       # Setup
       %{
-        scheduled_departure_times: [departure_time_1, departure_time_2, _, _, _],
-        scheduled_arrival_times: [_, _, arrival_time_2, _, _],
+        scheduled_departure_times: [_, departure_time_1, departure_time_2, _, _],
         schedules: schedules,
-        stop_sequences: [_, _, _, stop_seq, _],
-        stops: [_, this_stop, stop_0, stop_1, stop_2] = stops,
+        stop_sequences: [_, _, stop_seq, _, _],
+        stops: [_, _, this_stop, _, _] = stops,
         trip_id: trip_id,
         trip: trip,
         route: route
@@ -3002,19 +3001,13 @@ defmodule Dotcom.UpcomingDeparturesTest do
         PredictedScheduleHelper.predicted_schedule_trip_data(
           route_factory_types: [:bus_route, :commuter_rail_route, :ferry_route],
           stop_count: 5,
-          skipped_stops: [2, 3, 4]
+          skipped_stops: [0, 1, 3, 4]
         )
 
       expect(Predictions.Repo.Mock, :all, fn _ ->
         stops
         |> Enum.map(fn stop ->
           %Predictions.Prediction{
-            schedule_relationship:
-              if stop == this_stop do
-                nil
-              else
-                :skipped
-              end,
             route: route,
             trip: trip,
             stop: stop
@@ -3034,10 +3027,18 @@ defmodule Dotcom.UpcomingDeparturesTest do
           trip_id: trip_id
         })
 
-      dbg(trip_details.stops_after, limit: :infinity)
       # Verify
-      assert trip_details.stops_after |> Enum.count() == 3,
-             "Unexpected number of stops_after, expected 4 got #{trip_details.stops_before |> Enum.count()}"
+      after_count =
+        trip_details.stops_after |> Enum.filter(fn s -> !s.cancelled? end) |> Enum.count()
+
+      assert after_count == 2,
+             "Unexpected number of stops_after, expected 2 got #{after_count}"
+
+      before_count =
+        trip_details.stops_before |> Enum.filter(fn s -> !s.cancelled? end) |> Enum.count()
+
+      assert before_count == 0,
+             "Unexpected number of stops_before, expected 0 got #{after_count}"
     end
 
     test "uses `departure_time` as other_stop.time if `arrival_time` isn't available" do

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -2953,6 +2953,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
              ]
     end
 
+    @tag :skip
     test "does not include past scheduled stops in trip details" do
       # Setup
       %{


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [📅🔎 Skipped Stops disappear when the schedule drifts into the past, even if the vehicle is still upstream](https://app.asana.com/1/15492006741476/project/555089885850811/task/1213813725381825?focus=true)

## Implementation

Removed time filtering from predicted schedules on trip details so that we continue to show skipped stops that have predictions in the past, but the vehicle hasn't skipped yet on this trip

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Local ------------------------- Dev
<img width="1362" height="610" alt="Screenshot 2026-06-04 at 1 40 21 PM" src="https://github.com/user-attachments/assets/946319ed-33db-49be-aeb1-1de9a9cfbe3d" />


## How to test

Find a route with skipped stops, preferably a bus.  Find a stop right before the skipped stops, watch a vehicle approach and confirm that the skipped stops do not disappear while the vehicle is still on it's way to your stop.

If there's a Red Sox home game, the 8, 19, 60, and 65 will be skipping stops around Fenway and you can use this link and vary the route between those to find a bus that is coming soon.  I got lucky, these seem to be rather infrequent busses.

https://dev.mbtace.com/departures/?route_id=65&direction_id=1&stop_id=1806

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
