### PR TITLE
refactor(UpcomingDepartures.Server): listen to service date

### DIFF
--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -24,16 +24,18 @@ defmodule Dotcom.UpcomingDepartures.Server do
     %{route_id: route_id, direction_id: direction_id, stop_id: stop_id} = params
     route = @routes_repo.get(route_id)
 
-    schedules =
+    _ = Dotcom.ServiceDateRollover.subscribe()
+
+    schedules_fn = fn date ->
       @schedules_repo.by_route_ids([route_id],
         direction_id: direction_id,
-        date: ServiceDateTime.service_date(),
+        date: date,
         stop_ids: [stop_id]
       )
+    end
 
-    departures_fn = fn ->
+    predicted_schedules_fn = fn schedules ->
       get_predicted_schedules(schedules, route_id, direction_id, stop_id)
-      |> @upcoming_departures_module.upcoming_departures(%{route: route})
     end
 
     send(self(), :refresh)
@@ -41,7 +43,13 @@ defmodule Dotcom.UpcomingDepartures.Server do
     topic = Dotcom.UpcomingDepartures.topic_name(params)
     Logger.notice("Starting server for #{topic}.")
 
-    {:ok, %{departures_fn: departures_fn, topic: topic}}
+    {:ok,
+     %{
+       predicted_schedules_fn: predicted_schedules_fn,
+       schedules_fn: schedules_fn,
+       route: route,
+       topic: topic
+     }}
   end
 
   defp get_predicted_schedules(schedules, route_id, direction_id, stop_id) do
@@ -64,11 +72,21 @@ defmodule Dotcom.UpcomingDepartures.Server do
 
       count ->
         Logger.notice("Sending departures for #{topic} to #{count} subscribers")
-        :ok = DotcomWeb.Endpoint.broadcast(topic, "upcoming_departures", state.departures_fn.())
+
+        :ok =
+          DotcomWeb.Endpoint.broadcast(topic, "upcoming_departures", compute_departures(state))
+
         _ = Process.send_after(self(), :refresh, @refresh_interval_ms)
 
         {:noreply, state}
     end
+  end
+
+  def handle_info({:service_date_rollover, new_service_date}, state) do
+    updated_departures = compute_departures(state, new_service_date)
+    Logger.notice("Date change - Re-sending departures for #{state.topic}")
+    :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", updated_departures)
+    {:noreply, state}
   end
 
   def handle_info(_, state), do: {:noreply, state}
@@ -76,13 +94,19 @@ defmodule Dotcom.UpcomingDepartures.Server do
   @impl GenServer
   def handle_cast({:subscribe, caller_pid}, state) do
     Logger.notice("subscribing #{inspect(caller_pid)} to #{state.topic}")
-    send(caller_pid, {:upcoming_departures, state.departures_fn.()})
+    send(caller_pid, {:upcoming_departures, compute_departures(state)})
     {:noreply, state}
   end
 
   @impl GenServer
   def terminate(_reason, state) do
     :ok = DotcomWeb.Endpoint.broadcast(state.topic, "upcoming_departures", :terminated)
+  end
+
+  defp compute_departures(state, service_date \\ ServiceDateTime.service_date()) do
+    state.schedules_fn.(service_date)
+    |> state.predicted_schedules_fn.()
+    |> @upcoming_departures_module.upcoming_departures(%{route: state.route})
   end
 
   defp topic_subscriber_count(topic) do

--- a/test/dotcom/upcoming_departures/server_test.exs
+++ b/test/dotcom/upcoming_departures/server_test.exs
@@ -25,7 +25,14 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       stop_id: "stop-#{n}"
     }
 
-    %{params: params, topic: topic}
+    state = %{
+      predicted_schedules_fn: fn _ -> [] end,
+      schedules_fn: fn _ -> [] end,
+      route: Factories.Routes.Route.build(:route),
+      topic: topic
+    }
+
+    %{params: params, topic: topic, state: state}
   end
 
   describe "start_link/1" do
@@ -56,9 +63,10 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       assert state.topic == Dotcom.UpcomingDepartures.topic_name(params)
     end
 
-    test "stores a zero-arity departures_fn in state", %{params: params} do
+    test "stores helpful functions in state", %{params: params} do
       {:ok, state} = Server.init(params)
-      assert is_function(state.departures_fn, 0)
+      assert is_function(state.schedules_fn, 1)
+      assert is_function(state.predicted_schedules_fn, 1)
     end
 
     test "queues a :refresh message to trigger the initial broadcast", %{params: params} do
@@ -80,11 +88,15 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
   end
 
   describe "handle_info/2 - :refresh" do
-    test "broadcasts upcoming departures to the PubSub topic", %{topic: topic} do
+    test "broadcasts upcoming departures to the PubSub topic", %{state: state} do
+      topic = state.topic
       subscribe_and_track(topic)
 
       fake_departures = [:departure_a, :departure_b]
-      state = %{departures_fn: fn -> fake_departures end, topic: topic}
+
+      expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 1, fn _, _ ->
+        fake_departures
+      end)
 
       assert {:noreply, ^state} = Server.handle_info(:refresh, state)
 
@@ -119,19 +131,19 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
   end
 
   describe "handle_cast/2 - :subscribe" do
-    test "sends upcoming departures directly to the specified pid", %{topic: topic} do
+    test "sends upcoming departures directly to the specified pid", %{state: state} do
       fake_result = :service_ended
