### PR TITLE
[feat] Stale old alerts on line diagram banner

### DIFF
--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -137,7 +137,6 @@ defmodule Alerts.Alert do
     |> set_priority()
     |> set_direction_ids()
     |> ensure_entity_set()
-    |> check_freshness()
   end
 
   @spec update(t(), Keyword.t()) :: t()
@@ -181,17 +180,14 @@ defmodule Alerts.Alert do
     %__MODULE__{alert | priority: Priority.priority(alert)}
   end
 
-  defp check_freshness(%__MODULE__{} = alert) do
+  def stale?(%__MODULE__{} = alert) do
     now = Timex.now()
     five_weeks_ago = DateTime.add(now, -5 * 7, :day)
 
-    stale? =
-      case Dotcom.Alerts.StartTime.next_active_time(alert, now) do
-        {:current, datetime} -> datetime |> DateTime.before?(five_weeks_ago)
-        _ -> false
-      end
-
-    %__MODULE__{alert | stale?: stale?}
+    case Dotcom.Alerts.StartTime.next_active_time(alert, now) do
+      {:current, datetime} -> datetime |> DateTime.before?(five_weeks_ago)
+      _ -> false
+    end
   end
 
   @spec build_struct(Keyword.t()) :: t()

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -190,7 +190,7 @@ defmodule Alerts.Alert do
       if is_nil(current_active_period) do
         false
       else
-        current_active_period |> elem(0) |> DateTime.before?(five_weeks_ago)
+        (current_active_period |> elem(0) || now) |> DateTime.before?(five_weeks_ago)
       end
 
     %__MODULE__{alert | stale?: stale?}
@@ -200,24 +200,12 @@ defmodule Alerts.Alert do
   def current_active_period(%__MODULE__{} = alert, now) do
     alert.active_period
     |> Enum.find(fn {start, stop} ->
-      cond do
-        is_nil(start) and DateTime.after?(stop, now) ->
-          true
-
-        is_nil(start) ->
-          false
-
-        is_nil(stop) and DateTime.before?(start, now) ->
-          true
-
-        is_nil(stop) ->
-          false
-
-        DateTime.before?(start, now) and DateTime.after?(stop, now) ->
-          true
-
-        true ->
-          false
+      case {start, stop} do
+        # nil start should never happen, but some tests include it
+        {nil, stop} -> DateTime.after?(stop, now)
+        {start, nil} -> DateTime.before?(start, now)
+        {start, stop} -> DateTime.before?(start, now) and DateTime.after?(stop, now)
+        _ -> false
       end
     end)
   end

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -58,6 +58,7 @@ defmodule Alerts.Alert do
             lifecycle: :unknown,
             priority: :low,
             severity: 5,
+            stale?: false,
             updated_at: Timex.now(),
             url: ""
 
@@ -116,6 +117,7 @@ defmodule Alerts.Alert do
           lifecycle: lifecycle,
           priority: Priority.priority_level(),
           severity: severity,
+          stale?: boolean(),
           updated_at: DateTime.t(),
           url: String.t() | nil
         }
@@ -135,6 +137,7 @@ defmodule Alerts.Alert do
     |> set_priority()
     |> set_direction_ids()
     |> ensure_entity_set()
+    |> check_freshness()
   end
 
   @spec update(t(), Keyword.t()) :: t()
@@ -176,6 +179,29 @@ defmodule Alerts.Alert do
   @spec set_priority(map) :: map
   defp set_priority(%__MODULE__{} = alert) do
     %__MODULE__{alert | priority: Priority.priority(alert)}
+  end
+
+  defp check_freshness(%__MODULE__{} = alert) do
+    now = Timex.now()
+    five_weeks_ago = DateTime.add(now, -5 * 7, :day)
+    current_active_period = current_active_period(alert, now)
+
+    stale? =
+      if is_nil(current_active_period) do
+        false
+      else
+        current_active_period |> elem(0) |> DateTime.before?(five_weeks_ago)
+      end
+
+    %__MODULE__{alert | stale?: stale?}
+  end
+
+  def current_active_period(%__MODULE__{} = alert, now) do
+    alert.active_period
+    |> Enum.find(fn {start, stop} ->
+      (DateTime.before?(start, now) and (is_nil(stop) or DateTime.after?(stop, now))) or
+        (is_nil(start) and DateTime.after?(stop, now))
+    end)
   end
 
   @spec build_struct(Keyword.t()) :: t()

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -58,7 +58,6 @@ defmodule Alerts.Alert do
             lifecycle: :unknown,
             priority: :low,
             severity: 5,
