### PR TITLE
fix(perf): Store subway status in ETS, rather than a GenServer's state

### DIFF
--- a/lib/dotcom/system_status/subway_cache.ex
+++ b/lib/dotcom/system_status/subway_cache.ex
@@ -41,7 +41,7 @@ defmodule Dotcom.SystemStatus.SubwayCache do
 
     status = status()
 
-    :ets.new(:subway_status, [:named_table, :set, :protected])
+    :ets.new(:subway_status, [:named_table, :set, :protected, read_concurrency: true])
     :ets.insert(:subway_status, {"status", status})
 
     {:ok, status}

--- a/lib/dotcom/system_status/subway_cache.ex
+++ b/lib/dotcom/system_status/subway_cache.ex
@@ -21,7 +21,11 @@ defmodule Dotcom.SystemStatus.SubwayCache do
 
   @impl Behaviour
   def subway_status() do
-    GenServer.call(__MODULE__, :subway_status)
+    :ets.lookup(:subway_status, "status")
+    |> case do
+      [{"status", status}] -> status
+      _ -> status()
+    end
   end
 
   @impl Behaviour
@@ -35,12 +39,12 @@ defmodule Dotcom.SystemStatus.SubwayCache do
   def init(_opts) do
     Alerts.Cache.Store.subscribe()
 
-    {:ok, status()}
-  end
+    status = status()
 
-  @impl true
-  def handle_call(:subway_status, _from, status) do
-    {:reply, status, status}
+    :ets.new(:subway_status, [:named_table, :set, :protected])
+    :ets.insert(:subway_status, {"status", status})
+
+    {:ok, status}
   end
 
   @impl true
@@ -48,6 +52,7 @@ defmodule Dotcom.SystemStatus.SubwayCache do
     new_status = status()
 
     if new_status != old_status do
+      :ets.insert(:subway_status, {"status", new_status})
       DotcomWeb.Endpoint.broadcast(@pubsub_topic, "subway_status_updated", new_status)
     end
 


### PR DESCRIPTION
## Scope

Turns out - having every consumer request subway status from the `SubwayCache` GenServer raises the possibility of overwhelming the GenServer, since GenServers are a single thread.

This change has the homepage controller process reach directly into an ETS table instead (well, through the `SubwayCache` module, but at least it doesn't use `GenServer.call`).

**Asana Ticket:** [📈 Don't interact with  SystemStatus.SubwayCache per page load](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216126412298207?focus=true)

## Implementation

- Store subway status in an ETS table, rather than GenServer state.
- `SystemStatus.SubwayCache` still alerts consumers when there's been an update.

## Screenshots

No visible change.

## How to test

Observe that subway status still works as usual, and even that [the subway alerts page](http://localhost:4001/alerts/subway) still live-updates!