### PR TITLE
feat(SubwayStatus): Show effect if unique when combining Green Line rows

### DIFF
--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -191,8 +191,12 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
     |> put_in([:route_info, :branch_ids], combined_branch_ids)
   end
 
-  defp combine_status_entries(%{status: status1}, %{status: status2}) when status1 == status2,
-    do: %{status: status1, prefix: nil, plural: true, future: false}
+  defp combine_status_entries(
+         %{status: status1, prefix: prefix1, future: future1},
+         %{status: status2, prefix: prefix2, future: future2}
+       )
+       when status1 == status2 and prefix1 == prefix2 and future1 == future2,
+       do: %{status: status1, prefix: prefix1, plural: true, future: future1}
 
   defp combine_status_entries(_status_entry1, _status_entry2), do: see_alerts_status()
 

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -185,9 +185,6 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
         |> Enum.sort()
       end
 
-    # dbg(row1.status_entry)
-    # dbg(row2.status_entry)
-
     row1
     |> Map.put(:status_entry, combine_status_entries(row1.status_entry, row2.status_entry))
     |> Map.put(:alerts, row1.alerts ++ row2.alerts)

--- a/lib/dotcom_web/components/system_status/subway_status.ex
+++ b/lib/dotcom_web/components/system_status/subway_status.ex
@@ -174,7 +174,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
 
   defp combine_rows(
          %{route_info: %{branch_ids: branch_ids1}} = row1,
-         %{route_info: %{branch_ids: branch_ids2}} = _row2
+         %{route_info: %{branch_ids: branch_ids2}} = row2
        ) do
     combined_branch_ids =
       if Enum.empty?(branch_ids1) || Enum.empty?(branch_ids2) do
@@ -185,10 +185,19 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatus do
         |> Enum.sort()
       end
 
+    # dbg(row1.status_entry)
+    # dbg(row2.status_entry)
+
     row1
-    |> Map.put(:status_entry, see_alerts_status())
+    |> Map.put(:status_entry, combine_status_entries(row1.status_entry, row2.status_entry))
+    |> Map.put(:alerts, row1.alerts ++ row2.alerts)
     |> put_in([:route_info, :branch_ids], combined_branch_ids)
   end
+
+  defp combine_status_entries(%{status: status1}, %{status: status2}) when status1 == status2,
+    do: %{status: status1, prefix: nil, plural: true, future: false}
+
+  defp combine_status_entries(_status_entry1, _status_entry2), do: see_alerts_status()
 
   defp add_url(row) do
     route_id = route_id_from_route_info(row.route_info)

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -145,7 +145,9 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
         |> Enum.map(fn branch_id ->
           Factories.Alerts.Alert.build(:alert_for_route,
             route_id: branch_id,
-            effect: Faker.Util.pick(service_impacting_effects())
+            effect:
+              Faker.Util.pick(service_impacting_effects())
+              |> then(fn {effect, _severity} -> effect end)
           )
           |> Factories.Alerts.Alert.active_now()
         end)
@@ -154,9 +156,72 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
       rows = status_rows_for_alerts(alerts)
 
       # Verify
-      assert rows
-             |> for_route("Green")
-             |> Enum.map(&status_label_text_for_row/1) == ["See Alerts", "Normal Service"]
+      assert [affected_row, normal_row] = rows |> for_route("Green")
+
+      assert status_label_text_for_row(normal_row) == "Normal Service"
+      refute status_label_text_for_row(affected_row) == "Normal Service"
+    end
+
+    test "combines collapsed Green line alerts into 'See Alerts' if their effects are different" do
+      # Setup
+      affected_branches =
+        Faker.Util.sample_uniq(2, fn -> Faker.Util.pick(GreenLine.branch_ids()) end)
+
+      effects =
+        Faker.Util.sample_uniq(2, fn ->
+          Faker.Util.pick(service_impacting_effects())
+          |> then(fn {effect, _severity} -> effect end)
+        end)
+
+      alerts =
+        Enum.zip(affected_branches, effects)
+        |> Enum.map(fn {branch_id, effect} ->
+          Factories.Alerts.Alert.build(:alert_for_route,
+            route_id: branch_id,
+            effect: effect
+          )
+          |> Factories.Alerts.Alert.active_now()
+        end)
+
+      # Exercise
+      rows = status_rows_for_alerts(alerts)
+
+      # Verify
+      assert [affected_row, _normal_row] = rows |> for_route("Green")
+
+      assert status_label_text_for_row(affected_row) == "See Alerts"
+    end
+
+    test "shows effect label for collapsed Green line alerts if they all have the same effect" do
+      # Setup
+      affected_branches =
+        Faker.Util.sample_uniq(2, fn -> Faker.Util.pick(GreenLine.branch_ids()) end)
+
+      # Excluding `:station_closure` from this test because it follows
+      # different pluralizing rules than the other effects, we do care
+      # that other statuses are pluralized properly, and we're testing
+      # the `:station_closure` case below anyway.
+      {effect, _severity} =
+        Faker.Util.pick(@effects_with_simple_descriptions -- [station_closure: 1])
+
+      alerts =
+        affected_branches
+        |> Enum.map(fn branch_id ->
+          Factories.Alerts.Alert.build(:alert_for_route,
+            route_id: branch_id,
+            effect: effect
+          )
+          |> Factories.Alerts.Alert.active_now()
+        end)
+
+      # Exercise
+      rows = status_rows_for_alerts(alerts)
+
+      # Verify
+      assert [affected_row, _normal_row] = rows |> for_route("Green")
+
+      assert status_label_text_for_row(affected_row) ==
+               status_label_text_for_effect_plural(effect)
     end
 
     test "groups Green line alerts correctly between normal and affected rows when collapsed" do
