### PR TITLE
QF | [WC]: Add World Cup callout to Commuter Rail alerts page

### DIFF
--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -376,6 +376,33 @@ defmodule DotcomWeb.Components do
     """
   end
 
+  attr(:rest, :global, include: ~w(disabled))
+  attr(:class, :string, default: "")
+
+  @doc """
+  Callout for commuter rail alerts during the world cup
+  """
+  def cr_alert_intercept(assigns) do
+    ~H"""
+    <.descriptive_link
+      href="/schedules/commuter-rail"
+      class={@class}
+      {@rest}
+    >
+      <:title>
+        {~t(Your Commuter Rail trip will be affected by the World Cup.)}
+      </:title>
+      <p class="c-descriptive-link__world-cup">
+        {gettext(
+          "Service changes are in effect June 6 – July 12. Check each day of your line’s %{timetable_link} for the most up-to-date schedule.",
+          timetable_link: "<span class='underline font-medium'>timetable</span>"
+        )
+        |> Phoenix.HTML.raw()}
+      </p>
+    </.descriptive_link>
+    """
+  end
+
   attr(:rest, :global)
   slot :inner_block, required: true
 

--- a/lib/dotcom_web/live/commuter_rail_alerts_live.ex
+++ b/lib/dotcom_web/live/commuter_rail_alerts_live.ex
@@ -67,6 +67,7 @@ defmodule DotcomWeb.CommuterRailAlertsLive do
           {DotcomWeb.AlertView.render("_t-alerts.html")}
         </:sidebar_bottom>
         <:main_section>
+          <.cr_alert_intercept class="mb-3" />
           <section id="current_status">
             <.alerts_commuter_rail_status commuter_rail_status={@commuter_rail_status} />
           </section>


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [QF | ⚽️ Add World Cup callout to Commuter Rail alerts page](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215427982095990?focus=true)

## Implementation

Created a verion of the world_cup_intercept component for commuter rail alerts that links to the timetable list page.  Added that component to commuter_rail_alerts_live

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
### Mobile
<img width="282" height="543" alt="Screenshot 2026-06-08 at 11 31 30 AM" src="https://github.com/user-attachments/assets/e3cc3479-6ff7-4d24-b80c-e9d0c991a001" />
### Desktop
<img width="834" height="484" alt="Screenshot 2026-06-08 at 11 31 08 AM" src="https://github.com/user-attachments/assets/ffe553aa-600f-47a0-a27a-50bd331ee093" />



## How to test

http://localhost:4001/alerts/commuter-rail
Confirm that the callout matches the mockup and that it links to `/schedules/commuter-rail`

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
