### PR TITLE
fix(Departures): Handle the case when a prediction has a nil trip

### DIFF
--- a/lib/dotcom/predictions/event_broadcaster.ex
+++ b/lib/dotcom/predictions/event_broadcaster.ex
@@ -4,7 +4,7 @@ defmodule Dotcom.Predictions.EventBroadcaster do
   """
   use GenStage
 
-  alias Predictions.{Prediction, StreamParser}
+  alias Predictions.StreamParser
   alias ServerSentEventStage.Event
 
   def start_link(opts) do
@@ -118,13 +118,9 @@ defmodule Dotcom.Predictions.EventBroadcaster do
     with %JsonApi{data: data} <- JsonApi.parse(json_api_data) do
       data
       |> Stream.map(fn %JsonApi.Item{id: id} = item ->
-        check_tripless_prediction(id, StreamParser.parse(item))
+        {id, StreamParser.parse(item)}
       end)
-      |> Stream.reject(fn item -> item == :error end)
       |> Enum.to_list()
     end
   end
-
-  defp check_tripless_prediction(_, %Prediction{trip: nil}), do: :error
-  defp check_tripless_prediction(id, parsed), do: {id, parsed}
 end

--- a/lib/dotcom/upcoming_departures/processor.ex
+++ b/lib/dotcom/upcoming_departures/processor.ex
@@ -154,9 +154,10 @@ defmodule Dotcom.UpcomingDepartures.Processor do
         route_type: route_type
       }) do
     trip = predicted_schedule |> PredictedSchedule.trip()
+    trip_id = predicted_schedule |> PredictedSchedule.trip_id()
     stop_sequence = PredictedSchedule.stop_sequence(predicted_schedule)
     vehicle = PredictedSchedule.vehicle(predicted_schedule)
-    vehicle_at_stop_status = vehicle_at_stop_status(vehicle, trip.id, stop_sequence)
+    vehicle_at_stop_status = vehicle_at_stop_status(vehicle, trip_id, stop_sequence)
 
     predicted_schedule_route = PredictedSchedule.route(predicted_schedule)
 
@@ -171,6 +172,7 @@ defmodule Dotcom.UpcomingDepartures.Processor do
           route_type: route_type,
           status: PredictedSchedule.status(predicted_schedule),
           now: now,
+          trip: trip,
           vehicle_at_stop_status: vehicle_at_stop_status
         }),
       arrival_substatus:
@@ -178,16 +180,16 @@ defmodule Dotcom.UpcomingDepartures.Processor do
           predicted_schedule: predicted_schedule,
           route_type: route_type
         }),
-      crowding: crowding(vehicle, trip.id),
-      headsign: stop_headsign || trip.headsign,
+      crowding: crowding(vehicle, trip_id),
+      headsign: stop_headsign || (trip && trip.headsign),
       last_trip?: PredictedSchedule.last_trip?(predicted_schedule),
       platform_name: platform_name(predicted_schedule),
       route: predicted_schedule_route,
       stop_sequence: stop_sequence,
       time: PredictedSchedule.display_time(predicted_schedule),
-      trip_id: trip.id,
+      trip_id: trip_id,
       trip_name:
-        if(route_type == :commuter_rail,
+        if(route_type == :commuter_rail && trip,
           do: trip_name(predicted_schedule_route, trip.name),
           else: nil
         ),
@@ -323,8 +325,11 @@ defmodule Dotcom.UpcomingDepartures.Processor do
           predicted_schedule: PredictedSchedule.t(),
           route_type: Route.route_type(),
           status: nil | String.t(),
+          trip: Schedules.Trip.t() | nil,
           vehicle_at_stop_status: vehicle_at_stop_status_t()
         }) :: UpcomingDeparture.arrival_status_t()
+  defp arrival_status(%{trip: nil}), do: :hidden
+
   defp arrival_status(%{
          predicted_schedule: %PredictedSchedule{prediction: nil},
          route_type: :subway

--- a/lib/predicted_schedule.ex
+++ b/lib/predicted_schedule.ex
@@ -204,7 +204,20 @@ defmodule PredictedSchedule do
   """
   @spec trip(PredictedSchedule.t()) :: Schedules.Trip.t() | nil
   def trip(%PredictedSchedule{schedule: %Schedule{trip: trip}}), do: trip
