### PR TITLE
refactor(UpcomingDepartures): pass in predicted schedules

### DIFF
--- a/lib/dotcom/upcoming_departures.ex
+++ b/lib/dotcom/upcoming_departures.ex
@@ -6,7 +6,7 @@ defmodule Dotcom.UpcomingDepartures do
 
   alias Dotcom.UpcomingDepartures.{Processor, Server}
 
-  defdelegate upcoming_departures(args), to: Processor
+  defdelegate upcoming_departures(predicted_schedules, args), to: Processor
 
   defdelegate trip_details(args), to: Processor
 

--- a/lib/dotcom/upcoming_departures/behaviour.ex
+++ b/lib/dotcom/upcoming_departures/behaviour.ex
@@ -5,7 +5,7 @@ defmodule Dotcom.UpcomingDepartures.Behaviour do
 
   alias Dotcom.UpcomingDepartures.{UpcomingDeparture, UpcomingTripDetails}
 
-  @callback upcoming_departures(map()) ::
+  @callback upcoming_departures([PredictedSchedule.t()], map()) ::
               [UpcomingDeparture.t()]
               | :no_realtime
               | :no_service

--- a/lib/dotcom/upcoming_departures/processor.ex
+++ b/lib/dotcom/upcoming_departures/processor.ex
@@ -14,7 +14,6 @@ defmodule Dotcom.UpcomingDepartures.Processor do
 
   alias Dotcom.ScheduleFinder.{TripDetails, Platforms}
   alias Dotcom.UpcomingDepartures.{UpcomingDeparture, UpcomingTripDetails}
-  alias Dotcom.Utils.ServiceDateTime
   alias Predictions.Prediction
   alias Routes.Route
   alias Schedules.Schedule
@@ -31,31 +30,9 @@ defmodule Dotcom.UpcomingDepartures.Processor do
            :after_stop | :before_stop | :different_trip | Vehicles.Vehicle.status()
 
   @impl Dotcom.UpcomingDepartures.Behaviour
-  def upcoming_departures(%{
-        direction_id: direction_id,
-        route: route,
-        stop_id: stop_id
-      }) do
+  def upcoming_departures(predicted_schedules, %{route: route}) do
     now = @date_time.now()
     route_type = Route.type_atom(route)
-
-    predictions =
-      @predictions_repo.all(
-        route: route.id,
-        direction_id: direction_id,
-        include_terminals: true,
-        discard_past_subway_predictions: false
-      )
-      |> Enum.filter(&(&1.stop.id == stop_id))
-
-    schedules =
-      @schedules_repo.by_route_ids([route.id],
-        direction_id: direction_id,
-        date: ServiceDateTime.service_date(now),
-        stop_ids: [stop_id]
-      )
-
-    predicted_schedules = PredictedSchedule.group(predictions, schedules)
 
     predicted_schedules_at_stop =
       predicted_schedules

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -7,8 +7,12 @@ defmodule Dotcom.UpcomingDepartures.Server do
 
   use GenServer, restart: :transient
 
+  alias Dotcom.Utils.ServiceDateTime
+
   @refresh_interval_ms 5000
+  @predictions_repo Application.compile_env!(:dotcom, :repo_modules)[:predictions]
   @routes_repo Application.compile_env!(:dotcom, :repo_modules)[:routes]
+  @schedules_repo Application.compile_env!(:dotcom, :repo_modules)[:schedules]
   @upcoming_departures_module Application.compile_env!(:dotcom, :upcoming_departures_module)
 
   def start_link(params) do
@@ -20,12 +24,16 @@ defmodule Dotcom.UpcomingDepartures.Server do
     %{route_id: route_id, direction_id: direction_id, stop_id: stop_id} = params
     route = @routes_repo.get(route_id)
 
-    departures_fn = fn ->
-      @upcoming_departures_module.upcoming_departures(%{
+    schedules =
+      @schedules_repo.by_route_ids([route_id],
         direction_id: direction_id,
-        route: route,
-        stop_id: stop_id
-      })
+        date: ServiceDateTime.service_date(),
+        stop_ids: [stop_id]
+      )
+
+    departures_fn = fn ->
+      get_predicted_schedules(schedules, route_id, direction_id, stop_id)
+      |> @upcoming_departures_module.upcoming_departures(%{route: route})
     end
 
     send(self(), :refresh)
@@ -34,6 +42,17 @@ defmodule Dotcom.UpcomingDepartures.Server do
     Logger.notice("Starting server for #{topic}.")
 
     {:ok, %{departures_fn: departures_fn, topic: topic}}
+  end
+
+  defp get_predicted_schedules(schedules, route_id, direction_id, stop_id) do
+    @predictions_repo.all(
+      route: route_id,
+      direction_id: direction_id,
+      include_terminals: true,
+      discard_past_subway_predictions: false
+    )
+    |> Enum.filter(&(&1.stop.id == stop_id))
+    |> PredictedSchedule.group(schedules)
   end
 
   @impl GenServer

--- a/test/dotcom/upcoming_departures/server_test.exs
+++ b/test/dotcom/upcoming_departures/server_test.exs
@@ -12,7 +12,9 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
     stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
     stub(Routes.Repo.Mock, :get, fn id -> Factories.Routes.Route.build(:route, id: id) end)
     stub(Stops.Repo.Mock, :get, fn id -> Factories.Stops.Stop.build(:stop, id: id) end)
