### PR TITLE
feat(timetable): Upcoming Changes for commuter rail

### DIFF
--- a/lib/dotcom_web/components/components.ex
+++ b/lib/dotcom_web/components/components.ex
@@ -136,6 +136,7 @@ defmodule DotcomWeb.Components do
 
   slot(:heading, required: false, doc: "Large title shown at top of container.")
   slot(:inner_block, required: true)
+  attr(:class, :string, default: "")
   attr(:hide_divider, :boolean, required: false, default: false)
 
   @doc """
@@ -171,7 +172,11 @@ defmodule DotcomWeb.Components do
   """
   def bordered_container(assigns) do
     ~H"""
-    <div class="px-2 py-3 md:px-5 md:py-4 border-[1px] bg-white border-gray-lightest rounded-lg">
+    <div class={[
+      @class,
+      "px-2 py-3 md:px-5 md:py-4 border-[1px]",
+      "bg-white border-gray-lightest rounded-lg"
+    ]}>
       <div :if={@heading} class="font-heading font-bold text-[1.75rem] leading-normal">
         {render_slot(@heading)}
       </div>

--- a/lib/dotcom_web/components/planned_disruptions.ex
+++ b/lib/dotcom_web/components/planned_disruptions.ex
@@ -89,8 +89,7 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
   defp heading(assigns) do
     time_range_str =
       assigns.alert
-      |> alert_date_range()
-      |> formatted_date_range()
+      |> format_date_range_for_alert()
 
     assigns = assign(assigns, time_range_str: time_range_str)
 
@@ -103,6 +102,12 @@ defmodule DotcomWeb.Components.PlannedDisruptions do
       status={@alert.effect}
     />
     """
+  end
+
+  def format_date_range_for_alert(alert) do
+    alert
+    |> alert_date_range()
+    |> formatted_date_range()
   end
 
   defp formatted_date_range({nil, nil}), do: nil

--- a/lib/dotcom_web/components/system_status/commuter_rail_info_widget.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_info_widget.ex
@@ -7,13 +7,14 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailInfoWidget do
 
   import DotcomWeb.Components, only: [bordered_container: 1]
 
+  attr :class, :string, default: ""
   attr :heading_text, :string, required: true
   slot :inner_block, required: true
   slot :postscript, required: false
 
   def commuter_rail_info_widget(assigns) do
     ~H"""
-    <.bordered_container hide_divider>
+    <.bordered_container class={@class} hide_divider>
       <h2 class="font-heading font-bold text-[1.75rem] leading-normal" style="margin-top: inherit">
         {@heading_text}
       </h2>

--- a/lib/dotcom_web/components/system_status/commuter_rail_info_widget.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_info_widget.ex
@@ -1,0 +1,37 @@
+defmodule DotcomWeb.Components.SystemStatus.CommuterRailInfoWidget do
+  @moduledoc """
+  A template for a card containing rows of information
+  """
+
+  use DotcomWeb, :component
+
+  import DotcomWeb.Components, only: [bordered_container: 1]
+
+  attr :heading_text, :string, required: true
+  slot :inner_block, required: true
+  slot :postscript, required: false
+
+  def commuter_rail_info_widget(assigns) do
+    ~H"""
+    <.bordered_container hide_divider>
+      <h2 class="font-heading font-bold text-[1.75rem] leading-normal" style="margin-top: inherit">
+        {@heading_text}
+      </h2>
+      <div class="border-b-xs border-gray-lightest mt-4">
+        {render_slot(@inner_block)}
+      </div>
+      {render_slot(@postscript)}
+    </.bordered_container>
+    """
+  end
+
+  slot :inner_block
+
+  def row(assigns) do
+    ~H"""
+    <div class="border-t-xs border-gray-lightest py-3 px-1">
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+end

--- a/lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
@@ -13,13 +13,14 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailRouteStatus do
 
   alias Alerts.Alert
 
+  attr :class, :string, default: ""
   attr :status, :map
 
   def commuter_rail_route_status(%{status: nil} = assigns), do: ~H""
 
   def commuter_rail_route_status(assigns) do
     ~H"""
-    <.commuter_rail_info_widget heading_text={~t"Current Status"}>
+    <.commuter_rail_info_widget heading_text={~t"Current Status"} class={@class}>
       <.rows_for_status status={@status} />
     </.commuter_rail_info_widget>
     """

--- a/lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_route_status.ex
@@ -5,9 +5,11 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailRouteStatus do
 
   use DotcomWeb, :component
 
-  import DotcomWeb.Components, only: [bordered_container: 1, unstyled_accordion: 1]
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
   import DotcomWeb.Components.SystemStatus.StatusLabel, only: [status_label: 1]
+
+  import DotcomWeb.Components.SystemStatus.CommuterRailInfoWidget,
+    only: [commuter_rail_info_widget: 1, row: 1]
 
   alias Alerts.Alert
 
@@ -17,14 +19,9 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailRouteStatus do
 
   def commuter_rail_route_status(assigns) do
     ~H"""
-    <.bordered_container hide_divider>
-      <h2 class="font-heading font-bold text-[1.75rem] leading-normal" style="margin-top: inherit">
-        {~t"Current Status"}
-      </h2>
-      <div class="border-b-xs border-gray-lightest mt-4">
-        <.rows_for_status status={@status} />
-      </div>
-    </.bordered_container>
+    <.commuter_rail_info_widget heading_text={~t"Current Status"}>
+      <.rows_for_status status={@status} />
+    </.commuter_rail_info_widget>
     """
   end
 
@@ -129,16 +126,6 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailRouteStatus do
 
   defp trip?(%{trip_info: {:trip, _}}), do: true
   defp trip?(_), do: false
-
-  slot :inner_block
-
-  defp row(assigns) do
-    ~H"""
-    <div class="border-t-xs border-gray-lightest py-3 px-1">
-      {render_slot(@inner_block)}
-    </div>
-    """
-  end
 
   defp trip_info_heading(%{trip_info: {:trip, trip_info}} = assigns) do
     description =

