### PR TITLE
refactor(DetailedStopGroup): replace async_stream

### DIFF
--- a/lib/detailed_stop_group.ex
+++ b/lib/detailed_stop_group.ex
@@ -38,7 +38,8 @@ defmodule DetailedStopGroup do
     mode
     |> Route.types_for_mode()
     |> @routes_repo.by_type()
-    |> Enum.map(&{&1, @stops_repo.by_route(&1.id, 1)})
+    |> Task.async_stream(&{&1, @stops_repo.by_route(&1.id, 1)}, max_concurrency: 10, on_timeout: :kill_task)
+    |> Stream.map(fn {:ok, stops} -> stops end)
   end
 
   @spec from_grouped_stops([grouped_stops]) :: [
@@ -47,15 +48,15 @@ defmodule DetailedStopGroup do
   defp from_grouped_stops(grouped_stops) do
     grouped_stops
     |> Stream.map(&build_featured_stops/1)
-    |> Enum.to_list()
   end
 
   @spec build_featured_stops(grouped_stops) :: DetailedStopGroup.t()
   defp build_featured_stops({route, stops}) do
     featured_stops =
       stops
-      |> Enum.sort_by(& &1.name)
-      |> Enum.map(&build_featured_stop(route, &1))
+      |> Task.async_stream(&build_featured_stop(route, &1), max_concurrency: 10, on_timeout: :kill_task)
+      |> Stream.map(fn {:ok, featured_stop} -> featured_stop end)
+      |> Enum.sort_by(& &1.stop.name)
 
     {route, featured_stops}
   end

--- a/lib/detailed_stop_group.ex
+++ b/lib/detailed_stop_group.ex
@@ -38,7 +38,10 @@ defmodule DetailedStopGroup do
     mode
     |> Route.types_for_mode()
     |> @routes_repo.by_type()
-    |> Task.async_stream(&{&1, @stops_repo.by_route(&1.id, 1)}, max_concurrency: 10, on_timeout: :kill_task)
+    |> Task.async_stream(&{&1, @stops_repo.by_route(&1.id, 1)},
+      max_concurrency: 10,
+      on_timeout: :kill_task
+    )
     |> Stream.map(fn {:ok, stops} -> stops end)
   end
 
@@ -54,7 +57,10 @@ defmodule DetailedStopGroup do
   defp build_featured_stops({route, stops}) do
     featured_stops =
       stops
-      |> Task.async_stream(&build_featured_stop(route, &1), max_concurrency: 10, on_timeout: :kill_task)
+      |> Task.async_stream(&build_featured_stop(route, &1),
+        max_concurrency: 10,
+        on_timeout: :kill_task
+      )
       |> Stream.map(fn {:ok, featured_stop} -> featured_stop end)
       |> Enum.sort_by(& &1.stop.name)
 

--- a/lib/detailed_stop_group.ex
+++ b/lib/detailed_stop_group.ex
@@ -42,7 +42,7 @@ defmodule DetailedStopGroup do
       max_concurrency: 10,
       on_timeout: :kill_task
     )
