### PR TITLE
[Alerts] Fix alerts with URLs which have query parameters

### DIFF
--- a/lib/alerts/url_parsing_helpers.ex
+++ b/lib/alerts/url_parsing_helpers.ex
@@ -1,7 +1,7 @@
 defmodule Alerts.URLParsingHelpers do
   @moduledoc "Helpers to parse out the url from a string and create an html link"
 
-  @url_regex ~r/(https?:\/\/)?([\da-z\.-]+)\.([a-z]{2,6})([\/\w\.-]*)*\/?/i
+  @url_regex ~r/(https?:\/\/)?([\da-z\.-]+)\.([a-z]{2,6})([\/\w\.-\?&%#]*)*\/?/i
 
   @spec get_full_url(String.t()) :: String.t() | nil
   def get_full_url(text) do

--- a/test/alerts/url_parsing_helpers_test.exs
+++ b/test/alerts/url_parsing_helpers_test.exs
@@ -23,6 +23,21 @@ defmodule Alerts.URLParsingHelpersTest do
 
       assert get_full_url(text) == nil
     end
+
+    test "should return the url with special characters parsed from the text" do
+      word_fn = &Faker.Internet.domain_word/0
+
+      url =
+        "#{Faker.Util.pick(["http", "https"])}://#{word_fn.()}.#{Faker.Internet.domain_name()}/#{word_fn.()}/#{word_fn.()}?#{word_fn.()}=#{word_fn.()}&param_2=hello%20world##{word_fn.()}"
+
+      text =
+        "This is a test for url validation, the following URL should be completely parsed:  #{url} "
+
+      result = get_full_url(text)
+
+      assert result == url,
+             "Unexpected URL received: got #{result}, expected #{url}"
+    end
   end
 
   describe "create_url/1" do


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚠️ Fix alerts with URLs which have query parameters](https://app.asana.com/1/15492006741476/project/555089885850811/task/1213810651947031?focus=true)

## Implementation
Updated the url detecting regex to look for query param characters(`?` and `&`), url_escaped characters(ie `%20`), and `#`
Added a test for the new functionality

**Note:**  I'm not going to expand the scope of this ticket, but our URL regex pattern is a bit conservative in what it allows.  As long as we don't need to link to any [exotic domains](https://en.wikipedia.org/wiki/List_of_English-language_generic_Internet_top-level_domains) it'll be fine.  We should take a look at this sometime.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Branch
<img width="826" height="218" alt="Screenshot 2026-06-08 at 1 51 28 PM" src="https://github.com/user-attachments/assets/1ac71845-24b4-4228-87f1-de4bd52ef864" />


### Dev-Blue
<img width="828" height="223" alt="Screenshot 2026-06-08 at 1 51 36 PM" src="https://github.com/user-attachments/assets/85b1eaf7-a1a9-4a96-8118-4ddb8f1d3be2" />

## How to test

View an alert with a URL that has any combination of query parameters(`?foo=bar`), url escaped characters(`hello%20world`), and/or an anchor (`index.html#part3`)

I currently have one setup on dev here:

http://localhost:4001/schedules/CR-NewBedford/alerts

Confirm that the URL is fully parsed (correctly) and leads to the correct URL when clicked.

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