-    stub(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ -> :service_ended end)
+    stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+    stub(Predictions.Repo.Mock, :all, fn _ -> [] end)
+    stub(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _, _ -> :service_ended end)
 
     n = System.unique_integer([:positive])
     topic = "departures:route-#{n}:0:stop-#{n}"

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -1,5 +1,6 @@
 defmodule Dotcom.UpcomingDeparturesTest do
   use ExUnit.Case
+  # @moduletag :skip
 
   import Dotcom.Utils.Time, only: [truncate: 2]
   import Mox
@@ -23,7 +24,15 @@ defmodule Dotcom.UpcomingDeparturesTest do
     :ok
   end
 
-  describe "upcoming_departures/1" do
+  defp predicted_schedules_for_stop(schedules, predictions, stop_id) do
+    predictions
+    |> for_stop(stop_id)
+    |> PredictedSchedule.group(for_stop(schedules, stop_id))
+  end
+
+  defp for_stop(list, stop_id), do: Enum.filter(list, &(&1.stop.id == stop_id))
+
+  describe "upcoming_departures/2" do
     test "includes the stop_sequence, trip_id, and time in upcoming departures" do
       # Setup
       %{
@@ -37,19 +46,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data()
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -72,8 +73,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           route_factory_types: [:bus_route, :subway_route]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -83,12 +82,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -98,7 +93,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
     test "includes status if present for subway departures" do
       # Setup
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         prediction_statuses: statuses,
         route: route,
@@ -110,18 +104,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
           include_prediction_statuses: true
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       [_, status, _] = statuses
@@ -134,7 +121,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
       last_trip? = Faker.Util.pick([true, false])
 
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         route: route,
         stops: [_, stop, _],
@@ -145,18 +131,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
           last_trip?: last_trip?
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -166,7 +145,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
     test "includes trip name and platform name for commuter rail departures" do
       # Setup
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         route: route,
         platform_stop_ids: [_, platform_id, _],
@@ -179,8 +157,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           stop_id_options: Platforms.stations_with_commuter_rail_platforms()
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       platform_name = Faker.Pokemon.location()
@@ -191,13 +167,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -209,7 +180,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
     test "prepends 'Bus' to trip names for rail replacement buses" do
       # Setup
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         stops: [_, stop, _],
         trip: trip,
@@ -222,17 +192,12 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       original_route = Factories.Routes.Route.build(:commuter_rail_route)
 
-      expect(Predictions.Repo.Mock, :all, 1, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, 1, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, 1, fn _ -> vehicle end)
 
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+
       departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: original_route,
-          stop_id: stop.id
-        })
+        UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: original_route})
 
       # Verify
       assert [departure] = departures
@@ -243,7 +208,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
     test "does hide platform names for bus or commuter rail stops outside allowlist" do
       # Setup
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         route: route,
         platform_stop_ids: [_, platform_id, _],
@@ -254,8 +218,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           route_factory_types: [:bus_route, :commuter_rail_route]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       platform_name = Faker.Pokemon.location()
@@ -266,13 +228,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -282,7 +239,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
     test "strips 'Commuter Rail -' from platform name" do
       # Setup
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         route: route,
         platform_stop_ids: [_, platform_id, _],
@@ -294,8 +250,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           stop_id_options: Platforms.stations_with_commuter_rail_platforms()
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       platform_name = Faker.Pokemon.location()
@@ -309,13 +263,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -325,7 +274,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
     test "treats a platform name of 'Commuter Rail' as Track TBA" do
       # Setup
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         route: route,
         platform_stop_ids: [_, platform_id, _],
@@ -337,8 +285,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           stop_id_options: Platforms.stations_with_commuter_rail_platforms()
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       stub(Stops.Repo.Mock, :get, fn
@@ -347,13 +293,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -363,7 +304,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
     test "does not include trip name for bus or subway departures" do
       # Setup
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         route: route,
         platform_stop_ids: [_, platform_id, _],
@@ -374,8 +314,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           route_factory_types: [:subway_route, :bus_route]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       stub(Stops.Repo.Mock, :get, fn
@@ -384,13 +322,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -403,7 +336,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
       vehicle_id = String.upcase(vehicle_name)
 
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         route: route,
         platform_stop_ids: [_, platform_id, _],
@@ -414,8 +346,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       route_id = route.id
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle |> Map.put(:id, vehicle_id) end)
       stub(Routes.Repo.Mock, :get, fn ^route_id -> route end)
 
@@ -425,13 +355,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -444,7 +369,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
       vehicle_id = String.upcase(vehicle_name)
 
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         route: route,
         platform_stop_ids: [_, platform_id, _],
@@ -457,8 +381,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       route_id = route.id
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle |> Map.put(:id, vehicle_id) end)
       stub(Routes.Repo.Mock, :get, fn ^route_id -> route end)
 
@@ -468,13 +390,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -484,7 +401,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
     test "includes crowding data when available" do
       # Setup
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         route: route,
         platform_stop_ids: [_, platform_id, _],
