### PR TITLE
feat(UpcomingDeparturesLive): show 6/13 last train time during early 6/14

### DIFF
--- a/lib/dotcom/service_date_rollover.ex
+++ b/lib/dotcom/service_date_rollover.ex
@@ -43,8 +43,8 @@ defmodule Dotcom.ServiceDateRollover do
     {:noreply, state}
   end
 
-  def ms_to_next_rollover() do
-    end_of_service_day()
+  def ms_to_next_rollover(boundary_datetime \\ end_of_service_day()) do
+    boundary_datetime
     |> DateTime.shift(microsecond: {1, 4})
     |> DateTime.diff(@date_time_module.now(), :millisecond)
     |> max(1000)

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -10,6 +10,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
   import Dotcom.Utils.Time, only: [format!: 2]
   import DotcomWeb.RouteComponents, only: [lined_list: 1, lined_list_item: 1]
 
+  alias Dotcom.ServiceDateRollover
   alias DotcomWeb.Components.Departures
   alias Phoenix.{LiveView, LiveView.AsyncResult}
 
@@ -26,6 +27,11 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
       "direction_id" => direction_id,
       "stop_id" => stop_id
     } = session
+
+    _ =
+      if connected?(socket) do
+        ServiceDateRollover.subscribe()
+      end
 
     {:ok,
      socket
@@ -112,6 +118,11 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
   @impl LiveView
   def handle_info(:refresh_upcoming_departures, socket) do
     {:noreply, refresh_upcoming_trip_details(socket)}
+  end
+
+  # sent every night by `ServiceDateRollover`
+  def handle_info({:service_date_rollover, new_service_date}, socket) do
+    {:noreply, assign_last_trip_time(socket, new_service_date)}
   end
 
   def handle_info({:upcoming_departures, :loading}, socket) do

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -200,8 +200,29 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     assign(socket, :last_trip_time, nil)
   end
 
+  # WC special!
+  defp assign_last_trip_time(
+         %{assigns: assigns} = socket,
+         %Date{month: 6, day: 14, year: 2026} = date
+       ) do
+    yesterday_last_scheduled_time = get_last_trip_time(assigns, ~D[2026-06-13])
+
+    if last_trip_has_passed?(yesterday_last_scheduled_time) do
+      assign(socket, :last_trip_time, get_last_trip_time(assigns, date))
+    else
+      # don't reassign the last_trip_time! we'll have to reassign it later.
+      assign(socket, :last_trip_time, yesterday_last_scheduled_time)
+    end
+  end
+
   defp assign_last_trip_time(socket, date) do
     assign(socket, :last_trip_time, get_last_trip_time(socket.assigns, date))
+  end
+
+  defp last_trip_has_passed?(nil), do: false
+
+  defp last_trip_has_passed?(time) do
+    @date_time.now() |> DateTime.after?(time)
   end
 
   defp get_last_trip_time(assigns, date) do

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -36,17 +36,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
      |> assign_new(:stop, fn -> @stops_repo.get(stop_id) end)
      |> assign_new(:should_refresh?, fn -> true end)
      |> assign_new(:loaded_upcoming_trips, fn -> %{} end)
-     |> assign_new(:last_trip_time, fn assigns ->
-       if assigns.route.type in [0, 1] do
-         @schedules_repo.by_route_ids([route_id],
-           direction_id: direction_id,
-           stop_ids: [assigns.stop.id],
-           date: service_date()
-         )
-         |> List.last(%{})
-         |> Map.get(:time)
-       end
-     end)
+     |> assign_last_trip_time(service_date())
      |> assign(:departures, AsyncResult.loading())
      |> subscribe_to_upcoming_departures()}
   end
@@ -203,6 +193,26 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     Enum.reduce(trip_ids_and_stop_seqs, socket, fn {trip_id, stop_sequence}, s ->
       s |> assign_trip_details(trip_id, stop_sequence)
     end)
