### PR TITLE
6/19 | [Ferry] Create fare card for Harbor Loop (F10)

### DIFF
--- a/lib/dotcom/content_rewriters/liquid_objects/fare.ex
+++ b/lib/dotcom/content_rewriters/liquid_objects/fare.ex
@@ -28,6 +28,7 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.Fare do
           | :ferry_cross_harbor
           | :ferry_inner_harbor
           | :ferry_east_boston
+          | :ferry_harbor_loop
           | :ferry_lynn
           | :ferry_winthrop
           | :foxboro
@@ -66,6 +67,7 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.Fare do
     "ferry_cross_harbor",
     "ferry_inner_harbor",
     "ferry_east_boston",
+    "ferry_harbor_loop",
     "ferry_lynn",
     "ferry_winthrop",
     "foxboro",

--- a/lib/fares/fare_info.ex
+++ b/lib/fares/fare_info.ex
@@ -672,7 +672,7 @@ defmodule Fares.FareInfo do
         duration: :single_trip,
         media: [:mticket, :paper_ferry, :contactless_payment, :cash],
         reduced: nil,
-        cents: dollars_to_cents(east_boston_price)
+        cents: dollars_to_cents(harbor_loop_price)
       },
       %Fare{
         mode: :ferry,
@@ -680,7 +680,7 @@ defmodule Fares.FareInfo do
         duration: :round_trip,
         media: [:mticket, :paper_ferry, :contactless_payment, :cash],
         reduced: nil,
-        cents: dollars_to_cents(east_boston_price) * 2
+        cents: dollars_to_cents(harbor_loop_price) * 2
       }
     ]
 

--- a/lib/fares/fare_info.ex
+++ b/lib/fares/fare_info.ex
@@ -494,6 +494,7 @@ defmodule Fares.FareInfo do
         inner_harbor_month_price_reduced: inner_harbor_month_price_reduced,
         cross_harbor_price: cross_harbor_price,
         east_boston_price: east_boston_price,
+        harbor_loop_price: harbor_loop_price,
         lynn_price: lynn_price,
         winthrop_price: winthrop_price,
         commuter_ferry_price: commuter_ferry_price,

--- a/lib/fares/fare_info.ex
+++ b/lib/fares/fare_info.ex
@@ -214,6 +214,7 @@ defmodule Fares.FareInfo do
       inner_harbor_month_price_reduced: "30.00",
       cross_harbor_price: "9.75",
       east_boston_price: "2.40",
+      harbor_loop_price: "2.40",
       lynn_price: "7.00",
       winthrop_price: "6.50",
       commuter_ferry_price: "9.75",
@@ -664,6 +665,22 @@ defmodule Fares.FareInfo do
         reduced: :any,
         cents: dollars_to_cents(commuter_ferry_month_price_reduced),
         additional_valid_modes: [:subway, :bus, :commuter_rail]
+      },
+      %Fare{
+        mode: :ferry,
+        name: :ferry_harbor_loop,
+        duration: :single_trip,
+        media: [:mticket, :paper_ferry, :contactless_payment, :cash],
+        reduced: nil,
+        cents: dollars_to_cents(east_boston_price)
+      },
+      %Fare{
+        mode: :ferry,
+        name: :ferry_harbor_loop,
+        duration: :round_trip,
+        media: [:mticket, :paper_ferry, :contactless_payment, :cash],
+        reduced: nil,
+        cents: dollars_to_cents(east_boston_price) * 2
       }
     ]
 

--- a/lib/fares/fares.ex
+++ b/lib/fares/fares.ex
@@ -26,6 +26,7 @@ defmodule Fares do
           :ferry_cross_harbor
           | :ferry_inner_harbor
           | :ferry_east_boston
+          | :ferry_harbor_loop
           | :ferry_lynn
           | :ferry_winthrop
           | :commuter_ferry_logan
@@ -120,7 +121,7 @@ defmodule Fares do
         :ferry_winthrop
 
       true ->
-        :ferry_east_boston
+        :ferry_harbor_loop
     end
   end
 

--- a/lib/fares/format.ex
+++ b/lib/fares/format.ex
@@ -88,6 +88,7 @@ defmodule Fares.Format do
   def name(:express_bus), do: ~t"Express Bus"
   def name(:ferry_inner_harbor), do: ~t"Charlestown Ferry"
   def name(:ferry_cross_harbor), do: ~t"Cross Harbor Ferry"
+  def name(:ferry_harbor_loop), do: ~t"Harbor Loop Ferry"
   def name(:ferry_east_boston), do: ~t"East Boston Ferry"
   def name(:ferry_lynn), do: ~t"Lynn Ferry"
   def name(:ferry_winthrop), do: ~t"Winthrop/Quincy Ferry"


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [6/19 | ⛴️ Create fare card for Harbor Loop (F10)](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215207486959983?focus=true)

## Implementation

Added the fare info for the Harbor Loop Ferry
Updated the fare calculation logic to use the new harbor loop ferry price variable instead of piggybacking on the east boston ferry price.

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

N/A -- In theory this should make it available for content to add to the fares page.

## How to test

I don't know!

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
