### PR TITLE
fix: resolve memory leak under load

### DIFF
--- a/lib/dotcom_web/stats.ex
+++ b/lib/dotcom_web/stats.ex
@@ -28,13 +28,22 @@ defmodule DotcomWeb.Stats do
     status = metadata.conn.status
     duration = measurement[:duration]
 
-    Agent.update(__MODULE__, fn state ->
-      if Kernel.get_in(state, [method, path, status]) do
-        Kernel.update_in(state, [method, path, status], &(&1 ++ [duration]))
-      else
-        Kernel.put_in(state, [Access.key(method, %{}), Access.key(path, %{}), status], [duration])
-      end
-    end)
+    Agent.update(__MODULE__, &update_state(&1, method, path, status, duration))
+  end
+
+  defp update_state(state, method, path, status, duration) do
+    if Kernel.get_in(state, [method, path, status]) do
+      Kernel.update_in(state, [method, path, status], fn count_and_sum ->
+        {count, sum} = count_and_sum
+        {count + 1, sum + duration}
+      end)
+    else
+      Kernel.put_in(
+        state,
+        [Access.key(method, %{}), Access.key(path, %{}), status],
+        {1, duration}
+      )
+    end
   end
 
   @doc """
@@ -48,20 +57,23 @@ defmodule DotcomWeb.Stats do
     Agent.update(__MODULE__, fn _ -> %{} end)
   end
 
-  defp dispatch_method({method, stats}) do
-    Enum.each(stats, fn {path, statuses} ->
-      Enum.each(statuses, fn {status, durations} ->
-        dispatch_stat(method, path, status, durations)
+  defp dispatch_method(entry) do
+    {method, stats} = entry
+
+    Enum.each(stats, fn path_and_statuses ->
+      {path, statuses} = path_and_statuses
+
+      Enum.each(statuses, fn status_and_count_sum ->
+        {status, count_and_sum} = status_and_count_sum
+        {count, sum} = count_and_sum
+        dispatch_stat(method, path, status, count, sum)
       end)
     end)
   end
 
-  defp dispatch_stat(method, path, status, durations) do
-    count = Enum.count(durations)
-
+  defp dispatch_stat(method, path, status, count, sum) do
     avg =
-      durations
-      |> Enum.sum()
+      sum
       |> Kernel.div(count)
       |> System.convert_time_unit(:native, :millisecond)
 

--- a/lib/req/stats.ex
+++ b/lib/req/stats.ex
@@ -23,13 +23,22 @@ defmodule Req.Stats do
     status = metadata.status
     duration = measurement[:duration]
 
-    Agent.update(__MODULE__, fn state ->
-      if Kernel.get_in(state, [host, path, status]) do
-        Kernel.update_in(state, [host, path, status], &(&1 ++ [duration]))
-      else
-        Kernel.put_in(state, [Access.key(host, %{}), Access.key(path, %{}), status], [duration])
-      end
-    end)
+    Agent.update(__MODULE__, &update_state(&1, host, path, status, duration))
+  end
+
+  defp update_state(state, host, path, status, duration) do
+    if Kernel.get_in(state, [host, path, status]) do
+      Kernel.update_in(state, [host, path, status], fn count_and_sum ->
+        {count, sum} = count_and_sum
+        {count + 1, sum + duration}
+      end)
+    else
+      Kernel.put_in(
+        state,
+        [Access.key(host, %{}), Access.key(path, %{}), status],
+        {1, duration}
+      )
+    end
   end
 
   @doc """
@@ -43,20 +52,23 @@ defmodule Req.Stats do
     Agent.update(__MODULE__, fn _ -> %{} end)
   end
 
-  defp dispatch_host({host, stats}) do
-    Enum.each(stats, fn {path, statuses} ->
-      Enum.each(statuses, fn {status, durations} ->
-        dispatch_stat(host, path, status, durations)
+  defp dispatch_host(entry) do
+    {host, stats} = entry
+
+    Enum.each(stats, fn path_and_statuses ->
+      {path, statuses} = path_and_statuses
+
+      Enum.each(statuses, fn status_and_count_sum ->
+        {status, count_and_sum} = status_and_count_sum
+        {count, sum} = count_and_sum
+        dispatch_stat(host, path, status, count, sum)
       end)
     end)
   end
 
-  defp dispatch_stat(host, path, status, durations) do
-    count = Enum.count(durations)
-
+  defp dispatch_stat(host, path, status, count, sum) do
     avg =
-      durations
-      |> Enum.sum()
+      sum
       |> Kernel.div(count)
       |> System.convert_time_unit(:native, :millisecond)
 
@@ -68,8 +80,7 @@ defmodule Req.Stats do
   end
 
   defp strip_filename(path) do
-    path
-    |> (&Regex.replace(~r/\/$/, &1, "")).()
-    |> (&Regex.replace(~r/[\w|-]+\.\w+/, &1, "")).()
+    no_slash = Regex.replace(~r/\/$/, path, "")
+    Regex.replace(~r/[\w|-]+\.\w+/, no_slash, "")
   end
 end


### PR DESCRIPTION
The application experiences Out of Memory (OOM) crashes under high request volume due to unbounded memory accumulation in the metrics-collecting agents DotcomWeb.Stats and Req.Stats.

Specifically:
- These agents listen to Phoenix route dispatch and Req/Finch HTTP client telemetry events.
- For each unique route/status, they stored a list of all request durations.
- This caused memory footprint to grow linearly with the number of requests between dispatch flushes.
- The use of ++ list append is an O(N) operation that copies the list, generating excessive garbage collection overhead.

To fix this:
- Refactored both agents to aggregate metrics in constant memory using `{count, sum}` tuples instead of lists.
- On incoming events, the state is updated to `{count + 1, sum + duration}`.
- During dispatch, the average is calculated using `sum / count`.
- This ensures constant memory usage regardless of traffic volume.

This does not fix the underlying issue that this code is substantially duplicated.