### PR TITLE
fix: Allow `PredictedSchedule.Collection` to correctly handle Prediction ID changes

### DIFF
--- a/lib/predicted_schedule/collection.ex
+++ b/lib/predicted_schedule/collection.ex
@@ -74,7 +74,7 @@ defmodule PredictedSchedule.Collection do
 
   @type key_t() :: {Schedules.Trip.id_t(), non_neg_integer()}
   @type entry_t() :: %{
-          schedule: Schedules.Trip.t(),
+          schedule: Schedules.Schedule.t(),
           predictions: %{Predictions.Prediction.id_t() => Predictions.Prediction.t()}
         }
   @type t() :: %{

--- a/lib/predicted_schedule/collection.ex
+++ b/lib/predicted_schedule/collection.ex
@@ -186,9 +186,6 @@ defmodule PredictedSchedule.Collection do
             %PredictedSchedule{schedule: schedule, prediction: prediction}
           end)
       end
-
-      # dbg(schedule)
-      # dbg(predictions)
     end)
   end
 

--- a/lib/predicted_schedule/collection.ex
+++ b/lib/predicted_schedule/collection.ex
@@ -73,9 +73,13 @@ defmodule PredictedSchedule.Collection do
   """
 
   @type key_t() :: {Schedules.Trip.id_t(), non_neg_integer()}
+  @type entry_t() :: %{
+          schedule: Schedules.Trip.t(),
+          predictions: %{Predictions.Prediction.id_t() => Predictions.Prediction.t()}
+        }
   @type t() :: %{
-          base: %{key_t() => PredictedSchedule.t()},
-          populated: %{key_t() => PredictedSchedule.t()}
+          base: %{key_t() => entry_t()},
+          populated: %{key_t() => entry_t()}
         }
 
   @spec new([Schedules.Schedule.t()]) :: t()
@@ -86,7 +90,7 @@ defmodule PredictedSchedule.Collection do
     predicted_schedule_map =
       schedules
       |> Map.new(fn schedule ->
-        {key(schedule), %PredictedSchedule{schedule: schedule}}
+        {key(schedule), %{schedule: schedule, predictions: %{}}}
       end)
 
     %{base: predicted_schedule_map, populated: predicted_schedule_map}
@@ -102,9 +106,9 @@ defmodule PredictedSchedule.Collection do
       Map.update(
         populated,
         key(prediction),
-        %PredictedSchedule{prediction: prediction},
-        fn %PredictedSchedule{} = ps ->
-          %PredictedSchedule{ps | prediction: prediction}
+        %{schedule: nil, predictions: %{prediction.id => prediction}},
+        fn %{predictions: predictions} = ps ->
+          %{ps | predictions: predictions |> Map.put(prediction.id, prediction)}
         end
       )
 
@@ -120,15 +124,15 @@ defmodule PredictedSchedule.Collection do
   def delete_prediction(%{populated: populated} = collection, prediction) do
     key = key(prediction)
 
-    new_map =
-      populated
-      |> Map.get(key)
-      |> case do
-        %PredictedSchedule{schedule: schedule} = ps when schedule != nil ->
-          populated |> Map.put(key, %PredictedSchedule{ps | prediction: nil})
+    entry = populated |> Map.get(key)
+    new_predictions = entry.predictions |> Map.delete(prediction.id)
+    new_entry = %{entry | predictions: new_predictions}
 
-        _ ->
-          populated |> Map.delete(key)
+    new_map =
+      if new_entry == %{schedule: nil, predictions: %{}} do
+        populated |> Map.delete(key)
+      else
+        populated |> Map.put(key, new_entry)
       end
 
     %{collection | populated: new_map}
@@ -156,7 +160,7 @@ defmodule PredictedSchedule.Collection do
   """
   def update_schedules(%{populated: populated}, new_schedules) do
     populated