--- a/lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
@@ -50,7 +50,10 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges do
   defp later_changes_link(assigns) do
     ~H"""
     <div class="pt-md">
-      <.link patch={~p"/schedules/#{@route_id}/alerts"}>
+      <.link
+        data-test="later_changes_link"
+        patch={~p"/schedules/#{@route_id}/alerts"}
+      >
         {@later_count} later {Inflex.inflect("change", @later_count)}
         <.icon name="chevron-right" class="h-3 w-3 fill-brand-primary shrink-0" />
       </.link>

--- a/lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
@@ -5,6 +5,7 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges do
 
   use DotcomWeb, :component
 
+  import Dotcom.Alerts.StartTime, only: [active_in_next_n_days?: 2]
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
   import DotcomWeb.Components.PlannedDisruptions, only: [format_date_range_for_alert: 1]
 
@@ -14,32 +15,38 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges do
   import DotcomWeb.Components.SystemStatus.StatusRowHeading, only: [status_row_heading: 1]
 
   attr :class, :string, default: ""
-  attr :status, :map
+  attr :route_id, :string, required: true
+  attr :alerts, :list, required: true
 
-  def commuter_rail_upcoming_changes(%{status: nil} = assigns) do
+  def commuter_rail_upcoming_changes(%{alerts: upcoming_alerts} = assigns) do
+    grouped_alerts =
+      upcoming_alerts
+      |> Enum.group_by(&if active_in_next_n_days?(&1, 7), do: :soon, else: :later)
+      |> Enum.into(%{soon: [], later: []})
+
+    assigns =
+      assigns
+      |> assign(%{
+        soon: grouped_alerts.soon,
+        later: grouped_alerts.later
+      })
+
     ~H"""
     <.commuter_rail_info_widget class={@class} heading_text={~t"Upcoming Changes"}>
-      {~t"No changes posted for the next 7 days"}
-    </.commuter_rail_info_widget>
-    """
-  end
-
-  def commuter_rail_upcoming_changes(assigns) do
-    ~H"""
-    <.commuter_rail_info_widget class={@class} heading_text={~t"Upcoming Changes"}>
-      <.rows_for_upcoming alerts={@alerts} />
+      <.rows_for_upcoming alerts={@soon} />
       <:postscript>
-        {render_slot(@inner_block)}
+        <.later_changes_link later_count={Enum.count(@later)} route_id={@route_id} />
       </:postscript>
     </.commuter_rail_info_widget>
     """
   end
 
   attr :later_count, :integer, default: 0
+  attr :route_id, :string, required: true
 
-  def later_changes_link(%{later_count: 0} = assigns), do: ~H""
+  defp later_changes_link(%{later_count: 0} = assigns), do: ~H""
 
-  def later_changes_link(assigns) do
+  defp later_changes_link(assigns) do
     ~H"""
     <div class="pt-md">
       <.link patch={~p"/schedules/#{@route_id}/alerts"}>

--- a/lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
@@ -5,7 +5,7 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges do
 
   use DotcomWeb, :component
 
-  import Dotcom.Alerts.StartTime, only: [active_in_next_n_days?: 2]
+  import Dotcom.Alerts.StartTime, only: [next_active_time: 1, active_in_next_n_days?: 2]
   import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
   import DotcomWeb.Components.PlannedDisruptions, only: [format_date_range_for_alert: 1]
 
@@ -21,6 +21,7 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges do
   def commuter_rail_upcoming_changes(%{alerts: upcoming_alerts} = assigns) do
     grouped_alerts =
       upcoming_alerts
+      |> Enum.sort(&alert_period_sorter/2)
       |> Enum.group_by(&if active_in_next_n_days?(&1, 7), do: :soon, else: :later)
       |> Enum.into(%{soon: [], later: []})
 
@@ -88,5 +89,30 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges do
       </:content>
     </.unstyled_accordion>
     """
+  end
+
+  defp alert_period_sorter(a, b) do
+    {a_start, a_end} = alert_period_mapper(a)
+    {b_start, b_end} = alert_period_mapper(b)
+
+    start_comparison = Date.compare(a_start, b_start)
+
+    case start_comparison do
+      :eq -> Util.safe_time_compare(a_end, b_end)
+      _ -> start_comparison
+    end != :gt
+  end
+
+  defp alert_period_mapper(alert) do
+    {current, start_time} = next_active_time(alert)
+
+    {period_start, period_end} =
+      alert.active_period
+      |> Enum.find(fn {start, _} -> DateTime.compare(start, start_time) == :eq end)
+
+    {
+      if(current == :current, do: Util.now(), else: period_start),
+      period_end
+    }
   end
 end

--- a/lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
@@ -13,9 +13,12 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges do
 
   import DotcomWeb.Components.SystemStatus.StatusRowHeading, only: [status_row_heading: 1]
 
+  attr :class, :string, default: ""
+  attr :status, :map
+
   def commuter_rail_upcoming_changes(%{status: nil} = assigns) do
     ~H"""
-    <.commuter_rail_info_widget heading_text={~t"Upcoming Changes"}>
+    <.commuter_rail_info_widget class={@class} heading_text={~t"Upcoming Changes"}>
       {~t"No changes posted for the next 7 days"}
     </.commuter_rail_info_widget>
     """
@@ -23,7 +26,7 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges do
 
   def commuter_rail_upcoming_changes(assigns) do
     ~H"""
-    <.commuter_rail_info_widget heading_text={~t"Upcoming Changes"}>
+    <.commuter_rail_info_widget class={@class} heading_text={~t"Upcoming Changes"}>
       <.rows_for_upcoming alerts={@alerts} />
       <:postscript>
         {render_slot(@inner_block)}
