### PR TITLE
feat(load_tests): hang out on the page for some amount of time

### DIFF
--- a/integration/load_tests/departures.js
+++ b/integration/load_tests/departures.js
@@ -28,6 +28,11 @@ function chooseVisit(allVisits) {
   return expandedVisits[Math.floor(Math.random() * expandedVisits.length)];
 }
 
+function randomMinutes(min, max) {
+  const minMS = min * 60000;
+  const maxMS = max * 60000;
+  return Math.floor(Math.random() * (maxMS - minMS + 1)) + minMS;
+}
 /*
  *
 This load test expands upon the simpler scenario from view-departures.js
@@ -42,6 +47,7 @@ export async function loadScenario(page, context, events, test) {
   const path = chooseUrl(context.vars.sfVisits);
   await scenario({ page, baseURL: context.vars.target, path, test });
   const { step } = test;
+  await page.waitForTimeout(randomMinutes(1, 5)); // 5 minutes
   await step("Upcoming departures", async () => {
     const upcomingSection = page.getByTestId("upcoming-departures");
     const departure = upcomingSection.locator("details");
@@ -70,6 +76,7 @@ export async function loadScenario(page, context, events, test) {
       });
     }
   });
+  await page.waitForTimeout(randomMinutes(1, 5)); // 5 minutes
   await step("Daily schedules", async () => {
     const dailySchedulesSection = page.getByTestId("daily-schedules");
     await syncLiveView(page, expect);

--- a/integration/load_tests/departures.yml
+++ b/integration/load_tests/departures.yml
@@ -1,21 +1,14 @@
 config:
   target: "http://localhost:4001"
   phases:
-    - name: constantArrival
-      duration: "20s"
-      arrivalRate: 2
-      maxVusers: 4
+    - name: fixedArrivals
+      duration: "20m"
+      arrivalRate: 1
   environments:
     green:
       target: "http://dev-green.mbtace.com"
-      phases:
-        - duration: "20m"
-          arrivalRate: 2
     blue:
       target: "http://dev-blue.mbtace.com"
-      phases:
-        - duration: "20m"
-          arrivalRate: 2
   engines:
     playwright:
       aggregateByName: true

--- a/integration/load_tests/departures.yml
+++ b/integration/load_tests/departures.yml
@@ -11,9 +11,11 @@ config:
       target: "http://dev-blue.mbtace.com"
   engines:
     playwright:
-      aggregateByName: true
+      aggregateByName: false
       launchOptions:
         headless: true
+        slowMo: 500 # drag each test step out a bit!
+        timeout: 0 # disable the test timeout..supposedly
       contextOptions:
         userAgent: "Artillery"
   payload:

--- a/integration/scenarios/view-departures.js
+++ b/integration/scenarios/view-departures.js
@@ -4,7 +4,7 @@ import { chooseUrl } from "../load_tests/departures.js";
 
 export async function scenario({ page, baseURL, path }) {
   const url = `${baseURL}${path || chooseUrl()}`;
-  const response = await page.goto(url);
+  const response = await page.goto(url, { timeout: 0 });
   await page.waitForLoadState("domcontentloaded");
   await syncLiveView(page, expect);
   expect(response.status()).toBe(200);


### PR DESCRIPTION
## Scope

Just had some tweaks to the load tests that I've decided I liked enough to share!

## Implementation

- The tests execute pretty quickly, but humans don't. We add some random lingering here to simulate that
- Tried to make the Playwright tests a little smoother, with no set timeout and so on
- Removes `maxVusers: 4` from the load testing config so that we can spam the server with a lot more than 4 users!

## How to test

I've just been enjoying running more intense load tests.
I'll note I still get errors in my console about network timeouts, network empty responses, all sorts of nonsense, but at the same time I can check logs in Splunk and verify I'm definitely hitting it a lot.

To run the `/departures` page load tests:

```
// from the root directory, not /assets
npx artillery run -e blue ./integration/load_tests/departures.yml # hits dev-blue
npx artillery run -e green ./integration/load_tests/departures.yml # hits dev-green
npx artillery run ./integration/load_tests/departures.yml # default hits localhost:4001
```