-    |> Enum.map(fn {_key, %PredictedSchedule{prediction: prediction}} -> prediction end)
+    |> Enum.flat_map(fn {_key, %{predictions: predictions}} -> predictions |> Map.values() end)
     |> Enum.reject(&is_nil/1)
     |> Enum.reduce(new(new_schedules), fn prediction, new_collection ->
       new_collection |> put_prediction(prediction)
@@ -169,7 +173,23 @@ defmodule PredictedSchedule.Collection do
   """
   def to_list(%{populated: populated}) do
     populated
-    |> Map.values()
+    |> Enum.flat_map(fn {_, %{schedule: schedule, predictions: predictions}} ->
+      predictions
+      |> Enum.to_list()
+      |> case do
+        [] ->
+          [%PredictedSchedule{schedule: schedule}]
+
+        entry_list ->
+          entry_list
+          |> Enum.map(fn {_, prediction} ->
+            %PredictedSchedule{schedule: schedule, prediction: prediction}
+          end)
+      end
+
+      # dbg(schedule)
+      # dbg(predictions)
+    end)
   end
 
   @spec key(Schedules.Schedule.t() | Predictions.Prediction.t()) :: key_t()

--- a/lib/predicted_schedule/collection.ex
+++ b/lib/predicted_schedule/collection.ex
@@ -124,18 +124,23 @@ defmodule PredictedSchedule.Collection do
   def delete_prediction(%{populated: populated} = collection, prediction) do
     key = key(prediction)
 
-    entry = populated |> Map.get(key)
-    new_predictions = entry.predictions |> Map.delete(prediction.id)
-    new_entry = %{entry | predictions: new_predictions}
+    case populated do
+      %{^key => entry} ->
+        new_predictions = entry.predictions |> Map.delete(prediction.id)
+        new_entry = %{entry | predictions: new_predictions}
 
-    new_map =
-      if new_entry == %{schedule: nil, predictions: %{}} do
-        populated |> Map.delete(key)
-      else
-        populated |> Map.put(key, new_entry)
-      end
+        new_map =
+          if new_entry == %{schedule: nil, predictions: %{}} do
+            populated |> Map.delete(key)
+          else
+            populated |> Map.put(key, new_entry)
+          end
 
-    %{collection | populated: new_map}
+        %{collection | populated: new_map}
+
+      _ ->
+        collection
+    end
   end
 
   @spec clear_predictions(t()) :: t()

--- a/lib/predicted_schedule/collection.ex
+++ b/lib/predicted_schedule/collection.ex
@@ -180,19 +180,21 @@ defmodule PredictedSchedule.Collection do
     populated
     |> Enum.flat_map(fn {_, %{schedule: schedule, predictions: predictions}} ->
       predictions
-      |> Enum.to_list()
-      |> case do
-        [] ->
-          [%PredictedSchedule{schedule: schedule}]
-
-        entry_list ->
-          entry_list
-          |> Enum.map(fn {_, prediction} ->
-            %PredictedSchedule{schedule: schedule, prediction: prediction}
-          end)
-      end
+      |> Map.values()
+      |> to_prediction_list()
+      |> Enum.map(&%PredictedSchedule{schedule: schedule, prediction: &1})
     end)
   end
+
+  # This function is used to convert a list of predictions into a list
+  # to be mapped into predicted_schedules for a given schedule. If we
+  # have one or more predictions, then we want the list, but if we
+  # have none, then we want a single `nil` value, so that we get
+  # %PredictedSchedule{schedule: schedule, prediction: nil} as an end
+  # result.
+  @spec to_prediction_list([Predictions.Prediction.t()]) :: [Predictions.Prediction.t()] | [nil]
+  defp to_prediction_list([]), do: [nil]
+  defp to_prediction_list(list) when is_list(list), do: list
 
   @spec key(Schedules.Schedule.t() | Predictions.Prediction.t()) :: key_t()
   defp key(%{trip: %{id: trip_id}, stop_sequence: stop_sequence}) do

--- a/test/predicted_schedule/collection_test.exs
+++ b/test/predicted_schedule/collection_test.exs
@@ -151,6 +151,34 @@ defmodule PredictedSchedule.CollectionTest do
                MapSet.new(expected_predicted_schedule_list)
     end
 
+    test "can change prediction ID by adding the new followed by removing the old" do
+      # Setup
+      absent_schedule = Factories.Schedules.Schedule.build(:schedule)
+      base_prediction = build_prediction_from_schedule(absent_schedule)
+
+      prediction_ids = Faker.Util.sample_uniq(2, fn -> FactoryHelpers.build(:id) end)
+
+      [old_prediction, new_prediction] =
+        prediction_ids |> Enum.map(&(base_prediction |> Map.put(:id, &1)))
+
+      # Exercise
+      actual_predicted_schedule_list =
+        []
+        |> Collection.new()
+        |> Collection.put_prediction(old_prediction)
+        |> Collection.put_prediction(new_prediction)
+        |> Collection.delete_prediction(old_prediction)
+        |> Collection.to_list()
+        |> MapSet.new()
+
+      # Verify
+      expected_predicted_schedule_list =
+        [%PredictedSchedule{schedule: nil, prediction: new_prediction}]
+
+      assert MapSet.new(actual_predicted_schedule_list) ==
+               MapSet.new(expected_predicted_schedule_list)
+    end
+
     test "can clear the predictions" do
       # Setup
       [absent_schedule | schedules] = build_schedules(3)

--- a/test/predicted_schedule/collection_test.exs
+++ b/test/predicted_schedule/collection_test.exs
@@ -151,6 +151,28 @@ defmodule PredictedSchedule.CollectionTest do
                MapSet.new(expected_predicted_schedule_list)
     end
 
+    test "doesn't crash when removing a non-schedule-associated prediction that wasn't previously added" do
+      # Setup
+      [absent_schedule | schedules] = build_schedules(2)
+      prediction = build_prediction_from_schedule(absent_schedule)
+
+      # Exercise
+      actual_predicted_schedule_list =
+        schedules
+        |> Collection.new()
+        |> Collection.delete_prediction(prediction)
+        |> Collection.to_list()
+        |> MapSet.new()
+
+      # Verify
+      expected_predicted_schedule_list =
+        schedules
+        |> Enum.map(&%PredictedSchedule{schedule: &1, prediction: nil})
+
+      assert MapSet.new(actual_predicted_schedule_list) ==
+               MapSet.new(expected_predicted_schedule_list)
+    end
+
     test "can change prediction ID by adding the new followed by removing the old" do
       # Setup
       absent_schedule = Factories.Schedules.Schedule.build(:schedule)


### PR DESCRIPTION
Prediction ID changes are often represented as an ADD followed by a REMOVE. In the previous implementation, the fact that the REMOVE came last caused the prediction to fully get deleted. This now allows the Collection to store multiple predictions per {trip_id, stop_sequence}, and only removes the one that was intended to be removed.

Prediction ID changes are unusual... except at certain stations, like Forest Hills, where they happen all the time when a trip is assigned to a particular track!

## Scope

**Asana Ticket:** [📅🔎 Correctly handle when a Prediction's ID changes](https://app.asana.com/1/15492006741476/project/1210709545912056/task/1215634938817006?focus=true)

## Implementation

The fix is in `PredictedSchedule.Collection` - when a Prediction's ID changes, the API handles that by issuing an ADD event for the new ID, and then a REMOVE event for the old one. In our old implementation, we were treating predictions as unique per `{trip_id, stop_sequence}`, which meant that that second REMOVE was deleting the prediction that we'd just ADDed.

This fixes that by changing the underlying data structure in the collection per `{trip_id, stop_sequence}` to be something like 👇

```elixir
%{
  schedule: schedule,
  predictions: %{
    prediction_id_1 => prediction_1,
    prediction_id_2 => prediction_2
  }
}
```

That way, during that brief moment when a new prediction is ADDed with the new ID, it keeps track of both so that it can REMOVE the right one.

## Screenshots

<img width="2992" height="1600" alt="Screenshot 2026-06-11 at 12 26 29 PM" src="https://github.com/user-attachments/assets/bdda5e99-6573-4460-be3c-97c8c31b9476" />

## How to test

Watch [the Forest Hills Orange Line departures](http://localhost:4001/departures/?route_id=Orange&direction_id=1&stop_id=place-forhl). If you hang out on that page for long enough, you'll see trips start to disappear, typically a few minutes before departure. Well, you'll see that issue in [dev](https://dev.mbtace.com/departures/?route_id=Orange&direction_id=1&stop_id=place-forhl), but not [prod](https://www.mbta.com/departures/?route_id=Orange&direction_id=1&stop_id=place-forhl) (which doesn't have the latest streaming code yet), and you hopefully _won't_ see it when running this branch.
