### PR TITLE
cleanup: Disable `LiveDashboard` in deployed environments

### DIFF
--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -302,11 +302,13 @@ defmodule DotcomWeb.Router do
     # get("/vote", VoteController, :show)
   end
 
-  scope "/", DotcomWeb do
-    import Phoenix.LiveDashboard.Router
+  if Mix.env() != :prod do
+    scope "/", DotcomWeb do
+      import Phoenix.LiveDashboard.Router
 
-    pipe_through([:browser, :browser_live, :basic_auth_readonly])
-    live_dashboard("/dashboard")
+      pipe_through([:browser, :browser_live, :basic_auth_readonly])
+      live_dashboard("/dashboard")
+    end
   end
 
   scope "/", DotcomWeb do


### PR DESCRIPTION
## Scope

**Asana Ticket:** [🖋️ Disable LiveView dashboard in production](https://app.asana.com/1/15492006741476/project/385363666817452/task/1215395628112753?focus=true)

## How to test

Navigate to https://dev-green.mbtace.com/dashboard and observe that it 404's, rather than prompting for basic auth.

Navigate anywhere else and observe that the rest of the site still works.

Navigate to http://localhost:4001/dashboard and observe that it still exists and does prompt for basic auth.