### PR TITLE
feat(SF2.0/DS): Show the previous day's schedules after the service cutoff if there's still scheduled service

### DIFF
--- a/lib/dotcom/schedule_finder/service_groups.ex
+++ b/lib/dotcom/schedule_finder/service_groups.ex
@@ -23,7 +23,7 @@ defmodule Dotcom.ScheduleFinder.ServiceGroup do
   @spec for_route(Routes.Route.id_t(), Date.t()) :: [__MODULE__.t()]
   def for_route(route_id, current_date) do
     route_id
-    |> ServicePatterns.patterns_for_route()
+    |> ServicePatterns.patterns_for_route(current_date)
     |> Enum.map(fn sp ->
       %{
         now_date: if(current_date in sp.dates, do: current_date),

--- a/lib/dotcom/service_patterns.ex
+++ b/lib/dotcom/service_patterns.ex
@@ -29,8 +29,8 @@ defmodule Dotcom.ServicePatterns do
     |> Enum.any?(&Service.serves_date?(&1, date))
   end
 
-  @spec services_for_route(Routes.Route.id_t()) :: [Service.t()]
-  def services_for_route(route_id) do
+  @spec services_for_route(Routes.Route.id_t(), Date.t()) :: [Service.t()]
+  def services_for_route(route_id, current_date \\ ServiceDateTime.service_date()) do
     route_id
     |> @services_repo.by_route_id()
     |> Stream.reject(&(&1.typicality == :canonical))
@@ -38,7 +38,7 @@ defmodule Dotcom.ServicePatterns do
     |> Stream.map(&add_single_date_description/1)
     |> Stream.map(&{Service.all_valid_dates_for_service(&1), &1})
     |> Stream.map(&adjust_planned_description/1)
-    |> dedup_identical_services()
+    |> dedup_identical_services(current_date)
     |> dedup_similar_services()
   end
 
@@ -54,10 +54,10 @@ defmodule Dotcom.ServicePatterns do
           service_label: typical_label() | atypical_label()
         }
 
-  @spec patterns_for_route(Routes.Route.id_t()) :: [service_pattern()]
-  def patterns_for_route(route_id) do
+  @spec patterns_for_route(Routes.Route.id_t(), Date.t()) :: [service_pattern()]
+  def patterns_for_route(route_id, current_date \\ ServiceDateTime.service_date()) do
     route_id
-    |> services_for_route()
+    |> services_for_route(current_date)
     |> to_service_pattern()
   end
 
@@ -119,13 +119,13 @@ defmodule Dotcom.ServicePatterns do
 
   defp adjust_planned_description(other), do: other
 
-  defp dedup_identical_services(dated_services) do
+  defp dedup_identical_services(dated_services, current_date) do
     {_unique_dates, unique_services} =
       dated_services
       |> Enum.reject(fn {dates, _} ->
         dates
         |> List.last()
-        |> Date.before?(ServiceDateTime.service_date())
+        |> Date.before?(current_date)
       end)
       |> Enum.uniq_by(fn {dates, _} -> dates end)
       |> Enum.unzip()

--- a/lib/dotcom_web/live/schedule_finder_live.ex
+++ b/lib/dotcom_web/live/schedule_finder_live.ex
@@ -20,6 +20,7 @@ defmodule DotcomWeb.ScheduleFinderLive do
   alias Routes.Route
   alias Stops.Stop
 
+  @date_time Application.compile_env!(:dotcom, :date_time_module)
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
   @schedule_finder Application.compile_env!(:dotcom, :schedule_finder_module)
   @stops_repo Application.compile_env!(:dotcom, :repo_modules)[:stops]
@@ -39,7 +40,21 @@ defmodule DotcomWeb.ScheduleFinderLive do
   def mount(params, _session, socket) do
     case validate_params(params) do
       {:ok, %{route: route, stop: stop, direction_id: direction_id}} ->
-        service_groups = ServiceGroup.for_route(route.id, service_date())
+        today = service_date()
+        yesterday = today |> Date.shift(day: -1)
+
+        yesterday_service_date? =
+          future_trips_from_yesterdays_service?(%{
+            direction_id: direction_id,
+            now: @date_time.now(),
+            route_id: route.id,
+            stop_id: stop.id,
+            yesterday: yesterday
+          })
+
+        service_date = if yesterday_service_date?, do: yesterday, else: today
+        service_groups = ServiceGroup.for_route(route.id, service_date)
+
         all_services = Enum.flat_map(service_groups, & &1.services)
         selected_service = Enum.find(all_services, %{}, &(&1.now_date || &1.next_date))
 
@@ -61,10 +76,11 @@ defmodule DotcomWeb.ScheduleFinderLive do
           end)
           |> assign_new(:daily_schedule_date, fn assigns ->
             # Current date if there's service today, next available service date otherwise... or current date if there's no service at all!
-            if assigns.service_today? do
-              service_date()
-            else
-              Map.get(selected_service, :next_date, service_date())
+
+            cond do
+              yesterday_service_date? -> yesterday
+              assigns.service_today? -> today
+              true -> Map.get(selected_service, :next_date, today)
             end
           end)
           |> assign_alerts()
