### PR TITLE
feat(ferry-fare-cards): Add `cash`, and rename `Winthrop/Quincy` to `Winthrop and Quincy`

### DIFF
--- a/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
+++ b/lib/dotcom_web/templates/cms/paragraph/_fare_card.html.heex
@@ -39,8 +39,10 @@ media =
         ~t", ",
         Fares.Format.media(:paper_ferry),
         ~t", ",
+        Fares.Format.media(:contactless_payment),
+        ~t", ",
         ~t"or ",
-        Fares.Format.media(:contactless_payment)
+        Fares.Format.media(:cash)
       ]
 
     %Fares.Summary{} ->

--- a/lib/fares/format.ex
+++ b/lib/fares/format.ex
@@ -91,7 +91,7 @@ defmodule Fares.Format do
   def name(:ferry_harbor_loop), do: ~t"Harbor Loop Ferry"
   def name(:ferry_east_boston), do: ~t"East Boston Ferry"
   def name(:ferry_lynn), do: ~t"Lynn Ferry"
-  def name(:ferry_winthrop), do: ~t"Winthrop/Quincy Ferry"
+  def name(:ferry_winthrop), do: ~t"Winthrop and Quincy Ferry"
   def name(:ferry_george), do: ~t"Georges Island"
   def name(:commuter_ferry), do: ~t"Hingham/Hull Ferry"
   def name(:commuter_ferry_logan), do: ~t"Commuter Ferry to Logan Airport"

--- a/test/fares/format_test.exs
+++ b/test/fares/format_test.exs
@@ -63,7 +63,7 @@ defmodule Fares.FormatTest do
       assert name(%Fare{name: :ferry_cross_harbor}) == "Cross Harbor Ferry"
       assert name(%Fare{name: :ferry_east_boston}) == "East Boston Ferry"
       assert name(%Fare{name: :ferry_lynn}) == "Lynn Ferry"
-      assert name(%Fare{name: :ferry_winthrop}) == "Winthrop/Quincy Ferry"
+      assert name(%Fare{name: :ferry_winthrop}) == "Winthrop and Quincy Ferry"
       assert name(%Fare{name: :commuter_ferry}) == "Hingham/Hull Ferry"
     end
 


### PR DESCRIPTION
## Scope

**Asana Ticket:** [QF | ⛴️ 💸 Small ferry fare card updates by 7/10](https://app.asana.com/1/15492006741476/project/555089885850811/task/1216145824673855?focus=true)

## Screenshots

<img width="2508" height="788" alt="Screenshot 2026-07-01 at 2 57 57 PM" src="https://github.com/user-attachments/assets/e230e942-75a5-4b41-84de-b99bacfe99fc" />


## How to test

I made a ["Ferry Card Previews" page](http://localhost:4001/fares/fare-card-previews?preview=&vid=latest&nid=7926) that you can view locally if you set `CMS_API_BASE_URL=https://dev-mbta.pantheonsite.io` (or [on dev-green](https://dev-green.mbtace.com/fares/fare-card-previews?preview=&vid=latest&nid=7926) if you want to see what that page looks like without the changes on this branch). 

Only the two fare cards at the bottom of that page are relevant for this PR - the "Invalid Fare Invalid Duration" ones are [fixed in a different PR](https://github.com/mbta/dotcom/pull/3294).