### PR TITLE
fix(Plugs.RecentlyVisited): handle task timeout

### DIFF
--- a/lib/dotcom_web/controllers/mode_controller.ex
+++ b/lib/dotcom_web/controllers/mode_controller.ex
@@ -6,9 +6,8 @@ defmodule DotcomWeb.ModeController do
 
   alias CMS.{Partial.Teaser, Repo}
   alias DotcomWeb.Mode
+  alias DotcomWeb.Plugs.RecentlyVisited
   alias Routes.Route
-
-  plug(DotcomWeb.Plugs.RecentlyVisited)
 
   def subway(conn, params), do: Mode.Hub.index(Mode.SubwayController, conn, params)
   def bus(conn, params), do: Mode.Hub.index(Mode.BusController, conn, params)
@@ -23,6 +22,7 @@ defmodule DotcomWeb.ModeController do
 
   def index(conn, _params) do
     conn
+    |> RecentlyVisited.call(RecentlyVisited.init([]))
     |> async_assign_default(:alerts, fn -> Alerts.Repo.all(conn.assigns.date_time) end, [])
     |> async_assign_default(:green_routes, fn -> green_routes() end)
     |> async_assign_default(:grouped_routes, fn -> filtered_grouped_routes([:bus]) end)

--- a/lib/dotcom_web/plugs/recently_visited.ex
+++ b/lib/dotcom_web/plugs/recently_visited.ex
@@ -30,18 +30,9 @@ defmodule DotcomWeb.Plugs.RecentlyVisited do
       routes
       |> String.split("|")
       |> Task.async_stream(&@routes_repo.get/1, max_concurrency: 4, on_timeout: :kill_task)
-      |> Enum.reduce([], &parse_route_response/2)
-      |> Enum.reverse()
+      |> Stream.filter(&match?({:ok, %Route{listed?: true}}, &1))
+      |> Stream.map(fn {:ok, route} -> route end)
 
     Conn.assign(conn, :recently_visited, route_list)
-  end
-
-  @spec parse_route_response({:ok, Route.t() | nil} | {:error, any}, [Route.t()]) :: [Route.t()]
-  defp parse_route_response({:ok, %Route{listed?: true} = route}, acc) do
-    [route | acc]
-  end
-
-  defp parse_route_response(_, acc) do
-    acc
   end
 end

--- a/lib/dotcom_web/plugs/recently_visited.ex
+++ b/lib/dotcom_web/plugs/recently_visited.ex
@@ -29,22 +29,11 @@ defmodule DotcomWeb.Plugs.RecentlyVisited do
     route_list =
       routes
       |> String.split("|")
-      |> Task.async_stream(&get_route/1)
+      |> Task.async_stream(&@routes_repo.get/1, max_concurrency: 4, on_timeout: :kill_task)
       |> Enum.reduce([], &parse_route_response/2)
       |> Enum.reverse()
 
     Conn.assign(conn, :recently_visited, route_list)
-  end
-
-  @spec get_route(String.t()) :: Route.t() | nil
-  defp get_route("Green") do
-    "Green-B"
-    |> @routes_repo.get()
-    |> Route.to_naive()
-  end
-
-  defp get_route(route) do
-    @routes_repo.get(route)
   end
 
   @spec parse_route_response({:ok, Route.t() | nil} | {:error, any}, [Route.t()]) :: [Route.t()]

--- a/test/dotcom_web/plugs/recently_visited_test.exs
+++ b/test/dotcom_web/plugs/recently_visited_test.exs
@@ -34,7 +34,7 @@ defmodule DotcomWeb.Plugs.RecentlyVisitedTest do
                %Route{} = green,
                %Route{} = green_b,
                %Route{} = blue
-             ] = conn.assigns.recently_visited
+             ] = conn.assigns.recently_visited |> Enum.to_list()
 
       assert red.id == "Red"
       assert green.id == "Green"
@@ -50,7 +50,7 @@ defmodule DotcomWeb.Plugs.RecentlyVisitedTest do
         |> Map.put(:cookies, cookies)
         |> RecentlyVisited.call([])
 
-      assert [%Route{id: "Red"}] = conn.assigns.recently_visited
+      assert [%Route{id: "Red"}] = conn.assigns.recently_visited |> Enum.to_list()
     end
 
     test "does not assign :recently_visited if cookie doesn't exist", %{conn: conn} do
@@ -86,7 +86,8 @@ defmodule DotcomWeb.Plugs.RecentlyVisitedTest do
         |> Map.put(:cookies, cookies)
         |> RecentlyVisited.call([])
 
-      assert {:ok, [%Route{id: "Red"}]} = Map.fetch(conn.assigns, :recently_visited)
+      assert {:ok, visited} = Map.fetch(conn.assigns, :recently_visited)
+      assert [%Route{id: "Red"}] = visited |> Enum.to_list()
     end
 
     test "does not include unlisted routes", %{conn: conn} do
@@ -103,7 +104,8 @@ defmodule DotcomWeb.Plugs.RecentlyVisitedTest do
         |> Map.put(:cookies, cookies)
         |> RecentlyVisited.call([])
 
-      assert {:ok, []} = Map.fetch(conn.assigns, :recently_visited)
+      assert {:ok, visited} = Map.fetch(conn.assigns, :recently_visited)
+      assert [] = visited |> Enum.to_list()
     end
   end
 end


### PR DESCRIPTION
## Scope

<!-- Why does this PR exist? -->

(from the homepage) [MBTA-DOTCOM-JN](https://mbtace.sentry.io/issues/6079862075/events/afd4cfe8de014220a8ff3449f67d3fac/)
(from the mode pages, e.g. `/schedules/bus`) [MBTA-DOTCOM-JM](https://mbtace.sentry.io/issues/6079861891/events/a28602675ed1432eb0cb6be382f0b851/)

```
Uncaught exit - {:timeout, {Task.Supervised, :stream, [5000]}}
    lib/task/supervised.ex:349: Elixir.Task.Supervised.Task.Supervised.stream_reduce/7
    lib/enum.ex:4570: Elixir.Enum.Enum.reduce/3
    lib/dotcom_web/plugs/recently_visited.ex:33: Elixir.DotcomWeb.Plugs.RecentlyVisited.DotcomWeb.Plugs.RecentlyVisited.assign_recently_visited/2
    lib/dotcom_web/controllers/mode_controller.ex:1: Elixir.DotcomWeb.ModeController.DotcomWeb.ModeController.phoenix_controller_pipeline/2
    lib/phoenix/router.ex:416: Elixir.Phoenix.Router.Phoenix.Router.__call__/5
    deps/plug/lib/plug/error_handler.ex:80: Elixir.DotcomWeb.Router.DotcomWeb.Router.call/2
    lib/dotcom_web/endpoint.ex:1: Elixir.DotcomWeb.Endpoint.DotcomWeb.Endpoint.plug_builder_call/2
    lib/dotcom_web/endpoint.ex:1: Elixir.DotcomWeb.Endpoint.DotcomWeb.Endpoint."call (overridable 3)"/2
```


## Implementation

The `Task.async_stream/3` call wasn't handling the timeout! So now we can handle the timeout, by specifying `on_timeout`. (We don't do anything special with the result - if we can't fetch the route we'll ignore it.)

I also adjusted the call in the `ModeController`: it turns out we were calling the plug on each mode, but we don't even show Recently Visited routes on those pages. So now it's only run on the `/schedules/` page.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216174323767596