### PR TITLE
feat(ServiceDateRollover): message on date change

### DIFF
--- a/lib/dotcom/service_date_rollover.ex
+++ b/lib/dotcom/service_date_rollover.ex
@@ -1,0 +1,57 @@
+defmodule Dotcom.ServiceDateRollover do
+  @moduledoc """
+  Notifies via PubSub when the service date advances to the next service date
+
+  // subscribe to updates
+  _ = Dotcom.ServiceDateRollover.subscribe()
+
+  // handle the update
+  def handle_info({:service_date_rollover, new_service_date}, socket)
+  """
+
+  use GenServer
+
+  import Dotcom.Utils.ServiceDateTime, only: [end_of_service_day: 0, service_date: 0]
+
+  @date_time_module Application.compile_env!(:dotcom, :date_time_module)
+  @topic_name "service_date_rollover"
+
+  def start_link(_opts \\ []) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(_) do
+    {:ok, %{}, {:continue, :schedule_next_run}}
+  end
+
+  @impl GenServer
+  def handle_info(:dispatch_change, state) do
+    _ =
+      Phoenix.PubSub.broadcast(
+        Dotcom.PubSub,
+        @topic_name,
+        {:service_date_rollover, service_date()}
+      )
+
+    {:noreply, state, {:continue, :schedule_next_run}}
+  end
+
+  @impl GenServer
+  def handle_continue(:schedule_next_run, state) do
+    Process.send_after(self(), :dispatch_change, ms_to_next_rollover())
+    {:noreply, state}
+  end
+
+  def ms_to_next_rollover() do
+    end_of_service_day()
+    |> DateTime.shift(microsecond: {1, 4})
+    |> DateTime.diff(@date_time_module.now(), :millisecond)
+  end
+
+  def subscribe() do
+    Phoenix.PubSub.subscribe(Dotcom.PubSub, @topic_name)
+  end
+
+  def topic_name(), do: @topic_name
+end

--- a/lib/dotcom/utils/service_date_time.ex
+++ b/lib/dotcom/utils/service_date_time.ex
@@ -4,13 +4,6 @@ defmodule Dotcom.Utils.ServiceDateTime do
   Currently, we consider the most general case where service starts at 03:00:00am and ends at 02:59:59am.
 
   In the future, we aim to add route-specific service times.
-
-  The service range continuum:
-
-  <---before today---|---this week---|---next week---|---after next week--->
-                     today
-
-  Before today and after next week are open intervals. Today is included in this week.
   """
 
   use Dotcom.Gettext.Sigils
@@ -56,7 +49,12 @@ defmodule Dotcom.Utils.ServiceDateTime do
   end
 
   @doc """
