### PR TITLE
fix: homepage guide images use static URL

### DIFF
--- a/lib/dotcom_web/templates/page/_user_guides.html.heex
+++ b/lib/dotcom_web/templates/page/_user_guides.html.heex
@@ -22,8 +22,8 @@
           "/guides/bus-guide"
         }
       ] %>
-      <a :for={{header, image, link} <- guides} class="guide" href={link}>
-        <img src={image} />
+      <a :for={{header, image_path, link} <- guides} class="guide" href={link}>
+        <img src={Util.site_path(:static_url, image_path)} alt="" />
         <h3>{header}</h3>
       </a>
     </div>


### PR DESCRIPTION
## Scope

While investigating the June 21 DDoS attempt I found a _lot_ of requests to mbta.com/sites/default/files... and it was solely due to these three images on the homepage, which happen to be hardcoded in this particular way.

## Implementation

When these images load,

- request is made to  mbta.com/sites/default/files..
- it responds with a 301, redirecting to cdn.mbta.com/sites/default/files...
- the guide image loads

We can skip the whole redirecting piece by directly linking to the CDN, which can be done with one of our helper functions.

As a bonus I marked these images as decorative by adding `alt=""`, because these images were all missing any `alt` attribute before 😵‍💫 

## How to test

On prod, it should use cdn.mbta.com as the host for the URL.