@@ -579,6 +595,31 @@ defmodule DotcomWeb.ScheduleFinderLive do
         route: route_name,
         stop: stop.name
       )
+    end
+  end
+
+  defp future_trips_from_yesterdays_service?(%{
+         direction_id: direction_id,
+         now: now,
+         route_id: route_id,
+         stop_id: stop_id,
+         yesterday: yesterday
+       }) do
+    [route_id]
+    |> Schedules.Repo.by_route_ids(
+      direction_id: direction_id,
+      stop_ids: stop_id,
+      date: yesterday
+    )
+    |> Enum.map(&(&1.departure_time || &1.arrival_time))
+    |> case do
+      [] ->
+        false
+
+      time_list ->
+        time_list
+        |> Enum.max_by(& &1, DateTime)
+        |> DateTime.after?(now)
     end
   end
 end

--- a/test/dotcom/schedule_finder/service_groups_test.exs
+++ b/test/dotcom/schedule_finder/service_groups_test.exs
@@ -42,11 +42,13 @@ defmodule Dotcom.ScheduleFinder.ServiceGroupTest do
     end
 
     test "if no active routes, mark next active route" do
-      inactive_date = Faker.Date.backward(1) |> Date.shift(day: -120)
+      inactive_date = Generators.Date.random_date()
       route_id = FactoryHelpers.build(:id)
 
       expect(Services.Repo.Mock, :by_route_id, fn ^route_id ->
-        build_list(50, :service)
+        build_list(50, :service,
+          removed_dates: [inactive_date |> Dotcom.Utils.Time.format!(:iso_date)]
+        )
       end)
 
       # not every groups will necessarily have a service which is now/next since that's calculated across all groups. so check all of them

--- a/test/dotcom_web/live/schedule_finder_live_test.exs
+++ b/test/dotcom_web/live/schedule_finder_live_test.exs
@@ -18,6 +18,8 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
 
     stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
 
+    stub(MBTA.Api.Mock, :get_json, fn "/schedules/", _ -> %JsonApi{} end)
+
     :ok
   end
 


### PR DESCRIPTION
## Scope

**Asana Ticket:** [⚽️🦉 Update Daily Schedules "Now" logic](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214585567694856?focus=true)

## Implementation

There are three commits here - two to grease the wheels and one to actually make the change

### [fix: Implicit inactivity in `ServiceGroupsTest`](https://github.com/mbta/dotcom/commit/5436a92f66526fa989a1afad10b3b7b8f13debd5)

