### PR TITLE
fix: configure gc_interval for Nebulex local cache

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -69,7 +69,8 @@ config :dotcom, tile_server_url: tile_server_url
 
 config :dotcom, Dotcom.Cache.Multilevel.Local,
   max_size: 1_000_000,
-  allocated_memory: 2_000_000_000
+  allocated_memory: 2_000_000_000,
+  gc_interval: :timer.hours(12)
 
 config :elixir, ansi_enabled: true
 


### PR DESCRIPTION
https://nebulex.hexdocs.pm/declarative-caching.html#memory-management

Without the `gc_interval` I don't think we're actually evicting anything from the cache.