@@ -31,6 +34,8 @@ defmodule DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges do
     </.commuter_rail_info_widget>
     """
   end
+
+  attr :later_count, :integer, default: 0
 
   def later_changes_link(%{later_count: 0} = assigns), do: ~H""
 

--- a/lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
+++ b/lib/dotcom_web/components/system_status/commuter_rail_upcoming_changes.ex
@@ -1,0 +1,80 @@
+defmodule DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges do
+  @moduledoc """
+  Component displaying upcoming changes of a specific commuter rail line.
+  """
+
+  use DotcomWeb, :component
+
+  import DotcomWeb.Components.Alerts, only: [embedded_alert: 1]
+  import DotcomWeb.Components.PlannedDisruptions, only: [format_date_range_for_alert: 1]
+
+  import DotcomWeb.Components.SystemStatus.CommuterRailInfoWidget,
+    only: [commuter_rail_info_widget: 1, row: 1]
+
+  import DotcomWeb.Components.SystemStatus.StatusRowHeading, only: [status_row_heading: 1]
+
+  def commuter_rail_upcoming_changes(%{status: nil} = assigns) do
+    ~H"""
+    <.commuter_rail_info_widget heading_text={~t"Upcoming Changes"}>
+      {~t"No changes posted for the next 7 days"}
+    </.commuter_rail_info_widget>
+    """
+  end
+
+  def commuter_rail_upcoming_changes(assigns) do
+    ~H"""
+    <.commuter_rail_info_widget heading_text={~t"Upcoming Changes"}>
+      <.rows_for_upcoming alerts={@alerts} />
+      <:postscript>
+        {render_slot(@inner_block)}
+      </:postscript>
+    </.commuter_rail_info_widget>
+    """
+  end
+
+  def later_changes_link(%{later_count: 0} = assigns), do: ~H""
+
+  def later_changes_link(assigns) do
+    ~H"""
+    <div class="pt-md">
+      <.link patch={~p"/schedules/#{@route_id}/alerts"}>
+        {@later_count} later {Inflex.inflect("change", @later_count)}
+        <.icon name="chevron-right" class="h-3 w-3 fill-brand-primary shrink-0" />
+      </.link>
+    </div>
+    """
+  end
+
+  defp rows_for_upcoming(%{alerts: []} = assigns) do
+    ~H"""
+    <.row>
+      {~t"No changes posted for the next 7 days"}
+    </.row>
+    """
+  end
+
+  defp rows_for_upcoming(assigns) do
+    ~H"""
+    <.unstyled_accordion
+      :for={alert <- @alerts}
+      summary_class="flex items-center hover:bg-brand-primary-lightest cursor-pointer group/row"
+      chevron_class="border-t-[1px] border-gray-lightest fill-gray-dark px-2 py-3 self-stretch flex items-center"
+    >
+      <:heading>
+        <.status_row_heading
+          future
+          alerts={[alert]}
+          prefix={format_date_range_for_alert(alert)}
+          route_ids={[]}
+          status={alert.effect}
+          remove_pill_col={true}
+          hide_route_pill={true}
+        />
+      </:heading>
+      <:content>
+        <.embedded_alert alert={alert} />
+      </:content>
+    </.unstyled_accordion>
+    """
+  end
+end

--- a/lib/dotcom_web/components/system_status/status_row_heading.ex
+++ b/lib/dotcom_web/components/system_status/status_row_heading.ex
@@ -18,6 +18,7 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
   attr :alerts, :list, default: []
   attr :future, :boolean, default: false
   attr :hide_route_pill, :boolean, default: false
+  attr :remove_pill_col, :boolean, default: false
   attr :plural, :boolean, default: false
   attr :prefix, :string, default: nil
   attr :route_ids, :list, required: true
@@ -43,14 +44,18 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
       |> assign(:subheading_text, subheading_text)
 
     ~H"""
-    <div class="grid grid-cols-[min-content_auto] items-start grow">
-      <.top_padding hide_route_pill={@hide_route_pill} />
+    <div class={[!assigns.remove_pill_col && "grid grid-cols-[min-content_auto]", "items-start grow"]}>
+      <.top_padding
+        hide_route_pill={@hide_route_pill}
+        remove_pill_col={@remove_pill_col}
+      />
 
       <.heading
         future={@future}
         hide_route_pill={@hide_route_pill}
         plural={@plural}
         prefix={@prefix}
+        remove_pill_col={@remove_pill_col}
         route_ids={@route_ids}
         severity={severity(@alerts)}
         status={@status}
@@ -58,14 +63,17 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
         subheading_text={@subheading_text}
       />
 
-      <.bottom_padding hide_route_pill={@hide_route_pill} />
+      <.bottom_padding
+        hide_route_pill={@hide_route_pill}
+        remove_pill_col={@remove_pill_col}
+      />
     </div>
     """
   end
 
   defp bottom_padding(assigns) do
     ~H"""
-    <div class="h-3"></div>
+    <div :if={!@remove_pill_col} class="h-3"></div>
     <div class="h-3"></div>
     """
   end
@@ -87,7 +95,11 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
       |> assign(:description, description)
 
     ~H"""
-    <div class={["flex items-center pl-1 pr-2", @hide_route_pill && "opacity-0"]} data-route-pill>
+    <div
+      :if={!@remove_pill_col}
+      class={["flex items-center pl-1 pr-2", @hide_route_pill && "opacity-0"]}
+      data-route-pill
+    >
       <.subway_route_pill class="group-hover/row:ring-brand-primary-lightest" route_ids={@route_ids} />
     </div>
 
@@ -229,7 +241,11 @@ defmodule DotcomWeb.Components.SystemStatus.StatusRowHeading do
 
   defp top_padding(assigns) do
     ~H"""
-    <div class={["h-3", !@hide_route_pill && "border-t-xs border-gray-lightest"]}></div>
+    <div
+      :if={!@remove_pill_col}
+      class={["h-3", !@hide_route_pill && "border-t-xs border-gray-lightest"]}
+    >
+    </div>
     <div class={["h-3", "border-t-xs border-gray-lightest"]}></div>
     """
   end

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -83,7 +83,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   defp assign_cr_upcoming(%{assigns: %{alerts: alerts}} = conn) do
     cr_upcoming =
       alerts
-      |> Enum.filter(&upcoming_alert?/1)
+      |> Enum.filter(&future_alert?/1)
       |> Enum.sort(&alert_period_sorter/2)
 
     grouped_alerts =
@@ -99,19 +99,16 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     })
   end
 
-  defp upcoming_alert?(alert) do
-    later = DateTime.shift(Util.now(), day: 7)
-
+  defp future_alert?(alert) do
     case next_active_time(alert) do
+      {:future, _} -> true
+
       {:current, start_time} ->
         {_, end_time} =
           alert.active_period
           |> Enum.find(fn {start, _} -> DateTime.compare(start, start_time) == :eq end)
 
         Util.safe_time_compare(end_time, Util.end_of_service()) == :gt
-
-      {:future, start_time} ->
-        start_time |> DateTime.before?(later)
 
       _ ->
         false

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -6,6 +6,8 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
 
   require Logger
 
+  import Dotcom.Alerts.StartTime, only: [active_in_next_n_days?: 2]
+  import Dotcom.SystemStatus, only: [active_now_or_later_on_day?: 2]
   import Dotcom.SystemStatus.CommuterRail, only: [commuter_rail_route_status: 1]
 
   alias Dotcom.Timetables
@@ -52,6 +54,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     |> assign(:direction_name, direction_name)
     |> assign(:formatted_date, formatted_date)
     |> assign_cr_status()
