### PR TITLE
feat(CMS.Repo): cache teasers response

### DIFF
--- a/lib/cms/repo.ex
+++ b/lib/cms/repo.ex
@@ -280,8 +280,13 @@ defmodule CMS.Repo do
   def teasers(opts \\ []) when is_list(opts) do
     opts
     |> teaser_path()
-    |> @cms_api.view(teaser_params(opts))
+    |> get_teaser_response(teaser_params(opts))
     |> do_teasers(opts)
+  end
+
+  @decorate cacheable(cache: @cache, on_error: :nothing, opts: [ttl: :timer.minutes(5)])
+  defp get_teaser_response(path, params) do
+    @cms_api.view(path, params)
   end
 
   @spec teaser_path(Keyword.t()) :: String.t()


### PR DESCRIPTION
## Scope

All the other content pulled into the homepage is cached except for the teasers, now they are too!

## Implementation

This particular call populates the Press Releases and Events section of the homepage, and is called a few other places around the website. From the content folks, Sarah considers 5 minutes an okay TTL for this type of content. And it should also be sufficient to make a notable impact on the number of requests we send to Drupal during a request flood.
