### PR TITLE
[ferry] [fare]: Charlestown and Winthrop/Quincy fares changes

### DIFF
--- a/lib/fares/fare_info.ex
+++ b/lib/fares/fare_info.ex
@@ -209,7 +209,7 @@ defmodule Fares.FareInfo do
     },
     %{
       mode: :ferry,
-      inner_harbor_price: "3.70",
+      inner_harbor_price: "2.40",
       inner_harbor_month_price: "90.00",
       inner_harbor_month_price_reduced: "30.00",
       cross_harbor_price: "9.75",

--- a/lib/fares/fares.ex
+++ b/lib/fares/fares.ex
@@ -98,54 +98,21 @@ defmodule Fares do
   end
 
   def calculate_ferry(origin, destination, between)
-      when "Boat-Long" in [origin, destination] and "Boat-Logan" in [origin, destination] do
-    long_way_around_trip_logic(between)
-  end
-
-  def calculate_ferry(origin, destination, between)
-      when "Boat-Long" in [origin, destination] and "Boat-Lewis" in [origin, destination] do
-    long_way_around_trip_logic(between)
-  end
-
-  def calculate_ferry(origin, destination, between)
-      when "Boat-Long-North-5B" in [origin, destination] and "Boat-Lewis" in [origin, destination] do
-    long_way_around_trip_logic(between)
-  end
-
-  def calculate_ferry(origin, destination, between)
+      when "Boat-Long" in [origin, destination] and "Boat-Logan" in [origin, destination]
+      when "Boat-Long" in [origin, destination] and "Boat-Lewis" in [origin, destination]
+      when "Boat-Long-North-5B" in [origin, destination] and "Boat-Lewis" in [origin, destination]
       when origin in @loop_ferry_stops and destination in @loop_ferry_stops and
-             origin != destination do
-    long_way_around_trip_logic(between)
-  end
-
-  def calculate_ferry(origin, destination)
-      when origin in @inner_harbor_winthrop and destination in @inner_harbor_winthrop do
-    :ferry_inner_harbor
-  end
-
-  def calculate_ferry(origin, destination, between)
+             origin != destination
       when origin in @winthrop_ferry_stops and destination in @winthrop_ferry_stops do
     long_way_around_trip_logic(between)
   end
 
   def calculate_ferry(origin, destination)
+      when origin in @inner_harbor_winthrop and destination in @inner_harbor_winthrop
       when origin in @loop_ferry_stops and destination in @loop_ferry_stops and
-             origin != destination do
-    :ferry_inner_harbor
-  end
-
-  def calculate_ferry(origin, destination)
-      when "Boat-Long" in [origin, destination] and "Boat-Logan" in [origin, destination] do
-    :ferry_inner_harbor
-  end
-
-  def calculate_ferry(origin, destination)
+             origin != destination
+      when "Boat-Long" in [origin, destination] and "Boat-Logan" in [origin, destination]
       when "Boat-Long-North-5B" in [origin, destination] and "Boat-Lewis" in [origin, destination] do
-    :ferry_inner_harbor
-  end
-
-  def calculate_ferry(origin, destination)
-      when origin in @inner_harbor_winthrop and destination in @inner_harbor_winthrop do
     :ferry_inner_harbor
   end
 
@@ -156,19 +123,6 @@ defmodule Fares do
 
   def calculate_ferry(origin, destination, _) do
     calculate_ferry(origin, destination)
-  end
-
-  def long_way_around_trip_logic(between) do
-    cond do
-      "Hingham" in between or "Hull" in between ->
-        :commuter_ferry
-
-      "Quincy" in between or "Winthrop Landing" in between ->
-        :ferry_winthrop
-
-      true ->
-        :ferry_inner_harbor
-    end
   end
 
   @spec calculate_ferry(String.t(), String.t()) :: ferry_name
@@ -195,6 +149,19 @@ defmodule Fares do
 
   def calculate_ferry(_origin, _destination) do
     :commuter_ferry
+  end
+
+  def long_way_around_trip_logic(between) do
+    cond do
+      "Hingham" in between or "Hull" in between ->
+        :commuter_ferry
+
+      "Quincy" in between or "Winthrop Landing" in between ->
+        :ferry_winthrop
+
+      true ->
+        :ferry_inner_harbor
+    end
   end
 
   @spec silver_line_rapid_transit?(Route.id_t()) :: boolean

--- a/lib/fares/fares.ex
+++ b/lib/fares/fares.ex
@@ -25,7 +25,11 @@ defmodule Fares do
     "Boat-Winthrop",
     "Boat-Logan"
   ]