@@ -495,8 +411,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       crowding = Faker.Util.pick([:not_crowded, :some_crowding, :crowded])
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle |> Map.put(:crowding, crowding) end)
 
       stub(Stops.Repo.Mock, :get, fn
@@ -505,13 +419,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -521,7 +430,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
     test "does not include crowding data if the predictions' assigned vehicle has a different trip ID" do
       # Setup
       %{
-        predicted_arrival_times: [_, arrival_time, _],
         predictions: predictions,
         route: route,
         platform_stop_ids: [_, platform_id, _],
@@ -532,8 +440,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       crowding = Faker.Util.pick([:not_crowded, :some_crowding, :crowded])
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle |> Map.put(:crowding, crowding) end)
 
       stub(Stops.Repo.Mock, :get, fn
@@ -542,13 +448,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -564,9 +465,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
           Faker.Util.pick([:bus_route, :commuter_rail_route, :ferry_route])
         )
 
-      route_id = route.id
       stop_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
       stop_sequence = Faker.random_between(1, 10_000)
 
       [trip_id_1, trip_id_2] = Faker.Util.sample_uniq(2, fn -> FactoryHelpers.build(:id) end)
@@ -579,45 +478,33 @@ defmodule Dotcom.UpcomingDeparturesTest do
           {arrival_time_1, ServiceDateTime.end_of_service_day(now)}
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _opts ->
-        [
-          Factories.Predictions.Prediction.build(:prediction,
-            arrival_time: arrival_time_1,
-            departure_time: arrival_time_1 |> DateTime.shift(second: 30),
-            stop: Factories.Stops.Stop.build(:stop, id: stop_id),
-            stop_sequence: stop_sequence,
-            trip: Factories.Schedules.Trip.build(:trip, id: trip_id_1)
-          )
-        ]
-      end)
+      predictions = [
+        Factories.Predictions.Prediction.build(:prediction,
+          arrival_time: arrival_time_1,
+          departure_time: arrival_time_1 |> DateTime.shift(second: 30),
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id),
+          stop_sequence: stop_sequence,
+          trip: Factories.Schedules.Trip.build(:trip, id: trip_id_1)
+        )
+      ]
 
       stub(Vehicles.Repo.Mock, :get, fn _ ->
         Factories.Vehicles.Vehicle.build(:vehicle, stop_sequence: stop_sequence)
       end)
 
-      expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: date, stop_ids: [^stop_id] ->
-          assert date == ServiceDateTime.service_date(now)
-
-          [
-            Factories.Schedules.Schedule.build(:schedule,
-              arrival_time: arrival_time_2,
-              departure_time: arrival_time_2 |> DateTime.shift(second: 30),
-              time: arrival_time_2,
-              stop: Factories.Stops.Stop.build(:stop, id: stop_id),
-              trip: Factories.Schedules.Trip.build(:trip, id: trip_id_2)
-            )
-          ]
-      end)
+      schedules = [
+        Factories.Schedules.Schedule.build(:schedule,
+          arrival_time: arrival_time_2,
+          departure_time: arrival_time_2 |> DateTime.shift(second: 30),
+          time: arrival_time_2,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id),
+          trip: Factories.Schedules.Trip.build(:trip, id: trip_id_2)
+        )
+      ]
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          now: now,
-          route: route,
-          stop_id: stop_id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop_id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures |> Enum.map(& &1.trip_id) == [
@@ -631,40 +518,28 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = Dotcom.Utils.DateTime.now()
 
       route = Factories.Routes.Route.build(:subway_route)
-      route_id = route.id
       stop_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
 
       scheduled_arrival_time =
         Generators.DateTime.random_time_range_date_time(
           {now, ServiceDateTime.end_of_service_day(now)}
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _opts ->
-        []
-      end)
-
-      expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: date, stop_ids: [^stop_id] ->
-          assert date == ServiceDateTime.service_date(now)
-
-          [
-            Factories.Schedules.Schedule.build(:schedule,
-              arrival_time: scheduled_arrival_time,
-              departure_time: scheduled_arrival_time |> DateTime.shift(second: 30),
-              time: scheduled_arrival_time,
-              stop: Factories.Stops.Stop.build(:stop, id: stop_id)
-            )
-          ]
-      end)
+      schedules = [
+        Factories.Schedules.Schedule.build(:schedule,
+          arrival_time: scheduled_arrival_time,
+          departure_time: scheduled_arrival_time |> DateTime.shift(second: 30),
+          time: scheduled_arrival_time,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id)
+        )
+      ]
 
       # Exercise
+      predicted_schedules = predicted_schedules_for_stop(schedules, [], stop_id)
+
       departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          now: now,
-          route: route,
-          stop_id: stop_id
+        UpcomingDepartures.upcoming_departures(predicted_schedules, %{
+          route: route
         })
 
       # Verify
@@ -677,7 +552,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = Dotcom.Utils.DateTime.now()
 
       route = Factories.Routes.Route.build(:subway_route)
-      route_id = route.id
       stop_id = FactoryHelpers.build(:id)
       direction_id = Faker.Util.pick([0, 1])
 