-    |> Stream.map(fn {:ok, stops} -> stops end)
+    |> Enum.map(fn {:ok, stops} -> stops end)
   end
 
   @spec from_grouped_stops([grouped_stops]) :: [
@@ -51,6 +51,7 @@ defmodule DetailedStopGroup do
   defp from_grouped_stops(grouped_stops) do
     grouped_stops
     |> Stream.map(&build_featured_stops/1)
+    |> Enum.to_list()
   end
 
   @spec build_featured_stops(grouped_stops) :: DetailedStopGroup.t()

--- a/lib/detailed_stop_group.ex
+++ b/lib/detailed_stop_group.ex
@@ -38,8 +38,7 @@ defmodule DetailedStopGroup do
     mode
     |> Route.types_for_mode()
     |> @routes_repo.by_type()
-    |> Task.async_stream(&{&1, @stops_repo.by_route(&1.id, 1)})
-    |> Enum.map(fn {:ok, stops} -> stops end)
+    |> Enum.map(&{&1, @stops_repo.by_route(&1.id, 1)})
   end
 
   @spec from_grouped_stops([grouped_stops]) :: [
@@ -47,8 +46,8 @@ defmodule DetailedStopGroup do
         ]
   defp from_grouped_stops(grouped_stops) do
     grouped_stops
-    |> Task.async_stream(&build_featured_stops(&1))
-    |> Enum.map(fn {:ok, featured_stops} -> featured_stops end)
+    |> Stream.map(&build_featured_stops/1)
+    |> Enum.to_list()
   end
 
   @spec build_featured_stops(grouped_stops) :: DetailedStopGroup.t()
@@ -56,8 +55,7 @@ defmodule DetailedStopGroup do
     featured_stops =
       stops
       |> Enum.sort_by(& &1.name)
-      |> Task.async_stream(&build_featured_stop(route, &1))
-      |> Enum.map(fn {:ok, featured_stop} -> featured_stop end)
+      |> Enum.map(&build_featured_stop(route, &1))
 
     {route, featured_stops}
   end

--- a/lib/dotcom_web/controllers/stop_controller.ex
+++ b/lib/dotcom_web/controllers/stop_controller.ex
@@ -266,7 +266,7 @@ defmodule DotcomWeb.StopController do
   defp separate_mattapan(stop_info) do
     case Enum.find(stop_info, fn {route, _stops} -> route.id == "Mattapan" end) do
       nil -> {nil, stop_info}
-      mattapan -> {mattapan, Stream.reject(stop_info, & &1 == mattapan)}
+      mattapan -> {mattapan, Stream.reject(stop_info, &(&1 == mattapan))}
     end
   end
 

--- a/lib/dotcom_web/controllers/stop_controller.ex
+++ b/lib/dotcom_web/controllers/stop_controller.ex
@@ -257,7 +257,6 @@ defmodule DotcomWeb.StopController do
   defp get_stop_info do
     [:subway, :commuter_rail, :ferry]
     |> Stream.flat_map(&DetailedStopGroup.from_mode/1)
-    |> Enum.to_list()
     |> separate_mattapan()
   end
 
@@ -267,7 +266,7 @@ defmodule DotcomWeb.StopController do
   defp separate_mattapan(stop_info) do
     case Enum.find(stop_info, fn {route, _stops} -> route.id == "Mattapan" end) do
       nil -> {nil, stop_info}
-      mattapan -> {mattapan, List.delete(stop_info, mattapan)}
+      mattapan -> {mattapan, Stream.reject(stop_info, & &1 == mattapan)}
     end
   end
 

--- a/lib/dotcom_web/controllers/stop_controller.ex
+++ b/lib/dotcom_web/controllers/stop_controller.ex
@@ -257,6 +257,7 @@ defmodule DotcomWeb.StopController do
   defp get_stop_info do
     [:subway, :commuter_rail, :ferry]
     |> Stream.flat_map(&DetailedStopGroup.from_mode/1)
+    |> Enum.to_list()
     |> separate_mattapan()
   end
 
@@ -266,7 +267,7 @@ defmodule DotcomWeb.StopController do
   defp separate_mattapan(stop_info) do
     case Enum.find(stop_info, fn {route, _stops} -> route.id == "Mattapan" end) do
       nil -> {nil, stop_info}
-      mattapan -> {mattapan, Stream.reject(stop_info, &(&1 == mattapan))}
+      mattapan -> {mattapan, Enum.reject(stop_info, &(&1 == mattapan))}
     end
   end
 

--- a/lib/dotcom_web/controllers/stop_controller.ex
+++ b/lib/dotcom_web/controllers/stop_controller.ex
@@ -256,8 +256,8 @@ defmodule DotcomWeb.StopController do
   @spec get_stop_info :: {DetailedStopGroup.t(), [DetailedStopGroup.t()]}
   defp get_stop_info do
     [:subway, :commuter_rail, :ferry]
-    |> Task.async_stream(&DetailedStopGroup.from_mode/1)
-    |> Enum.flat_map(fn {:ok, stops} -> stops end)
+    |> Stream.flat_map(&DetailedStopGroup.from_mode/1)
+    |> Enum.to_list()
     |> separate_mattapan()
   end
 


### PR DESCRIPTION

## Scope

[MBTA-DOTCOM-JV](https://mbtace.sentry.io/issues/6093873308/events/ce2d22dec17d4baf8a693d4531d542d1/)

In the continued vein of, we unearth old but recurring Sentry issues from the archive...

```
Uncaught exit - {:timeout, {Task.Supervised, :stream, [5000]}}
    lib/task/supervised.ex:349: Elixir.Task.Supervised.Task.Supervised.stream_reduce/7
    lib/enum.ex:4570: Elixir.Enum.Enum.flat_map/2
    lib/dotcom_web/controllers/stop_controller.ex:269: Elixir.DotcomWeb.StopController.DotcomWeb.StopController.get_stop_info/0
    lib/dotcom_web/controllers/stop_controller.ex:44: Elixir.DotcomWeb.StopController.DotcomWeb.StopController.show/2
    lib/dotcom_web/controllers/stop_controller.ex:1: Elixir.DotcomWeb.StopController.DotcomWeb.StopController.action/2
    lib/dotcom_web/controllers/stop_controller.ex:1: Elixir.DotcomWeb.StopController.DotcomWeb.StopController.phoenix_controller_pipeline/2
    lib/phoenix/router.ex:416: Elixir.Phoenix.Router.Phoenix.Router.__call__/5
    deps/plug/lib/plug/error_handler.ex:80: Elixir.DotcomWeb.Router.DotcomWeb.Router.call/2
```

## Implementation

This message appears when `Task.async_stream` doesn't specify an `on_timeout` action - the default behavior is the task exits!

In this case I think it's better if we don't create possible timeouts: just get everything anyway without async calls, since we'll always want this page (`/stops`) to list all the stops.

I think the code had likely been structured this way because fetching and processing all the stops can be kinda slow. So this updated code leverages `Stream` over `Enum` in a few spots for some hopeful performance improvements. The flame charts are still massive here, but I did see this page go from producing an SVG of 5.2MB to one that's 3.4MB...

| Before | After |
|--------|--------|
| <img width="1276" height="29000" style="display: block;" alt="flame_on (detailedstop before)" src="https://github.com/user-attachments/assets/87a7bbf2-64c5-47fc-8cc5-377e29984ceb" /> | <img width="1276" height="29000" alt="flame_on (detailedstop after)" src="https://github.com/user-attachments/assets/4db5fe22-e701-4621-8319-7736a095f766" /> | 
