### PR TITLE
fix(PageController): don't copy the whole conn

### DIFF
--- a/lib/dotcom_web/controllers/page_controller.ex
+++ b/lib/dotcom_web/controllers/page_controller.ex
@@ -15,7 +15,6 @@ defmodule DotcomWeb.PageController do
     WhatsHappeningItem
   }
 
-  plug(:alerts)
   plug(DotcomWeb.Plugs.RecentlyVisited)
   plug(:subway_status)
 
@@ -25,29 +24,31 @@ defmodule DotcomWeb.PageController do
   def index(conn, _params) do
     {promoted, remainder} = whats_happening_items()
     banner = banner()
+    date = conn.assigns.date
+    date_time = conn.assigns.date_time
 
     conn
     |> assign(
       :meta_description,
       ~t"Public transit in the Greater Boston region. Routes, schedules, trip planner, fares, service alerts, real-time updates, and general information."
     )
+    |> assign(:banner, banner)
+    |> assign(:promoted_items, promoted)
+    |> assign(:whats_happening_items, remainder)
     |> async_assign_default(:news, &news/0, [])
     |> async_assign_default(:photo, &photo/0)
-    |> async_assign_default(:banner, fn -> banner end)
-    |> async_assign_default(:promoted_items, fn -> promoted end)
-    |> async_assign_default(:whats_happening_items, fn -> remainder end)
     |> async_assign_default(
       :alerts,
       fn ->
-        conn.assigns.date_time
+        date_time
         |> Alerts.Repo.all()
-        |> Enum.filter(&Alerts.Match.any_time_match?(&1, conn.assigns.date_time))
+        |> Enum.filter(&Alerts.Match.any_time_match?(&1, date_time))
       end,
       []
     )
     |> async_assign_default(
       :event_teasers,
-      fn -> CMS.Repo.next_n_event_teasers(conn.assigns.date, 6) end,
+      fn -> CMS.Repo.next_n_event_teasers(date, 6) end,
       []
     )
     |> await_assign_all_default(__MODULE__)
@@ -134,12 +135,6 @@ defmodule DotcomWeb.PageController do
   @spec do_add_utm_url(content, String.t()) :: content
   defp do_add_utm_url(%Teaser{} = item, url), do: %{item | path: url}
   defp do_add_utm_url(item, url), do: %{item | utm_url: url}
-
-  defp alerts(conn, _opts) do
-    alerts = Alerts.Repo.all(conn.assigns.date_time)
-
-    assign(conn, :alerts, alerts)
-  end
 
   defp subway_status(conn, _opts) do
     assign(conn, :subway_status, Dotcom.SystemStatus.subway_status())


### PR DESCRIPTION
If we use `conn` in the async closure, the whole thing (including any existing data) is copied. By extracting only the items we need, we limit the amount of extra memory used.