### PR TITLE
perf(UpcomingDepartures): Use a more performant data structure to combine predictions and schedules into predicted schedules

### DIFF
--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -44,36 +44,28 @@ defmodule Dotcom.UpcomingDepartures.Server do
       |> Enum.filter(&(&1.stop.id == stop_id))
     end
 
+    upcoming_departures_fn = fn predicted_schedules ->
+      predicted_schedules
+      |> @upcoming_departures_module.upcoming_departures(%{route: route})
+    end
+
     send(self(), :refresh)
 
     topic = Dotcom.UpcomingDepartures.topic_name(params)
     Logger.notice("Starting server for #{topic}.")
 
-    build_departures_fn_from_date = fn date ->
-      base_predicted_schedules =
-        date
-        |> schedules_fn.()
-        |> PredictedSchedule.Collection.new()
-
-      fn ->
-        predictions_fn.()
-        |> Enum.reduce(base_predicted_schedules, fn prediction, collection ->
-          PredictedSchedule.Collection.put_prediction(collection, prediction)
-        end)
-        |> PredictedSchedule.Collection.to_list()
-        |> @upcoming_departures_module.upcoming_departures(%{route: route})
-      end
-    end
-
-    departures_fn =
+    base_predicted_schedules =
       ServiceDateTime.service_date()
-      |> build_departures_fn_from_date.()
+      |> schedules_fn.()
+      |> PredictedSchedule.Collection.new()
 
     {:ok,
      %{
-       build_departures_fn_from_date: build_departures_fn_from_date,
-       departures_fn: departures_fn,
-       topic: topic
+       base_predicted_schedules: base_predicted_schedules,
+       predictions_fn: predictions_fn,
+       schedules_fn: schedules_fn,
+       topic: topic,
+       upcoming_departures_fn: upcoming_departures_fn
      }}
   end
 
@@ -128,13 +120,21 @@ defmodule Dotcom.UpcomingDepartures.Server do
   end
 
   defp update_service_date(state, new_service_date) do
-    new_departures_fn = state.build_departures_fn_from_date.(new_service_date)
+    base_predicted_schedules =
+      new_service_date
+      |> state.schedules_fn.()
+      |> PredictedSchedule.Collection.new()
 
-    %{state | departures_fn: new_departures_fn}
+    %{state | base_predicted_schedules: base_predicted_schedules}
   end
 
   defp upcoming_departures(state) do
-    state.departures_fn.()
+    state.predictions_fn.()
+    |> Enum.reduce(state.base_predicted_schedules, fn prediction, collection ->
+      PredictedSchedule.Collection.put_prediction(collection, prediction)
+    end)
+    |> PredictedSchedule.Collection.to_list()
+    |> state.upcoming_departures_fn.()
   end
 
   defp topic_subscriber_count(topic) do

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -24,15 +24,17 @@ defmodule Dotcom.UpcomingDepartures.Server do
     %{route_id: route_id, direction_id: direction_id, stop_id: stop_id} = params
     route = @routes_repo.get(route_id)
 
