### PR TITLE
refactor(Alerts.Sort): more performant comparison

### DIFF
--- a/lib/alerts/sort.ex
+++ b/lib/alerts/sort.ex
@@ -54,7 +54,7 @@ defmodule Alerts.Sort do
       lifecycle_index(alert.lifecycle),
       -alert.severity,
       -updated_at_date(alert.updated_at),
-      first_future_active_period_start(alert.active_period, now),
+      first_future_active_period_start(alert, now),
       alert.id
     }
   end
@@ -91,26 +91,10 @@ defmodule Alerts.Sort do
   defp priority(%{priority: :high}), do: 0
   defp priority(%{priority: :system}), do: 1
 
-  # atoms are greater than any integer
-  defp first_future_active_period_start([], _now), do: :infinity
-
-  defp first_future_active_period_start(periods, now) do
-    # first active period that's in the future
-    now_unix = DateTime.to_unix(now, :second)
-
-    future_periods =
-      for {start, _} <- periods,
-          start,
-          # wrap in a list to avoid an Erlang 19.3 issue
-          unix <- [DateTime.to_unix(start)],
-          unix > now_unix do
-        unix
-      end
-
-    if future_periods == [] do
-      :infinity
-    else
-      Enum.min(future_periods)
+  defp first_future_active_period_start(alert, now) do
+    case Dotcom.Alerts.StartTime.next_active_time(alert, now) do
+      {_, datetime} -> DateTime.to_unix(datetime)
+      :past -> :infinity
     end
   end
 end

--- a/lib/dotcom/alerts/start_time.ex
+++ b/lib/dotcom/alerts/start_time.ex
@@ -41,6 +41,9 @@ defmodule Dotcom.Alerts.StartTime do
         time
       ) do
     cond do
+      is_nil(start_time) ->
+        next_active_period_active_time(rest_of_active_periods, time)
+
       ends_before?(end_time, time) ->
         next_active_period_active_time(rest_of_active_periods, time)
 

--- a/lib/dotcom/alerts/start_time.ex
+++ b/lib/dotcom/alerts/start_time.ex
@@ -41,11 +41,13 @@ defmodule Dotcom.Alerts.StartTime do
         time
       ) do
     cond do
-      is_nil(start_time) ->
-        next_active_period_active_time(rest_of_active_periods, time)
-
+      # period already ended -- keep iterating
       ends_before?(end_time, time) ->
         next_active_period_active_time(rest_of_active_periods, time)
+
+      # period hasn't ended yet, but no defined start time -- use the current time
+      is_nil(start_time) ->
+        {:current, time}
 
       DateTime.before?(start_time, time) ->
         {:current, start_time}

--- a/lib/dotcom_web/controllers/stop_controller.ex
+++ b/lib/dotcom_web/controllers/stop_controller.ex
@@ -31,7 +31,6 @@ defmodule DotcomWeb.StopController do
           routes: [route_with_directions]
         }
 
-  plug(:alerts)
   plug(DotcomWeb.Plugs.DateTime)
   plug(DotcomWeb.Plugs.AlertsByTimeframe)
 
@@ -81,6 +80,7 @@ defmodule DotcomWeb.StopController do
         conn
         |> assign(:breadcrumbs, breadcrumbs(stop, routes_by_stop))
         |> meta_description(stop, routes_by_stop)
+        |> assign_alerts()
         |> render("show.html", %{
           stop: stop,
           amenity_param: Map.get(params, "amenity", "") |> String.to_atom(),
@@ -347,11 +347,11 @@ defmodule DotcomWeb.StopController do
   @spec includes_predictions?(TransitNearMe.headsign_data()) :: boolean
   defp includes_predictions?(%{times: times}), do: Enum.any?(times, &(&1.prediction != nil))
 
-  defp alerts(%{assigns: %{alerts: alerts}} = conn, _opts) do
+  defp assign_alerts(%{assigns: %{alerts: alerts}} = conn) do
     assign(conn, :all_alerts_count, length(alerts))
   end
 
-  defp alerts(%{path_params: %{"id" => id}} = conn, _opts) do
+  defp assign_alerts(%{path_params: %{"id" => id}} = conn) do
     stop_id = URI.decode_www_form(id)
 
     alerts =
@@ -364,7 +364,7 @@ defmodule DotcomWeb.StopController do
     |> assign(:all_alerts_count, length(alerts))
   end
 
-  defp alerts(conn, _opts) do
+  defp assign_alerts(conn) do
     assign(conn, :alerts, AlertsRepo.all(conn.assigns.date_time))
   end
 

--- a/test/dotcom/alerts/start_time_test.exs
+++ b/test/dotcom/alerts/start_time_test.exs
@@ -66,6 +66,15 @@ defmodule Dotcom.Alerts.StartTimeTest do
 
       assert next_active_time(alert, time) == :past
     end
+
+    test "returns :current if active period has nil start time but ends in the future" do
+      time = Test.Support.Generators.DateTime.random_date_time()
+      end_time = Test.Support.Generators.DateTime.random_date_time_after(time)
+
+      alert = Alert.build(:alert, active_period: [{nil, end_time}])
+
+      assert next_active_time(alert, time) == {:current, time}
+    end
   end
 
   describe "active?/2" do


### PR DESCRIPTION

## Scope

While tackling #3310 I noticed that `Alerts.Sort.sort/2` was featuring _prominently_ in my flame charts, and I wanted to see if I could do anything about that.

## Implementation

**_First of all_**. `/stops/<mode>` pages don't even show alerts. So the first commit moves the call which assigns alerts to `conn` to the specific method behind rendering the individual stop pages, instead of being invoked for every page handled by `DotcomWeb.StopController`.

Then when debugging `Alerts.Sort.sort/2`, I noticed the sorting logic included assessing the next active period start time. And I remembered we'd later implemented a different function for computing that, over at `Dotcom.Alerts.StartTime.next_active_time/2`! So I wanted to see if reusing that was more performant (and looks like it is!).

These charts were generated from loading South Station page with an already warmed cache.

| Before (6.5MB) | After (3.3MB) |
|--------|--------|
| <img width="1276" height="28975" alt="flame_on (alert before)" src="https://github.com/user-attachments/assets/56d51252-8244-4019-a4fb-de3881e265b2" /> | <img width="1276" height="25700" alt="flame_on (alert after)" src="https://github.com/user-attachments/assets/ba43ecd3-0340-4f4f-bf47-a416e2905db5" />  | 

## How to test

We could verify if the subway **Planned Work** section still sorts those alerts in the same way as before.