+    |> assign_cr_upcoming()
     |> assign_banner_alerts()
     |> put_view(ScheduleView)
     |> render("show.html", [])
@@ -72,10 +75,11 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
         commuter_rail_route_status(route.id)
       end
 
-    conn |> assign(:cr_status, cr_status)
+    conn
+    |> assign(:cr_status, cr_status)
   end
 
-  defp assign_banner_alerts(%{assigns: %{alerts: alerts, cr_status: cr_status}} = conn) do
+  defp assign_cr_upcoming(%{assigns: %{alerts: alerts, cr_status: cr_status}} = conn) do
     status_alert_ids =
       case cr_status do
         status when is_map(status) ->
@@ -87,7 +91,47 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
       end
       |> MapSet.new()
 
-    banner_alerts = alerts |> Enum.reject(&MapSet.member?(status_alert_ids, &1.id))
+    cr_upcoming =
+      alerts
+      |> Enum.reject(
+        &(MapSet.member?(status_alert_ids, &1.id) || active_now_or_later_on_day?(&1, Util.now()))
+      )
+
+    grouped_alerts =
+      cr_upcoming
+      |> Enum.group_by(&if active_in_next_n_days?(&1, 7), do: :soon, else: :later)
+      |> Enum.into(%{soon: [], later: []})
+
+    conn
+    |> assign(%{
+      cr_upcoming: cr_upcoming,
+      cr_soon: grouped_alerts.soon,
+      cr_later: grouped_alerts.later
+    })
+  end
+
+  defp assign_banner_alerts(
+         %{assigns: %{alerts: alerts, cr_status: cr_status, cr_upcoming: cr_upcoming}} = conn
+       ) do
+    status_alert_ids =
+      case cr_status do
+        status when is_map(status) ->
+          cr_status
+          |> Enum.flat_map(fn {_, entries} -> entries |> Enum.map(& &1.alert.id) end)
+
+        _ ->
+          []
+      end
+
+    upcoming_alert_ids =
+      cr_upcoming
+      |> Enum.map(& &1.id)
+
+    alert_ids =
+      (status_alert_ids ++ upcoming_alert_ids)
+      |> MapSet.new()
+
+    banner_alerts = alerts |> Enum.reject(&MapSet.member?(alert_ids, &1.id))
 
     conn
     |> assign(:banner_alerts, banner_alerts)

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -6,9 +6,7 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
 
   require Logger
 
-  import Dotcom.Alerts.StartTime,
-    only: [next_active_time: 1, active_in_next_n_days?: 2]
-
+  import Dotcom.Alerts.StartTime, only: [next_active_time: 1]
   import Dotcom.SystemStatus.CommuterRail, only: [commuter_rail_route_status: 1]
 
   alias Dotcom.Timetables
@@ -80,28 +78,24 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     |> assign(:cr_status, cr_status)
   end
 
-  defp assign_cr_upcoming(%{assigns: %{alerts: alerts}} = conn) do
+  defp assign_cr_upcoming(%{assigns: %{alerts: alerts, route: route}} = conn) do
     cr_upcoming =
-      alerts
-      |> Enum.filter(&future_alert?/1)
-      |> Enum.sort(&alert_period_sorter/2)
-
-    grouped_alerts =
-      cr_upcoming
-      |> Enum.group_by(&if active_in_next_n_days?(&1, 7), do: :soon, else: :later)
-      |> Enum.into(%{soon: [], later: []})
+      if Routes.Route.type_atom(route) == :commuter_rail do
+        alerts
+        |> Enum.filter(&future_alert?/1)
+        |> Enum.sort(&alert_period_sorter/2)
+      else
+        []
+      end
 
     conn
-    |> assign(%{
-      cr_upcoming: cr_upcoming,
-      cr_soon: grouped_alerts.soon,
-      cr_later: grouped_alerts.later
-    })
+    |> assign(:cr_upcoming, cr_upcoming)
   end
 
   defp future_alert?(alert) do
     case next_active_time(alert) do
-      {:future, _} -> true
+      {:future, _} ->
+        true
 
       {:current, start_time} ->
         {_, end_time} =

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -6,9 +6,9 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
 
   require Logger
 
-  import Dotcom.Alerts, only: [sort_by_start_time_sorter: 2]
   import Dotcom.Alerts.StartTime,
-    only: [next_active_period_active_time: 2, active_in_next_n_days?: 2]
+    only: [next_active_time: 1, active_in_next_n_days?: 2]
+
   import Dotcom.SystemStatus.CommuterRail, only: [commuter_rail_route_status: 1]
 
   alias Dotcom.Timetables
@@ -84,11 +84,11 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     cr_upcoming =
       alerts
       |> Enum.filter(&upcoming_alert?/1)
-      |> Enum.sort(&sort_by_start_time_sorter/2)
+      |> Enum.sort(&alert_period_sorter/2)
 
     grouped_alerts =
       cr_upcoming
-      |> Enum.group_by(& if active_in_next_n_days?(&1, 7), do: :soon, else: :later)
+      |> Enum.group_by(&if active_in_next_n_days?(&1, 7), do: :soon, else: :later)
       |> Enum.into(%{soon: [], later: []})
 
     conn
@@ -100,20 +100,47 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
   end
 
   defp upcoming_alert?(alert) do
-    now = Util.now()
-    later = DateTime.shift(now, day: 7)
+    later = DateTime.shift(Util.now(), day: 7)
 
-    case next_active_period_active_time(alert.active_period, now) do
+    case next_active_time(alert) do
       {:current, start_time} ->
         {_, end_time} =
           alert.active_period
           |> Enum.find(fn {start, _} -> DateTime.compare(start, start_time) == :eq end)
 
-        if end_time == nil, do: true, else: DateTime.after?(end_time, Util.end_of_service())
+        Util.safe_time_compare(end_time, Util.end_of_service()) == :gt
 
-      {:future, start_time} -> start_time |> DateTime.before?(later)
-      _ -> false
+      {:future, start_time} ->
+        start_time |> DateTime.before?(later)
+
+      _ ->
+        false
     end