[This test](https://github.com/mbta/dotcom/blob/bbca826ae8bb08c0e925adf330ff21b707c0cfd1/test/dotcom/schedule_finder/service_groups_test.exs#L44-L56) needs a date, as well as a whole bunch of services, none of which are active on that date. The previous iteration of the test was implicitly using the following facts to achieve that:
- [A service whose last service date was in the past would get filtered out by `ServicePatterns`](https://github.com/mbta/dotcom/blob/bbca826ae8bb08c0e925adf330ff21b707c0cfd1/lib/dotcom/service_patterns.ex#L125-L129)
- [Factory-built services have active date ranges of no more than 119 days](https://github.com/mbta/dotcom/blob/bbca826ae8bb08c0e925adf330ff21b707c0cfd1/test/support/factories/services/service.ex#L24-L27) (59 days ago to 59 days from now is a span of 119 days)

Those two things combined meant that if we picked a service date at least 120 days in the past, all services returned by `ServicePatterns` (and thus by `ServiceGroups`) would either be filtered out due to being in the past, or would have no overlap with `inactive_date`.

Unfortunately, this only works if `ServicePatterns` uses its own concept of `current_date`, separate from the `current_date` that `ServiceGroups` knows about, which is incompatible with this feature (see below)

Fortunately, the fix was easy! Just add `inactive_date` to the factory-built services' `removed_dates`!

### [refactor: Pass `current_date` into `ServicePatterns`](https://github.com/mbta/dotcom/commit/244ce8af556da483f40bfd66267b2acc755f3daf)

This resolves a discrepancy between `ServicePatterns`, [which was using `ServiceDateTime.service_date()`](https://github.com/mbta/dotcom/blob/bbca826ae8bb08c0e925adf330ff21b707c0cfd1/lib/dotcom/service_patterns.ex#L125-L129) (which always returns today's date if it's after 3AM; yesterday's date if it's before 3AM), and `ServiceGroup`, [which was using a passed-in `current_date`](https://github.com/mbta/dotcom/blob/bbca826ae8bb08c0e925adf330ff21b707c0cfd1/lib/dotcom/schedule_finder/service_groups.ex#L24-L38). 

This discrepancy didn't really matter before this PR, since [the passed-in date was always `service_date()` anyway](https://github.com/mbta/dotcom/blob/bbca826ae8bb08c0e925adf330ff21b707c0cfd1/lib/dotcom_web/live/schedule_finder_live.ex#L42), but this PR changes that.

### [feat(SF2.0/DS): Show the previous day's schedules after the service cutoff if there's still scheduled service](https://github.com/mbta/dotcom/commit/ec7de9ccb2f9ade8bc6ddc539ba56130f92021f5)

In schedule finder, if there are any trips remaining from the previous day's service, do two things:
1. Use yesterday's service date instead of today's as the `daily_schedule_date` (used to load schedules into the `Daily Schedules` section)
2. Pass yesterday's service date instead of today's into `ServiceGroup.for_route/2`.

## Screenshots

(For these screenshots, I mangled `ScheduleFinderLive` to replace the `Upcoming Departures` section with the current time according to `@date_time.now()`. That's for illustrative purposes, and not actually part of this PR.)

<img width="999" height="674" alt="Screenshot 2026-06-08 at 12 52 17 PM" src="https://github.com/user-attachments/assets/639e1591-2022-4f3c-8afe-ff1dd780dc38" />

Notice that it's still showing the `Jun 13` service, even after 3AM!

This is based on the last scheduled trip _at this route/stop/direction_, so the service day will be different at different stops, even on the same route.

<img width="999" height="670" alt="Screenshot 2026-06-08 at 11 02 11 AM" src="https://github.com/user-attachments/assets/94b131f3-59b0-4b59-87cd-a39ca05d863e" />

## How to test

Update the [definition of `DateTime.now()`](https://github.com/mbta/dotcom/blob/bbca826ae8bb08c0e925adf330ff21b707c0cfd1/lib/dotcom/utils/date_time.ex#L30) to something like 👇 and then check out some [upcoming](http://localhost:4001/departures?route_id=39&direction_id=0&stop_id=21365) [departures](http://localhost:4001/departures?route_id=39&direction_id=0&stop_id=91391) [pages](http://localhost:4001/departures?route_id=52&direction_id=1&stop_id=8507).

```elixir
def now(), do: ~N[2026-06-14T04:41:00] |> Timex.to_datetime("America/New_York")
```

You should see that the late-night routes (39, 1, SL*, etc...) should cling to June 13 until their last scheduled trips, and other routes will make the normal 3AM transition.

(Don't be alarmed if you see the `Upcoming Departures` section get messed up when you mangle `DateTime.now()` - `UpcomingDepartures` does a lot of comparison between live prediction data and `now()`, and while you can easily change `now()`, you can't change live prediction data as easily. Ironically, that seems to manifest as all predicted trips claiming to be `Now` 😅) 