-
+  @inner_harbor_winthrop [
+    "Boat-Aquarium",
+    "Boat-Fan",
+    "Boat-Logan"
+  ]
   @loop_ferry_stops ["Boat-Commonwealth", "Boat-Aquarium", "Boat-Lovejoy", "Boat-Logan"]
 
   @type ferry_name ::
@@ -114,9 +118,41 @@ defmodule Fares do
     long_way_around_trip_logic(between)
   end
 
+  def calculate_ferry(origin, destination)
+      when origin in @inner_harbor_winthrop and destination in @inner_harbor_winthrop do
+    :ferry_inner_harbor
+  end
+
   def calculate_ferry(origin, destination, between)
       when origin in @winthrop_ferry_stops and destination in @winthrop_ferry_stops do
+    dbg({origin, destination, between})
     long_way_around_trip_logic(between)
+  end
+
+  def calculate_ferry(origin, destination)
+      when origin in @loop_ferry_stops and destination in @loop_ferry_stops and
+             origin != destination do
+    :ferry_inner_harbor
+  end
+
+  def calculate_ferry(origin, destination)
+      when "Boat-Long" in [origin, destination] and "Boat-Logan" in [origin, destination] do
+    :ferry_inner_harbor
+  end
+
+  def calculate_ferry(origin, destination)
+      when "Boat-Long-North-5B" in [origin, destination] and "Boat-Lewis" in [origin, destination] do
+    :ferry_inner_harbor
+  end
+
+  def calculate_ferry(origin, destination)
+      when origin in @inner_harbor_winthrop and destination in @inner_harbor_winthrop do
+    :ferry_inner_harbor
+  end
+
+  def calculate_ferry(origin, destination)
+      when origin in @winthrop_ferry_stops and destination in @winthrop_ferry_stops do
+    :ferry_winthrop
   end
 
   def calculate_ferry(origin, destination, _) do
@@ -132,7 +168,7 @@ defmodule Fares do
         :ferry_winthrop
 
       true ->
-        :ferry_harbor_loop
+        :ferry_inner_harbor
     end
   end
 
@@ -156,10 +192,6 @@ defmodule Fares do
       when "Boat-Charlestown" in [origin, destination] and
              "Boat-Long-South" in [origin, destination] do
     :ferry_inner_harbor
-  end
-
-  def calculate_ferry(origin, destination) when "Boat-Logan" in [origin, destination] do
-    :commuter_ferry_logan
   end
 
   def calculate_ferry(_origin, _destination) do

--- a/lib/fares/fares.ex
+++ b/lib/fares/fares.ex
@@ -125,7 +125,6 @@ defmodule Fares do
 
   def calculate_ferry(origin, destination, between)
       when origin in @winthrop_ferry_stops and destination in @winthrop_ferry_stops do
-    dbg({origin, destination, between})
     long_way_around_trip_logic(between)
   end
 

--- a/lib/fares/fares.ex
+++ b/lib/fares/fares.ex
@@ -18,7 +18,13 @@ defmodule Fares do
   @express_route_set MapSet.new(@express_routes)
 
   # For the time being, these stops are ONLY served by the Winthrop Ferry
