### PR TITLE
perf: Don't recompute subway status on the homepage on every page load

### DIFF
--- a/lib/dotcom_web/controllers/page_controller.ex
+++ b/lib/dotcom_web/controllers/page_controller.ex
@@ -21,6 +21,8 @@ defmodule DotcomWeb.PageController do
   @type content :: Banner.t() | Teaser.t() | WhatsHappeningItem.t()
   @type whats_happening_set :: {nil | [WhatsHappeningItem.t()], nil | [WhatsHappeningItem.t()]}
 
+  @subway_status_cache Application.compile_env!(:dotcom, :system_status_cache_modules)[:subway]
+
   def index(conn, _params) do
     {promoted, remainder} = whats_happening_items()
     banner = banner()
@@ -137,6 +139,6 @@ defmodule DotcomWeb.PageController do
   defp do_add_utm_url(item, url), do: %{item | utm_url: url}
 
   defp subway_status(conn, _opts) do
-    assign(conn, :subway_status, Dotcom.SystemStatus.subway_status())
+    assign(conn, :subway_status, @subway_status_cache.subway_status())
   end
 end


### PR DESCRIPTION
## Scope

Way back when, we [introduced](https://github.com/mbta/dotcom/pull/2675) `SystemStatus.SubwayCache`, which computes subway status whenever there's an update to alerts, so that each consumer doesn't need to load the alerts and re-compute status on its own.

...but the homepage wasn't using it!

**Asana Ticket:** [📈 Don't re-compute subway status on each homepage load](https://app.asana.com/1/15492006741476/project/1215975015154295/task/1216013342009144?focus=true)

## How to test

Look at subway status on the [homepage](http://localhost:4001), and compare it to the analogous deployed environment. Observe no difference.