### PR TITLE
cleanup: Remove SF2.0 and WC Timetable links on the preview page

### DIFF
--- a/lib/dotcom_web/live/preview_live.ex
+++ b/lib/dotcom_web/live/preview_live.ex
@@ -3,32 +3,18 @@ defmodule DotcomWeb.PreviewLive do
   A page that we can visit that links to the other preview pages that currently exist.
   """
 
-  alias DotcomWeb.WorldCupTimetableLive
   use DotcomWeb, :live_view
 
   alias DotcomWeb.Router.Helpers
-  alias DotcomWeb.ScheduleFinderLive
   alias DotcomWeb.StopMapLive
   alias Phoenix.LiveView
 
   @pages [
     %{
-      arguments: [[route_id: "Red", direction_id: "0"]],
-      icon_name: "icon-realtime-tracking",
-      module: ScheduleFinderLive,
-      title: "Schedule Finder 2.0"
-    },
-    %{
       arguments: [],
       icon_name: "icon-stop-default",
       module: StopMapLive,
       title: "Stop Page Map"
-    },
-    %{
-      arguments: [],
-      icon_name: "football",
-      module: WorldCupTimetableLive,
-      title: "World Cup Timetable"
     }
   ]
 

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -352,7 +352,6 @@ defmodule DotcomWeb.Router do
       layout: {DotcomWeb.LayoutView, :preview},
       on_mount: DotcomWeb.Plugs.PutFlagsInAssignsHook do
       live "/", PreviewLive
-      live "/schedules/bostonstadium", WorldCupTimetableLive
       live "/stop-map", StopMapLive
     end
   end


### PR DESCRIPTION
## Scope

No ticket, but since we've long-since released ~SF2.0~ _the departures page_ and the WC timetables, we don't need the preview page links anymore.

## Implementation

![Animation of a cat trying to delete something (though apparently missing the laptop entirely)](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExenU3ZjB2Ymo1OWduOWtuc2NnZHJqeW1vZjh2b2p2cTR5YXJkcm11byZlcD12MV9naWZzX3NlYXJjaCZjdD1n/HWu8n0mKAMVQJ9u3un/giphy.gif)

## Screenshots

<img width="2004" height="1222" alt="Screenshot 2026-06-23 at 10 12 16 AM" src="https://github.com/user-attachments/assets/4ff7e65d-30fd-4e56-9e62-9b702aaf531f" />

## How to test

Look at the [preview page](http://localhost:4001/preview), and experience the joy of "less is more".