-  The service range for the given date_time.
+  The service range for the given date_time. The service range continuum:
+
+  <---before today---|---this week---|---next week---|---after next week--->
+                     today
+
+  Before today and after next week are open intervals. Today is included in this week.
   """
   @spec service_range(DateTime.t()) :: named_service_range()
   def service_range(date_time) do

--- a/test/dotcom/service_date_rollover_test.exs
+++ b/test/dotcom/service_date_rollover_test.exs
@@ -1,0 +1,123 @@
+defmodule Dotcom.ServiceDateRolloverTest do
+  # async: false because multiple test processes subscribing to the same PubSub topic
+  # can receive each other's broadcasts, causing non-deterministic failures.
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  import Mox
+  import Dotcom.ServiceDateRollover
+
+  alias Dotcom.Utils.ServiceDateTime
+
+  @date_time_module Application.compile_env!(:dotcom, :date_time_module)
+  @timezone Application.compile_env!(:dotcom, :timezone)
+
+  setup :verify_on_exit!
+  # Global mode lets the GenServer process (a separate BEAM process) access the
+  # stubs defined by the test process. Safe because async: false prevents concurrency.
+  setup :set_mox_global
+
+  setup do
+    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+
+    :ok
+  end
+
+  describe "init/1" do
+    test "initializes with empty state and continues to :schedule_next_run" do
+      assert {:ok, %{}, {:continue, :schedule_next_run}} = Dotcom.ServiceDateRollover.init([])
+    end
+  end
+
+  describe "ms_to_next_rollover/0" do
+    test "returns a positive number of milliseconds" do
+      assert ms_to_next_rollover() > 0
+    end
+
+    test "returns the correct number of milliseconds to the next service day rollover" do
+      # Setup: compute the expected value using the same formula as the function under test
+      now = @date_time_module.now()
+
+      expected_rollover =
+        ServiceDateTime.end_of_service_day(now)
+        |> DateTime.shift(microsecond: {1, 4})
+
+      expected_ms = DateTime.diff(expected_rollover, now, :millisecond)
+
+      # Exercise / Verify
+      assert ms_to_next_rollover() == expected_ms
+    end
+
+    test "returns fewer milliseconds when now is closer to the rollover" do
+      first = ms_to_next_rollover()
+      Process.sleep(10)
+      second = ms_to_next_rollover()
+
+      # Verify
+      assert first > second
+    end
+  end
+
+  describe "handle_info/2 :dispatch_change" do
+    setup do
+      {:ok, pid} = start_supervised({Dotcom.ServiceDateRollover, []}, id: :service_date_rollover)
+      :ok = Phoenix.PubSub.subscribe(Dotcom.PubSub, topic_name())
+      %{pid: pid}
+    end
+
+    test "broadcasts the current service date to PubSub subscribers", %{pid: pid} do
+      # Setup
+      expected_date = ServiceDateTime.service_date()
+
+      # Exercise
+      send(pid, :dispatch_change)
+
+      # Verify
+      assert_receive {:service_date_rollover, ^expected_date}
+    end
+
+    test "keeps the GenServer alive after dispatching", %{pid: pid} do
+      # Exercise
+      send(pid, :dispatch_change)
+      assert_receive {:service_date_rollover, _}
+
+      # Verify: GenServer rescheduled itself and is still running
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "GenServer startup" do
+    test "starts successfully" do
+      assert {:ok, pid} =
+               start_supervised({Dotcom.ServiceDateRollover, []}, id: :service_date_rollover)
+
+      assert Process.alive?(pid)
+    end
+  end
+
+  # Moved to its own describe with a setup-level stub so the near-rollover value is
+  # globally visible to the GenServer process. A stub set in a test body is only
+  # accessible to the test process, causing the GenServer's mock call to fail.
+  describe "GenServer startup near rollover" do
+    setup do
+      # ~50ms before the service day rollover so the scheduled timer fires quickly
+      near_rollover = ~N[2024-06-16 02:59:59.950000] |> Timex.to_datetime(@timezone)
+      stub(@date_time_module, :now, fn -> near_rollover end)
+      :ok
+    end
+
+    test "automatically dispatches :service_date_rollover when the rollover time elapses" do
+      :ok = Phoenix.PubSub.subscribe(Dotcom.PubSub, topic_name())
+      {:ok, _pid} = start_supervised({Dotcom.ServiceDateRollover, []}, id: :service_date_rollover)
+
+      assert_receive {:service_date_rollover, _date}, 200
+    end
+
+    test "subscribe/0 subscribes to the service date rollover topic" do
+      :ok = Dotcom.ServiceDateRollover.subscribe()
+      {:ok, _pid} = start_supervised({Dotcom.ServiceDateRollover, []}, id: :service_date_rollover)
+
+      assert_receive {:service_date_rollover, _date}, 200
+    end
+  end
+end


### PR DESCRIPTION
## Scope

Ticket TBA, I noticed that the schedules being fetched in #3228 would persist if the process happened to stay alive to the next service day, but by then we'd want to update Upcoming Departures to reflect to the new day's schedules. 

## Implementation

To help us be aware of when we've elapsed from one service day to the next, I wrote a GenServer to broadcast a message when this happens. The implementation is heavily inspired by [the technique described in this post](https://smartlogic.io/blog/genserver-nightly-task/amp/).

When your process wants to know about the updated service date:
```elixir
# subscribe to updates
_ = Dotcom.ServiceDateRollover.subscribe()
```
When the service date changes you'll get this message to handle
```elixir
# handle the update
def handle_info({:service_date_rollover, new_service_date}, socket) do
  # do something with the new date
end
```

## Screenshots

I don't use it anywhere yet, so nothing user-facing changes here.

## How to test

Added some tests!
