### PR TITLE
[ferry]: Winthrop, Quincy ferries are missing their stops on /stops

### DIFF
--- a/lib/detailed_stop_group.ex
+++ b/lib/detailed_stop_group.ex
@@ -38,7 +38,7 @@ defmodule DetailedStopGroup do
     mode
     |> Route.types_for_mode()
     |> @routes_repo.by_type()
-    |> Task.async_stream(&{&1, @stops_repo.by_route(&1.id, 0)})
+    |> Task.async_stream(&{&1, @stops_repo.by_route(&1.id, 1)})
     |> Enum.map(fn {:ok, stops} -> stops end)
   end
 


### PR DESCRIPTION


<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [⛴️ Winthrop, Quincy ferries are missing their stops on /stops](https://app.asana.com/1/15492006741476/project/555089885850811/task/1210764957782338?focus=true)

## Implementation

Routes Boat-F6 and Boat-F7 have no stops when direction_id = 0 in the API.  We default to direction 0 when listing stops on the stops page.  This change defaults to direction 1 instead.  Should the API be updated?

API direction_id=1:  https://api-v3.mbta.com/stops?filter%5Broute%5D=Boat-F6&filter[direction_id]=1
API direction_id=0: https://api-v3.mbta.com/stops?filter%5Broute%5D=Boat-F6&filter[direction_id]=0
Boat-F7 shows the same

<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots
<img width="1242" height="457" alt="Screenshot 2026-06-22 at 11 19 23 AM" src="https://github.com/user-attachments/assets/3f0e39f7-1c43-470c-8e0a-045f32bee13a" />

## How to test

http://localhost:4001/stops/ferry#ferry-tab

Confirm that the Winthrop and Quincy ferries have their stops listed on the stop page
Confirm that all other lines still show their stops now that we've revered the direction

<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
