### PR TITLE
fix: Remove `id` field from `mbta-logo` SVG icon

### DIFF
--- a/priv/static/icon-svg/mbta-logo.svg
+++ b/priv/static/icon-svg/mbta-logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="mbta-logo" role="img" viewBox="0 0 36 36">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" role="img" viewBox="0 0 36 36">
     <path fill="#1c1e23" d="m18 34.4a16.4 16.4 0 1 1 16.4-16.4 16.34585 16.34585 0 0 1 -16.4 16.4zm0-34.4a18 18 0 1 0 18 18 18.05292 18.05292 0 0 0 -18-18"/>
     <path fill="#1c1e23" d="m6.6 15.7h8.6v14h5.6v-14h8.6v-5.7h-22.8z"/>
 </svg>


### PR DESCRIPTION
## Scope

This clears up a whole bunch of 👇 warnings:
```elixir
warning: Duplicate id found while testing LiveView: mbta-logo

    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="mbta-logo" role="img" viewBox="0 0 36 36"><path fill="#1c1e23" d="m18 34.4a16.4 16.4 0 1 1 16.4-16.4 16.34585 16.34585 0 0 1 -16.4 16.4zm0-34.4a18 18 0 1 0 18 18 18.05292 18.05292 0 0 0 -18-18"></path><path fill="#1c1e23" d="m6.6 15.7h8.6v14h5.6v-14h8.6v-5.7h-22.8z"></path></svg>
    <svg class="size-5 fill-current" aria-hidden="true" data-test="stop_banner_icon:station" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="mbta-logo" role="img" viewBox="0 0 36 36"><path fill="#1c1e23" d="m18 34.4a16.4 16.4 0 1 1 16.4-16.4 16.34585 16.34585 0 0 1 -16.4 16.4zm0-34.4a18 18 0 1 0 18 18 18.05292 18.05292 0 0 0 -18-18"></path><path fill="#1c1e23" d="m6.6 15.7h8.6v14h5.6v-14h8.6v-5.7h-22.8z"></path></svg>
```

(There are still a few warnings related to masks in flag icons, but those are harder to get rid of, and those warnings only show up when you run the world cup live view tests - versus these, which show up for any test that loads any page at all.)