-  def trip(%PredictedSchedule{prediction: %Prediction{trip: trip}}), do: trip
+
+  def trip(%PredictedSchedule{prediction: %Prediction{trip: trip}}) when not is_nil(trip),
+    do: trip
+
+  def trip(%PredictedSchedule{prediction: %Prediction{trip_id: trip_id}}),
+    do: @schedules_repo.trip(trip_id)
+
+  @doc """
+  Returns the trip_id for a given PredictedSchedule.
+  """
+  @spec trip_id(PredictedSchedule.t()) :: Schedules.Trip.id_t() | nil
+  def trip_id(%PredictedSchedule{prediction: %Prediction{trip: %Trip{id: trip_id}}}), do: trip_id
+  def trip_id(%PredictedSchedule{prediction: %Prediction{trip_id: trip_id}}), do: trip_id
+  def trip_id(%PredictedSchedule{schedule: %Schedule{trip: %Trip{id: trip_id}}}), do: trip_id
 
   @doc """
   Returns the direction ID for a given PredictedSchedule

--- a/lib/predicted_schedule/collection.ex
+++ b/lib/predicted_schedule/collection.ex
@@ -173,7 +173,6 @@ defmodule PredictedSchedule.Collection do
   end
 
   @spec key(Schedules.Schedule.t() | Predictions.Prediction.t()) :: key_t()
-  defp key(%{trip: %{id: trip_id}, stop_sequence: stop_sequence}) do
-    {trip_id, stop_sequence}
-  end
+  defp key(%{trip: %{id: trip_id}, stop_sequence: stop_sequence}), do: {trip_id, stop_sequence}
+  defp key(%{trip_id: trip_id, stop_sequence: stop_sequence}), do: {trip_id, stop_sequence}
 end

--- a/lib/predictions/prediction.ex
+++ b/lib/predictions/prediction.ex
@@ -7,6 +7,7 @@ defmodule Predictions.Prediction do
 
   defstruct id: nil,
             trip: nil,
+            trip_id: nil,
             stop: nil,
             platform_stop_id: nil,
             route: nil,
@@ -31,6 +32,7 @@ defmodule Predictions.Prediction do
   @type t :: %__MODULE__{
           id: id_t,
           trip: Schedules.Trip.t() | nil,
+          trip_id: Schedules.Trip.id_t() | nil,
           stop: stop,
           platform_stop_id: Stops.Stop.id_t() | nil,
           route: Routes.Route.t(),

--- a/lib/predictions/repo.ex
+++ b/lib/predictions/repo.ex
@@ -256,6 +256,7 @@ defmodule Predictions.Repo do
       %Predictions.Prediction{
         id: id,
         trip: trip,
+        trip_id: trip_id,
         stop: stop,
         platform_stop_id: platform_stop_id,
         route: route,

--- a/lib/predictions/stream_parser.ex
+++ b/lib/predictions/stream_parser.ex
@@ -44,6 +44,7 @@ defmodule Predictions.StreamParser do
       stop: @stops_repo.get_parent(stop),
       platform_stop_id: stop_id(item),
       trip: trip,
+      trip_id: included_trip_id(item),
       schedule_relationship: Parser.schedule_relationship(item),
       status: Parser.status(item),
       track: track,
@@ -91,6 +92,12 @@ defmodule Predictions.StreamParser do
     do: @schedules_repo.trip(id)
 
   defp included_trip(_), do: nil
+
+  @spec included_trip_id(Item.t()) :: Trip.id_t() | nil
+  defp included_trip_id(%Item{relationships: %{"trip" => [%Item{id: id} | _]}}),
+    do: id
+
+  defp included_trip_id(_), do: nil
 
   @spec stop_id(Item.t()) :: Stops.Stop.id_t() | nil
   defp stop_id(%Item{relationships: %{"stop" => [%Item{id: id}]}}), do: id

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -20,13 +20,25 @@ defmodule Dotcom.UpcomingDeparturesTest do
       Factories.Stops.Stop.build(:stop, id: id, parent_id: nil)
     end)
 
+    stub(Schedules.Repo.Mock, :trip, fn id ->
+      Factories.Schedules.Trip.build(:trip, id: id)
+    end)
+
     :ok
   end
 
   defp predicted_schedules_for_stop(schedules, predictions, stop_id) do
-    predictions
-    |> for_stop(stop_id)
-    |> PredictedSchedule.group(for_stop(schedules, stop_id))
+    predictions_for_stop = predictions |> for_stop(stop_id)
+    schedules_for_stop = schedules |> for_stop(stop_id)
+
+    predictions_for_stop
+    |> Enum.reduce(
+      PredictedSchedule.Collection.new(schedules_for_stop),
+      fn prediction, collection ->
+        collection |> PredictedSchedule.Collection.put_prediction(prediction)
+      end
+    )
+    |> PredictedSchedule.Collection.to_list()
   end
 
   defp for_stop(list, stop_id), do: Enum.filter(list, &(&1.stop.id == stop_id))
@@ -176,18 +188,88 @@ defmodule Dotcom.UpcomingDeparturesTest do
       assert departure.platform_name == platform_name
     end
 
+    test "uses data from Schedules.Repo.trip/1 when prediction.trip is nil" do
+      # Setup
+      %{
+        predictions: predictions,
+        route: route,
+        platform_stop_ids: [_, platform_id, _],
+        stops: [_, stop, _],
+        trip: trip,
+        trip_id: trip_id,
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data()
+
+      expect(Schedules.Repo.Mock, :trip, fn ^trip_id -> trip end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
+      platform_name = Faker.Pokemon.location()
+
+      stub(Stops.Repo.Mock, :get, fn
+        ^platform_id -> Factories.Stops.Stop.build(:stop, platform_name: platform_name)
+        _ -> Factories.Stops.Stop.build(:stop)
+      end)
+
+      # Exercise
+      non_trip_predictions = predictions |> Enum.map(&Map.put(&1, :trip, nil))
+
+      predicted_schedules = predicted_schedules_for_stop([], non_trip_predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
+
+      # Verify
+      assert [departure] = departures
+
+      assert departure.headsign == trip.headsign
+    end
+
+    test "excludes departures whose trip is nil" do
+      # Setup
+      %{
+        predictions: predictions,
+        route: route,
+        platform_stop_ids: [_, platform_id, _],
+        stops: [_, stop, _],
+        trip_id: trip_id,
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data()
+
+      expect(Schedules.Repo.Mock, :trip, fn ^trip_id -> nil end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
+      platform_name = Faker.Pokemon.location()
+
+      stub(Stops.Repo.Mock, :get, fn
+        ^platform_id -> Factories.Stops.Stop.build(:stop, platform_name: platform_name)
+        _ -> Factories.Stops.Stop.build(:stop)
+      end)
+
+      # Exercise
+      non_trip_predictions = predictions |> Enum.map(&Map.put(&1, :trip, nil))
+
+      predicted_schedules = predicted_schedules_for_stop([], non_trip_predictions, stop.id)
+      departures = UpcomingDepartures.upcoming_departures(predicted_schedules, %{route: route})
+
+      # Verify
+      refute match?([_departure], departures)
+    end
+
     test "prepends 'Bus' to trip names for rail replacement buses" do
       # Setup
       %{
         predictions: predictions,
         stops: [_, stop, _],
         trip: trip,
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
           route_factory_types: [:rail_replacement_bus_route],
           stop_id_options: Platforms.stations_with_commuter_rail_platforms()
         )
+
+      stub(Schedules.Repo.Mock, :trip, fn ^trip_id -> trip end)
 
       original_route = Factories.Routes.Route.build(:commuter_rail_route)
 
@@ -2012,12 +2094,16 @@ defmodule Dotcom.UpcomingDeparturesTest do
         predictions: predictions,
         schedules: schedules,
         stops: [_, _, stop, _],
+        trip: trip,
+        trip_id: trip_id,
         vehicle: vehicle
       } =
         PredictedScheduleHelper.predicted_schedule_trip_data(
           vehicle_stop_index: 0,
           stop_count: 4
         )
+
+      stub(Schedules.Repo.Mock, :trip, fn ^trip_id -> trip end)
 
       updated_schedules =
         schedules
@@ -2037,7 +2123,7 @@ defmodule Dotcom.UpcomingDeparturesTest do
 
       # Verify
       assert [%{headsign: headsign}] = departures
-      assert updated_schedules |> Enum.find(fn s -> s.trip.headsign == headsign end)
+      assert headsign == trip.headsign
     end
   end
 

--- a/test/predicted_schedule/collection_test.exs
+++ b/test/predicted_schedule/collection_test.exs
@@ -208,6 +208,34 @@ defmodule PredictedSchedule.CollectionTest do
       assert MapSet.new(actual_predicted_schedule_list) ==
                MapSet.new(expected_predicted_schedule_list)
     end
+
+    test "works with predictions that have nil trips" do
+      # Setup
+      [prediction_1, prediction_2] =
+        2
+        |> build_schedules()
+        |> Enum.map(&build_prediction_from_schedule/1)
+        |> Enum.map(&Map.put(&1, :trip, nil))
+
+      # Exercise
+      actual_predicted_schedule_list =
+        []
+        |> Collection.new()
+        |> Collection.put_prediction(prediction_1)
+        |> Collection.put_prediction(prediction_2)
+        |> Collection.to_list()
+        |> MapSet.new()
+
+      # Verify
+      expected_predicted_schedule_list =
+        [
+          %PredictedSchedule{schedule: nil, prediction: prediction_1},
+          %PredictedSchedule{schedule: nil, prediction: prediction_2}
+        ]
+
+      assert MapSet.new(actual_predicted_schedule_list) ==
+               MapSet.new(expected_predicted_schedule_list)
+    end
   end
 
   defp build_schedules(count) do

--- a/test/predicted_schedule_test.exs
+++ b/test/predicted_schedule_test.exs
@@ -6,6 +6,8 @@ defmodule PredictedScheduleTest do
   import PredictedSchedule
   import Test.Support.Factories.Predictions.Prediction
 
+  alias Test.Support.FactoryHelpers
+  alias Test.Support.Factories
   alias Predictions.Prediction
   alias Schedules.{Schedule, ScheduleCondensed, Trip}
   alias Stops.Stop
@@ -467,6 +469,33 @@ defmodule PredictedScheduleTest do
 
     test "returns nil when status is not available" do
       refute PredictedSchedule.status(%PredictedSchedule{})
+    end
+  end
+
+  describe "trip_id/1" do
+    test "uses prediction.trip.id if available" do
+      trip = Factories.Schedules.Trip.build(:trip)
+      predicted_schedule = %PredictedSchedule{prediction: %Prediction{trip: trip}}
+      assert trip_id(predicted_schedule) == trip.id
+    end
+
+    # This can happen for added trips if the prediction becomes
+    # available in the API before the trip is. It's typically a
+    # transient state, but still one we need to handle.
+    test "uses prediction.trip_id when trip is nil" do
+      trip_id = FactoryHelpers.build(:id)
+
+      predicted_schedule = %PredictedSchedule{
+        prediction: %Prediction{trip: nil, trip_id: trip_id}
+      }
+
+      assert trip_id(predicted_schedule) == trip_id
+    end
+
+    test "uses schedule.trip.id when there's no prediction" do
+      trip = Factories.Schedules.Trip.build(:trip)
+      predicted_schedule = %PredictedSchedule{prediction: nil, schedule: %Schedule{trip: trip}}
+      assert trip_id(predicted_schedule) == trip.id
     end
   end
 

--- a/test/predictions/stream_parser_test.exs
+++ b/test/predictions/stream_parser_test.exs
@@ -80,6 +80,7 @@ defmodule Predictions.StreamParserTest do
                time: time,
                track: track,
                trip: trip,
+               trip_id: trip_id,
                vehicle_id: vehicle_id,
                last_trip?: last_trip?
              } = StreamParser.parse(item)
@@ -87,12 +88,58 @@ defmodule Predictions.StreamParserTest do
       assert %Route{id: "route_id"} = route
       assert %Stop{id: ^stop_id} = stop
       assert %Trip{id: "trip_id"} = trip
+      assert trip_id == "trip_id"
       assert time == ~N[2016-01-01 00:00:00] |> Timezone.convert("Etc/UTC-4")
       assert arrival_time == ~N[2016-01-01 00:00:00] |> Timezone.convert("Etc/UTC-4")
       assert departure_time == ~N[2016-09-15 15:40:00] |> Timezone.convert("Etc/UTC-4")
       assert track == stop.platform_code
       assert "vehicle_id" = vehicle_id
       assert last_trip? == expected_last_trip
+    end
+
+    test "includes the trip ID even if the trip doesn't exist in the `Schedules.Repo` yet" do
+      trip_id = "trip_id"
+
+      Schedules.Repo.Mock
+      |> stub(:trip, fn ^trip_id -> nil end)
+
+      item = %Item{
+        id: "TEST-ID",
+        attributes: %{
+          "arrival_time" => "2016-01-01T00:00:00-04:00",
+          "bikes_allowed" => 1,
+          "departure_time" => "2016-09-15T15:40:00-04:00",
+          "direction_id" => 1,
+          "headsign" => "Back Bay",
+          "name" => "",
+          "status" => "On Time",
+          "last_trip" => false
+        },
+        relationships: %{
+          "route" => [
+            %Item{id: "route_id"},
+            %Item{id: "wrong"}
+          ],
+          "stop" => [
+            %Item{id: "stop_id"}
+          ],
+          "trip" => [
+            %Item{id: trip_id}
+          ],
+          "vehicle" => [
+            %Item{id: "vehicle_id"}
+          ]
+        },
+        type: "prediction"
+      }
+
+      assert %Prediction{
+               trip: trip,
+               trip_id: trip_id
+             } = StreamParser.parse(item)
+
+      assert trip == nil
+      assert trip_id == "trip_id"
     end
 
     test "When no vehicle relationship parses vehicle_id as nil" do

--- a/test/support/factories/predictions/prediction.ex
+++ b/test/support/factories/predictions/prediction.ex
@@ -10,6 +10,8 @@ defmodule Test.Support.Factories.Predictions.Prediction do
   alias Test.Support.FactoryHelpers
 
   def prediction_factory do
+    trip = Trip.build(:trip)
+
     %Prediction{
       id: FactoryHelpers.build(:id),
       arrival_time: Timex.now() |> Timex.shift(minutes: 10),
@@ -21,7 +23,8 @@ defmodule Test.Support.Factories.Predictions.Prediction do
       stop: Stop.build(:stop),
       time: Faker.DateTime.forward(1),
       track: Faker.Util.digit() |> FactoryHelpers.nullable_item(),
-      trip: Trip.build(:trip),
+      trip: trip,
+      trip_id: trip.id,
       vehicle_id: FactoryHelpers.build(:nullable_id),
       last_trip?: false
     }

--- a/test/support/predicted_scheduler_helper.ex
+++ b/test/support/predicted_scheduler_helper.ex
@@ -131,6 +131,7 @@ defmodule Test.Support.PredictedScheduleHelper do
             stop: stop,
             stop_sequence: stop_sequence,
             trip: prediction_trip,
+            trip_id: prediction_trip.id,
             vehicle_id: if(missing_vehicle?, do: nil, else: vehicle.id)
           },
           %{


### PR DESCRIPTION
Sometimes (especially for added trips), a prediction will become available before its associated trip is. We handle that reasonably gracefully - we create the prediction like `%Prediction{trip: nil}`, and then pass it thru to the rest of the system.

The problem is that some of its consumers depend on the trip information, like its headsign, so we do actually need to get ahold of the right trip eventually. For predictions partway through a trip, they often jitter by a second or two, so we get events that cause us to re-parse the prediction, and re-fetch the trip, but for predictions near the beginning, they can be stable for a long time before jittering.

This PR addresses that by having `UpcomingDepartures.Processor` fetch the trip itself, and use that instead of the prediction's trip for things like headsign. That way, we'll get trip info as soon (on potentially a five second delay due to `UpcomingDepartures.Server`'s refresh) as its available, rather than having to wait for the prediction to jitter itself into another update.

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [📅🔎 Show departures for predictions with nil trips if their trip ID corresponds to a real trip](https://app.asana.com/1/15492006741476/project/1210709545912056/task/1215623459165604?focus=true)

## Implementation

- This adds the `trip_id` field directly to the `%Prediction{}` struct so that if the `trip` itself isn't available, the `trip_id` can still be used.
- It makes little touches to a zillion different files (okay, 13) in order to parse and correctly handle the presence of that field.

## Screenshots

I haven't been able to figure out how to get good screenshots of this, especially because right now there are some (I think intentional) data differences between dev and prod.

## How to test

[Green Line Westbound predictions at Government Center](http://localhost:4001/departures/?route_id=Green&direction_id=0&stop_id=place-gover) are a decent place to see this, because trips get added there pretty frequently (see also [GL-B](http://localhost:4001/departures/?route_id=Green-B&direction_id=0&stop_id=place-gover) and [GL-C](http://localhost:4001/departures/?route_id=Green-C&direction_id=0&stop_id=place-gover) there, since the added trips are usually B or C branch, seeing as they start at Gov't Ctr).