### PR TITLE
fix: `ServiceDateRollover` doc formatting

### DIFF
--- a/lib/dotcom/service_date_rollover.ex
+++ b/lib/dotcom/service_date_rollover.ex
@@ -2,11 +2,11 @@ defmodule Dotcom.ServiceDateRollover do
   @moduledoc """
   Notifies via PubSub when the service date advances to the next service date
 
-  // subscribe to updates
-  _ = Dotcom.ServiceDateRollover.subscribe()
+      // subscribe to updates
+      _ = Dotcom.ServiceDateRollover.subscribe()
 
-  // handle the update
-  def handle_info({:service_date_rollover, new_service_date}, socket)
+      // handle the update
+      def handle_info({:service_date_rollover, new_service_date}, socket)
   """
 
   use GenServer


### PR DESCRIPTION
## Scope

No ticket - just a thing I noticed while snooping around the code.

## Screenshots

[Current `main` on the left](https://mbta.github.io/dotcom/Dotcom.ServiceDateRollover.html); this branch on the right.
<img width="2844" height="1540" alt="Screenshot 2026-06-09 at 11 02 35 PM" src="https://github.com/user-attachments/assets/2d183260-6334-4e79-91f6-842888506d28" />