### PR TITLE
fix(StopController): delete unused function

### DIFF
--- a/lib/dotcom_web/controllers/stop_controller.ex
+++ b/lib/dotcom_web/controllers/stop_controller.ex
@@ -253,6 +253,10 @@ defmodule DotcomWeb.StopController do
     json(conn, json_safe_routes)
   end
 
+  def api(conn, _params) do
+    json(conn, [])
+  end
+
   @doc "Redirect users who type in a URL with a slash to the correct URL"
   def stop_with_slash_redirect(conn, %{"path" => path}) do
     real_id = Enum.join(path, "/")

--- a/lib/dotcom_web/controllers/stop_controller.ex
+++ b/lib/dotcom_web/controllers/stop_controller.ex
@@ -15,7 +15,7 @@ defmodule DotcomWeb.StopController do
   alias Leaflet.MapData.Polyline
   alias Plug.Conn
   alias RoutePatterns.RoutePattern
-  alias Routes.{Group, Route}
+  alias Routes.Route
   alias Services.Service
   alias Stops.Stop
   alias Util.AndOr
@@ -244,19 +244,6 @@ defmodule DotcomWeb.StopController do
     Map.put(route_pattern, :representative_trip_polyline, polyline)
   end
 
-  @spec api(Conn.t(), map) :: Conn.t()
-  def api(conn, %{"id" => stop_id}) do
-    routes_by_stop = @routes_repo.by_stop(stop_id)
-    grouped_routes = grouped_routes(routes_by_stop)
-    routes_map = routes_map(grouped_routes, stop_id, conn.assigns.date_time)
-    json_safe_routes = json_safe_routes(routes_map)
-    json(conn, json_safe_routes)
-  end
-
-  def api(conn, _params) do
-    json(conn, [])
-  end
-
   @doc "Redirect users who type in a URL with a slash to the correct URL"
   def stop_with_slash_redirect(conn, %{"path" => path}) do
     real_id = Enum.join(path, "/")
@@ -282,14 +269,6 @@ defmodule DotcomWeb.StopController do
       nil -> {nil, stop_info}
       mattapan -> {mattapan, List.delete(stop_info, mattapan)}
     end
-  end
-
-  @spec grouped_routes([Route.t()]) :: [{Route.gtfs_route_type(), [Route.t()]}]
-  defp grouped_routes(routes) do
-    routes
-    |> Enum.sort_by(& &1.sort_order)
-    |> Enum.group_by(&Route.type_atom/1)
-    |> Enum.sort_by(&Group.sorter/1)
   end
 
   @spec routes_map([{Route.gtfs_route_type(), [Route.t()]}], Stop.id_t(), DateTime.t()) :: [
@@ -370,30 +349,6 @@ defmodule DotcomWeb.StopController do
 
   defp alerts(conn, _opts) do
     assign(conn, :alerts, AlertsRepo.all(conn.assigns.date_time))
-  end
-
-  @type json_safe_routes :: %{
-          required(:group_name) => atom,
-          required(:routes) => map
-        }
-  @spec json_safe_routes([routes_map_t]) :: [json_safe_routes]
-  defp json_safe_routes(routes_map) do
-    Enum.map(routes_map, fn group_and_routes ->
-      safe_routes = Enum.map(group_and_routes.routes, &json_safe_route_with_directions(&1))
-
-      %{
-        group_name: group_and_routes.group_name,
-        routes: safe_routes
-      }
-    end)
-  end
-
-  @spec json_safe_route_with_directions(route_with_directions) :: map
-  defp json_safe_route_with_directions(%{route: route, directions: directions}) do
-    %{
-      route: Route.to_json_safe(route),
-      directions: directions
-    }
   end
 
   @spec breadcrumbs(Stop.t(), [Route.t()]) :: [Util.Breadcrumb.t()]

--- a/lib/dotcom_web/router.ex
+++ b/lib/dotcom_web/router.ex
@@ -247,7 +247,6 @@ defmodule DotcomWeb.Router do
     get("/stops/Lansdowne", Redirector, to: "/stops/Yawkey")
     get("/stops/place-dudly", Redirector, to: "/stops/place-nubn")
 
-    get("/stops/api", StopController, :api)
     resources("/stops", StopController, only: [:index, :show])
     get("/stops/*path", StopController, :stop_with_slash_redirect)
 

--- a/test/dotcom_web/controllers/stop_controller_test.exs
+++ b/test/dotcom_web/controllers/stop_controller_test.exs
@@ -129,26 +129,6 @@ defmodule DotcomWeb.StopControllerTest do
     end
   end
 
-  describe "api" do
-    @tag :external
-    test "returns json with departure data", %{conn: conn} do
-      path = stop_path(conn, :api, id: "place-sstat")
-      assert path == "/stops/api?id=place-sstat"
-
-      response =
-        conn
-        |> get(path)
-        |> json_response(200)
-
-      assert is_list(response)
-      refute Enum.empty?(response)
-
-      for item <- response do
-        assert %{"group_name" => _, "routes" => _} = item
-      end
-    end
-  end
-
   describe "show/2" do
     setup _ do
       stub(Alerts.Repo.Mock, :by_route_ids, fn _stop_id, _datetime -> [] end)


### PR DESCRIPTION
## Scope

Sentry issue: [MBTA-DOTCOM-11R](https://mbtace.sentry.io/issues/6999517702/events/fe5148d201e14c1a84e5b49158e84f3f/)

## Implementation

~~Just added the missing function clause!~~
I'm not sure why it's being called without a stop ID, however I also can't find it being used _with_ a stop ID!
It seems that code was [added in this very old PR](https://github.com/mbta/dotcom-legacy/pull/3083/changes#diff-b3039cf99c66ed5cadf497c0a1e1273f19bab86c4159e9221e65af684c92678d), and this endpoint isn't used by anything anymore. So this PR deletes it.

## How to test

`/stops/api` will return a 404 instead of a 500 now 🤷🏼‍♀️ 