-  @winthrop_ferry_stops ["Boat-Aquarium", "Boat-Fan", "Boat-Quincy", "Boat-Winthrop"]
+  @winthrop_ferry_stops [
+    "Boat-Aquarium",
+    "Boat-Fan",
+    "Boat-Quincy",
+    "Boat-Winthrop",
+    "Boat-Logan"
+  ]
 
   @loop_ferry_stops ["Boat-Commonwealth", "Boat-Aquarium", "Boat-Lovejoy", "Boat-Logan"]
 
@@ -108,6 +114,11 @@ defmodule Fares do
     long_way_around_trip_logic(between)
   end
 
+  def calculate_ferry(origin, destination, between)
+      when origin in @winthrop_ferry_stops and destination in @winthrop_ferry_stops do
+    long_way_around_trip_logic(between)
+  end
+
   def calculate_ferry(origin, destination, _) do
     calculate_ferry(origin, destination)
   end
@@ -117,7 +128,7 @@ defmodule Fares do
       "Hingham" in between or "Hull" in between ->
         :commuter_ferry
 
-      "Quincy" in between ->
+      "Quincy" in between or "Winthrop Landing" in between ->
         :ferry_winthrop
 
       true ->
@@ -134,11 +145,6 @@ defmodule Fares do
   def calculate_ferry(origin, destination)
       when "Boat-Blossom" in [origin, destination] do
     :ferry_lynn
-  end
-
-  def calculate_ferry(origin, destination)
-      when origin in @winthrop_ferry_stops or destination in @winthrop_ferry_stops do
-    :ferry_winthrop
   end
 
   def calculate_ferry(origin, destination)

--- a/test/dotcom/content_rewriters/liquid_objects/fare_test.exs
+++ b/test/dotcom/content_rewriters/liquid_objects/fare_test.exs
@@ -195,7 +195,7 @@ defmodule Dotcom.ContentRewriters.LiquidObjects.FareTest do
              |> Repo.all()
              |> fare_result(:ferry) == "$1.10 – $4.85"
 
-      assert fare_request("ferry_inner_harbor:reduced") == {:ok, "$1.85"}
+      assert fare_request("ferry_inner_harbor:reduced") == {:ok, "$1.20"}
       assert fare_request("ferry_east_boston:reduced") == {:ok, "$1.10"}
       assert fare_request("ferry_cross_harbor:reduced") == {:ok, "$4.85"}
       assert fare_request("ferry:reduced") == {:ok, "$1.10 – $4.85"}

--- a/test/dotcom_web/views/helpers_test.exs
+++ b/test/dotcom_web/views/helpers_test.exs
@@ -166,7 +166,7 @@ defmodule DotcomWeb.ViewHelpersTest do
         end)
 
       assert fares == [
-               "mTicket App, paper ferry ticket, contactless payment, or cash $3.70",
+               "mTicket App, paper ferry ticket, contactless payment, or cash $2.40",
                "CharlieTicket $90.00",
                "mTicket App $80.00"
              ]

--- a/test/fares/fares_test.exs
+++ b/test/fares/fares_test.exs
@@ -8,6 +8,17 @@ defmodule FaresTest do
 
   setup :verify_on_exit!
 
+  def assert_ferry(origin, destination, expected_fare) do
+    {_, received_fare} = Fares.fare_for_stops(:ferry, origin, destination)
+
+    if(origin != destination) do
+      assert received_fare == expected_fare,
+             "Unexpected fare for #{origin} to #{destination}, got #{received_fare} expected #{expected_fare}"
+    else
+      assert true
+    end
+  end
+
   describe "calculate_commuter_rail/2" do
     test "when the origin is zone 6, finds the zone 6 fares" do
       assert Fares.calculate_commuter_rail("6", "1A") == {:zone, "6"}
@@ -23,8 +34,12 @@ defmodule FaresTest do
   end
 
   describe "fare_for_stops/3" do