-    schedules =
-      @schedules_repo.by_route_ids([route_id],
+    base_predicted_schedules =
+      [route_id]
+      |> @schedules_repo.by_route_ids(
         direction_id: direction_id,
         date: ServiceDateTime.service_date(),
         stop_ids: [stop_id]
       )
+      |> PredictedSchedule.Collection.new()
 
     departures_fn = fn ->
-      get_predicted_schedules(schedules, route_id, direction_id, stop_id)
+      get_predicted_schedules(base_predicted_schedules, route_id, direction_id, stop_id)
       |> @upcoming_departures_module.upcoming_departures(%{route: route})
     end
 
@@ -44,7 +46,7 @@ defmodule Dotcom.UpcomingDepartures.Server do
     {:ok, %{departures_fn: departures_fn, topic: topic}}
   end
 
-  defp get_predicted_schedules(schedules, route_id, direction_id, stop_id) do
+  defp get_predicted_schedules(base_predicted_schedules, route_id, direction_id, stop_id) do
     @predictions_repo.all(
       route: route_id,
       direction_id: direction_id,
@@ -52,7 +54,10 @@ defmodule Dotcom.UpcomingDepartures.Server do
       discard_past_subway_predictions: false
     )
     |> Enum.filter(&(&1.stop.id == stop_id))
-    |> PredictedSchedule.group(schedules)
+    |> Enum.reduce(base_predicted_schedules, fn prediction, collection ->
+      PredictedSchedule.Collection.put_prediction(collection, prediction)
+    end)
+    |> PredictedSchedule.Collection.to_list()
   end
 
   @impl GenServer

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -50,11 +50,17 @@ defmodule Dotcom.UpcomingDepartures.Server do
     Logger.notice("Starting server for #{topic}.")
 
     build_departures_fn_from_date = fn date ->
-      schedules = schedules_fn.(date)
+      base_predicted_schedules =
+        date
+        |> schedules_fn.()
+        |> PredictedSchedule.Collection.new()
 
       fn ->
         predictions_fn.()
-        |> PredictedSchedule.group(schedules)
+        |> Enum.reduce(base_predicted_schedules, fn prediction, collection ->
+          PredictedSchedule.Collection.put_prediction(collection, prediction)
+        end)
+        |> PredictedSchedule.Collection.to_list()
         |> @upcoming_departures_module.upcoming_departures(%{route: route})
       end
     end

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -24,17 +24,15 @@ defmodule Dotcom.UpcomingDepartures.Server do
     %{route_id: route_id, direction_id: direction_id, stop_id: stop_id} = params
     route = @routes_repo.get(route_id)
 
-    base_predicted_schedules =
-      [route_id]
-      |> @schedules_repo.by_route_ids(
+    schedules =
+      @schedules_repo.by_route_ids([route_id],
         direction_id: direction_id,
         date: ServiceDateTime.service_date(),
         stop_ids: [stop_id]
       )
-      |> PredictedSchedule.Collection.new()
 
     departures_fn = fn ->
-      get_predicted_schedules(base_predicted_schedules, route_id, direction_id, stop_id)
+      get_predicted_schedules(schedules, route_id, direction_id, stop_id)
       |> @upcoming_departures_module.upcoming_departures(%{route: route})
     end
 
@@ -46,7 +44,7 @@ defmodule Dotcom.UpcomingDepartures.Server do
     {:ok, %{departures_fn: departures_fn, topic: topic}}
   end
 
-  defp get_predicted_schedules(base_predicted_schedules, route_id, direction_id, stop_id) do
+  defp get_predicted_schedules(schedules, route_id, direction_id, stop_id) do
     @predictions_repo.all(
       route: route_id,
       direction_id: direction_id,
@@ -54,10 +52,7 @@ defmodule Dotcom.UpcomingDepartures.Server do
       discard_past_subway_predictions: false
     )
     |> Enum.filter(&(&1.stop.id == stop_id))
-    |> Enum.reduce(base_predicted_schedules, fn prediction, collection ->
-      PredictedSchedule.Collection.put_prediction(collection, prediction)
-    end)
-    |> PredictedSchedule.Collection.to_list()
+    |> PredictedSchedule.group(schedules)
   end
 
   @impl GenServer

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -34,8 +34,14 @@ defmodule Dotcom.UpcomingDepartures.Server do
       )
     end
 
-    predicted_schedules_fn = fn schedules ->
-      get_predicted_schedules(schedules, route_id, direction_id, stop_id)
+    predictions_fn = fn ->
+      @predictions_repo.all(
+        route: route_id,
+        direction_id: direction_id,
+        include_terminals: true,
+        discard_past_subway_predictions: false
+      )
+      |> Enum.filter(&(&1.stop.id == stop_id))
     end
 
     send(self(), :refresh)
@@ -43,28 +49,26 @@ defmodule Dotcom.UpcomingDepartures.Server do
     topic = Dotcom.UpcomingDepartures.topic_name(params)
     Logger.notice("Starting server for #{topic}.")
 
-    departures_fn = fn service_date ->
-      schedules_fn.(service_date)
-      |> predicted_schedules_fn.()
-      |> @upcoming_departures_module.upcoming_departures(%{route: route})
+    build_departures_fn_from_date = fn date ->
+      schedules = schedules_fn.(date)
+
+      fn ->
+        predictions_fn.()
+        |> PredictedSchedule.group(schedules)
+        |> @upcoming_departures_module.upcoming_departures(%{route: route})
+      end
     end
+
+    departures_fn =
+      ServiceDateTime.service_date()
+      |> build_departures_fn_from_date.()
 
     {:ok,
      %{
+       build_departures_fn_from_date: build_departures_fn_from_date,
        departures_fn: departures_fn,
        topic: topic
      }}
-  end
-
-  defp get_predicted_schedules(schedules, route_id, direction_id, stop_id) do
-    @predictions_repo.all(
-      route: route_id,
-      direction_id: direction_id,
-      include_terminals: true,
-      discard_past_subway_predictions: false
-    )
-    |> Enum.filter(&(&1.stop.id == stop_id))
-    |> PredictedSchedule.group(schedules)
   end
 
   @impl GenServer
@@ -81,7 +85,7 @@ defmodule Dotcom.UpcomingDepartures.Server do
           DotcomWeb.Endpoint.broadcast(
             topic,
             "upcoming_departures",
-            state.departures_fn.(ServiceDateTime.service_date())
+            state.departures_fn.()
           )
 
         _ = Process.send_after(self(), :refresh, @refresh_interval_ms)
@@ -91,10 +95,12 @@ defmodule Dotcom.UpcomingDepartures.Server do
   end
 
   def handle_info({:service_date_rollover, new_service_date}, state) do
-    updated_departures = state.departures_fn.(new_service_date)
+    new_departures_fn = state.build_departures_fn_from_date.(new_service_date)
+
+    updated_departures = new_departures_fn.()
     Logger.notice("Date change - Re-sending departures for #{state.topic}")
     :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", updated_departures)
-    {:noreply, state}
+    {:noreply, %{state | departures_fn: new_departures_fn}}
   end
 
   def handle_info(_, state), do: {:noreply, state}
@@ -102,7 +108,7 @@ defmodule Dotcom.UpcomingDepartures.Server do
   @impl GenServer
   def handle_cast({:subscribe, caller_pid}, state) do
     Logger.notice("subscribing #{inspect(caller_pid)} to #{state.topic}")
-    send(caller_pid, {:upcoming_departures, state.departures_fn.(ServiceDateTime.service_date())})
+    send(caller_pid, {:upcoming_departures, state.departures_fn.()})
     {:noreply, state}
   end
 

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -43,11 +43,15 @@ defmodule Dotcom.UpcomingDepartures.Server do
     topic = Dotcom.UpcomingDepartures.topic_name(params)
     Logger.notice("Starting server for #{topic}.")
 
+    departures_fn = fn service_date ->
+      schedules_fn.(service_date)
+      |> predicted_schedules_fn.()
+      |> @upcoming_departures_module.upcoming_departures(%{route: route})
+    end
+
     {:ok,
      %{
-       predicted_schedules_fn: predicted_schedules_fn,
-       schedules_fn: schedules_fn,
-       route: route,
+       departures_fn: departures_fn,
        topic: topic
      }}
   end
@@ -74,7 +78,11 @@ defmodule Dotcom.UpcomingDepartures.Server do
         Logger.notice("Sending departures for #{topic} to #{count} subscribers")
 
         :ok =
-          DotcomWeb.Endpoint.broadcast(topic, "upcoming_departures", compute_departures(state))
+          DotcomWeb.Endpoint.broadcast(
+            topic,
+            "upcoming_departures",
+            state.departures_fn.(ServiceDateTime.service_date())
+          )
 
         _ = Process.send_after(self(), :refresh, @refresh_interval_ms)
 
@@ -83,7 +91,7 @@ defmodule Dotcom.UpcomingDepartures.Server do
   end
 
   def handle_info({:service_date_rollover, new_service_date}, state) do
-    updated_departures = compute_departures(state, new_service_date)
+    updated_departures = state.departures_fn.(new_service_date)
     Logger.notice("Date change - Re-sending departures for #{state.topic}")
     :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", updated_departures)
     {:noreply, state}
@@ -94,19 +102,13 @@ defmodule Dotcom.UpcomingDepartures.Server do
   @impl GenServer
   def handle_cast({:subscribe, caller_pid}, state) do
     Logger.notice("subscribing #{inspect(caller_pid)} to #{state.topic}")
-    send(caller_pid, {:upcoming_departures, compute_departures(state)})
+    send(caller_pid, {:upcoming_departures, state.departures_fn.(ServiceDateTime.service_date())})
     {:noreply, state}
   end
 
   @impl GenServer
   def terminate(_reason, state) do
     :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", :terminated)
-  end
-
-  defp compute_departures(state, service_date \\ ServiceDateTime.service_date()) do
-    state.schedules_fn.(service_date)
-    |> state.predicted_schedules_fn.()
-    |> @upcoming_departures_module.upcoming_departures(%{route: state.route})
   end
 
   defp topic_subscriber_count(topic) do

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -87,26 +87,19 @@ defmodule Dotcom.UpcomingDepartures.Server do
       count ->
         Logger.notice("Sending departures for #{topic} to #{count} subscribers")
 
-        :ok =
-          DotcomWeb.Endpoint.broadcast(
-            topic,
-            "upcoming_departures",
-            state.departures_fn.()
-          )
-
         _ = Process.send_after(self(), :refresh, @refresh_interval_ms)
 
-        {:noreply, state}
+        {:noreply, state |> broadcast_departures()}
     end
   end
 
   def handle_info({:service_date_rollover, new_service_date}, state) do
-    new_departures_fn = state.build_departures_fn_from_date.(new_service_date)
-
-    updated_departures = new_departures_fn.()
     Logger.notice("Date change - Re-sending departures for #{state.topic}")
-    :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", updated_departures)
-    {:noreply, %{state | departures_fn: new_departures_fn}}
+
+    {:noreply,
+     state
+     |> update_service_date(new_service_date)
+     |> broadcast_departures()}
   end
 
   def handle_info(_, state), do: {:noreply, state}
@@ -114,13 +107,34 @@ defmodule Dotcom.UpcomingDepartures.Server do
   @impl GenServer
   def handle_cast({:subscribe, caller_pid}, state) do
     Logger.notice("subscribing #{inspect(caller_pid)} to #{state.topic}")
-    send(caller_pid, {:upcoming_departures, state.departures_fn.()})
+    send(caller_pid, {:upcoming_departures, upcoming_departures(state)})
     {:noreply, state}
   end
 
   @impl GenServer
   def terminate(_reason, state) do
     :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", :terminated)
+  end
+
+  defp broadcast_departures(state) do
+    :ok =
+      DotcomWeb.Endpoint.broadcast(
+        state.topic,
+        "upcoming_departures",
+        upcoming_departures(state)
+      )
+
+    state
+  end
+
+  defp update_service_date(state, new_service_date) do
+    new_departures_fn = state.build_departures_fn_from_date.(new_service_date)
+
+    %{state | departures_fn: new_departures_fn}
+  end
+
+  defp upcoming_departures(state) do
+    state.departures_fn.()
   end
 
   defp topic_subscriber_count(topic) do

--- a/lib/predicted_schedule/collection.ex
+++ b/lib/predicted_schedule/collection.ex
@@ -92,20 +92,14 @@ defmodule PredictedSchedule.Collection do
   it attaches the prediction to that schedule; otherwise, it creates a new entry.
   """
   def put_prediction(collection, prediction) do
-    key = key(prediction)
-
-    new_predicted_schedule =
-      collection
-      |> Map.get(key)
-      |> case do
-        %PredictedSchedule{} = ps ->
-          %PredictedSchedule{ps | prediction: prediction}
-
-        _ ->
-          %PredictedSchedule{prediction: prediction}
+    Map.update(
+      collection,
+      key(prediction),
+      %PredictedSchedule{prediction: prediction},
+      fn %PredictedSchedule{} = ps ->
+        %PredictedSchedule{ps | prediction: prediction}
       end
-
-    collection |> Map.put(key, new_predicted_schedule)
+    )
   end
 
   @spec delete_prediction(t(), Predictions.Prediction.t()) :: t()

--- a/lib/predicted_schedule/collection.ex
+++ b/lib/predicted_schedule/collection.ex
@@ -1,0 +1,144 @@
+defmodule PredictedSchedule.Collection do
+  @moduledoc """
+  A data structure for efficiently combining `Predictions.Prediction`'s and `Schedules.Schedule`'s into
+  `PredictedSchedule`'s.
+
+  `PredictedSchedule.Collection` provides the `new/1` function to construct a new collection from
+  schedules, and a `to_list/1` function to convert its data into a list. In the absence of
+  predictions, it converts each schedule to a `PredictedSchedule` with a `nil` prediction.
+      iex> schedule =
+      ...>   %Schedules.Schedule{
+      ...>     trip: %Schedules.Trip{id: "trip_id"},
+      ...>     stop_sequence: 100
+      ...>   }
+      iex> [schedule]
+      ...> |> PredictedSchedule.Collection.new()
+      ...> |> PredictedSchedule.Collection.to_list()
+      [
+        %PredictedSchedule{schedule: schedule, prediction: nil}
+      ]
+
+  When given a prediction, it attaches that prediction to its associated schedule, if possible.
+      iex> schedule =
+      ...>   %Schedules.Schedule{
+      ...>     trip: %Schedules.Trip{id: "trip_id"},
+      ...>     stop_sequence: 100
+      ...>   }
+      iex> prediction =
+      ...>   %Predictions.Prediction{
+      ...>     trip: %Schedules.Trip{id: "trip_id"},
+      ...>     stop_sequence: 100
+      ...>   }
+      iex> [schedule]
+      ...> |> PredictedSchedule.Collection.new()
+      ...> |> PredictedSchedule.Collection.put_prediction(prediction)
+      ...> |> PredictedSchedule.Collection.to_list()
+      [
+        %PredictedSchedule{schedule: schedule, prediction: prediction}
+      ]
+
+  If a prediction isn't associated with a schedule, then it creates a new entry for it.
+      iex> prediction =
+      ...>   %Predictions.Prediction{
+      ...>     trip: %Schedules.Trip{id: "trip_id"},
+      ...>     stop_sequence: 100
+      ...>   }
+      iex> []
+      ...> |> PredictedSchedule.Collection.new()
+      ...> |> PredictedSchedule.Collection.put_prediction(prediction)
+      ...> |> PredictedSchedule.Collection.to_list()
+      [
+        %PredictedSchedule{schedule: nil, prediction: prediction}
+      ]
+
+  Predictions can also be removed.
+      iex> schedule =
+      ...>   %Schedules.Schedule{
+      ...>     trip: %Schedules.Trip{id: "trip_id"},
+      ...>     stop_sequence: 100
+      ...>   }
+      iex> prediction =
+      ...>   %Predictions.Prediction{
+      ...>     trip: %Schedules.Trip{id: "trip_id"},
+      ...>     stop_sequence: 100
+      ...>   }
+      iex> [schedule]
+      ...> |> PredictedSchedule.Collection.new()
+      ...> |> PredictedSchedule.Collection.put_prediction(prediction)
+      ...> |> PredictedSchedule.Collection.delete_prediction(prediction)
+      ...> |> PredictedSchedule.Collection.to_list()
+      [
+        %PredictedSchedule{schedule: schedule, prediction: nil}
+      ]
+  """
+
+  @type key_t() :: {Schedules.Trip.id_t(), non_neg_integer()}
+  @type t() :: %{key_t() => PredictedSchedule.t()}
+
+  @spec new([Schedules.Schedule.t()]) :: t()
+  @doc """
+  Constructs a new `Collection` from a list of schedules.
+  """
+  def new(schedules) do
+    schedules
+    |> Map.new(fn schedule ->
+      {key(schedule), %PredictedSchedule{schedule: schedule}}
+    end)
+  end
+
+  @spec put_prediction(t(), Predictions.Prediction.t()) :: t()
+  @doc """
+  Efficiently adds a prediction to the `Collection`. If there is an associated schedule,
+  it attaches the prediction to that schedule; otherwise, it creates a new entry.
+  """
+  def put_prediction(collection, prediction) do
+    key = key(prediction)
+
+    new_predicted_schedule =
+      collection
+      |> Map.get(key)
+      |> case do
+        %PredictedSchedule{} = ps ->
+          %PredictedSchedule{ps | prediction: prediction}
+
+        _ ->
+          %PredictedSchedule{prediction: prediction}
+      end
+
+    collection |> Map.put(key, new_predicted_schedule)
+  end
+
+  @spec delete_prediction(t(), Predictions.Prediction.t()) :: t()
+  @doc """
+  Efficiently removes a prediction from the `Collection`. If there was a schedule associated
+  with that prediction, then the schedule is preserved; if there wasn't one, then the entry
+  is removed.
+  """
+  def delete_prediction(collection, prediction) do
+    key = key(prediction)
+
+    collection
+    |> Map.get(key)
+    |> case do
+      %PredictedSchedule{schedule: schedule} = ps when schedule != nil ->
+        collection |> Map.put(key, %PredictedSchedule{ps | prediction: nil})
+
+      _ ->
+        collection |> Map.delete(key)
+    end
+  end
+
+  @spec to_list(t()) :: [PredictedSchedule.t()]
+  @doc """
+  Returns a list containing the `PredictedSchedule`'s in the `Collection`.
+  """
+  def to_list(collection) do
+    collection
+    |> Map.values()
+  end
+
+  @spec key(Schedules.Schedule.t() | Predictions.Prediction.t()) :: key_t()
+  defp key(%{trip: %{id: trip_id}, stop_sequence: stop_sequence}) do
+    {trip_id, stop_sequence}
+  end
+end

--- a/test/dotcom/upcoming_departures/server_test.exs
+++ b/test/dotcom/upcoming_departures/server_test.exs
@@ -25,12 +25,7 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       stop_id: "stop-#{n}"
     }
 
-    state = %{
-      predicted_schedules_fn: fn _ -> [] end,
-      schedules_fn: fn _ -> [] end,
-      route: Factories.Routes.Route.build(:route),
-      topic: topic
-    }
+    {:ok, state} = Server.init(params)
 
     %{params: params, topic: topic, state: state}
   end
@@ -61,12 +56,6 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
     test "stores the topic in state", %{params: params} do
       {:ok, state} = Server.init(params)
       assert state.topic == Dotcom.UpcomingDepartures.topic_name(params)
-    end
-
-    test "stores helpful functions in state", %{params: params} do
-      {:ok, state} = Server.init(params)
-      assert is_function(state.schedules_fn, 1)
-      assert is_function(state.predicted_schedules_fn, 1)
     end
 
     test "queues a :refresh message to trigger the initial broadcast", %{params: params} do

--- a/test/dotcom_web/live/upcoming_departures_live_test.exs
+++ b/test/dotcom_web/live/upcoming_departures_live_test.exs
@@ -104,7 +104,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
         time: @date_time_module.now() |> DateTime.shift(minute: 40)
       )
 
-    expect(Schedules.Repo.Mock, :by_route_ids, 4, fn _, _ ->
+    expect(Schedules.Repo.Mock, :by_route_ids, 3, fn _, _ ->
       schedules ++ [last_schedule]
     end)
 

--- a/test/predicted_schedule/collection_test.exs
+++ b/test/predicted_schedule/collection_test.exs
@@ -84,6 +84,27 @@ defmodule PredictedSchedule.CollectionTest do
                MapSet.new(expected_predicted_schedule_list)
     end
 
+    test "doesn't crash when removing a schedule-associated prediction that wasn't previously added" do
+      # Setup
+      schedules = [schedule | _] = build_schedules(2)
+      prediction = build_prediction_from_schedule(schedule)
+
+      # Exercise
+      actual_predicted_schedule_list =
+        schedules
+        |> Collection.new()
+        |> Collection.delete_prediction(prediction)
+        |> Collection.to_list()
+        |> MapSet.new()
+
+      # Verify
+      expected_predicted_schedule_list =
+        schedules |> Enum.map(&%PredictedSchedule{schedule: &1, prediction: nil})
+
+      assert MapSet.new(actual_predicted_schedule_list) ==
+               MapSet.new(expected_predicted_schedule_list)
+    end
+
     test "adds a PredictedSchedule with no schedule if a prediction doesn't correspond to a schedule" do
       # Setup
       [absent_schedule | schedules] = build_schedules(2)
@@ -117,6 +138,28 @@ defmodule PredictedSchedule.CollectionTest do
         schedules
         |> Collection.new()
         |> Collection.put_prediction(prediction)
+        |> Collection.delete_prediction(prediction)
+        |> Collection.to_list()
+        |> MapSet.new()
+
+      # Verify
+      expected_predicted_schedule_list =
+        schedules
+        |> Enum.map(&%PredictedSchedule{schedule: &1, prediction: nil})
+
+      assert MapSet.new(actual_predicted_schedule_list) ==
+               MapSet.new(expected_predicted_schedule_list)
+    end
+
+    test "doesn't crash when removing a non-schedule-associated prediction that wasn't previously added" do
+      # Setup
+      [absent_schedule | schedules] = build_schedules(2)
+      prediction = build_prediction_from_schedule(absent_schedule)
+
+      # Exercise
+      actual_predicted_schedule_list =
+        schedules
+        |> Collection.new()
         |> Collection.delete_prediction(prediction)
         |> Collection.to_list()
         |> MapSet.new()

--- a/test/predicted_schedule/collection_test.exs
+++ b/test/predicted_schedule/collection_test.exs
@@ -1,0 +1,152 @@
+defmodule PredictedSchedule.CollectionTest do
+  use ExUnit.Case, async: true
+  doctest PredictedSchedule.Collection
+
+  import Mox
+
+  alias PredictedSchedule.Collection
+  alias Test.Support.Factories
+  alias Test.Support.FactoryHelpers
+
+  setup do
+    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+    :ok
+  end
+
+  describe "PredictedSchedule.Collection" do
+    test "is empty if passed an empty list of schedules" do
+      collection = Collection.new([])
+
+      assert collection |> Collection.to_list() |> Enum.empty?()
+    end
+
+    test "starts out with a bunch of PredictedSchedules with no predictions" do
+      # Setup
+      schedules = build_schedules(2)
+
+      # Exercise
+      actual_predicted_schedule_list =
+        schedules
+        |> Collection.new()
+        |> Collection.to_list()
+
+      # Verify
+      expected_predicted_schedule_list =
+        schedules
+        |> Enum.map(&%PredictedSchedule{schedule: &1, prediction: nil})
+
+      assert MapSet.new(actual_predicted_schedule_list) ==
+               MapSet.new(expected_predicted_schedule_list)
+    end
+
+    test "attaches a prediction to the right schedule" do
+      # Setup
+      schedules = [schedule | other_schedules] = build_schedules(2)
+      prediction = build_prediction_from_schedule(schedule)
+
+      # Exercise
+      actual_predicted_schedule_list =
+        schedules
+        |> Collection.new()
+        |> Collection.put_prediction(prediction)
+        |> Collection.to_list()
+        |> MapSet.new()
+
+      # Verify
+      expected_predicted_schedule_list =
+        (other_schedules
+         |> Enum.map(&%PredictedSchedule{schedule: &1, prediction: nil})) ++
+          [%PredictedSchedule{schedule: schedule, prediction: prediction}]
+
+      assert MapSet.new(actual_predicted_schedule_list) ==
+               MapSet.new(expected_predicted_schedule_list)
+    end
+
+    test "removes a schedule-associated prediction and keeps the schedule intact" do
+      # Setup
+      schedules = [schedule | _] = build_schedules(2)
+      prediction = build_prediction_from_schedule(schedule)
+
+      # Exercise
+      actual_predicted_schedule_list =
+        schedules
+        |> Collection.new()
+        |> Collection.put_prediction(prediction)
+        |> Collection.delete_prediction(prediction)
+        |> Collection.to_list()
+        |> MapSet.new()
+
+      # Verify
+      expected_predicted_schedule_list =
+        schedules |> Enum.map(&%PredictedSchedule{schedule: &1, prediction: nil})
+
+      assert MapSet.new(actual_predicted_schedule_list) ==
+               MapSet.new(expected_predicted_schedule_list)
+    end
+
+    test "adds a PredictedSchedule with no schedule if a prediction doesn't correspond to a schedule" do
+      # Setup
+      [absent_schedule | schedules] = build_schedules(2)
+      prediction = build_prediction_from_schedule(absent_schedule)
+
+      # Exercise
+      actual_predicted_schedule_list =
+        schedules
+        |> Collection.new()
+        |> Collection.put_prediction(prediction)
+        |> Collection.to_list()
+        |> MapSet.new()
+
+      # Verify
+      expected_predicted_schedule_list =
+        (schedules
+         |> Enum.map(&%PredictedSchedule{schedule: &1, prediction: nil})) ++
+          [%PredictedSchedule{schedule: nil, prediction: prediction}]
+
+      assert MapSet.new(actual_predicted_schedule_list) ==
+               MapSet.new(expected_predicted_schedule_list)
+    end
+
+    test "fully removes a PredictedSchedule with no schedule when removing the prediction" do
+      # Setup
+      [absent_schedule | schedules] = build_schedules(2)
+      prediction = build_prediction_from_schedule(absent_schedule)
+
+      # Exercise
+      actual_predicted_schedule_list =
+        schedules
+        |> Collection.new()
+        |> Collection.put_prediction(prediction)
+        |> Collection.delete_prediction(prediction)
+        |> Collection.to_list()
+        |> MapSet.new()
+
+      # Verify
+      expected_predicted_schedule_list =
+        schedules
+        |> Enum.map(&%PredictedSchedule{schedule: &1, prediction: nil})
+
+      assert MapSet.new(actual_predicted_schedule_list) ==
+               MapSet.new(expected_predicted_schedule_list)
+    end
+  end
+
+  defp build_schedules(count) do
+    Faker.Util.sample_uniq(count, fn ->
+      {FactoryHelpers.build(:id), Faker.random_between(1, 10000)}
+    end)
+    |> Enum.map(fn {trip_id, stop_sequence} ->
+      Factories.Schedules.Schedule.build(:schedule,
+        trip: Factories.Schedules.Trip.build(:trip, id: trip_id),
+        stop_sequence: stop_sequence
+      )
+    end)
+  end
+
+  defp build_prediction_from_schedule(schedule) do
+    Factories.Predictions.Prediction.build(:prediction,
+      trip: schedule.trip,
+      stop_sequence: schedule.stop_sequence
+    )
+  end
+end

--- a/test/predicted_schedule/collection_test.exs
+++ b/test/predicted_schedule/collection_test.exs
@@ -133,7 +133,7 @@ defmodule PredictedSchedule.CollectionTest do
 
   defp build_schedules(count) do
     Faker.Util.sample_uniq(count, fn ->
-      {FactoryHelpers.build(:id), Faker.random_between(1, 10000)}
+      {FactoryHelpers.build(:id), Faker.random_between(1, 10_000)}
     end)
     |> Enum.map(fn {trip_id, stop_sequence} ->
       Factories.Schedules.Schedule.build(:schedule,


### PR DESCRIPTION
## Scope

**Asana Ticket:** [📅🔎🎭 Better data structure for combining predictions and schedules into predicted_schedules](https://app.asana.com/1/15492006741476/project/1205718271156548/task/1214587664555345?focus=true)

## Implementation

I genuinely don't know if this PR would be easier to read commit-by-commit or not, since there's a decent amount of work and un-work going on. The meat of the actual change is in [this commit](https://github.com/mbta/dotcom/pull/3244/changes/99bb3dbc19a227ea8ae3b101b4e49080447f9763), but it's surrounded by a decent amount of refactoring before and after.

👇 Below is the journey that this PR went through 👇 

### First Pass

- [feat: Create a data structure for efficiently creating `PredictedSchedule`'s](https://github.com/mbta/dotcom/pull/3244/changes/5e61376b38552411e98654b54a66c90136495add)
- [refactor(SF2.0/perf): Use `PredictedSchedule.Collection` in `UpcomingDepartures.Server`](https://github.com/mbta/dotcom/pull/3244/changes/f5d6cbbfbe24623905fd286c7b7035bc0b9cb368)
  - Part of the joy of the first pass was that the change to actually use this data structure was minimal. This commit will get reverted in the next section, but enjoy the minimal change while it's here!
- [fix: Credo prefers 10_000 over 10000](https://github.com/mbta/dotcom/pull/3244/changes/d37ba25385cbd3209253301d16418984307c9a1d)
- [style (and maybe perf?): Use Map.update/4 instead of case %{...} do ...](https://github.com/mbta/dotcom/pull/3244/changes/96009a181d769efbc0fbee58de557bb0f15d01fc)

### Merge

As alluded to earlier, the original implementation conflicted with https://github.com/mbta/dotcom/pull/3245. 

- [Revert "refactor(SF2.0/perf): Use `PredictedSchedule.Collection` in `UpcomingDepartures.Server`"](https://github.com/mbta/dotcom/pull/3244/changes/2551a02072065290f911358b11bbf8d49a8fc329)
  - The easiest way to resolve this particular merge conflict was to undo our attempt and redo later. This is the undo.
- [Merge remote-tracking branch 'origin/main' into jdl/feat/predicted-schedule-data-structure](https://github.com/mbta/dotcom/pull/3244/changes/dcb9bab5db82d2fa310a8099a9fd9955f329782d)

### Refactor to make the code compatible with `Collection` again

These two commits are somewhat chunky refactors that move schedule-fetching outside of `departures_fn`, so that `departures_fn` can eventually work with a pre-populated `Collection` instead of a raw list of schedules. This works using a nested function-returning-a-function, a dubious code choice that has a certain type of elegance, but ultimately was more confusing than necessary.

- [refactor: Inline `compute_departures` and simplify state](https://github.com/mbta/dotcom/pull/3244/changes/f9b0cbf8034890ddd01390e23b08e5c82bcfbf37)
- [perf: Only fetch schedules on `:init` and `:service_date_rollover`](https://github.com/mbta/dotcom/pull/3244/changes/2280d305f3331daa0f0a5781554b9b000fa75aa2)
  - This also restores the fact that schedules are only fetched when they change, rather than on every `:refresh`.

### ✨ Easy Change ✨ 

- [perf/refactor: Use `PredictedSchedule.Collection` in `UpcomingDeparture.Server`](https://github.com/mbta/dotcom/pull/3244/changes/99bb3dbc19a227ea8ae3b101b4e49080447f9763)

### More refactors

`build_departures_fn_from_date` has a certain type of functional-programming elegance (and could also be somewhat accurately called `departures_fn_fn`), but it was also getting pretty confusing. These two commits clean that up, and replace it with a few simpler anonymous-functions-in-state whose purpose is clearer.

- [refactor: Extract broadcast_departures and a few other utility functions](https://github.com/mbta/dotcom/pull/3244/changes/4883ca2a7fb3daca6fd5c80701634603b806345c)
  - Just a few simple cleanups to make it easier for me to wrap my mind around removing `build_departures_fn_from_date`.
- [refactor: Remove the doubly-nested curried function](https://github.com/mbta/dotcom/pull/3244/changes/7678b3c48135909da1c64a090fddf1cccd3f67c4)

### Test cleanup/fixes

- [fix: Server tests](https://github.com/mbta/dotcom/pull/3244/changes/66ae6bc156168c96ff1b54be115bbeb2b3596f97)
- [fix: UpcomingDeparturesLive test](https://github.com/mbta/dotcom/pull/3244/changes/1f0c40fdefd3eee02ef49a73da585ceed84a0664)
- [tests: Add tests for deleting predictions that haven't yet been added](https://github.com/mbta/dotcom/pull/3244/changes/dda95b973f6e043f6856fc5932d9972121cf50d2)

## Screenshots

<img width="2994" height="1300" alt="Screenshot 2026-06-09 at 4 12 14 PM" src="https://github.com/user-attachments/assets/896d2b53-16e9-4d74-8033-206ac216cea7" />

No visual changes expected. Here's a screenshot of no visual changes for [this departures page](http://localhost:4001/departures?route_id=68&direction_id=1&stop_id=2222) for good measure 🙂 

## How to test

Compare any departures page you feel like with production. There should be no change.

We also are hoping to perf test this.