@@ -691,33 +565,26 @@ defmodule Dotcom.UpcomingDeparturesTest do
           {now, ServiceDateTime.end_of_service_day(now)}
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _opts ->
-        []
-      end)
-
-      expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: date, stop_ids: [^stop_id] ->
-          assert date == ServiceDateTime.service_date(now)
-
-          [
-            Factories.Schedules.Schedule.build(:schedule,
-              arrival_time: scheduled_arrival_time_1,
-              departure_time: scheduled_arrival_time_1 |> DateTime.shift(second: 30),
-              time: scheduled_arrival_time_1,
-              stop: Factories.Stops.Stop.build(:stop, id: stop_id)
-            ),
-            Factories.Schedules.Schedule.build(:schedule,
-              arrival_time: scheduled_arrival_time_2,
-              departure_time: scheduled_arrival_time_2 |> DateTime.shift(second: 30),
-              time: scheduled_arrival_time_2,
-              stop: Factories.Stops.Stop.build(:stop, id: stop_id)
-            )
-          ]
-      end)
+      schedules = [
+        Factories.Schedules.Schedule.build(:schedule,
+          arrival_time: scheduled_arrival_time_1,
+          departure_time: scheduled_arrival_time_1 |> DateTime.shift(second: 30),
+          time: scheduled_arrival_time_1,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id)
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          arrival_time: scheduled_arrival_time_2,
+          departure_time: scheduled_arrival_time_2 |> DateTime.shift(second: 30),
+          time: scheduled_arrival_time_2,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id)
+        )
+      ]
 
       # Exercise
+      predicted_schedules = predicted_schedules_for_stop(schedules, [], stop_id)
+
       departures =
-        UpcomingDepartures.upcoming_departures(%{
+        UpcomingDepartures.upcoming_departures(predicted_schedules, %{
           direction_id: direction_id,
           now: now,
           route: route,
@@ -733,9 +600,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = Dotcom.Utils.DateTime.now()
 
       route = Factories.Routes.Route.build(:subway_route)
-      route_id = route.id
       stop_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
 
       scheduled_arrival_time_1 =
         Generators.DateTime.random_time_range_date_time(
@@ -747,37 +612,26 @@ defmodule Dotcom.UpcomingDeparturesTest do
           {now, ServiceDateTime.end_of_service_day(now)}
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _opts ->
-        []
-      end)
-
-      expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: date, stop_ids: [^stop_id] ->
-          assert date == ServiceDateTime.service_date(now)
-
-          [
-            Factories.Schedules.Schedule.build(:schedule,
-              arrival_time: scheduled_arrival_time_1,
-              departure_time: scheduled_arrival_time_1 |> DateTime.shift(second: 30),
-              time: scheduled_arrival_time_1,
-              stop: Factories.Stops.Stop.build(:stop, id: stop_id)
-            ),
-            Factories.Schedules.Schedule.build(:schedule,
-              arrival_time: scheduled_arrival_time_2,
-              departure_time: scheduled_arrival_time_2 |> DateTime.shift(second: 30),
-              time: scheduled_arrival_time_2,
-              stop: Factories.Stops.Stop.build(:stop, id: stop_id)
-            )
-          ]
-      end)
+      schedules = [
+        Factories.Schedules.Schedule.build(:schedule,
+          arrival_time: scheduled_arrival_time_1,
+          departure_time: scheduled_arrival_time_1 |> DateTime.shift(second: 30),
+          time: scheduled_arrival_time_1,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id)
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          arrival_time: scheduled_arrival_time_2,
+          departure_time: scheduled_arrival_time_2 |> DateTime.shift(second: 30),
+          time: scheduled_arrival_time_2,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id)
+        )
+      ]
 
       # Exercise
-      assert UpcomingDepartures.upcoming_departures(%{
-               direction_id: direction_id,
-               now: now,
-               route: route,
-               stop_id: stop_id
-             }) == :no_realtime
+      predicted_schedules = predicted_schedules_for_stop(schedules, [], stop_id)
+
+      assert UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route}) ==
+               :no_realtime
     end
 
     test "returns :no_realtime with departures if bus/commuter/ferry rail schedules" do
@@ -789,9 +643,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
         |> Faker.Util.pick()
         |> Factories.Routes.Route.build()
 
-      route_id = route.id
       stop_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
 
       scheduled_arrival_time_1 =
         Generators.DateTime.random_time_range_date_time(
@@ -803,38 +655,26 @@ defmodule Dotcom.UpcomingDeparturesTest do
           {now, ServiceDateTime.end_of_service_day(now)}
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _opts ->
-        []
-      end)
-
-      expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: date, stop_ids: [^stop_id] ->
-          assert date == ServiceDateTime.service_date(now)
-
-          [
-            Factories.Schedules.Schedule.build(:schedule,
-              arrival_time: scheduled_arrival_time_1,
-              departure_time: scheduled_arrival_time_1 |> DateTime.shift(second: 30),
-              time: scheduled_arrival_time_1,
-              stop: Factories.Stops.Stop.build(:stop, id: stop_id)
-            ),
-            Factories.Schedules.Schedule.build(:schedule,
-              arrival_time: scheduled_arrival_time_2,
-              departure_time: scheduled_arrival_time_2 |> DateTime.shift(second: 30),
-              time: scheduled_arrival_time_2,
-              stop: Factories.Stops.Stop.build(:stop, id: stop_id)
-            )
-          ]
-      end)
+      schedules = [
+        Factories.Schedules.Schedule.build(:schedule,
+          arrival_time: scheduled_arrival_time_1,
+          departure_time: scheduled_arrival_time_1 |> DateTime.shift(second: 30),
+          time: scheduled_arrival_time_1,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id)
+        ),
+        Factories.Schedules.Schedule.build(:schedule,
+          arrival_time: scheduled_arrival_time_2,
+          departure_time: scheduled_arrival_time_2 |> DateTime.shift(second: 30),
+          time: scheduled_arrival_time_2,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id)
+        )
+      ]
 
       # Exercise
