### PR TITLE
further improvements to stats logging

### DIFF
--- a/lib/dotcom_web/stats.ex
+++ b/lib/dotcom_web/stats.ex
@@ -1,14 +1,28 @@
 defmodule DotcomWeb.Stats do
   @moduledoc """
-  This Agent attaches to telemetry events emitted by Phoenix and aggregates them.
+  This GenServer attaches to telemetry events emitted by Phoenix and aggregates them by path and status.
   """
 
-  use Agent
+  use GenServer
 
   @doc """
-  Starts the Agent and attaches to `[:phoenix, :router_dispatch, :stop]` telemetry events.
+  Starts the GenServer.
   """
-  def start_link(initial_value \\ %{}) do
+  def start_link(_initial_value \\ %{}) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @doc """
+  Dispatches the aggregated stats.
+  """
+  def dispatch_stats do
+    GenServer.call(__MODULE__, :dispatch_stats)
+  end
+
+  @doc """
+  Attaches to the Phoenix telemetry events.
+  """
+  def init(_) do
     :telemetry.attach(
       "phoenix-router_dispatch-stop",
       [:phoenix, :router_dispatch, :stop],
@@ -16,11 +30,21 @@ defmodule DotcomWeb.Stats do
       nil
     )
 
-    Agent.start_link(fn -> initial_value end, name: __MODULE__)
+    Telemetry.Stats.new_table(__MODULE__)
+
+    {:ok, nil}
   end
 
   @doc """
-  Handles telemetry events and aggregates them by path and status.
+  Handles synchronous call to dispatch and reset the stats.
+  """
+  def handle_call(:dispatch_stats, _from, state) do
+    Telemetry.Stats.dispatch_stats(__MODULE__, [:dotcom_web, :request], :method)
+    {:reply, :ok, state}
+  end
+
+  @doc """
+  Handles telemetry events and aggregates them by path and status directly in the ETS table.
   """
   def handle_event(_name, measurement, metadata, _config) do
     method = metadata.conn.method
@@ -28,20 +52,6 @@ defmodule DotcomWeb.Stats do
     status = metadata.conn.status
     duration = measurement[:duration]
 
-    Agent.update(__MODULE__, fn state ->
-      Telemetry.Stats.record_stat(state, method, path, status, duration)
-    end)
-  end
-
-  @doc """
-  Dispatches the aggregated stats to the `[:phoenix, :router_dispatch, :stop]` telemetry event.
-
-  Resets the Agent state after dispatching the stats.
-  """
-  def dispatch_stats do
-    Agent.get(__MODULE__, & &1)
-    |> Telemetry.Stats.dispatch_stats([:dotcom_web, :request], :method)
-
-    Agent.update(__MODULE__, fn _ -> %{} end)
+    Telemetry.Stats.record_stat(__MODULE__, method, path, status, duration)
   end
 end

--- a/lib/dotcom_web/stats.ex
+++ b/lib/dotcom_web/stats.ex
@@ -28,22 +28,9 @@ defmodule DotcomWeb.Stats do
     status = metadata.conn.status
     duration = measurement[:duration]
 
-    Agent.update(__MODULE__, &update_state(&1, method, path, status, duration))
-  end
-
-  defp update_state(state, method, path, status, duration) do
-    if Kernel.get_in(state, [method, path, status]) do
-      Kernel.update_in(state, [method, path, status], fn count_and_sum ->
-        {count, sum} = count_and_sum
-        {count + 1, sum + duration}
-      end)
-    else
-      Kernel.put_in(
-        state,
-        [Access.key(method, %{}), Access.key(path, %{}), status],
-        {1, duration}
-      )
-    end
+    Agent.update(__MODULE__, fn state ->
+      Telemetry.Stats.record_stat(state, method, path, status, duration)
+    end)
   end
 
   @doc """
@@ -52,35 +39,9 @@ defmodule DotcomWeb.Stats do
   Resets the Agent state after dispatching the stats.
   """
   def dispatch_stats do
-    Enum.each(Agent.get(__MODULE__, & &1), &dispatch_method/1)
+    Agent.get(__MODULE__, & &1)
+    |> Telemetry.Stats.dispatch_stats([:dotcom_web, :request], :method)
 
     Agent.update(__MODULE__, fn _ -> %{} end)
