### PR TITLE
feat(WorldCup): Hide past matches and show teams for upcoming matches when known

### DIFF
--- a/lib/dotcom_web/components/world_cup_timetable/match_link.ex
+++ b/lib/dotcom_web/components/world_cup_timetable/match_link.ex
@@ -11,11 +11,13 @@ defmodule DotcomWeb.WorldCupTimetable.MatchLink do
     :bolivia,
     :england,
     :france,
+    :germany,
     :ghana,
     :haiti,
     :iraq,
     :morocco,
     :norway,
+    :paraguay,
     :scotland,
     :suriname
   ]
@@ -24,6 +26,7 @@ defmodule DotcomWeb.WorldCupTimetable.MatchLink do
   attr :selected, :boolean, default: false
   attr :label, :string, required: true
   attr :teams, :any, required: true
+  attr :match_title, :string, default: nil
   attr :time, Time, required: true
 
   def match_link(assigns) do
@@ -33,6 +36,7 @@ defmodule DotcomWeb.WorldCupTimetable.MatchLink do
       patch={~p"/schedules/bostonstadium?#{[date: Date.to_string(@date)]}"}
     >
       <div class="font-bold">{@label} ({formatted_datetime(@date, @time)})</div>
+      <.match_title match_title={@match_title} teams={@teams} />
       <.teams selected={false} teams={@teams} />
     </.link>
     """
@@ -42,6 +46,7 @@ defmodule DotcomWeb.WorldCupTimetable.MatchLink do
     ~H"""
     <div class="w-full p-sm rounded-lg border-xs border-charcoal-70 no-underline bg-brand-primary text-white justify-between">
       <div class="font-bold">{@label} ({formatted_datetime(@date, @time)})</div>
+      <.match_title match_title={@match_title} teams={@teams} />
       <.teams selected teams={@teams} />
     </div>
     """
@@ -52,6 +57,10 @@ defmodule DotcomWeb.WorldCupTimetable.MatchLink do
       date: date |> Dotcom.Utils.Time.format!(:month_day_short),
       time: time |> Util.narrow_time()
     )
+  end
+
+  defp teams(%{teams: nil} = assigns) do
+    ~H""
   end
 
   defp teams(%{teams: [_team1, _team2]} = assigns) do
@@ -66,6 +75,14 @@ defmodule DotcomWeb.WorldCupTimetable.MatchLink do
   defp teams(assigns) do
     ~H"""
     <span class="text-lg font-bold">{@teams}</span>
+    """
+  end
+
+  defp match_title(assigns) do
+    ~H"""
+    <span class={[if(@teams == nil, do: "text-lg", else: "text-sm"), "font-bold"]}>
+      {@match_title}
+    </span>
     """
   end
 

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -178,7 +178,7 @@ defmodule DotcomWeb.WorldCupTimetableLive do
   defp upcoming_matches() do
     @match_list
     |> Enum.reject(fn %{match_date: date} ->
-      Date.before?(date, Dotcom.Utils.ServiceDateTime.service_date())
+      Date.before?(date |> Date.shift(day: 1), Dotcom.Utils.ServiceDateTime.service_date())
     end)
   end
 end

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -180,5 +180,9 @@ defmodule DotcomWeb.WorldCupTimetableLive do
     |> Enum.reject(fn %{match_date: date} ->
       Date.before?(date |> Date.shift(day: 1), Dotcom.Utils.ServiceDateTime.service_date())
     end)
+    |> case do
+      [] -> @match_list |> Enum.take(-1)
+      upcoming_matches -> upcoming_matches
+    end
   end
 end

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -85,9 +85,11 @@ defmodule DotcomWeb.WorldCupTimetableLive do
     route = @routes_repo.get("CR-Foxboro")
     alerts = @alerts_repo.by_route_ids([route.id], now)
 
+    match_list = upcoming_matches()
+
     {:ok,
      assign(socket, %{
-       match_list: @match_list,
+       match_list: match_list,
        selected_match: nil,
        date_time: @date_time.now(),
        route: route,
@@ -121,5 +123,12 @@ defmodule DotcomWeb.WorldCupTimetableLive do
       />
     </svg>
     """
