### PR TITLE
fix(alert): More permissive URL regex

### DIFF
--- a/lib/alerts/url_parsing_helpers.ex
+++ b/lib/alerts/url_parsing_helpers.ex
@@ -1,7 +1,7 @@
 defmodule Alerts.URLParsingHelpers do
   @moduledoc "Helpers to parse out the url from a string and create an html link"
 
-  @url_regex ~r/(https?:\/\/)?([\da-z\.-]+)\.([a-z]{2,6})([\/\w\.-\?&%#]*)*\/?/i
+  @url_regex ~r/(https?:\/\/)?([\da-z\.-]+)\.([a-z]{2,6})([\/\w\!-\@_\[\]]*)*\/?/i
 
   @spec get_full_url(String.t()) :: String.t() | nil
   def get_full_url(text) do

--- a/test/alerts/url_parsing_helpers_test.exs
+++ b/test/alerts/url_parsing_helpers_test.exs
@@ -26,9 +26,15 @@ defmodule Alerts.URLParsingHelpersTest do
 
     test "should return the url with special characters parsed from the text" do
       word_fn = &Faker.Internet.domain_word/0
+      # \"#$%&'()*+,-./0123456789:;<=>?@
+      special_chars =
+        Enum.to_list(33..64) # numbers corresponding to ASCII characters between ! and @
+        |> Enum.map(fn x -> <<x::utf8>> end)
+        |> List.to_string
 
       url =
-        "#{Faker.Util.pick(["http", "https"])}://#{word_fn.()}.#{Faker.Internet.domain_name()}/#{word_fn.()}/#{word_fn.()}?#{word_fn.()}=#{word_fn.()}&param_2=hello%20world##{word_fn.()}"
+        "#{Faker.Util.pick(["http", "https"])}://#{word_fn.()}.#{Faker.Internet.domain_name()}/#{word_fn.()}/#{word_fn.()}?#{word_fn.()}=#{word_fn.()}&param_2=hello%20world##{word_fn.()}#{special_chars}"
+        |> dbg()
 
       text =
         "This is a test for url validation, the following URL should be completely parsed:  #{url} "

--- a/test/alerts/url_parsing_helpers_test.exs
+++ b/test/alerts/url_parsing_helpers_test.exs
@@ -26,11 +26,11 @@ defmodule Alerts.URLParsingHelpersTest do
 
     test "should return the url with special characters parsed from the text" do
       word_fn = &Faker.Internet.domain_word/0
-      # \"#$%&'()*+,-./0123456789:;<=>?@
+      # Characters between ! and @ :  !\"#$%&'()*+,-./0123456789:;<=>?@
       special_chars =
-        Enum.to_list(33..64) # numbers corresponding to ASCII characters between ! and @
+        Enum.to_list(33..64)
         |> Enum.map(fn x -> <<x::utf8>> end)
-        |> List.to_string
+        |> List.to_string()
 
       url =
         "#{Faker.Util.pick(["http", "https"])}://#{word_fn.()}.#{Faker.Internet.domain_name()}/#{word_fn.()}/#{word_fn.()}?#{word_fn.()}=[#{word_fn.()}]&param_2=hello%20world##{word_fn.()}#{special_chars}"

--- a/test/alerts/url_parsing_helpers_test.exs
+++ b/test/alerts/url_parsing_helpers_test.exs
@@ -33,8 +33,7 @@ defmodule Alerts.URLParsingHelpersTest do
         |> List.to_string
 
       url =
-        "#{Faker.Util.pick(["http", "https"])}://#{word_fn.()}.#{Faker.Internet.domain_name()}/#{word_fn.()}/#{word_fn.()}?#{word_fn.()}=#{word_fn.()}&param_2=hello%20world##{word_fn.()}#{special_chars}"
-        |> dbg()
+        "#{Faker.Util.pick(["http", "https"])}://#{word_fn.()}.#{Faker.Internet.domain_name()}/#{word_fn.()}/#{word_fn.()}?#{word_fn.()}=[#{word_fn.()}]&param_2=hello%20world##{word_fn.()}#{special_chars}"
 
       text =
         "This is a test for url validation, the following URL should be completely parsed:  #{url} "


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⚠️ Fix alerts with URLs with weird chars](https://app.asana.com/1/15492006741476/project/385363666817452/task/1215629073500541)

## Implementation
Adds a bunch of characters to the url regex to be allowed. 
<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
Before: link shown is split
<img width="712" height="332" alt="image" src="https://github.com/user-attachments/assets/7880f3cb-3031-438a-b1e1-926af838acf3" />

After: link is together
<img width="589" height="369" alt="image" src="https://github.com/user-attachments/assets/d16c1547-d8c3-4281-886d-c7cf9b1be996" />


## How to test
Find some live alerts in local that are broken (need to be pointed to `api-dev`) and verify they're no longer broken.

http://localhost:4001/schedules/CR-Providence/timetable 
Providence currently has one

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
