### PR TITLE
fix(a11y): Don't read out icons in fare cards

### DIFF
--- a/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+++ b/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
@@ -101,7 +101,7 @@ card_title = [content_tag(:span, name, class: "c-fare-card__mode"), duration] %>
 
 <%= content_tag :div, class: "grid-container" do %>
   <div class="c-fares-grid">
-    <div aria-hidden= "true">
+    <div aria-hidden="true">
       {mode_icon(mode, :default)}
     </div>
     <div>

--- a/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+++ b/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
@@ -70,7 +70,7 @@ card_classes =
 card_title = [content_tag(:span, name, class: "c-fare-card__mode"), duration] %>
 
 <%= content_tag :div, class: card_classes do %>
-  <div class="c-fare-card__icon">
+  <div class="c-fare-card__icon" aria-hidden="true">
     {mode_icon(mode, :default)}
   </div>
 
@@ -101,7 +101,7 @@ card_title = [content_tag(:span, name, class: "c-fare-card__mode"), duration] %>
 
 <%= content_tag :div, class: "grid-container" do %>
   <div class="c-fares-grid">
-    <div>
+    <div aria-hidden= "true">
       {mode_icon(mode, :default)}
     </div>
     <div>

--- a/lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
+++ b/lib/dotcom_web/templates/cms/paragraph/_grouped_fare_card.html.heex
@@ -29,7 +29,7 @@
   <%= extend_width :cards do %>
     <%= content_tag :div, class: card_classes do %>
       <div class="c-fare-card__header">
-        <div class="c-fare-card__icon">
+        <div class="c-fare-card__icon" aria-hidden="true">
           {mode_icon(group_fare.mode, :default)}
         </div>
 


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [♿️🎧 Mode Page: Decorative mode icon is read out as "image" in Fares section of /subway, /commuter-rail, etc](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214647592812619)

## Implementation
Added `aria-hidden="true"` to the fare card templates so that screen readers won't read them 
<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
No visual changes

## How to test
When using VoiceOver on the local pages utilizing the following templates with this branch checked out, observe that you cannot navigate to the icons using VO and VO does not read them out: 
- individual fare cards : [example page - fares page](http://localhost:4001/fares)
- grouped fare card : [example page - subway fares page](http://localhost:4001/fares/subway-fares)

All content pages should be using these fare cards, but doing a spot check on other fare pages may be valuable just in case.
<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