-    # a subset of possible ferry stops
-    @ferries ~w(Boat-Hingham Boat-Charlestown Boat-Logan Boat-Long-South Boat-Lewis Boat-Blossom Boat-Winthrop)
+    @winthrop_quincy_ferry ~W(Boat-Fan Boat-Winthrop Boat-Logan Boat-Aquarium Boat-Quincy)
+    @hingham_hull_ferry ~W(Boat-Hingham Boat-Logan Boat-Long Boat-Hull)
+    @charlestown_ferry ~W(Boat-Charlestown Boat-Long-South)
+    @harbor_loop_ferry ~W(Boat-Lovejoy Boat-Aquarium Boat-Commonwealth Boat-Logan)
+    @east_boston_ferry ~W(Boat-Lewis Boat-Long-North-5B)
+    @lynn_ferry ~W(Boat-Blossom Boat-Long-North-5C)
 
     test "returns the name of the commuter rail fare given the origin and destination" do
       zone_1a_stop = Stop.build(:stop, %{zone: "1A"})
@@ -65,32 +80,71 @@ defmodule FaresTest do
       assert Fares.fare_for_stops(:commuter_rail, cr_stop.id, other_stop.id) == :error
     end
 
-    test "returns the name of the ferry fare given the origin and destination" do
-      for origin_id <- @ferries,
-          destination_id <- @ferries do
-        both = [origin_id, destination_id]
-        has_logan? = "Boat-Logan" in both
-        has_charlestown? = "Boat-Charlestown" in both
-        has_long? = "Boat-Long" in both
-        has_long_south? = "Boat-Long-South" in both
-        has_east_boston? = "Boat-Lewis" in both
-        has_lynn? = "Boat-Blossom" in both
-        has_winthrop? = "Boat-Winthrop" in both
+    test "returns the proper fare given a valid origin and destination on the hingham/hull lines" do
+      for origin <- @hingham_hull_ferry,
+          destination <- @hingham_hull_ferry do
+        both = [origin, destination]
+        hingham? = "Boat-Hingham" in both
+        hull? = "Boat-Hull" in both
 
-        expected_name =
+        expected_fare =
           cond do
-            has_logan? and has_charlestown? -> :ferry_cross_harbor
-            has_long? and has_logan? -> :ferry_east_boston
-            has_long_south? and has_charlestown? -> :ferry_inner_harbor
-            has_long? and has_east_boston? -> :ferry_east_boston
-            has_lynn? -> :ferry_lynn
-            has_winthrop? -> :ferry_winthrop
-            has_logan? -> :commuter_ferry_logan
-            true -> :commuter_ferry
+            hingham? -> :commuter_ferry
+            hull? -> :commuter_ferry
+            true -> :ferry_inner_harbor
           end
 
-        assert Fares.fare_for_stops(:ferry, origin_id, destination_id) == {:ok, expected_name},
-               "Unexpected result for #{origin_id} to #{destination_id}, expected #{expected_name}"
+        assert_ferry(origin, destination, expected_fare)
+      end
+    end
+
+    test "returns the proper fare given a valid origin and destination on the charlestown line" do
+      for origin <- @charlestown_ferry,
+          destination <- @charlestown_ferry do
+        expected_fare = :ferry_inner_harbor
+        assert_ferry(origin, destination, expected_fare)
+      end
+    end
+
+    test "returns the proper fare given a valid origin and destination on the lynn line" do
+      for origin <- @lynn_ferry,
+          destination <- @lynn_ferry do
+        expected_fare = :ferry_lynn
+        assert_ferry(origin, destination, expected_fare)
+      end
+    end
+
+    test "returns the proper fare given a valid origin and destination on the east boston line" do
+      for origin <- @east_boston_ferry,
+          destination <- @east_boston_ferry do
+        expected_fare = :ferry_inner_harbor
+        assert_ferry(origin, destination, expected_fare)
+      end
+    end
+
+    test "returns the proper fare given a valid origin and destination on the harbor loop line" do
+      for origin <- @harbor_loop_ferry,
+          destination <- @harbor_loop_ferry do
+        expected_fare = :ferry_inner_harbor
+        assert_ferry(origin, destination, expected_fare)
+      end
+    end
+
+    test "returns the proper fare given a valid origin and destination on the winthrop or quincy lines" do
+      for origin <- @winthrop_quincy_ferry,
+          destination <- @winthrop_quincy_ferry do
+        both = [origin, destination]
+        winthrop? = "Boat-Winthrop" in both
+        quincy? = "Boat-Quincy" in both
+
+        expected_fare =
+          cond do
+            winthrop? -> :ferry_winthrop
+            quincy? -> :ferry_winthrop
+            true -> :ferry_inner_harbor
+          end
+
+        assert_ferry(origin, destination, expected_fare)
       end
     end
 