+  end
+
+  defp alert_period_sorter(a, b) do
+    {a_start, a_end} = alert_period_mapper(a)
+    {b_start, b_end} = alert_period_mapper(b)
+
+    start_comparison = Date.compare(a_start, b_start)
+
+    case start_comparison do
+      :eq -> Util.safe_time_compare(a_end, b_end)
+      _ -> start_comparison
+    end != :gt
+  end
+
+  defp alert_period_mapper(alert) do
+    {current, start_time} = next_active_time(alert)
+
+    {period_start, period_end} =
+      alert.active_period
+      |> Enum.find(fn {start, _} -> DateTime.compare(start, start_time) == :eq end)
+
+    {
+      if(current == :current, do: Util.now(), else: period_start),
+      period_end
+    }
   end
 
   defp assign_banner_alerts(

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -6,8 +6,9 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
 
   require Logger
 
-  import Dotcom.Alerts.StartTime, only: [active_in_next_n_days?: 2]
-  import Dotcom.SystemStatus, only: [active_now_or_later_on_day?: 2]
+  import Dotcom.Alerts, only: [sort_by_start_time_sorter: 2]
+  import Dotcom.Alerts.StartTime,
+    only: [next_active_period_active_time: 2, active_in_next_n_days?: 2]
   import Dotcom.SystemStatus.CommuterRail, only: [commuter_rail_route_status: 1]
 
   alias Dotcom.Timetables
@@ -79,27 +80,15 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
     |> assign(:cr_status, cr_status)
   end
 
-  defp assign_cr_upcoming(%{assigns: %{alerts: alerts, cr_status: cr_status}} = conn) do
-    status_alert_ids =
-      case cr_status do
-        status when is_map(status) ->
-          cr_status
-          |> Enum.flat_map(fn {_, entries} -> entries |> Enum.map(& &1.alert.id) end)
-
-        _ ->
-          []
-      end
-      |> MapSet.new()
-
+  defp assign_cr_upcoming(%{assigns: %{alerts: alerts}} = conn) do
     cr_upcoming =
       alerts
-      |> Enum.reject(
-        &(MapSet.member?(status_alert_ids, &1.id) || active_now_or_later_on_day?(&1, Util.now()))
-      )
+      |> Enum.filter(&upcoming_alert?/1)
+      |> Enum.sort(&sort_by_start_time_sorter/2)
 
     grouped_alerts =
       cr_upcoming
-      |> Enum.group_by(&if active_in_next_n_days?(&1, 7), do: :soon, else: :later)
+      |> Enum.group_by(& if active_in_next_n_days?(&1, 7), do: :soon, else: :later)
       |> Enum.into(%{soon: [], later: []})
 
     conn
@@ -108,6 +97,23 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
       cr_soon: grouped_alerts.soon,
       cr_later: grouped_alerts.later
     })