-            stale?: false,
             updated_at: Timex.now(),
             url: ""
 
@@ -117,7 +116,6 @@ defmodule Alerts.Alert do
           lifecycle: lifecycle,
           priority: Priority.priority_level(),
           severity: severity,
-          stale?: boolean(),
           updated_at: DateTime.t(),
           url: String.t() | nil
         }

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -196,6 +196,7 @@ defmodule Alerts.Alert do
     %__MODULE__{alert | stale?: stale?}
   end
 
+  # credo:disable-for-next-line
   def current_active_period(%__MODULE__{} = alert, now) do
     alert.active_period
     |> Enum.find(fn {start, stop} ->

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -214,7 +214,7 @@ defmodule Alerts.Alert do
           false
 
         DateTime.before?(start, now) and DateTime.after?(stop, now) ->
-          false
+          true
 
         true ->
           false

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -199,8 +199,25 @@ defmodule Alerts.Alert do
   def current_active_period(%__MODULE__{} = alert, now) do
     alert.active_period
     |> Enum.find(fn {start, stop} ->
-      (DateTime.before?(start, now) and (is_nil(stop) or DateTime.after?(stop, now))) or
-        (is_nil(start) and DateTime.after?(stop, now))
+      cond do
+        is_nil(start) and DateTime.after?(stop, now) ->
+          true
+
+        is_nil(start) ->
+          false
+
+        is_nil(stop) and DateTime.before?(start, now) ->
+          true
+
+        is_nil(stop) ->
+          false
+
+        DateTime.before?(start, now) and DateTime.after?(stop, now) ->
+          true
+
+        true ->
+          false
+      end
     end)
   end
 

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -214,7 +214,7 @@ defmodule Alerts.Alert do
           false
 
         DateTime.before?(start, now) and DateTime.after?(stop, now) ->
-          true
+          false
 
         true ->
           false

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -184,29 +184,14 @@ defmodule Alerts.Alert do
   defp check_freshness(%__MODULE__{} = alert) do
     now = Timex.now()
     five_weeks_ago = DateTime.add(now, -5 * 7, :day)
-    current_active_period = current_active_period(alert, now)
 
     stale? =
-      if is_nil(current_active_period) do
-        false
-      else
-        (current_active_period |> elem(0) || now) |> DateTime.before?(five_weeks_ago)
+      case Dotcom.Alerts.StartTime.next_active_time(alert, now) do
+        {:current, datetime} -> datetime |> DateTime.before?(five_weeks_ago)
+        _ -> false
       end
 
     %__MODULE__{alert | stale?: stale?}
-  end
-
-  # credo:disable-for-next-line
-  def current_active_period(%__MODULE__{} = alert, now) do
-    alert.active_period
-    |> Enum.find(fn {start, stop} ->
-      case {start, stop} do
-        # nil start should never happen, but some tests include it
-        {nil, stop} -> DateTime.after?(stop, now)
-        {start, nil} -> DateTime.before?(start, now)
-        {start, stop} -> DateTime.before?(start, now) and DateTime.after?(stop, now)
-      end
-    end)
   end
 
   @spec build_struct(Keyword.t()) :: t()

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -205,7 +205,6 @@ defmodule Alerts.Alert do
         {nil, stop} -> DateTime.after?(stop, now)
         {start, nil} -> DateTime.before?(start, now)
         {start, stop} -> DateTime.before?(start, now) and DateTime.after?(stop, now)
-        _ -> false
       end
     end)
   end

--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -179,8 +179,8 @@ defmodule Alerts.Alert do
   end
 
   def stale?(%__MODULE__{} = alert) do
-    now = Timex.now()
-    five_weeks_ago = DateTime.add(now, -5 * 7, :day)
+    now = Dotcom.Utils.DateTime.now()
+    five_weeks_ago = DateTime.shift(now, week: -5)
 
     case Dotcom.Alerts.StartTime.next_active_time(alert, now) do
       {:current, datetime} -> datetime |> DateTime.before?(five_weeks_ago)

