### PR TITLE
feat: Load 6/13 schedules for upcoming departures on 6/14

### DIFF
--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -27,11 +27,23 @@ defmodule Dotcom.UpcomingDepartures.Server do
     _ = Dotcom.Predictions.Manager.subscribe(params)
 
     schedules_fn = fn date ->
-      @schedules_repo.by_route_ids([route_id],
-        direction_id: direction_id,
-        date: date,
-        stop_ids: [stop_id]
-      )
+      yesterday_late_night_schedules =
+        if date == ~D[2026-06-14] do
+          @schedules_repo.by_route_ids([route_id],
+            direction_id: direction_id,
+            date: ~D[2026-06-13],
+            stop_ids: [stop_id]
+          )
+        else
+          []
+        end
+
+      yesterday_late_night_schedules ++
+        @schedules_repo.by_route_ids([route_id],
+          direction_id: direction_id,
+          date: date,
+          stop_ids: [stop_id]
+        )
     end
 
     upcoming_departures_fn = fn predicted_schedules ->


### PR DESCRIPTION
## Scope

**Asana Ticket:** [⚽️🦉 Update Bus Upcoming Departures to query for yesterday schedules on 6/14 AM](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214585567694850?focus=true)

## Implementation

Add the 6/13 schedules to the schedule list for `UpcomingDepartures.Server` on 6/14. That way, once the service day change rolls around, in those first few hours between 3AM and 5AM, we won't suddenly drop the super-duper late-night trips just because they came from the previous day's schedule. 

> [!WARNING]
> For many of the other late-night-service-related tickets, we were able to fully generalize those solutions, and not treat 6/13 as any kind of special case. In this case though, trip ID's aren't necessarily unique from one day to the next, so loading multiple days' worth of schedules risks problems related to having multiple trips with the same ID. However... the trip ID's on 6/13 _will_ be different from 6/14 (because 6/13 is running late-night service and 6/14 isn't), so while this approach isn't safe in general, it is safe on 6/14 specifically.

## Screenshots

<img width="1248" height="1548" alt="Screenshot 2026-06-11 at 5 29 06 PM" src="https://github.com/user-attachments/assets/c0ab990c-ab37-4a12-9c1a-fecd0196346d" />

Before 3:00AM, we unambiguously show the 6/13 service day, which shows the 4:32 bus as the last bus.

<img width="1250" height="1560" alt="Screenshot 2026-06-11 at 5 30 28 PM" src="https://github.com/user-attachments/assets/3603a99c-7801-4977-8180-61f11e961927" />

After 3:00AM, we show trips from the both the 6/13 and 6/14 service days!

## How to test

As is tradition, I mangled [`Dotcom.Utils.DateTime.now/0`](https://github.com/mbta/dotcom/blob/87b971b825928404e779231af2a51e0a1915b978/lib/dotcom/utils/date_time.ex#L30) to return a custom timestamp 👇 
```elixir
def now(), do: ~N[2026-06-14T03:15:00] |> Timex.to_datetime(@timezone)
```

> [!TIP]
> If you do _only_ this, then you'll also see a bunch of `Now` predictions. I suppressed predictions for the screenshots above by replacing the implementation of [`Dotcom.UpcomingDepartures.Server.process_events/2`](https://github.com/mbta/dotcom/blob/87b971b825928404e779231af2a51e0a1915b978/lib/dotcom/upcoming_departures/server.ex#L113-L120) with 👇  
> ```elixir
> def process_events(state, _events), do: state
> ```