+  end
+
+  defp upcoming_alert?(alert) do
+    now = Util.now()
+    later = DateTime.shift(now, day: 7)
+
+    case next_active_period_active_time(alert.active_period, now) do
+      {:current, start_time} ->
+        {_, end_time} =
+          alert.active_period
+          |> Enum.find(fn {start, _} -> DateTime.compare(start, start_time) == :eq end)
+
+        if end_time == nil, do: true, else: DateTime.after?(end_time, Util.end_of_service())
+
+      {:future, start_time} -> start_time |> DateTime.before?(later)
+      _ -> false
+    end
   end
 
   defp assign_banner_alerts(

--- a/lib/dotcom_web/controllers/schedule/timetable_controller.ex
+++ b/lib/dotcom_web/controllers/schedule/timetable_controller.ex
@@ -83,7 +83,6 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
       if Routes.Route.type_atom(route) == :commuter_rail do
         alerts
         |> Enum.filter(&future_alert?/1)
-        |> Enum.sort(&alert_period_sorter/2)
       else
         []
       end
@@ -107,31 +106,6 @@ defmodule DotcomWeb.ScheduleController.TimetableController do
       _ ->
         false
     end
-  end
-
-  defp alert_period_sorter(a, b) do
-    {a_start, a_end} = alert_period_mapper(a)
-    {b_start, b_end} = alert_period_mapper(b)
-
-    start_comparison = Date.compare(a_start, b_start)
-
-    case start_comparison do
-      :eq -> Util.safe_time_compare(a_end, b_end)
-      _ -> start_comparison
-    end != :gt
-  end
-
-  defp alert_period_mapper(alert) do
-    {current, start_time} = next_active_time(alert)
-
-    {period_start, period_end} =
-      alert.active_period
-      |> Enum.find(fn {start, _} -> DateTime.compare(start, start_time) == :eq end)
-
-    {
-      if(current == :current, do: Util.now(), else: period_start),
-      period_end
-    }
   end
 
   defp assign_banner_alerts(

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -17,6 +17,14 @@
   class="mb-5"
 />
 
+{DotcomWeb.AlertView.group(
+  alerts: @banner_alerts,
+  route: @route,
+  date_time: @date_time,
+  priority_filter: :high,
+  always_show: List.wrap(@blocking_alert)
+)}
+
 <%= if commuter_rail?(@route) do %>
   <div class="md:flex md:justify-between items-start">
     <.commuter_rail_route_status

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -18,10 +18,12 @@
 />
 
 <%= if commuter_rail?(@route) do %>
-  <.commuter_rail_route_status status={@cr_status} />
-  <.commuter_rail_upcoming_changes alerts={@cr_soon}>
-    <.later_changes_link later_count={Enum.count(@cr_later)} route_id={@route.id} />
-  </.commuter_rail_upcoming_changes>
+  <div class="md:flex md:justify-between items-start">
+    <.commuter_rail_route_status status={@cr_status} class="mb-lg md:mb-0 md:w-[calc(50%-.75rem)]" />
+    <.commuter_rail_upcoming_changes alerts={@cr_soon} class="md:w-[calc(50%-.75rem)]">
+      <.later_changes_link later_count={Enum.count(@cr_later)} route_id={@route.id} />
+    </.commuter_rail_upcoming_changes>
+  </div>
   <div class="mt-4">
     <.track_changes track_changes={Enum.filter(@alerts, &(&1.effect == :track_change))} />
   </div>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -23,9 +23,11 @@
       status={@cr_status}
       class="mb-lg md:mb-0 md:w-[calc(50%-.75rem)]"
     />
-    <.commuter_rail_upcoming_changes alerts={@cr_soon} class="md:w-[calc(50%-.75rem)]">
-      <.later_changes_link later_count={Enum.count(@cr_later)} route_id={@route.id} />
-    </.commuter_rail_upcoming_changes>
+    <.commuter_rail_upcoming_changes
+      alerts={@cr_upcoming}
+      route_id={@route.id}
+      class="md:w-[calc(50%-.75rem)]"
+    />
   </div>
   <div class="mt-4">
     <.track_changes track_changes={Enum.filter(@alerts, &(&1.effect == :track_change))} />

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -17,16 +17,11 @@
   class="mb-5"
 />
 
-{DotcomWeb.AlertView.group(
-  alerts: @banner_alerts,
-  route: @route,
-  date_time: @date_time,
-  priority_filter: :high,
-  always_show: List.wrap(@blocking_alert)
-)}
-
 <%= if commuter_rail?(@route) do %>
   <.commuter_rail_route_status status={@cr_status} />
+  <.commuter_rail_upcoming_changes alerts={@cr_soon}>
+    <.later_changes_link later_count={Enum.count(@cr_later)} route_id={@route.id} />
+  </.commuter_rail_upcoming_changes>
   <div class="mt-4">
     <.track_changes track_changes={Enum.filter(@alerts, &(&1.effect == :track_change))} />
   </div>

--- a/lib/dotcom_web/templates/schedule/_timetable.html.heex
+++ b/lib/dotcom_web/templates/schedule/_timetable.html.heex
@@ -19,7 +19,10 @@
 
 <%= if commuter_rail?(@route) do %>
   <div class="md:flex md:justify-between items-start">
-    <.commuter_rail_route_status status={@cr_status} class="mb-lg md:mb-0 md:w-[calc(50%-.75rem)]" />
+    <.commuter_rail_route_status
+      status={@cr_status}
+      class="mb-lg md:mb-0 md:w-[calc(50%-.75rem)]"
+    />
     <.commuter_rail_upcoming_changes alerts={@cr_soon} class="md:w-[calc(50%-.75rem)]">
       <.later_changes_link later_count={Enum.count(@cr_later)} route_id={@route.id} />
     </.commuter_rail_upcoming_changes>

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -15,7 +15,7 @@ defmodule DotcomWeb.ScheduleView do
     only: [commuter_rail_route_status: 1]
 
   import DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges,
-    only: [commuter_rail_upcoming_changes: 1, later_changes_link: 1]
+    only: [commuter_rail_upcoming_changes: 1]
 
   alias CMS.Partial.RoutePdf
   alias Dotcom.MapHelpers

--- a/lib/dotcom_web/views/schedule_view.ex
+++ b/lib/dotcom_web/views/schedule_view.ex
@@ -14,6 +14,9 @@ defmodule DotcomWeb.ScheduleView do
   import DotcomWeb.Components.SystemStatus.CommuterRailRouteStatus,
     only: [commuter_rail_route_status: 1]
 
+  import DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges,
+    only: [commuter_rail_upcoming_changes: 1, later_changes_link: 1]
+
   alias CMS.Partial.RoutePdf
   alias Dotcom.MapHelpers
   alias DotcomWeb.PartialView.{HeaderTab, HeaderTabs, SvgIconWithCircle}

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -23,6 +23,26 @@ defmodule Util do
     # to_local_time(utc_now_fn.())
   end
 
+  @doc "Allows you to compare DateTime to nil values.
+  By default, nil is an indefinite future."
+  @spec safe_time_compare(DateTime.t(), DateTime.t(), boolean()) :: :lt | :eq | :gt
+  def safe_time_compare(a, b, nil_is_greater? \\ true) do
+    cond do
+      a == nil ->
+        if b == nil do
+          :eq
+        else
+          if nil_is_greater?, do: :gt, else: :lt
+        end
+
+      b == nil ->
+        if nil_is_greater?, do: :lt, else: :gt
+
+      true ->
+        DateTime.compare(a, b)
+    end
+  end
+
   @spec time_is_greater_or_equal?(
           DateTime.t() | NaiveDateTime.t(),
           DateTime.t() | NaiveDateTime.t()

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -23,7 +23,7 @@ defmodule Util do
     # to_local_time(utc_now_fn.())
   end
 
-  @doc "Allows you to compare DateTime to nil values.
+  @doc "Handles comparison of DateTime to nil values.
   By default, nil is an indefinite future."
   @spec safe_time_compare(DateTime.t(), DateTime.t(), boolean()) :: :lt | :eq | :gt
   def safe_time_compare(a, b, nil_is_greater? \\ true) do

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -25,21 +25,21 @@ defmodule Util do
 
   @doc "Handles comparison of DateTime to nil values.
   By default, nil is an indefinite future."
-  @spec safe_time_compare(DateTime.t(), DateTime.t(), boolean()) :: :lt | :eq | :gt
-  def safe_time_compare(a, b, nil_is_greater? \\ true) do
-    cond do
-      a == nil && b == nil ->
-        :eq
+  @spec safe_time_compare(DateTime.t() | nil, DateTime.t() | nil, boolean()) :: :lt | :eq | :gt
+  def safe_time_compare(a, b, nil_is_greater? \\ true)
 
-      a == nil ->
-        if nil_is_greater?, do: :gt, else: :lt
+  def safe_time_compare(nil, nil, _), do: :eq
 
-      b == nil ->
-        if nil_is_greater?, do: :lt, else: :gt
+  def safe_time_compare(nil, _, nil_is_greater?) do
+    if nil_is_greater?, do: :gt, else: :lt
+  end
 
-      true ->
-        DateTime.compare(a, b)
-    end
+  def safe_time_compare(_, nil, nil_is_greater?) do
+    if nil_is_greater?, do: :lt, else: :gt
+  end
+
+  def safe_time_compare(a, b, _) do
+    DateTime.compare(a, b)
   end
 
   @spec time_is_greater_or_equal?(

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -28,12 +28,11 @@ defmodule Util do
   @spec safe_time_compare(DateTime.t(), DateTime.t(), boolean()) :: :lt | :eq | :gt
   def safe_time_compare(a, b, nil_is_greater? \\ true) do
     cond do
+      a == nil && b == nil ->
+        :eq
+
       a == nil ->
-        if b == nil do
-          :eq
-        else
-          if nil_is_greater?, do: :gt, else: :lt
-        end
+        if nil_is_greater?, do: :gt, else: :lt
 
       b == nil ->
         if nil_is_greater?, do: :lt, else: :gt

--- a/test/dotcom_web/components/system_status/commuter_rail_upcoming_changes_test.exs
+++ b/test/dotcom_web/components/system_status/commuter_rail_upcoming_changes_test.exs
@@ -1,0 +1,143 @@
+defmodule DotcomWeb.SystemStatus.CommuterRailUpcomingChangesTest do
+  use ExUnit.Case
+
+  import DotcomWeb.Components.PlannedDisruptions, only: [format_date_range_for_alert: 1]
+  import Mox
+  import Phoenix.LiveViewTest
+
+  alias DotcomWeb.Components.SystemStatus.CommuterRailUpcomingChanges
+  alias Test.Support.Factories
+
+  setup do
+    stub(Dotcom.Alerts.AffectedStops.Mock, :affected_stops, fn _, _ -> [] end)
+    stub(Dotcom.Alerts.EndpointStops.Mock, :endpoint_stops, fn _, _ -> [] end)
+    stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+
+    :ok
+  end
+
+  describe "commuter_rail_upcoming_changes/1" do
+    test "only shows alerts active in the next seven days" do
+      # SETUP
+      today = Util.now()
+      within_week = DateTime.shift(today, day: 5)
+      after_week = DateTime.shift(today, day: 9)
+
+      alert1 = Factories.Alerts.Alert.build(:alert, active_period: [{within_week, nil}])
+      alert2 = Factories.Alerts.Alert.build(:alert, active_period: [{after_week, nil}])
+
+      # EXERCISE
+      rendered_alert_text = upcoming_alert_rows([alert1, alert2])
+
+      # VERIFY
+      assert Enum.count(rendered_alert_text) == 1
+      assert row_time_text_matches_alert_data?(Enum.at(rendered_alert_text, 0), alert1)
+    end
+
+    test "shows \"No changes posted for the next 7 days\" when there are no alerts in the next seven days" do
+      # SETUP
+      today = Util.now()
+      later = DateTime.shift(today, day: 9)
+
+      alert1 = Factories.Alerts.Alert.build(:alert, active_period: [{later, nil}])
+      alert2 = Factories.Alerts.Alert.build(:alert, active_period: [{later, nil}])
+
+      # EXERCISE
+      rendered_component = render_upcoming_changes([alert1, alert2])
+
+      # VERIFY
+      assert String.contains?(
+        rendered_component,
+        "No changes posted for the next 7 days"
+      )
+    end
+
+    test "displays alerts earliest to latest, first on start time bounded by today, then by end time" do
+      # SETUP
+      today = Util.now()
+      earlier = DateTime.shift(today, day: -2)
+      even_earlier = DateTime.shift(today, day: -5)
+      later = DateTime.shift(today, day: 1)
+      even_later = DateTime.shift(later, day: 4)
+      most_later = DateTime.shift(today, day: 6)
+
+      alert1 = Factories.Alerts.Alert.build(:alert, active_period: [{earlier, later}])
+      alert2 = Factories.Alerts.Alert.build(:alert, active_period: [{today, even_later}])
+      alert3 = Factories.Alerts.Alert.build(:alert, active_period: [{even_earlier, nil}])
+      alert4 = Factories.Alerts.Alert.build(:alert, active_period: [{later, even_later}])
+      alert5 = Factories.Alerts.Alert.build(:alert, active_period: [{later, most_later}])
+
+      ordered_alerts = [alert1, alert2, alert3, alert4, alert5]
+
+      ordered_alerts
+      |> Enum.map(& DotcomWeb.Components.PlannedDisruptions.format_date_range_for_alert(&1))
+
+      # EXERCISE
+      rendered_alert_text = upcoming_alert_rows(Enum.shuffle(ordered_alerts))
+
+      # VERIFY
+      alert_text_matches =
+        rendered_alert_text
+        |> Enum.with_index()
+        |> Enum.map(fn {element, index} ->
+          row_time_text_matches_alert_data?(element, Enum.at(ordered_alerts, index))
+        end)
+
+      assert Enum.all?(alert_text_matches)
+    end
+
+    test "doesn't render a link to alerts if there are no later alerts" do
+      # SETUP / EXERCISE
+      rendered_component = render_upcoming_changes([])
+
+      # VERIFY
+      assert !String.contains?(
+        rendered_component,
+        "later change"
+      )
+    end
+
+    test "renders a link to alerts if there is at least one later alert" do
+      # SETUP
+      today = Util.now()
+      later = DateTime.shift(today, day: 9)
+
+      alert1 = Factories.Alerts.Alert.build(:alert, active_period: [{later, nil}])
+      alert2 = Factories.Alerts.Alert.build(:alert, active_period: [{later, nil}])
+
+      # EXERCISE
+      rendered_component = render_upcoming_changes([alert1, alert2])
+
+      # VERIFY
+      assert String.contains?(
+        rendered_component,
+        "later change"
+      )
+    end
+  end
+
+  defp upcoming_alert_rows(alerts) do
+    render_upcoming_changes(alerts)
+    |> Floki.parse_document()
+    |> Kernel.then(fn {:ok, document} -> document end)
+    |> Floki.find("[data-test=\"status_label_text\"]")
+    |> Enum.map(&Floki.text/1)
+    |> Enum.map(&String.trim/1)
+  end
+
+  defp render_upcoming_changes(alerts) do
+    render_component(&CommuterRailUpcomingChanges.commuter_rail_upcoming_changes/1, %{
+      alerts: alerts,
+      route_id: Faker.Color.fancy_name()
+    })
+  end
+
+  defp row_time_text_matches_alert_data?(row_text, alert) do
+    time_text =
+      row_text
+      |> String.split(":")
+      |> Enum.at(0)
+
+    time_text == format_date_range_for_alert(alert)
+  end
+end

--- a/test/dotcom_web/components/system_status/commuter_rail_upcoming_changes_test.exs
+++ b/test/dotcom_web/components/system_status/commuter_rail_upcoming_changes_test.exs
@@ -87,14 +87,8 @@ defmodule DotcomWeb.SystemStatus.CommuterRailUpcomingChangesTest do
     end
 
     test "doesn't render a link to alerts if there are no later alerts" do
-      # SETUP / EXERCISE
-      rendered_component = render_upcoming_changes([])
-
-      # VERIFY
-      assert !String.contains?(
-               rendered_component,
-               "later change"
-             )
+      # SETUP / EXERCISE / VERIFY
+      assert length(later_changes_link([])) == 0
     end
 
     test "renders a link to alerts if there is at least one later alert" do
@@ -105,24 +99,16 @@ defmodule DotcomWeb.SystemStatus.CommuterRailUpcomingChangesTest do
       alert1 = Factories.Alerts.Alert.build(:alert, active_period: [{later, nil}])
       alert2 = Factories.Alerts.Alert.build(:alert, active_period: [{later, nil}])
 
-      # EXERCISE
-      rendered_component = render_upcoming_changes([alert1, alert2])
-
-      # VERIFY
-      assert String.contains?(
-               rendered_component,
-               "later change"
-             )
+      # EXERCISE / VERIFY
+      assert length(later_changes_link([alert1, alert2])) == 1
     end
   end
 
-  defp upcoming_alert_rows(alerts) do
+  defp later_changes_link(alerts) do
     render_upcoming_changes(alerts)
     |> Floki.parse_document()
     |> Kernel.then(fn {:ok, document} -> document end)
-    |> Floki.find("[data-test=\"status_label_text\"]")
-    |> Enum.map(&Floki.text/1)
-    |> Enum.map(&String.trim/1)
+    |> Floki.find("[data-test=\"later_changes_link\"]")
   end
 
   defp render_upcoming_changes(alerts) do
@@ -139,5 +125,14 @@ defmodule DotcomWeb.SystemStatus.CommuterRailUpcomingChangesTest do
       |> Enum.at(0)
 
     time_text == format_date_range_for_alert(alert)
+  end
+
+  defp upcoming_alert_rows(alerts) do
+    render_upcoming_changes(alerts)
+    |> Floki.parse_document()
+    |> Kernel.then(fn {:ok, document} -> document end)
+    |> Floki.find("[data-test=\"status_label_text\"]")
+    |> Enum.map(&Floki.text/1)
+    |> Enum.map(&String.trim/1)
   end
 end

--- a/test/dotcom_web/components/system_status/commuter_rail_upcoming_changes_test.exs
+++ b/test/dotcom_web/components/system_status/commuter_rail_upcoming_changes_test.exs
@@ -88,7 +88,7 @@ defmodule DotcomWeb.SystemStatus.CommuterRailUpcomingChangesTest do
 
     test "doesn't render a link to alerts if there are no later alerts" do
       # SETUP / EXERCISE / VERIFY
-      assert length(later_changes_link([])) == 0
+      assert later_changes_link([]) == []
     end
 
     test "renders a link to alerts if there is at least one later alert" do

--- a/test/dotcom_web/components/system_status/commuter_rail_upcoming_changes_test.exs
+++ b/test/dotcom_web/components/system_status/commuter_rail_upcoming_changes_test.exs
@@ -47,9 +47,9 @@ defmodule DotcomWeb.SystemStatus.CommuterRailUpcomingChangesTest do
 
       # VERIFY
       assert String.contains?(
-        rendered_component,
-        "No changes posted for the next 7 days"
-      )
+               rendered_component,
+               "No changes posted for the next 7 days"
+             )
     end
 
     test "displays alerts earliest to latest, first on start time bounded by today, then by end time" do
@@ -70,7 +70,7 @@ defmodule DotcomWeb.SystemStatus.CommuterRailUpcomingChangesTest do
       ordered_alerts = [alert1, alert2, alert3, alert4, alert5]
 
       ordered_alerts
-      |> Enum.map(& DotcomWeb.Components.PlannedDisruptions.format_date_range_for_alert(&1))
+      |> Enum.map(&DotcomWeb.Components.PlannedDisruptions.format_date_range_for_alert(&1))
 
       # EXERCISE
       rendered_alert_text = upcoming_alert_rows(Enum.shuffle(ordered_alerts))
@@ -92,9 +92,9 @@ defmodule DotcomWeb.SystemStatus.CommuterRailUpcomingChangesTest do
 
       # VERIFY
       assert !String.contains?(
-        rendered_component,
-        "later change"
-      )
+               rendered_component,
+               "later change"
+             )
     end
 
     test "renders a link to alerts if there is at least one later alert" do
@@ -110,9 +110,9 @@ defmodule DotcomWeb.SystemStatus.CommuterRailUpcomingChangesTest do
 
       # VERIFY
       assert String.contains?(
-        rendered_component,
-        "later change"
-      )
+               rendered_component,
+               "later change"
+             )
     end
   end
 

--- a/test/util/util_test.exs
+++ b/test/util/util_test.exs
@@ -18,6 +18,22 @@ defmodule UtilTest do
     end
   end
 
+  describe "safe_time_compare/2" do
+    test "when nil_is_greater? is true, handles nil values by treating them as infinitely in the future" do
+      date = DateTime.utc_now()
+      assert safe_time_compare(nil, date, true) == :gt
+      assert safe_time_compare(nil, nil, true) == :eq
+      assert safe_time_compare(date, nil, true) == :lt
+    end
+
+    test "when nil_is_greater? is false, handles nil values by treating them as infinitely in the past" do
+      date = DateTime.utc_now()
+      assert safe_time_compare(nil, date, false) == :lt
+      assert safe_time_compare(nil, nil, false) == :eq
+      assert safe_time_compare(date, nil, false) == :gt
+    end
+  end
+
   describe "to_local_time/1" do
     test "handles NaiveDateTime" do
       assert %DateTime{day: 02, hour: 0, zone_abbr: "EST"} =


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🟣⚽️ Upcoming Changes widget for Commuter Rail](https://app.asana.com/1/15492006741476/project/555089885850811/task/1215166490913220)

## Implementation

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
<img width="1215" height="593" alt="image" src="https://github.com/user-attachments/assets/3bc37dc3-4bc8-40bb-aecd-79c6bee10e78" />


Ferry still has banner alerts 
<img width="1226" height="274" alt="image" src="https://github.com/user-attachments/assets/a98d1e76-2919-4e7f-994d-e8bf46b415ba" />


## How to test
Changes are on dev-blue at the moment. Alerts are from Alerts Manager staging. 

[Newburyport timetable](https://dev-blue.mbtace.com/schedules/CR-Newburyport/timetable) on dev-blue for convenience.

Please verify the following: 
- Alerts that are only today do NOT appear in Upcoming Changes 
- Alerts that include today, but end in the future DO appear in Upcoming Changes
- Alerts that begin in the next 7 days appear in Upcoming Changes
- Alerts that begin after the next 7 days do NOT appear in Upcoming Changes
  -  if such alerts exist, "# later change(s) >" appears as a link at the bottom of the changes list
- Alerts are sorted in ascending order by start time, then end time
- Widgets stack for mobile widths

On ferry page (which also uses the timetable controller): 
- banner alerts still appear 
<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