@@ -250,7 +315,12 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
 
     test "collapses Green line rows if there is a Mattapan alert" do
       # Setup
-      {effect, severity} = Faker.Util.pick(service_impacting_effects())
+      # Excluding `:station_closure` from this test because it follows
+      # different pluralizing rules than the other effects, we do care
+      # that other statuses are pluralized properly, and we're testing
+      # the `:station_closure` case below anyway.
+      {effect, severity} =
+        Faker.Util.pick(@effects_with_simple_descriptions -- [station_closure: 1])
 
       alerts = [
         Factories.Alerts.Alert.build(:alert_for_route,
@@ -280,7 +350,7 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
       assert rows
              |> for_route("Green")
              |> Enum.map(&status_label_text_for_row/1) == [
-               "See Alerts"
+               status_label_text_for_effect_plural(effect)
              ]
     end
 
@@ -605,6 +675,45 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
 
       # Exercise
       status_rows_for_alerts([alert])
+    end
+
+    test "shows all affected stops for collapsed green line station closures" do
+      # Setup
+      affected_branches =
+        Faker.Util.sample_uniq(2, fn -> Faker.Util.pick(GreenLine.branch_ids()) end)
+
+      alerts =
+        affected_branches
+        |> Enum.map(fn branch_id ->
+          Factories.Alerts.Alert.build(:alert_for_route,
+            route_id: branch_id,
+            effect: :station_closure
+          )
+          |> Factories.Alerts.Alert.active_now()
+        end)
+
+      stops = Factories.Stops.Stop.build_list(2, :stop)
+
+      expect(Dotcom.Alerts.AffectedStops.Mock, :affected_stops, fn
+        [_], _ ->
+          stops |> Enum.take(1) |> Enum.map(&%{stop: &1, direction: :all})
+
+        [_, _], _ ->
+          stops |> Enum.map(&%{stop: &1, direction: :all})
+      end)
+
+      # Exercise
+      rows = status_rows_for_alerts(alerts)
+
+      # Verify
+      assert [affected_row, _normal_row] = rows |> for_route("Green")
+
+      [stop1, stop2] = stops
+
+      assert status_label_text_for_row(affected_row) == "Stops Skipped"
+
+      assert status_subheading_for_row(affected_row) ==
+               "#{stop1.name} & #{stop2.name}"
     end
 
     test "shows 'Stop Skipped' singular if a single station is closed" do
@@ -1304,6 +1413,11 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
   defp status_label_text_for_effect(:shuttle), do: "Shuttles"
   defp status_label_text_for_effect(:station_closure), do: "Stop Skipped"
   defp status_label_text_for_effect(effect), do: effect |> Atom.to_string() |> Recase.to_title()
+
+  defp status_label_text_for_effect_plural(:station_closure), do: "Stops Skipped"
+
+  defp status_label_text_for_effect_plural(effect),
+    do: effect |> status_label_text_for_effect() |> Inflex.pluralize()
 
   defp human_delay_severity(severity) do
     Alerts.Alert.human_severity(%Alerts.Alert{effect: :delay, severity: severity})

--- a/test/dotcom_web/components/system_status/subway_status_test.exs
+++ b/test/dotcom_web/components/system_status/subway_status_test.exs
@@ -224,6 +224,86 @@ defmodule DotcomWeb.Components.SystemStatus.SubwayStatusTest do
                status_label_text_for_effect_plural(effect)
     end
 
+    test "shows 'See Alerts' for collapsed Green line alerts if they all have the same effect, but different prefixes" do
+      # Setup
+      now = Dotcom.Utils.DateTime.now()
+
+      start_time =
+        random_time_range_date_time({now, Dotcom.Utils.ServiceDateTime.end_of_service_day(now)})
+
+      [branch_id1, branch_id2] =
+        Faker.Util.sample_uniq(2, fn -> Faker.Util.pick(GreenLine.branch_ids()) end)
+
+      {effect, _severity} = Faker.Util.pick(@effects_with_simple_descriptions)
+
+      alerts =
+        [
+          Factories.Alerts.Alert.build(:alert_for_route,
+            route_id: branch_id1,
+            effect: effect
+          )
+          |> Factories.Alerts.Alert.active_now(),
+          Factories.Alerts.Alert.build(:alert_for_route,
+            route_id: branch_id2,
+            effect: effect
+          )
+          |> Factories.Alerts.Alert.active_starting_at(start_time)
+        ]
+
+      # Exercise
+      rows = status_rows_for_alerts(alerts)
+
+      # Verify
+      assert [affected_row, _normal_row] = rows |> for_route("Green")
+
+      assert status_label_text_for_row(affected_row) == "See Alerts"
+    end
+
+    test "shows the prefix and the effect label for collapsed Green line alerts if they all have the same effect, and the same prefix" do
+      # Setup
+      now = Dotcom.Utils.DateTime.now()
+
+      start_time =
+        random_time_range_date_time({now, Dotcom.Utils.ServiceDateTime.end_of_service_day(now)})
+
+      [branch_id1, branch_id2] =
+        Faker.Util.sample_uniq(2, fn -> Faker.Util.pick(GreenLine.branch_ids()) end)
+
+      # Excluding `:station_closure` from this test because it follows
+      # different pluralizing rules than the other effects, we do care
+      # that other statuses are pluralized properly, and we're testing
+      # the `:station_closure` case below anyway.
+      {effect, _severity} =
+        Faker.Util.pick(@effects_with_simple_descriptions -- [station_closure: 1])
+
+      alerts =
+        [
+          Factories.Alerts.Alert.build(:alert_for_route,
+            route_id: branch_id1,
+            effect: effect
+          )
+          |> Factories.Alerts.Alert.active_starting_at(start_time),
+          Factories.Alerts.Alert.build(:alert_for_route,
+            route_id: branch_id2,
+            effect: effect
+          )
+          |> Factories.Alerts.Alert.active_starting_at(start_time)
+        ]
+
+      # Exercise
+      rows = status_rows_for_alerts(alerts)
+
+      # Verify
+      assert [affected_row, _normal_row] = rows |> for_route("Green")
+
+      expected_status_desc = effect |> status_label_text_for_effect_plural()
+      expected_prefix = Util.narrow_time(start_time)
+      expected_status_text = "#{expected_prefix}: #{expected_status_desc}"
+
+      assert status_label_text_for_row(affected_row) ==
+               expected_status_text
+    end
+
     test "groups Green line alerts correctly between normal and affected rows when collapsed" do
       # Setup
       affected_branches =


### PR DESCRIPTION
## Scope

**Asana Ticket:** [⚠️ Update homepage subway status to support multiple GL branch station bypasses](https://app.asana.com/1/15492006741476/project/1205718271156548/task/1215561885857034?focus=true)

## Implementation

- When combining Green line rows, if their statuses are the same (e.g. they're both `:station_closure`), then show the label text for that status, rather than "⚠️ See Alerts".

## Screenshots

- **Left:** Status from the [alerts page](http://localhost:4001/alerts/subway), to show off the state of the world. This view doesn't collapse rows, so this PR doesn't change how that behaves.
- **Middle:** Current behavior on `main` (shown in `dev-green` so I could try out different combos). Notice how it indiscriminately collapses to "⚠️ See Alerts".
- **Right:** This branch. In the first image, the two "Stop Skipped" rows are combined into a single row that lists the two stops. In the second image, the three rows are combined into a single row that just says "3 Stops". In the third image, one of the alerts has a future start time, so they still get combined to "⚠️ See Alerts". In the fourth image, the alerts don't all have the same effect, so they still get combined to "⚠️ See Alerts".

<img width="2998" height="1618" alt="Screenshot 2026-07-02 at 7 57 05 PM" src="https://github.com/user-attachments/assets/e01bd1e7-107c-49e7-86ec-a1e0dba7cb8d" />

<img width="3000" height="1616" alt="Screenshot 2026-07-02 at 7 55 00 PM" src="https://github.com/user-attachments/assets/3d04e595-0197-4198-b207-51e6d18049a3" />

<img width="2998" height="1626" alt="Screenshot 2026-07-02 at 8 16 17 PM" src="https://github.com/user-attachments/assets/6884e863-2728-4932-9b69-9cb00282378d" />

<img width="2998" height="1626" alt="Screenshot 2026-07-02 at 8 19 47 PM" src="https://github.com/user-attachments/assets/9b0b5df7-7416-491f-8da3-8d8eb9b26964" />


## How to test

Compare [homepage](http://localhost:4001/) subway status with [alerts page](http://localhost:4001/alerts/subway) subway status. Create alerts on different branches of the Green line with the same effects, and see that they show that effect (e.g. `Stops Skipped`). Create alerts with different effects or different start times and see that they still collapse to `See Alerts`. Try other scenarios that I didn't think of. Have fun!