+      predicted_schedules = predicted_schedules_for_stop(schedules, [], stop_id)
+
       assert {:no_realtime, departures} =
-               UpcomingDepartures.upcoming_departures(%{
-                 direction_id: direction_id,
-                 now: now,
-                 route: route,
-                 stop_id: stop_id
-               })
+               UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       assert [%UpcomingDeparture{} | _] = departures
     end
@@ -851,20 +691,13 @@ defmodule Dotcom.UpcomingDeparturesTest do
           route_factory_types: [:bus_route, :commuter_rail_route, :ferry_route]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
-
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(departure_time)
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, [], stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert {:no_realtime, [departure]} = departures
@@ -889,8 +722,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           seconds_behind: seconds_behind
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -900,12 +731,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = predicted_time |> DateTime.shift(second: -seconds_before_arrival)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -918,9 +745,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = Dotcom.Utils.DateTime.now()
 
       route = Factories.Routes.Route.build(:subway_route)
-      route_id = route.id
       stop_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
       stop_sequence = Faker.random_between(1, 10_000)
 
       [trip_id_1, trip_id_2] = Faker.Util.sample_uniq(2, fn -> FactoryHelpers.build(:id) end)
@@ -934,43 +759,34 @@ defmodule Dotcom.UpcomingDeparturesTest do
           {arrival_time_1, ServiceDateTime.end_of_service_day(now)}
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _opts ->
-        [
-          Factories.Predictions.Prediction.build(:prediction,
-            arrival_time: arrival_time_1,
-            stop: Factories.Stops.Stop.build(:stop, id: stop_id),
-            stop_sequence: stop_sequence,
-            trip: Factories.Schedules.Trip.build(:trip, id: trip_id_1)
-          )
-        ]
-      end)
+      predictions = [
+        Factories.Predictions.Prediction.build(:prediction,
+          arrival_time: arrival_time_1,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id),
+          stop_sequence: stop_sequence,
+          trip: Factories.Schedules.Trip.build(:trip, id: trip_id_1)
+        )
+      ]
 
       stub(Vehicles.Repo.Mock, :get, fn _ ->
         Factories.Vehicles.Vehicle.build(:vehicle, stop_sequence: stop_sequence)
       end)
 
-      expect(Schedules.Repo.Mock, :by_route_ids, fn
-        [^route_id], direction_id: ^direction_id, date: _date, stop_ids: [^stop_id] ->
-          [
-            Factories.Schedules.Schedule.build(:schedule,
-              arrival_time: arrival_time_2,
-              departure_time: arrival_time_2 |> DateTime.shift(second: 30),
-              time: arrival_time_2,
-              stop: Factories.Stops.Stop.build(:stop, id: stop_id),
-              trip: Factories.Schedules.Trip.build(:trip, id: trip_id_2)
-            )
-          ]
-      end)
+      schedules = [
+        Factories.Schedules.Schedule.build(:schedule,
+          arrival_time: arrival_time_2,
+          departure_time: arrival_time_2 |> DateTime.shift(second: 30),
+          time: arrival_time_2,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id),
+          trip: Factories.Schedules.Trip.build(:trip, id: trip_id_2)
+        )
+      ]
 
       stub(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          route: route,
-          stop_id: stop_id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop_id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures |> Enum.map(& &1.arrival_status) == [
@@ -988,20 +804,13 @@ defmodule Dotcom.UpcomingDeparturesTest do
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(route_factory_types: [:bus_route])
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
-
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.later_on_day(scheduled_time)
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, [], stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures == :service_ended
@@ -1009,28 +818,13 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
     test "shows :no_service if there are no trips" do
       # Setup
-      now = Dotcom.Utils.DateTime.now()
-
       route =
         Factories.Routes.Route.build(
           Faker.Util.pick([:bus_route, :commuter_rail_route, :ferry_route])
         )
 
-      route_id = route.id
-      stop_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
-
-      expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn [^route_id], _opts -> [] end)
-      expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
-
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          route: route,
-          stop_id: stop_id
-        })
+      departures = UpcomingDepartures.upcoming_departures([], %{route: route})
 
       # Verify
       assert departures == :no_service
@@ -1053,8 +847,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           seconds_behind: seconds_behind
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -1062,12 +854,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1088,21 +876,16 @@ defmodule Dotcom.UpcomingDeparturesTest do
           skipped_stops: [1]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(scheduled_time)
       end)
 
+      #
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1125,8 +908,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           skipped_stops: [1]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -1134,12 +915,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures == []
@@ -1158,20 +935,13 @@ defmodule Dotcom.UpcomingDeparturesTest do
           skipped_stops: [1]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