-  end
-
-  defp dispatch_method(entry) do
-    {method, stats} = entry
-
-    Enum.each(stats, fn path_and_statuses ->
-      {path, statuses} = path_and_statuses
-
-      Enum.each(statuses, fn status_and_count_sum ->
-        {status, count_and_sum} = status_and_count_sum
-        {count, sum} = count_and_sum
-        dispatch_stat(method, path, status, count, sum)
-      end)
-    end)
-  end
-
-  defp dispatch_stat(method, path, status, count, sum) do
-    avg =
-      sum
-      |> Kernel.div(count)
-      |> System.convert_time_unit(:native, :millisecond)
-
-    :telemetry.execute([:dotcom_web, :request], %{count: count, avg: avg}, %{
-      method: method,
-      path: path,
-      status: status
-    })
   end
 end

--- a/lib/req/stats.ex
+++ b/lib/req/stats.ex
@@ -43,15 +43,10 @@ defmodule Req.Stats do
   """
   def handle_event(_name, measurement, metadata, _config) do
     host = metadata.request.host
-    path = strip_filename(metadata.request.path)
+    path = Path.dirname(metadata.request.path)
     status = metadata.status
     duration = measurement[:duration]
 
     Telemetry.Stats.record_stat(__MODULE__, host, path, status, duration)
-  end
-
-  defp strip_filename(path) do
-    no_slash = Regex.replace(~r/\/$/, path, "")
-    Regex.replace(~r/[\w|-]+\.\w+/, no_slash, "")
   end
 end

--- a/lib/req/stats.ex
+++ b/lib/req/stats.ex
@@ -1,21 +1,45 @@
 defmodule Req.Stats do
   @moduledoc """
-  This Agent attaches to telemetry events emitted by Finch (used by Req) and aggregates them by host, path, and status.
+  This GenServer attaches to telemetry events emitted by Finch (used by Req) and aggregates them by host, path, and status.
   """
 
-  use Agent
+  use GenServer
 
   @doc """
-  Starts the Agent and attaches to `[:finch, :recv, :stop]` telemetry events.
+  Starts the GenServer.
   """
-  def start_link(initial_value \\ %{}) do
-    :telemetry.attach("finch-recv-stop", [:finch, :recv, :stop], &__MODULE__.handle_event/4, nil)
-
-    Agent.start_link(fn -> initial_value end, name: __MODULE__)
+  def start_link(_initial_value \\ %{}) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end
 
   @doc """
-  Handles telemetry events and aggregates them by host, path, and status.
+  Dispatches the aggregated stats to the `[:req, :request]` telemetry event.
+  """
+  def dispatch_stats do
+    GenServer.call(__MODULE__, :dispatch_stats)
+  end
+
+  @doc """
+  Attaches to the Req telemetry events.
+  """
+  def init(_) do
+    :telemetry.attach("finch-recv-stop", [:finch, :recv, :stop], &__MODULE__.handle_event/4, nil)
+
+    Telemetry.Stats.new_table(__MODULE__)
+
+    {:ok, nil}
+  end
+
+  @doc """
+  Handles synchronous call to dispatch and reset the stats.
+  """
+  def handle_call(:dispatch_stats, _from, state) do
+    Telemetry.Stats.dispatch_stats(__MODULE__, [:req, :request], :host)
+    {:reply, :ok, state}
+  end
+
+  @doc """
+  Handles telemetry events and aggregates them by host, path, and status directly in the ETS table.
   """
   def handle_event(_name, measurement, metadata, _config) do
     host = metadata.request.host
@@ -23,21 +47,7 @@ defmodule Req.Stats do
     status = metadata.status
     duration = measurement[:duration]
 
-    Agent.update(__MODULE__, fn state ->
-      Telemetry.Stats.record_stat(state, host, path, status, duration)
-    end)
-  end
-
-  @doc """
-  Dispatches the aggregated stats to the `[:req, :request]` telemetry event.
-
-  Resets the Agent state after dispatching the stats.
-  """
-  def dispatch_stats do
-    Agent.get(__MODULE__, & &1)
-    |> Telemetry.Stats.dispatch_stats([:req, :request], :host)
-
-    Agent.update(__MODULE__, fn _ -> %{} end)
+    Telemetry.Stats.record_stat(__MODULE__, host, path, status, duration)
   end
 
   defp strip_filename(path) do

--- a/lib/req/stats.ex
+++ b/lib/req/stats.ex
@@ -23,22 +23,9 @@ defmodule Req.Stats do
     status = metadata.status
     duration = measurement[:duration]
 
-    Agent.update(__MODULE__, &update_state(&1, host, path, status, duration))
-  end
-
-  defp update_state(state, host, path, status, duration) do
-    if Kernel.get_in(state, [host, path, status]) do
-      Kernel.update_in(state, [host, path, status], fn count_and_sum ->
-        {count, sum} = count_and_sum
-        {count + 1, sum + duration}
-      end)
-    else
-      Kernel.put_in(
-        state,
-        [Access.key(host, %{}), Access.key(path, %{}), status],
-        {1, duration}
-      )
-    end
+    Agent.update(__MODULE__, fn state ->
+      Telemetry.Stats.record_stat(state, host, path, status, duration)
+    end)
   end
 
   @doc """
