### PR TITLE
fix: use correct name when looking up UpcomingDepartures server

### DIFF
--- a/lib/dotcom/upcoming_departures.ex
+++ b/lib/dotcom/upcoming_departures.ex
@@ -38,7 +38,7 @@ defmodule Dotcom.UpcomingDepartures do
   end
 
   defp get_worker(params) do
-    GenServer.whereis({:global, params})
+    GenServer.whereis(Server.server_name(params))
   end
 
   defp start_worker(params) do

--- a/lib/dotcom/upcoming_departures/server.ex
+++ b/lib/dotcom/upcoming_departures/server.ex
@@ -15,7 +15,11 @@ defmodule Dotcom.UpcomingDepartures.Server do
   @upcoming_departures_module Application.compile_env!(:dotcom, :upcoming_departures_module)
 
   def start_link(params) do
-    GenServer.start_link(__MODULE__, params, name: {:global, {__MODULE__, params}})
+    GenServer.start_link(__MODULE__, params, name: server_name(params))
+  end
+
+  def server_name(params) do
+    {:global, {__MODULE__, params}}
   end
 
   @impl GenServer


### PR DESCRIPTION
The `whereis` call ended up being a no-op, since the name wasn't correct. This extracts the name to a function so that we use the same name in both checks.