-
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.later_on_day(scheduled_time)
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures == :service_ended
@@ -1191,8 +961,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           cancelled?: true
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -1200,12 +968,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1228,8 +992,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           cancelled?: true
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -1237,12 +999,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures == []
@@ -1261,20 +1019,13 @@ defmodule Dotcom.UpcomingDeparturesTest do
           cancelled?: true
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
-
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.later_on_day(scheduled_time)
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures == :service_ended
@@ -1294,8 +1045,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           missing_realtime?: true
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -1303,12 +1052,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1329,8 +1074,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           missing_realtime?: true
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -1338,12 +1081,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       refute match?([_departure], departures)
@@ -1355,13 +1094,9 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       route = Factories.Routes.Route.build(:route)
       stop_id = FactoryHelpers.build(:id)
-
-      direction_id = Faker.Util.pick([0, 1])
       stop_sequence = Faker.random_between(1, 10_000)
 
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
-
-      expect(Predictions.Repo.Mock, :all, fn _opts ->
+      predictions =
         Factories.Predictions.Prediction.build_list(2, :prediction,
           arrival_time: nil,
           departure_time: nil,
@@ -1374,7 +1109,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
               stop_sequence: stop_sequence
             )
           ]
-      end)
 
       stub(Vehicles.Repo.Mock, :get, fn _ ->
         Factories.Vehicles.Vehicle.build(:vehicle, stop_sequence: stop_sequence)
@@ -1383,12 +1117,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          route: route,
-          stop_id: stop_id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop_id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures |> Enum.count() == 1
@@ -1401,7 +1131,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
       route = Factories.Routes.Route.build(:route)
       stop_id = FactoryHelpers.build(:id)
       [trip_id1, trip_id2] = Faker.Util.sample_uniq(2, fn -> FactoryHelpers.build(:id) end)
-      direction_id = Faker.Util.pick([0, 1])
       stop_sequence = Faker.random_between(1, 10_000)
 
       minutes_until_arrival =
@@ -1410,9 +1139,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
       [arrival_time1, arrival_time2] =
         minutes_until_arrival |> Enum.map(&(now |> DateTime.shift(minute: &1)))
 
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
-
-      expect(Predictions.Repo.Mock, :all, fn _opts ->
+      predictions =
         [
           Factories.Predictions.Prediction.build(:prediction,
             arrival_time: arrival_time2,
@@ -1427,7 +1154,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
             trip: Factories.Schedules.Trip.build(:trip, id: trip_id1)
           )
         ]
-      end)
 
       stub(Vehicles.Repo.Mock, :get, fn _ ->
         Factories.Vehicles.Vehicle.build(:vehicle, stop_sequence: stop_sequence)
@@ -1436,12 +1162,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          route: route,
-          stop_id: stop_id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop_id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures |> Enum.map(& &1.trip_id) == [
@@ -1463,8 +1185,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           vehicle_stop_index: 0
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1474,12 +1194,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = departure_time |> DateTime.shift(second: -seconds_before_departure)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1488,43 +1204,32 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
     test "does not show an upcoming_departure for the last stop in a trip, when the departure_time is nil" do
       # Setup
-      now = Dotcom.Utils.DateTime.now()
 
       route = Factories.Routes.Route.build(:route)
       stop_id = FactoryHelpers.build(:id)
       trip_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
       stop_sequence = Faker.random_between(1, 10_000)
 
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
-
-      expect(Predictions.Repo.Mock, :all, fn _opts ->
-        [
-          Factories.Predictions.Prediction.build(:prediction,
-            departure_time: nil,
-            stop: Factories.Stops.Stop.build(:stop, id: stop_id),
-            trip: Factories.Schedules.Trip.build(:trip, id: trip_id)
-          ),
-          Factories.Predictions.Prediction.build(:prediction,
-            stop: Factories.Stops.Stop.build(:stop, id: stop_id),
-            stop_sequence: stop_sequence,
-            trip: Factories.Schedules.Trip.build(:trip, id: trip_id)
-          )
-        ]
-      end)
+      predictions = [
+        Factories.Predictions.Prediction.build(:prediction,
+          departure_time: nil,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id),
+          trip: Factories.Schedules.Trip.build(:trip, id: trip_id)
+        ),
+        Factories.Predictions.Prediction.build(:prediction,
+          stop: Factories.Stops.Stop.build(:stop, id: stop_id),
+          stop_sequence: stop_sequence,
+          trip: Factories.Schedules.Trip.build(:trip, id: trip_id)
+        )
+      ]
 
       stub(Vehicles.Repo.Mock, :get, fn _ ->
         Factories.Vehicles.Vehicle.build(:vehicle, stop_sequence: stop_sequence)
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          now: now,
-          route: route,
-          stop_id: stop_id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop_id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures |> Enum.count() == 1
@@ -1542,8 +1247,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           route_factory_types: [:bus_route, :subway_route]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1553,12 +1256,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1575,8 +1274,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(route_factory_types: [:subway_route])
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1585,12 +1282,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1610,8 +1303,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           vehicle_stop_index: 0
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1620,12 +1311,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1646,20 +1333,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
           vehicle_statuses: [:stopped]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
       now = Generators.DateTime.random_time_range_date_time({arrival_time, departure_time})
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1680,8 +1361,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           vehicle_stop_index: 0
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1690,12 +1369,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = departure_time |> DateTime.shift(second: -seconds_before_departure)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1718,20 +1393,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
           vehicle_stop_index: 0
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
       now = Generators.DateTime.random_time_range_date_time({arrival_time, departure_time})
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1752,8 +1421,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           vehicle_stop_index: 0
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1762,12 +1429,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = departure_time |> DateTime.shift(second: -seconds_before_departure)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1787,8 +1450,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           vehicle_statuses: [:stopped]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -1796,12 +1457,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1821,8 +1478,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           vehicle_stop_index: 2
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -1830,13 +1485,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert departures == []
@@ -1856,8 +1506,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           vehicle_on_different_trip?: true
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -1865,13 +1513,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [_] = departures
@@ -1887,21 +1530,14 @@ defmodule Dotcom.UpcomingDeparturesTest do
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(route_factory_types: [:bus_route])
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
       seconds_before_arrival = Faker.random_between(0, 29)
       now = arrival_time |> DateTime.shift(second: -seconds_before_arrival)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
-
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1922,8 +1558,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           vehicle_stop_index: 0
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       # Exercise
@@ -1932,12 +1566,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = departure_time |> DateTime.shift(second: -seconds_before_departure)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1959,8 +1589,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           seconds_behind: Faker.random_between(-59, 59)
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -1968,12 +1596,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -1994,8 +1618,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           route_factory_types: [:commuter_rail_route, :ferry_route]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -2003,12 +1625,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -2032,8 +1650,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           seconds_behind: Faker.random_between(-3600, -60)
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -2041,12 +1657,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -2070,8 +1682,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           seconds_behind: Faker.random_between(60, 3600)
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -2079,12 +1689,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -2107,8 +1713,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           seconds_behind: Faker.random_between(-3600, 3600)
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -2116,12 +1720,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -2140,20 +1740,13 @@ defmodule Dotcom.UpcomingDeparturesTest do
           route_factory_types: [:commuter_rail_route, :ferry_route]
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
-
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(scheduled_departure_time)
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, [], stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert {:no_realtime, [departure]} = departures
@@ -2171,20 +1764,13 @@ defmodule Dotcom.UpcomingDeparturesTest do
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(route_factory_types: [:bus_route])
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> [] end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
-
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
         Generators.ServiceDateTime.earlier_on_day(scheduled_arrival_time)
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, [], stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert {:no_realtime, [departure]} = departures
@@ -2211,8 +1797,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           prediction_status: api_status
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -2220,12 +1804,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -2250,8 +1830,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           seconds_behind: Faker.random_between(0, 59)
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -2259,12 +1837,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -2290,8 +1864,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           seconds_behind: Faker.random_between(60, 3600)
         )
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -2299,12 +1871,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [departure] = departures
@@ -2323,7 +1891,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
         )
 
       stop_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
 
       arrival_times =
         Faker.Util.sample_uniq(4, fn ->
@@ -2343,17 +1910,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
         end)
 
       stub(Vehicles.Repo.Mock, :get, fn _ -> Factories.Vehicles.Vehicle.build(:vehicle) end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          route: route,
-          stop_id: stop_id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop_id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert is_list(departures)
@@ -2374,7 +1935,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
       now = Dotcom.Utils.DateTime.now()
       route = Factories.Routes.Route.build(:subway_route)
       stop_id = FactoryHelpers.build(:id)
-      direction_id = Faker.Util.pick([0, 1])
 
       arrival_times =
         Faker.Util.sample_uniq(4, fn ->
@@ -2394,17 +1954,11 @@ defmodule Dotcom.UpcomingDeparturesTest do
         end)
 
       stub(Vehicles.Repo.Mock, :get, fn _ -> Factories.Vehicles.Vehicle.build(:vehicle) end)
-      expect(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
       expect(Dotcom.Utils.DateTime.Mock, :now, fn -> now end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: direction_id,
-          route: route,
-          stop_id: stop_id
-        })
+      predicted_schedules = predicted_schedules_for_stop([], predictions, stop_id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert is_list(departures)
@@ -2435,8 +1989,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           schedule |> Map.put(:stop_headsign, Faker.Pokemon.location())
         end)
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(updated_schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -2444,12 +1996,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(updated_schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [%{headsign: headsign}] = departures
@@ -2478,8 +2026,6 @@ defmodule Dotcom.UpcomingDeparturesTest do
           schedule |> Map.put(:stop_headsign, nil)
         end)
 
-      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
-      expect_schedule_call_filtered_by_stop(updated_schedules, route_id: route.id)
       expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
 
       expect(Dotcom.Utils.DateTime.Mock, :now, fn ->
@@ -2487,12 +2033,8 @@ defmodule Dotcom.UpcomingDeparturesTest do
       end)
 
       # Exercise
-      departures =
-        UpcomingDepartures.upcoming_departures(%{
-          direction_id: Faker.Util.pick([0, 1]),
-          route: route,
-          stop_id: stop.id
-        })
+      predicted_schedules = predicted_schedules_for_stop(updated_schedules, predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
 
       # Verify
       assert [%{headsign: headsign}] = departures
@@ -3134,14 +2676,5 @@ defmodule Dotcom.UpcomingDeparturesTest do
       refute trip_stop_0.cancelled?
       assert trip_stop_1.cancelled?
     end
-  end
-
-  defp expect_schedule_call_filtered_by_stop(schedules, route_id: route_id) do
-    expect(Schedules.Repo.Mock, :by_route_ids, fn [^route_id],
-                                                  direction_id: _,
-                                                  date: _,
-                                                  stop_ids: [stop_id] ->
-      schedules |> Enum.filter(&(&1.stop.id == stop_id))
-    end)
   end
 end

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -1,6 +1,5 @@
 defmodule Dotcom.UpcomingDeparturesTest do
   use ExUnit.Case
-  # @moduletag :skip
 
   import Dotcom.Utils.Time, only: [truncate: 2]
   import Mox

--- a/test/dotcom_web/live/schedule_finder_live_test.exs
+++ b/test/dotcom_web/live/schedule_finder_live_test.exs
@@ -31,6 +31,10 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
     allow(Routes.Repo.Mock, self(), fn ->
       GenServer.whereis({:global, upcoming_departure_params})
     end)
+
+    allow(Dotcom.Utils.DateTime.Mock, self(), fn ->
+      GenServer.whereis({:global, upcoming_departure_params})
+    end)
   end
 
   test "loads, fetching route info", %{conn: conn} do
@@ -410,7 +414,7 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
     end)
 
     Dotcom.UpcomingDepartures.Mock
-    |> stub(:upcoming_departures, fn _ -> :no_service end)
+    |> stub(:upcoming_departures, fn _, _ -> :no_service end)
 
     stub(Predictions.Repo.Mock, :all, fn _ -> [] end)
     stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)

--- a/test/dotcom_web/live/schedule_finder_live_test.exs
+++ b/test/dotcom_web/live/schedule_finder_live_test.exs
@@ -32,6 +32,10 @@ defmodule DotcomWeb.ScheduleFinderLiveTest do
       GenServer.whereis({:global, upcoming_departure_params})
     end)
 
+    allow(Schedules.Repo.Mock, self(), fn ->
+      GenServer.whereis({:global, upcoming_departure_params})
+    end)
+
     allow(Dotcom.Utils.DateTime.Mock, self(), fn ->
       GenServer.whereis({:global, upcoming_departure_params})
     end)

--- a/test/dotcom_web/live/upcoming_departures_live_test.exs
+++ b/test/dotcom_web/live/upcoming_departures_live_test.exs
@@ -25,8 +25,9 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     end)
 
     stub(Schedules.Repo.Mock, :by_route_ids, fn _, _ -> [] end)