+  end
+
+  defp upcoming_matches() do
+    @match_list
+    |> Enum.reject(fn {date, _time, _title, _teams, _timetable} ->
+      Date.before?(date, Dotcom.Utils.ServiceDateTime.service_date())
+    end)
   end
 end

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -90,8 +90,8 @@ defmodule DotcomWeb.WorldCupTimetableLive do
       match_date: ~D[2026-06-29],
       match_time: ~T[16:30:00],
       match_number: ~t"Match 74",
-      teams: [~t"Round of 32"],
-      match_title: nil,
+      teams: [:germany, :paraguay],
+      match_title: ~t"Round of 32",
       boarding_groups: [
         {~t"Boarding Group A", [~T[09:45:00], ~T[10:30:00]], [~T[11:45:00], ~T[12:30:00]]},
         {~t"Boarding Group B", [~T[11:00:00], ~T[11:30:00]], [~T[12:45:00], ~T[13:30:00]]},
@@ -104,8 +104,8 @@ defmodule DotcomWeb.WorldCupTimetableLive do
       match_date: ~D[2026-07-09],
       match_time: ~T[16:00:00],
       match_number: ~t"Match 97",
-      teams: [~t"Quarter Finals"],
-      match_title: nil,
+      teams: nil,
+      match_title: ~t"Quarter Finals",
       boarding_groups: [
         {~t"Boarding Group A", [~T[09:15:00], ~T[10:00:00]], [~T[11:15:00], ~T[12:00:00]]},
         {~t"Boarding Group B", [~T[10:30:00], ~T[11:00:00]], [~T[12:15:00], ~T[13:00:00]]},

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -103,7 +103,15 @@ defmodule DotcomWeb.WorldCupTimetableLive do
   end
 
   defp selected_match(selected_date) do
-    Enum.find(@match_list, fn {date, _, _, _, _} -> Date.to_string(date) == selected_date end)
+    case upcoming_matches() do
+      [match] ->
+        match
+
+      matches ->
+        Enum.find(matches, fn {date, _, _, _, _} ->
+          Date.to_string(date) == selected_date
+        end)
+    end
   end
 
   defp ticket_icon(assigns) do

--- a/lib/dotcom_web/live/world_cup_timetable_live.ex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.ex
@@ -16,67 +16,109 @@ defmodule DotcomWeb.WorldCupTimetableLive do
   @date_time Application.compile_env!(:dotcom, :date_time_module)
 
   @match_list [
-    {~D[2026-06-13], ~T[21:00:00], ~t"Match 5", [:haiti, :scotland],
-     [
-       {~t"Boarding Group A", [~T[14:15:00], ~T[14:45:00]], [~T[16:15:00], ~T[17:00:00]]},
-       {~t"Boarding Group B", [~T[15:30:00], ~T[16:00:00]], [~T[17:15:00], ~T[18:00:00]]},
-       {~t"Boarding Group C", [~T[16:00:00], ~T[16:30:00]], [~T[18:15:00], ~T[19:00:00]]},
-       {~t"Boarding Group D", [~T[17:00:00], ~T[17:30:00]], [~T[19:15:00], ~T[19:30:00]]},
-       {~t"Boarding Group E", [~T[17:45:00], ~T[18:00:00]], [~T[19:15:00], ~T[19:30:00]]}
-     ]},
-    {~D[2026-06-16], ~T[18:00:00], ~t"Match 18", [:iraq, :norway],
-     [
-       {~t"Boarding Group A", [~T[11:15:00], ~T[12:00:00]], [~T[13:15:00], ~T[14:00:00]]},
-       {~t"Boarding Group B", [~T[12:30:00], ~T[13:00:00]], [~T[14:15:00], ~T[15:00:00]]},
-       {~t"Boarding Group C", [~T[13:00:00], ~T[13:30:00]], [~T[15:15:00], ~T[16:00:00]]},
-       {~t"Boarding Group D", [~T[14:00:00], ~T[14:30:00]], [~T[16:15:00], ~T[16:30:00]]},
-       {~t"Boarding Group E", [~T[14:45:00], ~T[15:00:00]], [~T[16:15:00], ~T[16:30:00]]}
-     ]},
-    {~D[2026-06-19], ~T[18:00:00], ~t"Match 30", [:scotland, :morocco],
-     [
-       {~t"Boarding Group A", [~T[11:15:00], ~T[12:00:00]], [~T[13:15:00], ~T[14:00:00]]},
-       {~t"Boarding Group B", [~T[12:30:00], ~T[13:00:00]], [~T[14:15:00], ~T[15:00:00]]},
-       {~t"Boarding Group C", [~T[13:00:00], ~T[13:30:00]], [~T[15:15:00], ~T[16:00:00]]},
-       {~t"Boarding Group D", [~T[14:00:00], ~T[14:30:00]], [~T[16:15:00], ~T[16:30:00]]},
-       {~t"Boarding Group E", [~T[14:45:00], ~T[15:00:00]], [~T[16:15:00], ~T[16:30:00]]}
-     ]},
-    {~D[2026-06-23], ~T[16:00:00], ~t"Match 45", [:england, :ghana],
-     [
-       {~t"Boarding Group A", [~T[09:15:00], ~T[10:00:00]], [~T[11:15:00], ~T[12:00:00]]},
-       {~t"Boarding Group B", [~T[10:30:00], ~T[11:00:00]], [~T[12:15:00], ~T[13:00:00]]},
-       {~t"Boarding Group C", [~T[11:00:00], ~T[11:30:00]], [~T[13:15:00], ~T[14:00:00]]},
-       {~t"Boarding Group D", [~T[12:00:00], ~T[12:30:00]], [~T[14:15:00], ~T[14:30:00]]},
-       {~t"Boarding Group E", [~T[12:45:00], ~T[13:00:00]], [~T[14:15:00], ~T[14:30:00]]}
-     ]},
-    {~D[2026-06-26], ~T[15:00:00], ~t"Match 61", [:norway, :france],
-     [
-       {~t"Boarding Group A", [~T[08:15:00], ~T[09:00:00]], [~T[10:15:00], ~T[11:00:00]]},
-       {~t"Boarding Group B", [~T[09:30:00], ~T[10:00:00]], [~T[11:15:00], ~T[12:00:00]]},
-       {~t"Boarding Group C", [~T[10:00:00], ~T[10:30:00]], [~T[12:15:00], ~T[13:00:00]]},
-       {~t"Boarding Group D", [~T[11:00:00], ~T[11:30:00]], [~T[13:15:00], ~T[13:30:00]]},
-       {~t"Boarding Group E", [~T[11:45:00], ~T[12:00:00]], [~T[13:15:00], ~T[13:30:00]]}
-     ]},
-    {~D[2026-06-29], ~T[16:30:00], ~t"Match 74", [~t"Round of 32"],
-     [
-       {~t"Boarding Group A", [~T[09:45:00], ~T[10:30:00]], [~T[11:45:00], ~T[12:30:00]]},
-       {~t"Boarding Group B", [~T[11:00:00], ~T[11:30:00]], [~T[12:45:00], ~T[13:30:00]]},
-       {~t"Boarding Group C", [~T[11:30:00], ~T[12:00:00]], [~T[13:45:00], ~T[14:30:00]]},
-       {~t"Boarding Group D", [~T[12:30:00], ~T[13:00:00]], [~T[14:45:00], ~T[15:00:00]]},
-       {~t"Boarding Group E", [~T[13:15:00], ~T[13:30:00]], [~T[14:45:00], ~T[15:00:00]]}
-     ]},
-    {~D[2026-07-09], ~T[16:00:00], ~t"Match 97", [~t"Quarter Finals"],
-     [
-       {~t"Boarding Group A", [~T[09:15:00], ~T[10:00:00]], [~T[11:15:00], ~T[12:00:00]]},
-       {~t"Boarding Group B", [~T[10:30:00], ~T[11:00:00]], [~T[12:15:00], ~T[13:00:00]]},
-       {~t"Boarding Group C", [~T[11:00:00], ~T[11:30:00]], [~T[13:15:00], ~T[14:00:00]]},
-       {~t"Boarding Group D", [~T[12:00:00], ~T[12:30:00]], [~T[14:15:00], ~T[14:30:00]]},
-       {~t"Boarding Group E", [~T[12:45:00], ~T[13:00:00]], [~T[14:15:00], ~T[14:30:00]]}
-     ]}
+    %{
+      match_date: ~D[2026-06-13],
+      match_time: ~T[21:00:00],
+      match_number: ~t"Match 5",
+      teams: [:haiti, :scotland],
+      match_title: nil,
+      boarding_groups: [
+        {~t"Boarding Group A", [~T[14:15:00], ~T[14:45:00]], [~T[16:15:00], ~T[17:00:00]]},
+        {~t"Boarding Group B", [~T[15:30:00], ~T[16:00:00]], [~T[17:15:00], ~T[18:00:00]]},
+        {~t"Boarding Group C", [~T[16:00:00], ~T[16:30:00]], [~T[18:15:00], ~T[19:00:00]]},
+        {~t"Boarding Group D", [~T[17:00:00], ~T[17:30:00]], [~T[19:15:00], ~T[19:30:00]]},
+        {~t"Boarding Group E", [~T[17:45:00], ~T[18:00:00]], [~T[19:15:00], ~T[19:30:00]]}
+      ]
+    },
+    %{
+      match_date: ~D[2026-06-16],
+      match_time: ~T[18:00:00],
+      match_number: ~t"Match 18",
+      teams: [:iraq, :norway],
+      match_title: nil,
+      boarding_groups: [
+        {~t"Boarding Group A", [~T[11:15:00], ~T[12:00:00]], [~T[13:15:00], ~T[14:00:00]]},
+        {~t"Boarding Group B", [~T[12:30:00], ~T[13:00:00]], [~T[14:15:00], ~T[15:00:00]]},
+        {~t"Boarding Group C", [~T[13:00:00], ~T[13:30:00]], [~T[15:15:00], ~T[16:00:00]]},
+        {~t"Boarding Group D", [~T[14:00:00], ~T[14:30:00]], [~T[16:15:00], ~T[16:30:00]]},
+        {~t"Boarding Group E", [~T[14:45:00], ~T[15:00:00]], [~T[16:15:00], ~T[16:30:00]]}
+      ]
+    },
+    %{
+      match_date: ~D[2026-06-19],
+      match_time: ~T[18:00:00],
+      match_number: ~t"Match 30",
+      teams: [:scotland, :morocco],
+      match_title: nil,
+      boarding_groups: [
+        {~t"Boarding Group A", [~T[11:15:00], ~T[12:00:00]], [~T[13:15:00], ~T[14:00:00]]},
+        {~t"Boarding Group B", [~T[12:30:00], ~T[13:00:00]], [~T[14:15:00], ~T[15:00:00]]},
+        {~t"Boarding Group C", [~T[13:00:00], ~T[13:30:00]], [~T[15:15:00], ~T[16:00:00]]},
+        {~t"Boarding Group D", [~T[14:00:00], ~T[14:30:00]], [~T[16:15:00], ~T[16:30:00]]},
+        {~t"Boarding Group E", [~T[14:45:00], ~T[15:00:00]], [~T[16:15:00], ~T[16:30:00]]}
+      ]
+    },
+    %{
+      match_date: ~D[2026-06-23],
+      match_time: ~T[16:00:00],
+      match_number: ~t"Match 45",
+      teams: [:england, :ghana],
+      match_title: nil,
+      boarding_groups: [
+        {~t"Boarding Group A", [~T[09:15:00], ~T[10:00:00]], [~T[11:15:00], ~T[12:00:00]]},
+        {~t"Boarding Group B", [~T[10:30:00], ~T[11:00:00]], [~T[12:15:00], ~T[13:00:00]]},
+        {~t"Boarding Group C", [~T[11:00:00], ~T[11:30:00]], [~T[13:15:00], ~T[14:00:00]]},
+        {~t"Boarding Group D", [~T[12:00:00], ~T[12:30:00]], [~T[14:15:00], ~T[14:30:00]]},
+        {~t"Boarding Group E", [~T[12:45:00], ~T[13:00:00]], [~T[14:15:00], ~T[14:30:00]]}
+      ]
+    },
+    %{
+      match_date: ~D[2026-06-26],
+      match_time: ~T[15:00:00],
+      match_number: ~t"Match 61",
+      teams: [:norway, :france],
+      match_title: nil,
+      boarding_groups: [
+        {~t"Boarding Group A", [~T[08:15:00], ~T[09:00:00]], [~T[10:15:00], ~T[11:00:00]]},
+        {~t"Boarding Group B", [~T[09:30:00], ~T[10:00:00]], [~T[11:15:00], ~T[12:00:00]]},
+        {~t"Boarding Group C", [~T[10:00:00], ~T[10:30:00]], [~T[12:15:00], ~T[13:00:00]]},
+        {~t"Boarding Group D", [~T[11:00:00], ~T[11:30:00]], [~T[13:15:00], ~T[13:30:00]]},
+        {~t"Boarding Group E", [~T[11:45:00], ~T[12:00:00]], [~T[13:15:00], ~T[13:30:00]]}
+      ]
+    },
+    %{
+      match_date: ~D[2026-06-29],
+      match_time: ~T[16:30:00],
+      match_number: ~t"Match 74",
+      teams: [~t"Round of 32"],
+      match_title: nil,
+      boarding_groups: [
+        {~t"Boarding Group A", [~T[09:45:00], ~T[10:30:00]], [~T[11:45:00], ~T[12:30:00]]},
+        {~t"Boarding Group B", [~T[11:00:00], ~T[11:30:00]], [~T[12:45:00], ~T[13:30:00]]},
+        {~t"Boarding Group C", [~T[11:30:00], ~T[12:00:00]], [~T[13:45:00], ~T[14:30:00]]},
+        {~t"Boarding Group D", [~T[12:30:00], ~T[13:00:00]], [~T[14:45:00], ~T[15:00:00]]},
+        {~t"Boarding Group E", [~T[13:15:00], ~T[13:30:00]], [~T[14:45:00], ~T[15:00:00]]}
+      ]
+    },
+    %{
+      match_date: ~D[2026-07-09],
+      match_time: ~T[16:00:00],
+      match_number: ~t"Match 97",
+      teams: [~t"Quarter Finals"],
+      match_title: nil,
+      boarding_groups: [
+        {~t"Boarding Group A", [~T[09:15:00], ~T[10:00:00]], [~T[11:15:00], ~T[12:00:00]]},
+        {~t"Boarding Group B", [~T[10:30:00], ~T[11:00:00]], [~T[12:15:00], ~T[13:00:00]]},
+        {~t"Boarding Group C", [~T[11:00:00], ~T[11:30:00]], [~T[13:15:00], ~T[14:00:00]]},
+        {~t"Boarding Group D", [~T[12:00:00], ~T[12:30:00]], [~T[14:15:00], ~T[14:30:00]]},
+        {~t"Boarding Group E", [~T[12:45:00], ~T[13:00:00]], [~T[14:15:00], ~T[14:30:00]]}
+      ]
+    }
   ]
 
   def match_day?() do
     date = Dotcom.Utils.ServiceDateTime.service_date(@date_time_module.now())
-    @match_list |> Enum.any?(fn {match_date, _, _, _, _} -> match_date == date end)
+    @match_list |> Enum.any?(fn %{match_date: match_date} -> match_date == date end)
   end
 
   @impl true
@@ -108,8 +150,8 @@ defmodule DotcomWeb.WorldCupTimetableLive do
         match
 
       matches ->
-        Enum.find(matches, fn {date, _, _, _, _} ->
-          Date.to_string(date) == selected_date
+        Enum.find(matches, fn %{match_date: match_date} ->
+          Date.to_string(match_date) == selected_date
         end)
     end
   end
@@ -135,7 +177,7 @@ defmodule DotcomWeb.WorldCupTimetableLive do
 
   defp upcoming_matches() do
     @match_list
-    |> Enum.reject(fn {date, _time, _title, _teams, _timetable} ->
+    |> Enum.reject(fn %{match_date: date} ->
       Date.before?(date, Dotcom.Utils.ServiceDateTime.service_date())
     end)
   end

--- a/lib/dotcom_web/live/world_cup_timetable_live.html.heex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.html.heex
@@ -34,6 +34,7 @@
     <%= case @selected_match do %>
       <% {date, time, label, teams, _} -> %>
         <.button
+          :if={Enum.count(@match_list) > 1}
           variant="secondary"
           class="self-start"
           phx-click={JS.patch(~p"/schedules/bostonstadium")}

--- a/lib/dotcom_web/live/world_cup_timetable_live.html.heex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.html.heex
@@ -32,7 +32,7 @@
     class="w-full flex flex-col gap-4"
   >
     <%= case @selected_match do %>
-      <% {date, time, label, teams, _} -> %>
+      <% %{match_date: date, match_time: time, match_number: label, teams: teams} -> %>
         <.button
           :if={Enum.count(@match_list) > 1}
           variant="secondary"
@@ -47,7 +47,7 @@
         <div class="font-bold">Select a Match</div>
         <div class="grid grid-cols-[repeat(auto-fit,minmax(min(16.5rem,100%),1fr))] gap-2">
           <.match_link
-            :for={{date, time, label, teams, _} <- @match_list}
+            :for={%{match_date: date, match_time: time, match_number: label, teams: teams} <- @match_list}
             date={date}
             time={time}
             label={label}
@@ -57,7 +57,7 @@
     <% end %>
   </nav>
   <div :if={@selected_match} class="w-full overflow-x-auto">
-    <% {_, _, _, _, group_times} = @selected_match %>
+    <% %{boarding_groups: group_times} = @selected_match %>
     <h2 class="mt-0">{~t(Boarding Groups)}</h2>
     <table class="mbta-table max-w-fit ">
       <thead class="bg-brand-primary-lightest-contrast">

--- a/lib/dotcom_web/live/world_cup_timetable_live.html.heex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.html.heex
@@ -32,7 +32,7 @@
     class="w-full flex flex-col gap-4"
   >
     <%= case @selected_match do %>
-      <% %{match_date: date, match_time: time, match_number: label, teams: teams} -> %>
+      <% %{match_date: date, match_time: time, match_number: label, teams: teams, match_title: match_title} -> %>
         <.button
           :if={Enum.count(@match_list) > 1}
           variant="secondary"
@@ -42,16 +42,17 @@
           <.icon name="chevron-left" class="size-4 fill-current" aria-hidden />
           {~t(View all matches)}
         </.button>
-        <.selected_match_banner date={date} time={time} label={label} teams={teams} />
+        <.selected_match_banner date={date} time={time} label={label} teams={teams} match_title={match_title} />
       <% _ -> %>
         <div class="font-bold">Select a Match</div>
         <div class="grid grid-cols-[repeat(auto-fit,minmax(min(16.5rem,100%),1fr))] gap-2">
           <.match_link
-            :for={%{match_date: date, match_time: time, match_number: label, teams: teams} <- @match_list}
+            :for={%{match_date: date, match_time: time, match_number: label, teams: teams, match_title: match_title} <- @match_list}
             date={date}
             time={time}
             label={label}
             teams={teams}
+	    match_title={match_title}
           />
         </div>
     <% end %>

--- a/lib/dotcom_web/live/world_cup_timetable_live.html.heex
+++ b/lib/dotcom_web/live/world_cup_timetable_live.html.heex
@@ -42,17 +42,31 @@
           <.icon name="chevron-left" class="size-4 fill-current" aria-hidden />
           {~t(View all matches)}
         </.button>
-        <.selected_match_banner date={date} time={time} label={label} teams={teams} match_title={match_title} />
+        <.selected_match_banner
+          date={date}
+          time={time}
+          label={label}
+          teams={teams}
+          match_title={match_title}
+        />
       <% _ -> %>
         <div class="font-bold">Select a Match</div>
         <div class="grid grid-cols-[repeat(auto-fit,minmax(min(16.5rem,100%),1fr))] gap-2">
           <.match_link
-            :for={%{match_date: date, match_time: time, match_number: label, teams: teams, match_title: match_title} <- @match_list}
+            :for={
+              %{
+                match_date: date,
+                match_time: time,
+                match_number: label,
+                teams: teams,
+                match_title: match_title
+              } <- @match_list
+            }
             date={date}
             time={time}
             label={label}
             teams={teams}
-	    match_title={match_title}
+            match_title={match_title}
           />
         </div>
     <% end %>

--- a/priv/static/icon-svg/icon-flag-germany.svg
+++ b/priv/static/icon-svg/icon-flag-germany.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <mask id="icon-flag-germany-a">
+    <circle cx="256" cy="256" r="256" fill="#fff"/>
+  </mask>
+  <g mask="url(#icon-flag-germany-a)">
+    <path fill="#ffda44" d="m0 345 256.7-25.5L512 345v167H0z"/>
+    <path fill="#d80027" d="m0 167 255-23 257 23v178H0z"/>
+    <path fill="#333" d="M0 0h512v167H0z"/>
+  </g>
+</svg>

--- a/priv/static/icon-svg/icon-flag-paraguay.svg
+++ b/priv/static/icon-svg/icon-flag-paraguay.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <mask id="icon-flag-paraguay-a">
+    <circle cx="256" cy="256" r="256" fill="#fff"/>
+  </mask>
+  <g mask="url(#icon-flag-paraguay-a)">
+    <path fill="#eee" d="m0 144.7 255.3-36.5L512 144.7v222.6L250.5 407 0 367.3z"/>
+    <path fill="#d80027" d="M0 0h512v144.7H0z"/>
+    <path fill="#0052b4" d="M0 367.3h512V512H0z"/>
+    <path fill="#6da544" d="m319 182-23.6 23.5a55.5 55.5 0 0 1-39.4 95 55.7 55.7 0 0 1-39.3-95L193 182a89 89 0 1 0 126 0z"/>
+    <path fill="#ffda44" d="m256 211.5 8.3 25.5H291l-21.7 15.8 8.3 25.5-21.7-15.8-21.7 15.8 8.3-25.5-21.7-15.8h26.8z"/>
+  </g>
+</svg>

--- a/test/dotcom_web/live/world_cup_timetable_live_test.exs
+++ b/test/dotcom_web/live/world_cup_timetable_live_test.exs
@@ -14,7 +14,7 @@ defmodule DotcomWeb.WorldCupTimetableLiveTest do
         Test.Support.Factories.Routes.Route.commuter_rail_route_factory(%{id: "CR-Foxboro"})
       end)
 
-      datetime = Faker.DateTime.between(~D[2026-01-01], ~D[2026-12-30])
+      datetime = Faker.DateTime.between(~D[2026-01-01], ~D[2026-06-10])
 
       stub(Dotcom.Utils.DateTime.Mock, :now, fn ->
         datetime


### PR DESCRIPTION
## Scope

No ticket; I just thought it would make the page easier to navigate if we didn't show past matches, and we already have the ability to show 

## Implementation

This may be easiest to review commit-by-commit. The non-refactor commits ([1](https://github.com/mbta/dotcom/pull/3295/changes/8c6e64b68b77ccf72a7b52502cf6f7d85948b23f), [2](https://github.com/mbta/dotcom/pull/3295/changes/233e66ff6988fdfb70e5c11ce1e699dd34022969), and [4](https://github.com/mbta/dotcom/pull/3295/changes/1764d715e8fcbc4d24238a260d77a1df35f5b30f)) should be pretty easy to review on their own. I made the refactor commit because dealing with tuples more than 2-3 items long is a pain.

## Screenshots

<img width="2708" height="1636" alt="Screenshot 2026-06-29 at 10 34 04 AM" src="https://github.com/user-attachments/assets/dd66d706-0766-4bea-af81-862323ad906b" />


## How to test

Check out the [Boston Stadium Trains page](http://localhost:4001/schedules/bostonstadium)!

If you want to pretend that it's a future date, update [the definition of now](https://github.com/mbta/dotcom/blob/7819b4f0f6fa50a207cc83588b255cc3aec4cb89/lib/dotcom/utils/date_time.ex#L30) to 👇 
```elixir
def now(), do: ~N[2026-06-30T03:00:00] |> Timex.to_datetime("America/New_York")
```
