### PR TITLE
chore: replace verify_on_exit! with manual check

### DIFF
--- a/test/dotcom/service_date_rollover_test.exs
+++ b/test/dotcom/service_date_rollover_test.exs
@@ -12,13 +12,13 @@ defmodule Dotcom.ServiceDateRolloverTest do
   @date_time_module Application.compile_env!(:dotcom, :date_time_module)
   @timezone Application.compile_env!(:dotcom, :timezone)
 
-  setup :verify_on_exit!
   # Global mode lets the GenServer process (a separate BEAM process) access the
   # stubs defined by the test process. Safe because async: false prevents concurrency.
   setup :set_mox_global
 
   setup do
     stub_with(Dotcom.Utils.DateTime.Mock, Dotcom.Utils.DateTime)
+    on_exit(fn -> verify!() end)
 
     :ok
   end

--- a/test/dotcom_web/plugs/put_flags_in_session_test.exs
+++ b/test/dotcom_web/plugs/put_flags_in_session_test.exs
@@ -1,8 +1,6 @@
 defmodule DotcomWeb.Plugs.PutFlagsInSessionTest do
   use DotcomWeb.ConnCase, async: true
 
-  import DotcomWeb.Plugs.PutFlagsInSession
-
   describe "Put Flags in Session Plug" do
     test "flag is false if it has not been set", %{conn: conn} do
       conn =


### PR DESCRIPTION
Inspired by this issue report https://github.com/dashbitco/mox/issues/171

## Scope

@jlucytan reported flakiness with `Dotcom.ServiceDateRolloverTest` 

## Implementation

I'm curious to see if this helps!
