### PR TITLE
fix: resolve presence tracking process and stream leak in departures

### DIFF
--- a/lib/dotcom/predictions/manager.ex
+++ b/lib/dotcom/predictions/manager.ex
@@ -38,6 +38,7 @@ defmodule Dotcom.Predictions.Manager do
 
   def unsubscribe(params) do
     topic = topic_name(params)
+    _ = DotcomWeb.Presence.untrack(self(), topic, "predictions")
 
     :ok = Phoenix.PubSub.unsubscribe(Dotcom.PubSub, topic)
   end

--- a/lib/dotcom/upcoming_departures.ex
+++ b/lib/dotcom/upcoming_departures.ex
@@ -23,10 +23,10 @@ defmodule Dotcom.UpcomingDepartures do
 
   @spec unsubscribe(map()) :: :ok
   def unsubscribe(params) do
-    :ok =
-      params
-      |> topic_name()
-      |> DotcomWeb.Endpoint.unsubscribe()
+    topic = topic_name(params)
+    _ = DotcomWeb.Presence.untrack(self(), topic, "upcoming_departures")
+
+    :ok = DotcomWeb.Endpoint.unsubscribe(topic)
   end
 
   def topic_name(%{route_id: route_id, direction_id: direction_id, stop_id: stop_id}) do

--- a/test/dotcom/predictions/manager_test.exs
+++ b/test/dotcom/predictions/manager_test.exs
@@ -171,6 +171,21 @@ defmodule Dotcom.Predictions.ManagerTest do
   # ---------------------------------------------------------------------------
 
   describe "unsubscribe/1" do
+    test "correctly untracks presence" do
+      params = unique_params()
+      topic = Manager.topic_name(params)
+
+      # Subscribe and track presence
+      Manager.subscribe(params)
+      assert %{"predictions" => %{metas: [%{}]}} = DotcomWeb.Presence.list(topic)
+
+      # Unsubscribe
+      Manager.unsubscribe(params)
+
+      # Assert process is no longer tracked in Presence
+      assert %{} = DotcomWeb.Presence.list(topic)
+    end
+
     test "server process terminates when the last subscriber unsubscribes" do
       params = unique_params()
 

--- a/test/dotcom/upcoming_departures/server_test.exs
+++ b/test/dotcom/upcoming_departures/server_test.exs
@@ -241,4 +241,23 @@ defmodule Dotcom.UpcomingDepartures.ServerTest do
       topic: ^topic
     }
   end
+
+  describe "Dotcom.UpcomingDepartures integration" do
+    test "subscribe/1 and unsubscribe/1 correctly track and untrack presence", %{
+      params: params,
+      topic: topic
+    } do
+      # Subscribe
+      assert :ok = Dotcom.UpcomingDepartures.subscribe(params)
+
+      # Assert process is tracked in Presence
+      assert %{"upcoming_departures" => %{metas: [%{}]}} = DotcomWeb.Presence.list(topic)
+
+      # Unsubscribe
+      assert :ok = Dotcom.UpcomingDepartures.unsubscribe(params)
+
+      # Assert process is no longer tracked in Presence
+      assert %{} = DotcomWeb.Presence.list(topic)
+    end
+  end
 end


### PR DESCRIPTION
Makes sure we also untrack the Presence when we unsubscribe a Manager.