### PR TITLE
fix: Actually start the `ServiceDateRollover` worker

### DIFF
--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -51,6 +51,7 @@ defmodule Dotcom.Application do
           Predictions.Supervisor,
           Alerts.BusStopChangeSupervisor,
           Alerts.CacheSupervisor,
+          Dotcom.ServiceDateRollover,
           {DynamicSupervisor, name: Dotcom.UpcomingDepartures.Supervisor},
           {DynamicSupervisor, name: Dotcom.Predictions.Supervisor},
           {Phoenix.PubSub, name: Dotcom.PubSub},

--- a/lib/dotcom/application.ex
+++ b/lib/dotcom/application.ex
@@ -51,7 +51,6 @@ defmodule Dotcom.Application do
           Predictions.Supervisor,
           Alerts.BusStopChangeSupervisor,
           Alerts.CacheSupervisor,
-          Dotcom.ServiceDateRollover,
           {DynamicSupervisor, name: Dotcom.UpcomingDepartures.Supervisor},
           {DynamicSupervisor, name: Dotcom.Predictions.Supervisor},
           {Phoenix.PubSub, name: Dotcom.PubSub},
@@ -60,6 +59,7 @@ defmodule Dotcom.Application do
         ] ++
         if Application.get_env(:dotcom, :env) != :test do
           [
+            Dotcom.ServiceDateRollover,
             Dotcom.ViaFairmount,
             {Dotcom.SystemStatus.CommuterRailCache, []},
             {Dotcom.SystemStatus.SubwayCache, []}

--- a/lib/dotcom/service_date_rollover.ex
+++ b/lib/dotcom/service_date_rollover.ex
@@ -47,6 +47,7 @@ defmodule Dotcom.ServiceDateRollover do
     end_of_service_day()
     |> DateTime.shift(microsecond: {1, 4})
     |> DateTime.diff(@date_time_module.now(), :millisecond)
+    |> max(1000)
   end
 
   def subscribe() do

--- a/test/dotcom/service_date_rollover_test.exs
+++ b/test/dotcom/service_date_rollover_test.exs
@@ -111,14 +111,14 @@ defmodule Dotcom.ServiceDateRolloverTest do
       :ok = Phoenix.PubSub.subscribe(Dotcom.PubSub, topic_name())
       {:ok, _pid} = start_supervised({Dotcom.ServiceDateRollover, []}, id: :service_date_rollover)
 
-      assert_receive {:service_date_rollover, _date}, 200
+      assert_receive {:service_date_rollover, _date}, 1200
     end
 
     test "subscribe/0 subscribes to the service date rollover topic" do
       :ok = Dotcom.ServiceDateRollover.subscribe()
       {:ok, _pid} = start_supervised({Dotcom.ServiceDateRollover, []}, id: :service_date_rollover)
 
-      assert_receive {:service_date_rollover, _date}, 200
+      assert_receive {:service_date_rollover, _date}, 1200
     end
   end
 end


### PR DESCRIPTION
## Scope

No ticket - just realized that there actually was a way to test this.... and then realized that it wasn't working!

## Implementation

Two things:
1. Add `Dotcom.ServiceDateRollover` to the supervision tree.
2. Make sure that we don't try to schedule the "next rollover" for a time in the past.

Per point number 2, one of the times I was testing this out, I got 👇 error. Might as well avoid that!
```elixir
2026-06-10 22:03:00.009 [error] GenServer Dotcom.ServiceDateRollover terminating
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: out of range

    (erts 16.3) :erlang.send_after(-10, #PID<0.678.0>, :dispatch_change)
    (dotcom 0.0.1) lib/dotcom/service_date_rollover.ex:42: Dotcom.ServiceDateRollover.handle_continue/2
    (stdlib 7.3) gen_server.erl:2424: :gen_server.try_handle_continue/3
    (stdlib 7.3) gen_server.erl:2291: :gen_server.loop/4
    (stdlib 7.3) proc_lib.erl:333: :proc_lib.init_p_do_apply/3
Last message: {:continue, :schedule_next_run}
State: %{}
```

## Screenshots

https://github.com/user-attachments/assets/b3d1d8d0-2060-4914-8a3f-79b060b271bf

I was able to make `ServiceDateTime` pretend that the service-rollover-time was 9:59PM, which meant that today's bus schedules didn't show up until after that time (since before the service-rollover-time, it pulls yesterday's schedules instead, which are all in the past). So before service-rollover-time, bus schedules will be absent, and the last trip will be labeled `Last`; after service-rollover-time, today's schedules will populate. ☝️ video shows the schedules spontaneously populating (at my customized service-rollover-time of 9:59).

## How to test

It actually is possible to mangle `ServiceDateTime`'s [`service_date/0`](https://github.com/mbta/dotcom/blob/25fd37236c7a9a81a1ef11ad367776e519a05ea6/lib/dotcom/utils/service_date_time.ex#L39-L49) and [`end_of_service_day/0`](https://github.com/mbta/dotcom/blob/25fd37236c7a9a81a1ef11ad367776e519a05ea6/lib/dotcom/utils/service_date_time.ex#L130-L145) functions to set your service day to whenever you want (I chose one minute in the future). Most of that module assumes that the service rollover time will be right on the hour, so there's some additional mangling you might need to do if you want to be able to test it more than once per hour.

I rewrote the functions like so 👇 
```elixir
@service_rollover_time ~T[22:15:00] # ...or whatever time you choose

# Rewrote this entirely
def service_date(date_time \\ @date_time_module.now()) do
  calendar_date = DateTime.to_date(date_time)

  before_rollover_time? =
    date_time
    |> DateTime.to_time()
    |> Time.before?(@service_rollover_time)

  if before_rollover_time? do
    calendar_date |> Date.shift(day: -1)
  else
    calendar_date
  end
end

# ...

def end_of_service_day(date_time \\ @date_time_module.now())

def end_of_service_day(%Date{} = date) do
  date
  |> Timex.to_datetime(@timezone)
  |> coerce_ambiguous_date_time()
  |> Timex.shift(
    days: 1,
    hours: @service_rollover_time.hour,
    # Add this if you want a service-rollover-time that isn't right on the hour
    minutes: @service_rollover_time.minute,
    microseconds: -1
  )
  |> coerce_ambiguous_date_time()

  # Commented this because it only works if the service-rollover-time is right on the hour
  # |> Map.put(:hour, @service_rollover_time.hour - 1)
end

def end_of_service_day(%DateTime{} = date_time) do
  date_time
  |> service_date()
  |> end_of_service_day()
end
```

## Notes
I have now achieved semantic satiation with the phrase "service rollover time". I hope you're happy.