+    stub(Predictions.Repo.Mock, :all, fn _ -> [] end)
 
-    stub(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+    stub(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _, _ ->
       :no_service
     end)
 
@@ -51,7 +52,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     parent = self()
     ref = make_ref()
 
-    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _, _ ->
       send(parent, {ref, :done})
       :no_service
     end)
@@ -73,7 +74,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
 
     expect(Routes.Repo.Mock, :get, 3, fn ^route_id -> route end)
 
-    expect(Schedules.Repo.Mock, :by_route_ids, 2, fn routes, opts ->
+    expect(Schedules.Repo.Mock, :by_route_ids, 3, fn routes, opts ->
       assert routes == [route_id]
       assert Keyword.get(opts, :direction_id) == direction_id
       assert Keyword.get(opts, :stop_ids) == [stop_id]
@@ -85,7 +86,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     parent = self()
     ref = make_ref()
 
-    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _, _ ->
       send(parent, {ref, :done})
       :no_service
     end)
@@ -117,7 +118,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
         time: @date_time_module.now() |> DateTime.shift(minute: 40)
       )
 
-    expect(Schedules.Repo.Mock, :by_route_ids, 2, fn _, _ ->
+    expect(Schedules.Repo.Mock, :by_route_ids, 3, fn _, _ ->
       schedules ++ [last_schedule]
     end)
 
@@ -125,7 +126,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     ref = make_ref()
 
     # Available upcoming departures are earlier than the last scheduled time
-    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _, _ ->
       send(parent, {ref, :done})
 
       Factories.UpcomingDepartures.build_list(15, :upcoming_departure,
@@ -151,7 +152,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     parent = self()
     ref = make_ref()
 
-    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _, _ ->
       send(parent, {ref, :done})
       :service_ended
     end)
@@ -187,7 +188,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
       parent = self()
       ref = make_ref()
 
-      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _, _ ->
         send(parent, {ref, :done})
         {:no_realtime, upcoming_departures}
       end)
@@ -208,7 +209,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
       parent = self()
       ref = make_ref()
 
-      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _ ->
+      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _, _ ->
         send(parent, {ref, :done})
         :no_realtime
       end)
@@ -229,7 +230,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     parent = self()
     ref = make_ref()
 
-    stub(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _ ->
+    stub(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, fn _, _ ->
       send(parent, {ref, :done})
       :no_realtime
     end)


### PR DESCRIPTION
## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [📅🔎🎭 Refactor existing `UpcomingDepartures` module to take predicted_schedules as an input](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214587664555340?focus=true)

## Implementation

Attempted to take the simplest approach to the A/C, where the `upcoming_departures/1` function no longer fetches schedules and predictions and puts them together.

## Screenshots

No change

## How to test

No idea