--- a/lib/dotcom_web/templates/schedule/_line.html.heex
+++ b/lib/dotcom_web/templates/schedule/_line.html.heex
@@ -33,7 +33,7 @@
   {DotcomWeb.AlertView.group(
     alerts:
       @alerts
-      |> Enum.filter(fn %{stale?: stale?} -> !stale? end),
+      |> Enum.filter(fn alert -> !alert.stale?() end),
     route: @route,
     date_time: @date_time,
     priority_filter: :high

--- a/lib/dotcom_web/templates/schedule/_line.html.heex
+++ b/lib/dotcom_web/templates/schedule/_line.html.heex
@@ -31,7 +31,11 @@
 
 <div class="page-section m-schedule-line">
   {DotcomWeb.AlertView.group(
-    alerts: @alerts,
+    alerts:
+      @alerts
+      |> Enum.filter(fn %{created_at: created_at} ->
+        DateTime.after?(created_at, DateTime.add(@date_time, -5 * 7, :day))
+      end),
     route: @route,
     date_time: @date_time,
     priority_filter: :high

--- a/lib/dotcom_web/templates/schedule/_line.html.heex
+++ b/lib/dotcom_web/templates/schedule/_line.html.heex
@@ -33,7 +33,7 @@
   {DotcomWeb.AlertView.group(
     alerts:
       @alerts
-      |> Enum.filter(fn alert -> !Alerts.Alert.stale?(alert) end),
+      |> Enum.reject(&Alerts.Alert.stale?/1),
     route: @route,
     date_time: @date_time,
     priority_filter: :high

--- a/lib/dotcom_web/templates/schedule/_line.html.heex
+++ b/lib/dotcom_web/templates/schedule/_line.html.heex
@@ -33,9 +33,7 @@
   {DotcomWeb.AlertView.group(
     alerts:
       @alerts
-      |> Enum.filter(fn %{created_at: created_at} ->
-        DateTime.after?(created_at, DateTime.add(@date_time, -5 * 7, :day))
-      end),
+      |> Enum.filter(fn %{stale?: stale?} -> !stale? end),
     route: @route,
     date_time: @date_time,
     priority_filter: :high

--- a/lib/dotcom_web/templates/schedule/_line.html.heex
+++ b/lib/dotcom_web/templates/schedule/_line.html.heex
@@ -33,7 +33,7 @@
   {DotcomWeb.AlertView.group(
     alerts:
       @alerts
-      |> Enum.filter(fn alert -> !alert.stale?() end),
+      |> Enum.filter(fn alert -> !Alerts.Alert.stale?(alert) end),
     route: @route,
     date_time: @date_time,
     priority_filter: :high

--- a/test/alerts/alerts_test.exs
+++ b/test/alerts/alerts_test.exs
@@ -25,6 +25,43 @@ defmodule AlertsTest do
     end
   end
 
+  describe "check_freshness/1" do
+    test "Marks alerts with no end older than 5 weeks as stale" do
+      stale_start_date = Timex.now() |> DateTime.add(Enum.random(-10..-6) * 7, :day)
+      alert = new(effect: :delay, active_period: [{stale_start_date, nil}])
+
+      assert alert.stale?,
+             "Alert with no end was expected to be stale, but was not"
+    end
+
+    test "Marks alerts with an end older than 5 weeks as stale" do
+      stale_start_date = Timex.now() |> DateTime.add(Enum.random(-10..-6) * 7, :day)
+      stale_end_date = Timex.now() |> DateTime.add(Enum.random(1..10), :day)
+      alert = new(effect: :delay, active_period: [{stale_start_date, stale_end_date}])
+
+      assert alert.stale?,
+             "Alert with an end was expected to be stale, but was not #{stale_start_date}"
+    end
+
+    test "Marks alerts with no end younger than 5 weeks as fresh" do
+      fresh_start_date = Timex.now() |> DateTime.add(Enum.random(-4..-1) * 7, :day)
+      alert = new(effect: :delay, active_period: [{fresh_start_date, nil}])
+
+      assert !alert.stale?,
+             "Alert with no end was expected to be fresh, but was not"
+    end
+
+    test "Marks alerts with an end younger than 5 weeks as fresh" do
+      fresh_start_date = Timex.now() |> DateTime.add(Enum.random(-4..-1) * 7, :day)
+      fresh_end_date = Timex.now() |> DateTime.add(Enum.random(1..10), :day)
+
+      alert = new(effect: :delay, active_period: [{fresh_start_date, fresh_end_date}])
+
+      assert !alert.stale?,
+             "Alert with an end was expected to be fresh, but was not"
+    end
+  end
+
   describe "ongoing_effects/0" do
     test "returns a list" do
       assert is_list(ongoing_effects())

--- a/test/alerts/alerts_test.exs
+++ b/test/alerts/alerts_test.exs
@@ -43,6 +43,25 @@ defmodule AlertsTest do
              "Alert with an end was expected to be stale, but was not #{stale_start_date}"
     end
 
+    test "Handles alerts with multiple active periods correctly" do
+      stale_start_date = Timex.now() |> DateTime.add(Enum.random(-10..-6) * 7, :day)
+      stale_end_date = Timex.now() |> DateTime.add(Enum.random(1..10), :day)
+      future_start_date = Timex.now() |> DateTime.add(Enum.random(1..30), :day)
+      future_end_date = future_start_date |> DateTime.add(Enum.random(1..30), :day)
+
+      alert =
+        new(
+          effect: :delay,
+          active_period: [
+            {stale_start_date, stale_end_date},
+            {future_start_date, future_end_date}
+          ]
+        )
+
+      assert alert.stale?,
+             "Alert with an end was expected to be stale, but was not #{stale_start_date}"
+    end
+
     test "Marks alerts with no end younger than 5 weeks as fresh" do
       fresh_start_date = Timex.now() |> DateTime.add(Enum.random(-4..-1) * 7, :day)
       alert = new(effect: :delay, active_period: [{fresh_start_date, nil}])

--- a/test/alerts/alerts_test.exs
+++ b/test/alerts/alerts_test.exs
@@ -30,7 +30,7 @@ defmodule AlertsTest do
       stale_start_date = Timex.now() |> DateTime.add(Enum.random(-10..-6) * 7, :day)
       alert = new(effect: :delay, active_period: [{stale_start_date, nil}])
 
-      assert alert.stale?,
+      assert Alerts.Alert.stale?(alert),
              "Alert with no end was expected to be stale, but was not"
     end
 
@@ -39,7 +39,7 @@ defmodule AlertsTest do
       stale_end_date = Timex.now() |> DateTime.add(Enum.random(1..10), :day)
       alert = new(effect: :delay, active_period: [{stale_start_date, stale_end_date}])
 
-      assert alert.stale?,
+      assert Alerts.Alert.stale?(alert),
              "Alert with an end was expected to be stale, but was not #{stale_start_date}"
     end
 
@@ -58,7 +58,7 @@ defmodule AlertsTest do
           ]
         )
 
-      assert alert.stale?,
+      assert Alerts.Alert.stale?(alert),
              "Alert with an end was expected to be stale, but was not #{stale_start_date}"
     end
 
@@ -66,7 +66,7 @@ defmodule AlertsTest do
       fresh_start_date = Timex.now() |> DateTime.add(Enum.random(-4..-1) * 7, :day)
       alert = new(effect: :delay, active_period: [{fresh_start_date, nil}])
 
-      assert !alert.stale?,
+      assert !Alerts.Alert.stale?(alert),
              "Alert with no end was expected to be fresh, but was not"
     end
 
@@ -76,7 +76,7 @@ defmodule AlertsTest do
 
       alert = new(effect: :delay, active_period: [{fresh_start_date, fresh_end_date}])
 
-      assert !alert.stale?,
+      assert !Alerts.Alert.stale?(alert),
              "Alert with an end was expected to be fresh, but was not"
     end
   end

--- a/test/alerts/match_test.exs
+++ b/test/alerts/match_test.exs
@@ -67,10 +67,9 @@ defmodule Alerts.MatchTest do
           %InformedEntity{stop: "1"}
         ],
         active_period: [
-          {nil, ~N[2016-06-01T00:00:00]},
-          {NaiveDateTime.from_erl!({{2016, 6, 2}, {0, 0, 0}}),
-           NaiveDateTime.from_erl!({{2016, 6, 2}, {1, 0, 0}})},
-          {NaiveDateTime.from_erl!({{2016, 6, 3}, {0, 0, 0}}), nil}
+          {nil, ~U(2016-06-01 00:00:00Z)},
+          {~U(2016-06-02 00:00:00Z), ~U(2016-06-02 01:00:00Z)},
+          {~U(2016-06-03 00:00:00Z), nil}
         ]
       )
     ]
@@ -79,28 +78,28 @@ defmodule Alerts.MatchTest do
 
     assert Alerts.Match.match(alerts, ie) == alerts
 
-    assert Alerts.Match.match(alerts, ie, NaiveDateTime.from_erl!({{2016, 6, 1}, {0, 0, 0}})) ==
+    assert Alerts.Match.match(alerts, ie, ~U(2016-06-01 00:00:00Z)) ==
              alerts
 
-    assert Alerts.Match.match(alerts, ie, NaiveDateTime.from_erl!({{2016, 6, 2}, {0, 0, 0}})) ==
+    assert Alerts.Match.match(alerts, ie, ~U(2016-06-02 00:00:00Z)) ==
              alerts
 
-    assert Alerts.Match.match(alerts, ie, NaiveDateTime.from_erl!({{2016, 6, 2}, {0, 30, 0}})) ==
+    assert Alerts.Match.match(alerts, ie, ~U(2016-06-02 00:30:00Z)) ==
              alerts
 
-    assert Alerts.Match.match(alerts, ie, NaiveDateTime.from_erl!({{2016, 6, 3}, {0, 0, 0}})) ==
+    assert Alerts.Match.match(alerts, ie, ~U(2016-06-03 00:00:00Z)) ==
              alerts
 
-    assert Alerts.Match.match(alerts, ie, NaiveDateTime.from_erl!({{2016, 6, 4}, {0, 0, 0}})) ==
+    assert Alerts.Match.match(alerts, ie, ~U(2016-06-04 00:00:00Z)) ==
              alerts
 
-    assert Alerts.Match.match(alerts, ie, NaiveDateTime.from_erl!({{2016, 5, 20}, {0, 0, 0}})) ==
+    assert Alerts.Match.match(alerts, ie, ~U(2016-05-20 00:00:00Z)) ==
              alerts
 
-    assert Alerts.Match.match(alerts, ie, NaiveDateTime.from_erl!({{2016, 6, 1}, {12, 0, 0}})) ==
+    assert Alerts.Match.match(alerts, ie, ~U(2016-06-01 12:00:00Z)) ==
              []
 
-    assert Alerts.Match.match(alerts, ie, NaiveDateTime.from_erl!({{2016, 6, 2}, {12, 0, 0}})) ==
+    assert Alerts.Match.match(alerts, ie, ~U(2016-06-02 12:00:00Z)) ==
              []
   end
 


### PR DESCRIPTION

<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

<!-- Why does this PR exist? -->

**Asana Ticket:** [🐬 Stale Symphony alert on line diagram banner on GL and GL-E pages](https://app.asana.com/1/15492006741476/project/555089885850811/task/1214740102739529?focus=true)

## Implementation

- Added logic to alerts.ex to identify and mark alerts as stale when the current active period has started more than five weeks ago
- Added filter to remove stale alerts from the line diagram page.
- Added tests

Interestingly the Symphony alert has been downgraded in priority and no longer shows on the line diagram anyway.


<!--
  What has changed, and why?
  - What does it accomplish/fix?
  - What thinking went into it?
  - What were the potential hurdles, and how were they overcome?
  - What remaining questions need to be answered, if any?
-->

## Screenshots

### Dev-Blue 
<img width="708" height="429" alt="Screenshot 2026-06-29 at 3 13 26 PM" src="https://github.com/user-attachments/assets/3c7cfd2a-b8c4-4015-b0bb-6d8350303345" />


### Local
<img width="706" height="339" alt="Screenshot 2026-06-29 at 3 13 19 PM" src="https://github.com/user-attachments/assets/e463a959-0159-44f6-92d3-028569d1d0ad" />


## How to test

http://localhost:4001/schedules/1/line

https://dev-blue.mbtace.com/schedules/1/line

On dev-green/blue, Bus 1 has a perpetual delay that started in May.  Confirm it shows up on dev-blue/green, but not on this branch (when pointed at dev-blue/green)



<!--
  Provide URLs where we can see the change
  - On a staging server if deployed to one, or:
  - A relative path to be checked out locally
-->