@@ -47,36 +34,10 @@ defmodule Req.Stats do
   Resets the Agent state after dispatching the stats.
   """
   def dispatch_stats do
-    Enum.each(Agent.get(__MODULE__, & &1), &dispatch_host/1)
+    Agent.get(__MODULE__, & &1)
+    |> Telemetry.Stats.dispatch_stats([:req, :request], :host)
 
     Agent.update(__MODULE__, fn _ -> %{} end)
-  end
-
-  defp dispatch_host(entry) do
-    {host, stats} = entry
-
-    Enum.each(stats, fn path_and_statuses ->
-      {path, statuses} = path_and_statuses
-
-      Enum.each(statuses, fn status_and_count_sum ->
-        {status, count_and_sum} = status_and_count_sum
-        {count, sum} = count_and_sum
-        dispatch_stat(host, path, status, count, sum)
-      end)
-    end)
-  end
-
-  defp dispatch_stat(host, path, status, count, sum) do
-    avg =
-      sum
-      |> Kernel.div(count)
-      |> System.convert_time_unit(:native, :millisecond)
-
-    :telemetry.execute([:req, :request], %{count: count, avg: avg}, %{
-      host: host,
-      path: path,
-      status: status
-    })
   end
 
   defp strip_filename(path) do

--- a/lib/telemetry/stats.ex
+++ b/lib/telemetry/stats.ex
@@ -1,0 +1,57 @@
+defmodule Telemetry.Stats do
+  @moduledoc """
+  Shared aggregation and dispatch logic for telemetry stats.
+  """
+
+  @doc """
+  Updates the nested map state with the given duration.
+  """
+  def record_stat(state, key1, key2, status, duration) do
+    if Kernel.get_in(state, [key1, key2, status]) do
+      Kernel.update_in(state, [key1, key2, status], fn count_and_sum ->
+        {count, sum} = count_and_sum
+        {count + 1, sum + duration}
+      end)
+    else
+      Kernel.put_in(state, [Access.key(key1, %{}), Access.key(key2, %{}), status], {1, duration})
+    end
+  end
+
+  @doc """
+  Traverses the aggregated stats and executes the telemetry event for each.
+  """
+  def dispatch_stats(state, event, key1_label) do
+    Enum.each(state, fn entry ->
+      {key1, stats} = entry
+      dispatch_key1(stats, event, key1_label, key1)
+    end)
+  end
+
+  defp dispatch_key1(stats, event, key1_label, key1) do
+    Enum.each(stats, fn path_entry ->
+      {path, statuses} = path_entry
+      dispatch_path(statuses, event, key1_label, key1, path)
+    end)
+  end
+
+  defp dispatch_path(statuses, event, key1_label, key1, path) do
+    Enum.each(statuses, fn status_entry ->
+      {status, count_and_sum} = status_entry
+      {count, sum} = count_and_sum
+      dispatch_stat(event, key1_label, key1, path, status, count, sum)
+    end)
+  end
+
+  defp dispatch_stat(event, key1_label, key1, path, status, count, sum) do
+    avg =
+      sum
+      |> Kernel.div(count)
+      |> System.convert_time_unit(:native, :millisecond)
+
+    :telemetry.execute(event, %{count: count, avg: avg}, %{
+      key1_label => key1,
+      path: path,
+      status: status
+    })
+  end
+end

--- a/lib/telemetry/stats.ex
+++ b/lib/telemetry/stats.ex
@@ -1,43 +1,64 @@
 defmodule Telemetry.Stats do
   @moduledoc """