--- a/test/fares/fares_test.exs
+++ b/test/fares/fares_test.exs
@@ -11,7 +11,7 @@ defmodule FaresTest do
   def assert_ferry(origin, destination, expected_fare) do
     {_, received_fare} = Fares.fare_for_stops(:ferry, origin, destination)
 
-    if(origin != destination) do
+    if origin != destination do
       assert received_fare == expected_fare,
              "Unexpected fare for #{origin} to #{destination}, got #{received_fare} expected #{expected_fare}"
     else


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⛴️ 💸 Charlestown and Winthrop/Quincy fares changes](https://app.asana.com/1/15492006741476/project/385363666817452/task/1215569227214979?focus=true)

## Implementation

Updated the Charlestown Ferry price
Updated the Winthrop/Quincy logic to detect long-way-around trips

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Charlestown Ferry New Price
<img width="1217" height="545" alt="Screenshot 2026-06-17 at 1 27 04 PM" src="https://github.com/user-attachments/assets/8ff76b0f-f233-4903-be1e-06b4f787e6c3" />

### Winthrop/Quincy Ferry long-way-around via Winthrop
<img width="1251" height="584" alt="Screenshot 2026-06-17 at 1 05 26 PM" src="https://github.com/user-attachments/assets/c6f5e75b-af9d-4b39-9417-76745ead65eb" />

### Winthrop/Quincy Ferry long-way-around via Quincy
<img width="1244" height="619" alt="Screenshot 2026-06-17 at 1 05 15 PM" src="https://github.com/user-attachments/assets/d68a10ce-5e87-403c-9779-42a518aee05b" />

### Winthrop/Quincy Ferry Fan Pier to Logan
<img width="1250" height="583" alt="Screenshot 2026-06-17 at 1 05 01 PM" src="https://github.com/user-attachments/assets/32c383d6-25a4-4e01-b8fa-928fbef7d835" />

### Winthrop/Quincy Ferry Fan Pier to Logan via Central Wharf
<img width="1245" height="601" alt="Screenshot 2026-06-17 at 1 04 47 PM" src="https://github.com/user-attachments/assets/7aeaa7e5-7535-4d26-aaf8-f75ab2ba6eaf" />


### TODO:
What's with this? 
<img width="423" height="242" alt="Screenshot 2026-06-17 at 2 40 36 PM" src="https://github.com/user-attachments/assets/afc512e9-52cb-496d-bfba-5cadd09ad565" />

It looks fine in the details of that trip, but looks like a bus in the summary.



## How to test

http://localhost:4001/trip-planner

- Confirm the Charlestown Ferry fare is now $2.40 (Note, you'll have to restart your server for the new fares to be used, normal auto-reload doesn't work.)
- Confirm Winthrop/Quincy trips that don't leave the inner harbor cost $2.40
- Confirm Winthrop/Quincy trips that visit either Winthrop or Quincy (regardless of ultimate destination or origin) cost $6.50



<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