+  end
+
+  defp assign_last_trip_time(%{assigns: %{route: %{type: route_type}}} = socket, _)
+       when route_type not in [0, 1] do
+    assign(socket, :last_trip_time, nil)
+  end
+
+  defp assign_last_trip_time(socket, date) do
+    assign(socket, :last_trip_time, get_last_trip_time(socket.assigns, date))
+  end
+
+  defp get_last_trip_time(assigns, date) do
+    [assigns.route_id]
+    |> @schedules_repo.by_route_ids(
+      direction_id: assigns.direction_id,
+      stop_ids: [assigns.stop_id],
+      date: date
+    )
+    |> List.last(%{})
+    |> Map.get(:time)
   end
 
   attr :upcoming_departures, :any,

--- a/lib/dotcom_web/live/upcoming_departures_live.ex
+++ b/lib/dotcom_web/live/upcoming_departures_live.ex
@@ -120,7 +120,7 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
     {:noreply, refresh_upcoming_trip_details(socket)}
   end
 
-  # sent every night by `ServiceDateRollover`
+  # sent every night by `ServiceDateRollover`, or in special case by `assign_last_trip_time`
   def handle_info({:service_date_rollover, new_service_date}, socket) do
     {:noreply, assign_last_trip_time(socket, new_service_date)}
   end
@@ -222,6 +222,8 @@ defmodule DotcomWeb.Live.UpcomingDeparturesLive do
       assign(socket, :last_trip_time, get_last_trip_time(assigns, date))
     else
       # don't reassign the last_trip_time! we'll have to reassign it later.
+      later = ServiceDateRollover.ms_to_next_rollover(yesterday_last_scheduled_time)
+      Process.send_after(self(), {:service_date_rollover, date}, later)
       assign(socket, :last_trip_time, yesterday_last_scheduled_time)
     end
   end


### PR DESCRIPTION
## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚽️🦉 Update Subway "Service Continues Until" logic](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214585567694853?focus=true)

<img width="628" height="73" alt="image" src="https://github.com/user-attachments/assets/985e05f3-b676-43d2-bf01-d675757ac1b8" />

The goal is avoiding this saying the wrong thing while service is still underway early 6/14 past the end of the 6/13 service day.

## Implementation

I didn't really change anything about the logic behind showing/hiding the "scheduled service continues" section, but I did adjust what value that last time resolves to.

- [refactor(UpcomingDeparturesLive): extract last_trip_time](https://github.com/mbta/dotcom/pull/3255/commits/efd805cc72438d3b3bf9d2f500929ba87ab8f50b) simply moves some code around
- [feat(UpcomingDeparturesLive): 6/13 last train time](https://github.com/mbta/dotcom/pull/3255/commits/08c87affe18d632087a0bedc54e06a71a3af1e1a) adds a special case for 6/14, where we might be at the time of day where we actually want to continue showing the 6/13 last train time.
- [feat(UpcomingDeparturesLive): handle :service_date_rollover](https://github.com/mbta/dotcom/pull/3255/commits/952bfa7c7a9f66f9b3b13a623eadde940b081cd2) adds a feature where we actually respond to the change in service date in real time (as established in https://github.com/mbta/dotcom/pull/3245)
- [feat(UpcomingDeparturesLive): postpone date rollover](https://github.com/mbta/dotcom/pull/3255/commits/927d86d5f2a2dddb07641efe0716ea4a302155d3) leverages the same `handle_info` clause as the previous commit, and sends our own `{:service_date_rollover, new_date}` tuple.

Technically this approach can be generalized to any date which happens to have service past the official service date rollover time.

## How to test

I borrowed the now-hacking from #3254 thanks :D
Please ignore the departure times, heh

First let's watch 6/13 to 6/14

Before midnight
<img width="626" height="624" alt="image" src="https://github.com/user-attachments/assets/c78e63e8-7f0e-4d67-967c-801f808ef94f" />

Now 6/14, so.. after midnight, and even after 3am! 
<img width="668" height="631" alt="image" src="https://github.com/user-attachments/assets/58e991ec-ae15-49ae-9938-56c7fb912cdf" />

After the last train we actually show 6/14
<img width="651" height="629" alt="image" src="https://github.com/user-attachments/assets/6449155e-120d-43d9-818f-0ef03cc241d5" />

Then it works as normal (changing ~3am), here's 6/15
<img width="651" height="631" alt="image" src="https://github.com/user-attachments/assets/5ca82813-4c8b-4d9e-b74a-14d4f2e3a37b" />