-      state = %{departures_fn: fn -> fake_result end, topic: topic}
-
       Server.handle_cast({:subscribe, self()}, state)
 
       assert_receive {:upcoming_departures, ^fake_result}
     end
 
-    test "does not publish to PubSub – only sends to the target pid", %{topic: topic} do
+    test "does not publish to PubSub – only sends to the target pid", %{
+      topic: topic,
+      state: state
+    } do
       subscribe_and_track(topic)
       other_pid = spawn(fn -> Process.sleep(:infinity) end)
-      state = %{departures_fn: fn -> [:trip] end, topic: topic}
 
       Server.handle_cast({:subscribe, other_pid}, state)
 

--- a/test/dotcom_web/live/upcoming_departures_live_test.exs
+++ b/test/dotcom_web/live/upcoming_departures_live_test.exs
@@ -34,6 +34,26 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
     :ok
   end
 
+  defp allow_mocks(route_id, stop_id, direction_id) do
+    upcoming_departure_params = %{
+      route_id: route_id,
+      direction_id: direction_id,
+      stop_id: stop_id
+    }
+
+    allow(Routes.Repo.Mock, self(), fn ->
+      GenServer.whereis({:global, upcoming_departure_params})
+    end)
+
+    allow(Schedules.Repo.Mock, self(), fn ->
+      GenServer.whereis({:global, upcoming_departure_params})
+    end)
+
+    allow(Dotcom.Utils.DateTime.Mock, self(), fn ->
+      GenServer.whereis({:global, upcoming_departure_params})
+    end)
+  end
+
   test "loads, fetching route, stop info & subscribing to upcoming departures", %{conn: conn} do
     route_id_param = FactoryHelpers.build(:id)
     stop_id_param = FactoryHelpers.build(:id)
@@ -272,11 +292,16 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
   end
 
   defp start_live_view(conn, route_id \\ nil, direction_id \\ nil, stop_id \\ nil) do
+    route_id = route_id || FactoryHelpers.build(:id)
+    direction_id = direction_id || FactoryHelpers.build(:direction_id)
+    stop_id = stop_id || FactoryHelpers.build(:id)
+    allow_mocks(route_id, stop_id, direction_id)
+
     live_isolated(conn, UpcomingDeparturesLive,
       session: %{
-        "route_id" => route_id || FactoryHelpers.build(:id),
-        "direction_id" => direction_id || FactoryHelpers.build(:direction_id),
-        "stop_id" => stop_id || FactoryHelpers.build(:id)
+        "route_id" => route_id,
+        "direction_id" => direction_id,
+        "stop_id" => stop_id
       },
       on_error: :warn
     )

--- a/test/dotcom_web/live/upcoming_departures_live_test.exs
+++ b/test/dotcom_web/live/upcoming_departures_live_test.exs
@@ -86,40 +86,6 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
            |> has_element?()
   end
 
-  test "fetches schedules info on load for subway", %{conn: conn} do
-    route_id = FactoryHelpers.build(:id)
-    route = Factories.Routes.Route.build(:route, %{id: route_id, type: Faker.Util.pick([0, 1])})
-    stop_id = FactoryHelpers.build(:id)
-    direction_id = FactoryHelpers.build(:direction_id)
-
-    expect(Routes.Repo.Mock, :get, 3, fn ^route_id -> route end)
-
-    expect(Schedules.Repo.Mock, :by_route_ids, 3, fn routes, opts ->
-      assert routes == [route_id]
-      assert Keyword.get(opts, :direction_id) == direction_id
-      assert Keyword.get(opts, :stop_ids) == [stop_id]
-      assert Keyword.get(opts, :date) == Dotcom.Utils.ServiceDateTime.service_date()
-
-      []
-    end)
-
-    parent = self()
-    ref = make_ref()
-
-    expect(Dotcom.UpcomingDepartures.Mock, :upcoming_departures, 2, fn _, _ ->
-      send(parent, {ref, :done})
-      :no_service
-    end)
-
-    {:ok, view, _} = start_live_view(conn, route_id, direction_id, stop_id)
-    assert_receive {^ref, :done}
-    assert_receive {^ref, :done}
-
-    assert view
-           |> element("[data-test=\"u_d:async_success\"]")
-           |> has_element?()
-  end
-
   test "shows last scheduled trip for subway", %{conn: conn} do
     route = Factories.Routes.Route.build(:subway_route)
     stop = Factories.Stops.Stop.build(:stop)
@@ -138,7 +104,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLiveTest do
         time: @date_time_module.now() |> DateTime.shift(minute: 40)
       )
 
-    expect(Schedules.Repo.Mock, :by_route_ids, 3, fn _, _ ->
+    expect(Schedules.Repo.Mock, :by_route_ids, 4, fn _, _ ->
       schedules ++ [last_schedule]
     end)
 


### PR DESCRIPTION
## Scope

TBA, this is a followup to #3238 where we actually use it to get the new service date when it happens!

## Implementation

- Have the `UpcomingDepartures.Server` subscribe to changes to the service date
- Get the new service date, and use it to immediately recompute and re-broadcast upcoming departures to subscribers

This required a little bit of updating to the internals, so that our computation takes a date as an optional input.

## Screenshots

No change... yet

## How to test

Open to ideas
