### PR TITLE
feat(dependabot): limit PRs for root package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "assets" # Location of package manifests
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 2
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Scope

We have two `package.json` files! It turns out the root level one was using the default Dependabot configuration (which is set to 5 open PRs)

## Implementation

- Adds configuration for NPM packages in the `/` directory
- Adjusts the total number of open PRs across all 3 configurations to 5 total