-  Shared aggregation and dispatch logic for telemetry stats.
+  Shared aggregation and dispatch logic for telemetry stats using ETS.
   """
 
   @doc """
-  Updates the nested map state with the given duration.
+  Creates a new public ETS table with write concurrency enabled.
   """
-  def record_stat(state, key1, key2, status, duration) do
-    if Kernel.get_in(state, [key1, key2, status]) do
-      Kernel.update_in(state, [key1, key2, status], fn count_and_sum ->
-        {count, sum} = count_and_sum
-        {count + 1, sum + duration}
-      end)
-    else
-      Kernel.put_in(state, [Access.key(key1, %{}), Access.key(key2, %{}), status], {1, duration})
+  def new_table(name) do
+    _ = :ets.new(name, [:named_table, :public, :set, write_concurrency: true])
+
+    :ok
+  end
+
+  @doc """
+  Updates the ETS table with the given duration.
+  """
+  def record_stat(table, key1, key2, status, duration) do
+    key = {key1, key2, status}
+
+    try do
+      :ets.update_counter(table, key, [{2, 1}, {3, duration}], {key, 0, 0})
+    rescue
+      ArgumentError ->
+        # The table is likely being swapped during dispatch. Retry after a tiny sleep.
+        Process.sleep(1)
+
+        try do
+          :ets.update_counter(table, key, [{2, 1}, {3, duration}], {key, 0, 0})
+        rescue
+          ArgumentError ->
+            # stats aren't required; make sure we don't crash
+            :ok
+        end
     end
   end
 
   @doc """
-  Traverses the aggregated stats and executes the telemetry event for each.
+  Swaps the ETS table, retrieves all stats, and dispatches them.
   """
-  def dispatch_stats(state, event, key1_label) do
-    Enum.each(state, fn entry ->
-      {key1, stats} = entry
-      dispatch_key1(stats, event, key1_label, key1)
-    end)
-  end
+  def dispatch_stats(table, event, key1_label) do
+    temp_name = :"#{table}_temp_"
 
-  defp dispatch_key1(stats, event, key1_label, key1) do
-    Enum.each(stats, fn path_entry ->
-      {path, statuses} = path_entry
-      dispatch_path(statuses, event, key1_label, key1, path)
-    end)
-  end
+    # Rename current table to temp name
+    :ets.rename(table, temp_name)
 
-  defp dispatch_path(statuses, event, key1_label, key1, path) do
-    Enum.each(statuses, fn status_entry ->
-      {status, count_and_sum} = status_entry
-      {count, sum} = count_and_sum
+    # Recreate the active table under the original name
+    new_table(table)
+
+    # Allow a brief moment for any ongoing writes to the old table to finish
+    Process.sleep(1)
+
+    # Retrieve all objects from the temporary table
+    stats = :ets.tab2list(temp_name)
+
+    # Delete the temporary table
+    :ets.delete(temp_name)
+
+    # Dispatch the retrieved stats
+    Enum.each(stats, fn entry ->
+      {{key1, path, status}, count, sum} = entry
       dispatch_stat(event, key1_label, key1, path, status, count, sum)
     end)
   end


### PR DESCRIPTION
- centralize implementation (`Telemetry.Stats`)
- use built-in `Path.dirname/1` instead of custom Regex
- use ETS table for concurrent metric logging, instead of having all requests go through a single Agent (metric calculation still goes through the agent)

When all of the metric logging goes through a single Agent, we lose the concurrency we'd otherwise have. Each request needs to wait for previous requests to make their log, creating a single bottleneck. By using an ETS table with `{:write_concurrency, true}` each process can update the metrics concurrently without blocking each other.