### PR TITLE
Gate flags path behind basic auth

### DIFF
--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -76,7 +76,7 @@ defmodule DotcomWeb.Router do
   end
 
   scope "/_flags", Laboratory do
-    pipe_through([:browser, :browser_live])
+    pipe_through([:basic_auth])
     forward("/", Router)
   end
 


### PR DESCRIPTION
## Scope

While it's unlikely that users outside the MBTA organization will visit the feature-flagging route, we should gate it behind `basic_auth`. 

## How to test
* Navigate to `/_flags`
* Input credentials
