### PR TITLE
feat(ServicePatterns): use real service names

### DIFF
--- a/lib/dotcom/service_patterns.ex
+++ b/lib/dotcom/service_patterns.ex
@@ -42,16 +42,14 @@ defmodule Dotcom.ServicePatterns do
     |> dedup_similar_services()
   end
 
-  @type typical_type :: :monday_thursday | :friday | :weekday | :saturday | :sunday | :weekend
-  @type typical_label :: {:typical, typical_type, String.t()}
-  @type atypical_label :: {Service.typicality(), Date.t(), String.t()}
   @type pattern_group ::
           :holiday_service | :extra_service | :planned_disruption | :current | :future | :other
   @type pattern_group_label :: {pattern_group(), String.t()}
+  @type service_label :: {Service.typicality(), Date.t(), String.t()}
   @type service_pattern :: %{
           group_label: pattern_group_label(),
           dates: [Date.t()],
-          service_label: typical_label() | atypical_label()
+          service_label: service_label()
         }
 
   @spec patterns_for_route(Routes.Route.id_t(), Date.t()) :: [service_pattern()]
@@ -278,33 +276,7 @@ defmodule Dotcom.ServicePatterns do
           service: Service.t(),
           dates: [Date.t()],
           group_label: pattern_group_label()
-        }) :: typical_label() | atypical_label()
-  defp similar_typical_items(%{
-         dates: dates,
-         service: %Service{typicality: :typical_service} = service
-       }) do
-    typical_groups = [
-      {:monday_thursday, ~t"Monday - Thursday schedules",
-       fn s ->
-         s.type == :weekday &&
-           (s.valid_days == [1, 2, 3, 4] || s.description =~ "Monday - Thursday")
-       end},
-      {:friday, ~t"Friday schedules",
-       fn s ->
-         s.type == :weekday && (s.valid_days == [5] || s.description =~ "Friday")
-       end},
-      {:weekday, ~t"Weekday schedules", fn s -> s.type == :weekday end},
-      {:saturday, ~t"Saturday schedules", fn s -> s.type == :saturday end},
-      {:sunday, ~t"Sunday schedules", fn s -> s.type == :sunday end},
-      {:weekend, ~t"Weekend schedules", fn s -> s.type == :weekend end}
-    ]
-
-    case Enum.find(typical_groups, fn {_, _, func} -> func.(service) end) do
-      {key, label, _} -> {:typical, key, label}
-      _ -> {service.typicality, List.first(dates), service.description}
-    end
-  end
-
+        }) :: service_label()
   defp similar_typical_items(%{dates: dates, service: service}),
     do: {service.typicality, List.first(dates), service.description}
 

--- a/lib/dotcom/service_patterns.ex
+++ b/lib/dotcom/service_patterns.ex
@@ -278,7 +278,9 @@ defmodule Dotcom.ServicePatterns do
           group_label: pattern_group_label()
         }) :: service_label()
   defp similar_typical_items(%{dates: dates, service: service}),
-    do: {service.typicality, List.first(dates), service.description}
+    do:
+      {service.typicality, List.first(dates),
+       String.replace(service.description, " (no school)", "")}
 
   defp merge_items({{group_label, label}, [%{service: _, dates: dates}]}) do
     %{service_label: label, dates: dates, group_label: group_label}

--- a/test/dotcom/service_patterns_test.exs
+++ b/test/dotcom/service_patterns_test.exs
@@ -84,7 +84,7 @@ defmodule Dotcom.ServicePatternsTest do
         ]
       end)
 
-      assert [%{service_label: {:typical, :weekday, "Weekday schedules"}}] =
+      assert [%{service_label: {_, _, "Weekdays"}}] =
                patterns_for_route(route_id)
     end
 


### PR DESCRIPTION

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** followup to [Update description for light/heavy rail friday services](https://app.asana.com/1/15492006741476/project/584764604969369/task/1215810819619276?focus=true)

## Implementation

Our current logic overrides the names for typical schedules, which means we couldn't show the named "Friday and Matchday schedule". This removes the override and lets the service descriptions from the data shine through. 

This might have some unexpected results across other routes so I'll put it on dev-green for folks to explore.

## Screenshots

<img width="1260" height="644" alt="image" src="https://github.com/user-attachments/assets/6ec212e6-abbe-43b2-9df9-1eb9af80b7b4" />

## How to test

Go to the departures page for your favorite routes and observe that for typical (non-holiday/extra/disruption/etc) services the description actually matches what comes from the V3 API!