### PR TITLE
fix(Departures): Don't hide `trip_stop`s from trips that the vehicle isn't currently serving

### DIFF
--- a/lib/dotcom/schedule_finder/trip_details.ex
+++ b/lib/dotcom/schedule_finder/trip_details.ex
@@ -259,7 +259,10 @@ defmodule Dotcom.ScheduleFinder.TripDetails do
   defp drop_predicted_schedules_before_current_station(predicted_schedules, %Vehicle{} = vehicle),
     do:
       predicted_schedules
-      |> Enum.reject(&(PredictedSchedule.stop_sequence(&1) < vehicle.stop_sequence))
+      |> Enum.reject(
+        &(PredictedSchedule.trip_id(&1) == vehicle.trip_id &&
+            PredictedSchedule.stop_sequence(&1) < vehicle.stop_sequence)
+      )
 
   defp drop_first_trip_stop_if_vehicle_is_stopped(
          [_trip_stop_to_drop | remaining_trip_stops],

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -2415,6 +2415,38 @@ defmodule Dotcom.UpcomingDeparturesTest do
       assert trip_details.stops_before |> Enum.map(& &1.stop_id) == [stop_1.id, stop_2.id]
     end
 
+    test "drops all stops before the current vehicle" do
+      # Setup
+      %{
+        predicted_arrival_times: [_, _, _, arrival_time, _],
+        predictions: predictions,
+        stop_sequences: [_, _, _, stop_seq, _],
+        stops: [_stop_0, _stop_1, _stop_2, stop, _],
+        trip_id: trip_id,
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(
+          stop_count: 5,
+          vehicle_stop_index: 3
+        )
+
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
+      # Exercise
+      trip_details =
+        UpcomingDepartures.trip_details(%{
+          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
+        })
+
+      # Verify
+      assert trip_details.stops_before == []
+    end
+
     test "shows a vehicle status of :scheduled_to_depart if the trip has no predictions and all schedules are in the future" do
       # Setup
       %{

--- a/test/dotcom/upcoming_departures_test.exs
+++ b/test/dotcom/upcoming_departures_test.exs
@@ -2447,6 +2447,43 @@ defmodule Dotcom.UpcomingDeparturesTest do
       assert trip_details.stops_before == []
     end
 
+    test "does not drop any stops if the vehicle is serving a different trip" do
+      # Setup
+      %{
+        predicted_arrival_times: [_, _, _, arrival_time, _],
+        predictions: predictions,
+        stop_sequences: [_, _, _, stop_seq, _],
+        stops: [stop_0, stop_1, stop_2, stop, _],
+        trip_id: trip_id,
+        vehicle: vehicle
+      } =
+        PredictedScheduleHelper.predicted_schedule_trip_data(
+          stop_count: 5,
+          vehicle_stop_index: 3,
+          vehicle_on_different_trip?: true
+        )
+
+      expect(Predictions.Repo.Mock, :all, fn _ -> predictions end)
+      expect(Schedules.Repo.Mock, :schedule_for_trip, fn ^trip_id -> [] end)
+      expect(Vehicles.Repo.Mock, :get, fn _ -> vehicle end)
+
+      # Exercise
+      trip_details =
+        UpcomingDepartures.trip_details(%{
+          now: Generators.ServiceDateTime.earlier_on_day(arrival_time),
+          stop_id: stop.id,
+          stop_sequence: stop_seq,
+          trip_id: trip_id
+        })
+
+      # Verify
+      assert trip_details.stops_before |> Enum.map(& &1.stop_id) == [
+               stop_0.id,
+               stop_1.id,
+               stop_2.id
+             ]
+    end
+
     test "shows a vehicle status of :scheduled_to_depart if the trip has no predictions and all schedules are in the future" do
       # Setup
       %{


### PR DESCRIPTION
<!--
  GitHub will add a Dotcom team member as a required reviewer;
  feel free to additionally assign other people if desired
-->

## Scope

The normal happy case is as follows:
- Imagine a trip serving **Stop A** (stop sequence `10`), **Stop B** (stop sequence `20`), and **Stop C** (stop sequence `30`)
- The vehicle has passed **Stop A**, so its current stop sequence is `20`.
- `TripDetails` hides **Stop A**, while still showing **Stops** **B** and **C**.

The bug is as follows:
- Imagine a trip `ABC` serving **Stop A** (stop sequence `10`) and **Stop B** (stop sequence `20`)
- The vehicle is currently serving a different trip `XYZ`, which visits **Stops X** (stop sequence `10`), **Y** (stop sequence `20`), and **Z** (stop sequence `30`)
- The vehicle has passed **Stop Y** on this previous trip, so its stop sequence is `30`.
- `TripDetails` for trip `ABC` compares the vehicle's stop sequence (`30`) to its own stop sequences, and erroneously hides **Stops A** and **B** (when they should be shown, because trip `ABC` hasn't even started yet).

**Asana Ticket:** [📅🔎🐞 Only hide stops in `TripDetails` based on stop sequence if the vehicle is serving the trip in question](https://app.asana.com/1/15492006741476/project/1210709545912056/task/1216127754736582?focus=true)

## Implementation

- When considering "already-visited" stops to drop in `TripDetails`, only drop `trip_stop`'s whose trip ID matches the vehicle's trip ID.

## Screenshots

<img width="1000" height="819" alt="Screenshot 2026-06-30 at 9 44 57 AM" src="https://github.com/user-attachments/assets/fcdeb05d-7f6f-4482-a228-a61f26edc771" />

## How to test

Most routes near or at the beginning of their route will have a few trips whose vehicle is `Finishing another trip` (which is the state where this bug can happen). For instance, the [Red Line at Alewife](http://localhost:4001/departures?route_id=Red&direction_id=0&stop_id=place-alfcl), or the [1 at Nubian](http://localhost:4001/departures?route_id=1&direction_id=0&stop_id=place-nubn).

On this branch, a trip in the state `Finishing another trip` will show the entire trip... on `main`, a trip in that state will drop earlier stops in its trip, seemingly at random.